### PR TITLE
Bug fix and small enhancement in multiple specialization

### DIFF
--- a/src/AST.hs
+++ b/src/AST.hs
@@ -91,6 +91,7 @@ import           Data.Map as Map
 import           Data.Maybe
 import           Data.Set as Set
 import           Data.Word (Word8)
+import           Flow             ((|>))
 import           Numeric          (showHex)
 import           Options
 import           System.Exit
@@ -1671,9 +1672,18 @@ isCompiled (ProcDefSrc _) = False
 
 instance Show ProcImpln where
     show (ProcDefSrc stmts) = showBody 4 stmts
-    -- TODO: show [SpeczProcBodies]
-    show (ProcDefPrim proto body analysis _)
-        = show proto ++ ":" ++ show analysis ++ showBlock 4 body
+    show (ProcDefPrim proto body analysis speczVersions) =
+        let speczBodies = Map.toList speczVersions
+                |> List.map (\(ver, body) ->
+                        "\n  [" ++ speczIdToString ver ++ "]:" ++
+                        case body of
+                            Nothing -> " Missing"
+                            Just body -> showBlock 4 body)
+                |> intercalate "\n"
+        in
+            show proto ++ ":" ++ show analysis ++ showBlock 4 body 
+                    ++ speczBodies
+
 
 instance Show ProcAnalysis where
     show (ProcAnalysis procArgAliasMap procArgAliasMultiSpeczInfo) =

