### PR TITLE
Implement a better way of handling parameters in alias analysis.

### DIFF
--- a/src/AST.hs
+++ b/src/AST.hs
@@ -1593,12 +1593,12 @@ data ProcImpln
 
 -- | The identity of each specialized version. It needs to be a bijection
 -- between this Id and the specialized condition. 
--- Currently, [Int] is enought. We can change it to [Tuple] when there 
--- are more things to consider. More detial can be found in [Transform.hs]
+-- Currently, "Int" is enought. We can change it to "Tuple" when there 
+-- are more things to consider. More detial can be found in "Transform.hs"
 type SpeczVersionId = Int
 
 
--- Convert [SpeczVersionId] to [String] so it can be shorter in function
+-- Convert "SpeczVersionId" to "String" so it can be shorter in function
 -- name.
 speczIdToString :: SpeczVersionId -> String
 speczIdToString speczId = 
@@ -1610,7 +1610,8 @@ speczIdToString speczId =
 -- actual implementation
 type SpeczProcBodies = Map SpeczVersionId ProcBody
 
--- | Use UnionFind method to record the alias information
+
+-- | Use to record the alias relation between arguments of a procedure.
 type AliasMap = DisjointSet PrimVarName
 
 
@@ -1618,10 +1619,12 @@ type AliasMap = DisjointSet PrimVarName
 showAliasMap :: AliasMap -> String
 showAliasMap aliasMap = show $ aliasMapToAliasPairs aliasMap
 
+
 -- | a synonym function to hide the impletation of how unionfind is converted to
 -- alias pairs
 aliasMapToAliasPairs :: AliasMap -> [(PrimVarName, PrimVarName)]
 aliasMapToAliasPairs aliasMap = Set.toList $ dsToTransitivePairs aliasMap
+
 
 -- | Multiple specialization info for global alias 
 type AliasMultiSpeczInfo = [PrimVarName]

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -10,7 +10,7 @@ module Util (sameLength, maybeNth, setMapInsert,
              emptyDS, addOneToDS, unionTwoInDS, 
              combineTwoDS, removeSingletonFromDS,
              addConnectedGroupToDS, removeOneFromDS,
-             removeFromDS, connectedToOthersInDS,
+             removeFromDS, connectedItemsInDS,
              mapDS, filterDS, dsToTransitivePairs) where
 
 
@@ -93,6 +93,7 @@ type DisjointSet a = Set (Set a)
 
 emptyDS = Set.empty
 
+
 _findOneInSet :: (a -> Bool) -> Set a -> Maybe a
 _findOneInSet f = 
     Set.foldr 
@@ -101,6 +102,7 @@ _findOneInSet f =
                 Just _ -> result
                 Nothing -> if f x then Just x else Nothing
             ) Nothing
+
 
 addOneToDS :: Ord a => a -> DisjointSet a -> DisjointSet a
 addOneToDS x ds = 
@@ -136,6 +138,7 @@ unionTwoInDS x y ds =
             in
                 Set.insert newSet'' ds''
 
+
 combineTwoDS :: Ord a => DisjointSet a -> DisjointSet a -> DisjointSet a
 combineTwoDS =
     Set.foldr (\set ds -> addConnectedGroupToDS (Set.toList set) ds)
@@ -162,16 +165,20 @@ removeSingletonFromDS :: Ord a => DisjointSet a -> DisjointSet a
 removeSingletonFromDS =
     Set.filter (\x -> Set.size x > 1)
 
-connectedToOthersInDS :: Ord a => a -> DisjointSet a -> Bool
-connectedToOthersInDS x ds =
+
+-- return a set of items that the given item is connected to.
+connectedItemsInDS :: Ord a => a -> DisjointSet a -> Set a
+connectedItemsInDS x ds =
     case _findOneInSet (Set.member x) ds of 
-        Nothing -> False
-        Just xSet -> Set.size xSet > 1
+        Nothing -> Set.empty
+        Just xSet -> Set.delete x xSet
+
 
 -- The map function must be a bijection, i.e. 1-to-1 mapping.
-mapDS :: Ord a => (a -> a) -> DisjointSet a -> DisjointSet a
+mapDS :: (Ord a, Ord b) => (a -> b) -> DisjointSet a -> DisjointSet b
 mapDS f = 
     Set.map (Set.map f)
+
 
 filterDS :: Ord a => (a -> Bool) -> DisjointSet a -> DisjointSet a
 filterDS f ds =

--- a/test-cases/final-dump/alias_type4.exp
+++ b/test-cases/final-dump/alias_type4.exp
@@ -41,13 +41,13 @@ AFTER EVERYTHING:
     foreign lpvm alloc(16:wybe.int, ?tmp$9#0:alias_type4.posrec)
     foreign lpvm mutate(~tmp$9#0:alias_type4.posrec, ?tmp$10#0:alias_type4.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$6#0:alias_type4.position)
     foreign lpvm mutate(~tmp$10#0:alias_type4.posrec, ?tmp$11#0:alias_type4.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    alias_type4.foo<0>(~tmp$11#0:alias_type4.posrec, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @alias_type4:16:2
+    alias_type4.foo<0>[1](~tmp$11#0:alias_type4.posrec, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @alias_type4:16:2
 
 
 foo > public (1 calls)
 0: foo(r1#0:alias_type4.posrec, io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
- AliasMultiSpeczInfo: []
+ AliasMultiSpeczInfo: [r1#0]
     foreign lpvm access(~r1#0:alias_type4.posrec, 0:wybe.int, ?tmp$0#0:alias_type4.position)
     foreign lpvm mutate noalias(~tmp$0#0:alias_type4.position, ?%pos1#1:alias_type4.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 1111:wybe.int)
     foreign lpvm access(~pos1#1:alias_type4.position, 0:wybe.int, ?tmp$1#0:wybe.int)
@@ -96,7 +96,7 @@ entry:
   %15 = inttoptr i64 %14 to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
   store  i64 1, i64* %16 
-  tail call fastcc  void  @"alias_type4.foo<0>"(i64  %11)  
+  tail call fastcc  void  @"alias_type4.foo<0>[1]"(i64  %11)  
   ret void 
 }
 
@@ -120,6 +120,23 @@ entry:
   %29 = getelementptr  i64, i64* %28, i64 0 
   %30 = load  i64, i64* %29 
   tail call ccc  void  @print_int(i64  %30)  
+  tail call ccc  void  @putchar(i8  10)  
+  ret void 
+}
+
+
+define external fastcc  void @"alias_type4.foo<0>[1]"(i64  %"r1#0")    {
+entry:
+  %31 = inttoptr i64 %"r1#0" to i64* 
+  %32 = getelementptr  i64, i64* %31, i64 0 
+  %33 = load  i64, i64* %32 
+  %34 = inttoptr i64 %33 to i64* 
+  %35 = getelementptr  i64, i64* %34, i64 0 
+  store  i64 1111, i64* %35 
+  %36 = inttoptr i64 %33 to i64* 
+  %37 = getelementptr  i64, i64* %36, i64 0 
+  %38 = load  i64, i64* %37 
+  tail call ccc  void  @print_int(i64  %38)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }


### PR DESCRIPTION
This PR is a part of #31.

This PR introduces a better way of handling parameters in alias analysis, so we can have a preciser analysis and more optimize opportunities.

In this approach, we consider a parameter as two things, a normal variable and a thing that the variable is (or maybe) alias to outside the procedure scpoe. More detail can be found at around line 37 in `AST.hs`.