### PR TITLE
Combine file path properly & make insertLPVMDataLd to be blocking

### DIFF
--- a/src/Builder.hs
+++ b/src/Builder.hs
@@ -798,7 +798,7 @@ buildExecutable targetMod fpath = do
             logBuild "o Creating temp Main module @ .../tmp/tmpMain.o"
             tempDir <- liftIO getTemporaryDirectory
             liftIO $ createDirectoryIfMissing False (tempDir </> "wybetemp")
-            let tmpMainOFile = tempDir </> "wybetemp/" </> "tmpMain.o"
+            let tmpMainOFile = tempDir </> "wybetemp" </> "tmpMain.o"
             emitObjectFile mainMod tmpMainOFile
 
             ofiles <- mapM (loadObjectFile . fst) depends

--- a/src/ObjectInterface.hs
+++ b/src/ObjectInterface.hs
@@ -36,22 +36,20 @@ import Macho
 -- 'BL.ByteString' into it.
 -- ld reads the bs from a new tmpFile which is created with the contents
 -- of the given 'BL.ByteString'.
-insertLPVMDataLd :: BL.ByteString -> FilePath -> IO ()
-insertLPVMDataLd bs obj =
-    do tempDir <- getTemporaryDirectory
-       liftIO $ createDirectoryIfMissing False (tempDir </> "wybetemp")
-       let modFile = takeBaseName obj ++ ".module"
-       let lpvmFile = tempDir </> "wybetemp/" ++ modFile
-       BL.writeFile lpvmFile bs
-       let args = [obj] ++ ["-r"]
-                  ++ ["-sectcreate", "__LPVM", "__lpvm", lpvmFile]
-                  ++ ["-o", obj]
-       (exCode, _, serr) <- readCreateProcessWithExitCode (proc "ld" args) ""
-       case exCode of
-           ExitSuccess -> return ()
-           _ -> shouldnt $ "ld: " ++ serr
-       -- Cleanup
-       return ()
+insertLPVMDataLd :: BL.ByteString -> FilePath -> IO (Either String ())
+insertLPVMDataLd bs obj = do
+    tempDir <- getTemporaryDirectory
+    createDirectoryIfMissing False (tempDir </> "wybetemp")
+    let modFile = takeBaseName obj ++ ".module"
+    let lpvmFile = tempDir </> "wybetemp" </> modFile
+    BL.writeFile lpvmFile bs
+    let args = [obj] ++ ["-r"]
+                ++ ["-sectcreate", "__LPVM", "__lpvm", lpvmFile]
+                ++ ["-o", obj]
+    (exCode, _, serr) <- readCreateProcessWithExitCode (proc "ld" args) ""
+    case exCode of
+        ExitSuccess  -> return $ Right ()
+        _ -> return $ Left serr
 
 -- | Extract string data from the segment __LPVM, section __lpvm of the
 -- given object file. An empty string is returned if there is no data


### PR DESCRIPTION
I am working on porting this compiler to ubuntu. I noticed the following problems which I believe should be considered as bugs even on macOS and should be merged into master.

1.  </> is the operator for combining file path from System.FilePath. The problem here is that the getTemporaryDirectory does not guarantee that it returns a path with a trailing slash. (although it is usually the case on macOS).

2. It calls the ld but never wait for it to complete. It works only because this step is fairly fast.

