### PR TITLE
Supporting link-time dead code elimination on Linux

### DIFF
--- a/src/Codegen.hs
+++ b/src/Codegen.hs
@@ -238,6 +238,7 @@ globalDefine isForeign rettype label argtypes body
                                False)
                , returnType = rettype
                , basicBlocks = body
+               , section = Just $ fromString $ ".text." ++ label
                }
 
 

--- a/src/Codegen.hs
+++ b/src/Codegen.hs
@@ -68,7 +68,7 @@ import           AST                             (Compiler, Prim, PrimProto,
 import           LLVM.Context
 import           LLVM.Module
 import           Options                         (LogSelection (Blocks,Codegen))
-import           Config                          (wordSize)
+import           Config                          (wordSize, functionDefSection)
 import           Unsafe.Coerce
 
 ----------------------------------------------------------------------------
@@ -238,7 +238,7 @@ globalDefine isForeign rettype label argtypes body
                                False)
                , returnType = rettype
                , basicBlocks = body
-               , section = Just $ fromString $ ".text." ++ label
+               , section = fmap fromString $ functionDefSection label
                }
 
 

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -10,13 +10,15 @@
 --  OSes.
 module Config (sourceExtension, objectExtension, executableExtension,
                interfaceExtension, bitcodeExtension,
-               ldArgs, wordSize, wordSizeBytes,
+               wordSize, wordSizeBytes,
                availableTagBits, tagMask, smallestAllocatedAddress,
-               assemblyExtension, archiveExtension, magicVersion)
+               assemblyExtension, archiveExtension, magicVersion,
+               linkerDeadStripArgs, functionDefSection)
     where
 
 import Data.Word
 import qualified Data.List as List
+import Distribution.System (buildOS, OS (..))
 import Foreign.Storable
 
 
@@ -92,12 +94,29 @@ sharedLibDirName :: String
 sharedLibDirName = "lib/"
 
 
-ldArgs :: [String]
-ldArgs = ["-demangle", "-dynamic"]
-
-
 -- | Magic version number for the current iteration of LPVM.
 magicVersion :: [Word8]
 magicVersion =
     let magicStr = "WB01"
     in List.map (fromIntegral . fromEnum) magicStr
+
+
+-- | Arguments of dead code elimination for linker
+-- Look for "Link time dead code elimination" in "Emit.hs" for more detail
+linkerDeadStripArgs :: [String]
+linkerDeadStripArgs =
+    case buildOS of 
+        OSX   -> ["-dead_strip"]
+        Linux -> ["-Wl,--gc-sections"]
+        _     -> error "Unsupported operation system"
+
+
+-- | Given the name of a function and return which section to store it,
+-- Nothing means the default section. For now, we put functions in separate
+-- sections on Linux to fit the "-Wl,--gc-sections" above.
+functionDefSection :: String -> Maybe String
+functionDefSection label =
+    case buildOS of 
+        OSX   -> Nothing
+        Linux -> Just $ ".text." ++ label
+        _     -> error "Unsupported operation system"

--- a/src/Emit.hs
+++ b/src/Emit.hs
@@ -237,22 +237,6 @@ suppressLdWarnings s = intercalate "\n" $ List.filter notWarning $ lines s
     notWarning l = not ("ld: warning:" `List.isPrefixOf` l)
 
 
--- | Remove the lpvm section from the given file. It's only effective on Linux,
--- since we don't need it on macOS.
-removeLPVMSection :: FilePath -> IO (Either String ())
-removeLPVMSection target =
-    case buildOS of 
-        OSX   -> return $ Right ()
-        Linux -> do
-            let args = ["--remove-section", "__LPVM.__lpvm", target]
-            (exCode, _, serr) <-
-                    readCreateProcessWithExitCode (proc "objcopy" args) ""
-            case exCode of
-                ExitSuccess  -> return $ Right ()
-                _ -> return $ Left serr
-        _     -> shouldnt "Unsupported operation system"
-
-
 -- | With the `ld` linker, link the object files and create target
 -- executable.
 makeExec :: [FilePath]          -- Object Files


### PR DESCRIPTION
Related issue: #60 

Note that I didn't put all platform-specific things in `Config.hs`, because I don't think they fit the context of config. You can find all of them (including previous ones) by searching usages of `buildOS`.