### PR TITLE
Fix issue #13

### DIFF
--- a/src/AST.hs
+++ b/src/AST.hs
@@ -317,6 +317,7 @@ data MessageLevel = Informational | Warning | Error
 --  compiling the module's dependencies.
 data CompilerState = Compiler {
   options :: Options,            -- ^compiler options specified on command line
+  tmpDir  :: FilePath,             -- ^tmp directory for this build
   msgs :: [(MessageLevel, String)],  -- ^warnings, error messages, and info messages
   errorState :: Bool,            -- ^whether or not we've seen any errors
   modules :: Map ModSpec Module, -- ^all known modules except what we're loading
@@ -333,7 +334,7 @@ type Compiler = StateT CompilerState IO
 -- |Run a compiler function from outside the Compiler monad.
 runCompiler :: Options -> Compiler t -> IO t
 runCompiler opts comp = evalStateT comp
-                        (Compiler opts [] False Map.empty 0 [] [] Map.empty)
+                        (Compiler opts "" [] False Map.empty 0 [] [] Map.empty)
 
 
 -- |Apply some transformation function to the compiler state.

--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -205,11 +205,12 @@ makeAssemblyFile file llmod =
 -- representation into the '__lpvm' section in it.
 makeWrappedObjFile :: FilePath -> LLVMAST.Module -> BL.ByteString -> Compiler ()
 makeWrappedObjFile file llmod modBS = do
+    tmpDir <- gets tmpDir
     result <- liftIO $ withContext $ \_ ->
         withModule llmod $ \m -> do
             withHostTargetMachine $ \tm ->
                 writeObjectToFile tm (File file) m
-            insertLPVMData modBS file
+            insertLPVMData tmpDir modBS file
     case result of
         Right () -> return ()
         Left serr -> Error <!> serr

--- a/src/ObjectInterface.hs
+++ b/src/ObjectInterface.hs
@@ -22,8 +22,6 @@ import           Data.Maybe (isJust)
 import           Distribution.System       (buildOS, OS (..)) 
 import           System.Exit               (ExitCode (..))
 import           System.Process
-import           System.Directory          (createDirectoryIfMissing
-                                           ,getTemporaryDirectory)
 import System.FilePath (takeBaseName, (</>))
 import Control.Monad.Trans (liftIO)
 import Macho

--- a/src/ObjectInterface.hs
+++ b/src/ObjectInterface.hs
@@ -126,7 +126,10 @@ extractLPVMDataLinux objFile = do
     createDirectoryIfMissing False (tempDir </> "wybetemp")
     let modFile = takeBaseName objFile ++ ".out.module"
     let lpvmFile = tempDir </> "wybetemp" </> modFile
+    -- [objcopy] tries to write to the file even we only need read permission.
+    -- We force it to write to /dev/null so it's "read-only".
     let args = ["--dump-section", "__LPVM.__lpvm=" ++ lpvmFile] ++ [objFile]
+               ++ ["/dev/null"]
     (exCode, _, serr) <- readCreateProcessWithExitCode (proc "objcopy" args) ""
     case exCode of
         ExitSuccess  -> do

--- a/src/ObjectInterface.hs
+++ b/src/ObjectInterface.hs
@@ -33,15 +33,14 @@ import Macho
 ----------------------------------------------------------------------------
 
 -- | Save LPVM data [BL.ByteString] into the given object file.
+-- The first [FilePath] is for [tmpDir]
 -- Currently supports macOS & Linux.
 -- On macOS, it stores in segment [__LPVM], section [__lpvm].
 -- On Linux, it sotres in section [__LPVM.__lpvm].
-insertLPVMData :: BL.ByteString -> FilePath -> IO (Either String ())
-insertLPVMData modBS objFile = do
-    tempDir <- getTemporaryDirectory
-    createDirectoryIfMissing False (tempDir </> "wybetemp")
+insertLPVMData :: FilePath -> BL.ByteString -> FilePath -> IO (Either String ())
+insertLPVMData tmpDir modBS objFile = do
     let modFile = takeBaseName objFile ++ ".module"
-    let lpvmFile = tempDir </> "wybetemp" </> modFile
+    let lpvmFile = tmpDir </> modFile
     BL.writeFile lpvmFile modBS
     case buildOS of 
         OSX   -> insertLPVMDataMacOS lpvmFile objFile
@@ -51,11 +50,12 @@ insertLPVMData modBS objFile = do
 
 -- | Extract LPVM data from the given object file 
 -- and return it as [BL.ByteString].
-extractLPVMData :: FilePath -> IO (Either String BL.ByteString)
-extractLPVMData objFile =
+-- The first [FilePath] is for [tmpDir]
+extractLPVMData :: FilePath -> FilePath -> IO (Either String BL.ByteString)
+extractLPVMData tmpDir objFile =
     case buildOS of 
-        OSX   -> extractLPVMDataMacOS objFile 
-        Linux -> extractLPVMDataLinux objFile 
+        OSX   -> extractLPVMDataMacOS tmpDir objFile 
+        Linux -> extractLPVMDataLinux tmpDir objFile
         _     -> shouldnt "Unsupported operation system"
 
 ----------------------------------------------------------------------------
@@ -103,8 +103,8 @@ insertLPVMDataLinux lpvmFile objFile = do
         _ -> return $ Left serr
 
 -- | Actual implementation of [extractLPVMData] for macOS
-extractLPVMDataMacOS :: FilePath -> IO (Either String BL.ByteString)
-extractLPVMDataMacOS objFile = do
+extractLPVMDataMacOS :: FilePath -> FilePath -> IO (Either String BL.ByteString)
+extractLPVMDataMacOS _ objFile = do
     objBS <- liftIO $ BL.readFile objFile
     if not $ isMachoBytes objBS 
         then return $ Left ("Not a recognised object file: " ++ objFile)
@@ -120,12 +120,10 @@ extractLPVMDataMacOS objFile = do
 
 -- | Actual implementation of [extractLPVMData] for Linux
 -- Uses system [objcopy]
-extractLPVMDataLinux :: FilePath -> IO (Either String BL.ByteString)
-extractLPVMDataLinux objFile = do
-    tempDir <- getTemporaryDirectory
-    createDirectoryIfMissing False (tempDir </> "wybetemp")
+extractLPVMDataLinux :: FilePath -> FilePath -> IO (Either String BL.ByteString)
+extractLPVMDataLinux tmpDir objFile = do
     let modFile = takeBaseName objFile ++ ".out.module"
-    let lpvmFile = tempDir </> "wybetemp" </> modFile
+    let lpvmFile = tmpDir </> modFile
     -- [objcopy] tries to write to the file even we only need read permission.
     -- We force it to write to /dev/null so it's "read-only".
     let args = ["--dump-section", "__LPVM.__lpvm=" ++ lpvmFile] ++ [objFile]

--- a/wybe.cabal
+++ b/wybe.cabal
@@ -23,6 +23,7 @@ executable wybemk
                , llvm-hs == 6.3.0
                , llvm-hs-pure == 6.2.1
                , llvm-hs-pretty == 0.6.0.0
+               , temporary
                , text
                , mtl
                , old-time


### PR DESCRIPTION
Fix #13 

1. Make [extractLPVMDataLinux] to be read-only.

2. Use a clean tmpDir for each build. (Currently the wybe compiler reuses tmp files, so if the previous build used `sudo` and the next build doesn't, then there will be a permission issue.)