### PR TITLE
Bump haskell to lts-12.26 (GHC 8.4.4)

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-11.11
+resolver: lts-12.26
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
I am not sure if this is appropriate. The current haskell version (lts-11.11 GHC 8.2.2) seems to be a bit too old. The problem for me is that [Haskell-Ide-Engine](https://github.com/haskell/haskell-ide-engine) has dropped support of that version.
The lts-12.26 seems to be the newest one without upgrading any packages.