--- a/src/Builder.hs
+++ b/src/Builder.hs
@@ -184,7 +184,8 @@ import           ObjectInterface
 
 import           Optimise                  (optimiseMod)
 import           Options                   (LogSelection (..), Options,
-                                            optForce, optForceAll, optLibDirs)
+                                            optForce, optForceAll, optLibDirs,
+                                            optNoMultiSpecz)
 import           NewParser                 (parseWybe)
 import           Resources                 (resourceCheckMod,
                                             transformProcResources,
@@ -974,12 +975,14 @@ multiSpeczTopDownPass mainMod = do
     logBuild $ " === Running top-down pass starting from: " ++ show mainMod
     dependencies <- topDownOrderedDependencySCCs mainMod
     mapM_ (\ms -> do
-        logBuild $ " --- Running on: " ++ show ms
-        -- collecting all required spec versions
-        fixpointProcessSCC expandRequiredSpeczVersions ms
+        noMultiSpecz <- gets (optNoMultiSpecz . options)
+        unless noMultiSpecz $ do
+            logBuild $ " --- Running on: " ++ show ms
+            -- collecting all required spec versions
+            fixpointProcessSCC expandRequiredSpeczVersions ms
 
-        -- generating required specz versions
-        mapM_ (transformModuleProcs generateSpeczVersionInProc) ms
+            -- generating required specz versions
+            mapM_ (transformModuleProcs generateSpeczVersionInProc) ms
 
         -- transform lpvm code to llvm code.
         -- TODO: skip this if the module is unchanged.

--- a/src/Options.hs
+++ b/src/Options.hs
@@ -23,31 +23,33 @@ import           Version
 
 -- |Command line options for the wybe compiler.
 data Options = Options{
-    optForce         :: Bool     -- ^Compile specified files even if up to date
-    , optForceAll    :: Bool     -- ^Compile all files even if up to date
-    , optShowVersion :: Bool     -- ^Print compiler version and exit
-    , optHelpLog     :: Bool     -- ^Print log option help and exit
-    , optShowHelp    :: Bool     -- ^Print compiler help and exit
-    , optLibDirs     :: [String] -- ^Directories where library files live
-    , optLogAspects  :: Set LogSelection
+    optForce          :: Bool     -- ^Compile specified files even if up to date
+    , optForceAll     :: Bool     -- ^Compile all files even if up to date
+    , optShowVersion  :: Bool     -- ^Print compiler version and exit
+    , optHelpLog      :: Bool     -- ^Print log option help and exit
+    , optShowHelp     :: Bool     -- ^Print compiler help and exit
+    , optLibDirs      :: [String] -- ^Directories where library files live
+    , optLogAspects   :: Set LogSelection
                                  -- ^Which aspects to log
-    , optNoLLVMOpt   :: Bool     -- ^Don't run the LLVM optimisation passes
-    , optVerbose     :: Bool     -- ^Be verbose in compiler output
+    , optNoLLVMOpt    :: Bool     -- ^Don't run the LLVM optimisation passes
+    , optNoMultiSpecz :: Bool     -- ^Disable multiple specializatio
+    , optVerbose      :: Bool     -- ^Be verbose in compiler output
     } deriving Show
 
 
 -- |Defaults for all compiler options
 defaultOptions :: Options
-defaultOptions    = Options
- { optForce       = False
- , optForceAll    = False
- , optShowVersion = False
- , optHelpLog     = False
- , optShowHelp    = False
- , optLibDirs     = []
- , optLogAspects  = Set.empty
- , optNoLLVMOpt   = False
- , optVerbose     = False
+defaultOptions     = Options
+ { optForce        = False
+ , optForceAll     = False
+ , optShowVersion  = False
+ , optHelpLog      = False
+ , optShowHelp     = False
+ , optLibDirs      = []
+ , optLogAspects   = Set.empty
+ , optNoLLVMOpt    = False
+ , optNoMultiSpecz = False 
+ , optVerbose      = False
  }
 
 -- |All compiler features we may want to log
@@ -125,6 +127,9 @@ options =
  , Option ['s']     ["no-llvm-opt"]
      (NoArg (\opts -> opts { optNoLLVMOpt = True }))
      "don't run the LLVM optimisation pass manager on the emitted LLVM"
+ , Option []     ["no-multi-specz"]
+     (NoArg (\opts -> opts { optNoMultiSpecz = True }))
+     "disable multiple specialization"
  , Option ['v']     ["verbose"]
      (NoArg (\opts -> opts { optVerbose = True }))
      "dump verbose messages after compilation"

--- a/src/Transform.hs
+++ b/src/Transform.hs
@@ -13,13 +13,14 @@ module Transform (transformProc,
 import           AliasAnalysis
 import           AST
 import           Control.Monad
+import           Control.Monad.Trans.State
 import           Data.Bits     as Bits
 import           Data.List     as List
 import           Data.Map      as Map
 import           Data.Maybe    as Maybe
 import           Data.Set      as Set
 import           Flow          ((|>))
-import           Options       (LogSelection (Transform))
+import           Options       (LogSelection (Transform), optNoMultiSpecz)
 import           Util
 
 
@@ -148,7 +149,10 @@ transformPrim ((aliasMap, deadCells), prims) prim = do
     
     (primc', deadCells') <- case primc of
             PrimCall spec args -> do
-                spec' <- _updatePrimCallForSpecz spec args aliasMap
+                noMultiSpecz <- gets (optNoMultiSpecz . options)
+                spec' <- if noMultiSpecz
+                    then return spec
+                    else _updatePrimCallForSpecz spec args aliasMap
                 return (PrimCall spec' args, deadCells)
             PrimForeign "lpvm" "mutate" flags args -> do
                 let args' = _updateMutateForAlias aliasMap args

--- a/src/Transform.hs
+++ b/src/Transform.hs
@@ -199,6 +199,9 @@ _updatePrimCallForSpecz spec args aliasMap = do
                 List.elem param calleeInterestingParams
                 -- it should be an interesting variable
                 && Right [] == isArgVarInteresting aliasMap arg
+                -- if a argument is used more than once,
+                -- then it should be aliased
+                && isArgVarUsedOnceInArgs arg args
             ) (pairArgVarWithParam args calleeProto)
     let nonAliasedParams = List.map snd nonAliasedArgWithParams
     return 
@@ -206,7 +209,8 @@ _updatePrimCallForSpecz spec args aliasMap = do
         then spec
         else
             let speczId = 
-                    Just $ nonAliasedParamsToSpeczId calleeMultiSpeczInfo nonAliasedParams
+                    Just $ nonAliasedParamsToSpeczId
+                            calleeMultiSpeczInfo nonAliasedParams
             in
             spec { procSpeczVersionID = speczId })
 

--- a/test-cases/final-dump/alias_cyclic.exp
+++ b/test-cases/final-dump/alias_cyclic.exp
@@ -51,6 +51,19 @@ updateX > public (2 calls)
         foreign llvm move(~p1#0:position.position, ?p2#0:position.position) @alias_cyclic:16:24
         foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
 
+  [1]:
+    foreign lpvm access(p1#0:position.position, 0:wybe.int, ?tmp$0#0:wybe.int)
+    foreign llvm icmp sgt(tmp$0#0:wybe.int, 101:wybe.int, ?tmp$3#0:wybe.bool) @wybe:nn:nn
+    case ~tmp$3#0:wybe.bool of
+    0:
+        foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int) @wybe:nn:nn
+        foreign lpvm mutate noalias(~%p1#0:position.position, ?%p1#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:wybe.int)
+        alias_cyclic.updateY<0>[1](~p1#1:position.position, ?p2#0:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @alias_cyclic:19:16
+
+    1:
+        foreign llvm move(~p1#0:position.position, ?p2#0:position.position) @alias_cyclic:16:24
+        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+
 
 
 updateY > public (1 calls)
@@ -63,6 +76,19 @@ updateY > public (1 calls)
     0:
         foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int) @wybe:nn:nn
         foreign lpvm mutate noalias(~%p1#0:position.position, ?%p1#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:wybe.int)
+        alias_cyclic.updateX<0>[1](~p1#1:position.position, ?p2#0:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @alias_cyclic:10:19
+
+    1:
+        foreign llvm move(~p1#0:position.position, ?p2#0:position.position) @alias_cyclic:7:24
+        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+
+  [1]:
+    foreign lpvm access(p1#0:position.position, 8:wybe.int, ?tmp$0#0:wybe.int)
+    foreign llvm icmp sgt(tmp$0#0:wybe.int, 901:wybe.int, ?tmp$3#0:wybe.bool) @wybe:nn:nn
+    case ~tmp$3#0:wybe.bool of
+    0:
+        foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int) @wybe:nn:nn
+        foreign lpvm mutate noalias(~%p1#0:position.position, ?%p1#1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:wybe.int)
         alias_cyclic.updateX<0>[1](~p1#1:position.position, ?p2#0:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @alias_cyclic:10:19
 
     1:

--- a/test-cases/final-dump/alias_m.exp
+++ b/test-cases/final-dump/alias_m.exp
@@ -114,6 +114,19 @@ bar > public (0 calls)
         foreign llvm move(~p1#0:position.position, ?p3#1:position.position)
         foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
 
+  [1]:
+    foreign lpvm access(p1#0:position.position, 8:wybe.int, ?tmp$0#0:wybe.int)
+    foreign llvm icmp sgt(tmp$0#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.bool) @wybe:nn:nn
+    case ~tmp$3#0:wybe.bool of
+    0:
+        foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int) @wybe:nn:nn
+        foreign lpvm mutate noalias(~%p1#0:position.position, ?%p1#1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:wybe.int)
+        alias_mfoo.foo<0>[1](~p1#1:position.position, ?p2#0:position.position, ?p3#1:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @alias_mbar:13:13
+
+    1:
+        foreign llvm move(~p1#0:position.position, ?p3#1:position.position)
+        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+
 
   LLVM code       :
 
@@ -206,6 +219,27 @@ foo > public (0 calls)
     0:
         foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.int) @wybe:nn:nn
         foreign lpvm mutate noalias(~%p1#0:position.position, ?%p1#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3#0:wybe.int)
+        alias_mbar.bar<0>[1](~p1#1:position.position, ?p3#0:position.position, ~#io#0:wybe.phantom, ?#io#2:wybe.phantom) @alias_mfoo:15:14
+        foreign lpvm alloc(16:wybe.int, ?tmp$16#0:position.position)
+        foreign lpvm mutate(~tmp$16#0:position.position, ?tmp$17#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm mutate(~tmp$17#0:position.position, ?p2#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+
+    1:
+        foreign llvm move(~p1#0:position.position, ?p2#0:position.position) @alias_mfoo:9:13
+        foreign lpvm alloc(16:wybe.int, ?tmp$11#0:position.position)
+        foreign lpvm mutate(~tmp$11#0:position.position, ?tmp$12#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign lpvm mutate(~tmp$12#0:position.position, ?tmp$1#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign llvm move(tmp$1#0:position.position, ?p3#0:position.position) @alias_mfoo:10:13
+        foreign c print_string("p3:":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @wybe:nn:nn
+        position.printPosition<0>(~tmp$1#0:position.position, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @alias_mfoo:12:14
+
+  [1]:
+    foreign lpvm access(p1#0:position.position, 0:wybe.int, ?tmp$0#0:wybe.int)
+    foreign llvm icmp sgt(tmp$0#0:wybe.int, 1:wybe.int, ?tmp$5#0:wybe.bool) @wybe:nn:nn
+    case ~tmp$5#0:wybe.bool of
+    0:
+        foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.int) @wybe:nn:nn
+        foreign lpvm mutate noalias(~%p1#0:position.position, ?%p1#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3#0:wybe.int)
         alias_mbar.bar<0>[1](~p1#1:position.position, ?p3#0:position.position, ~#io#0:wybe.phantom, ?#io#2:wybe.phantom) @alias_mfoo:15:14
         foreign lpvm alloc(16:wybe.int, ?tmp$16#0:position.position)
         foreign lpvm mutate(~tmp$16#0:position.position, ?tmp$17#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)

--- a/test-cases/final-dump/alias_mbar.exp
+++ b/test-cases/final-dump/alias_mbar.exp
@@ -28,6 +28,19 @@ bar > public (0 calls)
         foreign llvm move(~p1#0:position.position, ?p3#1:position.position)
         foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
 
+  [1]:
+    foreign lpvm access(p1#0:position.position, 8:wybe.int, ?tmp$0#0:wybe.int)
+    foreign llvm icmp sgt(tmp$0#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.bool) @wybe:nn:nn
+    case ~tmp$3#0:wybe.bool of
+    0:
+        foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int) @wybe:nn:nn
+        foreign lpvm mutate noalias(~%p1#0:position.position, ?%p1#1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:wybe.int)
+        alias_mfoo.foo<0>[1](~p1#1:position.position, ?p2#0:position.position, ?p3#1:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @alias_mbar:13:13
+
+    1:
+        foreign llvm move(~p1#0:position.position, ?p3#1:position.position)
+        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+
 
   LLVM code       :
 
@@ -120,6 +133,27 @@ foo > public (0 calls)
     0:
         foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.int) @wybe:nn:nn
         foreign lpvm mutate noalias(~%p1#0:position.position, ?%p1#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3#0:wybe.int)
+        alias_mbar.bar<0>[1](~p1#1:position.position, ?p3#0:position.position, ~#io#0:wybe.phantom, ?#io#2:wybe.phantom) @alias_mfoo:15:14
+        foreign lpvm alloc(16:wybe.int, ?tmp$16#0:position.position)
+        foreign lpvm mutate(~tmp$16#0:position.position, ?tmp$17#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm mutate(~tmp$17#0:position.position, ?p2#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+
+    1:
+        foreign llvm move(~p1#0:position.position, ?p2#0:position.position) @alias_mfoo:9:13
+        foreign lpvm alloc(16:wybe.int, ?tmp$11#0:position.position)
+        foreign lpvm mutate(~tmp$11#0:position.position, ?tmp$12#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign lpvm mutate(~tmp$12#0:position.position, ?tmp$1#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign llvm move(tmp$1#0:position.position, ?p3#0:position.position) @alias_mfoo:10:13
+        foreign c print_string("p3:":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @wybe:nn:nn
+        position.printPosition<0>(~tmp$1#0:position.position, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @alias_mfoo:12:14
+
+  [1]:
+    foreign lpvm access(p1#0:position.position, 0:wybe.int, ?tmp$0#0:wybe.int)
+    foreign llvm icmp sgt(tmp$0#0:wybe.int, 1:wybe.int, ?tmp$5#0:wybe.bool) @wybe:nn:nn
+    case ~tmp$5#0:wybe.bool of
+    0:
+        foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.int) @wybe:nn:nn
+        foreign lpvm mutate noalias(~%p1#0:position.position, ?%p1#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3#0:wybe.int)
         alias_mbar.bar<0>[1](~p1#1:position.position, ?p3#0:position.position, ~#io#0:wybe.phantom, ?#io#2:wybe.phantom) @alias_mfoo:15:14
         foreign lpvm alloc(16:wybe.int, ?tmp$16#0:position.position)
         foreign lpvm mutate(~tmp$16#0:position.position, ?tmp$17#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)

--- a/test-cases/final-dump/alias_mfoo.exp
+++ b/test-cases/final-dump/alias_mfoo.exp
@@ -28,6 +28,19 @@ bar > public (0 calls)
         foreign llvm move(~p1#0:position.position, ?p3#1:position.position)
         foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
 
+  [1]:
+    foreign lpvm access(p1#0:position.position, 8:wybe.int, ?tmp$0#0:wybe.int)
+    foreign llvm icmp sgt(tmp$0#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.bool) @wybe:nn:nn
+    case ~tmp$3#0:wybe.bool of
+    0:
+        foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int) @wybe:nn:nn
+        foreign lpvm mutate noalias(~%p1#0:position.position, ?%p1#1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:wybe.int)
+        alias_mfoo.foo<0>[1](~p1#1:position.position, ?p2#0:position.position, ?p3#1:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @alias_mbar:13:13
+
+    1:
+        foreign llvm move(~p1#0:position.position, ?p3#1:position.position)
+        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+
 
   LLVM code       :
 
@@ -120,6 +133,27 @@ foo > public (0 calls)
     0:
         foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.int) @wybe:nn:nn
         foreign lpvm mutate noalias(~%p1#0:position.position, ?%p1#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3#0:wybe.int)
+        alias_mbar.bar<0>[1](~p1#1:position.position, ?p3#0:position.position, ~#io#0:wybe.phantom, ?#io#2:wybe.phantom) @alias_mfoo:15:14
+        foreign lpvm alloc(16:wybe.int, ?tmp$16#0:position.position)
+        foreign lpvm mutate(~tmp$16#0:position.position, ?tmp$17#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm mutate(~tmp$17#0:position.position, ?p2#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+
+    1:
+        foreign llvm move(~p1#0:position.position, ?p2#0:position.position) @alias_mfoo:9:13
+        foreign lpvm alloc(16:wybe.int, ?tmp$11#0:position.position)
+        foreign lpvm mutate(~tmp$11#0:position.position, ?tmp$12#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign lpvm mutate(~tmp$12#0:position.position, ?tmp$1#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign llvm move(tmp$1#0:position.position, ?p3#0:position.position) @alias_mfoo:10:13
+        foreign c print_string("p3:":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @wybe:nn:nn
+        position.printPosition<0>(~tmp$1#0:position.position, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @alias_mfoo:12:14
+
+  [1]:
+    foreign lpvm access(p1#0:position.position, 0:wybe.int, ?tmp$0#0:wybe.int)
+    foreign llvm icmp sgt(tmp$0#0:wybe.int, 1:wybe.int, ?tmp$5#0:wybe.bool) @wybe:nn:nn
+    case ~tmp$5#0:wybe.bool of
+    0:
+        foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.int) @wybe:nn:nn
+        foreign lpvm mutate noalias(~%p1#0:position.position, ?%p1#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3#0:wybe.int)
         alias_mbar.bar<0>[1](~p1#1:position.position, ?p3#0:position.position, ~#io#0:wybe.phantom, ?#io#2:wybe.phantom) @alias_mfoo:15:14
         foreign lpvm alloc(16:wybe.int, ?tmp$16#0:position.position)
         foreign lpvm mutate(~tmp$16#0:position.position, ?tmp$17#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)

--- a/test-cases/final-dump/alias_scc_proc.exp
+++ b/test-cases/final-dump/alias_scc_proc.exp
@@ -47,6 +47,19 @@ bar > public (1 calls)
         foreign llvm move(~p1#0:position.position, ?p3#1:position.position)
         foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
 
+  [1]:
+    foreign lpvm access(p1#0:position.position, 8:wybe.int, ?tmp$0#0:wybe.int)
+    foreign llvm icmp sgt(tmp$0#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.bool) @wybe:nn:nn
+    case ~tmp$3#0:wybe.bool of
+    0:
+        foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int) @wybe:nn:nn
+        foreign lpvm mutate noalias(~%p1#0:position.position, ?%p1#1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:wybe.int)
+        alias_scc_proc.foo<0>[1](~p1#1:position.position, ?p2#0:position.position, ?p3#1:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @alias_scc_proc:24:19
+
+    1:
+        foreign llvm move(~p1#0:position.position, ?p3#1:position.position)
+        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+
 
 
 foo > public (2 calls)
@@ -59,6 +72,27 @@ foo > public (2 calls)
     0:
         foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.int) @wybe:nn:nn
         foreign lpvm mutate noalias(~%p1#0:position.position, ?%p1#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3#0:wybe.int)
+        alias_scc_proc.bar<0>[1](~p1#1:position.position, ?p3#0:position.position, ~#io#0:wybe.phantom, ?#io#2:wybe.phantom) @alias_scc_proc:13:16
+        foreign lpvm alloc(16:wybe.int, ?tmp$16#0:position.position)
+        foreign lpvm mutate(~tmp$16#0:position.position, ?tmp$17#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm mutate(~tmp$17#0:position.position, ?p2#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+
+    1:
+        foreign llvm move(~p1#0:position.position, ?p2#0:position.position) @alias_scc_proc:7:21
+        foreign lpvm alloc(16:wybe.int, ?tmp$11#0:position.position)
+        foreign lpvm mutate(~tmp$11#0:position.position, ?tmp$12#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign lpvm mutate(~tmp$12#0:position.position, ?tmp$1#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign llvm move(tmp$1#0:position.position, ?p3#0:position.position) @alias_scc_proc:8:21
+        foreign c print_string("--- Inside foo: expect p3(3,3):":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @wybe:nn:nn
+        position.printPosition<0>(~tmp$1#0:position.position, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @alias_scc_proc:10:22
+
+  [1]:
+    foreign lpvm access(p1#0:position.position, 0:wybe.int, ?tmp$0#0:wybe.int)
+    foreign llvm icmp sgt(tmp$0#0:wybe.int, 1:wybe.int, ?tmp$5#0:wybe.bool) @wybe:nn:nn
+    case ~tmp$5#0:wybe.bool of
+    0:
+        foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.int) @wybe:nn:nn
+        foreign lpvm mutate noalias(~%p1#0:position.position, ?%p1#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3#0:wybe.int)
         alias_scc_proc.bar<0>[1](~p1#1:position.position, ?p3#0:position.position, ~#io#0:wybe.phantom, ?#io#2:wybe.phantom) @alias_scc_proc:13:16
         foreign lpvm alloc(16:wybe.int, ?tmp$16#0:position.position)
         foreign lpvm mutate(~tmp$16#0:position.position, ?tmp$17#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)

--- a/test-cases/final-dump/alias_type4.exp
+++ b/test-cases/final-dump/alias_type4.exp
@@ -53,6 +53,12 @@ foo > public (1 calls)
     foreign lpvm access(~pos1#1:alias_type4.position, 0:wybe.int, ?tmp$1#0:wybe.int)
     foreign c print_int(~tmp$1#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$8#0:wybe.phantom) @wybe:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp$8#0:wybe.phantom, ?#io#1:wybe.phantom) @wybe:nn:nn
+  [1]:
+    foreign lpvm access(~r1#0:alias_type4.posrec, 0:wybe.int, ?tmp$0#0:alias_type4.position)
+    foreign lpvm mutate noalias(~tmp$0#0:alias_type4.position, ?%pos1#1:alias_type4.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1111:wybe.int)
+    foreign lpvm access(~pos1#1:alias_type4.position, 0:wybe.int, ?tmp$1#0:wybe.int)
+    foreign c print_int(~tmp$1#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$8#0:wybe.phantom) @wybe:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$8#0:wybe.phantom, ?#io#1:wybe.phantom) @wybe:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/multi_specz.exp
+++ b/test-cases/final-dump/multi_specz.exp
@@ -97,6 +97,11 @@ foo > public (2 calls)
     multi_specz.modifyAndPrint<0>(~x2#0:multi_specz.position, 222:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @multi_specz:18:6
     multi_specz.modifyAndPrint<0>(~x3#0:multi_specz.position, 333:wybe.int, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @multi_specz:19:6
     multi_specz.modifyAndPrint<0>(~x4#0:multi_specz.position, 444:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @multi_specz:20:6
+  [3]:
+    multi_specz.modifyAndPrint<0>[1](~x1#0:multi_specz.position, 111:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @multi_specz:17:6
+    multi_specz.modifyAndPrint<0>[1](~x2#0:multi_specz.position, 222:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @multi_specz:18:6
+    multi_specz.modifyAndPrint<0>(~x3#0:multi_specz.position, 333:wybe.int, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @multi_specz:19:6
+    multi_specz.modifyAndPrint<0>(~x4#0:multi_specz.position, 444:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @multi_specz:20:6
 
 
 modifyAndPrint > public (4 calls)
@@ -104,6 +109,9 @@ modifyAndPrint > public (4 calls)
  AliasPairs: []
  AliasMultiSpeczInfo: [pos#0]
     foreign lpvm mutate noalias(~%pos#0:multi_specz.position, ?%pos#1:multi_specz.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~v#0:wybe.int)
+    multi_specz.printPosition<0>(~pos#1:multi_specz.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @multi_specz:13:6
+  [1]:
+    foreign lpvm mutate noalias(~%pos#0:multi_specz.position, ?%pos#1:multi_specz.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v#0:wybe.int)
     multi_specz.printPosition<0>(~pos#1:multi_specz.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @multi_specz:13:6
 
 

--- a/test-cases/final-dump/multi_specz_cyclic_exe.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_exe.exp
@@ -183,6 +183,33 @@ foo1 > public (0 calls)
         multi_specz_cyclic_lib.modifyAndPrint<0>(~x3#0:multi_specz_cyclic_lib.position, 333:wybe.int, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @multi_specz_cyclic_lib:23:14
         multi_specz_cyclic_lib.modifyAndPrint<0>(~x4#0:multi_specz_cyclic_lib.position, 444:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @multi_specz_cyclic_lib:24:14
 
+  [3]:
+    foreign llvm sub(~n#0:wybe.int, 1:wybe.int, ?tmp$0#0:wybe.int) @wybe:nn:nn
+    foreign llvm icmp slt(tmp$0#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool) @wybe:nn:nn
+    case ~tmp$1#0:wybe.bool of
+    0:
+        multi_specz_cyclic_lib2.foo2<0>[9](~x2#0:multi_specz_cyclic_lib.position, ~x3#0:multi_specz_cyclic_lib.position, ~x4#0:multi_specz_cyclic_lib.position, ~x1#0:multi_specz_cyclic_lib.position, ~tmp$0#0:wybe.int, ~#io#0:wybe.phantom, ?#io#4:wybe.phantom) @multi_specz_cyclic_lib:26:14
+
+    1:
+        multi_specz_cyclic_lib.modifyAndPrint<0>[1](~x1#0:multi_specz_cyclic_lib.position, 111:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @multi_specz_cyclic_lib:21:14
+        multi_specz_cyclic_lib.modifyAndPrint<0>[1](~x2#0:multi_specz_cyclic_lib.position, 222:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @multi_specz_cyclic_lib:22:14
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x3#0:multi_specz_cyclic_lib.position, 333:wybe.int, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @multi_specz_cyclic_lib:23:14
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x4#0:multi_specz_cyclic_lib.position, 444:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @multi_specz_cyclic_lib:24:14
+
+
+  [c]:
+    foreign llvm sub(~n#0:wybe.int, 1:wybe.int, ?tmp$0#0:wybe.int) @wybe:nn:nn
+    foreign llvm icmp slt(tmp$0#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool) @wybe:nn:nn
+    case ~tmp$1#0:wybe.bool of
+    0:
+        multi_specz_cyclic_lib2.foo2<0>[6](~x2#0:multi_specz_cyclic_lib.position, ~x3#0:multi_specz_cyclic_lib.position, ~x4#0:multi_specz_cyclic_lib.position, ~x1#0:multi_specz_cyclic_lib.position, ~tmp$0#0:wybe.int, ~#io#0:wybe.phantom, ?#io#4:wybe.phantom) @multi_specz_cyclic_lib:26:14
+
+    1:
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x1#0:multi_specz_cyclic_lib.position, 111:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @multi_specz_cyclic_lib:21:14
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x2#0:multi_specz_cyclic_lib.position, 222:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @multi_specz_cyclic_lib:22:14
+        multi_specz_cyclic_lib.modifyAndPrint<0>[1](~x3#0:multi_specz_cyclic_lib.position, 333:wybe.int, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @multi_specz_cyclic_lib:23:14
+        multi_specz_cyclic_lib.modifyAndPrint<0>[1](~x4#0:multi_specz_cyclic_lib.position, 444:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @multi_specz_cyclic_lib:24:14
+
 
 
 modifyAndPrint > public (4 calls)
@@ -190,6 +217,9 @@ modifyAndPrint > public (4 calls)
  AliasPairs: []
  AliasMultiSpeczInfo: [pos#0]
     foreign lpvm mutate noalias(~%pos#0:multi_specz_cyclic_lib.position, ?%pos#1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~v#0:wybe.int)
+    multi_specz_cyclic_lib.printPosition<0>(~pos#1:multi_specz_cyclic_lib.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @multi_specz_cyclic_lib:15:6
+  [1]:
+    foreign lpvm mutate noalias(~%pos#0:multi_specz_cyclic_lib.position, ?%pos#1:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v#0:wybe.int)
     multi_specz_cyclic_lib.printPosition<0>(~pos#1:multi_specz_cyclic_lib.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @multi_specz_cyclic_lib:15:6
 
 
@@ -623,6 +653,33 @@ foo2 > public (0 calls)
         multi_specz_cyclic_lib.modifyAndPrint<0>(~x2#0:multi_specz_cyclic_lib.position, 222:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @multi_specz_cyclic_lib2:7:14
         multi_specz_cyclic_lib.modifyAndPrint<0>(~x3#0:multi_specz_cyclic_lib.position, 333:wybe.int, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @multi_specz_cyclic_lib2:8:14
         multi_specz_cyclic_lib.modifyAndPrint<0>(~x4#0:multi_specz_cyclic_lib.position, 444:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @multi_specz_cyclic_lib2:9:14
+
+  [6]:
+    foreign llvm sub(~n#0:wybe.int, 1:wybe.int, ?tmp$0#0:wybe.int) @wybe:nn:nn
+    foreign llvm icmp slt(tmp$0#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool) @wybe:nn:nn
+    case ~tmp$1#0:wybe.bool of
+    0:
+        multi_specz_cyclic_lib.foo1<0>[3](~x2#0:multi_specz_cyclic_lib.position, ~x3#0:multi_specz_cyclic_lib.position, ~x4#0:multi_specz_cyclic_lib.position, ~x1#0:multi_specz_cyclic_lib.position, ~tmp$0#0:wybe.int, ~#io#0:wybe.phantom, ?#io#4:wybe.phantom) @multi_specz_cyclic_lib2:11:14
+
+    1:
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x1#0:multi_specz_cyclic_lib.position, 111:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @multi_specz_cyclic_lib2:6:14
+        multi_specz_cyclic_lib.modifyAndPrint<0>[1](~x2#0:multi_specz_cyclic_lib.position, 222:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @multi_specz_cyclic_lib2:7:14
+        multi_specz_cyclic_lib.modifyAndPrint<0>[1](~x3#0:multi_specz_cyclic_lib.position, 333:wybe.int, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @multi_specz_cyclic_lib2:8:14
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x4#0:multi_specz_cyclic_lib.position, 444:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @multi_specz_cyclic_lib2:9:14
+
+
+  [9]:
+    foreign llvm sub(~n#0:wybe.int, 1:wybe.int, ?tmp$0#0:wybe.int) @wybe:nn:nn
+    foreign llvm icmp slt(tmp$0#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool) @wybe:nn:nn
+    case ~tmp$1#0:wybe.bool of
+    0:
+        multi_specz_cyclic_lib.foo1<0>[c](~x2#0:multi_specz_cyclic_lib.position, ~x3#0:multi_specz_cyclic_lib.position, ~x4#0:multi_specz_cyclic_lib.position, ~x1#0:multi_specz_cyclic_lib.position, ~tmp$0#0:wybe.int, ~#io#0:wybe.phantom, ?#io#4:wybe.phantom) @multi_specz_cyclic_lib2:11:14
+
+    1:
+        multi_specz_cyclic_lib.modifyAndPrint<0>[1](~x1#0:multi_specz_cyclic_lib.position, 111:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @multi_specz_cyclic_lib2:6:14
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x2#0:multi_specz_cyclic_lib.position, 222:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @multi_specz_cyclic_lib2:7:14
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x3#0:multi_specz_cyclic_lib.position, 333:wybe.int, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @multi_specz_cyclic_lib2:8:14
+        multi_specz_cyclic_lib.modifyAndPrint<0>[1](~x4#0:multi_specz_cyclic_lib.position, 444:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @multi_specz_cyclic_lib2:9:14
 
 
   LLVM code       :

--- a/test-cases/final-dump/multi_specz_reverse.exp
+++ b/test-cases/final-dump/multi_specz_reverse.exp
@@ -112,6 +112,20 @@ list_reverse_helper > public (2 calls)
         foreign lpvm mutate(~tmp$9#0:multi_specz_reverse.intlist, ?tmp$10#0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~acc#0:multi_specz_reverse.intlist)
         multi_specz_reverse.list_reverse_helper<0>(~t#0:multi_specz_reverse.intlist, ~tmp$10#0:multi_specz_reverse.intlist, ?$#0:multi_specz_reverse.intlist) @multi_specz_reverse:14:29
 
+  [1]:
+    foreign llvm icmp ne(lst#0:multi_specz_reverse.intlist, 0:wybe.int, ?tmp$5#0:wybe.bool)
+    case ~tmp$5#0:wybe.bool of
+    0:
+        foreign llvm move(~acc#0:multi_specz_reverse.intlist, ?$#0:multi_specz_reverse.intlist) @multi_specz_reverse:13:5
+
+    1:
+        foreign lpvm access(lst#0:multi_specz_reverse.intlist, 0:wybe.int, ?h#0:wybe.int)
+        foreign lpvm access(~lst#0:multi_specz_reverse.intlist, 8:wybe.int, ?t#0:multi_specz_reverse.intlist)
+        foreign llvm move(~lst#0:multi_specz_reverse.intlist, ?tmp$8#0:multi_specz_reverse.intlist)
+        foreign lpvm mutate(~tmp$8#0:multi_specz_reverse.intlist, ?tmp$9#0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h#0:wybe.int)
+        foreign lpvm mutate(~tmp$9#0:multi_specz_reverse.intlist, ?tmp$10#0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~acc#0:multi_specz_reverse.intlist)
+        multi_specz_reverse.list_reverse_helper<0>[1](~t#0:multi_specz_reverse.intlist, ~tmp$10#0:multi_specz_reverse.intlist, ?$#0:multi_specz_reverse.intlist) @multi_specz_reverse:14:29
+
 
   LLVM code       :
 

--- a/test-cases/final-dump/type_list.exp
+++ b/test-cases/final-dump/type_list.exp
@@ -64,6 +64,20 @@ AFTER EVERYTHING:
         foreign lpvm mutate(~tmp$8#0:type_list.intlist, ?tmp$9#0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h#0:wybe.int)
         foreign lpvm mutate(~tmp$9#0:type_list.intlist, ?$#0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:type_list.intlist)
 
+  [1]:
+    foreign llvm icmp ne(x#0:type_list.intlist, 0:wybe.int, ?tmp$5#0:wybe.bool)
+    case ~tmp$5#0:wybe.bool of
+    0:
+        foreign llvm move(~y#0:type_list.intlist, ?$#0:type_list.intlist) @type_list:3:5
+
+    1:
+        foreign lpvm access(x#0:type_list.intlist, 0:wybe.int, ?h#0:wybe.int)
+        foreign lpvm access(~x#0:type_list.intlist, 8:wybe.int, ?t#0:type_list.intlist)
+        type_list.++<0>[1](~t#0:type_list.intlist, ~y#0:type_list.intlist, ?tmp$2#0:type_list.intlist) @type_list:5:13
+        foreign llvm move(~x#0:type_list.intlist, ?tmp$8#0:type_list.intlist)
+        foreign lpvm mutate(~tmp$8#0:type_list.intlist, ?tmp$9#0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h#0:wybe.int)
+        foreign lpvm mutate(~tmp$9#0:type_list.intlist, ?$#0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:type_list.intlist)
+
 
 
 length > public (2 calls)


### PR DESCRIPTION
This PR is part of #31.
It includes:

1. **A bug fix.**
If a variable is used more than once in a proc call (such as `foo(x, !x)`), then that variable (`x`) should be considered as aliased. The previous code handles this case incorrectly.
2. **Add a new flag `--no-multi-specz` for disabling multiple specialization.**
3. **Prints out lpvm code of multiple specialization versions in FinalDump.**