### PR TITLE
 Maintain two maps while numbering variables, one for variable assign…

### DIFF
--- a/test-cases/final-dump/backwards_assign.exp
+++ b/test-cases/final-dump/backwards_assign.exp
@@ -1,0 +1,113 @@
+======================================================================
+AFTER EVERYTHING:
+ Module backwards_assign
+  public submods  : 
+  public types    : 
+  public resources: 
+  public procs    : backwards_assign.<0>
+  imports         : use wybe
+  types           : 
+  resources       : 
+  procs           : 
+
+*main* > public inline (0 calls)
+0: (argc#0:wybe.int, ?argc#1:wybe.int, argv#0:wybe.int, ?argv#1:wybe.int, exit_code#0:wybe.int, ?exit_code#1:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+ AliasPairs: []
+ AliasMultiSpeczInfo: []
+    backwards_assign.gen$1<0>(~argc#0:wybe.int, ~argv#0:wybe.int, ~exit_code#0:wybe.int, 0:wybe.int, ~io#0:wybe.phantom, ?argc#1:wybe.int, ?argv#1:wybe.int, ?exit_code#1:wybe.int, ?io#1:wybe.phantom) @backwards_assign:6:1
+
+
+backwards_assign > inline (3 calls)
+0: backwards_assign(?output#0:wybe.int, input#0:wybe.int):
+ AliasPairs: []
+ AliasMultiSpeczInfo: []
+    foreign llvm add(~input#0:wybe.int, 1:wybe.int, ?output#0:wybe.int) @wybe:nn:nn
+
+
+gen$1 > (2 calls)
+0: gen$1(argc#0:wybe.int, argv#0:wybe.int, exit_code#0:wybe.int, i#0:wybe.int, io#0:wybe.phantom, ?argc#1:wybe.int, ?argv#1:wybe.int, ?exit_code#1:wybe.int, ?io#2:wybe.phantom):
+ AliasPairs: []
+ AliasMultiSpeczInfo: []
+    foreign c print_int(i#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$4#0:wybe.phantom) @wybe:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$4#0:wybe.phantom, ?#io#1:wybe.phantom) @wybe:nn:nn
+    foreign llvm add(~i#0:wybe.int, 1:wybe.int, ?i#1:wybe.int) @wybe:nn:nn
+    foreign llvm icmp slt(i#1:wybe.int, 10:wybe.int, ?tmp$1#0:wybe.bool) @wybe:nn:nn
+    case ~tmp$1#0:wybe.bool of
+    0:
+        foreign llvm move(~argc#0:wybe.int, ?argc#1:wybe.int)
+        foreign llvm move(~argv#0:wybe.int, ?argv#1:wybe.int)
+        foreign llvm move(~exit_code#0:wybe.int, ?exit_code#1:wybe.int)
+        foreign llvm move(~io#1:wybe.phantom, ?io#2:wybe.phantom)
+
+    1:
+        backwards_assign.gen$1<0>(~argc#0:wybe.int, ~argv#0:wybe.int, ~exit_code#0:wybe.int, ~i#1:wybe.int, ~io#1:wybe.phantom, ?argc#1:wybe.int, ?argv#1:wybe.int, ?exit_code#1:wybe.int, ?io#2:wybe.phantom) @backwards_assign:6:1
+
+
+
+gen$2 > inline (1 calls)
+0: gen$2(argc#0:wybe.int, argv#0:wybe.int, exit_code#0:wybe.int, [i#0:wybe.int], io#0:wybe.phantom, [?argc#0:wybe.int], [?argv#0:wybe.int], [?exit_code#0:wybe.int], [?io#0:wybe.phantom]):
+ AliasPairs: []
+ AliasMultiSpeczInfo: []
+
+  LLVM code       :
+
+; ModuleID = 'backwards_assign'
+
+
+ 
+
+
+declare external ccc  void @putchar(i8)    
+
+
+declare external ccc  void @print_int(i64)    
+
+
+declare external ccc  i8* @wybe_malloc(i32)    
+
+
+declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
+
+
+define external fastcc  {i64, i64, i64} @"backwards_assign.<0>"(i64  %"argc#0", i64  %"argv#0", i64  %"exit_code#0")    {
+entry:
+  %1 = tail call fastcc  {i64, i64, i64}  @"backwards_assign.gen$1<0>"(i64  %"argc#0", i64  %"argv#0", i64  %"exit_code#0", i64  0)  
+  %2 = extractvalue {i64, i64, i64} %1, 0 
+  %3 = extractvalue {i64, i64, i64} %1, 1 
+  %4 = extractvalue {i64, i64, i64} %1, 2 
+  %5 = insertvalue {i64, i64, i64} undef, i64 %2, 0 
+  %6 = insertvalue {i64, i64, i64} %5, i64 %3, 1 
+  %7 = insertvalue {i64, i64, i64} %6, i64 %4, 2 
+  ret {i64, i64, i64} %7 
+}
+
+
+define external fastcc  i64 @"backwards_assign.backwards_assign<0>"(i64  %"input#0")    {
+entry:
+  %"output#0" = add   i64 %"input#0", 1 
+  ret i64 %"output#0" 
+}
+
+
+define external fastcc  {i64, i64, i64} @"backwards_assign.gen$1<0>"(i64  %"argc#0", i64  %"argv#0", i64  %"exit_code#0", i64  %"i#0")    {
+entry:
+  tail call ccc  void  @print_int(i64  %"i#0")  
+  tail call ccc  void  @putchar(i8  10)  
+  %"i#1" = add   i64 %"i#0", 1 
+  %"tmp$1#0" = icmp slt i64 %"i#1", 10 
+  br i1 %"tmp$1#0", label %if.then, label %if.else 
+if.then:
+  %8 = tail call fastcc  {i64, i64, i64}  @"backwards_assign.gen$1<0>"(i64  %"argc#0", i64  %"argv#0", i64  %"exit_code#0", i64  %"i#1")  
+  %9 = extractvalue {i64, i64, i64} %8, 0 
+  %10 = extractvalue {i64, i64, i64} %8, 1 
+  %11 = extractvalue {i64, i64, i64} %8, 2 
+  %12 = insertvalue {i64, i64, i64} undef, i64 %9, 0 
+  %13 = insertvalue {i64, i64, i64} %12, i64 %10, 1 
+  %14 = insertvalue {i64, i64, i64} %13, i64 %11, 2 
+  ret {i64, i64, i64} %14 
+if.else:
+  %15 = insertvalue {i64, i64, i64} undef, i64 %"argc#0", 0 
+  %16 = insertvalue {i64, i64, i64} %15, i64 %"argv#0", 1 
+  %17 = insertvalue {i64, i64, i64} %16, i64 %"exit_code#0", 2 
+  ret {i64, i64, i64} %17 
+}

--- a/test-cases/final-dump/backwards_assign.wybe
+++ b/test-cases/final-dump/backwards_assign.wybe
@@ -1,0 +1,10 @@
+def backwards_assign(?output, input) {
+    ?output = input + 1
+}
+
+?i = 0
+do {
+    !println(i)
+    backwards_assign(?i, i)
+    while i < 10
+}


### PR DESCRIPTION
…ments and one for uses.  At the end of each statement, the current variable one becomes the assignments one.  This ensures that variable uses get the right number even when they appear after an assignment in the statement.