### PR TITLE
Fixed if statement example in WYBE.md

### DIFF
--- a/WYBE.md
+++ b/WYBE.md
@@ -412,10 +412,11 @@ test to provide code to execute if none of the preceding tests succeeds.
 For example:
 ```
 if {x < 0     :: !println("negative")
-    x = 0     :: !println("zero")
-    otherwise :: !println("positive")
+    | x = 0     :: !println("zero")
+    | otherwise :: !println("positive")
 }
 ```
+
 
 
 ## Iteration statements


### PR DESCRIPTION
Fixed missing `|` between test statements in `WYBE.md`