### PR TITLE
Add Github Actions for running tests.

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,36 @@
+name: CI (macOS)
+
+# Disabled, the [brew install llvm-hs/llvm/llvm-6.0] below
+# is way too slow. 
+on:
+    push:
+      branches-ignore:
+        - '**'
+# on:
+#     push:
+#       branches:
+#       - master
+#     pull_request:
+#       branches:
+#       - master
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: |
+        brew install haskell-stack
+        brew install bdw-gc
+        brew install llvm-hs/llvm/llvm-6.0
+        brew install dwdiff
+        brew install coreutils
+    - name: Install & build Haskell Stack dependencies
+        run: stack build --only-dependencies
+    #   TODO: cache things above?
+    - name: Build
+      run: make
+    - name: Run tests
+      run: make test

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,0 +1,34 @@
+name: CI (Ubuntu)
+
+on:
+    push:
+      branches:
+      - master
+    pull_request:
+      branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: |
+        sudo apt-get install clang
+        sudo apt-get install libgc-dev
+        sudo apt-get install llvm-6.0
+        sudo apt-get install libtinfo-dev
+        sudo apt-get install dwdiff
+    # GitHub-hosted runners provide Haskell Stack
+    # https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md
+    # - name: Install Haskell Stack
+    #   run: wget -qO- https://get.haskellstack.org/ | sh
+    - name: Install & build Haskell Stack dependencies
+      run: stack build --only-dependencies
+    #   TODO: cache things above?
+    - name: Build
+      run: make
+    - name: Run tests
+      run: make test


### PR DESCRIPTION
The macOS one is disabled due to the slowness. The ubuntu one works pretty good (It could be better since there is a ~10 mins overhead of stack building dependencies). 

Without any addtional settings, this CI won't  affect current workflow at all. It simply attachs the CI results to related commits\PRs on the web interface. We can talk about adding the CI check to the workflow during the meeting this week.