### PR TITLE
Expanding ProcDefPrim to include ProcSpec

### DIFF
--- a/src/AST.hs
+++ b/src/AST.hs
@@ -1829,8 +1829,8 @@ data ProcImpln
     | ProcDefPrim {
         procImplnProcSpec :: ProcSpec, 
         procImplnProto :: PrimProto, 
-        procImplnBody :: ProcBody,       -- ^defn in LPVM (clausal) form
-        procImplnAnalysis :: ProcAnalysis, 
+        procImplnBody :: ProcBody,       
+        procImplnAnalysis :: ProcAnalysis, -- ^defn in LPVM (clausal) form
         procImplnSpeczBodies :: SpeczProcBodies
     }
     -- defn in SSA (LLVM) form along with any needed extern definitions

--- a/src/AST.hs
+++ b/src/AST.hs
@@ -1116,8 +1116,14 @@ getProcPrimProto :: ProcSpec -> Compiler PrimProto
 getProcPrimProto pspec = do
     def <- getProcDef pspec
     case procImpln def of
-        ProcDefPrim{ procImplnProcSpec = pspec2, procImplnProto = proto}
+        impln@ProcDefPrim{ procImplnProcSpec = pspec2, procImplnProto = proto}
             | pspec == pspec2 -> return proto
+            | and [ procSpecMod pspec == procSpecMod pspec2, 
+                    procSpecName pspec == procSpecName pspec2, 
+                    procSpecID pspec == procSpecID pspec2 ] -> do
+                let impln' = impln{procImplnProcSpec = pspec}
+                updateProcDef (\_ -> def{procImpln = impln'}) pspec
+                return proto
             | otherwise -> 
                 shouldnt $ "get compiled proc but procSpec not mathcing: " ++ 
                            show pspec ++ ", " ++ show pspec2

--- a/src/Builder.hs
+++ b/src/Builder.hs
@@ -859,7 +859,9 @@ updateInterfaceHash mspec = do
             if mod == mspec
             then
                 let p = (modProcs impl ! procName) !! procID in
-                let ProcDefPrim proto body analysis _ = procImpln p in
+                let proto = procImplnProto $ procImpln p in
+                let body = procImplnBody $ procImpln p in
+                let analysis = procImplnAnalysis $ procImpln p in
                 if procInline p
                 then InlineProc proto body
                 else NormalProc proto analysis
@@ -926,7 +928,7 @@ fixpointProcessSCC processor scc = do        -- must find fixpoint
 
 
 
-transformModuleProcs :: (ProcDef -> Compiler ProcDef) -> ModSpec ->
+transformModuleProcs :: (ProcDef -> Int -> Compiler ProcDef) -> ModSpec ->
                         Compiler ()
 transformModuleProcs trans thisMod = do
     logBuild $ "**** Reentering module " ++ showModSpec thisMod
@@ -935,7 +937,7 @@ transformModuleProcs trans thisMod = do
     (names,procs) <- unzip <$>
                      getModuleImplementationField (Map.toList . modProcs)
     -- for each name we have a list of procdefs, so we must double map
-    procs' <- mapM (mapM trans) procs
+    procs' <- mapM (zipWithM (flip trans) [0..]) procs
     updateImplementation
         (\imp -> imp { modProcs = Map.union
                                   (Map.fromList $ zip names procs')

--- a/src/Callers.hs
+++ b/src/Callers.hs
@@ -42,7 +42,7 @@ noteImplnCallers :: ModSpec -> ProcSpec -> ProcImpln ->
                     Map Ident [ProcDef] -> Map Ident [ProcDef]
 noteImplnCallers _ _ (ProcDefSrc _) _ =
   shouldnt "scanning unprocessed code for calls"
-noteImplnCallers mod caller (ProcDefPrim _ body _ _) procs =
+noteImplnCallers mod caller ProcDefPrim{procImplnBody = body} procs =
   let callers = foldBodyDistrib (noteCall mod caller)
                 Map.empty mergeCallers mergeCallers
                 body
@@ -109,7 +109,7 @@ procBody :: ProcDef -> ProcBody
 procBody def =
   case procImpln def of
       ProcDefSrc _         -> shouldnt "Analysing un-compiled code"
-      ProcDefPrim _ body _ _-> body
+      ProcDefPrim{procImplnBody = body} -> body
 
 
 -- |Finding all procs called by a given proc body

--- a/src/Clause.hs
+++ b/src/Clause.hs
@@ -135,7 +135,7 @@ evalClauseComp clcomp =
 -- |Compile a ProcDefSrc to a ProcDefPrim, ie, compile a proc
 --  definition in source form to one in clausal form.
 compileProc :: ProcDef -> Int -> Compiler ProcDef
-compileProc proc procID = -- XXX use the id to generate procSpec
+compileProc proc procID = 
     evalClauseComp $ do
         let ProcDefSrc body = procImpln proc
         let proto = procProto proc

--- a/src/Clause.hs
+++ b/src/Clause.hs
@@ -134,8 +134,8 @@ evalClauseComp clcomp =
 
 -- |Compile a ProcDefSrc to a ProcDefPrim, ie, compile a proc
 --  definition in source form to one in clausal form.
-compileProc :: ProcDef -> Compiler ProcDef
-compileProc proc =
+compileProc :: ProcDef -> Int -> Compiler ProcDef
+compileProc proc procID = -- XXX use the id to generate procSpec
     evalClauseComp $ do
         let ProcDefSrc body = procImpln proc
         let proto = procProto proc
@@ -156,7 +156,9 @@ compileProc proc =
         let proto' = PrimProto (procProtoName proto) params'
         logClause $ "  comparams: " ++ show params'
         callSiteCount <- gets nextCallSiteID
-        return $ proc { procImpln = ProcDefPrim proto' compiled
+        mSpec <- lift $ getModule modSpec
+        let pSpec = ProcSpec mSpec procName procID Set.empty
+        return $ proc { procImpln = ProcDefPrim pSpec proto' compiled
                                         emptyProcAnalysis Map.empty,
                         procCallSiteCount = callSiteCount}
 

--- a/src/Expansion.hs
+++ b/src/Expansion.hs
@@ -30,8 +30,9 @@ procExpansion :: ProcSpec -> ProcDef -> Compiler ProcDef
 procExpansion pspec def = do
     logMsg Expansion $ replicate 50 '='
     logMsg Expansion $ "*** Try to expand proc " ++ show pspec
-    let ProcDefPrim { procImplnProto = proto, procImplnBody = body } = 
-         procImpln def
+    let impln = procImpln def
+    let proto = procImplnProto impln
+    let body = procImplnBody impln
     logMsg Expansion $ "    initial body: " ++ show (procImpln def)
     let tmp = procTmpCount def
     let (ins,outs) = inputOutputParams proto
@@ -40,9 +41,9 @@ procExpansion pspec def = do
                         execStateT (expandBody body) st
     let proto' = proto {primProtoParams = markParamNeededness used ins
                                           <$> primProtoParams proto}
-    let procImpln' = 
-         (procImpln def){ procImplnProto = proto, procImplnBody = body }
-    let def' = def { procImpln = procImpln', 
+    let impln' = 
+         (procImpln def){ procImplnProto = proto', procImplnBody = body' }
+    let def' = def { procImpln = impln', 
                      procTmpCount = tmp',
                      procCallSiteCount = nextCallSiteID st' }
     if def /= def'

--- a/src/Expansion.hs
+++ b/src/Expansion.hs
@@ -41,8 +41,7 @@ procExpansion pspec def = do
                         execStateT (expandBody body) st
     let proto' = proto {primProtoParams = markParamNeededness used ins
                                           <$> primProtoParams proto}
-    let impln' = 
-         (procImpln def){ procImplnProto = proto', procImplnBody = body' }
+    let impln' = impln{ procImplnProto = proto', procImplnBody = body' }
     let def' = def { procImpln = impln', 
                      procTmpCount = tmp',
                      procCallSiteCount = nextCallSiteID st' }

--- a/src/Optimise.hs
+++ b/src/Optimise.hs
@@ -113,7 +113,8 @@ decideInlining def
        || procCallCount def <= 1 && procVis def == Private
     then return $ def { procInlining = Inline }
     else return def
-    where ProcDefPrim proto body _ _ = procImpln def
+    where proto = procImplnProto $ procImpln def
+          body = procImplnBody $ procImpln def
 decideInlining def = return def
 
 

--- a/src/Resources.hs
+++ b/src/Resources.hs
@@ -68,8 +68,8 @@ checkOneResource rspec impln@(SimpleResource ty init pos) = do
 
 -- |Make sure all resource for the specified proc are module qualified,
 --  making them canonical.
-canonicaliseProcResources :: ProcDef -> Compiler ProcDef
-canonicaliseProcResources pd = do
+canonicaliseProcResources :: ProcDef -> Int -> Compiler ProcDef
+canonicaliseProcResources pd _ = do
     logResources $ "Canonicalising resources used by proc " ++ procName pd
     let proto = procProto pd
     let pos = procPos pd
@@ -100,8 +100,8 @@ canonicaliseResourceFlow pos spec = do
 --  just blindly transforms resources into variables and parameters,
 --  counting on the later variable use/def analysis to ensure that
 --  resources are defined before they're used or returned.
-transformProcResources :: ProcDef -> Compiler ProcDef
-transformProcResources pd = do
+transformProcResources :: ProcDef -> Int -> Compiler ProcDef
+transformProcResources pd _ = do
     logResources $ "--------------------------------------\n"
     logResources $ "Adding resources to:" ++ showProcDef 4 pd
     let proto = procProto pd

--- a/src/Transform.hs
+++ b/src/Transform.hs
@@ -34,14 +34,14 @@ import           Util
 -- This is the extra pass after found the alais analysis fixed point
 --
 ----------------------------------------------------------------
-transformProc :: ProcDef -> Compiler ProcDef
-transformProc def
+transformProc :: ProcDef -> Int -> Compiler ProcDef
+transformProc def _
     | not (procInline def) = do
-        let (ProcDefPrim proto body analysis speczBodies) = procImpln def
+        let ProcDefPrim{procImplnBody = body} = procImpln def
         body' <- transformProcBody def generalVersion
-        return def {procImpln = ProcDefPrim proto body' analysis speczBodies}
+        return def {procImpln = (procImpln def){procImplnBody = body'}}
 
-transformProc def = return def
+transformProc def _ = return def
 
 
 -- init aliasMap based on the given "nonAliasedParams",
@@ -71,7 +71,9 @@ transformProcBody :: ProcDef -> SpeczVersion -> Compiler ProcBody
 transformProcBody procDef speczVersion = do
     when (procInline procDef) $ shouldnt "transforming an inline proc"
 
-    let (ProcDefPrim proto body analysis speczBodies) = procImpln procDef
+    let proto = procImplnProto $ procImpln procDef
+    let body = procImplnBody $ procImpln procDef
+    let analysis = procImplnAnalysis $ procImpln procDef
     logTransform $ replicate 60 '~'
     logTransform $ show proto
     logTransform $ "[" ++ show (speczVersionToId speczVersion) ++ "] :"
@@ -282,7 +284,8 @@ expandRequiredSpeczVersionsByProc :: Set ProcSpec -> ProcSpec
         -> Compiler (Set ProcSpec)
 expandRequiredSpeczVersionsByProc required pspec = do
     procDef <- getProcDef pspec
-    let ProcDefPrim _ _ analysis speczBodies = procImpln procDef
+    let analysis = procImplnAnalysis $ procImpln procDef
+    let speczBodies = procImplnSpeczBodies $ procImpln procDef
     -- get it's currently existed/required versions
     let speczVersions = Set.filter (sameBaseProc pspec) required
                         |> Set.map procSpeczVersion
@@ -359,13 +362,15 @@ updateRequiredMultiSpeczInMod mod versions = do
                         Nothing -> proc
                         Just versions ->
                             let procImp = procImpln proc in
-                            let ProcDefPrim pp pb pa speczBodies = procImp in
+                            let speczBodies = procImplnSpeczBodies procImp in
                             let speczBodies' = List.foldl (\bodies version ->
                                     Map.insertWith (\_ old -> old) 
                                             version Nothing bodies
-                                    ) speczBodies versions
+                                    ) speczBodies versions in
+                            let newProcImpln = 
+                                    procImp{procImplnSpeczBodies=speczBodies'}
                             in
-                            proc {procImpln = ProcDefPrim pp pb pa speczBodies'}
+                            proc {procImpln=newProcImpln}
                             ) procs [0..]
                 ) procName procMap
             ) procMap (groupByFst versions)
@@ -379,11 +384,11 @@ updateRequiredMultiSpeczInMod mod versions = do
 
 -- For the given "ProcDef", generates all specz versions that are required but
 -- haven't got generated.
-generateSpeczVersionInProc :: ProcDef -> Compiler ProcDef
-generateSpeczVersionInProc def
+generateSpeczVersionInProc :: ProcDef -> Int -> Compiler ProcDef
+generateSpeczVersionInProc def _
     | not (procInline def) = do
         let procImp = procImpln def
-        let ProcDefPrim proto body analysis speczBodies = procImp
+        let speczBodies = procImplnSpeczBodies procImp
         if List.any isNothing (Map.elems speczBodies)
         then do -- missing required specz versions
             -- mark the current module as changed
@@ -402,11 +407,11 @@ generateSpeczVersionInProc def
                         ) (Map.toAscList speczBodies)
             let speczBodies' = Map.fromDistinctAscList speczBodiesList
             return $
-                def {procImpln = ProcDefPrim proto body analysis speczBodies'}
+                def {procImpln = procImp{procImplnSpeczBodies=speczBodies'}}
         else
             return def
 
-generateSpeczVersionInProc def = return def
+generateSpeczVersionInProc def _ = return def
 
 
 -- Similar to "List.groupBy"

--- a/src/Transform.hs
+++ b/src/Transform.hs
@@ -37,9 +37,10 @@ import           Util
 transformProc :: ProcDef -> Int -> Compiler ProcDef
 transformProc def _
     | not (procInline def) = do
-        let ProcDefPrim{procImplnBody = body} = procImpln def
+        let impln = procImpln def
+        let body = procImplnBody impln
         body' <- transformProcBody def generalVersion
-        return def {procImpln = (procImpln def){procImplnBody = body'}}
+        return def {procImpln = impln{procImplnBody = body'}}
 
 transformProc def _ = return def
 

--- a/src/Unbranch.hs
+++ b/src/Unbranch.hs
@@ -93,8 +93,8 @@ import Options (LogSelection(Unbranch))
 --  to a SemiDet proc, or a fork each of whose branches satisfies this
 --  constraint.
 
-unbranchProc :: ProcDef -> Compiler ProcDef
-unbranchProc = unbranchProc' Nothing
+unbranchProc :: ProcDef -> Int -> Compiler ProcDef
+unbranchProc proc _ = unbranchProc' Nothing proc
 
 
 unbranchProc' :: Maybe LoopInfo -> ProcDef -> Compiler ProcDef

--- a/test-cases/complex/exp/testcase_multi_specz-drone.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-drone.exp
@@ -37,7 +37,8 @@ AFTER BUILDING MAIN:
   procs           : 
 
 *main* > {inline} (0 calls)
-0: (argc#0:wybe.int, argv#0:wybe.array.raw_array(wybe.string), ?exit_code#0:wybe.int, ?io#2:wybe.phantom):
+0: .<0>
+(argc#0:wybe.int, argv#0:wybe.array.raw_array(wybe.string), ?exit_code#0:wybe.int, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c {semipure} gc_init() @memory_management:12:1
@@ -67,7 +68,8 @@ LLVM code       : None
   procs           : 
 
 *main* > public (0 calls)
-0: (argc#0:wybe.int, [?argc#0:wybe.int], ?arguments#2:wybe.array(wybe.string), argv#0:wybe.array.raw_array(wybe.string), [?argv#0:wybe.array.raw_array(wybe.string)], ?command#2:wybe.string, ?exit_code#1:wybe.int, io#0:wybe.phantom, [?io#0:wybe.phantom]):
+0: command_line.<0>
+(argc#0:wybe.int, [?argc#0:wybe.int], ?arguments#2:wybe.array(wybe.string), argv#0:wybe.array.raw_array(wybe.string), [?argv#0:wybe.array.raw_array(wybe.string)], ?command#2:wybe.string, ?exit_code#1:wybe.int, io#0:wybe.phantom, [?io#0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$9#0:wybe.array(?T))
@@ -85,7 +87,8 @@ LLVM code       : None
 
 
 set_exit_code > public {inline} (0 calls)
-0: set_exit_code(code#0:wybe.int, [exit_code#0:wybe.int], ?exit_code#1:wybe.int):
+0: command_line.set_exit_code<0>
+set_exit_code(code#0:wybe.int, [exit_code#0:wybe.int], ?exit_code#1:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(~code#0:wybe.int, ?exit_code#1:wybe.int) @command_line:27:5
@@ -163,7 +166,8 @@ entry:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#3:wybe.phantom):
+0: drone.<0>
+(io#0:wybe.phantom, ?io#3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(4,(drone.loop<0>,fromList [NonAliasedParamCond 0 []]))]
@@ -188,7 +192,8 @@ entry:
 
 
 do_action > (2 calls)
-0: do_action(d#0:drone.drone_info, ?d#2:drone.drone_info, action#0:wybe.char, ?success#2:wybe.bool):
+0: drone.do_action<0>
+do_action(d#0:drone.drone_info, ?d#2:drone.drone_info, action#0:wybe.char, ?success#2:wybe.bool):
  AliasPairs: [(d#0,d#2)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(5,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(10,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(15,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(20,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(25,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(30,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(33,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 [0]]))]
@@ -263,7 +268,8 @@ do_action > (2 calls)
 
 
 drone_init > (3 calls)
-0: drone_init(?$#0:drone.drone_info):
+0: drone.drone_init<0>
+drone_init(?$#0:drone.drone_info):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(32:wybe.int, ?tmp$5#0:drone.drone_info)
@@ -274,7 +280,8 @@ drone_init > (3 calls)
 
 
 gen$1 > {inline} (2 calls)
-0: gen$1([ch#0:wybe.char], [d#0:drone.drone_info], io#0:wybe.phantom, [tmp$0#0:drone.drone_info], ?io#2:wybe.phantom):
+0: drone.gen$1<0>
+gen$1([ch#0:wybe.char], [d#0:drone.drone_info], io#0:wybe.phantom, [tmp$0#0:drone.drone_info], ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c {impure} malloc_count(?mc#0:wybe.int) @memory_management:9:5
@@ -284,7 +291,8 @@ gen$1 > {inline} (2 calls)
 
 
 gen$2 > (7 calls)
-0: gen$2([action#0:wybe.char], d#0:drone.drone_info, success#0:wybe.bool, [tmp$0#0:wybe.bool], ?d#1:drone.drone_info, [?success#0:wybe.bool]):
+0: drone.gen$2<0>
+gen$2([action#0:wybe.char], d#0:drone.drone_info, success#0:wybe.bool, [tmp$0#0:wybe.bool], ?d#1:drone.drone_info, [?success#0:wybe.bool]):
  AliasPairs: [(d#0,d#1)]
  InterestingCallProperties: [InterestingUnaliased 1]
     case success#0:wybe.bool of
@@ -299,7 +307,8 @@ gen$2 > (7 calls)
 
 
 gen$3 > (5 calls)
-0: gen$3([ch#0:wybe.char], d#0:drone.drone_info, io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: drone.gen$3<0>
+gen$3([ch#0:wybe.char], d#0:drone.drone_info, io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 1]
  MultiSpeczDepInfo: [(3,(drone.loop<0>,fromList [NonAliasedParamCond 0 [1]]))]
@@ -316,7 +325,8 @@ gen$3 > (5 calls)
 
 
 loop > (2 calls)
-0: loop(d#0:drone.drone_info, ch#0:wybe.char, io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: drone.loop<0>
+loop(d#0:drone.drone_info, ch#0:wybe.char, io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(4,(drone.gen$3<0>,fromList [NonAliasedParamCond 1 [0]])),(6,(drone.do_action<0>,fromList [NonAliasedParamCond 0 [0]])),(10,(drone.gen$3<0>,fromList [NonAliasedParamCond 1 [0]])),(11,(drone.gen$3<0>,fromList [NonAliasedParamCond 1 [0]])),(12,(drone.gen$3<0>,fromList [NonAliasedParamCond 1 [0]])),(13,(drone.gen$3<0>,fromList [NonAliasedParamCond 1 [0]]))]
@@ -368,7 +378,8 @@ loop > (2 calls)
 
 
 print_info > {inline} (1 calls)
-0: print_info(d#0:drone.drone_info, io#0:wybe.phantom, ?io#9:wybe.phantom):
+0: drone.print_info<0>
+print_info(d#0:drone.drone_info, io#0:wybe.phantom, ?io#9:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("(":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:30:35
@@ -410,7 +421,8 @@ LLVM code       : None
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:drone.drone_info, $right#0:drone.drone_info, ?$$#0:wybe.bool):
+0: drone.drone_info./=<0>
+/=($left#0:drone.drone_info, $right#0:drone.drone_info, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -450,7 +462,8 @@ LLVM code       : None
 
 
 = > public {inline} (1 calls)
-0: =($left#0:drone.drone_info, $right#0:drone.drone_info, ?$$#0:wybe.bool):
+0: drone.drone_info.=<0>
+=($left#0:drone.drone_info, $right#0:drone.drone_info, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
@@ -486,19 +499,22 @@ LLVM code       : None
 
 
 count > public {inline} (0 calls)
-0: count($rec#0:drone.drone_info, ?$#0:wybe.int):
+0: drone.drone_info.count<0>
+count($rec#0:drone.drone_info, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 count > public {inline} (0 calls)
-1: count($rec#0:drone.drone_info, ?$rec#1:drone.drone_info, $field#0:wybe.int):
+1: drone.drone_info.count<1>
+count($rec#0:drone.drone_info, ?$rec#1:drone.drone_info, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:drone.drone_info, ?%$rec#1:drone.drone_info, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 drone_info > public {inline} (0 calls)
-0: drone_info(x#0:wybe.int, y#0:wybe.int, z#0:wybe.int, count#0:wybe.int, ?$#0:drone.drone_info):
+0: drone.drone_info.drone_info<0>
+drone_info(x#0:wybe.int, y#0:wybe.int, z#0:wybe.int, count#0:wybe.int, ?$#0:drone.drone_info):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(32:wybe.int, ?$rec#0:drone.drone_info)
@@ -507,7 +523,8 @@ drone_info > public {inline} (0 calls)
     foreign lpvm mutate(~%$rec#2:drone.drone_info, ?%$rec#3:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~z#0:wybe.int)
     foreign lpvm mutate(~%$rec#3:drone.drone_info, ?%$#0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~count#0:wybe.int)
 drone_info > public {inline} (14 calls)
-1: drone_info(?x#0:wybe.int, ?y#0:wybe.int, ?z#0:wybe.int, ?count#0:wybe.int, $#0:drone.drone_info):
+1: drone.drone_info.drone_info<1>
+drone_info(?x#0:wybe.int, ?y#0:wybe.int, ?z#0:wybe.int, ?count#0:wybe.int, $#0:drone.drone_info):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?x#0:wybe.int)
@@ -517,36 +534,42 @@ drone_info > public {inline} (14 calls)
 
 
 x > public {inline} (0 calls)
-0: x($rec#0:drone.drone_info, ?$#0:wybe.int):
+0: drone.drone_info.x<0>
+x($rec#0:drone.drone_info, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 x > public {inline} (0 calls)
-1: x($rec#0:drone.drone_info, ?$rec#1:drone.drone_info, $field#0:wybe.int):
+1: drone.drone_info.x<1>
+x($rec#0:drone.drone_info, ?$rec#1:drone.drone_info, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:drone.drone_info, ?%$rec#1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 y > public {inline} (0 calls)
-0: y($rec#0:drone.drone_info, ?$#0:wybe.int):
+0: drone.drone_info.y<0>
+y($rec#0:drone.drone_info, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 y > public {inline} (0 calls)
-1: y($rec#0:drone.drone_info, ?$rec#1:drone.drone_info, $field#0:wybe.int):
+1: drone.drone_info.y<1>
+y($rec#0:drone.drone_info, ?$rec#1:drone.drone_info, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:drone.drone_info, ?%$rec#1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 z > public {inline} (0 calls)
-0: z($rec#0:drone.drone_info, ?$#0:wybe.int):
+0: drone.drone_info.z<0>
+z($rec#0:drone.drone_info, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 z > public {inline} (0 calls)
-1: z($rec#0:drone.drone_info, ?$rec#1:drone.drone_info, $field#0:wybe.int):
+1: drone.drone_info.z<1>
+z($rec#0:drone.drone_info, ?$rec#1:drone.drone_info, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:drone.drone_info, ?%$rec#1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
@@ -569,7 +592,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > {inline} (0 calls)
-0: (argc#0:wybe.int, argv#0:wybe.array.raw_array(wybe.string), ?exit_code#0:wybe.int, ?io#2:wybe.phantom):
+0: .<0>
+(argc#0:wybe.int, argv#0:wybe.array.raw_array(wybe.string), ?exit_code#0:wybe.int, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c {semipure} gc_init() @memory_management:12:1
@@ -634,7 +658,8 @@ entry:
   procs           : 
 
 *main* > public (0 calls)
-0: (argc#0:wybe.int, [?argc#0:wybe.int], ?arguments#2:wybe.array(wybe.string), argv#0:wybe.array.raw_array(wybe.string), [?argv#0:wybe.array.raw_array(wybe.string)], ?command#2:wybe.string, ?exit_code#1:wybe.int, io#0:wybe.phantom, [?io#0:wybe.phantom]):
+0: command_line.<0>
+(argc#0:wybe.int, [?argc#0:wybe.int], ?arguments#2:wybe.array(wybe.string), argv#0:wybe.array.raw_array(wybe.string), [?argv#0:wybe.array.raw_array(wybe.string)], ?command#2:wybe.string, ?exit_code#1:wybe.int, io#0:wybe.phantom, [?io#0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$9#0:wybe.array(?T))
@@ -652,7 +677,8 @@ entry:
 
 
 set_exit_code > public {inline} (0 calls)
-0: set_exit_code(code#0:wybe.int, [exit_code#0:wybe.int], ?exit_code#1:wybe.int):
+0: command_line.set_exit_code<0>
+set_exit_code(code#0:wybe.int, [exit_code#0:wybe.int], ?exit_code#1:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(~code#0:wybe.int, ?exit_code#1:wybe.int) @command_line:27:5
@@ -730,7 +756,8 @@ entry:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#3:wybe.phantom):
+0: drone.<0>
+(io#0:wybe.phantom, ?io#3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(4,(drone.loop<0>,fromList [NonAliasedParamCond 0 []]))]
@@ -755,7 +782,8 @@ entry:
 
 
 do_action > (2 calls)
-0: do_action(d#0:drone.drone_info, ?d#2:drone.drone_info, action#0:wybe.char, ?success#2:wybe.bool):
+0: drone.do_action<0>[410bae77d3]
+do_action(d#0:drone.drone_info, ?d#2:drone.drone_info, action#0:wybe.char, ?success#2:wybe.bool):
  AliasPairs: [(d#0,d#2)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(5,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(10,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(15,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(20,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(25,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(30,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(33,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 [0]]))]
@@ -899,7 +927,8 @@ do_action > (2 calls)
 
 
 drone_init > (3 calls)
-0: drone_init(?$#0:drone.drone_info):
+0: drone.drone_init<0>
+drone_init(?$#0:drone.drone_info):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(32:wybe.int, ?tmp$5#0:drone.drone_info)
@@ -910,7 +939,8 @@ drone_init > (3 calls)
 
 
 gen$1 > {inline} (2 calls)
-0: gen$1([ch#0:wybe.char], [d#0:drone.drone_info], io#0:wybe.phantom, [tmp$0#0:drone.drone_info], ?io#2:wybe.phantom):
+0: drone.gen$1<0>
+gen$1([ch#0:wybe.char], [d#0:drone.drone_info], io#0:wybe.phantom, [tmp$0#0:drone.drone_info], ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c {impure} malloc_count(?mc#0:wybe.int) @memory_management:9:5
@@ -920,7 +950,8 @@ gen$1 > {inline} (2 calls)
 
 
 gen$2 > (7 calls)
-0: gen$2([action#0:wybe.char], d#0:drone.drone_info, success#0:wybe.bool, [tmp$0#0:wybe.bool], ?d#1:drone.drone_info, [?success#0:wybe.bool]):
+0: drone.gen$2<0>[6dacb8fd25]
+gen$2([action#0:wybe.char], d#0:drone.drone_info, success#0:wybe.bool, [tmp$0#0:wybe.bool], ?d#1:drone.drone_info, [?success#0:wybe.bool]):
  AliasPairs: [(d#0,d#1)]
  InterestingCallProperties: [InterestingUnaliased 1]
     case success#0:wybe.bool of
@@ -945,7 +976,8 @@ gen$2 > (7 calls)
 
 
 gen$3 > (5 calls)
-0: gen$3([ch#0:wybe.char], d#0:drone.drone_info, io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: drone.gen$3<0>[6dacb8fd25]
+gen$3([ch#0:wybe.char], d#0:drone.drone_info, io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 1]
  MultiSpeczDepInfo: [(3,(drone.loop<0>,fromList [NonAliasedParamCond 0 [1]]))]
@@ -973,7 +1005,8 @@ gen$3 > (5 calls)
 
 
 loop > (2 calls)
-0: loop(d#0:drone.drone_info, ch#0:wybe.char, io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: drone.loop<0>[410bae77d3]
+loop(d#0:drone.drone_info, ch#0:wybe.char, io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(4,(drone.gen$3<0>,fromList [NonAliasedParamCond 1 [0]])),(6,(drone.do_action<0>,fromList [NonAliasedParamCond 0 [0]])),(10,(drone.gen$3<0>,fromList [NonAliasedParamCond 1 [0]])),(11,(drone.gen$3<0>,fromList [NonAliasedParamCond 1 [0]])),(12,(drone.gen$3<0>,fromList [NonAliasedParamCond 1 [0]])),(13,(drone.gen$3<0>,fromList [NonAliasedParamCond 1 [0]]))]
@@ -1071,7 +1104,8 @@ loop > (2 calls)
 
 
 print_info > {inline} (1 calls)
-0: print_info(d#0:drone.drone_info, io#0:wybe.phantom, ?io#9:wybe.phantom):
+0: drone.print_info<0>
+print_info(d#0:drone.drone_info, io#0:wybe.phantom, ?io#9:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("(":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:30:35
@@ -1751,7 +1785,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:drone.drone_info, $right#0:drone.drone_info, ?$$#0:wybe.bool):
+0: drone.drone_info./=<0>
+/=($left#0:drone.drone_info, $right#0:drone.drone_info, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -1791,7 +1826,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:drone.drone_info, $right#0:drone.drone_info, ?$$#0:wybe.bool):
+0: drone.drone_info.=<0>
+=($left#0:drone.drone_info, $right#0:drone.drone_info, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
@@ -1827,19 +1863,22 @@ entry:
 
 
 count > public {inline} (0 calls)
-0: count($rec#0:drone.drone_info, ?$#0:wybe.int):
+0: drone.drone_info.count<0>
+count($rec#0:drone.drone_info, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 count > public {inline} (0 calls)
-1: count($rec#0:drone.drone_info, ?$rec#1:drone.drone_info, $field#0:wybe.int):
+1: drone.drone_info.count<1>
+count($rec#0:drone.drone_info, ?$rec#1:drone.drone_info, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:drone.drone_info, ?%$rec#1:drone.drone_info, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 drone_info > public {inline} (0 calls)
-0: drone_info(x#0:wybe.int, y#0:wybe.int, z#0:wybe.int, count#0:wybe.int, ?$#0:drone.drone_info):
+0: drone.drone_info.drone_info<0>
+drone_info(x#0:wybe.int, y#0:wybe.int, z#0:wybe.int, count#0:wybe.int, ?$#0:drone.drone_info):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(32:wybe.int, ?$rec#0:drone.drone_info)
@@ -1848,7 +1887,8 @@ drone_info > public {inline} (0 calls)
     foreign lpvm mutate(~%$rec#2:drone.drone_info, ?%$rec#3:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~z#0:wybe.int)
     foreign lpvm mutate(~%$rec#3:drone.drone_info, ?%$#0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~count#0:wybe.int)
 drone_info > public {inline} (14 calls)
-1: drone_info(?x#0:wybe.int, ?y#0:wybe.int, ?z#0:wybe.int, ?count#0:wybe.int, $#0:drone.drone_info):
+1: drone.drone_info.drone_info<1>
+drone_info(?x#0:wybe.int, ?y#0:wybe.int, ?z#0:wybe.int, ?count#0:wybe.int, $#0:drone.drone_info):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?x#0:wybe.int)
@@ -1858,36 +1898,42 @@ drone_info > public {inline} (14 calls)
 
 
 x > public {inline} (0 calls)
-0: x($rec#0:drone.drone_info, ?$#0:wybe.int):
+0: drone.drone_info.x<0>
+x($rec#0:drone.drone_info, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 x > public {inline} (0 calls)
-1: x($rec#0:drone.drone_info, ?$rec#1:drone.drone_info, $field#0:wybe.int):
+1: drone.drone_info.x<1>
+x($rec#0:drone.drone_info, ?$rec#1:drone.drone_info, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:drone.drone_info, ?%$rec#1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 y > public {inline} (0 calls)
-0: y($rec#0:drone.drone_info, ?$#0:wybe.int):
+0: drone.drone_info.y<0>
+y($rec#0:drone.drone_info, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 y > public {inline} (0 calls)
-1: y($rec#0:drone.drone_info, ?$rec#1:drone.drone_info, $field#0:wybe.int):
+1: drone.drone_info.y<1>
+y($rec#0:drone.drone_info, ?$rec#1:drone.drone_info, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:drone.drone_info, ?%$rec#1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 z > public {inline} (0 calls)
-0: z($rec#0:drone.drone_info, ?$#0:wybe.int):
+0: drone.drone_info.z<0>
+z($rec#0:drone.drone_info, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 z > public {inline} (0 calls)
-1: z($rec#0:drone.drone_info, ?$rec#1:drone.drone_info, $field#0:wybe.int):
+1: drone.drone_info.z<1>
+z($rec#0:drone.drone_info, ?$rec#1:drone.drone_info, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:drone.drone_info, ?%$rec#1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field#0:wybe.int)

--- a/test-cases/complex/exp/testcase_multi_specz-int_list.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-int_list.exp
@@ -105,7 +105,8 @@ AFTER BUILDING MAIN:
   procs           : 
 
 *main* > {inline} (0 calls)
-0: (argc#0:wybe.int, argv#0:wybe.array.raw_array(wybe.string), ?exit_code#0:wybe.int, ?io#2:wybe.phantom):
+0: .<0>
+(argc#0:wybe.int, argv#0:wybe.array.raw_array(wybe.string), ?exit_code#0:wybe.int, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c {semipure} gc_init() @memory_management:12:1
@@ -135,7 +136,8 @@ LLVM code       : None
   procs           : 
 
 *main* > public (0 calls)
-0: (argc#0:wybe.int, [?argc#0:wybe.int], ?arguments#2:wybe.array(wybe.string), argv#0:wybe.array.raw_array(wybe.string), [?argv#0:wybe.array.raw_array(wybe.string)], ?command#2:wybe.string, ?exit_code#1:wybe.int, io#0:wybe.phantom, [?io#0:wybe.phantom]):
+0: command_line.<0>
+(argc#0:wybe.int, [?argc#0:wybe.int], ?arguments#2:wybe.array(wybe.string), argv#0:wybe.array.raw_array(wybe.string), [?argv#0:wybe.array.raw_array(wybe.string)], ?command#2:wybe.string, ?exit_code#1:wybe.int, io#0:wybe.phantom, [?io#0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$9#0:wybe.array(?T))
@@ -153,7 +155,8 @@ LLVM code       : None
 
 
 set_exit_code > public {inline} (0 calls)
-0: set_exit_code(code#0:wybe.int, [exit_code#0:wybe.int], ?exit_code#1:wybe.int):
+0: command_line.set_exit_code<0>
+set_exit_code(code#0:wybe.int, [exit_code#0:wybe.int], ?exit_code#1:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(~code#0:wybe.int, ?exit_code#1:wybe.int) @command_line:27:5
@@ -250,7 +253,8 @@ entry:
   procs           : 
 
 append > public (0 calls)
-0: append(lst#0:int_list.int_list, v#0:wybe.int, ?$#0:int_list.int_list):
+0: int_list.append<0>
+append(lst#0:int_list.int_list, v#0:wybe.int, ?$#0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.extend<0>,fromList [NonAliasedParamCond 0 [0]]))]
@@ -261,7 +265,8 @@ append > public (0 calls)
 
 
 count > public (3 calls)
-0: count(lst#0:int_list.int_list, x#0:wybe.int, ?$#0:wybe.int):
+0: int_list.count<0>
+count(lst#0:int_list.int_list, x#0:wybe.int, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(lst#0:int_list.int_list, 0:wybe.int, ?tmp$7#0:wybe.bool)
@@ -285,7 +290,8 @@ count > public (3 calls)
 
 
 extend > public (3 calls)
-0: extend(lst1#0:int_list.int_list, lst2#0:int_list.int_list, ?$#0:int_list.int_list):
+0: int_list.extend<0>[410bae77d3]
+extend(lst1#0:int_list.int_list, lst2#0:int_list.int_list, ?$#0:int_list.int_list):
  AliasPairs: [($#0,lst2#0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(int_list.extend<0>,fromList [NonAliasedParamCond 0 [0]]))]
@@ -305,14 +311,16 @@ extend > public (3 calls)
 
 
 gen$1 > {inline} (2 calls)
-0: gen$1([h#0:wybe.int], [lst#0:int_list.int_list], [t#0:int_list.int_list], tmp$2#0:wybe.int, tmp$3#0:wybe.int, [x#0:wybe.int], ?$#0:wybe.int):
+0: int_list.gen$1<0>
+gen$1([h#0:wybe.int], [lst#0:int_list.int_list], [t#0:int_list.int_list], tmp$2#0:wybe.int, tmp$3#0:wybe.int, [x#0:wybe.int], ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm add(~tmp$2#0:wybe.int, ~tmp$3#0:wybe.int, ?$#0:wybe.int) @int:8:24
 
 
 gen$2 > (2 calls)
-0: gen$2(result#0:int_list.int_list, start#0:wybe.int, step#0:wybe.int, stop#0:wybe.int, tmp$0#0:int_list.int_list, ?result#1:int_list.int_list):
+0: int_list.gen$2<0>[410bae77d3]
+gen$2(result#0:int_list.int_list, start#0:wybe.int, step#0:wybe.int, stop#0:wybe.int, tmp$0#0:int_list.int_list, ?result#1:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(3,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.gen$2<0>,fromList [NonAliasedParamCond 0 [0]]))]
@@ -331,7 +339,8 @@ gen$2 > (2 calls)
 
 
 gen$3 > {inline} (1 calls)
-0: gen$3(result#0:int_list.int_list, start#0:wybe.int, step#0:wybe.int, stop#0:wybe.int, tmp$0#0:int_list.int_list, ?result#2:int_list.int_list):
+0: int_list.gen$3<0>
+gen$3(result#0:int_list.int_list, start#0:wybe.int, step#0:wybe.int, stop#0:wybe.int, tmp$0#0:int_list.int_list, ?result#2:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$5#0:int_list.int_list)
@@ -342,7 +351,8 @@ gen$3 > {inline} (1 calls)
 
 
 greater > (3 calls)
-0: greater(lst#0:int_list.int_list, v#0:wybe.int, ?$#0:int_list.int_list):
+0: int_list.greater<0>
+greater(lst#0:int_list.int_list, v#0:wybe.int, ?$#0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.greater<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.greater<0>,fromList [NonAliasedParamCond 0 [0]]))]
@@ -369,14 +379,16 @@ greater > (3 calls)
 
 
 index > public {inline} (0 calls)
-0: index(lst#0:int_list.int_list, x#0:wybe.int, ?$#0:wybe.int):
+0: int_list.index<0>
+index(lst#0:int_list.int_list, x#0:wybe.int, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     int_list.index_helper<0>(~lst#0:int_list.int_list, 0:wybe.int, ~x#0:wybe.int, ?$#0:wybe.int) #0 @int_list:94:42
 
 
 index_helper > (2 calls)
-0: index_helper(lst#0:int_list.int_list, idx#0:wybe.int, x#0:wybe.int, ?$#0:wybe.int):
+0: int_list.index_helper<0>
+index_helper(lst#0:int_list.int_list, idx#0:wybe.int, x#0:wybe.int, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(lst#0:int_list.int_list, 0:wybe.int, ?tmp$8#0:wybe.bool)
@@ -400,7 +412,8 @@ index_helper > (2 calls)
 
 
 insert > public (2 calls)
-0: insert(lst#0:int_list.int_list, idx#0:wybe.int, v#0:wybe.int, ?$#0:int_list.int_list):
+0: int_list.insert<0>[410bae77d3]
+insert(lst#0:int_list.int_list, idx#0:wybe.int, v#0:wybe.int, ?$#0:int_list.int_list):
  AliasPairs: [($#0,lst#0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(4,(int_list.insert<0>,fromList [NonAliasedParamCond 0 [0]])),(7,(int_list.insert<0>,fromList [NonAliasedParamCond 0 [0]]))]
@@ -431,7 +444,8 @@ insert > public (2 calls)
 
 
 lesser > (3 calls)
-0: lesser(lst#0:int_list.int_list, v#0:wybe.int, ?$#0:int_list.int_list):
+0: int_list.lesser<0>
+lesser(lst#0:int_list.int_list, v#0:wybe.int, ?$#0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.lesser<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.lesser<0>,fromList [NonAliasedParamCond 0 [0]]))]
@@ -458,7 +472,8 @@ lesser > (3 calls)
 
 
 pop > public (1 calls)
-0: pop(lst#0:int_list.int_list, idx#0:wybe.int, ?$#0:int_list.int_list):
+0: int_list.pop<0>[410bae77d3]
+pop(lst#0:int_list.int_list, idx#0:wybe.int, ?$#0:int_list.int_list):
  AliasPairs: [($#0,lst#0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(3,(int_list.pop<0>,fromList [NonAliasedParamCond 0 [0]]))]
@@ -486,7 +501,8 @@ pop > public (1 calls)
 
 
 print > public (2 calls)
-0: print(x#0:int_list.int_list, io#0:wybe.phantom, ?io#3:wybe.phantom):
+0: int_list.print<0>
+print(x#0:int_list.int_list, io#0:wybe.phantom, ?io#3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(x#0:int_list.int_list, 0:wybe.int, ?tmp$2#0:wybe.bool)
@@ -504,7 +520,8 @@ print > public (2 calls)
 
 
 println > public {inline} (0 calls)
-0: println(x#0:int_list.int_list, io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: int_list.println<0>
+println(x#0:int_list.int_list, io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     int_list.print<0>(~x#0:int_list.int_list, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @int_list:17:6
@@ -512,14 +529,16 @@ println > public {inline} (0 calls)
 
 
 range > public {inline} (0 calls)
-0: range(start#0:wybe.int, stop#0:wybe.int, step#0:wybe.int, ?result#1:int_list.int_list):
+0: int_list.range<0>
+range(start#0:wybe.int, stop#0:wybe.int, step#0:wybe.int, ?result#1:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
     int_list.gen$2<0>(0:int_list.int_list, ~start#0:wybe.int, ~step#0:wybe.int, ~stop#0:wybe.int, 0:int_list.int_list, ?result#1:int_list.int_list) #1 @int_list:26:5
 
 
 remove > public (1 calls)
-0: remove(lst#0:int_list.int_list, v#0:wybe.int, ?$#0:int_list.int_list):
+0: int_list.remove<0>[410bae77d3]
+remove(lst#0:int_list.int_list, v#0:wybe.int, ?$#0:int_list.int_list):
  AliasPairs: [($#0,lst#0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.remove<0>,fromList [NonAliasedParamCond 0 [0]]))]
@@ -546,14 +565,16 @@ remove > public (1 calls)
 
 
 reverse > public {inline} (1 calls)
-0: reverse(lst#0:int_list.int_list, ?$#0:int_list.int_list):
+0: int_list.reverse<0>
+reverse(lst#0:int_list.int_list, ?$#0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
     int_list.reverse_helper<0>(~lst#0:int_list.int_list, 0:int_list.int_list, ?$#0:int_list.int_list) #1 @int_list:140:42
 
 
 reverse_helper > (2 calls)
-0: reverse_helper(lst#0:int_list.int_list, acc#0:int_list.int_list, ?$#0:int_list.int_list):
+0: int_list.reverse_helper<0>
+reverse_helper(lst#0:int_list.int_list, acc#0:int_list.int_list, ?$#0:int_list.int_list):
  AliasPairs: [($#0,acc#0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]]))]
@@ -573,7 +594,8 @@ reverse_helper > (2 calls)
 
 
 sort > public (2 calls)
-0: sort(lst#0:int_list.int_list, ?$#0:int_list.int_list):
+0: int_list.sort<0>[410bae77d3]
+sort(lst#0:int_list.int_list, ?$#0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.sort<0>,fromList [NonAliasedParamCond 0 []])),(3,(int_list.greater<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.sort<0>,fromList [NonAliasedParamCond 0 []])),(6,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []]))]
@@ -617,7 +639,8 @@ LLVM code       : None
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:int_list.int_list, $right#0:int_list.int_list, ?$$#0:wybe.bool):
+0: int_list.int_list./=<0>
+/=($left#0:int_list.int_list, $right#0:int_list.int_list, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     int_list.int_list.=<0>(~$left#0:int_list.int_list, ~$right#0:int_list.int_list, ?tmp$0#0:wybe.bool) #0
@@ -625,7 +648,8 @@ LLVM code       : None
 
 
 = > public (2 calls)
-0: =($left#0:int_list.int_list, $right#0:int_list.int_list, ?$$#0:wybe.bool):
+0: int_list.int_list.=<0>
+=($left#0:int_list.int_list, $right#0:int_list.int_list, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($left#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -657,21 +681,24 @@ LLVM code       : None
 
 
 [] > public {inline} (0 calls)
-0: [](?$#0:int_list.int_list):
+0: int_list.int_list.[]<0>
+[](?$#0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(0:int_list.int_list, ?$#0:int_list.int_list)
 
 
 [|] > public {inline} (0 calls)
-0: [|](head#0:wybe.int, tail#0:int_list.int_list, ?$#0:int_list.int_list):
+0: int_list.int_list.[|]<0>
+[|](head#0:wybe.int, tail#0:int_list.int_list, ?$#0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:int_list.int_list)
     foreign lpvm mutate(~%$rec#0:int_list.int_list, ?%$rec#1:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:int_list.int_list, ?%$#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail#0:int_list.int_list)
 [|] > public {inline} (12 calls)
-1: [|](?head#0:wybe.int, ?tail#0:int_list.int_list, $#0:int_list.int_list, ?$$#0:wybe.bool):
+1: int_list.int_list.[|]<1>
+[|](?head#0:wybe.int, ?tail#0:int_list.int_list, $#0:int_list.int_list, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -689,7 +716,8 @@ LLVM code       : None
 
 
 head > public {inline} (0 calls)
-0: head($rec#0:int_list.int_list, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: int_list.int_list.head<0>
+head($rec#0:int_list.int_list, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -703,7 +731,8 @@ head > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 head > public {inline} (0 calls)
-1: head($rec#0:int_list.int_list, ?$rec#1:int_list.int_list, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: int_list.int_list.head<1>
+head($rec#0:int_list.int_list, ?$rec#1:int_list.int_list, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -719,7 +748,8 @@ head > public {inline} (0 calls)
 
 
 tail > public {inline} (0 calls)
-0: tail($rec#0:int_list.int_list, ?$#0:int_list.int_list, ?$$#0:wybe.bool):
+0: int_list.int_list.tail<0>
+tail($rec#0:int_list.int_list, ?$#0:int_list.int_list, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -733,7 +763,8 @@ tail > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 tail > public {inline} (0 calls)
-1: tail($rec#0:int_list.int_list, ?$rec#1:int_list.int_list, $field#0:int_list.int_list, ?$$#0:wybe.bool):
+1: int_list.int_list.tail<1>
+tail($rec#0:int_list.int_list, ?$rec#1:int_list.int_list, $field#0:int_list.int_list, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -762,7 +793,8 @@ LLVM code       : None
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#22:wybe.phantom):
+0: int_list_test.<0>
+(io#0:wybe.phantom, ?io#22:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(24,(int_list_test.test_int_list<0>,fromList [NonAliasedParamCond 0 [],NonAliasedParamCond 1 [],NonAliasedParamCond 2 []])),(34,(int_list.gen$2<0>,fromList [NonAliasedParamCond 0 []])),(35,(int_list.gen$2<0>,fromList [NonAliasedParamCond 0 []])),(36,(int_list.gen$2<0>,fromList [NonAliasedParamCond 0 []]))]
@@ -820,7 +852,8 @@ LLVM code       : None
 
 
 test_int_list > (2 calls)
-0: test_int_list(x#0:int_list.int_list, y#0:int_list.int_list, z#0:int_list.int_list, io#0:wybe.phantom, ?io#10:wybe.phantom):
+0: int_list_test.test_int_list<0>
+test_int_list(x#0:int_list.int_list, y#0:int_list.int_list, z#0:int_list.int_list, io#0:wybe.phantom, ?io#10:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0,InterestingUnaliased 1,InterestingUnaliased 2]
  MultiSpeczDepInfo: [(2,(int_list.append<0>,fromList [NonAliasedParamCond 0 [1]])),(7,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []])),(8,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []])),(11,(int_list.insert<0>,fromList [NonAliasedParamCond 0 []])),(12,(int_list.pop<0>,fromList [NonAliasedParamCond 0 []])),(13,(int_list.remove<0>,fromList [NonAliasedParamCond 0 []])),(16,(int_list.sort<0>,fromList [NonAliasedParamCond 0 []])),(19,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]])),(20,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [2]]))]
@@ -872,7 +905,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > {inline} (0 calls)
-0: (argc#0:wybe.int, argv#0:wybe.array.raw_array(wybe.string), ?exit_code#0:wybe.int, ?io#2:wybe.phantom):
+0: .<0>
+(argc#0:wybe.int, argv#0:wybe.array.raw_array(wybe.string), ?exit_code#0:wybe.int, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c {semipure} gc_init() @memory_management:12:1
@@ -937,7 +971,8 @@ entry:
   procs           : 
 
 *main* > public (0 calls)
-0: (argc#0:wybe.int, [?argc#0:wybe.int], ?arguments#2:wybe.array(wybe.string), argv#0:wybe.array.raw_array(wybe.string), [?argv#0:wybe.array.raw_array(wybe.string)], ?command#2:wybe.string, ?exit_code#1:wybe.int, io#0:wybe.phantom, [?io#0:wybe.phantom]):
+0: command_line.<0>
+(argc#0:wybe.int, [?argc#0:wybe.int], ?arguments#2:wybe.array(wybe.string), argv#0:wybe.array.raw_array(wybe.string), [?argv#0:wybe.array.raw_array(wybe.string)], ?command#2:wybe.string, ?exit_code#1:wybe.int, io#0:wybe.phantom, [?io#0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$9#0:wybe.array(?T))
@@ -955,7 +990,8 @@ entry:
 
 
 set_exit_code > public {inline} (0 calls)
-0: set_exit_code(code#0:wybe.int, [exit_code#0:wybe.int], ?exit_code#1:wybe.int):
+0: command_line.set_exit_code<0>
+set_exit_code(code#0:wybe.int, [exit_code#0:wybe.int], ?exit_code#1:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(~code#0:wybe.int, ?exit_code#1:wybe.int) @command_line:27:5
@@ -1052,7 +1088,8 @@ entry:
   procs           : 
 
 append > public (0 calls)
-0: append(lst#0:int_list.int_list, v#0:wybe.int, ?$#0:int_list.int_list):
+0: int_list.append<0>[410bae77d3]
+append(lst#0:int_list.int_list, v#0:wybe.int, ?$#0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.extend<0>,fromList [NonAliasedParamCond 0 [0]]))]
@@ -1068,7 +1105,8 @@ append > public (0 calls)
 
 
 count > public (3 calls)
-0: count(lst#0:int_list.int_list, x#0:wybe.int, ?$#0:wybe.int):
+0: int_list.count<0>
+count(lst#0:int_list.int_list, x#0:wybe.int, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(lst#0:int_list.int_list, 0:wybe.int, ?tmp$7#0:wybe.bool)
@@ -1092,7 +1130,8 @@ count > public (3 calls)
 
 
 extend > public (3 calls)
-0: extend(lst1#0:int_list.int_list, lst2#0:int_list.int_list, ?$#0:int_list.int_list):
+0: int_list.extend<0>[410bae77d3]
+extend(lst1#0:int_list.int_list, lst2#0:int_list.int_list, ?$#0:int_list.int_list):
  AliasPairs: [($#0,lst2#0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(int_list.extend<0>,fromList [NonAliasedParamCond 0 [0]]))]
@@ -1123,14 +1162,16 @@ extend > public (3 calls)
 
 
 gen$1 > {inline} (2 calls)
-0: gen$1([h#0:wybe.int], [lst#0:int_list.int_list], [t#0:int_list.int_list], tmp$2#0:wybe.int, tmp$3#0:wybe.int, [x#0:wybe.int], ?$#0:wybe.int):
+0: int_list.gen$1<0>
+gen$1([h#0:wybe.int], [lst#0:int_list.int_list], [t#0:int_list.int_list], tmp$2#0:wybe.int, tmp$3#0:wybe.int, [x#0:wybe.int], ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm add(~tmp$2#0:wybe.int, ~tmp$3#0:wybe.int, ?$#0:wybe.int) @int:8:24
 
 
 gen$2 > (2 calls)
-0: gen$2(result#0:int_list.int_list, start#0:wybe.int, step#0:wybe.int, stop#0:wybe.int, tmp$0#0:int_list.int_list, ?result#1:int_list.int_list):
+0: int_list.gen$2<0>
+gen$2(result#0:int_list.int_list, start#0:wybe.int, step#0:wybe.int, stop#0:wybe.int, tmp$0#0:int_list.int_list, ?result#1:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(3,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.gen$2<0>,fromList [NonAliasedParamCond 0 [0]]))]
@@ -1162,7 +1203,8 @@ gen$2 > (2 calls)
 
 
 gen$3 > {inline} (1 calls)
-0: gen$3(result#0:int_list.int_list, start#0:wybe.int, step#0:wybe.int, stop#0:wybe.int, tmp$0#0:int_list.int_list, ?result#2:int_list.int_list):
+0: int_list.gen$3<0>
+gen$3(result#0:int_list.int_list, start#0:wybe.int, step#0:wybe.int, stop#0:wybe.int, tmp$0#0:int_list.int_list, ?result#2:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$5#0:int_list.int_list)
@@ -1173,7 +1215,8 @@ gen$3 > {inline} (1 calls)
 
 
 greater > (3 calls)
-0: greater(lst#0:int_list.int_list, v#0:wybe.int, ?$#0:int_list.int_list):
+0: int_list.greater<0>[410bae77d3]
+greater(lst#0:int_list.int_list, v#0:wybe.int, ?$#0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.greater<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.greater<0>,fromList [NonAliasedParamCond 0 [0]]))]
@@ -1219,14 +1262,16 @@ greater > (3 calls)
 
 
 index > public {inline} (0 calls)
-0: index(lst#0:int_list.int_list, x#0:wybe.int, ?$#0:wybe.int):
+0: int_list.index<0>
+index(lst#0:int_list.int_list, x#0:wybe.int, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     int_list.index_helper<0>(~lst#0:int_list.int_list, 0:wybe.int, ~x#0:wybe.int, ?$#0:wybe.int) #0 @int_list:94:42
 
 
 index_helper > (2 calls)
-0: index_helper(lst#0:int_list.int_list, idx#0:wybe.int, x#0:wybe.int, ?$#0:wybe.int):
+0: int_list.index_helper<0>
+index_helper(lst#0:int_list.int_list, idx#0:wybe.int, x#0:wybe.int, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(lst#0:int_list.int_list, 0:wybe.int, ?tmp$8#0:wybe.bool)
@@ -1250,7 +1295,8 @@ index_helper > (2 calls)
 
 
 insert > public (2 calls)
-0: insert(lst#0:int_list.int_list, idx#0:wybe.int, v#0:wybe.int, ?$#0:int_list.int_list):
+0: int_list.insert<0>[410bae77d3]
+insert(lst#0:int_list.int_list, idx#0:wybe.int, v#0:wybe.int, ?$#0:int_list.int_list):
  AliasPairs: [($#0,lst#0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(4,(int_list.insert<0>,fromList [NonAliasedParamCond 0 [0]])),(7,(int_list.insert<0>,fromList [NonAliasedParamCond 0 [0]]))]
@@ -1303,7 +1349,8 @@ insert > public (2 calls)
 
 
 lesser > (3 calls)
-0: lesser(lst#0:int_list.int_list, v#0:wybe.int, ?$#0:int_list.int_list):
+0: int_list.lesser<0>
+lesser(lst#0:int_list.int_list, v#0:wybe.int, ?$#0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.lesser<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.lesser<0>,fromList [NonAliasedParamCond 0 [0]]))]
@@ -1330,7 +1377,8 @@ lesser > (3 calls)
 
 
 pop > public (1 calls)
-0: pop(lst#0:int_list.int_list, idx#0:wybe.int, ?$#0:int_list.int_list):
+0: int_list.pop<0>[410bae77d3]
+pop(lst#0:int_list.int_list, idx#0:wybe.int, ?$#0:int_list.int_list):
  AliasPairs: [($#0,lst#0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(3,(int_list.pop<0>,fromList [NonAliasedParamCond 0 [0]]))]
@@ -1377,7 +1425,8 @@ pop > public (1 calls)
 
 
 print > public (2 calls)
-0: print(x#0:int_list.int_list, io#0:wybe.phantom, ?io#3:wybe.phantom):
+0: int_list.print<0>
+print(x#0:int_list.int_list, io#0:wybe.phantom, ?io#3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(x#0:int_list.int_list, 0:wybe.int, ?tmp$2#0:wybe.bool)
@@ -1395,7 +1444,8 @@ print > public (2 calls)
 
 
 println > public {inline} (0 calls)
-0: println(x#0:int_list.int_list, io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: int_list.println<0>
+println(x#0:int_list.int_list, io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     int_list.print<0>(~x#0:int_list.int_list, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @int_list:17:6
@@ -1403,14 +1453,16 @@ println > public {inline} (0 calls)
 
 
 range > public {inline} (0 calls)
-0: range(start#0:wybe.int, stop#0:wybe.int, step#0:wybe.int, ?result#1:int_list.int_list):
+0: int_list.range<0>
+range(start#0:wybe.int, stop#0:wybe.int, step#0:wybe.int, ?result#1:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
     int_list.gen$2<0>(0:int_list.int_list, ~start#0:wybe.int, ~step#0:wybe.int, ~stop#0:wybe.int, 0:int_list.int_list, ?result#1:int_list.int_list) #1 @int_list:26:5
 
 
 remove > public (1 calls)
-0: remove(lst#0:int_list.int_list, v#0:wybe.int, ?$#0:int_list.int_list):
+0: int_list.remove<0>[410bae77d3]
+remove(lst#0:int_list.int_list, v#0:wybe.int, ?$#0:int_list.int_list):
  AliasPairs: [($#0,lst#0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.remove<0>,fromList [NonAliasedParamCond 0 [0]]))]
@@ -1456,14 +1508,16 @@ remove > public (1 calls)
 
 
 reverse > public {inline} (1 calls)
-0: reverse(lst#0:int_list.int_list, ?$#0:int_list.int_list):
+0: int_list.reverse<0>
+reverse(lst#0:int_list.int_list, ?$#0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
     int_list.reverse_helper<0>(~lst#0:int_list.int_list, 0:int_list.int_list, ?$#0:int_list.int_list) #1 @int_list:140:42
 
 
 reverse_helper > (2 calls)
-0: reverse_helper(lst#0:int_list.int_list, acc#0:int_list.int_list, ?$#0:int_list.int_list):
+0: int_list.reverse_helper<0>[410bae77d3]
+reverse_helper(lst#0:int_list.int_list, acc#0:int_list.int_list, ?$#0:int_list.int_list):
  AliasPairs: [($#0,acc#0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]]))]
@@ -1494,7 +1548,8 @@ reverse_helper > (2 calls)
 
 
 sort > public (2 calls)
-0: sort(lst#0:int_list.int_list, ?$#0:int_list.int_list):
+0: int_list.sort<0>[410bae77d3]
+sort(lst#0:int_list.int_list, ?$#0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.sort<0>,fromList [NonAliasedParamCond 0 []])),(3,(int_list.greater<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.sort<0>,fromList [NonAliasedParamCond 0 []])),(6,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []]))]
@@ -2242,7 +2297,8 @@ if.else:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:int_list.int_list, $right#0:int_list.int_list, ?$$#0:wybe.bool):
+0: int_list.int_list./=<0>
+/=($left#0:int_list.int_list, $right#0:int_list.int_list, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     int_list.int_list.=<0>(~$left#0:int_list.int_list, ~$right#0:int_list.int_list, ?tmp$0#0:wybe.bool) #0
@@ -2250,7 +2306,8 @@ if.else:
 
 
 = > public (2 calls)
-0: =($left#0:int_list.int_list, $right#0:int_list.int_list, ?$$#0:wybe.bool):
+0: int_list.int_list.=<0>
+=($left#0:int_list.int_list, $right#0:int_list.int_list, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($left#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -2282,21 +2339,24 @@ if.else:
 
 
 [] > public {inline} (0 calls)
-0: [](?$#0:int_list.int_list):
+0: int_list.int_list.[]<0>
+[](?$#0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(0:int_list.int_list, ?$#0:int_list.int_list)
 
 
 [|] > public {inline} (0 calls)
-0: [|](head#0:wybe.int, tail#0:int_list.int_list, ?$#0:int_list.int_list):
+0: int_list.int_list.[|]<0>
+[|](head#0:wybe.int, tail#0:int_list.int_list, ?$#0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:int_list.int_list)
     foreign lpvm mutate(~%$rec#0:int_list.int_list, ?%$rec#1:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:int_list.int_list, ?%$#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail#0:int_list.int_list)
 [|] > public {inline} (12 calls)
-1: [|](?head#0:wybe.int, ?tail#0:int_list.int_list, $#0:int_list.int_list, ?$$#0:wybe.bool):
+1: int_list.int_list.[|]<1>
+[|](?head#0:wybe.int, ?tail#0:int_list.int_list, $#0:int_list.int_list, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -2314,7 +2374,8 @@ if.else:
 
 
 head > public {inline} (0 calls)
-0: head($rec#0:int_list.int_list, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: int_list.int_list.head<0>
+head($rec#0:int_list.int_list, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -2328,7 +2389,8 @@ head > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 head > public {inline} (0 calls)
-1: head($rec#0:int_list.int_list, ?$rec#1:int_list.int_list, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: int_list.int_list.head<1>
+head($rec#0:int_list.int_list, ?$rec#1:int_list.int_list, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -2344,7 +2406,8 @@ head > public {inline} (0 calls)
 
 
 tail > public {inline} (0 calls)
-0: tail($rec#0:int_list.int_list, ?$#0:int_list.int_list, ?$$#0:wybe.bool):
+0: int_list.int_list.tail<0>
+tail($rec#0:int_list.int_list, ?$#0:int_list.int_list, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -2358,7 +2421,8 @@ tail > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 tail > public {inline} (0 calls)
-1: tail($rec#0:int_list.int_list, ?$rec#1:int_list.int_list, $field#0:int_list.int_list, ?$$#0:wybe.bool):
+1: int_list.int_list.tail<1>
+tail($rec#0:int_list.int_list, ?$rec#1:int_list.int_list, $field#0:int_list.int_list, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -2576,7 +2640,8 @@ if.else:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#22:wybe.phantom):
+0: int_list_test.<0>
+(io#0:wybe.phantom, ?io#22:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(24,(int_list_test.test_int_list<0>,fromList [NonAliasedParamCond 0 [],NonAliasedParamCond 1 [],NonAliasedParamCond 2 []])),(34,(int_list.gen$2<0>,fromList [NonAliasedParamCond 0 []])),(35,(int_list.gen$2<0>,fromList [NonAliasedParamCond 0 []])),(36,(int_list.gen$2<0>,fromList [NonAliasedParamCond 0 []]))]
@@ -2634,7 +2699,8 @@ if.else:
 
 
 test_int_list > (2 calls)
-0: test_int_list(x#0:int_list.int_list, y#0:int_list.int_list, z#0:int_list.int_list, io#0:wybe.phantom, ?io#10:wybe.phantom):
+0: int_list_test.test_int_list<0>[9e35cb823b]
+test_int_list(x#0:int_list.int_list, y#0:int_list.int_list, z#0:int_list.int_list, io#0:wybe.phantom, ?io#10:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0,InterestingUnaliased 1,InterestingUnaliased 2]
  MultiSpeczDepInfo: [(2,(int_list.append<0>,fromList [NonAliasedParamCond 0 [1]])),(7,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []])),(8,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []])),(11,(int_list.insert<0>,fromList [NonAliasedParamCond 0 []])),(12,(int_list.pop<0>,fromList [NonAliasedParamCond 0 []])),(13,(int_list.remove<0>,fromList [NonAliasedParamCond 0 []])),(16,(int_list.sort<0>,fromList [NonAliasedParamCond 0 []])),(19,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]])),(20,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [2]]))]

--- a/test-cases/final-dump/aaa.exp
+++ b/test-cases/final-dump/aaa.exp
@@ -12,7 +12,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: aaa.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("AAA: Init":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
@@ -60,7 +61,8 @@ entry:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: bbb.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("BBB: Init":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
@@ -108,7 +110,8 @@ entry:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: ccc.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("CCC: Init":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
@@ -155,7 +158,8 @@ entry:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: ddd.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("DDD: Init":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn

--- a/test-cases/final-dump/afterbreak.exp
+++ b/test-cases/final-dump/afterbreak.exp
@@ -10,14 +10,16 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: afterbreak.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     afterbreak.gen$1<0>(~io#0:wybe.phantom, 1:wybe.int, ?io#1:wybe.phantom) #0 @afterbreak:nn:nn
 
 
 gen$1 > (2 calls)
-0: gen$1(io#0:wybe.phantom, x#0:wybe.int, ?io#1:wybe.phantom):
+0: afterbreak.gen$1<0>
+gen$1(io#0:wybe.phantom, x#0:wybe.int, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_sgt(x#0:wybe.int, 10:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
@@ -34,7 +36,8 @@ gen$1 > (2 calls)
 
 
 gen$2 > {inline} (1 calls)
-0: gen$2(io#0:wybe.phantom, [tmp$0#0:wybe.int], [x#0:wybe.int], y#0:wybe.int, ?io#2:wybe.phantom):
+0: afterbreak.gen$2<0>
+gen$2(io#0:wybe.phantom, [tmp$0#0:wybe.int], [x#0:wybe.int], y#0:wybe.int, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_int(y#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$3#0:wybe.phantom) @io:nn:nn

--- a/test-cases/final-dump/alias1.exp
+++ b/test-cases/final-dump/alias1.exp
@@ -15,7 +15,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#6:wybe.phantom):
+0: alias1.<0>
+(io#0:wybe.phantom, ?io#6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("-------------- Calling foo: ":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
@@ -30,7 +31,8 @@ AFTER EVERYTHING:
 
 
 bar > public (1 calls)
-0: bar(io#0:wybe.phantom, ?io#11:wybe.phantom):
+0: alias1.bar<0>
+bar(io#0:wybe.phantom, ?io#11:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$3#0:position.position)
@@ -53,7 +55,8 @@ bar > public (1 calls)
 
 
 baz > public (1 calls)
-0: baz(io#0:wybe.phantom, ?io#15:wybe.phantom):
+0: alias1.baz<0>
+baz(io#0:wybe.phantom, ?io#15:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$5#0:position.position)
@@ -84,7 +87,8 @@ baz > public (1 calls)
 
 
 foo > public (1 calls)
-0: foo(io#0:wybe.phantom, ?io#11:wybe.phantom):
+0: alias1.foo<0>
+foo(io#0:wybe.phantom, ?io#11:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$3#0:position.position)
@@ -107,7 +111,8 @@ foo > public (1 calls)
 
 
 replicate > public (3 calls)
-0: replicate(p1#0:position.position, ?p2#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: alias1.replicate<0>
+replicate(p1#0:position.position, ?p2#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: [(p1#0,p2#0)]
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$4#0:position.position)
@@ -432,7 +437,8 @@ entry:
   procs           : 
 
 printPosition > public (0 calls)
-0: printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+0: position.printPosition<0>
+printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -515,7 +521,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position./=<0>
+/=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -535,7 +542,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position.=<0>
+=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
@@ -553,14 +561,16 @@ entry:
 
 
 position > public {inline} (0 calls)
-0: position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+0: position.position.position<0>
+position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
     foreign lpvm mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:position.position, ?%$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
 position > public {inline} (6 calls)
-1: position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+1: position.position.position<1>
+position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
@@ -568,24 +578,28 @@ position > public {inline} (6 calls)
 
 
 x > public {inline} (0 calls)
-0: x($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.x<0>
+x($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 x > public {inline} (0 calls)
-1: x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.x<1>
+x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 y > public {inline} (0 calls)
-0: y($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.y<0>
+y($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 y > public {inline} (0 calls)
-1: y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.y<1>
+y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)

--- a/test-cases/final-dump/alias2.exp
+++ b/test-cases/final-dump/alias2.exp
@@ -13,7 +13,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#5:wybe.phantom):
+0: alias2.<0>
+(io#0:wybe.phantom, ?io#5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("copy a position":wybe.string, ~#io#0:wybe.phantom, ?tmp$3#0:wybe.phantom) @io:nn:nn
@@ -29,7 +30,8 @@ AFTER EVERYTHING:
 
 
 fcopy > public (0 calls)
-0: fcopy(p1#0:position.position, ?$#0:position.position):
+0: alias2.fcopy<0>
+fcopy(p1#0:position.position, ?$#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$5#0:position.position)
@@ -42,7 +44,8 @@ fcopy > public (0 calls)
 
 
 pcopy > public (1 calls)
-0: pcopy(p1#0:position.position, ?p2#2:position.position, io#0:wybe.phantom, ?io#3:wybe.phantom):
+0: alias2.pcopy<0>
+pcopy(p1#0:position.position, ?p2#2:position.position, io#0:wybe.phantom, ?io#3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$5#0:position.position)
@@ -206,7 +209,8 @@ entry:
   procs           : 
 
 printPosition > public (0 calls)
-0: printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+0: position.printPosition<0>
+printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -289,7 +293,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position./=<0>
+/=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -309,7 +314,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position.=<0>
+=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
@@ -327,14 +333,16 @@ entry:
 
 
 position > public {inline} (0 calls)
-0: position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+0: position.position.position<0>
+position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
     foreign lpvm mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:position.position, ?%$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
 position > public {inline} (6 calls)
-1: position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+1: position.position.position<1>
+position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
@@ -342,24 +350,28 @@ position > public {inline} (6 calls)
 
 
 x > public {inline} (0 calls)
-0: x($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.x<0>
+x($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 x > public {inline} (0 calls)
-1: x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.x<1>
+x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 y > public {inline} (0 calls)
-0: y($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.y<0>
+y($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 y > public {inline} (0 calls)
-1: y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.y<1>
+y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)

--- a/test-cases/final-dump/alias3.exp
+++ b/test-cases/final-dump/alias3.exp
@@ -13,14 +13,16 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: alias3.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     alias3.bar<0>(~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @alias3:38:2
 
 
 bar > public (1 calls)
-0: bar(io#0:wybe.phantom, ?io#11:wybe.phantom):
+0: alias3.bar<0>
+bar(io#0:wybe.phantom, ?io#11:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$3#0:position.position)
@@ -43,7 +45,8 @@ bar > public (1 calls)
 
 
 replicate1 > public (1 calls)
-0: replicate1(p1#0:position.position, ?p2#2:position.position, io#0:wybe.phantom, ?io#7:wybe.phantom):
+0: alias3.replicate1<0>
+replicate1(p1#0:position.position, ?p2#2:position.position, io#0:wybe.phantom, ?io#7:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("--- Inside replicate1: ":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
@@ -206,7 +209,8 @@ entry:
   procs           : 
 
 printPosition > public (0 calls)
-0: printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+0: position.printPosition<0>
+printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -289,7 +293,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position./=<0>
+/=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -309,7 +314,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position.=<0>
+=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
@@ -327,14 +333,16 @@ entry:
 
 
 position > public {inline} (0 calls)
-0: position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+0: position.position.position<0>
+position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
     foreign lpvm mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:position.position, ?%$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
 position > public {inline} (6 calls)
-1: position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+1: position.position.position<1>
+position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
@@ -342,24 +350,28 @@ position > public {inline} (6 calls)
 
 
 x > public {inline} (0 calls)
-0: x($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.x<0>
+x($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 x > public {inline} (0 calls)
-1: x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.x<1>
+x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 y > public {inline} (0 calls)
-0: y($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.y<0>
+y($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 y > public {inline} (0 calls)
-1: y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.y<1>
+y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)

--- a/test-cases/final-dump/alias4.exp
+++ b/test-cases/final-dump/alias4.exp
@@ -13,14 +13,16 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: alias4.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     alias4.bar<0>(~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @alias4:32:2
 
 
 bar > public (1 calls)
-0: bar(io#0:wybe.phantom, ?io#11:wybe.phantom):
+0: alias4.bar<0>
+bar(io#0:wybe.phantom, ?io#11:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$3#0:position.position)
@@ -43,7 +45,8 @@ bar > public (1 calls)
 
 
 replicate1 > public (1 calls)
-0: replicate1(p1#0:position.position, ?p2#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: alias4.replicate1<0>
+replicate1(p1#0:position.position, ?p2#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$6#0:position.position)
@@ -203,7 +206,8 @@ entry:
   procs           : 
 
 printPosition > public (0 calls)
-0: printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+0: position.printPosition<0>
+printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -286,7 +290,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position./=<0>
+/=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -306,7 +311,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position.=<0>
+=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
@@ -324,14 +330,16 @@ entry:
 
 
 position > public {inline} (0 calls)
-0: position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+0: position.position.position<0>
+position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
     foreign lpvm mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:position.position, ?%$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
 position > public {inline} (6 calls)
-1: position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+1: position.position.position<1>
+position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
@@ -339,24 +347,28 @@ position > public {inline} (6 calls)
 
 
 x > public {inline} (0 calls)
-0: x($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.x<0>
+x($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 x > public {inline} (0 calls)
-1: x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.x<1>
+x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 y > public {inline} (0 calls)
-0: y($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.y<0>
+y($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 y > public {inline} (0 calls)
-1: y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.y<1>
+y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)

--- a/test-cases/final-dump/alias5.exp
+++ b/test-cases/final-dump/alias5.exp
@@ -12,14 +12,16 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: alias5.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     alias5.bar<0>(~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @alias5:28:2
 
 
 bar > public (1 calls)
-0: bar(io#0:wybe.phantom, ?io#10:wybe.phantom):
+0: alias5.bar<0>
+bar(io#0:wybe.phantom, ?io#10:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     alias5.replicate1<0>(100:wybe.int, ?p2#0:wybe.int, 800:wybe.int, ?p4#0:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @alias5:14:4
@@ -39,7 +41,8 @@ bar > public (1 calls)
 
 
 replicate1 > public (2 calls)
-0: replicate1(v1#0:wybe.int, ?v2#0:wybe.int, v3#0:wybe.int, ?v4#1:wybe.int, io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: alias5.replicate1<0>
+replicate1(v1#0:wybe.int, ?v2#0:wybe.int, v3#0:wybe.int, ?v4#1:wybe.int, io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("random replicate1":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn

--- a/test-cases/final-dump/alias_cyclic.exp
+++ b/test-cases/final-dump/alias_cyclic.exp
@@ -14,14 +14,16 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: alias_cyclic.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     alias_cyclic.bar<0>(~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @alias_cyclic:nn:nn
 
 
 bar > public (1 calls)
-0: bar(io#0:wybe.phantom, ?io#5:wybe.phantom):
+0: alias_cyclic.bar<0>
+bar(io#0:wybe.phantom, ?io#5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$3#0:position.position)
@@ -35,7 +37,8 @@ bar > public (1 calls)
 
 
 updateX > public (2 calls)
-0: updateX(p1#0:position.position, ?p2#0:position.position, io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: alias_cyclic.updateX<0>[410bae77d3]
+updateX(p1#0:position.position, ?p2#0:position.position, io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: [(p1#0,p2#0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(6,(alias_cyclic.updateY<0>,fromList [NonAliasedParamCond 0 []]))]
@@ -67,7 +70,8 @@ updateX > public (2 calls)
 
 
 updateY > public (1 calls)
-0: updateY(p1#0:position.position, ?p2#0:position.position, io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: alias_cyclic.updateY<0>[410bae77d3]
+updateY(p1#0:position.position, ?p2#0:position.position, io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: [(p1#0,p2#0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(6,(alias_cyclic.updateX<0>,fromList [NonAliasedParamCond 0 []]))]
@@ -266,7 +270,8 @@ if.else:
   procs           : 
 
 printPosition > public (0 calls)
-0: printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+0: position.printPosition<0>
+printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -349,7 +354,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position./=<0>
+/=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -369,7 +375,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position.=<0>
+=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
@@ -387,14 +394,16 @@ entry:
 
 
 position > public {inline} (0 calls)
-0: position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+0: position.position.position<0>
+position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
     foreign lpvm mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:position.position, ?%$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
 position > public {inline} (6 calls)
-1: position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+1: position.position.position<1>
+position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
@@ -402,24 +411,28 @@ position > public {inline} (6 calls)
 
 
 x > public {inline} (0 calls)
-0: x($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.x<0>
+x($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 x > public {inline} (0 calls)
-1: x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.x<1>
+x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 y > public {inline} (0 calls)
-0: y($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.y<0>
+y($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 y > public {inline} (0 calls)
-1: y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.y<1>
+y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)

--- a/test-cases/final-dump/alias_data.exp
+++ b/test-cases/final-dump/alias_data.exp
@@ -13,21 +13,24 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: alias_data.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     alias_data.bar<0>(~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @alias_data:nn:nn
 
 
 backup > public {inline} (1 calls)
-0: backup(student1#0:student.student, ?student2#0:student.student, io#0:wybe.phantom, [?io#0:wybe.phantom]):
+0: alias_data.backup<0>
+backup(student1#0:student.student, ?student2#0:student.student, io#0:wybe.phantom, [?io#0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(~student1#0:student.student, ?student2#0:student.student) @alias_data:nn:nn
 
 
 bar > public (1 calls)
-0: bar(io#0:wybe.phantom, ?io#5:wybe.phantom):
+0: alias_data.bar<0>
+bar(io#0:wybe.phantom, ?io#5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$4#0:student.course)
@@ -153,7 +156,8 @@ entry:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: student.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$4#0:student.course)
@@ -166,7 +170,8 @@ entry:
 
 
 printStudent > public (1 calls)
-0: printStudent(stu#0:student.student, io#0:wybe.phantom, ?io#6:wybe.phantom):
+0: student.printStudent<0>
+printStudent(stu#0:student.student, io#0:wybe.phantom, ?io#6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("student id: ":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -295,7 +300,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:student.course, $right#0:student.course, ?$$#0:wybe.bool):
+0: student.course./=<0>
+/=($left#0:student.course, $right#0:student.course, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -316,7 +322,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:student.course, $right#0:student.course, ?$$#0:wybe.bool):
+0: student.course.=<0>
+=($left#0:student.course, $right#0:student.course, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$code#0:wybe.int)
@@ -335,26 +342,30 @@ entry:
 
 
 code > public {inline} (0 calls)
-0: code($rec#0:student.course, ?$#0:wybe.int):
+0: student.course.code<0>
+code($rec#0:student.course, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 code > public {inline} (0 calls)
-1: code($rec#0:student.course, ?$rec#1:student.course, $field#0:wybe.int):
+1: student.course.code<1>
+code($rec#0:student.course, ?$rec#1:student.course, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm mutate(~%$rec#0:student.course, ?%$rec#1:student.course, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 course > public {inline} (0 calls)
-0: course(code#0:wybe.int, name#0:wybe.string, ?$#0:student.course):
+0: student.course.course<0>
+course(code#0:wybe.int, name#0:wybe.string, ?$#0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:student.course)
     foreign lpvm mutate(~%$rec#0:student.course, ?%$rec#1:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~code#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:student.course, ?%$#0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~name#0:wybe.string)
 course > public {inline} (6 calls)
-1: course(?code#0:wybe.int, ?name#0:wybe.string, $#0:student.course):
+1: student.course.course<1>
+course(?code#0:wybe.int, ?name#0:wybe.string, $#0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?code#0:wybe.int)
@@ -362,12 +373,14 @@ course > public {inline} (6 calls)
 
 
 name > public {inline} (0 calls)
-0: name($rec#0:student.course, ?$#0:wybe.string):
+0: student.course.name<0>
+name($rec#0:student.course, ?$#0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.string)
 name > public {inline} (0 calls)
-1: name($rec#0:student.course, ?$rec#1:student.course, $field#0:wybe.string):
+1: student.course.name<1>
+name($rec#0:student.course, ?$rec#1:student.course, $field#0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:student.course, ?%$rec#1:student.course, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.string)
@@ -545,7 +558,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:student.student, $right#0:student.student, ?$$#0:wybe.bool):
+0: student.student./=<0>
+/=($left#0:student.student, $right#0:student.student, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -578,7 +592,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:student.student, $right#0:student.student, ?$$#0:wybe.bool):
+0: student.student.=<0>
+=($left#0:student.student, $right#0:student.student, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$id#0:wybe.int)
@@ -608,38 +623,44 @@ entry:
 
 
 id > public {inline} (0 calls)
-0: id($rec#0:student.student, ?$#0:wybe.int):
+0: student.student.id<0>
+id($rec#0:student.student, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 id > public {inline} (0 calls)
-1: id($rec#0:student.student, ?$rec#1:student.student, $field#0:wybe.int):
+1: student.student.id<1>
+id($rec#0:student.student, ?$rec#1:student.student, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm mutate(~%$rec#0:student.student, ?%$rec#1:student.student, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 major > public {inline} (0 calls)
-0: major($rec#0:student.student, ?$#0:student.course):
+0: student.student.major<0>
+major($rec#0:student.student, ?$#0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:student.course)
 major > public {inline} (0 calls)
-1: major($rec#0:student.student, ?$rec#1:student.student, $field#0:student.course):
+1: student.student.major<1>
+major($rec#0:student.student, ?$rec#1:student.student, $field#0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:student.student, ?%$rec#1:student.student, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:student.course)
 
 
 student > public {inline} (0 calls)
-0: student(id#0:wybe.int, major#0:student.course, ?$#0:student.student):
+0: student.student.student<0>
+student(id#0:wybe.int, major#0:student.course, ?$#0:student.student):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:student.student)
     foreign lpvm mutate(~%$rec#0:student.student, ?%$rec#1:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~id#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:student.student, ?%$#0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~major#0:student.course)
 student > public {inline} (6 calls)
-1: student(?id#0:wybe.int, ?major#0:student.course, $#0:student.student):
+1: student.student.student<1>
+student(?id#0:wybe.int, ?major#0:student.course, $#0:student.student):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?id#0:wybe.int)

--- a/test-cases/final-dump/alias_des.exp
+++ b/test-cases/final-dump/alias_des.exp
@@ -13,14 +13,16 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: alias_des.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     alias_des.foo<0>(~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @alias_des:nn:nn
 
 
 foo > public (1 calls)
-0: foo(io#0:wybe.phantom, ?io#3:wybe.phantom):
+0: alias_des.foo<0>
+foo(io#0:wybe.phantom, ?io#3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     alias_des.replicate<0>(?p2#0:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @alias_des:nn:nn
@@ -30,7 +32,8 @@ foo > public (1 calls)
 
 
 replicate > public (1 calls)
-0: replicate(?p2#1:position.position, io#0:wybe.phantom, ?io#4:wybe.phantom):
+0: alias_des.replicate<0>
+replicate(?p2#1:position.position, io#0:wybe.phantom, ?io#4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$8#0:position.position)
@@ -164,7 +167,8 @@ entry:
   procs           : 
 
 printPosition > public (0 calls)
-0: printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+0: position.printPosition<0>
+printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -247,7 +251,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position./=<0>
+/=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -267,7 +272,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position.=<0>
+=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
@@ -285,14 +291,16 @@ entry:
 
 
 position > public {inline} (0 calls)
-0: position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+0: position.position.position<0>
+position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
     foreign lpvm mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:position.position, ?%$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
 position > public {inline} (6 calls)
-1: position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+1: position.position.position<1>
+position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
@@ -300,24 +308,28 @@ position > public {inline} (6 calls)
 
 
 x > public {inline} (0 calls)
-0: x($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.x<0>
+x($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 x > public {inline} (0 calls)
-1: x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.x<1>
+x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 y > public {inline} (0 calls)
-0: y($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.y<0>
+y($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 y > public {inline} (0 calls)
-1: y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.y<1>
+y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)

--- a/test-cases/final-dump/alias_des2.exp
+++ b/test-cases/final-dump/alias_des2.exp
@@ -11,7 +11,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: alias_des2.<0>
+(io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$3#0:position.position)
@@ -85,7 +86,8 @@ entry:
   procs           : 
 
 printPosition > public (0 calls)
-0: printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+0: position.printPosition<0>
+printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -168,7 +170,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position./=<0>
+/=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -188,7 +191,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position.=<0>
+=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
@@ -206,14 +210,16 @@ entry:
 
 
 position > public {inline} (0 calls)
-0: position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+0: position.position.position<0>
+position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
     foreign lpvm mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:position.position, ?%$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
 position > public {inline} (6 calls)
-1: position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+1: position.position.position<1>
+position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
@@ -221,24 +227,28 @@ position > public {inline} (6 calls)
 
 
 x > public {inline} (0 calls)
-0: x($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.x<0>
+x($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 x > public {inline} (0 calls)
-1: x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.x<1>
+x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 y > public {inline} (0 calls)
-0: y($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.y<0>
+y($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 y > public {inline} (0 calls)
-1: y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.y<1>
+y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)

--- a/test-cases/final-dump/alias_fork1.exp
+++ b/test-cases/final-dump/alias_fork1.exp
@@ -12,7 +12,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: alias_fork1.<0>
+(io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(24:wybe.int, ?tmp$10#0:mytree.tree)
@@ -30,14 +31,16 @@ AFTER EVERYTHING:
 
 
 gen$1 > {inline} (2 calls)
-0: gen$1([k1#0:wybe.int], [k2#0:wybe.int], [l1#0:mytree.tree], [l2#0:mytree.tree], [r1#0:mytree.tree], [r2#0:mytree.tree], [tl#0:mytree.tree], tmp$2#0:mytree.tree, [tr#0:mytree.tree], ?$#0:mytree.tree):
+0: alias_fork1.gen$1<0>
+gen$1([k1#0:wybe.int], [k2#0:wybe.int], [l1#0:mytree.tree], [l2#0:mytree.tree], [r1#0:mytree.tree], [r2#0:mytree.tree], [tl#0:mytree.tree], tmp$2#0:mytree.tree, [tr#0:mytree.tree], ?$#0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(~tmp$2#0:mytree.tree, ?$#0:mytree.tree) @alias_fork1:5:5
 
 
 simpleMerge > public (1 calls)
-0: simpleMerge(tl#0:mytree.tree, tr#0:mytree.tree, ?$#0:mytree.tree):
+0: alias_fork1.simpleMerge<0>
+simpleMerge(tl#0:mytree.tree, tr#0:mytree.tree, ?$#0:mytree.tree):
  AliasPairs: [($#0,tl#0),($#0,tr#0),(tl#0,tr#0)]
  InterestingCallProperties: []
     foreign llvm icmp_ne(tl#0:mytree.tree, 0:wybe.int, ?tmp$15#0:wybe.bool)
@@ -270,7 +273,8 @@ if.else2:
   procs           : 
 
 printTree > public {inline} (0 calls)
-0: printTree(t#0:mytree.tree, io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: mytree.printTree<0>
+printTree(t#0:mytree.tree, io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     mytree.printTree1<0>(~t#0:mytree.tree, "{":wybe.string, ?%prefix#1:wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @mytree:nn:nn
@@ -278,7 +282,8 @@ printTree > public {inline} (0 calls)
 
 
 printTree1 > public (3 calls)
-0: printTree1(t#0:mytree.tree, prefix#0:wybe.string, ?prefix#3:wybe.string, io#0:wybe.phantom, ?io#4:wybe.phantom):
+0: mytree.printTree1<0>
+printTree1(t#0:mytree.tree, prefix#0:wybe.string, ?prefix#3:wybe.string, io#0:wybe.phantom, ?io#4:wybe.phantom):
  AliasPairs: [(prefix#0,prefix#3)]
  InterestingCallProperties: []
     foreign llvm icmp_ne(t#0:mytree.tree, 0:wybe.int, ?tmp$2#0:wybe.bool)
@@ -383,7 +388,8 @@ if.else:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:mytree.tree, $right#0:mytree.tree, ?$$#0:wybe.bool):
+0: mytree.tree./=<0>
+/=($left#0:mytree.tree, $right#0:mytree.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     mytree.tree.=<0>(~$left#0:mytree.tree, ~$right#0:mytree.tree, ?tmp$0#0:wybe.bool) #0
@@ -391,7 +397,8 @@ if.else:
 
 
 = > public (7 calls)
-0: =($left#0:mytree.tree, $right#0:mytree.tree, ?$$#0:wybe.bool):
+0: mytree.tree.=<0>
+=($left#0:mytree.tree, $right#0:mytree.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($left#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -432,14 +439,16 @@ if.else:
 
 
 empty > public {inline} (0 calls)
-0: empty(?$#0:mytree.tree):
+0: mytree.tree.empty<0>
+empty(?$#0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(0:mytree.tree, ?$#0:mytree.tree)
 
 
 key > public {inline} (0 calls)
-0: key($rec#0:mytree.tree, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: mytree.tree.key<0>
+key($rec#0:mytree.tree, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -453,7 +462,8 @@ key > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 key > public {inline} (0 calls)
-1: key($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: mytree.tree.key<1>
+key($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -469,7 +479,8 @@ key > public {inline} (0 calls)
 
 
 left > public {inline} (0 calls)
-0: left($rec#0:mytree.tree, ?$#0:mytree.tree, ?$$#0:wybe.bool):
+0: mytree.tree.left<0>
+left($rec#0:mytree.tree, ?$#0:mytree.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -483,7 +494,8 @@ left > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 left > public {inline} (0 calls)
-1: left($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:mytree.tree, ?$$#0:wybe.bool):
+1: mytree.tree.left<1>
+left($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:mytree.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -499,7 +511,8 @@ left > public {inline} (0 calls)
 
 
 node > public {inline} (0 calls)
-0: node(left#0:mytree.tree, key#0:wybe.int, right#0:mytree.tree, ?$#0:mytree.tree):
+0: mytree.tree.node<0>
+node(left#0:mytree.tree, key#0:wybe.int, right#0:mytree.tree, ?$#0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(24:wybe.int, ?$rec#0:mytree.tree)
@@ -507,7 +520,8 @@ node > public {inline} (0 calls)
     foreign lpvm mutate(~%$rec#1:mytree.tree, ?%$rec#2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key#0:wybe.int)
     foreign lpvm mutate(~%$rec#2:mytree.tree, ?%$#0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right#0:mytree.tree)
 node > public {inline} (16 calls)
-1: node(?left#0:mytree.tree, ?key#0:wybe.int, ?right#0:mytree.tree, $#0:mytree.tree, ?$$#0:wybe.bool):
+1: mytree.tree.node<1>
+node(?left#0:mytree.tree, ?key#0:wybe.int, ?right#0:mytree.tree, $#0:mytree.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -527,7 +541,8 @@ node > public {inline} (16 calls)
 
 
 right > public {inline} (0 calls)
-0: right($rec#0:mytree.tree, ?$#0:mytree.tree, ?$$#0:wybe.bool):
+0: mytree.tree.right<0>
+right($rec#0:mytree.tree, ?$#0:mytree.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -541,7 +556,8 @@ right > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 right > public {inline} (0 calls)
-1: right($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:mytree.tree, ?$$#0:wybe.bool):
+1: mytree.tree.right<1>
+right($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:mytree.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)

--- a/test-cases/final-dump/alias_fork2.exp
+++ b/test-cases/final-dump/alias_fork2.exp
@@ -12,7 +12,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#4:wybe.phantom):
+0: alias_fork2.<0>
+(io#0:wybe.phantom, ?io#4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(24:wybe.int, ?tmp$9#0:mytree.tree)
@@ -42,7 +43,8 @@ AFTER EVERYTHING:
 
 
 gen$1 > (2 calls)
-0: gen$1(io#0:wybe.phantom, t#0:mytree.tree, t1#0:mytree.tree, [tmp$0#0:mytree.tree], [tmp$1#0:mytree.tree], [tmp$2#0:mytree.tree], [tmp$3#0:mytree.tree], ?io#6:wybe.phantom):
+0: alias_fork2.gen$1<0>
+gen$1(io#0:wybe.phantom, t#0:mytree.tree, t1#0:mytree.tree, [tmp$0#0:mytree.tree], [tmp$1#0:mytree.tree], [tmp$2#0:mytree.tree], [tmp$3#0:mytree.tree], ?io#6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("expect t1 - 1000:":wybe.string, ~#io#0:wybe.phantom, ?tmp$7#0:wybe.phantom) @io:nn:nn
@@ -60,7 +62,8 @@ gen$1 > (2 calls)
 
 
 simpleMerge > public (3 calls)
-0: simpleMerge(tl#0:mytree.tree, ?$#0:mytree.tree):
+0: alias_fork2.simpleMerge<0>
+simpleMerge(tl#0:mytree.tree, ?$#0:mytree.tree):
  AliasPairs: [($#0,tl#0)]
  InterestingCallProperties: []
     foreign lpvm alloc(24:wybe.int, ?tmp$5#0:mytree.tree)
@@ -251,7 +254,8 @@ entry:
   procs           : 
 
 printTree > public {inline} (0 calls)
-0: printTree(t#0:mytree.tree, io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: mytree.printTree<0>
+printTree(t#0:mytree.tree, io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     mytree.printTree1<0>(~t#0:mytree.tree, "{":wybe.string, ?%prefix#1:wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @mytree:nn:nn
@@ -259,7 +263,8 @@ printTree > public {inline} (0 calls)
 
 
 printTree1 > public (3 calls)
-0: printTree1(t#0:mytree.tree, prefix#0:wybe.string, ?prefix#3:wybe.string, io#0:wybe.phantom, ?io#4:wybe.phantom):
+0: mytree.printTree1<0>
+printTree1(t#0:mytree.tree, prefix#0:wybe.string, ?prefix#3:wybe.string, io#0:wybe.phantom, ?io#4:wybe.phantom):
  AliasPairs: [(prefix#0,prefix#3)]
  InterestingCallProperties: []
     foreign llvm icmp_ne(t#0:mytree.tree, 0:wybe.int, ?tmp$2#0:wybe.bool)
@@ -364,7 +369,8 @@ if.else:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:mytree.tree, $right#0:mytree.tree, ?$$#0:wybe.bool):
+0: mytree.tree./=<0>
+/=($left#0:mytree.tree, $right#0:mytree.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     mytree.tree.=<0>(~$left#0:mytree.tree, ~$right#0:mytree.tree, ?tmp$0#0:wybe.bool) #0
@@ -372,7 +378,8 @@ if.else:
 
 
 = > public (7 calls)
-0: =($left#0:mytree.tree, $right#0:mytree.tree, ?$$#0:wybe.bool):
+0: mytree.tree.=<0>
+=($left#0:mytree.tree, $right#0:mytree.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($left#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -413,14 +420,16 @@ if.else:
 
 
 empty > public {inline} (0 calls)
-0: empty(?$#0:mytree.tree):
+0: mytree.tree.empty<0>
+empty(?$#0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(0:mytree.tree, ?$#0:mytree.tree)
 
 
 key > public {inline} (0 calls)
-0: key($rec#0:mytree.tree, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: mytree.tree.key<0>
+key($rec#0:mytree.tree, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -434,7 +443,8 @@ key > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 key > public {inline} (0 calls)
-1: key($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: mytree.tree.key<1>
+key($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -450,7 +460,8 @@ key > public {inline} (0 calls)
 
 
 left > public {inline} (0 calls)
-0: left($rec#0:mytree.tree, ?$#0:mytree.tree, ?$$#0:wybe.bool):
+0: mytree.tree.left<0>
+left($rec#0:mytree.tree, ?$#0:mytree.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -464,7 +475,8 @@ left > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 left > public {inline} (0 calls)
-1: left($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:mytree.tree, ?$$#0:wybe.bool):
+1: mytree.tree.left<1>
+left($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:mytree.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -480,7 +492,8 @@ left > public {inline} (0 calls)
 
 
 node > public {inline} (0 calls)
-0: node(left#0:mytree.tree, key#0:wybe.int, right#0:mytree.tree, ?$#0:mytree.tree):
+0: mytree.tree.node<0>
+node(left#0:mytree.tree, key#0:wybe.int, right#0:mytree.tree, ?$#0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(24:wybe.int, ?$rec#0:mytree.tree)
@@ -488,7 +501,8 @@ node > public {inline} (0 calls)
     foreign lpvm mutate(~%$rec#1:mytree.tree, ?%$rec#2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key#0:wybe.int)
     foreign lpvm mutate(~%$rec#2:mytree.tree, ?%$#0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right#0:mytree.tree)
 node > public {inline} (16 calls)
-1: node(?left#0:mytree.tree, ?key#0:wybe.int, ?right#0:mytree.tree, $#0:mytree.tree, ?$$#0:wybe.bool):
+1: mytree.tree.node<1>
+node(?left#0:mytree.tree, ?key#0:wybe.int, ?right#0:mytree.tree, $#0:mytree.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -508,7 +522,8 @@ node > public {inline} (16 calls)
 
 
 right > public {inline} (0 calls)
-0: right($rec#0:mytree.tree, ?$#0:mytree.tree, ?$$#0:wybe.bool):
+0: mytree.tree.right<0>
+right($rec#0:mytree.tree, ?$#0:mytree.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -522,7 +537,8 @@ right > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 right > public {inline} (0 calls)
-1: right($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:mytree.tree, ?$$#0:wybe.bool):
+1: mytree.tree.right<1>
+right($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:mytree.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)

--- a/test-cases/final-dump/alias_fork3.exp
+++ b/test-cases/final-dump/alias_fork3.exp
@@ -12,7 +12,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#3:wybe.phantom):
+0: alias_fork3.<0>
+(io#0:wybe.phantom, ?io#3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(24:wybe.int, ?tmp$9#0:mytree.tree)
@@ -33,7 +34,8 @@ AFTER EVERYTHING:
 
 
 simpleSlice > public (1 calls)
-0: simpleSlice(tr#0:mytree.tree, ?$#0:mytree.tree):
+0: alias_fork3.simpleSlice<0>
+simpleSlice(tr#0:mytree.tree, ?$#0:mytree.tree):
  AliasPairs: [($#0,tr#0)]
  InterestingCallProperties: []
     foreign llvm icmp_ne(tr#0:mytree.tree, 0:wybe.int, ?tmp$7#0:wybe.bool)
@@ -179,7 +181,8 @@ if.else:
   procs           : 
 
 printTree > public {inline} (0 calls)
-0: printTree(t#0:mytree.tree, io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: mytree.printTree<0>
+printTree(t#0:mytree.tree, io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     mytree.printTree1<0>(~t#0:mytree.tree, "{":wybe.string, ?%prefix#1:wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @mytree:nn:nn
@@ -187,7 +190,8 @@ printTree > public {inline} (0 calls)
 
 
 printTree1 > public (3 calls)
-0: printTree1(t#0:mytree.tree, prefix#0:wybe.string, ?prefix#3:wybe.string, io#0:wybe.phantom, ?io#4:wybe.phantom):
+0: mytree.printTree1<0>
+printTree1(t#0:mytree.tree, prefix#0:wybe.string, ?prefix#3:wybe.string, io#0:wybe.phantom, ?io#4:wybe.phantom):
  AliasPairs: [(prefix#0,prefix#3)]
  InterestingCallProperties: []
     foreign llvm icmp_ne(t#0:mytree.tree, 0:wybe.int, ?tmp$2#0:wybe.bool)
@@ -292,7 +296,8 @@ if.else:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:mytree.tree, $right#0:mytree.tree, ?$$#0:wybe.bool):
+0: mytree.tree./=<0>
+/=($left#0:mytree.tree, $right#0:mytree.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     mytree.tree.=<0>(~$left#0:mytree.tree, ~$right#0:mytree.tree, ?tmp$0#0:wybe.bool) #0
@@ -300,7 +305,8 @@ if.else:
 
 
 = > public (7 calls)
-0: =($left#0:mytree.tree, $right#0:mytree.tree, ?$$#0:wybe.bool):
+0: mytree.tree.=<0>
+=($left#0:mytree.tree, $right#0:mytree.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($left#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -341,14 +347,16 @@ if.else:
 
 
 empty > public {inline} (0 calls)
-0: empty(?$#0:mytree.tree):
+0: mytree.tree.empty<0>
+empty(?$#0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(0:mytree.tree, ?$#0:mytree.tree)
 
 
 key > public {inline} (0 calls)
-0: key($rec#0:mytree.tree, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: mytree.tree.key<0>
+key($rec#0:mytree.tree, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -362,7 +370,8 @@ key > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 key > public {inline} (0 calls)
-1: key($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: mytree.tree.key<1>
+key($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -378,7 +387,8 @@ key > public {inline} (0 calls)
 
 
 left > public {inline} (0 calls)
-0: left($rec#0:mytree.tree, ?$#0:mytree.tree, ?$$#0:wybe.bool):
+0: mytree.tree.left<0>
+left($rec#0:mytree.tree, ?$#0:mytree.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -392,7 +402,8 @@ left > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 left > public {inline} (0 calls)
-1: left($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:mytree.tree, ?$$#0:wybe.bool):
+1: mytree.tree.left<1>
+left($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:mytree.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -408,7 +419,8 @@ left > public {inline} (0 calls)
 
 
 node > public {inline} (0 calls)
-0: node(left#0:mytree.tree, key#0:wybe.int, right#0:mytree.tree, ?$#0:mytree.tree):
+0: mytree.tree.node<0>
+node(left#0:mytree.tree, key#0:wybe.int, right#0:mytree.tree, ?$#0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(24:wybe.int, ?$rec#0:mytree.tree)
@@ -416,7 +428,8 @@ node > public {inline} (0 calls)
     foreign lpvm mutate(~%$rec#1:mytree.tree, ?%$rec#2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key#0:wybe.int)
     foreign lpvm mutate(~%$rec#2:mytree.tree, ?%$#0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right#0:mytree.tree)
 node > public {inline} (16 calls)
-1: node(?left#0:mytree.tree, ?key#0:wybe.int, ?right#0:mytree.tree, $#0:mytree.tree, ?$$#0:wybe.bool):
+1: mytree.tree.node<1>
+node(?left#0:mytree.tree, ?key#0:wybe.int, ?right#0:mytree.tree, $#0:mytree.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -436,7 +449,8 @@ node > public {inline} (16 calls)
 
 
 right > public {inline} (0 calls)
-0: right($rec#0:mytree.tree, ?$#0:mytree.tree, ?$$#0:wybe.bool):
+0: mytree.tree.right<0>
+right($rec#0:mytree.tree, ?$#0:mytree.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -450,7 +464,8 @@ right > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 right > public {inline} (0 calls)
-1: right($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:mytree.tree, ?$$#0:wybe.bool):
+1: mytree.tree.right<1>
+right($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:mytree.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)

--- a/test-cases/final-dump/alias_m.exp
+++ b/test-cases/final-dump/alias_m.exp
@@ -12,7 +12,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#7:wybe.phantom):
+0: alias_m.<0>
+(io#0:wybe.phantom, ?io#7:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$3#0:position.position)
@@ -97,7 +98,8 @@ entry:
   procs           : 
 
 bar > public (0 calls)
-0: bar(p1#0:position.position, ?p3#1:position.position, io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: alias_mbar.bar<0>[410bae77d3]
+bar(p1#0:position.position, ?p3#1:position.position, io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: [(p1#0,p3#1)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(6,(alias_mfoo.foo<0>,fromList [NonAliasedParamCond 0 []]))]
@@ -208,7 +210,8 @@ if.else:
   procs           : 
 
 foo > public (0 calls)
-0: foo(p1#0:position.position, ?p2#0:position.position, ?p3#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: alias_mfoo.foo<0>[410bae77d3]
+foo(p1#0:position.position, ?p2#0:position.position, ?p3#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: [(p1#0,p2#0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(9,(alias_mbar.bar<0>,fromList [NonAliasedParamCond 0 []]))]
@@ -401,7 +404,8 @@ if.else:
   procs           : 
 
 printPosition > public (0 calls)
-0: printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+0: position.printPosition<0>
+printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -484,7 +488,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position./=<0>
+/=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -504,7 +509,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position.=<0>
+=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
@@ -522,14 +528,16 @@ entry:
 
 
 position > public {inline} (0 calls)
-0: position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+0: position.position.position<0>
+position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
     foreign lpvm mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:position.position, ?%$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
 position > public {inline} (6 calls)
-1: position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+1: position.position.position<1>
+position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
@@ -537,24 +545,28 @@ position > public {inline} (6 calls)
 
 
 x > public {inline} (0 calls)
-0: x($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.x<0>
+x($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 x > public {inline} (0 calls)
-1: x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.x<1>
+x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 y > public {inline} (0 calls)
-0: y($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.y<0>
+y($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 y > public {inline} (0 calls)
-1: y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.y<1>
+y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)

--- a/test-cases/final-dump/alias_mbar.exp
+++ b/test-cases/final-dump/alias_mbar.exp
@@ -12,7 +12,8 @@ AFTER EVERYTHING:
   procs           : 
 
 bar > public (0 calls)
-0: bar(p1#0:position.position, ?p3#1:position.position, io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: alias_mbar.bar<0>[410bae77d3]
+bar(p1#0:position.position, ?p3#1:position.position, io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: [(p1#0,p3#1)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(6,(alias_mfoo.foo<0>,fromList [NonAliasedParamCond 0 []]))]
@@ -123,7 +124,8 @@ if.else:
   procs           : 
 
 foo > public (0 calls)
-0: foo(p1#0:position.position, ?p2#0:position.position, ?p3#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: alias_mfoo.foo<0>[410bae77d3]
+foo(p1#0:position.position, ?p2#0:position.position, ?p3#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: [(p1#0,p2#0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(9,(alias_mbar.bar<0>,fromList [NonAliasedParamCond 0 []]))]
@@ -316,7 +318,8 @@ if.else:
   procs           : 
 
 printPosition > public (0 calls)
-0: printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+0: position.printPosition<0>
+printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -399,7 +402,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position./=<0>
+/=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -419,7 +423,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position.=<0>
+=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
@@ -437,14 +442,16 @@ entry:
 
 
 position > public {inline} (0 calls)
-0: position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+0: position.position.position<0>
+position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
     foreign lpvm mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:position.position, ?%$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
 position > public {inline} (6 calls)
-1: position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+1: position.position.position<1>
+position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
@@ -452,24 +459,28 @@ position > public {inline} (6 calls)
 
 
 x > public {inline} (0 calls)
-0: x($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.x<0>
+x($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 x > public {inline} (0 calls)
-1: x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.x<1>
+x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 y > public {inline} (0 calls)
-0: y($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.y<0>
+y($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 y > public {inline} (0 calls)
-1: y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.y<1>
+y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)

--- a/test-cases/final-dump/alias_mfoo.exp
+++ b/test-cases/final-dump/alias_mfoo.exp
@@ -12,7 +12,8 @@ AFTER EVERYTHING:
   procs           : 
 
 bar > public (0 calls)
-0: bar(p1#0:position.position, ?p3#1:position.position, io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: alias_mbar.bar<0>[410bae77d3]
+bar(p1#0:position.position, ?p3#1:position.position, io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: [(p1#0,p3#1)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(6,(alias_mfoo.foo<0>,fromList [NonAliasedParamCond 0 []]))]
@@ -123,7 +124,8 @@ if.else:
   procs           : 
 
 foo > public (0 calls)
-0: foo(p1#0:position.position, ?p2#0:position.position, ?p3#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: alias_mfoo.foo<0>[410bae77d3]
+foo(p1#0:position.position, ?p2#0:position.position, ?p3#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: [(p1#0,p2#0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(9,(alias_mbar.bar<0>,fromList [NonAliasedParamCond 0 []]))]
@@ -316,7 +318,8 @@ if.else:
   procs           : 
 
 printPosition > public (0 calls)
-0: printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+0: position.printPosition<0>
+printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -399,7 +402,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position./=<0>
+/=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -419,7 +423,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position.=<0>
+=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
@@ -437,14 +442,16 @@ entry:
 
 
 position > public {inline} (0 calls)
-0: position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+0: position.position.position<0>
+position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
     foreign lpvm mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:position.position, ?%$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
 position > public {inline} (6 calls)
-1: position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+1: position.position.position<1>
+position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
@@ -452,24 +459,28 @@ position > public {inline} (6 calls)
 
 
 x > public {inline} (0 calls)
-0: x($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.x<0>
+x($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 x > public {inline} (0 calls)
-1: x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.x<1>
+x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 y > public {inline} (0 calls)
-0: y($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.y<0>
+y($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 y > public {inline} (0 calls)
-1: y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.y<1>
+y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)

--- a/test-cases/final-dump/alias_mod_param.exp
+++ b/test-cases/final-dump/alias_mod_param.exp
@@ -12,7 +12,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#3:wybe.phantom):
+0: alias_mod_param.<0>
+(io#0:wybe.phantom, ?io#3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$3#0:position.position)
@@ -24,7 +25,8 @@ AFTER EVERYTHING:
 
 
 foo > public (1 calls)
-0: foo(pa#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: alias_mod_param.foo<0>
+foo(pa#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
     foreign lpvm {noalias} mutate(~%pa#0:position.position, ?%pa#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 1111:wybe.int)
@@ -115,7 +117,8 @@ entry:
   procs           : 
 
 printPosition > public (0 calls)
-0: printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+0: position.printPosition<0>
+printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -198,7 +201,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position./=<0>
+/=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -218,7 +222,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position.=<0>
+=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
@@ -236,14 +241,16 @@ entry:
 
 
 position > public {inline} (0 calls)
-0: position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+0: position.position.position<0>
+position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
     foreign lpvm mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:position.position, ?%$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
 position > public {inline} (6 calls)
-1: position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+1: position.position.position<1>
+position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
@@ -251,24 +258,28 @@ position > public {inline} (6 calls)
 
 
 x > public {inline} (0 calls)
-0: x($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.x<0>
+x($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 x > public {inline} (0 calls)
-1: x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.x<1>
+x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 y > public {inline} (0 calls)
-0: y($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.y<0>
+y($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 y > public {inline} (0 calls)
-1: y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.y<1>
+y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)

--- a/test-cases/final-dump/alias_multifunc.exp
+++ b/test-cases/final-dump/alias_multifunc.exp
@@ -14,14 +14,16 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: alias_multifunc.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     alias_multifunc.bar<0>(~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @alias_multifunc:nn:nn
 
 
 bar > public (1 calls)
-0: bar(io#0:wybe.phantom, ?io#15:wybe.phantom):
+0: alias_multifunc.bar<0>
+bar(io#0:wybe.phantom, ?io#15:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$3#0:position.position)
@@ -48,7 +50,8 @@ bar > public (1 calls)
 
 
 replicate1 > public (1 calls)
-0: replicate1(p1#0:position.position, ?p2#0:position.position, ?p3#0:position.position, io#0:wybe.phantom, ?io#3:wybe.phantom):
+0: alias_multifunc.replicate1<0>
+replicate1(p1#0:position.position, ?p2#0:position.position, ?p3#0:position.position, io#0:wybe.phantom, ?io#3:wybe.phantom):
  AliasPairs: [(p1#0,p2#0),(p1#0,p3#0),(p2#0,p3#0)]
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$4#0:position.position)
@@ -63,7 +66,8 @@ replicate1 > public (1 calls)
 
 
 replicate2 > public (1 calls)
-0: replicate2(p1#0:position.position, ?p2#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: alias_multifunc.replicate2<0>
+replicate2(p1#0:position.position, ?p2#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: [(p1#0,p2#0)]
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$4#0:position.position)
@@ -259,7 +263,8 @@ entry:
   procs           : 
 
 printPosition > public (0 calls)
-0: printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+0: position.printPosition<0>
+printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -342,7 +347,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position./=<0>
+/=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -362,7 +368,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position.=<0>
+=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
@@ -380,14 +387,16 @@ entry:
 
 
 position > public {inline} (0 calls)
-0: position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+0: position.position.position<0>
+position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
     foreign lpvm mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:position.position, ?%$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
 position > public {inline} (6 calls)
-1: position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+1: position.position.position<1>
+position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
@@ -395,24 +404,28 @@ position > public {inline} (6 calls)
 
 
 x > public {inline} (0 calls)
-0: x($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.x<0>
+x($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 x > public {inline} (0 calls)
-1: x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.x<1>
+x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 y > public {inline} (0 calls)
-0: y($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.y<0>
+y($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 y > public {inline} (0 calls)
-1: y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.y<1>
+y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)

--- a/test-cases/final-dump/alias_multifunc1.exp
+++ b/test-cases/final-dump/alias_multifunc1.exp
@@ -13,7 +13,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#16:wybe.phantom):
+0: alias_multifunc1.<0>
+(io#0:wybe.phantom, ?io#16:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$3#0:position.position)
@@ -43,7 +44,8 @@ AFTER EVERYTHING:
 
 
 replicate1 > public (1 calls)
-0: replicate1(p1#0:position.position, ?p2#1:position.position, ?p3#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: alias_multifunc1.replicate1<0>
+replicate1(p1#0:position.position, ?p2#1:position.position, ?p3#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: [(p1#0,p3#0)]
  InterestingCallProperties: []
     alias_multifunc1.replicate2<0>(~p1#0:position.position, ?p2#0:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @alias_multifunc1:13:6
@@ -52,7 +54,8 @@ replicate1 > public (1 calls)
 
 
 replicate2 > public (2 calls)
-0: replicate2(p1#0:position.position, ?p2#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: alias_multifunc1.replicate2<0>
+replicate2(p1#0:position.position, ?p2#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: [(p1#0,p2#0)]
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$4#0:position.position)
@@ -241,7 +244,8 @@ entry:
   procs           : 
 
 printPosition > public (0 calls)
-0: printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+0: position.printPosition<0>
+printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -324,7 +328,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position./=<0>
+/=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -344,7 +349,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position.=<0>
+=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
@@ -362,14 +368,16 @@ entry:
 
 
 position > public {inline} (0 calls)
-0: position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+0: position.position.position<0>
+position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
     foreign lpvm mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:position.position, ?%$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
 position > public {inline} (6 calls)
-1: position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+1: position.position.position<1>
+position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
@@ -377,24 +385,28 @@ position > public {inline} (6 calls)
 
 
 x > public {inline} (0 calls)
-0: x($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.x<0>
+x($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 x > public {inline} (0 calls)
-1: x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.x<1>
+x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 y > public {inline} (0 calls)
-0: y($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.y<0>
+y($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 y > public {inline} (0 calls)
-1: y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.y<1>
+y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)

--- a/test-cases/final-dump/alias_multifunc2.exp
+++ b/test-cases/final-dump/alias_multifunc2.exp
@@ -13,7 +13,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#15:wybe.phantom):
+0: alias_multifunc2.<0>
+(io#0:wybe.phantom, ?io#15:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$3#0:position.position)
@@ -40,7 +41,8 @@ AFTER EVERYTHING:
 
 
 replicate1 > public (1 calls)
-0: replicate1(p1#0:position.position, ?p2#1:position.position, ?p3#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: alias_multifunc2.replicate1<0>
+replicate1(p1#0:position.position, ?p2#1:position.position, ?p3#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: [(p1#0,p3#0)]
  InterestingCallProperties: []
     alias_multifunc2.replicate2<0>(~p1#0:position.position, ?p2#0:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @alias_multifunc2:14:6
@@ -49,7 +51,8 @@ replicate1 > public (1 calls)
 
 
 replicate2 > public (2 calls)
-0: replicate2(p1#0:position.position, ?p2#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: alias_multifunc2.replicate2<0>
+replicate2(p1#0:position.position, ?p2#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: [(p1#0,p2#0)]
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$4#0:position.position)
@@ -229,7 +232,8 @@ entry:
   procs           : 
 
 printPosition > public (0 calls)
-0: printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+0: position.printPosition<0>
+printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -312,7 +316,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position./=<0>
+/=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -332,7 +337,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position.=<0>
+=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
@@ -350,14 +356,16 @@ entry:
 
 
 position > public {inline} (0 calls)
-0: position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+0: position.position.position<0>
+position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
     foreign lpvm mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:position.position, ?%$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
 position > public {inline} (6 calls)
-1: position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+1: position.position.position<1>
+position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
@@ -365,24 +373,28 @@ position > public {inline} (6 calls)
 
 
 x > public {inline} (0 calls)
-0: x($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.x<0>
+x($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 x > public {inline} (0 calls)
-1: x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.x<1>
+x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 y > public {inline} (0 calls)
-0: y($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.y<0>
+y($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 y > public {inline} (0 calls)
-1: y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.y<1>
+y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)

--- a/test-cases/final-dump/alias_multifunc3.exp
+++ b/test-cases/final-dump/alias_multifunc3.exp
@@ -12,7 +12,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#11:wybe.phantom):
+0: alias_multifunc3.<0>
+(io#0:wybe.phantom, ?io#11:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$3#0:position.position)
@@ -35,7 +36,8 @@ AFTER EVERYTHING:
 
 
 replicate1 > public (1 calls)
-0: replicate1(pa#0:position.position, ?pb#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+0: alias_multifunc3.replicate1<0>
+replicate1(pa#0:position.position, ?pb#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
  AliasPairs: [(pa#0,pb#0)]
  InterestingCallProperties: []
     foreign llvm move(pa#0:position.position, ?pb#0:position.position) @alias_multifunc3:6:5
@@ -186,7 +188,8 @@ entry:
   procs           : 
 
 printPosition > public (0 calls)
-0: printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+0: position.printPosition<0>
+printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -269,7 +272,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position./=<0>
+/=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -289,7 +293,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position.=<0>
+=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
@@ -307,14 +312,16 @@ entry:
 
 
 position > public {inline} (0 calls)
-0: position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+0: position.position.position<0>
+position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
     foreign lpvm mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:position.position, ?%$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
 position > public {inline} (6 calls)
-1: position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+1: position.position.position<1>
+position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
@@ -322,24 +329,28 @@ position > public {inline} (6 calls)
 
 
 x > public {inline} (0 calls)
-0: x($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.x<0>
+x($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 x > public {inline} (0 calls)
-1: x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.x<1>
+x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 y > public {inline} (0 calls)
-0: y($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.y<0>
+y($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 y > public {inline} (0 calls)
-1: y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.y<1>
+y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)

--- a/test-cases/final-dump/alias_multifunc4.exp
+++ b/test-cases/final-dump/alias_multifunc4.exp
@@ -14,7 +14,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#18:wybe.phantom):
+0: alias_multifunc4.<0>
+(io#0:wybe.phantom, ?io#18:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$3#0:position.position)
@@ -44,7 +45,8 @@ AFTER EVERYTHING:
 
 
 replicate1 > public (1 calls)
-0: replicate1(pa#0:position.position, ?pb#1:position.position, ?pc#0:position.position, io#0:wybe.phantom, [?io#0:wybe.phantom]):
+0: alias_multifunc4.replicate1<0>
+replicate1(pa#0:position.position, ?pb#1:position.position, ?pc#0:position.position, io#0:wybe.phantom, [?io#0:wybe.phantom]):
  AliasPairs: [(pa#0,pc#0)]
  InterestingCallProperties: []
     foreign llvm move(pa#0:position.position, ?pc#0:position.position) @alias_multifunc4:8:5
@@ -56,7 +58,8 @@ replicate1 > public (1 calls)
 
 
 replicate21 > public (1 calls)
-0: replicate21(?pb#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: alias_multifunc4.replicate21<0>
+replicate21(?pb#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$3#0:position.position)
@@ -69,7 +72,8 @@ replicate21 > public (1 calls)
 
 
 replicate22 > public (1 calls)
-0: replicate22(?pb#0:position.position, ?pc#1:position.position, io#0:wybe.phantom, ?io#4:wybe.phantom):
+0: alias_multifunc4.replicate22<0>
+replicate22(?pb#0:position.position, ?pc#1:position.position, io#0:wybe.phantom, ?io#4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$3#0:position.position)
@@ -304,7 +308,8 @@ entry:
   procs           : 
 
 printPosition > public (0 calls)
-0: printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+0: position.printPosition<0>
+printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -387,7 +392,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position./=<0>
+/=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -407,7 +413,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position.=<0>
+=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
@@ -425,14 +432,16 @@ entry:
 
 
 position > public {inline} (0 calls)
-0: position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+0: position.position.position<0>
+position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
     foreign lpvm mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:position.position, ?%$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
 position > public {inline} (6 calls)
-1: position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+1: position.position.position<1>
+position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
@@ -440,24 +449,28 @@ position > public {inline} (6 calls)
 
 
 x > public {inline} (0 calls)
-0: x($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.x<0>
+x($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 x > public {inline} (0 calls)
-1: x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.x<1>
+x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 y > public {inline} (0 calls)
-0: y($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.y<0>
+y($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 y > public {inline} (0 calls)
-1: y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.y<1>
+y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)

--- a/test-cases/final-dump/alias_recursion1.exp
+++ b/test-cases/final-dump/alias_recursion1.exp
@@ -12,7 +12,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#18:wybe.phantom):
+0: alias_recursion1.<0>
+(io#0:wybe.phantom, ?io#18:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$7#0:position.position)
@@ -48,7 +49,8 @@ AFTER EVERYTHING:
 
 
 if_test > public (2 calls)
-0: if_test(a#0:position.position, b#0:position.position, ?r#0:position.position):
+0: alias_recursion1.if_test<0>
+if_test(a#0:position.position, b#0:position.position, ?r#0:position.position):
  AliasPairs: [(a#0,b#0),(a#0,r#0),(b#0,r#0)]
  InterestingCallProperties: []
     foreign lpvm access(a#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
@@ -221,7 +223,8 @@ if.else:
   procs           : 
 
 printPosition > public (0 calls)
-0: printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+0: position.printPosition<0>
+printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -304,7 +307,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position./=<0>
+/=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -324,7 +328,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position.=<0>
+=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
@@ -342,14 +347,16 @@ entry:
 
 
 position > public {inline} (0 calls)
-0: position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+0: position.position.position<0>
+position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
     foreign lpvm mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:position.position, ?%$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
 position > public {inline} (6 calls)
-1: position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+1: position.position.position<1>
+position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
@@ -357,24 +364,28 @@ position > public {inline} (6 calls)
 
 
 x > public {inline} (0 calls)
-0: x($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.x<0>
+x($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 x > public {inline} (0 calls)
-1: x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.x<1>
+x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 y > public {inline} (0 calls)
-0: y($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.y<0>
+y($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 y > public {inline} (0 calls)
-1: y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.y<1>
+y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)

--- a/test-cases/final-dump/alias_scc_proc.exp
+++ b/test-cases/final-dump/alias_scc_proc.exp
@@ -13,7 +13,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#8:wybe.phantom):
+0: alias_scc_proc.<0>
+(io#0:wybe.phantom, ?io#8:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$3#0:position.position)
@@ -31,7 +32,8 @@ AFTER EVERYTHING:
 
 
 bar > public (1 calls)
-0: bar(p1#0:position.position, ?p3#1:position.position, io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: alias_scc_proc.bar<0>[410bae77d3]
+bar(p1#0:position.position, ?p3#1:position.position, io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: [(p1#0,p3#1)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(6,(alias_scc_proc.foo<0>,fromList [NonAliasedParamCond 0 []]))]
@@ -63,7 +65,8 @@ bar > public (1 calls)
 
 
 foo > public (2 calls)
-0: foo(p1#0:position.position, ?p2#0:position.position, ?p3#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: alias_scc_proc.foo<0>[410bae77d3]
+foo(p1#0:position.position, ?p2#0:position.position, ?p3#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: [(p1#0,p2#0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(9,(alias_scc_proc.bar<0>,fromList [NonAliasedParamCond 0 []]))]
@@ -352,7 +355,8 @@ if.else:
   procs           : 
 
 printPosition > public (0 calls)
-0: printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+0: position.printPosition<0>
+printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -435,7 +439,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position./=<0>
+/=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -455,7 +460,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position.=<0>
+=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
@@ -473,14 +479,16 @@ entry:
 
 
 position > public {inline} (0 calls)
-0: position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+0: position.position.position<0>
+position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
     foreign lpvm mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:position.position, ?%$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
 position > public {inline} (6 calls)
-1: position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+1: position.position.position<1>
+position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
@@ -488,24 +496,28 @@ position > public {inline} (6 calls)
 
 
 x > public {inline} (0 calls)
-0: x($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.x<0>
+x($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 x > public {inline} (0 calls)
-1: x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.x<1>
+x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 y > public {inline} (0 calls)
-0: y($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.y<0>
+y($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 y > public {inline} (0 calls)
-1: y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.y<1>
+y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)

--- a/test-cases/final-dump/alias_type1.exp
+++ b/test-cases/final-dump/alias_type1.exp
@@ -30,7 +30,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: alias_type1.<0>
+(io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$6#0:alias_type1.position)
@@ -130,7 +131,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:alias_type1.position, $right#0:alias_type1.position, ?$$#0:wybe.bool):
+0: alias_type1.position./=<0>
+/=($left#0:alias_type1.position, $right#0:alias_type1.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -150,7 +152,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:alias_type1.position, $right#0:alias_type1.position, ?$$#0:wybe.bool):
+0: alias_type1.position.=<0>
+=($left#0:alias_type1.position, $right#0:alias_type1.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
@@ -168,14 +171,16 @@ entry:
 
 
 position > public {inline} (0 calls)
-0: position(x#0:wybe.int, y#0:wybe.int, ?$#0:alias_type1.position):
+0: alias_type1.position.position<0>
+position(x#0:wybe.int, y#0:wybe.int, ?$#0:alias_type1.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:alias_type1.position)
     foreign lpvm mutate(~%$rec#0:alias_type1.position, ?%$rec#1:alias_type1.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:alias_type1.position, ?%$#0:alias_type1.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
 position > public {inline} (6 calls)
-1: position(?x#0:wybe.int, ?y#0:wybe.int, $#0:alias_type1.position):
+1: alias_type1.position.position<1>
+position(?x#0:wybe.int, ?y#0:wybe.int, $#0:alias_type1.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
@@ -183,24 +188,28 @@ position > public {inline} (6 calls)
 
 
 x > public {inline} (0 calls)
-0: x($rec#0:alias_type1.position, ?$#0:wybe.int):
+0: alias_type1.position.x<0>
+x($rec#0:alias_type1.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 x > public {inline} (0 calls)
-1: x($rec#0:alias_type1.position, ?$rec#1:alias_type1.position, $field#0:wybe.int):
+1: alias_type1.position.x<1>
+x($rec#0:alias_type1.position, ?$rec#1:alias_type1.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:alias_type1.position, ?%$rec#1:alias_type1.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 y > public {inline} (0 calls)
-0: y($rec#0:alias_type1.position, ?$#0:wybe.int):
+0: alias_type1.position.y<0>
+y($rec#0:alias_type1.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 y > public {inline} (0 calls)
-1: y($rec#0:alias_type1.position, ?$rec#1:alias_type1.position, $field#0:wybe.int):
+1: alias_type1.position.y<1>
+y($rec#0:alias_type1.position, ?$rec#1:alias_type1.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:alias_type1.position, ?%$rec#1:alias_type1.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
@@ -373,7 +382,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:alias_type1.posrec, $right#0:alias_type1.posrec, ?$$#0:wybe.bool):
+0: alias_type1.posrec./=<0>
+/=($left#0:alias_type1.posrec, $right#0:alias_type1.posrec, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -405,7 +415,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:alias_type1.posrec, $right#0:alias_type1.posrec, ?$$#0:wybe.bool):
+0: alias_type1.posrec.=<0>
+=($left#0:alias_type1.posrec, $right#0:alias_type1.posrec, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$a#0:wybe.int)
@@ -434,38 +445,44 @@ entry:
 
 
 a > public {inline} (0 calls)
-0: a($rec#0:alias_type1.posrec, ?$#0:wybe.int):
+0: alias_type1.posrec.a<0>
+a($rec#0:alias_type1.posrec, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 a > public {inline} (0 calls)
-1: a($rec#0:alias_type1.posrec, ?$rec#1:alias_type1.posrec, $field#0:wybe.int):
+1: alias_type1.posrec.a<1>
+a($rec#0:alias_type1.posrec, ?$rec#1:alias_type1.posrec, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm mutate(~%$rec#0:alias_type1.posrec, ?%$rec#1:alias_type1.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 p > public {inline} (0 calls)
-0: p($rec#0:alias_type1.posrec, ?$#0:alias_type1.position):
+0: alias_type1.posrec.p<0>
+p($rec#0:alias_type1.posrec, ?$#0:alias_type1.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:alias_type1.position)
 p > public {inline} (0 calls)
-1: p($rec#0:alias_type1.posrec, ?$rec#1:alias_type1.posrec, $field#0:alias_type1.position):
+1: alias_type1.posrec.p<1>
+p($rec#0:alias_type1.posrec, ?$rec#1:alias_type1.posrec, $field#0:alias_type1.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:alias_type1.posrec, ?%$rec#1:alias_type1.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:alias_type1.position)
 
 
 posrec > public {inline} (0 calls)
-0: posrec(a#0:wybe.int, p#0:alias_type1.position, ?$#0:alias_type1.posrec):
+0: alias_type1.posrec.posrec<0>
+posrec(a#0:wybe.int, p#0:alias_type1.position, ?$#0:alias_type1.posrec):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:alias_type1.posrec)
     foreign lpvm mutate(~%$rec#0:alias_type1.posrec, ?%$rec#1:alias_type1.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:alias_type1.posrec, ?%$#0:alias_type1.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p#0:alias_type1.position)
 posrec > public {inline} (6 calls)
-1: posrec(?a#0:wybe.int, ?p#0:alias_type1.position, $#0:alias_type1.posrec):
+1: alias_type1.posrec.posrec<1>
+posrec(?a#0:wybe.int, ?p#0:alias_type1.position, $#0:alias_type1.posrec):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?a#0:wybe.int)

--- a/test-cases/final-dump/alias_type2.exp
+++ b/test-cases/final-dump/alias_type2.exp
@@ -30,7 +30,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: alias_type2.<0>
+(io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$7#0:alias_type2.position)
@@ -146,7 +147,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:alias_type2.position, $right#0:alias_type2.position, ?$$#0:wybe.bool):
+0: alias_type2.position./=<0>
+/=($left#0:alias_type2.position, $right#0:alias_type2.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -166,7 +168,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:alias_type2.position, $right#0:alias_type2.position, ?$$#0:wybe.bool):
+0: alias_type2.position.=<0>
+=($left#0:alias_type2.position, $right#0:alias_type2.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
@@ -184,14 +187,16 @@ entry:
 
 
 position > public {inline} (0 calls)
-0: position(x#0:wybe.int, y#0:wybe.int, ?$#0:alias_type2.position):
+0: alias_type2.position.position<0>
+position(x#0:wybe.int, y#0:wybe.int, ?$#0:alias_type2.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:alias_type2.position)
     foreign lpvm mutate(~%$rec#0:alias_type2.position, ?%$rec#1:alias_type2.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:alias_type2.position, ?%$#0:alias_type2.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
 position > public {inline} (6 calls)
-1: position(?x#0:wybe.int, ?y#0:wybe.int, $#0:alias_type2.position):
+1: alias_type2.position.position<1>
+position(?x#0:wybe.int, ?y#0:wybe.int, $#0:alias_type2.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
@@ -199,24 +204,28 @@ position > public {inline} (6 calls)
 
 
 x > public {inline} (0 calls)
-0: x($rec#0:alias_type2.position, ?$#0:wybe.int):
+0: alias_type2.position.x<0>
+x($rec#0:alias_type2.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 x > public {inline} (0 calls)
-1: x($rec#0:alias_type2.position, ?$rec#1:alias_type2.position, $field#0:wybe.int):
+1: alias_type2.position.x<1>
+x($rec#0:alias_type2.position, ?$rec#1:alias_type2.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:alias_type2.position, ?%$rec#1:alias_type2.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 y > public {inline} (0 calls)
-0: y($rec#0:alias_type2.position, ?$#0:wybe.int):
+0: alias_type2.position.y<0>
+y($rec#0:alias_type2.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 y > public {inline} (0 calls)
-1: y($rec#0:alias_type2.position, ?$rec#1:alias_type2.position, $field#0:wybe.int):
+1: alias_type2.position.y<1>
+y($rec#0:alias_type2.position, ?$rec#1:alias_type2.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:alias_type2.position, ?%$rec#1:alias_type2.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
@@ -389,7 +398,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:alias_type2.posrec, $right#0:alias_type2.posrec, ?$$#0:wybe.bool):
+0: alias_type2.posrec./=<0>
+/=($left#0:alias_type2.posrec, $right#0:alias_type2.posrec, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:alias_type2.position)
@@ -421,7 +431,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:alias_type2.posrec, $right#0:alias_type2.posrec, ?$$#0:wybe.bool):
+0: alias_type2.posrec.=<0>
+=($left#0:alias_type2.posrec, $right#0:alias_type2.posrec, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$p#0:alias_type2.position)
@@ -450,38 +461,44 @@ entry:
 
 
 a > public {inline} (0 calls)
-0: a($rec#0:alias_type2.posrec, ?$#0:wybe.int):
+0: alias_type2.posrec.a<0>
+a($rec#0:alias_type2.posrec, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 a > public {inline} (0 calls)
-1: a($rec#0:alias_type2.posrec, ?$rec#1:alias_type2.posrec, $field#0:wybe.int):
+1: alias_type2.posrec.a<1>
+a($rec#0:alias_type2.posrec, ?$rec#1:alias_type2.posrec, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm mutate(~%$rec#0:alias_type2.posrec, ?%$rec#1:alias_type2.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 p > public {inline} (0 calls)
-0: p($rec#0:alias_type2.posrec, ?$#0:alias_type2.position):
+0: alias_type2.posrec.p<0>
+p($rec#0:alias_type2.posrec, ?$#0:alias_type2.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:alias_type2.position)
 p > public {inline} (0 calls)
-1: p($rec#0:alias_type2.posrec, ?$rec#1:alias_type2.posrec, $field#0:alias_type2.position):
+1: alias_type2.posrec.p<1>
+p($rec#0:alias_type2.posrec, ?$rec#1:alias_type2.posrec, $field#0:alias_type2.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:alias_type2.posrec, ?%$rec#1:alias_type2.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:alias_type2.position)
 
 
 posrec > public {inline} (0 calls)
-0: posrec(p#0:alias_type2.position, a#0:wybe.int, ?$#0:alias_type2.posrec):
+0: alias_type2.posrec.posrec<0>
+posrec(p#0:alias_type2.position, a#0:wybe.int, ?$#0:alias_type2.posrec):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:alias_type2.posrec)
     foreign lpvm mutate(~%$rec#0:alias_type2.posrec, ?%$rec#1:alias_type2.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p#0:alias_type2.position)
     foreign lpvm mutate(~%$rec#1:alias_type2.posrec, ?%$#0:alias_type2.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a#0:wybe.int)
 posrec > public {inline} (6 calls)
-1: posrec(?p#0:alias_type2.position, ?a#0:wybe.int, $#0:alias_type2.posrec):
+1: alias_type2.posrec.posrec<1>
+posrec(?p#0:alias_type2.position, ?a#0:wybe.int, $#0:alias_type2.posrec):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?p#0:alias_type2.position)

--- a/test-cases/final-dump/alias_type3.exp
+++ b/test-cases/final-dump/alias_type3.exp
@@ -30,7 +30,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: alias_type3.<0>
+(io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$8#0:alias_type3.position)
@@ -151,7 +152,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:alias_type3.position, $right#0:alias_type3.position, ?$$#0:wybe.bool):
+0: alias_type3.position./=<0>
+/=($left#0:alias_type3.position, $right#0:alias_type3.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -171,7 +173,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:alias_type3.position, $right#0:alias_type3.position, ?$$#0:wybe.bool):
+0: alias_type3.position.=<0>
+=($left#0:alias_type3.position, $right#0:alias_type3.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
@@ -189,14 +192,16 @@ entry:
 
 
 position > public {inline} (0 calls)
-0: position(x#0:wybe.int, y#0:wybe.int, ?$#0:alias_type3.position):
+0: alias_type3.position.position<0>
+position(x#0:wybe.int, y#0:wybe.int, ?$#0:alias_type3.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:alias_type3.position)
     foreign lpvm mutate(~%$rec#0:alias_type3.position, ?%$rec#1:alias_type3.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:alias_type3.position, ?%$#0:alias_type3.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
 position > public {inline} (6 calls)
-1: position(?x#0:wybe.int, ?y#0:wybe.int, $#0:alias_type3.position):
+1: alias_type3.position.position<1>
+position(?x#0:wybe.int, ?y#0:wybe.int, $#0:alias_type3.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
@@ -204,24 +209,28 @@ position > public {inline} (6 calls)
 
 
 x > public {inline} (0 calls)
-0: x($rec#0:alias_type3.position, ?$#0:wybe.int):
+0: alias_type3.position.x<0>
+x($rec#0:alias_type3.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 x > public {inline} (0 calls)
-1: x($rec#0:alias_type3.position, ?$rec#1:alias_type3.position, $field#0:wybe.int):
+1: alias_type3.position.x<1>
+x($rec#0:alias_type3.position, ?$rec#1:alias_type3.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:alias_type3.position, ?%$rec#1:alias_type3.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 y > public {inline} (0 calls)
-0: y($rec#0:alias_type3.position, ?$#0:wybe.int):
+0: alias_type3.position.y<0>
+y($rec#0:alias_type3.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 y > public {inline} (0 calls)
-1: y($rec#0:alias_type3.position, ?$rec#1:alias_type3.position, $field#0:wybe.int):
+1: alias_type3.position.y<1>
+y($rec#0:alias_type3.position, ?$rec#1:alias_type3.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:alias_type3.position, ?%$rec#1:alias_type3.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
@@ -394,7 +403,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:alias_type3.posrec, $right#0:alias_type3.posrec, ?$$#0:wybe.bool):
+0: alias_type3.posrec./=<0>
+/=($left#0:alias_type3.posrec, $right#0:alias_type3.posrec, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:alias_type3.position)
@@ -426,7 +436,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:alias_type3.posrec, $right#0:alias_type3.posrec, ?$$#0:wybe.bool):
+0: alias_type3.posrec.=<0>
+=($left#0:alias_type3.posrec, $right#0:alias_type3.posrec, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$p#0:alias_type3.position)
@@ -455,38 +466,44 @@ entry:
 
 
 a > public {inline} (0 calls)
-0: a($rec#0:alias_type3.posrec, ?$#0:wybe.int):
+0: alias_type3.posrec.a<0>
+a($rec#0:alias_type3.posrec, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 a > public {inline} (0 calls)
-1: a($rec#0:alias_type3.posrec, ?$rec#1:alias_type3.posrec, $field#0:wybe.int):
+1: alias_type3.posrec.a<1>
+a($rec#0:alias_type3.posrec, ?$rec#1:alias_type3.posrec, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm mutate(~%$rec#0:alias_type3.posrec, ?%$rec#1:alias_type3.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 p > public {inline} (0 calls)
-0: p($rec#0:alias_type3.posrec, ?$#0:alias_type3.position):
+0: alias_type3.posrec.p<0>
+p($rec#0:alias_type3.posrec, ?$#0:alias_type3.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:alias_type3.position)
 p > public {inline} (0 calls)
-1: p($rec#0:alias_type3.posrec, ?$rec#1:alias_type3.posrec, $field#0:alias_type3.position):
+1: alias_type3.posrec.p<1>
+p($rec#0:alias_type3.posrec, ?$rec#1:alias_type3.posrec, $field#0:alias_type3.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:alias_type3.posrec, ?%$rec#1:alias_type3.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:alias_type3.position)
 
 
 posrec > public {inline} (0 calls)
-0: posrec(p#0:alias_type3.position, a#0:wybe.int, ?$#0:alias_type3.posrec):
+0: alias_type3.posrec.posrec<0>
+posrec(p#0:alias_type3.position, a#0:wybe.int, ?$#0:alias_type3.posrec):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:alias_type3.posrec)
     foreign lpvm mutate(~%$rec#0:alias_type3.posrec, ?%$rec#1:alias_type3.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p#0:alias_type3.position)
     foreign lpvm mutate(~%$rec#1:alias_type3.posrec, ?%$#0:alias_type3.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a#0:wybe.int)
 posrec > public {inline} (6 calls)
-1: posrec(?p#0:alias_type3.position, ?a#0:wybe.int, $#0:alias_type3.posrec):
+1: alias_type3.posrec.posrec<1>
+posrec(?p#0:alias_type3.position, ?a#0:wybe.int, $#0:alias_type3.posrec):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?p#0:alias_type3.position)

--- a/test-cases/final-dump/alias_type4.exp
+++ b/test-cases/final-dump/alias_type4.exp
@@ -31,7 +31,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: alias_type4.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(2,(alias_type4.foo<0>,fromList [NonAliasedParamCond 0 []]))]
@@ -45,7 +46,8 @@ AFTER EVERYTHING:
 
 
 foo > public (1 calls)
-0: foo(r1#0:alias_type4.posrec, io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: alias_type4.foo<0>[410bae77d3]
+foo(r1#0:alias_type4.posrec, io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
     foreign lpvm access(~r1#0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:alias_type4.position)
@@ -165,7 +167,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:alias_type4.position, $right#0:alias_type4.position, ?$$#0:wybe.bool):
+0: alias_type4.position./=<0>
+/=($left#0:alias_type4.position, $right#0:alias_type4.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -185,7 +188,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:alias_type4.position, $right#0:alias_type4.position, ?$$#0:wybe.bool):
+0: alias_type4.position.=<0>
+=($left#0:alias_type4.position, $right#0:alias_type4.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
@@ -203,14 +207,16 @@ entry:
 
 
 position > public {inline} (0 calls)
-0: position(x#0:wybe.int, y#0:wybe.int, ?$#0:alias_type4.position):
+0: alias_type4.position.position<0>
+position(x#0:wybe.int, y#0:wybe.int, ?$#0:alias_type4.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:alias_type4.position)
     foreign lpvm mutate(~%$rec#0:alias_type4.position, ?%$rec#1:alias_type4.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:alias_type4.position, ?%$#0:alias_type4.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
 position > public {inline} (6 calls)
-1: position(?x#0:wybe.int, ?y#0:wybe.int, $#0:alias_type4.position):
+1: alias_type4.position.position<1>
+position(?x#0:wybe.int, ?y#0:wybe.int, $#0:alias_type4.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
@@ -218,24 +224,28 @@ position > public {inline} (6 calls)
 
 
 x > public {inline} (0 calls)
-0: x($rec#0:alias_type4.position, ?$#0:wybe.int):
+0: alias_type4.position.x<0>
+x($rec#0:alias_type4.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 x > public {inline} (0 calls)
-1: x($rec#0:alias_type4.position, ?$rec#1:alias_type4.position, $field#0:wybe.int):
+1: alias_type4.position.x<1>
+x($rec#0:alias_type4.position, ?$rec#1:alias_type4.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:alias_type4.position, ?%$rec#1:alias_type4.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 y > public {inline} (0 calls)
-0: y($rec#0:alias_type4.position, ?$#0:wybe.int):
+0: alias_type4.position.y<0>
+y($rec#0:alias_type4.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 y > public {inline} (0 calls)
-1: y($rec#0:alias_type4.position, ?$rec#1:alias_type4.position, $field#0:wybe.int):
+1: alias_type4.position.y<1>
+y($rec#0:alias_type4.position, ?$rec#1:alias_type4.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:alias_type4.position, ?%$rec#1:alias_type4.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
@@ -408,7 +418,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:alias_type4.posrec, $right#0:alias_type4.posrec, ?$$#0:wybe.bool):
+0: alias_type4.posrec./=<0>
+/=($left#0:alias_type4.posrec, $right#0:alias_type4.posrec, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:alias_type4.position)
@@ -440,7 +451,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:alias_type4.posrec, $right#0:alias_type4.posrec, ?$$#0:wybe.bool):
+0: alias_type4.posrec.=<0>
+=($left#0:alias_type4.posrec, $right#0:alias_type4.posrec, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$p#0:alias_type4.position)
@@ -469,38 +481,44 @@ entry:
 
 
 a > public {inline} (0 calls)
-0: a($rec#0:alias_type4.posrec, ?$#0:wybe.int):
+0: alias_type4.posrec.a<0>
+a($rec#0:alias_type4.posrec, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 a > public {inline} (0 calls)
-1: a($rec#0:alias_type4.posrec, ?$rec#1:alias_type4.posrec, $field#0:wybe.int):
+1: alias_type4.posrec.a<1>
+a($rec#0:alias_type4.posrec, ?$rec#1:alias_type4.posrec, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm mutate(~%$rec#0:alias_type4.posrec, ?%$rec#1:alias_type4.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 p > public {inline} (0 calls)
-0: p($rec#0:alias_type4.posrec, ?$#0:alias_type4.position):
+0: alias_type4.posrec.p<0>
+p($rec#0:alias_type4.posrec, ?$#0:alias_type4.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:alias_type4.position)
 p > public {inline} (0 calls)
-1: p($rec#0:alias_type4.posrec, ?$rec#1:alias_type4.posrec, $field#0:alias_type4.position):
+1: alias_type4.posrec.p<1>
+p($rec#0:alias_type4.posrec, ?$rec#1:alias_type4.posrec, $field#0:alias_type4.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:alias_type4.posrec, ?%$rec#1:alias_type4.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:alias_type4.position)
 
 
 posrec > public {inline} (0 calls)
-0: posrec(p#0:alias_type4.position, a#0:wybe.int, ?$#0:alias_type4.posrec):
+0: alias_type4.posrec.posrec<0>
+posrec(p#0:alias_type4.position, a#0:wybe.int, ?$#0:alias_type4.posrec):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:alias_type4.posrec)
     foreign lpvm mutate(~%$rec#0:alias_type4.posrec, ?%$rec#1:alias_type4.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p#0:alias_type4.position)
     foreign lpvm mutate(~%$rec#1:alias_type4.posrec, ?%$#0:alias_type4.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a#0:wybe.int)
 posrec > public {inline} (6 calls)
-1: posrec(?p#0:alias_type4.position, ?a#0:wybe.int, $#0:alias_type4.posrec):
+1: alias_type4.posrec.posrec<1>
+posrec(?p#0:alias_type4.position, ?a#0:wybe.int, $#0:alias_type4.posrec):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?p#0:alias_type4.position)

--- a/test-cases/final-dump/backwards_assign.exp
+++ b/test-cases/final-dump/backwards_assign.exp
@@ -10,21 +10,24 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: backwards_assign.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     backwards_assign.gen$1<0>(0:wybe.int, ~io#0:wybe.phantom, ?io#1:wybe.phantom) #0 @backwards_assign:nn:nn
 
 
 backwards_assign > {inline} (3 calls)
-0: backwards_assign(?output#0:wybe.int, input#0:wybe.int):
+0: backwards_assign.backwards_assign<0>
+backwards_assign(?output#0:wybe.int, input#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm add(~input#0:wybe.int, 1:wybe.int, ?output#0:wybe.int) @int:nn:nn
 
 
 gen$1 > (2 calls)
-0: gen$1(i#0:wybe.int, io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: backwards_assign.gen$1<0>
+gen$1(i#0:wybe.int, io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_int(i#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$3#0:wybe.phantom) @io:nn:nn

--- a/test-cases/final-dump/bar.exp
+++ b/test-cases/final-dump/bar.exp
@@ -11,7 +11,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: bar.<0>
+(io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     numbers.factorial<0>(4:wybe.int, ?tmp$0#0:wybe.int) #0 @bar:nn:nn
@@ -68,7 +69,8 @@ entry:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: numbers.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("Numbers has been initialised.":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
@@ -76,7 +78,8 @@ entry:
 
 
 factorial > public (1 calls)
-0: factorial(n#0:wybe.int, ?$#0:wybe.int):
+0: numbers.factorial<0>
+factorial(n#0:wybe.int, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_sle(n#0:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.bool) @int:nn:nn
@@ -92,7 +95,8 @@ factorial > public (1 calls)
 
 
 toCelsius > public {inline} (0 calls)
-0: toCelsius(f#0:wybe.float, ?$#0:wybe.float):
+0: numbers.toCelsius<0>
+toCelsius(f#0:wybe.float, ?$#0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm fsub(~f#0:wybe.float, 32.0:wybe.float, ?tmp$1#0:wybe.float) @float:nn:nn

--- a/test-cases/final-dump/bbb.exp
+++ b/test-cases/final-dump/bbb.exp
@@ -11,7 +11,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: bbb.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("BBB: Init":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
@@ -58,7 +59,8 @@ entry:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: ddd.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("DDD: Init":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn

--- a/test-cases/final-dump/call_site_id.exp
+++ b/test-cases/final-dump/call_site_id.exp
@@ -12,7 +12,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#4:wybe.phantom):
+0: call_site_id.<0>
+(io#0:wybe.phantom, ?io#4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c read_int(?x#0:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -47,14 +48,16 @@ AFTER EVERYTHING:
 
 
 bar > public {inline} (9 calls)
-0: bar(x#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: call_site_id.bar<0>
+bar(x#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     call_site_id.foo<0>(~x#0:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @call_site_id:nn:nn
 
 
 foo > public (1 calls)
-0: foo(x#0:wybe.int, io#0:wybe.phantom, ?io#8:wybe.phantom):
+0: call_site_id.foo<0>
+foo(x#0:wybe.int, io#0:wybe.phantom, ?io#8:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" ":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn

--- a/test-cases/final-dump/ccc.exp
+++ b/test-cases/final-dump/ccc.exp
@@ -11,7 +11,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: ccc.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("CCC: Init":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
@@ -58,7 +59,8 @@ entry:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: ddd.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("DDD: Init":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn

--- a/test-cases/final-dump/chain_assign.exp
+++ b/test-cases/final-dump/chain_assign.exp
@@ -10,7 +10,8 @@ AFTER EVERYTHING:
   procs           : 
 
 chain > {inline} (0 calls)
-0: chain(?z#0:wybe.int):
+0: chain_assign.chain<0>
+chain(?z#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(1:wybe.int, ?z#0:wybe.int) @chain_assign:nn:nn

--- a/test-cases/final-dump/commonsubexpr.exp
+++ b/test-cases/final-dump/commonsubexpr.exp
@@ -10,7 +10,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: commonsubexpr.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_int(198:wybe.int, ~#io#0:wybe.phantom, ?tmp$6#0:wybe.phantom) @io:nn:nn
@@ -22,7 +23,8 @@ AFTER EVERYTHING:
 
 
 common_subexpr > {inline} (1 calls)
-0: common_subexpr(x#0:wybe.int, io#0:wybe.phantom, ?io#3:wybe.phantom):
+0: commonsubexpr.common_subexpr<0>
+common_subexpr(x#0:wybe.int, io#0:wybe.phantom, ?io#3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm add(x#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int) @int:nn:nn

--- a/test-cases/final-dump/compute.exp
+++ b/test-cases/final-dump/compute.exp
@@ -11,7 +11,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: compute.<0>
+(io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     math.utils.factorial<0>(4:wybe.int, ?tmp$0#0:wybe.int) #0 @compute:nn:nn
@@ -95,7 +96,8 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
   procs           : 
 
 toCelsius > public {inline} (0 calls)
-0: toCelsius(f#0:wybe.float, ?$#0:wybe.float):
+0: math.temperature.toCelsius<0>
+toCelsius(f#0:wybe.float, ?$#0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm fsub(~f#0:wybe.float, 32.0:wybe.float, ?tmp$1#0:wybe.float) @float:nn:nn
@@ -133,7 +135,8 @@ entry:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: math.utils.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("Utils has been initialised.":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
@@ -141,7 +144,8 @@ entry:
 
 
 factorial > public (1 calls)
-0: factorial(n#0:wybe.int, ?$#0:wybe.int):
+0: math.utils.factorial<0>
+factorial(n#0:wybe.int, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_sle(n#0:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.bool) @int:nn:nn

--- a/test-cases/final-dump/constfold.exp
+++ b/test-cases/final-dump/constfold.exp
@@ -13,28 +13,32 @@ AFTER EVERYTHING:
   procs           : 
 
 fold_add > public {inline} (3 calls)
-0: fold_add(?$#0:wybe.int):
+0: constfold.fold_add<0>
+fold_add(?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(42:wybe.int, ?$#0:wybe.int) @constfold:nn:nn
 
 
 fold_mult > public {inline} (3 calls)
-0: fold_mult(?$#0:wybe.int):
+0: constfold.fold_mult<0>
+fold_mult(?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(42:wybe.int, ?$#0:wybe.int) @constfold:nn:nn
 
 
 fold_test > public {inline} (0 calls)
-0: fold_test(?$#0:wybe.int):
+0: constfold.fold_test<0>
+fold_test(?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(42:wybe.int, ?$#0:wybe.int) @constfold:nn:nn
 
 
 fortytwo > public {inline} (0 calls)
-0: fortytwo(?$#0:wybe.int):
+0: constfold.fortytwo<0>
+fortytwo(?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(42:wybe.int, ?$#0:wybe.int) @constfold:nn:nn

--- a/test-cases/final-dump/constructors.exp
+++ b/test-cases/final-dump/constructors.exp
@@ -16,7 +16,8 @@ AFTER EVERYTHING:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:constructors, $right#0:constructors, ?$$#0:wybe.bool):
+0: constructors./=<0>
+/=($left#0:constructors, $right#0:constructors, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     constructors.=<0>(~$left#0:constructors, ~$right#0:constructors, ?tmp$0#0:wybe.bool) #0
@@ -24,7 +25,8 @@ AFTER EVERYTHING:
 
 
 = > public (1 calls)
-0: =($left#0:constructors, $right#0:constructors, ?$$#0:wybe.bool):
+0: constructors.=<0>
+=($left#0:constructors, $right#0:constructors, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($left#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -47,13 +49,15 @@ AFTER EVERYTHING:
 
 
 just > public {inline} (0 calls)
-0: just(value#0:wybe.int, ?$#0:constructors):
+0: constructors.just<0>
+just(value#0:wybe.int, ?$#0:constructors):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?$rec#0:constructors)
     foreign lpvm mutate(~%$rec#0:constructors, ?%$#0:constructors, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~value#0:wybe.int)
 just > public {inline} (8 calls)
-1: just(?value#0:wybe.int, $#0:constructors, ?$$#0:wybe.bool):
+1: constructors.just<1>
+just(?value#0:wybe.int, $#0:constructors, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -69,14 +73,16 @@ just > public {inline} (8 calls)
 
 
 nothing > public {inline} (0 calls)
-0: nothing(?$#0:constructors):
+0: constructors.nothing<0>
+nothing(?$#0:constructors):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(0:constructors, ?$#0:constructors)
 
 
 value > public {inline} (0 calls)
-0: value($rec#0:constructors, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: constructors.value<0>
+value($rec#0:constructors, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -90,7 +96,8 @@ value > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 value > public {inline} (0 calls)
-1: value($rec#0:constructors, ?$rec#1:constructors, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: constructors.value<1>
+value($rec#0:constructors, ?$rec#1:constructors, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)

--- a/test-cases/final-dump/coordinate.exp
+++ b/test-cases/final-dump/coordinate.exp
@@ -23,7 +23,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#4:wybe.phantom):
+0: coordinate.<0>
+(io#0:wybe.phantom, ?io#4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(24:wybe.int, ?tmp$7#0:coordinate.Coordinate)
@@ -41,7 +42,8 @@ AFTER EVERYTHING:
 
 
 fcopy > public {inline} (1 calls)
-0: fcopy(crd1#0:coordinate.Coordinate, ?$#0:coordinate.Coordinate):
+0: coordinate.fcopy<0>
+fcopy(crd1#0:coordinate.Coordinate, ?$#0:coordinate.Coordinate):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(~crd1#0:coordinate.Coordinate, ?$#0:coordinate.Coordinate) @coordinate:nn:nn
@@ -136,7 +138,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:coordinate.Coordinate, $right#0:coordinate.Coordinate, ?$$#0:wybe.bool):
+0: coordinate.Coordinate./=<0>
+/=($left#0:coordinate.Coordinate, $right#0:coordinate.Coordinate, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -166,7 +169,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:coordinate.Coordinate, $right#0:coordinate.Coordinate, ?$$#0:wybe.bool):
+0: coordinate.Coordinate.=<0>
+=($left#0:coordinate.Coordinate, $right#0:coordinate.Coordinate, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
@@ -193,7 +197,8 @@ entry:
 
 
 Coordinate > public {inline} (0 calls)
-0: Coordinate(x#0:wybe.int, y#0:wybe.int, z#0:wybe.int, ?$#0:coordinate.Coordinate):
+0: coordinate.Coordinate.Coordinate<0>
+Coordinate(x#0:wybe.int, y#0:wybe.int, z#0:wybe.int, ?$#0:coordinate.Coordinate):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(24:wybe.int, ?$rec#0:coordinate.Coordinate)
@@ -201,7 +206,8 @@ Coordinate > public {inline} (0 calls)
     foreign lpvm mutate(~%$rec#1:coordinate.Coordinate, ?%$rec#2:coordinate.Coordinate, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~y#0:wybe.int)
     foreign lpvm mutate(~%$rec#2:coordinate.Coordinate, ?%$#0:coordinate.Coordinate, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~z#0:wybe.int)
 Coordinate > public {inline} (10 calls)
-1: Coordinate(?x#0:wybe.int, ?y#0:wybe.int, ?z#0:wybe.int, $#0:coordinate.Coordinate):
+1: coordinate.Coordinate.Coordinate<1>
+Coordinate(?x#0:wybe.int, ?y#0:wybe.int, ?z#0:wybe.int, $#0:coordinate.Coordinate):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?x#0:wybe.int)
@@ -210,36 +216,42 @@ Coordinate > public {inline} (10 calls)
 
 
 x > public {inline} (0 calls)
-0: x($rec#0:coordinate.Coordinate, ?$#0:wybe.int):
+0: coordinate.Coordinate.x<0>
+x($rec#0:coordinate.Coordinate, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 x > public {inline} (0 calls)
-1: x($rec#0:coordinate.Coordinate, ?$rec#1:coordinate.Coordinate, $field#0:wybe.int):
+1: coordinate.Coordinate.x<1>
+x($rec#0:coordinate.Coordinate, ?$rec#1:coordinate.Coordinate, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:coordinate.Coordinate, ?%$rec#1:coordinate.Coordinate, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 y > public {inline} (0 calls)
-0: y($rec#0:coordinate.Coordinate, ?$#0:wybe.int):
+0: coordinate.Coordinate.y<0>
+y($rec#0:coordinate.Coordinate, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 y > public {inline} (0 calls)
-1: y($rec#0:coordinate.Coordinate, ?$rec#1:coordinate.Coordinate, $field#0:wybe.int):
+1: coordinate.Coordinate.y<1>
+y($rec#0:coordinate.Coordinate, ?$rec#1:coordinate.Coordinate, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:coordinate.Coordinate, ?%$rec#1:coordinate.Coordinate, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 z > public {inline} (0 calls)
-0: z($rec#0:coordinate.Coordinate, ?$#0:wybe.int):
+0: coordinate.Coordinate.z<0>
+z($rec#0:coordinate.Coordinate, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 z > public {inline} (0 calls)
-1: z($rec#0:coordinate.Coordinate, ?$rec#1:coordinate.Coordinate, $field#0:wybe.int):
+1: coordinate.Coordinate.z<1>
+z($rec#0:coordinate.Coordinate, ?$rec#1:coordinate.Coordinate, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:coordinate.Coordinate, ?%$rec#1:coordinate.Coordinate, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field#0:wybe.int)

--- a/test-cases/final-dump/ddd.exp
+++ b/test-cases/final-dump/ddd.exp
@@ -10,7 +10,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: ddd.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("DDD: Init":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn

--- a/test-cases/final-dump/dead_cell_size.exp
+++ b/test-cases/final-dump/dead_cell_size.exp
@@ -45,7 +45,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#3:wybe.phantom):
+0: dead_cell_size.<0>
+(io#0:wybe.phantom, ?io#3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(4,(dead_cell_size.bar<0>,fromList [NonAliasedParamCond 0 []])),(7,(dead_cell_size.diff_type<0>,fromList [NonAliasedParamCond 0 []]))]
@@ -64,7 +65,8 @@ AFTER EVERYTHING:
 
 
 bar > public (1 calls)
-0: bar(x#0:dead_cell_size.t, ?x#1:dead_cell_size.t):
+0: dead_cell_size.bar<0>[410bae77d3]
+bar(x#0:dead_cell_size.t, ?x#1:dead_cell_size.t):
  AliasPairs: [(x#0,x#1)]
  InterestingCallProperties: [InterestingUnaliased 0]
     foreign llvm icmp_ne(x#0:dead_cell_size.t, 0:wybe.int, ?tmp$3#0:wybe.bool)
@@ -106,7 +108,8 @@ bar > public (1 calls)
 
 
 diff_type > public (1 calls)
-0: diff_type(x#0:dead_cell_size.t, ?y#0:dead_cell_size.t2):
+0: dead_cell_size.diff_type<0>[410bae77d3]
+diff_type(x#0:dead_cell_size.t, ?y#0:dead_cell_size.t2):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
     foreign llvm icmp_ne(x#0:dead_cell_size.t, 0:wybe.int, ?tmp$5#0:wybe.bool)
@@ -151,7 +154,8 @@ diff_type > public (1 calls)
 
 
 foo > public (1 calls)
-0: foo(x#0:dead_cell_size.t, ?x#1:dead_cell_size.t):
+0: dead_cell_size.foo<0>
+foo(x#0:dead_cell_size.t, ?x#1:dead_cell_size.t):
  AliasPairs: [(x#0,x#1)]
  InterestingCallProperties: []
     foreign llvm icmp_ne(x#0:dead_cell_size.t, 0:wybe.int, ?tmp$3#0:wybe.bool)
@@ -178,7 +182,8 @@ foo > public (1 calls)
 
 
 print_t > public (2 calls)
-0: print_t(x#0:dead_cell_size.t, io#0:wybe.phantom, ?io#8:wybe.phantom):
+0: dead_cell_size.print_t<0>
+print_t(x#0:dead_cell_size.t, io#0:wybe.phantom, ?io#8:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     dead_cell_size.t.=<0>(0:dead_cell_size.t, x#0:dead_cell_size.t, ?tmp$4#0:wybe.bool) #1 @dead_cell_size:nn:nn
@@ -240,7 +245,8 @@ print_t > public (2 calls)
 
 
 print_t2 > public (1 calls)
-0: print_t2(x#0:dead_cell_size.t2, io#0:wybe.phantom, ?io#4:wybe.phantom):
+0: dead_cell_size.print_t2<0>
+print_t2(x#0:dead_cell_size.t2, io#0:wybe.phantom, ?io#4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     dead_cell_size.t2.=<0>(0:dead_cell_size.t2, x#0:dead_cell_size.t2, ?tmp$2#0:wybe.bool) #1 @dead_cell_size:nn:nn
@@ -637,7 +643,8 @@ if.else1:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:dead_cell_size.t, $right#0:dead_cell_size.t, ?$$#0:wybe.bool):
+0: dead_cell_size.t./=<0>
+/=($left#0:dead_cell_size.t, $right#0:dead_cell_size.t, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     dead_cell_size.t.=<0>(~$left#0:dead_cell_size.t, ~$right#0:dead_cell_size.t, ?tmp$0#0:wybe.bool) #0
@@ -645,7 +652,8 @@ if.else1:
 
 
 = > public (1 calls)
-0: =($left#0:dead_cell_size.t, $right#0:dead_cell_size.t, ?$$#0:wybe.bool):
+0: dead_cell_size.t.=<0>
+=($left#0:dead_cell_size.t, $right#0:dead_cell_size.t, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($left#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -750,20 +758,23 @@ if.else1:
 
 
 ta > public {inline} (0 calls)
-0: ta(?$#0:dead_cell_size.t):
+0: dead_cell_size.t.ta<0>
+ta(?$#0:dead_cell_size.t):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(0:dead_cell_size.t, ?$#0:dead_cell_size.t)
 
 
 tb > public {inline} (0 calls)
-0: tb(tb1#0:wybe.int, ?$#0:dead_cell_size.t):
+0: dead_cell_size.t.tb<0>
+tb(tb1#0:wybe.int, ?$#0:dead_cell_size.t):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?$rec#0:dead_cell_size.t)
     foreign lpvm mutate(~%$rec#0:dead_cell_size.t, ?%$#0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~tb1#0:wybe.int)
 tb > public {inline} (14 calls)
-1: tb(?tb1#0:wybe.int, $#0:dead_cell_size.t, ?$$#0:wybe.bool):
+1: dead_cell_size.t.tb<1>
+tb(?tb1#0:wybe.int, $#0:dead_cell_size.t, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -788,7 +799,8 @@ tb > public {inline} (14 calls)
 
 
 tb1 > public {inline} (0 calls)
-0: tb1($rec#0:dead_cell_size.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: dead_cell_size.t.tb1<0>
+tb1($rec#0:dead_cell_size.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -811,7 +823,8 @@ tb1 > public {inline} (0 calls)
 
 
 tb1 > public {inline} (0 calls)
-1: tb1($rec#0:dead_cell_size.t, ?$rec#1:dead_cell_size.t, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: dead_cell_size.t.tb1<1>
+tb1($rec#0:dead_cell_size.t, ?$rec#1:dead_cell_size.t, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -836,7 +849,8 @@ tb1 > public {inline} (0 calls)
 
 
 tc > public {inline} (0 calls)
-0: tc(tc1#0:wybe.int, tc2#0:wybe.int, tc3#0:wybe.int, ?$#0:dead_cell_size.t):
+0: dead_cell_size.t.tc<0>
+tc(tc1#0:wybe.int, tc2#0:wybe.int, tc3#0:wybe.int, ?$#0:dead_cell_size.t):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(24:wybe.int, ?$rec#0:dead_cell_size.t)
@@ -845,7 +859,8 @@ tc > public {inline} (0 calls)
     foreign lpvm mutate(~%$rec#2:dead_cell_size.t, ?%$rec#3:dead_cell_size.t, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tc3#0:wybe.int)
     foreign llvm or(~$rec#3:dead_cell_size.t, 1:wybe.int, ?$#0:dead_cell_size.t)
 tc > public {inline} (11 calls)
-1: tc(?tc1#0:wybe.int, ?tc2#0:wybe.int, ?tc3#0:wybe.int, $#0:dead_cell_size.t, ?$$#0:wybe.bool):
+1: dead_cell_size.t.tc<1>
+tc(?tc1#0:wybe.int, ?tc2#0:wybe.int, ?tc3#0:wybe.int, $#0:dead_cell_size.t, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -876,7 +891,8 @@ tc > public {inline} (11 calls)
 
 
 tc1 > public {inline} (0 calls)
-0: tc1($rec#0:dead_cell_size.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: dead_cell_size.t.tc1<0>
+tc1($rec#0:dead_cell_size.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -899,7 +915,8 @@ tc1 > public {inline} (0 calls)
 
 
 tc1 > public {inline} (0 calls)
-1: tc1($rec#0:dead_cell_size.t, ?$rec#1:dead_cell_size.t, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: dead_cell_size.t.tc1<1>
+tc1($rec#0:dead_cell_size.t, ?$rec#1:dead_cell_size.t, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -924,7 +941,8 @@ tc1 > public {inline} (0 calls)
 
 
 tc2 > public {inline} (0 calls)
-0: tc2($rec#0:dead_cell_size.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: dead_cell_size.t.tc2<0>
+tc2($rec#0:dead_cell_size.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -947,7 +965,8 @@ tc2 > public {inline} (0 calls)
 
 
 tc2 > public {inline} (0 calls)
-1: tc2($rec#0:dead_cell_size.t, ?$rec#1:dead_cell_size.t, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: dead_cell_size.t.tc2<1>
+tc2($rec#0:dead_cell_size.t, ?$rec#1:dead_cell_size.t, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -972,7 +991,8 @@ tc2 > public {inline} (0 calls)
 
 
 tc3 > public {inline} (0 calls)
-0: tc3($rec#0:dead_cell_size.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: dead_cell_size.t.tc3<0>
+tc3($rec#0:dead_cell_size.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -995,7 +1015,8 @@ tc3 > public {inline} (0 calls)
 
 
 tc3 > public {inline} (0 calls)
-1: tc3($rec#0:dead_cell_size.t, ?$rec#1:dead_cell_size.t, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: dead_cell_size.t.tc3<1>
+tc3($rec#0:dead_cell_size.t, ?$rec#1:dead_cell_size.t, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1020,14 +1041,16 @@ tc3 > public {inline} (0 calls)
 
 
 td > public {inline} (0 calls)
-0: td(td1#0:wybe.int, ?$#0:dead_cell_size.t):
+0: dead_cell_size.t.td<0>
+td(td1#0:wybe.int, ?$#0:dead_cell_size.t):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?$rec#0:dead_cell_size.t)
     foreign lpvm mutate(~%$rec#0:dead_cell_size.t, ?%$rec#1:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~td1#0:wybe.int)
     foreign llvm or(~$rec#1:dead_cell_size.t, 2:wybe.int, ?$#0:dead_cell_size.t)
 td > public {inline} (5 calls)
-1: td(?td1#0:wybe.int, $#0:dead_cell_size.t, ?$$#0:wybe.bool):
+1: dead_cell_size.t.td<1>
+td(?td1#0:wybe.int, $#0:dead_cell_size.t, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1052,7 +1075,8 @@ td > public {inline} (5 calls)
 
 
 td1 > public {inline} (0 calls)
-0: td1($rec#0:dead_cell_size.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: dead_cell_size.t.td1<0>
+td1($rec#0:dead_cell_size.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1075,7 +1099,8 @@ td1 > public {inline} (0 calls)
 
 
 td1 > public {inline} (0 calls)
-1: td1($rec#0:dead_cell_size.t, ?$rec#1:dead_cell_size.t, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: dead_cell_size.t.td1<1>
+td1($rec#0:dead_cell_size.t, ?$rec#1:dead_cell_size.t, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1705,7 +1730,8 @@ if.else1:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:dead_cell_size.t2, $right#0:dead_cell_size.t2, ?$$#0:wybe.bool):
+0: dead_cell_size.t2./=<0>
+/=($left#0:dead_cell_size.t2, $right#0:dead_cell_size.t2, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     dead_cell_size.t2.=<0>(~$left#0:dead_cell_size.t2, ~$right#0:dead_cell_size.t2, ?tmp$0#0:wybe.bool) #0
@@ -1713,7 +1739,8 @@ if.else1:
 
 
 = > public (1 calls)
-0: =($left#0:dead_cell_size.t2, $right#0:dead_cell_size.t2, ?$$#0:wybe.bool):
+0: dead_cell_size.t2.=<0>
+=($left#0:dead_cell_size.t2, $right#0:dead_cell_size.t2, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($left#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1736,7 +1763,8 @@ if.else1:
 
 
 a > public {inline} (0 calls)
-0: a($rec#0:dead_cell_size.t2, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: dead_cell_size.t2.a<0>
+a($rec#0:dead_cell_size.t2, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1750,7 +1778,8 @@ a > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 a > public {inline} (0 calls)
-1: a($rec#0:dead_cell_size.t2, ?$rec#1:dead_cell_size.t2, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: dead_cell_size.t2.a<1>
+a($rec#0:dead_cell_size.t2, ?$rec#1:dead_cell_size.t2, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1766,20 +1795,23 @@ a > public {inline} (0 calls)
 
 
 t2a > public {inline} (0 calls)
-0: t2a(?$#0:dead_cell_size.t2):
+0: dead_cell_size.t2.t2a<0>
+t2a(?$#0:dead_cell_size.t2):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(0:dead_cell_size.t2, ?$#0:dead_cell_size.t2)
 
 
 t2b > public {inline} (0 calls)
-0: t2b(a#0:wybe.int, ?$#0:dead_cell_size.t2):
+0: dead_cell_size.t2.t2b<0>
+t2b(a#0:wybe.int, ?$#0:dead_cell_size.t2):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?$rec#0:dead_cell_size.t2)
     foreign lpvm mutate(~%$rec#0:dead_cell_size.t2, ?%$#0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~a#0:wybe.int)
 t2b > public {inline} (8 calls)
-1: t2b(?a#0:wybe.int, $#0:dead_cell_size.t2, ?$$#0:wybe.bool):
+1: dead_cell_size.t2.t2b<1>
+t2b(?a#0:wybe.int, $#0:dead_cell_size.t2, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)

--- a/test-cases/final-dump/decimal.exp
+++ b/test-cases/final-dump/decimal.exp
@@ -10,7 +10,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#10:wybe.phantom):
+0: decimal.<0>
+(io#0:wybe.phantom, ?io#10:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_float(1.0e-2:wybe.float, ~#io#0:wybe.phantom, ?tmp$3#0:wybe.phantom) @io:nn:nn

--- a/test-cases/final-dump/early_error.exp
+++ b/test-cases/final-dump/early_error.exp
@@ -10,7 +10,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: early_error.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("should print this":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
@@ -20,7 +21,8 @@ AFTER EVERYTHING:
 
 
 my_error > {terminal,inline,semipure} (1 calls)
-0: my_error(msg#0:wybe.string):
+0: early_error.my_error<0>
+my_error(msg#0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c {impure} puts(~msg#0:wybe.string) @early_error:nn:nn

--- a/test-cases/final-dump/early_exit.exp
+++ b/test-cases/final-dump/early_exit.exp
@@ -10,7 +10,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: early_exit.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("should print this":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn

--- a/test-cases/final-dump/early_exit2.exp
+++ b/test-cases/final-dump/early_exit2.exp
@@ -10,7 +10,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: early_exit2.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("should print this":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
@@ -19,7 +20,8 @@ AFTER EVERYTHING:
 
 
 my_exit > {terminal,inline} (1 calls)
-0: my_exit(code#0:wybe.int):
+0: early_exit2.my_exit<0>
+my_exit(code#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c {terminal,semipure} exit(~code#0:wybe.int) @early_exit2:7:5

--- a/test-cases/final-dump/exp_if.exp
+++ b/test-cases/final-dump/exp_if.exp
@@ -11,7 +11,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: exp_if.<0>
+(io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("expect larger: ":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -20,7 +21,8 @@ AFTER EVERYTHING:
 
 
 if_test > public (1 calls)
-0: if_test(x#0:wybe.int, ?$#0:wybe.string):
+0: exp_if.if_test<0>
+if_test(x#0:wybe.int, ?$#0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_sgt(~x#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn

--- a/test-cases/final-dump/exp_print.exp
+++ b/test-cases/final-dump/exp_print.exp
@@ -10,7 +10,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#6:wybe.phantom):
+0: exp_print.<0>
+(io#0:wybe.phantom, ?io#6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("print(x:string) creates a newline already":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn

--- a/test-cases/final-dump/exp_simple.exp
+++ b/test-cases/final-dump/exp_simple.exp
@@ -10,7 +10,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#7:wybe.phantom):
+0: exp_simple.<0>
+(io#0:wybe.phantom, ?io#7:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_int(3:wybe.int, ~#io#0:wybe.phantom, ?tmp$8#0:wybe.phantom) @io:nn:nn
@@ -28,7 +29,8 @@ AFTER EVERYTHING:
 
 
 foreign_add > {inline} (1 calls)
-0: foreign_add(?$#0:wybe.int):
+0: exp_simple.foreign_add<0>
+foreign_add(?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(3:wybe.int, ?$#0:wybe.int) @exp_simple:nn:nn

--- a/test-cases/final-dump/func_factorial.exp
+++ b/test-cases/final-dump/func_factorial.exp
@@ -11,7 +11,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: func_factorial.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     func_factorial.factorial<0>(5:wybe.int, ?tmp$0#0:wybe.int) #0 @func_factorial:nn:nn
@@ -20,7 +21,8 @@ AFTER EVERYTHING:
 
 
 factorial > public (2 calls)
-0: factorial(n#0:wybe.int, ?$#0:wybe.int):
+0: func_factorial.factorial<0>
+factorial(n#0:wybe.int, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_sle(n#0:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.bool) @int:nn:nn

--- a/test-cases/final-dump/func_let.exp
+++ b/test-cases/final-dump/func_let.exp
@@ -11,14 +11,16 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: func_let.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_int(40:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
 
 
 quad > public {inline} (1 calls)
-0: quad(x#0:wybe.int, ?$#0:wybe.int):
+0: func_let.quad<0>
+quad(x#0:wybe.int, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm add(~x#0:wybe.int, ~x#0:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn

--- a/test-cases/final-dump/func_quadruple.exp
+++ b/test-cases/final-dump/func_quadruple.exp
@@ -11,14 +11,16 @@ AFTER EVERYTHING:
   procs           : 
 
 double > public {inline} (2 calls)
-0: double(a#0:wybe.int, ?$#0:wybe.int):
+0: func_quadruple.double<0>
+double(a#0:wybe.int, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm add(~a#0:wybe.int, ~a#0:wybe.int, ?$#0:wybe.int) @int:nn:nn
 
 
 quadruple > public {inline} (0 calls)
-0: quadruple(a#0:wybe.int, ?$#0:wybe.int):
+0: func_quadruple.quadruple<0>
+quadruple(a#0:wybe.int, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm add(~a#0:wybe.int, ~a#0:wybe.int, ?tmp$1#0:wybe.int) @int:nn:nn

--- a/test-cases/final-dump/func_typed.exp
+++ b/test-cases/final-dump/func_typed.exp
@@ -10,7 +10,8 @@ AFTER EVERYTHING:
   procs           : 
 
 plus > public {inline} (0 calls)
-0: plus(a#0:wybe.int, b#0:wybe.int, ?$#0:wybe.int):
+0: func_typed.plus<0>
+plus(a#0:wybe.int, b#0:wybe.int, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm add(~a#0:wybe.int, ~b#0:wybe.int, ?$#0:wybe.int) @int:nn:nn

--- a/test-cases/final-dump/func_untyped.exp
+++ b/test-cases/final-dump/func_untyped.exp
@@ -10,7 +10,8 @@ AFTER EVERYTHING:
   procs           : 
 
 incr > {inline} (0 calls)
-0: incr(a#0:wybe.int, ?$#0:wybe.int):
+0: func_untyped.incr<0>
+incr(a#0:wybe.int, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm add(~a#0:wybe.int, 1:wybe.int, ?$#0:wybe.int) @int:nn:nn

--- a/test-cases/final-dump/func_where.exp
+++ b/test-cases/final-dump/func_where.exp
@@ -10,7 +10,8 @@ AFTER EVERYTHING:
   procs           : 
 
 quad > public {inline} (0 calls)
-0: quad(x#0:wybe.int, ?$#0:wybe.int):
+0: func_where.quad<0>
+quad(x#0:wybe.int, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm add(~x#0:wybe.int, ~x#0:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn

--- a/test-cases/final-dump/generic_list.exp
+++ b/test-cases/final-dump/generic_list.exp
@@ -18,7 +18,8 @@ AFTER EVERYTHING:
   procs           : 
 
 append > public (1 calls)
-0: append(x#0:generic_list(?T), y#0:generic_list(?T), ?$#0:generic_list(?T)):
+0: generic_list.append<0>
+append(x#0:generic_list(?T), y#0:generic_list(?T), ?$#0:generic_list(?T)):
  AliasPairs: [($#0,y#0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(generic_list.append<0>,fromList [NonAliasedParamCond 0 [0]]))]
@@ -38,7 +39,8 @@ append > public (1 calls)
 
 
 car > public {inline} (0 calls)
-0: car($rec#0:generic_list(?T), ?$#0:?T, ?$$#0:wybe.bool):
+0: generic_list.car<0>
+car($rec#0:generic_list(?T), ?$#0:?T, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -52,7 +54,8 @@ car > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 car > public {inline} (0 calls)
-1: car($rec#0:generic_list(?T), ?$rec#1:generic_list(?T), $field#0:?T, ?$$#0:wybe.bool):
+1: generic_list.car<1>
+car($rec#0:generic_list(?T), ?$rec#1:generic_list(?T), $field#0:?T, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -68,7 +71,8 @@ car > public {inline} (0 calls)
 
 
 cdr > public {inline} (0 calls)
-0: cdr($rec#0:generic_list(?T), ?$#0:generic_list(?T), ?$$#0:wybe.bool):
+0: generic_list.cdr<0>
+cdr($rec#0:generic_list(?T), ?$#0:generic_list(?T), ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -82,7 +86,8 @@ cdr > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 cdr > public {inline} (0 calls)
-1: cdr($rec#0:generic_list(?T), ?$rec#1:generic_list(?T), $field#0:generic_list(?T), ?$$#0:wybe.bool):
+1: generic_list.cdr<1>
+cdr($rec#0:generic_list(?T), ?$rec#1:generic_list(?T), $field#0:generic_list(?T), ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -98,14 +103,16 @@ cdr > public {inline} (0 calls)
 
 
 cons > public {inline} (1 calls)
-0: cons(car#0:?T, cdr#0:generic_list(?T), ?$#0:generic_list(?T)):
+0: generic_list.cons<0>
+cons(car#0:?T, cdr#0:generic_list(?T), ?$#0:generic_list(?T)):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:generic_list(?T))
     foreign lpvm mutate(~%$rec#0:generic_list(?T), ?%$rec#1:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~car#0:?T)
     foreign lpvm mutate(~%$rec#1:generic_list(?T), ?%$#0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr#0:generic_list(?T))
 cons > public {inline} (6 calls)
-1: cons(?car#0:?T, ?cdr#0:generic_list(?T), $#0:generic_list(?T), ?$$#0:wybe.bool):
+1: generic_list.cons<1>
+cons(?car#0:?T, ?cdr#0:generic_list(?T), $#0:generic_list(?T), ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -123,14 +130,16 @@ cons > public {inline} (6 calls)
 
 
 length > public {inline} (0 calls)
-0: length(x#0:generic_list(?T), ?$#0:wybe.int):
+0: generic_list.length<0>
+length(x#0:generic_list(?T), ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     generic_list.length1<0>(~x#0:generic_list(?T), 0:wybe.int, ?$#0:wybe.int) #0 @generic_list:nn:nn
 
 
 length1 > (2 calls)
-0: length1(x#0:generic_list(?T), acc#0:wybe.int, ?$#0:wybe.int):
+0: generic_list.length1<0>
+length1(x#0:generic_list(?T), acc#0:wybe.int, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(x#0:generic_list(?T), 0:wybe.int, ?tmp$5#0:wybe.bool)
@@ -146,7 +155,8 @@ length1 > (2 calls)
 
 
 nil > public {inline} (0 calls)
-0: nil(?$#0:generic_list(?T)):
+0: generic_list.nil<0>
+nil(?$#0:generic_list(?T)):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(0:generic_list(?T), ?$#0:generic_list(?T))

--- a/test-cases/final-dump/generic_use.exp
+++ b/test-cases/final-dump/generic_use.exp
@@ -18,7 +18,8 @@ AFTER EVERYTHING:
   procs           : 
 
 append > public (1 calls)
-0: append(x#0:generic_list(?T), y#0:generic_list(?T), ?$#0:generic_list(?T)):
+0: generic_list.append<0>
+append(x#0:generic_list(?T), y#0:generic_list(?T), ?$#0:generic_list(?T)):
  AliasPairs: [($#0,y#0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(generic_list.append<0>,fromList [NonAliasedParamCond 0 [0]]))]
@@ -38,7 +39,8 @@ append > public (1 calls)
 
 
 car > public {inline} (0 calls)
-0: car($rec#0:generic_list(?T), ?$#0:?T, ?$$#0:wybe.bool):
+0: generic_list.car<0>
+car($rec#0:generic_list(?T), ?$#0:?T, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -52,7 +54,8 @@ car > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 car > public {inline} (0 calls)
-1: car($rec#0:generic_list(?T), ?$rec#1:generic_list(?T), $field#0:?T, ?$$#0:wybe.bool):
+1: generic_list.car<1>
+car($rec#0:generic_list(?T), ?$rec#1:generic_list(?T), $field#0:?T, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -68,7 +71,8 @@ car > public {inline} (0 calls)
 
 
 cdr > public {inline} (0 calls)
-0: cdr($rec#0:generic_list(?T), ?$#0:generic_list(?T), ?$$#0:wybe.bool):
+0: generic_list.cdr<0>
+cdr($rec#0:generic_list(?T), ?$#0:generic_list(?T), ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -82,7 +86,8 @@ cdr > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 cdr > public {inline} (0 calls)
-1: cdr($rec#0:generic_list(?T), ?$rec#1:generic_list(?T), $field#0:generic_list(?T), ?$$#0:wybe.bool):
+1: generic_list.cdr<1>
+cdr($rec#0:generic_list(?T), ?$rec#1:generic_list(?T), $field#0:generic_list(?T), ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -98,14 +103,16 @@ cdr > public {inline} (0 calls)
 
 
 cons > public {inline} (1 calls)
-0: cons(car#0:?T, cdr#0:generic_list(?T), ?$#0:generic_list(?T)):
+0: generic_list.cons<0>
+cons(car#0:?T, cdr#0:generic_list(?T), ?$#0:generic_list(?T)):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:generic_list(?T))
     foreign lpvm mutate(~%$rec#0:generic_list(?T), ?%$rec#1:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~car#0:?T)
     foreign lpvm mutate(~%$rec#1:generic_list(?T), ?%$#0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr#0:generic_list(?T))
 cons > public {inline} (6 calls)
-1: cons(?car#0:?T, ?cdr#0:generic_list(?T), $#0:generic_list(?T), ?$$#0:wybe.bool):
+1: generic_list.cons<1>
+cons(?car#0:?T, ?cdr#0:generic_list(?T), $#0:generic_list(?T), ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -123,14 +130,16 @@ cons > public {inline} (6 calls)
 
 
 length > public {inline} (0 calls)
-0: length(x#0:generic_list(?T), ?$#0:wybe.int):
+0: generic_list.length<0>
+length(x#0:generic_list(?T), ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     generic_list.length1<0>(~x#0:generic_list(?T), 0:wybe.int, ?$#0:wybe.int) #0 @generic_list:nn:nn
 
 
 length1 > (2 calls)
-0: length1(x#0:generic_list(?T), acc#0:wybe.int, ?$#0:wybe.int):
+0: generic_list.length1<0>
+length1(x#0:generic_list(?T), acc#0:wybe.int, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(x#0:generic_list(?T), 0:wybe.int, ?tmp$5#0:wybe.bool)
@@ -146,7 +155,8 @@ length1 > (2 calls)
 
 
 nil > public {inline} (0 calls)
-0: nil(?$#0:generic_list(?T)):
+0: generic_list.nil<0>
+nil(?$#0:generic_list(?T)):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(0:generic_list(?T), ?$#0:generic_list(?T))
@@ -368,7 +378,8 @@ entry:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#5:wybe.phantom):
+0: generic_use.<0>
+(io#0:wybe.phantom, ?io#5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(8,(generic_use.nrev<0>,fromList [NonAliasedParamCond 0 []])),(15,(generic_use.reverse1<0>,fromList [NonAliasedParamCond 0 []]))]
@@ -390,7 +401,8 @@ entry:
 
 
 concat > public (3 calls)
-0: concat(l1#0:generic_list(?t), l2#0:generic_list(?t), ?$#0:generic_list(?t)):
+0: generic_use.concat<0>[410bae77d3]
+concat(l1#0:generic_list(?t), l2#0:generic_list(?t), ?$#0:generic_list(?t)):
  AliasPairs: [($#0,l2#0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(generic_use.concat<0>,fromList [NonAliasedParamCond 0 [0]]))]
@@ -421,14 +433,16 @@ concat > public (3 calls)
 
 
 fromto > public {inline} (2 calls)
-0: fromto(lo#0:wybe.int, hi#0:wybe.int, ?$#0:generic_list(wybe.int)):
+0: generic_use.fromto<0>
+fromto(lo#0:wybe.int, hi#0:wybe.int, ?$#0:generic_list(wybe.int)):
  AliasPairs: []
  InterestingCallProperties: []
     generic_use.fromto1<0>(~lo#0:wybe.int, ~hi#0:wybe.int, 0:generic_list(?T), ?$#0:generic_list(wybe.int)) #1 @generic_use:nn:nn
 
 
 fromto1 > (2 calls)
-0: fromto1(lo#0:wybe.int, hi#0:wybe.int, sofar#0:generic_list(wybe.int), ?$#0:generic_list(wybe.int)):
+0: generic_use.fromto1<0>
+fromto1(lo#0:wybe.int, hi#0:wybe.int, sofar#0:generic_list(wybe.int), ?$#0:generic_list(wybe.int)):
  AliasPairs: [($#0,sofar#0)]
  InterestingCallProperties: []
     foreign llvm icmp_sge(hi#0:wybe.int, lo#0:wybe.int, ?tmp$4#0:wybe.bool) @int:nn:nn
@@ -446,14 +460,16 @@ fromto1 > (2 calls)
 
 
 iota > public {inline} (1 calls)
-0: iota(n#0:wybe.int, ?$#0:generic_list(wybe.int)):
+0: generic_use.iota<0>
+iota(n#0:wybe.int, ?$#0:generic_list(wybe.int)):
  AliasPairs: []
  InterestingCallProperties: []
     generic_use.fromto1<0>(1:wybe.int, ~n#0:wybe.int, 0:generic_list(?T), ?$#0:generic_list(wybe.int)) #1 @generic_use:nn:nn
 
 
 nrev > public (2 calls)
-0: nrev(lst#0:generic_list(?t), ?$#0:generic_list(?t)):
+0: generic_use.nrev<0>[410bae77d3]
+nrev(lst#0:generic_list(?t), ?$#0:generic_list(?t)):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(generic_use.nrev<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(generic_use.concat<0>,fromList [NonAliasedParamCond 0 []]))]
@@ -486,7 +502,8 @@ nrev > public (2 calls)
 
 
 print > (1 calls)
-0: print(lst#0:generic_list(wybe.int), io#0:wybe.phantom, ?io#4:wybe.phantom):
+0: generic_use.print<0>
+print(lst#0:generic_list(wybe.int), io#0:wybe.phantom, ?io#4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c putchar('[':wybe.char, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -505,7 +522,8 @@ print > (1 calls)
 
 
 print_tail > (2 calls)
-0: print_tail(lst#0:generic_list(wybe.int), io#0:wybe.phantom, ?io#3:wybe.phantom):
+0: generic_use.print_tail<0>
+print_tail(lst#0:generic_list(wybe.int), io#0:wybe.phantom, ?io#3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(lst#0:generic_list(wybe.int), 0:wybe.int, ?tmp$2#0:wybe.bool)
@@ -523,7 +541,8 @@ print_tail > (2 calls)
 
 
 println > {inline} (5 calls)
-0: println(lst#0:generic_list(wybe.int), io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: generic_use.println<0>
+println(lst#0:generic_list(wybe.int), io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     generic_use.print<0>(~lst#0:generic_list(wybe.int), ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @generic_use:nn:nn
@@ -531,14 +550,16 @@ println > {inline} (5 calls)
 
 
 reverse > public {inline} (1 calls)
-0: reverse(lst#0:generic_list(?t), ?$#0:generic_list(?t)):
+0: generic_use.reverse<0>
+reverse(lst#0:generic_list(?t), ?$#0:generic_list(?t)):
  AliasPairs: []
  InterestingCallProperties: []
     generic_use.reverse1<0>(~lst#0:generic_list(?t), 0:generic_list(?T), ?$#0:generic_list(?t)) #1 @generic_use:nn:nn
 
 
 reverse1 > public (2 calls)
-0: reverse1(lst#0:generic_list(?t), suffix#0:generic_list(?t), ?$#0:generic_list(?t)):
+0: generic_use.reverse1<0>[410bae77d3]
+reverse1(lst#0:generic_list(?t), suffix#0:generic_list(?t), ?$#0:generic_list(?t)):
  AliasPairs: [($#0,suffix#0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(generic_use.reverse1<0>,fromList [NonAliasedParamCond 0 [0]]))]

--- a/test-cases/final-dump/import.exp
+++ b/test-cases/final-dump/import.exp
@@ -12,7 +12,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: import.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$5#0:position.position)
@@ -27,7 +28,8 @@ AFTER EVERYTHING:
 
 
 distance > public (1 calls)
-0: distance(p1#0:position.position, p2#0:position.position, ?$#0:wybe.int):
+0: import.distance<0>
+distance(p1#0:position.position, p2#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(p2#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
@@ -141,7 +143,8 @@ entry:
   procs           : 
 
 printPosition > public (0 calls)
-0: printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+0: position.printPosition<0>
+printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -224,7 +227,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position./=<0>
+/=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -244,7 +248,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position.=<0>
+=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
@@ -262,14 +267,16 @@ entry:
 
 
 position > public {inline} (0 calls)
-0: position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+0: position.position.position<0>
+position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
     foreign lpvm mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:position.position, ?%$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
 position > public {inline} (6 calls)
-1: position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+1: position.position.position<1>
+position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
@@ -277,24 +284,28 @@ position > public {inline} (6 calls)
 
 
 x > public {inline} (0 calls)
-0: x($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.x<0>
+x($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 x > public {inline} (0 calls)
-1: x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.x<1>
+x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 y > public {inline} (0 calls)
-0: y($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.y<0>
+y($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 y > public {inline} (0 calls)
-1: y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.y<1>
+y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)

--- a/test-cases/final-dump/import_in_sub_mod_lib.exp
+++ b/test-cases/final-dump/import_in_sub_mod_lib.exp
@@ -10,7 +10,8 @@ AFTER EVERYTHING:
   procs           : 
 
 foo > public {inline} (0 calls)
-0: foo(v#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: import_in_sub_mod_lib.foo<0>
+foo(v#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_int(~v#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn

--- a/test-cases/final-dump/import_in_sub_mod_main.exp
+++ b/test-cases/final-dump/import_in_sub_mod_main.exp
@@ -10,7 +10,8 @@ AFTER EVERYTHING:
   procs           : 
 
 foo > public {inline} (0 calls)
-0: foo(v#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: import_in_sub_mod_lib.foo<0>
+foo(v#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_int(~v#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
@@ -55,7 +56,8 @@ entry:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: import_in_sub_mod_main.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_int(10:wybe.int, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
@@ -100,7 +102,8 @@ entry:
   procs           : 
 
 bar > public {inline} (0 calls)
-0: bar(v#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: import_in_sub_mod_main.sub.bar<0>
+bar(v#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_int(~v#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn

--- a/test-cases/final-dump/inequality.exp
+++ b/test-cases/final-dump/inequality.exp
@@ -10,7 +10,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: inequality.<0>
+(io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     wybe.io.print<5>(1:wybe.bool, ~#io#0:wybe.phantom, ?tmp$6#0:wybe.phantom) #4 @io:nn:nn

--- a/test-cases/final-dump/inline_decl.exp
+++ b/test-cases/final-dump/inline_decl.exp
@@ -12,7 +12,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: inline_decl.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c putchar('h':wybe.char, ~#io#0:wybe.phantom, ?tmp$1#0:wybe.phantom) @io:nn:nn
@@ -31,14 +32,16 @@ AFTER EVERYTHING:
 
 
 finish > public {noinline} (1 calls)
-0: finish(io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: inline_decl.finish<0>
+finish(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c putchar('\n':wybe.char, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
 
 
 long > public {inline} (1 calls)
-0: long(io#0:wybe.phantom, ?io#13:wybe.phantom):
+0: inline_decl.long<0>
+long(io#0:wybe.phantom, ?io#13:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c putchar('h':wybe.char, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn

--- a/test-cases/final-dump/int_list.exp
+++ b/test-cases/final-dump/int_list.exp
@@ -23,7 +23,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: int_list.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$6#0:int_list.int_list)
@@ -40,7 +41,8 @@ AFTER EVERYTHING:
 
 
 print > public (2 calls)
-0: print(x#0:int_list.int_list, io#0:wybe.phantom, ?io#3:wybe.phantom):
+0: int_list.print<0>
+print(x#0:int_list.int_list, io#0:wybe.phantom, ?io#3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(x#0:int_list.int_list, 0:wybe.int, ?tmp$2#0:wybe.bool)
@@ -58,7 +60,8 @@ print > public (2 calls)
 
 
 println > public {inline} (1 calls)
-0: println(x#0:int_list.int_list, io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: int_list.println<0>
+println(x#0:int_list.int_list, io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     int_list.print<0>(~x#0:int_list.int_list, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @int_list:nn:nn
@@ -169,7 +172,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:int_list.int_list, $right#0:int_list.int_list, ?$$#0:wybe.bool):
+0: int_list.int_list./=<0>
+/=($left#0:int_list.int_list, $right#0:int_list.int_list, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     int_list.int_list.=<0>(~$left#0:int_list.int_list, ~$right#0:int_list.int_list, ?tmp$0#0:wybe.bool) #0
@@ -177,7 +181,8 @@ entry:
 
 
 = > public (2 calls)
-0: =($left#0:int_list.int_list, $right#0:int_list.int_list, ?$$#0:wybe.bool):
+0: int_list.int_list.=<0>
+=($left#0:int_list.int_list, $right#0:int_list.int_list, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($left#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -209,14 +214,16 @@ entry:
 
 
 cons > public {inline} (0 calls)
-0: cons(head#0:wybe.int, tail#0:int_list.int_list, ?$#0:int_list.int_list):
+0: int_list.int_list.cons<0>
+cons(head#0:wybe.int, tail#0:int_list.int_list, ?$#0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:int_list.int_list)
     foreign lpvm mutate(~%$rec#0:int_list.int_list, ?%$rec#1:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:int_list.int_list, ?%$#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail#0:int_list.int_list)
 cons > public {inline} (12 calls)
-1: cons(?head#0:wybe.int, ?tail#0:int_list.int_list, $#0:int_list.int_list, ?$$#0:wybe.bool):
+1: int_list.int_list.cons<1>
+cons(?head#0:wybe.int, ?tail#0:int_list.int_list, $#0:int_list.int_list, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -234,7 +241,8 @@ cons > public {inline} (12 calls)
 
 
 head > public {inline} (0 calls)
-0: head($rec#0:int_list.int_list, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: int_list.int_list.head<0>
+head($rec#0:int_list.int_list, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -248,7 +256,8 @@ head > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 head > public {inline} (0 calls)
-1: head($rec#0:int_list.int_list, ?$rec#1:int_list.int_list, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: int_list.int_list.head<1>
+head($rec#0:int_list.int_list, ?$rec#1:int_list.int_list, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -264,14 +273,16 @@ head > public {inline} (0 calls)
 
 
 nil > public {inline} (0 calls)
-0: nil(?$#0:int_list.int_list):
+0: int_list.int_list.nil<0>
+nil(?$#0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(0:int_list.int_list, ?$#0:int_list.int_list)
 
 
 tail > public {inline} (0 calls)
-0: tail($rec#0:int_list.int_list, ?$#0:int_list.int_list, ?$$#0:wybe.bool):
+0: int_list.int_list.tail<0>
+tail($rec#0:int_list.int_list, ?$#0:int_list.int_list, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -285,7 +296,8 @@ tail > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 tail > public {inline} (0 calls)
-1: tail($rec#0:int_list.int_list, ?$rec#1:int_list.int_list, $field#0:int_list.int_list, ?$$#0:wybe.bool):
+1: int_list.int_list.tail<1>
+tail($rec#0:int_list.int_list, ?$rec#1:int_list.int_list, $field#0:int_list.int_list, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)

--- a/test-cases/final-dump/io.exp
+++ b/test-cases/final-dump/io.exp
@@ -12,7 +12,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: io.<0>
+(io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_int(100:wybe.int, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
@@ -22,7 +23,8 @@ AFTER EVERYTHING:
 
 
 myprint_a > public {inline} (1 calls)
-0: myprint_a(x#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: io.myprint_a<0>
+myprint_a(x#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_int(~x#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
@@ -30,7 +32,8 @@ myprint_a > public {inline} (1 calls)
 
 
 myprint_b > public {inline} (1 calls)
-0: myprint_b(x#0:wybe.int, ?y#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: io.myprint_b<0>
+myprint_b(x#0:wybe.int, ?y#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_int(~x#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn

--- a/test-cases/final-dump/list_loop.exp
+++ b/test-cases/final-dump/list_loop.exp
@@ -21,7 +21,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: list_loop.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$8#0:list_loop.intlist)
@@ -37,7 +38,8 @@ AFTER EVERYTHING:
 
 
 gen$1 > (2 calls)
-0: gen$1(io#0:wybe.phantom, l#0:list_loop.intlist, tmp$0#0:list_loop.intlist, tmp$1#0:list_loop.intlist, tmp$2#0:list_loop.intlist, tmp$3#0:list_loop.intlist, x#0:list_loop.intlist, ?io#1:wybe.phantom):
+0: list_loop.gen$1<0>
+gen$1(io#0:wybe.phantom, l#0:list_loop.intlist, tmp$0#0:list_loop.intlist, tmp$1#0:list_loop.intlist, tmp$2#0:list_loop.intlist, tmp$3#0:list_loop.intlist, x#0:list_loop.intlist, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(l#0:list_loop.intlist, 0:wybe.int, ?tmp$7#0:wybe.bool)
@@ -55,7 +57,8 @@ gen$1 > (2 calls)
 
 
 gen$2 > {inline} (1 calls)
-0: gen$2(h#0:wybe.int, io#0:wybe.phantom, l#0:list_loop.intlist, tmp$0#0:list_loop.intlist, tmp$1#0:list_loop.intlist, tmp$2#0:list_loop.intlist, tmp$3#0:list_loop.intlist, x#0:list_loop.intlist, ?io#2:wybe.phantom):
+0: list_loop.gen$2<0>
+gen$2(h#0:wybe.int, io#0:wybe.phantom, l#0:list_loop.intlist, tmp$0#0:list_loop.intlist, tmp$1#0:list_loop.intlist, tmp$2#0:list_loop.intlist, tmp$3#0:list_loop.intlist, x#0:list_loop.intlist, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_int(h#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$7#0:wybe.phantom) @io:nn:nn
@@ -64,7 +67,8 @@ gen$2 > {inline} (1 calls)
 
 
 gen$3 > (2 calls)
-0: gen$3(h#0:wybe.int, io#0:wybe.phantom, l#0:list_loop.intlist, l2#0:list_loop.intlist, tmp$0#0:list_loop.intlist, tmp$1#0:list_loop.intlist, tmp$2#0:list_loop.intlist, tmp$3#0:list_loop.intlist, x#0:list_loop.intlist, ?io#1:wybe.phantom):
+0: list_loop.gen$3<0>
+gen$3(h#0:wybe.int, io#0:wybe.phantom, l#0:list_loop.intlist, l2#0:list_loop.intlist, tmp$0#0:list_loop.intlist, tmp$1#0:list_loop.intlist, tmp$2#0:list_loop.intlist, tmp$3#0:list_loop.intlist, x#0:list_loop.intlist, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(l2#0:list_loop.intlist, 0:wybe.int, ?tmp$6#0:wybe.bool)
@@ -85,7 +89,8 @@ gen$3 > (2 calls)
 
 
 gen$4 > {inline} (1 calls)
-0: gen$4(h#0:wybe.int, h2#0:wybe.int, io#0:wybe.phantom, l#0:list_loop.intlist, l2#0:list_loop.intlist, tmp$0#0:list_loop.intlist, tmp$1#0:list_loop.intlist, tmp$2#0:list_loop.intlist, tmp$3#0:list_loop.intlist, x#0:list_loop.intlist, ?io#5:wybe.phantom):
+0: list_loop.gen$4<0>
+gen$4(h#0:wybe.int, h2#0:wybe.int, io#0:wybe.phantom, l#0:list_loop.intlist, l2#0:list_loop.intlist, tmp$0#0:list_loop.intlist, tmp$1#0:list_loop.intlist, tmp$2#0:list_loop.intlist, tmp$3#0:list_loop.intlist, x#0:list_loop.intlist, ?io#5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("    ":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -256,7 +261,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:list_loop.intlist, $right#0:list_loop.intlist, ?$$#0:wybe.bool):
+0: list_loop.intlist./=<0>
+/=($left#0:list_loop.intlist, $right#0:list_loop.intlist, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     list_loop.intlist.=<0>(~$left#0:list_loop.intlist, ~$right#0:list_loop.intlist, ?tmp$0#0:wybe.bool) #0
@@ -264,7 +270,8 @@ entry:
 
 
 = > public (2 calls)
-0: =($left#0:list_loop.intlist, $right#0:list_loop.intlist, ?$$#0:wybe.bool):
+0: list_loop.intlist.=<0>
+=($left#0:list_loop.intlist, $right#0:list_loop.intlist, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($left#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -296,14 +303,16 @@ entry:
 
 
 cons > public {inline} (0 calls)
-0: cons(head#0:wybe.int, tail#0:list_loop.intlist, ?$#0:list_loop.intlist):
+0: list_loop.intlist.cons<0>
+cons(head#0:wybe.int, tail#0:list_loop.intlist, ?$#0:list_loop.intlist):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:list_loop.intlist)
     foreign lpvm mutate(~%$rec#0:list_loop.intlist, ?%$rec#1:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:list_loop.intlist, ?%$#0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail#0:list_loop.intlist)
 cons > public {inline} (12 calls)
-1: cons(?head#0:wybe.int, ?tail#0:list_loop.intlist, $#0:list_loop.intlist, ?$$#0:wybe.bool):
+1: list_loop.intlist.cons<1>
+cons(?head#0:wybe.int, ?tail#0:list_loop.intlist, $#0:list_loop.intlist, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -321,7 +330,8 @@ cons > public {inline} (12 calls)
 
 
 head > public {inline} (0 calls)
-0: head($rec#0:list_loop.intlist, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: list_loop.intlist.head<0>
+head($rec#0:list_loop.intlist, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -335,7 +345,8 @@ head > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 head > public {inline} (0 calls)
-1: head($rec#0:list_loop.intlist, ?$rec#1:list_loop.intlist, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: list_loop.intlist.head<1>
+head($rec#0:list_loop.intlist, ?$rec#1:list_loop.intlist, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -351,14 +362,16 @@ head > public {inline} (0 calls)
 
 
 nil > public {inline} (0 calls)
-0: nil(?$#0:list_loop.intlist):
+0: list_loop.intlist.nil<0>
+nil(?$#0:list_loop.intlist):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(0:list_loop.intlist, ?$#0:list_loop.intlist)
 
 
 tail > public {inline} (0 calls)
-0: tail($rec#0:list_loop.intlist, ?$#0:list_loop.intlist, ?$$#0:wybe.bool):
+0: list_loop.intlist.tail<0>
+tail($rec#0:list_loop.intlist, ?$#0:list_loop.intlist, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -372,7 +385,8 @@ tail > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 tail > public {inline} (0 calls)
-1: tail($rec#0:list_loop.intlist, ?$rec#1:list_loop.intlist, $field#0:list_loop.intlist, ?$$#0:wybe.bool):
+1: list_loop.intlist.tail<1>
+tail($rec#0:list_loop.intlist, ?$rec#1:list_loop.intlist, $field#0:list_loop.intlist, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)

--- a/test-cases/final-dump/list_this.exp
+++ b/test-cases/final-dump/list_this.exp
@@ -18,7 +18,8 @@ AFTER EVERYTHING:
   procs           : 
 
 append > public (1 calls)
-0: append(x#0:list_this(?T), y#0:list_this(?T), ?$#0:list_this(?T)):
+0: list_this.append<0>
+append(x#0:list_this(?T), y#0:list_this(?T), ?$#0:list_this(?T)):
  AliasPairs: [($#0,y#0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(list_this.append<0>,fromList [NonAliasedParamCond 0 [0]]))]
@@ -38,7 +39,8 @@ append > public (1 calls)
 
 
 car > public {inline} (0 calls)
-0: car($rec#0:list_this(?T), ?$#0:?T, ?$$#0:wybe.bool):
+0: list_this.car<0>
+car($rec#0:list_this(?T), ?$#0:?T, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -52,7 +54,8 @@ car > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 car > public {inline} (0 calls)
-1: car($rec#0:list_this(?T), ?$rec#1:list_this(?T), $field#0:?T, ?$$#0:wybe.bool):
+1: list_this.car<1>
+car($rec#0:list_this(?T), ?$rec#1:list_this(?T), $field#0:?T, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -68,7 +71,8 @@ car > public {inline} (0 calls)
 
 
 cdr > public {inline} (0 calls)
-0: cdr($rec#0:list_this(?T), ?$#0:list_this(?T), ?$$#0:wybe.bool):
+0: list_this.cdr<0>
+cdr($rec#0:list_this(?T), ?$#0:list_this(?T), ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -82,7 +86,8 @@ cdr > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 cdr > public {inline} (0 calls)
-1: cdr($rec#0:list_this(?T), ?$rec#1:list_this(?T), $field#0:list_this(?T), ?$$#0:wybe.bool):
+1: list_this.cdr<1>
+cdr($rec#0:list_this(?T), ?$rec#1:list_this(?T), $field#0:list_this(?T), ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -98,14 +103,16 @@ cdr > public {inline} (0 calls)
 
 
 cons > public {inline} (1 calls)
-0: cons(car#0:?T, cdr#0:list_this(?T), ?$#0:list_this(?T)):
+0: list_this.cons<0>
+cons(car#0:?T, cdr#0:list_this(?T), ?$#0:list_this(?T)):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:list_this(?T))
     foreign lpvm mutate(~%$rec#0:list_this(?T), ?%$rec#1:list_this(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~car#0:?T)
     foreign lpvm mutate(~%$rec#1:list_this(?T), ?%$#0:list_this(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr#0:list_this(?T))
 cons > public {inline} (6 calls)
-1: cons(?car#0:?T, ?cdr#0:list_this(?T), $#0:list_this(?T), ?$$#0:wybe.bool):
+1: list_this.cons<1>
+cons(?car#0:?T, ?cdr#0:list_this(?T), $#0:list_this(?T), ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -123,14 +130,16 @@ cons > public {inline} (6 calls)
 
 
 length > public {inline} (0 calls)
-0: length(x#0:list_this(?T), ?$#0:wybe.int):
+0: list_this.length<0>
+length(x#0:list_this(?T), ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     list_this.length1<0>(~x#0:list_this(?T), 0:wybe.int, ?$#0:wybe.int) #0 @list_this:nn:nn
 
 
 length1 > (2 calls)
-0: length1(x#0:list_this(?T), acc#0:wybe.int, ?$#0:wybe.int):
+0: list_this.length1<0>
+length1(x#0:list_this(?T), acc#0:wybe.int, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(x#0:list_this(?T), 0:wybe.int, ?tmp$5#0:wybe.bool)
@@ -146,7 +155,8 @@ length1 > (2 calls)
 
 
 nil > public {inline} (0 calls)
-0: nil(?$#0:list_this(?T)):
+0: list_this.nil<0>
+nil(?$#0:list_this(?T)):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(0:list_this(?T), ?$#0:list_this(?T))

--- a/test-cases/final-dump/loop_bug.exp
+++ b/test-cases/final-dump/loop_bug.exp
@@ -21,7 +21,8 @@ AFTER EVERYTHING:
   procs           : 
 
 gen$1 > (2 calls)
-0: gen$1([h#0:wybe.int], io#0:wybe.phantom, lst#0:loop_bug.int_list, t#0:loop_bug.int_list, ?io#1:wybe.phantom):
+0: loop_bug.gen$1<0>
+gen$1([h#0:wybe.int], io#0:wybe.phantom, lst#0:loop_bug.int_list, t#0:loop_bug.int_list, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(t#0:loop_bug.int_list, 0:wybe.int, ?tmp$2#0:wybe.bool)
@@ -39,7 +40,8 @@ gen$1 > (2 calls)
 
 
 gen$2 > {inline} (1 calls)
-0: gen$2(h#0:wybe.int, io#0:wybe.phantom, lst#0:loop_bug.int_list, t#0:loop_bug.int_list, ?io#3:wybe.phantom):
+0: loop_bug.gen$2<0>
+gen$2(h#0:wybe.int, io#0:wybe.phantom, lst#0:loop_bug.int_list, t#0:loop_bug.int_list, ?io#3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(", ":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -48,7 +50,8 @@ gen$2 > {inline} (1 calls)
 
 
 print > public (0 calls)
-0: print(lst#0:loop_bug.int_list, io#0:wybe.phantom, ?io#3:wybe.phantom):
+0: loop_bug.print<0>
+print(lst#0:loop_bug.int_list, io#0:wybe.phantom, ?io#3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c putchar('[':wybe.char, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -166,7 +169,8 @@ if.else:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:loop_bug.int_list, $right#0:loop_bug.int_list, ?$$#0:wybe.bool):
+0: loop_bug.int_list./=<0>
+/=($left#0:loop_bug.int_list, $right#0:loop_bug.int_list, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     loop_bug.int_list.=<0>(~$left#0:loop_bug.int_list, ~$right#0:loop_bug.int_list, ?tmp$0#0:wybe.bool) #0
@@ -174,7 +178,8 @@ if.else:
 
 
 = > public (2 calls)
-0: =($left#0:loop_bug.int_list, $right#0:loop_bug.int_list, ?$$#0:wybe.bool):
+0: loop_bug.int_list.=<0>
+=($left#0:loop_bug.int_list, $right#0:loop_bug.int_list, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($left#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -206,14 +211,16 @@ if.else:
 
 
 cons > public {inline} (0 calls)
-0: cons(head#0:wybe.int, tail#0:loop_bug.int_list, ?$#0:loop_bug.int_list):
+0: loop_bug.int_list.cons<0>
+cons(head#0:wybe.int, tail#0:loop_bug.int_list, ?$#0:loop_bug.int_list):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:loop_bug.int_list)
     foreign lpvm mutate(~%$rec#0:loop_bug.int_list, ?%$rec#1:loop_bug.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:loop_bug.int_list, ?%$#0:loop_bug.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail#0:loop_bug.int_list)
 cons > public {inline} (12 calls)
-1: cons(?head#0:wybe.int, ?tail#0:loop_bug.int_list, $#0:loop_bug.int_list, ?$$#0:wybe.bool):
+1: loop_bug.int_list.cons<1>
+cons(?head#0:wybe.int, ?tail#0:loop_bug.int_list, $#0:loop_bug.int_list, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -231,7 +238,8 @@ cons > public {inline} (12 calls)
 
 
 head > public {inline} (0 calls)
-0: head($rec#0:loop_bug.int_list, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: loop_bug.int_list.head<0>
+head($rec#0:loop_bug.int_list, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -245,7 +253,8 @@ head > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 head > public {inline} (0 calls)
-1: head($rec#0:loop_bug.int_list, ?$rec#1:loop_bug.int_list, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: loop_bug.int_list.head<1>
+head($rec#0:loop_bug.int_list, ?$rec#1:loop_bug.int_list, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -261,14 +270,16 @@ head > public {inline} (0 calls)
 
 
 nil > public {inline} (0 calls)
-0: nil(?$#0:loop_bug.int_list):
+0: loop_bug.int_list.nil<0>
+nil(?$#0:loop_bug.int_list):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(0:loop_bug.int_list, ?$#0:loop_bug.int_list)
 
 
 tail > public {inline} (0 calls)
-0: tail($rec#0:loop_bug.int_list, ?$#0:loop_bug.int_list, ?$$#0:wybe.bool):
+0: loop_bug.int_list.tail<0>
+tail($rec#0:loop_bug.int_list, ?$#0:loop_bug.int_list, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -282,7 +293,8 @@ tail > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 tail > public {inline} (0 calls)
-1: tail($rec#0:loop_bug.int_list, ?$rec#1:loop_bug.int_list, $field#0:loop_bug.int_list, ?$$#0:wybe.bool):
+1: loop_bug.int_list.tail<1>
+tail($rec#0:loop_bug.int_list, ?$rec#1:loop_bug.int_list, $field#0:loop_bug.int_list, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)

--- a/test-cases/final-dump/main_hello.exp
+++ b/test-cases/final-dump/main_hello.exp
@@ -19,7 +19,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (argc#0:wybe.int, [?argc#0:wybe.int], ?arguments#2:wybe.array(wybe.string), argv#0:wybe.array.raw_array(wybe.string), [?argv#0:wybe.array.raw_array(wybe.string)], ?command#2:wybe.string, ?exit_code#1:wybe.int, io#0:wybe.phantom, [?io#0:wybe.phantom]):
+0: command_line.<0>
+(argc#0:wybe.int, [?argc#0:wybe.int], ?arguments#2:wybe.array(wybe.string), argv#0:wybe.array.raw_array(wybe.string), [?argv#0:wybe.array.raw_array(wybe.string)], ?command#2:wybe.string, ?exit_code#1:wybe.int, io#0:wybe.phantom, [?io#0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$9#0:wybe.array(?T))
@@ -37,7 +38,8 @@ AFTER EVERYTHING:
 
 
 set_exit_code > public {inline} (0 calls)
-0: set_exit_code(code#0:wybe.int, [exit_code#0:wybe.int], ?exit_code#1:wybe.int):
+0: command_line.set_exit_code<0>
+set_exit_code(code#0:wybe.int, [exit_code#0:wybe.int], ?exit_code#1:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(~code#0:wybe.int, ?exit_code#1:wybe.int) @command_line:nn:nn
@@ -113,7 +115,8 @@ entry:
   procs           : 
 
 *main* > public (0 calls)
-0: (arguments#0:wybe.array(wybe.string), [?arguments#0:wybe.array(wybe.string)], command#0:wybe.string, [?command#0:wybe.string], [exit_code#0:wybe.int], ?exit_code#1:wybe.int, io#0:wybe.phantom, ?io#3:wybe.phantom):
+0: main_hello.<0>
+(arguments#0:wybe.array(wybe.string), [?arguments#0:wybe.array(wybe.string)], command#0:wybe.string, [?command#0:wybe.string], [exit_code#0:wybe.int], ?exit_code#1:wybe.int, io#0:wybe.phantom, ?io#3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(42:wybe.int, ?#exit_code#1:wybe.int) @command_line:nn:nn

--- a/test-cases/final-dump/main_hello2.exp
+++ b/test-cases/final-dump/main_hello2.exp
@@ -10,7 +10,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: main_hello2.<0>
+(io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("hello, ":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn

--- a/test-cases/final-dump/mainless.exp
+++ b/test-cases/final-dump/mainless.exp
@@ -10,7 +10,8 @@ AFTER EVERYTHING:
   procs           : 
 
 nothing_interesting > public {inline} (0 calls)
-0: nothing_interesting(?$#0:wybe.int):
+0: mainless.nothing_interesting<0>
+nothing_interesting(?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(7:wybe.int, ?$#0:wybe.int) @mainless:nn:nn

--- a/test-cases/final-dump/mixed_fields.exp
+++ b/test-cases/final-dump/mixed_fields.exp
@@ -27,7 +27,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: mixed_fields.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(32:wybe.int, ?tmp$8#0:mixed_fields)
@@ -41,7 +42,8 @@ AFTER EVERYTHING:
 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:mixed_fields, $right#0:mixed_fields, ?$$#0:wybe.bool):
+0: mixed_fields./=<0>
+/=($left#0:mixed_fields, $right#0:mixed_fields, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     mixed_fields.=<0>(~$left#0:mixed_fields, ~$right#0:mixed_fields, ?tmp$0#0:wybe.bool) #0
@@ -49,7 +51,8 @@ AFTER EVERYTHING:
 
 
 = > public (1 calls)
-0: =($left#0:mixed_fields, $right#0:mixed_fields, ?$$#0:wybe.bool):
+0: mixed_fields.=<0>
+=($left#0:mixed_fields, $right#0:mixed_fields, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$f2#0:wybe.char)
@@ -103,79 +106,92 @@ AFTER EVERYTHING:
 
 
 f1 > public {inline} (1 calls)
-0: f1($rec#0:mixed_fields, ?$#0:wybe.int):
+0: mixed_fields.f1<0>
+f1($rec#0:mixed_fields, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 f1 > public {inline} (0 calls)
-1: f1($rec#0:mixed_fields, ?$rec#1:mixed_fields, $field#0:wybe.int):
+1: mixed_fields.f1<1>
+f1($rec#0:mixed_fields, ?$rec#1:mixed_fields, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:mixed_fields, ?%$rec#1:mixed_fields, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 f2 > public {inline} (1 calls)
-0: f2($rec#0:mixed_fields, ?$#0:wybe.char):
+0: mixed_fields.f2<0>
+f2($rec#0:mixed_fields, ?$#0:wybe.char):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$#0:wybe.char)
 f2 > public {inline} (0 calls)
-1: f2($rec#0:mixed_fields, ?$rec#1:mixed_fields, $field#0:wybe.char):
+1: mixed_fields.f2<1>
+f2($rec#0:mixed_fields, ?$rec#1:mixed_fields, $field#0:wybe.char):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:mixed_fields, ?%$rec#1:mixed_fields, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field#0:wybe.char)
 
 
 f3 > public {inline} (1 calls)
-0: f3($rec#0:mixed_fields, ?$#0:wybe.int):
+0: mixed_fields.f3<0>
+f3($rec#0:mixed_fields, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 f3 > public {inline} (0 calls)
-1: f3($rec#0:mixed_fields, ?$rec#1:mixed_fields, $field#0:wybe.int):
+1: mixed_fields.f3<1>
+f3($rec#0:mixed_fields, ?$rec#1:mixed_fields, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:mixed_fields, ?%$rec#1:mixed_fields, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 f4 > public {inline} (1 calls)
-0: f4($rec#0:mixed_fields, ?$#0:wybe.bool):
+0: mixed_fields.f4<0>
+f4($rec#0:mixed_fields, ?$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?$#0:wybe.bool)
 f4 > public {inline} (0 calls)
-1: f4($rec#0:mixed_fields, ?$rec#1:mixed_fields, $field#0:wybe.bool):
+1: mixed_fields.f4<1>
+f4($rec#0:mixed_fields, ?$rec#1:mixed_fields, $field#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:mixed_fields, ?%$rec#1:mixed_fields, 1:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field#0:wybe.bool)
 
 
 f5 > public {inline} (1 calls)
-0: f5($rec#0:mixed_fields, ?$#0:wybe.int):
+0: mixed_fields.f5<0>
+f5($rec#0:mixed_fields, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 f5 > public {inline} (0 calls)
-1: f5($rec#0:mixed_fields, ?$rec#1:mixed_fields, $field#0:wybe.int):
+1: mixed_fields.f5<1>
+f5($rec#0:mixed_fields, ?$rec#1:mixed_fields, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:mixed_fields, ?%$rec#1:mixed_fields, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 f6 > public {inline} (1 calls)
-0: f6($rec#0:mixed_fields, ?$#0:wybe.char):
+0: mixed_fields.f6<0>
+f6($rec#0:mixed_fields, ?$#0:wybe.char):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?$#0:wybe.char)
 f6 > public {inline} (0 calls)
-1: f6($rec#0:mixed_fields, ?$rec#1:mixed_fields, $field#0:wybe.char):
+1: mixed_fields.f6<1>
+f6($rec#0:mixed_fields, ?$rec#1:mixed_fields, $field#0:wybe.char):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:mixed_fields, ?%$rec#1:mixed_fields, 2:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field#0:wybe.char)
 
 
 mixed > public {inline} (1 calls)
-0: mixed(f1#0:wybe.int, f2#0:wybe.char, f3#0:wybe.int, f4#0:wybe.bool, f5#0:wybe.int, f6#0:wybe.char, ?$#0:mixed_fields):
+0: mixed_fields.mixed<0>
+mixed(f1#0:wybe.int, f2#0:wybe.char, f3#0:wybe.int, f4#0:wybe.bool, f5#0:wybe.int, f6#0:wybe.char, ?$#0:mixed_fields):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(32:wybe.int, ?$rec#0:mixed_fields)
@@ -186,7 +202,8 @@ mixed > public {inline} (1 calls)
     foreign lpvm mutate(~%$rec#4:mixed_fields, ?%$rec#5:mixed_fields, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f3#0:wybe.int)
     foreign lpvm mutate(~%$rec#5:mixed_fields, ?%$#0:mixed_fields, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f5#0:wybe.int)
 mixed > public {inline} (22 calls)
-1: mixed(?f1#0:wybe.int, ?f2#0:wybe.char, ?f3#0:wybe.int, ?f4#0:wybe.bool, ?f5#0:wybe.int, ?f6#0:wybe.char, $#0:mixed_fields):
+1: mixed_fields.mixed<1>
+mixed(?f1#0:wybe.int, ?f2#0:wybe.char, ?f3#0:wybe.int, ?f4#0:wybe.bool, ?f5#0:wybe.int, ?f6#0:wybe.char, $#0:mixed_fields):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?f2#0:wybe.char)
@@ -198,7 +215,8 @@ mixed > public {inline} (22 calls)
 
 
 printit > public (1 calls)
-0: printit(ob#0:mixed_fields, io#0:wybe.phantom, ?io#6:wybe.phantom):
+0: mixed_fields.printit<0>
+printit(ob#0:mixed_fields, io#0:wybe.phantom, ?io#6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(ob#0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)

--- a/test-cases/final-dump/multi_out.exp
+++ b/test-cases/final-dump/multi_out.exp
@@ -11,13 +11,15 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, [?io#0:wybe.phantom]):
+0: multi_out.<0>
+(io#0:wybe.phantom, [?io#0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
 
 
 onetwothree > public {inline} (1 calls)
-0: onetwothree(?x#0:wybe.int, ?y#0:wybe.int, ?z#0:wybe.int):
+0: multi_out.onetwothree<0>
+onetwothree(?x#0:wybe.int, ?y#0:wybe.int, ?z#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(1:wybe.int, ?x#0:wybe.int) @multi_out:nn:nn

--- a/test-cases/final-dump/multi_specz.exp
+++ b/test-cases/final-dump/multi_specz.exp
@@ -15,7 +15,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: multi_specz.<0>
+(io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     multi_specz.bar1<0>(~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @multi_specz:nn:nn
@@ -23,7 +24,8 @@ AFTER EVERYTHING:
 
 
 bar1 > public (1 calls)
-0: bar1(io#0:wybe.phantom, ?io#6:wybe.phantom):
+0: multi_specz.bar1<0>
+bar1(io#0:wybe.phantom, ?io#6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(5,(multi_specz.foo<0>,fromList [NonAliasedParamCond 0 [],NonAliasedParamCond 1 []]))]
@@ -51,7 +53,8 @@ bar1 > public (1 calls)
 
 
 bar2 > public (1 calls)
-0: bar2(io#0:wybe.phantom, ?io#8:wybe.phantom):
+0: multi_specz.bar2<0>
+bar2(io#0:wybe.phantom, ?io#8:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$6#0:position.position)
@@ -80,7 +83,8 @@ bar2 > public (1 calls)
 
 
 foo > public (2 calls)
-0: foo(x1#0:position.position, x2#0:position.position, x3#0:position.position, x4#0:position.position, io#0:wybe.phantom, ?io#4:wybe.phantom):
+0: multi_specz.foo<0>
+foo(x1#0:position.position, x2#0:position.position, x3#0:position.position, x4#0:position.position, io#0:wybe.phantom, ?io#4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0,InterestingUnaliased 1,InterestingUnaliased 2,InterestingUnaliased 3]
  MultiSpeczDepInfo: [(0,(multi_specz.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [0]])),(1,(multi_specz.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [1]])),(2,(multi_specz.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [2]])),(3,(multi_specz.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [3]]))]
@@ -96,7 +100,8 @@ foo > public (2 calls)
 
 
 modifyAndPrint > public (4 calls)
-0: modifyAndPrint(pos#0:position.position, v#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: multi_specz.modifyAndPrint<0>
+modifyAndPrint(pos#0:position.position, v#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
     foreign lpvm {noalias} mutate(~%pos#0:position.position, ?%pos#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~v#0:wybe.int)
@@ -338,7 +343,8 @@ entry:
   procs           : 
 
 printPosition > public (0 calls)
-0: printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+0: position.printPosition<0>
+printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -421,7 +427,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position./=<0>
+/=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -441,7 +448,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position.=<0>
+=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
@@ -459,14 +467,16 @@ entry:
 
 
 position > public {inline} (0 calls)
-0: position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+0: position.position.position<0>
+position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
     foreign lpvm mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:position.position, ?%$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
 position > public {inline} (6 calls)
-1: position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+1: position.position.position<1>
+position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
@@ -474,24 +484,28 @@ position > public {inline} (6 calls)
 
 
 x > public {inline} (0 calls)
-0: x($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.x<0>
+x($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 x > public {inline} (0 calls)
-1: x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.x<1>
+x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 y > public {inline} (0 calls)
-0: y($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.y<0>
+y($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 y > public {inline} (0 calls)
-1: y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.y<1>
+y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)

--- a/test-cases/final-dump/multi_specz_cyclic_exe.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_exe.exp
@@ -12,14 +12,16 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: multi_specz_cyclic_exe.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     multi_specz_cyclic_exe.main<0>(~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @multi_specz_cyclic_exe:nn:nn
 
 
 main > public (1 calls)
-0: main(io#0:wybe.phantom, ?io#6:wybe.phantom):
+0: multi_specz_cyclic_exe.main<0>
+main(io#0:wybe.phantom, ?io#6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(5,(multi_specz_cyclic_lib.foo1<0>,fromList [NonAliasedParamCond 0 [],NonAliasedParamCond 1 []]))]
@@ -167,7 +169,8 @@ entry:
   procs           : 
 
 foo1 > public (0 calls)
-0: foo1(x1#0:multi_specz_cyclic_lib.position, x2#0:multi_specz_cyclic_lib.position, x3#0:multi_specz_cyclic_lib.position, x4#0:multi_specz_cyclic_lib.position, n#0:wybe.int, io#0:wybe.phantom, ?io#4:wybe.phantom):
+0: multi_specz_cyclic_lib.foo1<0>[7477e50a09]
+foo1(x1#0:multi_specz_cyclic_lib.position, x2#0:multi_specz_cyclic_lib.position, x3#0:multi_specz_cyclic_lib.position, x4#0:multi_specz_cyclic_lib.position, n#0:wybe.int, io#0:wybe.phantom, ?io#4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0,InterestingUnaliased 1,InterestingUnaliased 2,InterestingUnaliased 3]
  MultiSpeczDepInfo: [(2,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [0]])),(3,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [1]])),(4,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [2]])),(5,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [3]])),(7,(multi_specz_cyclic_lib2.foo2<0>,fromList [NonAliasedParamCond 0 [1],NonAliasedParamCond 1 [2],NonAliasedParamCond 2 [3],NonAliasedParamCond 3 [0]]))]
@@ -213,7 +216,8 @@ foo1 > public (0 calls)
 
 
 modifyAndPrint > public (4 calls)
-0: modifyAndPrint(pos#0:multi_specz_cyclic_lib.position, v#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: multi_specz_cyclic_lib.modifyAndPrint<0>
+modifyAndPrint(pos#0:multi_specz_cyclic_lib.position, v#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
     foreign lpvm {noalias} mutate(~%pos#0:multi_specz_cyclic_lib.position, ?%pos#1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~v#0:wybe.int)
@@ -224,7 +228,8 @@ modifyAndPrint > public (4 calls)
 
 
 printPosition > public (1 calls)
-0: printPosition(pos#0:multi_specz_cyclic_lib.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+0: multi_specz_cyclic_lib.printPosition<0>
+printPosition(pos#0:multi_specz_cyclic_lib.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -394,7 +399,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:multi_specz_cyclic_lib.position, $right#0:multi_specz_cyclic_lib.position, ?$$#0:wybe.bool):
+0: multi_specz_cyclic_lib.position./=<0>
+/=($left#0:multi_specz_cyclic_lib.position, $right#0:multi_specz_cyclic_lib.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -414,7 +420,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:multi_specz_cyclic_lib.position, $right#0:multi_specz_cyclic_lib.position, ?$$#0:wybe.bool):
+0: multi_specz_cyclic_lib.position.=<0>
+=($left#0:multi_specz_cyclic_lib.position, $right#0:multi_specz_cyclic_lib.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
@@ -432,14 +439,16 @@ entry:
 
 
 position > public {inline} (0 calls)
-0: position(x#0:wybe.int, y#0:wybe.int, ?$#0:multi_specz_cyclic_lib.position):
+0: multi_specz_cyclic_lib.position.position<0>
+position(x#0:wybe.int, y#0:wybe.int, ?$#0:multi_specz_cyclic_lib.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:multi_specz_cyclic_lib.position)
     foreign lpvm mutate(~%$rec#0:multi_specz_cyclic_lib.position, ?%$rec#1:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:multi_specz_cyclic_lib.position, ?%$#0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
 position > public {inline} (6 calls)
-1: position(?x#0:wybe.int, ?y#0:wybe.int, $#0:multi_specz_cyclic_lib.position):
+1: multi_specz_cyclic_lib.position.position<1>
+position(?x#0:wybe.int, ?y#0:wybe.int, $#0:multi_specz_cyclic_lib.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
@@ -447,24 +456,28 @@ position > public {inline} (6 calls)
 
 
 x > public {inline} (0 calls)
-0: x($rec#0:multi_specz_cyclic_lib.position, ?$#0:wybe.int):
+0: multi_specz_cyclic_lib.position.x<0>
+x($rec#0:multi_specz_cyclic_lib.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 x > public {inline} (0 calls)
-1: x($rec#0:multi_specz_cyclic_lib.position, ?$rec#1:multi_specz_cyclic_lib.position, $field#0:wybe.int):
+1: multi_specz_cyclic_lib.position.x<1>
+x($rec#0:multi_specz_cyclic_lib.position, ?$rec#1:multi_specz_cyclic_lib.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:multi_specz_cyclic_lib.position, ?%$rec#1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 y > public {inline} (0 calls)
-0: y($rec#0:multi_specz_cyclic_lib.position, ?$#0:wybe.int):
+0: multi_specz_cyclic_lib.position.y<0>
+y($rec#0:multi_specz_cyclic_lib.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 y > public {inline} (0 calls)
-1: y($rec#0:multi_specz_cyclic_lib.position, ?$rec#1:multi_specz_cyclic_lib.position, $field#0:wybe.int):
+1: multi_specz_cyclic_lib.position.y<1>
+y($rec#0:multi_specz_cyclic_lib.position, ?$rec#1:multi_specz_cyclic_lib.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:multi_specz_cyclic_lib.position, ?%$rec#1:multi_specz_cyclic_lib.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
@@ -630,7 +643,8 @@ entry:
   procs           : 
 
 foo2 > public (0 calls)
-0: foo2(x1#0:multi_specz_cyclic_lib.position, x2#0:multi_specz_cyclic_lib.position, x3#0:multi_specz_cyclic_lib.position, x4#0:multi_specz_cyclic_lib.position, n#0:wybe.int, io#0:wybe.phantom, ?io#4:wybe.phantom):
+0: multi_specz_cyclic_lib2.foo2<0>[ff3a297a4f]
+foo2(x1#0:multi_specz_cyclic_lib.position, x2#0:multi_specz_cyclic_lib.position, x3#0:multi_specz_cyclic_lib.position, x4#0:multi_specz_cyclic_lib.position, n#0:wybe.int, io#0:wybe.phantom, ?io#4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0,InterestingUnaliased 1,InterestingUnaliased 2,InterestingUnaliased 3]
  MultiSpeczDepInfo: [(2,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [0]])),(3,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [1]])),(4,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [2]])),(5,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [3]])),(7,(multi_specz_cyclic_lib.foo1<0>,fromList [NonAliasedParamCond 0 [1],NonAliasedParamCond 1 [2],NonAliasedParamCond 2 [3],NonAliasedParamCond 3 [0]]))]

--- a/test-cases/final-dump/multi_specz_cyclic_lib.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_lib.exp
@@ -23,7 +23,8 @@ AFTER EVERYTHING:
   procs           : 
 
 foo1 > public (0 calls)
-0: foo1(x1#0:multi_specz_cyclic_lib.position, x2#0:multi_specz_cyclic_lib.position, x3#0:multi_specz_cyclic_lib.position, x4#0:multi_specz_cyclic_lib.position, n#0:wybe.int, io#0:wybe.phantom, ?io#4:wybe.phantom):
+0: multi_specz_cyclic_lib.foo1<0>
+foo1(x1#0:multi_specz_cyclic_lib.position, x2#0:multi_specz_cyclic_lib.position, x3#0:multi_specz_cyclic_lib.position, x4#0:multi_specz_cyclic_lib.position, n#0:wybe.int, io#0:wybe.phantom, ?io#4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0,InterestingUnaliased 1,InterestingUnaliased 2,InterestingUnaliased 3]
  MultiSpeczDepInfo: [(2,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [0]])),(3,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [1]])),(4,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [2]])),(5,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [3]])),(7,(multi_specz_cyclic_lib2.foo2<0>,fromList [NonAliasedParamCond 0 [1],NonAliasedParamCond 1 [2],NonAliasedParamCond 2 [3],NonAliasedParamCond 3 [0]]))]
@@ -42,7 +43,8 @@ foo1 > public (0 calls)
 
 
 modifyAndPrint > public (4 calls)
-0: modifyAndPrint(pos#0:multi_specz_cyclic_lib.position, v#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: multi_specz_cyclic_lib.modifyAndPrint<0>
+modifyAndPrint(pos#0:multi_specz_cyclic_lib.position, v#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
     foreign lpvm {noalias} mutate(~%pos#0:multi_specz_cyclic_lib.position, ?%pos#1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~v#0:wybe.int)
@@ -50,7 +52,8 @@ modifyAndPrint > public (4 calls)
 
 
 printPosition > public (1 calls)
-0: printPosition(pos#0:multi_specz_cyclic_lib.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+0: multi_specz_cyclic_lib.printPosition<0>
+printPosition(pos#0:multi_specz_cyclic_lib.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -170,7 +173,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:multi_specz_cyclic_lib.position, $right#0:multi_specz_cyclic_lib.position, ?$$#0:wybe.bool):
+0: multi_specz_cyclic_lib.position./=<0>
+/=($left#0:multi_specz_cyclic_lib.position, $right#0:multi_specz_cyclic_lib.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -190,7 +194,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:multi_specz_cyclic_lib.position, $right#0:multi_specz_cyclic_lib.position, ?$$#0:wybe.bool):
+0: multi_specz_cyclic_lib.position.=<0>
+=($left#0:multi_specz_cyclic_lib.position, $right#0:multi_specz_cyclic_lib.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
@@ -208,14 +213,16 @@ entry:
 
 
 position > public {inline} (0 calls)
-0: position(x#0:wybe.int, y#0:wybe.int, ?$#0:multi_specz_cyclic_lib.position):
+0: multi_specz_cyclic_lib.position.position<0>
+position(x#0:wybe.int, y#0:wybe.int, ?$#0:multi_specz_cyclic_lib.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:multi_specz_cyclic_lib.position)
     foreign lpvm mutate(~%$rec#0:multi_specz_cyclic_lib.position, ?%$rec#1:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:multi_specz_cyclic_lib.position, ?%$#0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
 position > public {inline} (6 calls)
-1: position(?x#0:wybe.int, ?y#0:wybe.int, $#0:multi_specz_cyclic_lib.position):
+1: multi_specz_cyclic_lib.position.position<1>
+position(?x#0:wybe.int, ?y#0:wybe.int, $#0:multi_specz_cyclic_lib.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
@@ -223,24 +230,28 @@ position > public {inline} (6 calls)
 
 
 x > public {inline} (0 calls)
-0: x($rec#0:multi_specz_cyclic_lib.position, ?$#0:wybe.int):
+0: multi_specz_cyclic_lib.position.x<0>
+x($rec#0:multi_specz_cyclic_lib.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 x > public {inline} (0 calls)
-1: x($rec#0:multi_specz_cyclic_lib.position, ?$rec#1:multi_specz_cyclic_lib.position, $field#0:wybe.int):
+1: multi_specz_cyclic_lib.position.x<1>
+x($rec#0:multi_specz_cyclic_lib.position, ?$rec#1:multi_specz_cyclic_lib.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:multi_specz_cyclic_lib.position, ?%$rec#1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 y > public {inline} (0 calls)
-0: y($rec#0:multi_specz_cyclic_lib.position, ?$#0:wybe.int):
+0: multi_specz_cyclic_lib.position.y<0>
+y($rec#0:multi_specz_cyclic_lib.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 y > public {inline} (0 calls)
-1: y($rec#0:multi_specz_cyclic_lib.position, ?$rec#1:multi_specz_cyclic_lib.position, $field#0:wybe.int):
+1: multi_specz_cyclic_lib.position.y<1>
+y($rec#0:multi_specz_cyclic_lib.position, ?$rec#1:multi_specz_cyclic_lib.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:multi_specz_cyclic_lib.position, ?%$rec#1:multi_specz_cyclic_lib.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
@@ -406,7 +417,8 @@ entry:
   procs           : 
 
 foo2 > public (0 calls)
-0: foo2(x1#0:multi_specz_cyclic_lib.position, x2#0:multi_specz_cyclic_lib.position, x3#0:multi_specz_cyclic_lib.position, x4#0:multi_specz_cyclic_lib.position, n#0:wybe.int, io#0:wybe.phantom, ?io#4:wybe.phantom):
+0: multi_specz_cyclic_lib2.foo2<0>
+foo2(x1#0:multi_specz_cyclic_lib.position, x2#0:multi_specz_cyclic_lib.position, x3#0:multi_specz_cyclic_lib.position, x4#0:multi_specz_cyclic_lib.position, n#0:wybe.int, io#0:wybe.phantom, ?io#4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0,InterestingUnaliased 1,InterestingUnaliased 2,InterestingUnaliased 3]
  MultiSpeczDepInfo: [(2,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [0]])),(3,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [1]])),(4,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [2]])),(5,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [3]])),(7,(multi_specz_cyclic_lib.foo1<0>,fromList [NonAliasedParamCond 0 [1],NonAliasedParamCond 1 [2],NonAliasedParamCond 2 [3],NonAliasedParamCond 3 [0]]))]

--- a/test-cases/final-dump/multi_specz_cyclic_lib2.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_lib2.exp
@@ -23,7 +23,8 @@ AFTER EVERYTHING:
   procs           : 
 
 foo1 > public (0 calls)
-0: foo1(x1#0:multi_specz_cyclic_lib.position, x2#0:multi_specz_cyclic_lib.position, x3#0:multi_specz_cyclic_lib.position, x4#0:multi_specz_cyclic_lib.position, n#0:wybe.int, io#0:wybe.phantom, ?io#4:wybe.phantom):
+0: multi_specz_cyclic_lib.foo1<0>
+foo1(x1#0:multi_specz_cyclic_lib.position, x2#0:multi_specz_cyclic_lib.position, x3#0:multi_specz_cyclic_lib.position, x4#0:multi_specz_cyclic_lib.position, n#0:wybe.int, io#0:wybe.phantom, ?io#4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0,InterestingUnaliased 1,InterestingUnaliased 2,InterestingUnaliased 3]
  MultiSpeczDepInfo: [(2,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [0]])),(3,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [1]])),(4,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [2]])),(5,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [3]])),(7,(multi_specz_cyclic_lib2.foo2<0>,fromList [NonAliasedParamCond 0 [1],NonAliasedParamCond 1 [2],NonAliasedParamCond 2 [3],NonAliasedParamCond 3 [0]]))]
@@ -42,7 +43,8 @@ foo1 > public (0 calls)
 
 
 modifyAndPrint > public (4 calls)
-0: modifyAndPrint(pos#0:multi_specz_cyclic_lib.position, v#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: multi_specz_cyclic_lib.modifyAndPrint<0>
+modifyAndPrint(pos#0:multi_specz_cyclic_lib.position, v#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
     foreign lpvm {noalias} mutate(~%pos#0:multi_specz_cyclic_lib.position, ?%pos#1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~v#0:wybe.int)
@@ -50,7 +52,8 @@ modifyAndPrint > public (4 calls)
 
 
 printPosition > public (1 calls)
-0: printPosition(pos#0:multi_specz_cyclic_lib.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+0: multi_specz_cyclic_lib.printPosition<0>
+printPosition(pos#0:multi_specz_cyclic_lib.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -170,7 +173,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:multi_specz_cyclic_lib.position, $right#0:multi_specz_cyclic_lib.position, ?$$#0:wybe.bool):
+0: multi_specz_cyclic_lib.position./=<0>
+/=($left#0:multi_specz_cyclic_lib.position, $right#0:multi_specz_cyclic_lib.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -190,7 +194,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:multi_specz_cyclic_lib.position, $right#0:multi_specz_cyclic_lib.position, ?$$#0:wybe.bool):
+0: multi_specz_cyclic_lib.position.=<0>
+=($left#0:multi_specz_cyclic_lib.position, $right#0:multi_specz_cyclic_lib.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
@@ -208,14 +213,16 @@ entry:
 
 
 position > public {inline} (0 calls)
-0: position(x#0:wybe.int, y#0:wybe.int, ?$#0:multi_specz_cyclic_lib.position):
+0: multi_specz_cyclic_lib.position.position<0>
+position(x#0:wybe.int, y#0:wybe.int, ?$#0:multi_specz_cyclic_lib.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:multi_specz_cyclic_lib.position)
     foreign lpvm mutate(~%$rec#0:multi_specz_cyclic_lib.position, ?%$rec#1:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:multi_specz_cyclic_lib.position, ?%$#0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
 position > public {inline} (6 calls)
-1: position(?x#0:wybe.int, ?y#0:wybe.int, $#0:multi_specz_cyclic_lib.position):
+1: multi_specz_cyclic_lib.position.position<1>
+position(?x#0:wybe.int, ?y#0:wybe.int, $#0:multi_specz_cyclic_lib.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
@@ -223,24 +230,28 @@ position > public {inline} (6 calls)
 
 
 x > public {inline} (0 calls)
-0: x($rec#0:multi_specz_cyclic_lib.position, ?$#0:wybe.int):
+0: multi_specz_cyclic_lib.position.x<0>
+x($rec#0:multi_specz_cyclic_lib.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 x > public {inline} (0 calls)
-1: x($rec#0:multi_specz_cyclic_lib.position, ?$rec#1:multi_specz_cyclic_lib.position, $field#0:wybe.int):
+1: multi_specz_cyclic_lib.position.x<1>
+x($rec#0:multi_specz_cyclic_lib.position, ?$rec#1:multi_specz_cyclic_lib.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:multi_specz_cyclic_lib.position, ?%$rec#1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 y > public {inline} (0 calls)
-0: y($rec#0:multi_specz_cyclic_lib.position, ?$#0:wybe.int):
+0: multi_specz_cyclic_lib.position.y<0>
+y($rec#0:multi_specz_cyclic_lib.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 y > public {inline} (0 calls)
-1: y($rec#0:multi_specz_cyclic_lib.position, ?$rec#1:multi_specz_cyclic_lib.position, $field#0:wybe.int):
+1: multi_specz_cyclic_lib.position.y<1>
+y($rec#0:multi_specz_cyclic_lib.position, ?$rec#1:multi_specz_cyclic_lib.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:multi_specz_cyclic_lib.position, ?%$rec#1:multi_specz_cyclic_lib.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
@@ -406,7 +417,8 @@ entry:
   procs           : 
 
 foo2 > public (0 calls)
-0: foo2(x1#0:multi_specz_cyclic_lib.position, x2#0:multi_specz_cyclic_lib.position, x3#0:multi_specz_cyclic_lib.position, x4#0:multi_specz_cyclic_lib.position, n#0:wybe.int, io#0:wybe.phantom, ?io#4:wybe.phantom):
+0: multi_specz_cyclic_lib2.foo2<0>
+foo2(x1#0:multi_specz_cyclic_lib.position, x2#0:multi_specz_cyclic_lib.position, x3#0:multi_specz_cyclic_lib.position, x4#0:multi_specz_cyclic_lib.position, n#0:wybe.int, io#0:wybe.phantom, ?io#4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0,InterestingUnaliased 1,InterestingUnaliased 2,InterestingUnaliased 3]
  MultiSpeczDepInfo: [(2,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [0]])),(3,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [1]])),(4,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [2]])),(5,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [3]])),(7,(multi_specz_cyclic_lib.foo1<0>,fromList [NonAliasedParamCond 0 [1],NonAliasedParamCond 1 [2],NonAliasedParamCond 2 [3],NonAliasedParamCond 3 [0]]))]

--- a/test-cases/final-dump/multictr.exp
+++ b/test-cases/final-dump/multictr.exp
@@ -208,7 +208,8 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:multictr.card, $right#0:multictr.card, ?$$#0:wybe.bool):
+0: multictr.card./=<0>
+/=($left#0:multictr.card, $right#0:multictr.card, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_eq(~$left#0:multictr.card, ~$right#0:multictr.card, ?tmp$0#0:wybe.bool)
@@ -216,20 +217,23 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 
 = > public {inline} (1 calls)
-0: =($left#0:multictr.card, $right#0:multictr.card, ?$$#0:wybe.bool):
+0: multictr.card.=<0>
+=($left#0:multictr.card, $right#0:multictr.card, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_eq(~$left#0:multictr.card, ~$right#0:multictr.card, ?$$#0:!wybe.bool)
 
 
 card > public {inline} (0 calls)
-0: card(suit#0:multictr.suit, rank#0:multictr.rank, ?$#3:multictr.card):
+0: multictr.card.card<0>
+card(suit#0:multictr.suit, rank#0:multictr.rank, ?$#3:multictr.card):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm shl(~rank#0:!multictr.card, 2:multictr.card, ?$temp#1:multictr.card)
     foreign llvm or(~$temp#1:multictr.card, ~suit#0:!multictr.card, ?$#3:multictr.card)
 card > public {inline} (0 calls)
-1: card(?suit#0:multictr.suit, ?rank#0:multictr.rank, $#0:multictr.card):
+1: multictr.card.card<1>
+card(?suit#0:multictr.suit, ?rank#0:multictr.rank, $#0:multictr.card):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($#0:multictr.card, 3:multictr.card, ?$temp2#0:multictr.card)
@@ -240,14 +244,16 @@ card > public {inline} (0 calls)
 
 
 rank > public {inline} (0 calls)
-0: rank($rec#0:multictr.card, ?$#0:multictr.rank):
+0: multictr.card.rank<0>
+rank($rec#0:multictr.card, ?$#0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm lshr(~$rec#0:multictr.card, 2:multictr.card, ?$rec#1:multictr.card)
     foreign llvm and(~$rec#1:multictr.card, 15:multictr.card, ?$field#0:multictr.card)
     foreign lpvm cast(~$field#0:multictr.card, ?$#0:multictr.rank)
 rank > public {inline} (0 calls)
-1: rank($rec#0:multictr.card, ?$rec#2:multictr.card, $field#0:multictr.rank):
+1: multictr.card.rank<1>
+rank($rec#0:multictr.card, ?$rec#2:multictr.card, $field#0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(~$rec#0:multictr.card, -61:multictr.card, ?$rec#1:multictr.card)
@@ -256,13 +262,15 @@ rank > public {inline} (0 calls)
 
 
 suit > public {inline} (0 calls)
-0: suit($rec#0:multictr.card, ?$#0:multictr.suit):
+0: multictr.card.suit<0>
+suit($rec#0:multictr.card, ?$#0:multictr.suit):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(~$rec#0:multictr.card, 3:multictr.card, ?$field#0:multictr.card)
     foreign lpvm cast(~$field#0:multictr.card, ?$#0:multictr.suit)
 suit > public {inline} (0 calls)
-1: suit($rec#0:multictr.card, ?$rec#2:multictr.card, $field#0:multictr.suit):
+1: multictr.card.suit<1>
+suit($rec#0:multictr.card, ?$rec#2:multictr.card, $field#0:multictr.suit):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(~$rec#0:multictr.card, -4:multictr.card, ?$rec#1:multictr.card)
@@ -439,7 +447,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:multictr.complicated, $right#0:multictr.complicated, ?$$#0:wybe.bool):
+0: multictr.complicated./=<0>
+/=($left#0:multictr.complicated, $right#0:multictr.complicated, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     multictr.complicated.=<0>(~$left#0:multictr.complicated, ~$right#0:multictr.complicated, ?tmp$0#0:wybe.bool) #0
@@ -447,7 +456,8 @@ entry:
 
 
 = > public (1 calls)
-0: =($left#0:multictr.complicated, $right#0:multictr.complicated, ?$$#0:wybe.bool):
+0: multictr.complicated.=<0>
+=($left#0:multictr.complicated, $right#0:multictr.complicated, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($left#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -958,20 +968,23 @@ entry:
 
 
 autumn > public {inline} (0 calls)
-0: autumn(?$#0:multictr.complicated):
+0: multictr.complicated.autumn<0>
+autumn(?$#0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(3:multictr.complicated, ?$#0:multictr.complicated)
 
 
 c01 > public {inline} (0 calls)
-0: c01(f01#0:wybe.int, ?$#0:multictr.complicated):
+0: multictr.complicated.c01<0>
+c01(f01#0:wybe.int, ?$#0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr.complicated)
     foreign lpvm mutate(~%$rec#0:multictr.complicated, ?%$#0:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f01#0:wybe.int)
 c01 > public {inline} (40 calls)
-1: c01(?f01#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
+1: multictr.complicated.c01<1>
+c01(?f01#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -996,14 +1009,16 @@ c01 > public {inline} (40 calls)
 
 
 c02 > public {inline} (0 calls)
-0: c02(f02#0:wybe.int, ?$#0:multictr.complicated):
+0: multictr.complicated.c02<0>
+c02(f02#0:wybe.int, ?$#0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr.complicated)
     foreign lpvm mutate(~%$rec#0:multictr.complicated, ?%$rec#1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f02#0:wybe.int)
     foreign llvm or(~$rec#1:multictr.complicated, 1:wybe.int, ?$#0:multictr.complicated)
 c02 > public {inline} (35 calls)
-1: c02(?f02#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
+1: multictr.complicated.c02<1>
+c02(?f02#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1028,14 +1043,16 @@ c02 > public {inline} (35 calls)
 
 
 c03 > public {inline} (0 calls)
-0: c03(f03#0:wybe.int, ?$#0:multictr.complicated):
+0: multictr.complicated.c03<0>
+c03(f03#0:wybe.int, ?$#0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr.complicated)
     foreign lpvm mutate(~%$rec#0:multictr.complicated, ?%$rec#1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f03#0:wybe.int)
     foreign llvm or(~$rec#1:multictr.complicated, 2:wybe.int, ?$#0:multictr.complicated)
 c03 > public {inline} (33 calls)
-1: c03(?f03#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
+1: multictr.complicated.c03<1>
+c03(?f03#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1060,14 +1077,16 @@ c03 > public {inline} (33 calls)
 
 
 c04 > public {inline} (0 calls)
-0: c04(f04#0:wybe.int, ?$#0:multictr.complicated):
+0: multictr.complicated.c04<0>
+c04(f04#0:wybe.int, ?$#0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr.complicated)
     foreign lpvm mutate(~%$rec#0:multictr.complicated, ?%$rec#1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f04#0:wybe.int)
     foreign llvm or(~$rec#1:multictr.complicated, 3:wybe.int, ?$#0:multictr.complicated)
 c04 > public {inline} (31 calls)
-1: c04(?f04#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
+1: multictr.complicated.c04<1>
+c04(?f04#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1092,14 +1111,16 @@ c04 > public {inline} (31 calls)
 
 
 c05 > public {inline} (0 calls)
-0: c05(f05#0:wybe.int, ?$#0:multictr.complicated):
+0: multictr.complicated.c05<0>
+c05(f05#0:wybe.int, ?$#0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr.complicated)
     foreign lpvm mutate(~%$rec#0:multictr.complicated, ?%$rec#1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f05#0:wybe.int)
     foreign llvm or(~$rec#1:multictr.complicated, 4:wybe.int, ?$#0:multictr.complicated)
 c05 > public {inline} (29 calls)
-1: c05(?f05#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
+1: multictr.complicated.c05<1>
+c05(?f05#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1124,14 +1145,16 @@ c05 > public {inline} (29 calls)
 
 
 c06 > public {inline} (0 calls)
-0: c06(f06#0:wybe.int, ?$#0:multictr.complicated):
+0: multictr.complicated.c06<0>
+c06(f06#0:wybe.int, ?$#0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr.complicated)
     foreign lpvm mutate(~%$rec#0:multictr.complicated, ?%$rec#1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f06#0:wybe.int)
     foreign llvm or(~$rec#1:multictr.complicated, 5:wybe.int, ?$#0:multictr.complicated)
 c06 > public {inline} (27 calls)
-1: c06(?f06#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
+1: multictr.complicated.c06<1>
+c06(?f06#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1156,14 +1179,16 @@ c06 > public {inline} (27 calls)
 
 
 c07 > public {inline} (0 calls)
-0: c07(f07#0:wybe.int, ?$#0:multictr.complicated):
+0: multictr.complicated.c07<0>
+c07(f07#0:wybe.int, ?$#0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr.complicated)
     foreign lpvm mutate(~%$rec#0:multictr.complicated, ?%$rec#1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f07#0:wybe.int)
     foreign llvm or(~$rec#1:multictr.complicated, 6:wybe.int, ?$#0:multictr.complicated)
 c07 > public {inline} (25 calls)
-1: c07(?f07#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
+1: multictr.complicated.c07<1>
+c07(?f07#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1188,7 +1213,8 @@ c07 > public {inline} (25 calls)
 
 
 c08 > public {inline} (0 calls)
-0: c08(f08#0:wybe.int, ?$#0:multictr.complicated):
+0: multictr.complicated.c08<0>
+c08(f08#0:wybe.int, ?$#0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:multictr.complicated)
@@ -1196,7 +1222,8 @@ c08 > public {inline} (0 calls)
     foreign lpvm mutate(~%$rec#1:multictr.complicated, ?%$rec#2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f08#0:wybe.int)
     foreign llvm or(~$rec#2:multictr.complicated, 7:wybe.int, ?$#0:multictr.complicated)
 c08 > public {inline} (23 calls)
-1: c08(?f08#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
+1: multictr.complicated.c08<1>
+c08(?f08#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1230,7 +1257,8 @@ c08 > public {inline} (23 calls)
 
 
 c09 > public {inline} (0 calls)
-0: c09(f09#0:wybe.int, ?$#0:multictr.complicated):
+0: multictr.complicated.c09<0>
+c09(f09#0:wybe.int, ?$#0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:multictr.complicated)
@@ -1238,7 +1266,8 @@ c09 > public {inline} (0 calls)
     foreign lpvm mutate(~%$rec#1:multictr.complicated, ?%$rec#2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f09#0:wybe.int)
     foreign llvm or(~$rec#2:multictr.complicated, 7:wybe.int, ?$#0:multictr.complicated)
 c09 > public {inline} (21 calls)
-1: c09(?f09#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
+1: multictr.complicated.c09<1>
+c09(?f09#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1272,7 +1301,8 @@ c09 > public {inline} (21 calls)
 
 
 c10 > public {inline} (0 calls)
-0: c10(f10#0:wybe.int, ?$#0:multictr.complicated):
+0: multictr.complicated.c10<0>
+c10(f10#0:wybe.int, ?$#0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:multictr.complicated)
@@ -1280,7 +1310,8 @@ c10 > public {inline} (0 calls)
     foreign lpvm mutate(~%$rec#1:multictr.complicated, ?%$rec#2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f10#0:wybe.int)
     foreign llvm or(~$rec#2:multictr.complicated, 7:wybe.int, ?$#0:multictr.complicated)
 c10 > public {inline} (19 calls)
-1: c10(?f10#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
+1: multictr.complicated.c10<1>
+c10(?f10#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1314,7 +1345,8 @@ c10 > public {inline} (19 calls)
 
 
 c11 > public {inline} (0 calls)
-0: c11(f11#0:wybe.int, ?$#0:multictr.complicated):
+0: multictr.complicated.c11<0>
+c11(f11#0:wybe.int, ?$#0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:multictr.complicated)
@@ -1322,7 +1354,8 @@ c11 > public {inline} (0 calls)
     foreign lpvm mutate(~%$rec#1:multictr.complicated, ?%$rec#2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f11#0:wybe.int)
     foreign llvm or(~$rec#2:multictr.complicated, 7:wybe.int, ?$#0:multictr.complicated)
 c11 > public {inline} (17 calls)
-1: c11(?f11#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
+1: multictr.complicated.c11<1>
+c11(?f11#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1356,7 +1389,8 @@ c11 > public {inline} (17 calls)
 
 
 c12 > public {inline} (0 calls)
-0: c12(f12#0:wybe.int, ?$#0:multictr.complicated):
+0: multictr.complicated.c12<0>
+c12(f12#0:wybe.int, ?$#0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:multictr.complicated)
@@ -1364,7 +1398,8 @@ c12 > public {inline} (0 calls)
     foreign lpvm mutate(~%$rec#1:multictr.complicated, ?%$rec#2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f12#0:wybe.int)
     foreign llvm or(~$rec#2:multictr.complicated, 7:wybe.int, ?$#0:multictr.complicated)
 c12 > public {inline} (15 calls)
-1: c12(?f12#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
+1: multictr.complicated.c12<1>
+c12(?f12#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1398,7 +1433,8 @@ c12 > public {inline} (15 calls)
 
 
 c13 > public {inline} (0 calls)
-0: c13(f13#0:wybe.int, ?$#0:multictr.complicated):
+0: multictr.complicated.c13<0>
+c13(f13#0:wybe.int, ?$#0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:multictr.complicated)
@@ -1406,7 +1442,8 @@ c13 > public {inline} (0 calls)
     foreign lpvm mutate(~%$rec#1:multictr.complicated, ?%$rec#2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f13#0:wybe.int)
     foreign llvm or(~$rec#2:multictr.complicated, 7:wybe.int, ?$#0:multictr.complicated)
 c13 > public {inline} (13 calls)
-1: c13(?f13#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
+1: multictr.complicated.c13<1>
+c13(?f13#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1440,7 +1477,8 @@ c13 > public {inline} (13 calls)
 
 
 c14 > public {inline} (0 calls)
-0: c14(f14#0:wybe.int, ?$#0:multictr.complicated):
+0: multictr.complicated.c14<0>
+c14(f14#0:wybe.int, ?$#0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:multictr.complicated)
@@ -1448,7 +1486,8 @@ c14 > public {inline} (0 calls)
     foreign lpvm mutate(~%$rec#1:multictr.complicated, ?%$rec#2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f14#0:wybe.int)
     foreign llvm or(~$rec#2:multictr.complicated, 7:wybe.int, ?$#0:multictr.complicated)
 c14 > public {inline} (11 calls)
-1: c14(?f14#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
+1: multictr.complicated.c14<1>
+c14(?f14#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1482,7 +1521,8 @@ c14 > public {inline} (11 calls)
 
 
 c15 > public {inline} (0 calls)
-0: c15(f15#0:wybe.int, ?$#0:multictr.complicated):
+0: multictr.complicated.c15<0>
+c15(f15#0:wybe.int, ?$#0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:multictr.complicated)
@@ -1490,7 +1530,8 @@ c15 > public {inline} (0 calls)
     foreign lpvm mutate(~%$rec#1:multictr.complicated, ?%$rec#2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f15#0:wybe.int)
     foreign llvm or(~$rec#2:multictr.complicated, 7:wybe.int, ?$#0:multictr.complicated)
 c15 > public {inline} (9 calls)
-1: c15(?f15#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
+1: multictr.complicated.c15<1>
+c15(?f15#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1524,7 +1565,8 @@ c15 > public {inline} (9 calls)
 
 
 c16 > public {inline} (0 calls)
-0: c16(f16#0:wybe.int, ?$#0:multictr.complicated):
+0: multictr.complicated.c16<0>
+c16(f16#0:wybe.int, ?$#0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:multictr.complicated)
@@ -1532,7 +1574,8 @@ c16 > public {inline} (0 calls)
     foreign lpvm mutate(~%$rec#1:multictr.complicated, ?%$rec#2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f16#0:wybe.int)
     foreign llvm or(~$rec#2:multictr.complicated, 7:wybe.int, ?$#0:multictr.complicated)
 c16 > public {inline} (7 calls)
-1: c16(?f16#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
+1: multictr.complicated.c16<1>
+c16(?f16#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1566,7 +1609,8 @@ c16 > public {inline} (7 calls)
 
 
 c17 > public {inline} (0 calls)
-0: c17(f17#0:wybe.int, ?$#0:multictr.complicated):
+0: multictr.complicated.c17<0>
+c17(f17#0:wybe.int, ?$#0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:multictr.complicated)
@@ -1574,7 +1618,8 @@ c17 > public {inline} (0 calls)
     foreign lpvm mutate(~%$rec#1:multictr.complicated, ?%$rec#2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f17#0:wybe.int)
     foreign llvm or(~$rec#2:multictr.complicated, 7:wybe.int, ?$#0:multictr.complicated)
 c17 > public {inline} (5 calls)
-1: c17(?f17#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
+1: multictr.complicated.c17<1>
+c17(?f17#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1608,7 +1653,8 @@ c17 > public {inline} (5 calls)
 
 
 f01 > public {inline} (0 calls)
-0: f01($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: multictr.complicated.f01<0>
+f01($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($rec#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1631,7 +1677,8 @@ f01 > public {inline} (0 calls)
 
 
 f01 > public {inline} (0 calls)
-1: f01($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: multictr.complicated.f01<1>
+f01($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($rec#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1656,7 +1703,8 @@ f01 > public {inline} (0 calls)
 
 
 f02 > public {inline} (0 calls)
-0: f02($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: multictr.complicated.f02<0>
+f02($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($rec#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1679,7 +1727,8 @@ f02 > public {inline} (0 calls)
 
 
 f02 > public {inline} (0 calls)
-1: f02($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: multictr.complicated.f02<1>
+f02($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($rec#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1704,7 +1753,8 @@ f02 > public {inline} (0 calls)
 
 
 f03 > public {inline} (0 calls)
-0: f03($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: multictr.complicated.f03<0>
+f03($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($rec#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1727,7 +1777,8 @@ f03 > public {inline} (0 calls)
 
 
 f03 > public {inline} (0 calls)
-1: f03($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: multictr.complicated.f03<1>
+f03($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($rec#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1752,7 +1803,8 @@ f03 > public {inline} (0 calls)
 
 
 f04 > public {inline} (0 calls)
-0: f04($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: multictr.complicated.f04<0>
+f04($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($rec#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1775,7 +1827,8 @@ f04 > public {inline} (0 calls)
 
 
 f04 > public {inline} (0 calls)
-1: f04($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: multictr.complicated.f04<1>
+f04($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($rec#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1800,7 +1853,8 @@ f04 > public {inline} (0 calls)
 
 
 f05 > public {inline} (0 calls)
-0: f05($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: multictr.complicated.f05<0>
+f05($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($rec#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1823,7 +1877,8 @@ f05 > public {inline} (0 calls)
 
 
 f05 > public {inline} (0 calls)
-1: f05($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: multictr.complicated.f05<1>
+f05($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($rec#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1848,7 +1903,8 @@ f05 > public {inline} (0 calls)
 
 
 f06 > public {inline} (0 calls)
-0: f06($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: multictr.complicated.f06<0>
+f06($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($rec#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1871,7 +1927,8 @@ f06 > public {inline} (0 calls)
 
 
 f06 > public {inline} (0 calls)
-1: f06($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: multictr.complicated.f06<1>
+f06($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($rec#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1896,7 +1953,8 @@ f06 > public {inline} (0 calls)
 
 
 f07 > public {inline} (0 calls)
-0: f07($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: multictr.complicated.f07<0>
+f07($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($rec#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1919,7 +1977,8 @@ f07 > public {inline} (0 calls)
 
 
 f07 > public {inline} (0 calls)
-1: f07($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: multictr.complicated.f07<1>
+f07($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($rec#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1944,7 +2003,8 @@ f07 > public {inline} (0 calls)
 
 
 f08 > public {inline} (0 calls)
-0: f08($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: multictr.complicated.f08<0>
+f08($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($rec#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -1976,7 +2036,8 @@ f08 > public {inline} (0 calls)
 
 
 f08 > public {inline} (0 calls)
-1: f08($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: multictr.complicated.f08<1>
+f08($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($rec#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -2010,7 +2071,8 @@ f08 > public {inline} (0 calls)
 
 
 f09 > public {inline} (0 calls)
-0: f09($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: multictr.complicated.f09<0>
+f09($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($rec#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -2042,7 +2104,8 @@ f09 > public {inline} (0 calls)
 
 
 f09 > public {inline} (0 calls)
-1: f09($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: multictr.complicated.f09<1>
+f09($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($rec#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -2076,7 +2139,8 @@ f09 > public {inline} (0 calls)
 
 
 f10 > public {inline} (0 calls)
-0: f10($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: multictr.complicated.f10<0>
+f10($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($rec#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -2108,7 +2172,8 @@ f10 > public {inline} (0 calls)
 
 
 f10 > public {inline} (0 calls)
-1: f10($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: multictr.complicated.f10<1>
+f10($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($rec#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -2142,7 +2207,8 @@ f10 > public {inline} (0 calls)
 
 
 f11 > public {inline} (0 calls)
-0: f11($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: multictr.complicated.f11<0>
+f11($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($rec#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -2174,7 +2240,8 @@ f11 > public {inline} (0 calls)
 
 
 f11 > public {inline} (0 calls)
-1: f11($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: multictr.complicated.f11<1>
+f11($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($rec#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -2208,7 +2275,8 @@ f11 > public {inline} (0 calls)
 
 
 f12 > public {inline} (0 calls)
-0: f12($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: multictr.complicated.f12<0>
+f12($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($rec#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -2240,7 +2308,8 @@ f12 > public {inline} (0 calls)
 
 
 f12 > public {inline} (0 calls)
-1: f12($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: multictr.complicated.f12<1>
+f12($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($rec#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -2274,7 +2343,8 @@ f12 > public {inline} (0 calls)
 
 
 f13 > public {inline} (0 calls)
-0: f13($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: multictr.complicated.f13<0>
+f13($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($rec#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -2306,7 +2376,8 @@ f13 > public {inline} (0 calls)
 
 
 f13 > public {inline} (0 calls)
-1: f13($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: multictr.complicated.f13<1>
+f13($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($rec#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -2340,7 +2411,8 @@ f13 > public {inline} (0 calls)
 
 
 f14 > public {inline} (0 calls)
-0: f14($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: multictr.complicated.f14<0>
+f14($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($rec#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -2372,7 +2444,8 @@ f14 > public {inline} (0 calls)
 
 
 f14 > public {inline} (0 calls)
-1: f14($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: multictr.complicated.f14<1>
+f14($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($rec#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -2406,7 +2479,8 @@ f14 > public {inline} (0 calls)
 
 
 f15 > public {inline} (0 calls)
-0: f15($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: multictr.complicated.f15<0>
+f15($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($rec#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -2438,7 +2512,8 @@ f15 > public {inline} (0 calls)
 
 
 f15 > public {inline} (0 calls)
-1: f15($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: multictr.complicated.f15<1>
+f15($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($rec#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -2472,7 +2547,8 @@ f15 > public {inline} (0 calls)
 
 
 f16 > public {inline} (0 calls)
-0: f16($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: multictr.complicated.f16<0>
+f16($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($rec#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -2504,7 +2580,8 @@ f16 > public {inline} (0 calls)
 
 
 f16 > public {inline} (0 calls)
-1: f16($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: multictr.complicated.f16<1>
+f16($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($rec#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -2538,7 +2615,8 @@ f16 > public {inline} (0 calls)
 
 
 f17 > public {inline} (0 calls)
-0: f17($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: multictr.complicated.f17<0>
+f17($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($rec#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -2570,7 +2648,8 @@ f17 > public {inline} (0 calls)
 
 
 f17 > public {inline} (0 calls)
-1: f17($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: multictr.complicated.f17<1>
+f17($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge($rec#0:!wybe.int, 4:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -2604,21 +2683,24 @@ f17 > public {inline} (0 calls)
 
 
 spring > public {inline} (0 calls)
-0: spring(?$#0:multictr.complicated):
+0: multictr.complicated.spring<0>
+spring(?$#0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(1:multictr.complicated, ?$#0:multictr.complicated)
 
 
 summer > public {inline} (0 calls)
-0: summer(?$#0:multictr.complicated):
+0: multictr.complicated.summer<0>
+summer(?$#0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(2:multictr.complicated, ?$#0:multictr.complicated)
 
 
 winter > public {inline} (0 calls)
-0: winter(?$#0:multictr.complicated):
+0: multictr.complicated.winter<0>
+winter(?$#0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(0:multictr.complicated, ?$#0:multictr.complicated)
@@ -5334,7 +5416,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:multictr.length, $right#0:multictr.length, ?$$#0:wybe.bool):
+0: multictr.length./=<0>
+/=($left#0:multictr.length, $right#0:multictr.length, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_eq(~$left#0:multictr.length, ~$right#0:multictr.length, ?tmp$0#0:wybe.bool)
@@ -5342,31 +5425,36 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:multictr.length, $right#0:multictr.length, ?$$#0:wybe.bool):
+0: multictr.length.=<0>
+=($left#0:multictr.length, $right#0:multictr.length, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_eq(~$left#0:multictr.length, ~$right#0:multictr.length, ?$$#0:!wybe.bool)
 
 
 metres > public {inline} (0 calls)
-0: metres(value#0:wybe.float, ?$#2:multictr.length):
+0: multictr.length.metres<0>
+metres(value#0:wybe.float, ?$#2:multictr.length):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(~value#0:!multictr.length, ?$#2:multictr.length)
 metres > public {inline} (0 calls)
-1: metres(?value#0:wybe.float, $#0:multictr.length):
+1: multictr.length.metres<1>
+metres(?value#0:wybe.float, $#0:multictr.length):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm cast(~$#0:multictr.length, ?value#0:wybe.float)
 
 
 value > public {inline} (0 calls)
-0: value($rec#0:multictr.length, ?$#0:wybe.float):
+0: multictr.length.value<0>
+value($rec#0:multictr.length, ?$#0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm cast(~$rec#0:multictr.length, ?$#0:wybe.float)
 value > public {inline} (0 calls)
-1: value([$rec#0:multictr.length], ?$rec#2:multictr.length, $field#0:wybe.float):
+1: multictr.length.value<1>
+value([$rec#0:multictr.length], ?$rec#2:multictr.length, $field#0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(~$field#0:!multictr.length, ?$rec#2:multictr.length)
@@ -5444,7 +5532,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:multictr.maybe_int, $right#0:multictr.maybe_int, ?$$#0:wybe.bool):
+0: multictr.maybe_int./=<0>
+/=($left#0:multictr.maybe_int, $right#0:multictr.maybe_int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     multictr.maybe_int.=<0>(~$left#0:multictr.maybe_int, ~$right#0:multictr.maybe_int, ?tmp$0#0:wybe.bool) #0
@@ -5452,7 +5541,8 @@ entry:
 
 
 = > public (1 calls)
-0: =($left#0:multictr.maybe_int, $right#0:multictr.maybe_int, ?$$#0:wybe.bool):
+0: multictr.maybe_int.=<0>
+=($left#0:multictr.maybe_int, $right#0:multictr.maybe_int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($left#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -5475,13 +5565,15 @@ entry:
 
 
 just > public {inline} (0 calls)
-0: just(value#0:wybe.int, ?$#0:multictr.maybe_int):
+0: multictr.maybe_int.just<0>
+just(value#0:wybe.int, ?$#0:multictr.maybe_int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr.maybe_int)
     foreign lpvm mutate(~%$rec#0:multictr.maybe_int, ?%$#0:multictr.maybe_int, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~value#0:wybe.int)
 just > public {inline} (8 calls)
-1: just(?value#0:wybe.int, $#0:multictr.maybe_int, ?$$#0:wybe.bool):
+1: multictr.maybe_int.just<1>
+just(?value#0:wybe.int, $#0:multictr.maybe_int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -5497,14 +5589,16 @@ just > public {inline} (8 calls)
 
 
 nothing > public {inline} (0 calls)
-0: nothing(?$#0:multictr.maybe_int):
+0: multictr.maybe_int.nothing<0>
+nothing(?$#0:multictr.maybe_int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(0:multictr.maybe_int, ?$#0:multictr.maybe_int)
 
 
 value > public {inline} (0 calls)
-0: value($rec#0:multictr.maybe_int, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: multictr.maybe_int.value<0>
+value($rec#0:multictr.maybe_int, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -5518,7 +5612,8 @@ value > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 value > public {inline} (0 calls)
-1: value($rec#0:multictr.maybe_int, ?$rec#1:multictr.maybe_int, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: multictr.maybe_int.value<1>
+value($rec#0:multictr.maybe_int, ?$rec#1:multictr.maybe_int, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -5676,7 +5771,8 @@ if.else:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:multictr.number, $right#0:multictr.number, ?$$#0:wybe.bool):
+0: multictr.number./=<0>
+/=($left#0:multictr.number, $right#0:multictr.number, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     multictr.number.=<0>(~$left#0:multictr.number, ~$right#0:multictr.number, ?tmp$0#0:wybe.bool) #0
@@ -5684,7 +5780,8 @@ if.else:
 
 
 = > public (1 calls)
-0: =($left#0:multictr.number, $right#0:multictr.number, ?$$#0:wybe.bool):
+0: multictr.number.=<0>
+=($left#0:multictr.number, $right#0:multictr.number, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($left#0:multictr.number, 7:wybe.int, ?tmp$8#0:wybe.int)
@@ -5726,14 +5823,16 @@ if.else:
 
 
 float > public {inline} (0 calls)
-0: float(float_value#0:wybe.float, ?$#0:multictr.number):
+0: multictr.number.float<0>
+float(float_value#0:wybe.float, ?$#0:multictr.number):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr.number)
     foreign lpvm mutate(~%$rec#0:multictr.number, ?%$rec#1:multictr.number, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~float_value#0:wybe.float)
     foreign llvm or(~$rec#1:multictr.number, 1:wybe.int, ?$#0:multictr.number)
 float > public {inline} (5 calls)
-1: float(?float_value#0:wybe.float, $#0:multictr.number, ?$$#0:wybe.bool):
+1: multictr.number.float<1>
+float(?float_value#0:wybe.float, $#0:multictr.number, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($#0:!wybe.int, 7:wybe.int, ?tmp$1#0:!wybe.int)
@@ -5750,7 +5849,8 @@ float > public {inline} (5 calls)
 
 
 float_value > public {inline} (0 calls)
-0: float_value($rec#0:multictr.number, ?$#0:wybe.float, ?$$#0:wybe.bool):
+0: multictr.number.float_value<0>
+float_value($rec#0:multictr.number, ?$#0:wybe.float, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($rec#0:!wybe.int, 7:wybe.int, ?tmp$1#0:!wybe.int)
@@ -5765,7 +5865,8 @@ float_value > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 float_value > public {inline} (0 calls)
-1: float_value($rec#0:multictr.number, ?$rec#1:multictr.number, $field#0:wybe.float, ?$$#0:wybe.bool):
+1: multictr.number.float_value<1>
+float_value($rec#0:multictr.number, ?$rec#1:multictr.number, $field#0:wybe.float, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($rec#0:!wybe.int, 7:wybe.int, ?tmp$1#0:!wybe.int)
@@ -5782,13 +5883,15 @@ float_value > public {inline} (0 calls)
 
 
 int > public {inline} (0 calls)
-0: int(int_value#0:wybe.int, ?$#0:multictr.number):
+0: multictr.number.int<0>
+int(int_value#0:wybe.int, ?$#0:multictr.number):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr.number)
     foreign lpvm mutate(~%$rec#0:multictr.number, ?%$#0:multictr.number, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~int_value#0:wybe.int)
 int > public {inline} (10 calls)
-1: int(?int_value#0:wybe.int, $#0:multictr.number, ?$$#0:wybe.bool):
+1: multictr.number.int<1>
+int(?int_value#0:wybe.int, $#0:multictr.number, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($#0:!wybe.int, 7:wybe.int, ?tmp$1#0:!wybe.int)
@@ -5805,7 +5908,8 @@ int > public {inline} (10 calls)
 
 
 int_value > public {inline} (0 calls)
-0: int_value($rec#0:multictr.number, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: multictr.number.int_value<0>
+int_value($rec#0:multictr.number, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($rec#0:!wybe.int, 7:wybe.int, ?tmp$1#0:!wybe.int)
@@ -5820,7 +5924,8 @@ int_value > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 int_value > public {inline} (0 calls)
-1: int_value($rec#0:multictr.number, ?$rec#1:multictr.number, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: multictr.number.int_value<1>
+int_value($rec#0:multictr.number, ?$rec#1:multictr.number, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($rec#0:!wybe.int, 7:wybe.int, ?tmp$1#0:!wybe.int)
@@ -6075,7 +6180,8 @@ if.else:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:multictr.perhaps, $right#0:multictr.perhaps, ?$$#0:wybe.bool):
+0: multictr.perhaps./=<0>
+/=($left#0:multictr.perhaps, $right#0:multictr.perhaps, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_eq(~$left#0:multictr.perhaps, ~$right#0:multictr.perhaps, ?tmp$0#0:wybe.bool)
@@ -6083,31 +6189,36 @@ if.else:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:multictr.perhaps, $right#0:multictr.perhaps, ?$$#0:wybe.bool):
+0: multictr.perhaps.=<0>
+=($left#0:multictr.perhaps, $right#0:multictr.perhaps, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_eq(~$left#0:multictr.perhaps, ~$right#0:multictr.perhaps, ?$$#0:!wybe.bool)
 
 
 content > public {inline} (0 calls)
-0: content($rec#0:multictr.perhaps, ?$#0:multictr.maybe_int):
+0: multictr.perhaps.content<0>
+content($rec#0:multictr.perhaps, ?$#0:multictr.maybe_int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm cast(~$rec#0:multictr.perhaps, ?$#0:multictr.maybe_int)
 content > public {inline} (0 calls)
-1: content([$rec#0:multictr.perhaps], ?$rec#2:multictr.perhaps, $field#0:multictr.maybe_int):
+1: multictr.perhaps.content<1>
+content([$rec#0:multictr.perhaps], ?$rec#2:multictr.perhaps, $field#0:multictr.maybe_int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(~$field#0:!multictr.perhaps, ?$rec#2:multictr.perhaps)
 
 
 perhaps > public {inline} (0 calls)
-0: perhaps(content#0:multictr.maybe_int, ?$#2:multictr.perhaps):
+0: multictr.perhaps.perhaps<0>
+perhaps(content#0:multictr.maybe_int, ?$#2:multictr.perhaps):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(~content#0:!multictr.perhaps, ?$#2:multictr.perhaps)
 perhaps > public {inline} (0 calls)
-1: perhaps(?content#0:multictr.maybe_int, $#0:multictr.perhaps):
+1: multictr.perhaps.perhaps<1>
+perhaps(?content#0:multictr.maybe_int, $#0:multictr.perhaps):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm cast(~$#0:multictr.perhaps, ?content#0:multictr.maybe_int)
@@ -6189,7 +6300,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:multictr.rank, $right#0:multictr.rank, ?$$#0:wybe.bool):
+0: multictr.rank./=<0>
+/=($left#0:multictr.rank, $right#0:multictr.rank, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_eq(~$left#0:multictr.rank, ~$right#0:multictr.rank, ?tmp$0#0:wybe.bool)
@@ -6197,98 +6309,112 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:multictr.rank, $right#0:multictr.rank, ?$$#0:wybe.bool):
+0: multictr.rank.=<0>
+=($left#0:multictr.rank, $right#0:multictr.rank, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_eq(~$left#0:multictr.rank, ~$right#0:multictr.rank, ?$$#0:!wybe.bool)
 
 
 ace > public {inline} (0 calls)
-0: ace(?$#0:multictr.rank):
+0: multictr.rank.ace<0>
+ace(?$#0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(12:multictr.rank, ?$#0:multictr.rank)
 
 
 jack > public {inline} (0 calls)
-0: jack(?$#0:multictr.rank):
+0: multictr.rank.jack<0>
+jack(?$#0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(9:multictr.rank, ?$#0:multictr.rank)
 
 
 king > public {inline} (0 calls)
-0: king(?$#0:multictr.rank):
+0: multictr.rank.king<0>
+king(?$#0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(11:multictr.rank, ?$#0:multictr.rank)
 
 
 queen > public {inline} (0 calls)
-0: queen(?$#0:multictr.rank):
+0: multictr.rank.queen<0>
+queen(?$#0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(10:multictr.rank, ?$#0:multictr.rank)
 
 
 r10 > public {inline} (0 calls)
-0: r10(?$#0:multictr.rank):
+0: multictr.rank.r10<0>
+r10(?$#0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(8:multictr.rank, ?$#0:multictr.rank)
 
 
 r2 > public {inline} (0 calls)
-0: r2(?$#0:multictr.rank):
+0: multictr.rank.r2<0>
+r2(?$#0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(0:multictr.rank, ?$#0:multictr.rank)
 
 
 r3 > public {inline} (0 calls)
-0: r3(?$#0:multictr.rank):
+0: multictr.rank.r3<0>
+r3(?$#0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(1:multictr.rank, ?$#0:multictr.rank)
 
 
 r4 > public {inline} (0 calls)
-0: r4(?$#0:multictr.rank):
+0: multictr.rank.r4<0>
+r4(?$#0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(2:multictr.rank, ?$#0:multictr.rank)
 
 
 r5 > public {inline} (0 calls)
-0: r5(?$#0:multictr.rank):
+0: multictr.rank.r5<0>
+r5(?$#0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(3:multictr.rank, ?$#0:multictr.rank)
 
 
 r6 > public {inline} (0 calls)
-0: r6(?$#0:multictr.rank):
+0: multictr.rank.r6<0>
+r6(?$#0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(4:multictr.rank, ?$#0:multictr.rank)
 
 
 r7 > public {inline} (0 calls)
-0: r7(?$#0:multictr.rank):
+0: multictr.rank.r7<0>
+r7(?$#0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(5:multictr.rank, ?$#0:multictr.rank)
 
 
 r8 > public {inline} (0 calls)
-0: r8(?$#0:multictr.rank):
+0: multictr.rank.r8<0>
+r8(?$#0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(6:multictr.rank, ?$#0:multictr.rank)
 
 
 r9 > public {inline} (0 calls)
-0: r9(?$#0:multictr.rank):
+0: multictr.rank.r9<0>
+r9(?$#0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(7:multictr.rank, ?$#0:multictr.rank)
@@ -6422,7 +6548,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:multictr.simple, $right#0:multictr.simple, ?$$#0:wybe.bool):
+0: multictr.simple./=<0>
+/=($left#0:multictr.simple, $right#0:multictr.simple, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     multictr.simple.=<0>(~$left#0:multictr.simple, ~$right#0:multictr.simple, ?tmp$0#0:wybe.bool) #0
@@ -6430,7 +6557,8 @@ entry:
 
 
 = > public (1 calls)
-0: =($left#0:multictr.simple, $right#0:multictr.simple, ?$$#0:wybe.bool):
+0: multictr.simple.=<0>
+=($left#0:multictr.simple, $right#0:multictr.simple, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($left#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -6502,13 +6630,15 @@ entry:
 
 
 one > public {inline} (0 calls)
-0: one(one_field#0:wybe.int, ?$#0:multictr.simple):
+0: multictr.simple.one<0>
+one(one_field#0:wybe.int, ?$#0:multictr.simple):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr.simple)
     foreign lpvm mutate(~%$rec#0:multictr.simple, ?%$#0:multictr.simple, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~one_field#0:wybe.int)
 one > public {inline} (11 calls)
-1: one(?one_field#0:wybe.int, $#0:multictr.simple, ?$$#0:wybe.bool):
+1: multictr.simple.one<1>
+one(?one_field#0:wybe.int, $#0:multictr.simple, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -6533,7 +6663,8 @@ one > public {inline} (11 calls)
 
 
 one_field > public {inline} (0 calls)
-0: one_field($rec#0:multictr.simple, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: multictr.simple.one_field<0>
+one_field($rec#0:multictr.simple, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -6556,7 +6687,8 @@ one_field > public {inline} (0 calls)
 
 
 one_field > public {inline} (0 calls)
-1: one_field($rec#0:multictr.simple, ?$rec#1:multictr.simple, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: multictr.simple.one_field<1>
+one_field($rec#0:multictr.simple, ?$rec#1:multictr.simple, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -6581,7 +6713,8 @@ one_field > public {inline} (0 calls)
 
 
 two > public {inline} (0 calls)
-0: two(two_field1#0:wybe.int, two_field2#0:wybe.int, ?$#0:multictr.simple):
+0: multictr.simple.two<0>
+two(two_field1#0:wybe.int, two_field2#0:wybe.int, ?$#0:multictr.simple):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:multictr.simple)
@@ -6589,7 +6722,8 @@ two > public {inline} (0 calls)
     foreign lpvm mutate(~%$rec#1:multictr.simple, ?%$rec#2:multictr.simple, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~two_field2#0:wybe.int)
     foreign llvm or(~$rec#2:multictr.simple, 1:wybe.int, ?$#0:multictr.simple)
 two > public {inline} (7 calls)
-1: two(?two_field1#0:wybe.int, ?two_field2#0:wybe.int, $#0:multictr.simple, ?$$#0:wybe.bool):
+1: multictr.simple.two<1>
+two(?two_field1#0:wybe.int, ?two_field2#0:wybe.int, $#0:multictr.simple, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -6617,7 +6751,8 @@ two > public {inline} (7 calls)
 
 
 two_field1 > public {inline} (0 calls)
-0: two_field1($rec#0:multictr.simple, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: multictr.simple.two_field1<0>
+two_field1($rec#0:multictr.simple, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -6640,7 +6775,8 @@ two_field1 > public {inline} (0 calls)
 
 
 two_field1 > public {inline} (0 calls)
-1: two_field1($rec#0:multictr.simple, ?$rec#1:multictr.simple, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: multictr.simple.two_field1<1>
+two_field1($rec#0:multictr.simple, ?$rec#1:multictr.simple, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -6665,7 +6801,8 @@ two_field1 > public {inline} (0 calls)
 
 
 two_field2 > public {inline} (0 calls)
-0: two_field2($rec#0:multictr.simple, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: multictr.simple.two_field2<0>
+two_field2($rec#0:multictr.simple, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -6688,7 +6825,8 @@ two_field2 > public {inline} (0 calls)
 
 
 two_field2 > public {inline} (0 calls)
-1: two_field2($rec#0:multictr.simple, ?$rec#1:multictr.simple, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: multictr.simple.two_field2<1>
+two_field2($rec#0:multictr.simple, ?$rec#1:multictr.simple, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -6713,7 +6851,8 @@ two_field2 > public {inline} (0 calls)
 
 
 zero > public {inline} (0 calls)
-0: zero(?$#0:multictr.simple):
+0: multictr.simple.zero<0>
+zero(?$#0:multictr.simple):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(0:multictr.simple, ?$#0:multictr.simple)
@@ -7109,7 +7248,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:multictr.suit, $right#0:multictr.suit, ?$$#0:wybe.bool):
+0: multictr.suit./=<0>
+/=($left#0:multictr.suit, $right#0:multictr.suit, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_eq(~$left#0:multictr.suit, ~$right#0:multictr.suit, ?tmp$0#0:wybe.bool)
@@ -7117,35 +7257,40 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:multictr.suit, $right#0:multictr.suit, ?$$#0:wybe.bool):
+0: multictr.suit.=<0>
+=($left#0:multictr.suit, $right#0:multictr.suit, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_eq(~$left#0:multictr.suit, ~$right#0:multictr.suit, ?$$#0:!wybe.bool)
 
 
 clubs > public {inline} (0 calls)
-0: clubs(?$#0:multictr.suit):
+0: multictr.suit.clubs<0>
+clubs(?$#0:multictr.suit):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(0:multictr.suit, ?$#0:multictr.suit)
 
 
 diamonds > public {inline} (0 calls)
-0: diamonds(?$#0:multictr.suit):
+0: multictr.suit.diamonds<0>
+diamonds(?$#0:multictr.suit):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(1:multictr.suit, ?$#0:multictr.suit)
 
 
 hearts > public {inline} (0 calls)
-0: hearts(?$#0:multictr.suit):
+0: multictr.suit.hearts<0>
+hearts(?$#0:multictr.suit):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(2:multictr.suit, ?$#0:multictr.suit)
 
 
 spades > public {inline} (0 calls)
-0: spades(?$#0:multictr.suit):
+0: multictr.suit.spades<0>
+spades(?$#0:multictr.suit):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(3:multictr.suit, ?$#0:multictr.suit)
@@ -7215,21 +7360,24 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=([$left#0:multictr.unit], [$right#0:multictr.unit], ?$$#0:wybe.bool):
+0: multictr.unit./=<0>
+/=([$left#0:multictr.unit], [$right#0:multictr.unit], ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
 
 
 = > public {inline} (1 calls)
-0: =([$left#0:multictr.unit], [$right#0:multictr.unit], ?$$#0:wybe.bool):
+0: multictr.unit.=<0>
+=([$left#0:multictr.unit], [$right#0:multictr.unit], ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 
 unit > public {inline} (0 calls)
-0: unit(?$#0:multictr.unit):
+0: multictr.unit.unit<0>
+unit(?$#0:multictr.unit):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(0:multictr.unit, ?$#0:multictr.unit)

--- a/test-cases/final-dump/multictr2.exp
+++ b/test-cases/final-dump/multictr2.exp
@@ -50,7 +50,8 @@ AFTER EVERYTHING:
   procs           : 
 
 print_t > public (0 calls)
-0: print_t(x#0:multictr2.t, io#0:wybe.phantom, ?io#8:wybe.phantom):
+0: multictr2.print_t<0>
+print_t(x#0:multictr2.t, io#0:wybe.phantom, ?io#8:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(x#0:multictr2.t, 7:wybe.int, ?tmp$9#0:wybe.int)
@@ -418,7 +419,8 @@ if.else7:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:multictr2.t, $right#0:multictr2.t, ?$$#0:wybe.bool):
+0: multictr2.t./=<0>
+/=($left#0:multictr2.t, $right#0:multictr2.t, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     multictr2.t.=<0>(~$left#0:multictr2.t, ~$right#0:multictr2.t, ?tmp$0#0:wybe.bool) #0
@@ -426,7 +428,8 @@ if.else7:
 
 
 = > public (1 calls)
-0: =($left#0:multictr2.t, $right#0:multictr2.t, ?$$#0:wybe.bool):
+0: multictr2.t.=<0>
+=($left#0:multictr2.t, $right#0:multictr2.t, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($left#0:multictr2.t, 7:wybe.int, ?tmp$28#0:wybe.int)
@@ -588,13 +591,15 @@ if.else7:
 
 
 c01 > public {inline} (0 calls)
-0: c01(f01#0:wybe.int, ?$#0:multictr2.t):
+0: multictr2.t.c01<0>
+c01(f01#0:wybe.int, ?$#0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr2.t)
     foreign lpvm mutate(~%$rec#0:multictr2.t, ?%$#0:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f01#0:wybe.int)
 c01 > public {inline} (24 calls)
-1: c01(?f01#0:wybe.int, $#0:multictr2.t, ?$$#0:wybe.bool):
+1: multictr2.t.c01<1>
+c01(?f01#0:wybe.int, $#0:multictr2.t, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($#0:!wybe.int, 7:wybe.int, ?tmp$1#0:!wybe.int)
@@ -611,14 +616,16 @@ c01 > public {inline} (24 calls)
 
 
 c02 > public {inline} (0 calls)
-0: c02(f02#0:wybe.int, ?$#0:multictr2.t):
+0: multictr2.t.c02<0>
+c02(f02#0:wybe.int, ?$#0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr2.t)
     foreign lpvm mutate(~%$rec#0:multictr2.t, ?%$rec#1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f02#0:wybe.int)
     foreign llvm or(~$rec#1:multictr2.t, 1:wybe.int, ?$#0:multictr2.t)
 c02 > public {inline} (19 calls)
-1: c02(?f02#0:wybe.int, $#0:multictr2.t, ?$$#0:wybe.bool):
+1: multictr2.t.c02<1>
+c02(?f02#0:wybe.int, $#0:multictr2.t, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($#0:!wybe.int, 7:wybe.int, ?tmp$1#0:!wybe.int)
@@ -635,14 +642,16 @@ c02 > public {inline} (19 calls)
 
 
 c03 > public {inline} (0 calls)
-0: c03(f03#0:wybe.int, ?$#0:multictr2.t):
+0: multictr2.t.c03<0>
+c03(f03#0:wybe.int, ?$#0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr2.t)
     foreign lpvm mutate(~%$rec#0:multictr2.t, ?%$rec#1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f03#0:wybe.int)
     foreign llvm or(~$rec#1:multictr2.t, 2:wybe.int, ?$#0:multictr2.t)
 c03 > public {inline} (17 calls)
-1: c03(?f03#0:wybe.int, $#0:multictr2.t, ?$$#0:wybe.bool):
+1: multictr2.t.c03<1>
+c03(?f03#0:wybe.int, $#0:multictr2.t, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($#0:!wybe.int, 7:wybe.int, ?tmp$1#0:!wybe.int)
@@ -659,14 +668,16 @@ c03 > public {inline} (17 calls)
 
 
 c04 > public {inline} (0 calls)
-0: c04(f04#0:wybe.int, ?$#0:multictr2.t):
+0: multictr2.t.c04<0>
+c04(f04#0:wybe.int, ?$#0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr2.t)
     foreign lpvm mutate(~%$rec#0:multictr2.t, ?%$rec#1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f04#0:wybe.int)
     foreign llvm or(~$rec#1:multictr2.t, 3:wybe.int, ?$#0:multictr2.t)
 c04 > public {inline} (15 calls)
-1: c04(?f04#0:wybe.int, $#0:multictr2.t, ?$$#0:wybe.bool):
+1: multictr2.t.c04<1>
+c04(?f04#0:wybe.int, $#0:multictr2.t, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($#0:!wybe.int, 7:wybe.int, ?tmp$1#0:!wybe.int)
@@ -683,14 +694,16 @@ c04 > public {inline} (15 calls)
 
 
 c05 > public {inline} (0 calls)
-0: c05(f05#0:wybe.int, ?$#0:multictr2.t):
+0: multictr2.t.c05<0>
+c05(f05#0:wybe.int, ?$#0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr2.t)
     foreign lpvm mutate(~%$rec#0:multictr2.t, ?%$rec#1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f05#0:wybe.int)
     foreign llvm or(~$rec#1:multictr2.t, 4:wybe.int, ?$#0:multictr2.t)
 c05 > public {inline} (13 calls)
-1: c05(?f05#0:wybe.int, $#0:multictr2.t, ?$$#0:wybe.bool):
+1: multictr2.t.c05<1>
+c05(?f05#0:wybe.int, $#0:multictr2.t, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($#0:!wybe.int, 7:wybe.int, ?tmp$1#0:!wybe.int)
@@ -707,14 +720,16 @@ c05 > public {inline} (13 calls)
 
 
 c06 > public {inline} (0 calls)
-0: c06(f06#0:wybe.int, ?$#0:multictr2.t):
+0: multictr2.t.c06<0>
+c06(f06#0:wybe.int, ?$#0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr2.t)
     foreign lpvm mutate(~%$rec#0:multictr2.t, ?%$rec#1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f06#0:wybe.int)
     foreign llvm or(~$rec#1:multictr2.t, 5:wybe.int, ?$#0:multictr2.t)
 c06 > public {inline} (11 calls)
-1: c06(?f06#0:wybe.int, $#0:multictr2.t, ?$$#0:wybe.bool):
+1: multictr2.t.c06<1>
+c06(?f06#0:wybe.int, $#0:multictr2.t, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($#0:!wybe.int, 7:wybe.int, ?tmp$1#0:!wybe.int)
@@ -731,14 +746,16 @@ c06 > public {inline} (11 calls)
 
 
 c07 > public {inline} (0 calls)
-0: c07(f07#0:wybe.int, ?$#0:multictr2.t):
+0: multictr2.t.c07<0>
+c07(f07#0:wybe.int, ?$#0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr2.t)
     foreign lpvm mutate(~%$rec#0:multictr2.t, ?%$rec#1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f07#0:wybe.int)
     foreign llvm or(~$rec#1:multictr2.t, 6:wybe.int, ?$#0:multictr2.t)
 c07 > public {inline} (9 calls)
-1: c07(?f07#0:wybe.int, $#0:multictr2.t, ?$$#0:wybe.bool):
+1: multictr2.t.c07<1>
+c07(?f07#0:wybe.int, $#0:multictr2.t, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($#0:!wybe.int, 7:wybe.int, ?tmp$1#0:!wybe.int)
@@ -755,7 +772,8 @@ c07 > public {inline} (9 calls)
 
 
 c08 > public {inline} (0 calls)
-0: c08(f08_a#0:wybe.int, f08_b#0:wybe.int, f08_c#0:wybe.float, ?$#0:multictr2.t):
+0: multictr2.t.c08<0>
+c08(f08_a#0:wybe.int, f08_b#0:wybe.int, f08_c#0:wybe.float, ?$#0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(24:wybe.int, ?$rec#0:multictr2.t)
@@ -764,7 +782,8 @@ c08 > public {inline} (0 calls)
     foreign lpvm mutate(~%$rec#2:multictr2.t, ?%$rec#3:multictr2.t, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~f08_c#0:wybe.float)
     foreign llvm or(~$rec#3:multictr2.t, 7:wybe.int, ?$#0:multictr2.t)
 c08 > public {inline} (9 calls)
-1: c08(?f08_a#0:wybe.int, ?f08_b#0:wybe.int, ?f08_c#0:wybe.float, $#0:multictr2.t, ?$$#0:wybe.bool):
+1: multictr2.t.c08<1>
+c08(?f08_a#0:wybe.int, ?f08_b#0:wybe.int, ?f08_c#0:wybe.float, $#0:multictr2.t, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($#0:!wybe.int, 7:wybe.int, ?tmp$1#0:!wybe.int)
@@ -785,7 +804,8 @@ c08 > public {inline} (9 calls)
 
 
 f01 > public {inline} (0 calls)
-0: f01($rec#0:multictr2.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: multictr2.t.f01<0>
+f01($rec#0:multictr2.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($rec#0:!wybe.int, 7:wybe.int, ?tmp$1#0:!wybe.int)
@@ -800,7 +820,8 @@ f01 > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 f01 > public {inline} (0 calls)
-1: f01($rec#0:multictr2.t, ?$rec#1:multictr2.t, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: multictr2.t.f01<1>
+f01($rec#0:multictr2.t, ?$rec#1:multictr2.t, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($rec#0:!wybe.int, 7:wybe.int, ?tmp$1#0:!wybe.int)
@@ -817,7 +838,8 @@ f01 > public {inline} (0 calls)
 
 
 f02 > public {inline} (0 calls)
-0: f02($rec#0:multictr2.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: multictr2.t.f02<0>
+f02($rec#0:multictr2.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($rec#0:!wybe.int, 7:wybe.int, ?tmp$1#0:!wybe.int)
@@ -832,7 +854,8 @@ f02 > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 f02 > public {inline} (0 calls)
-1: f02($rec#0:multictr2.t, ?$rec#1:multictr2.t, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: multictr2.t.f02<1>
+f02($rec#0:multictr2.t, ?$rec#1:multictr2.t, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($rec#0:!wybe.int, 7:wybe.int, ?tmp$1#0:!wybe.int)
@@ -849,7 +872,8 @@ f02 > public {inline} (0 calls)
 
 
 f03 > public {inline} (0 calls)
-0: f03($rec#0:multictr2.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: multictr2.t.f03<0>
+f03($rec#0:multictr2.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($rec#0:!wybe.int, 7:wybe.int, ?tmp$1#0:!wybe.int)
@@ -864,7 +888,8 @@ f03 > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 f03 > public {inline} (0 calls)
-1: f03($rec#0:multictr2.t, ?$rec#1:multictr2.t, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: multictr2.t.f03<1>
+f03($rec#0:multictr2.t, ?$rec#1:multictr2.t, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($rec#0:!wybe.int, 7:wybe.int, ?tmp$1#0:!wybe.int)
@@ -881,7 +906,8 @@ f03 > public {inline} (0 calls)
 
 
 f04 > public {inline} (0 calls)
-0: f04($rec#0:multictr2.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: multictr2.t.f04<0>
+f04($rec#0:multictr2.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($rec#0:!wybe.int, 7:wybe.int, ?tmp$1#0:!wybe.int)
@@ -896,7 +922,8 @@ f04 > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 f04 > public {inline} (0 calls)
-1: f04($rec#0:multictr2.t, ?$rec#1:multictr2.t, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: multictr2.t.f04<1>
+f04($rec#0:multictr2.t, ?$rec#1:multictr2.t, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($rec#0:!wybe.int, 7:wybe.int, ?tmp$1#0:!wybe.int)
@@ -913,7 +940,8 @@ f04 > public {inline} (0 calls)
 
 
 f05 > public {inline} (0 calls)
-0: f05($rec#0:multictr2.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: multictr2.t.f05<0>
+f05($rec#0:multictr2.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($rec#0:!wybe.int, 7:wybe.int, ?tmp$1#0:!wybe.int)
@@ -928,7 +956,8 @@ f05 > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 f05 > public {inline} (0 calls)
-1: f05($rec#0:multictr2.t, ?$rec#1:multictr2.t, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: multictr2.t.f05<1>
+f05($rec#0:multictr2.t, ?$rec#1:multictr2.t, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($rec#0:!wybe.int, 7:wybe.int, ?tmp$1#0:!wybe.int)
@@ -945,7 +974,8 @@ f05 > public {inline} (0 calls)
 
 
 f06 > public {inline} (0 calls)
-0: f06($rec#0:multictr2.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: multictr2.t.f06<0>
+f06($rec#0:multictr2.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($rec#0:!wybe.int, 7:wybe.int, ?tmp$1#0:!wybe.int)
@@ -960,7 +990,8 @@ f06 > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 f06 > public {inline} (0 calls)
-1: f06($rec#0:multictr2.t, ?$rec#1:multictr2.t, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: multictr2.t.f06<1>
+f06($rec#0:multictr2.t, ?$rec#1:multictr2.t, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($rec#0:!wybe.int, 7:wybe.int, ?tmp$1#0:!wybe.int)
@@ -977,7 +1008,8 @@ f06 > public {inline} (0 calls)
 
 
 f07 > public {inline} (0 calls)
-0: f07($rec#0:multictr2.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: multictr2.t.f07<0>
+f07($rec#0:multictr2.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($rec#0:!wybe.int, 7:wybe.int, ?tmp$1#0:!wybe.int)
@@ -992,7 +1024,8 @@ f07 > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 f07 > public {inline} (0 calls)
-1: f07($rec#0:multictr2.t, ?$rec#1:multictr2.t, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: multictr2.t.f07<1>
+f07($rec#0:multictr2.t, ?$rec#1:multictr2.t, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($rec#0:!wybe.int, 7:wybe.int, ?tmp$1#0:!wybe.int)
@@ -1009,7 +1042,8 @@ f07 > public {inline} (0 calls)
 
 
 f08_a > public {inline} (0 calls)
-0: f08_a($rec#0:multictr2.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: multictr2.t.f08_a<0>
+f08_a($rec#0:multictr2.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($rec#0:!wybe.int, 7:wybe.int, ?tmp$1#0:!wybe.int)
@@ -1024,7 +1058,8 @@ f08_a > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 f08_a > public {inline} (0 calls)
-1: f08_a($rec#0:multictr2.t, ?$rec#1:multictr2.t, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: multictr2.t.f08_a<1>
+f08_a($rec#0:multictr2.t, ?$rec#1:multictr2.t, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($rec#0:!wybe.int, 7:wybe.int, ?tmp$1#0:!wybe.int)
@@ -1041,7 +1076,8 @@ f08_a > public {inline} (0 calls)
 
 
 f08_b > public {inline} (0 calls)
-0: f08_b($rec#0:multictr2.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: multictr2.t.f08_b<0>
+f08_b($rec#0:multictr2.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($rec#0:!wybe.int, 7:wybe.int, ?tmp$1#0:!wybe.int)
@@ -1056,7 +1092,8 @@ f08_b > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 f08_b > public {inline} (0 calls)
-1: f08_b($rec#0:multictr2.t, ?$rec#1:multictr2.t, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: multictr2.t.f08_b<1>
+f08_b($rec#0:multictr2.t, ?$rec#1:multictr2.t, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($rec#0:!wybe.int, 7:wybe.int, ?tmp$1#0:!wybe.int)
@@ -1073,7 +1110,8 @@ f08_b > public {inline} (0 calls)
 
 
 f08_c > public {inline} (0 calls)
-0: f08_c($rec#0:multictr2.t, ?$#0:wybe.float, ?$$#0:wybe.bool):
+0: multictr2.t.f08_c<0>
+f08_c($rec#0:multictr2.t, ?$#0:wybe.float, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($rec#0:!wybe.int, 7:wybe.int, ?tmp$1#0:!wybe.int)
@@ -1088,7 +1126,8 @@ f08_c > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 f08_c > public {inline} (0 calls)
-1: f08_c($rec#0:multictr2.t, ?$rec#1:multictr2.t, $field#0:wybe.float, ?$$#0:wybe.bool):
+1: multictr2.t.f08_c<1>
+f08_c($rec#0:multictr2.t, ?$rec#1:multictr2.t, $field#0:wybe.float, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and($rec#0:!wybe.int, 7:wybe.int, ?tmp$1#0:!wybe.int)

--- a/test-cases/final-dump/mutual_type.exp
+++ b/test-cases/final-dump/mutual_type.exp
@@ -45,7 +45,8 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:mutual_type.a, $right#0:mutual_type.a, ?$$#0:wybe.bool):
+0: mutual_type.a./=<0>
+/=($left#0:mutual_type.a, $right#0:mutual_type.a, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     mutual_type.a.=<0>(~$left#0:mutual_type.a, ~$right#0:mutual_type.a, ?tmp$0#0:wybe.bool) #0
@@ -53,7 +54,8 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 
 = > public (1 calls)
-0: =($left#0:mutual_type.a, $right#0:mutual_type.a, ?$$#0:wybe.bool):
+0: mutual_type.a.=<0>
+=($left#0:mutual_type.a, $right#0:mutual_type.a, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($left#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -85,14 +87,16 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 
 a > public {inline} (0 calls)
-0: a(ahead#0:wybe.int, atail#0:mutual_type.b, ?$#0:mutual_type.a):
+0: mutual_type.a.a<0>
+a(ahead#0:wybe.int, atail#0:mutual_type.b, ?$#0:mutual_type.a):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:mutual_type.a)
     foreign lpvm mutate(~%$rec#0:mutual_type.a, ?%$rec#1:mutual_type.a, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~ahead#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:mutual_type.a, ?%$#0:mutual_type.a, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~atail#0:mutual_type.b)
 a > public {inline} (12 calls)
-1: a(?ahead#0:wybe.int, ?atail#0:mutual_type.b, $#0:mutual_type.a, ?$$#0:wybe.bool):
+1: mutual_type.a.a<1>
+a(?ahead#0:wybe.int, ?atail#0:mutual_type.b, $#0:mutual_type.a, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -110,7 +114,8 @@ a > public {inline} (12 calls)
 
 
 ahead > public {inline} (0 calls)
-0: ahead($rec#0:mutual_type.a, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: mutual_type.a.ahead<0>
+ahead($rec#0:mutual_type.a, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -124,7 +129,8 @@ ahead > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 ahead > public {inline} (0 calls)
-1: ahead($rec#0:mutual_type.a, ?$rec#1:mutual_type.a, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: mutual_type.a.ahead<1>
+ahead($rec#0:mutual_type.a, ?$rec#1:mutual_type.a, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -140,7 +146,8 @@ ahead > public {inline} (0 calls)
 
 
 atail > public {inline} (0 calls)
-0: atail($rec#0:mutual_type.a, ?$#0:mutual_type.b, ?$$#0:wybe.bool):
+0: mutual_type.a.atail<0>
+atail($rec#0:mutual_type.a, ?$#0:mutual_type.b, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -154,7 +161,8 @@ atail > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 atail > public {inline} (0 calls)
-1: atail($rec#0:mutual_type.a, ?$rec#1:mutual_type.a, $field#0:mutual_type.b, ?$$#0:wybe.bool):
+1: mutual_type.a.atail<1>
+atail($rec#0:mutual_type.a, ?$rec#1:mutual_type.a, $field#0:mutual_type.b, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -170,7 +178,8 @@ atail > public {inline} (0 calls)
 
 
 no_a > public {inline} (0 calls)
-0: no_a(?$#0:mutual_type.a):
+0: mutual_type.a.no_a<0>
+no_a(?$#0:mutual_type.a):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(0:mutual_type.a, ?$#0:mutual_type.a)
@@ -386,7 +395,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:mutual_type.b, $right#0:mutual_type.b, ?$$#0:wybe.bool):
+0: mutual_type.b./=<0>
+/=($left#0:mutual_type.b, $right#0:mutual_type.b, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     mutual_type.b.=<0>(~$left#0:mutual_type.b, ~$right#0:mutual_type.b, ?tmp$0#0:wybe.bool) #0
@@ -394,7 +404,8 @@ entry:
 
 
 = > public (1 calls)
-0: =($left#0:mutual_type.b, $right#0:mutual_type.b, ?$$#0:wybe.bool):
+0: mutual_type.b.=<0>
+=($left#0:mutual_type.b, $right#0:mutual_type.b, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($left#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -426,14 +437,16 @@ entry:
 
 
 b > public {inline} (0 calls)
-0: b(bhead#0:wybe.int, btail#0:mutual_type.a, ?$#0:mutual_type.b):
+0: mutual_type.b.b<0>
+b(bhead#0:wybe.int, btail#0:mutual_type.a, ?$#0:mutual_type.b):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:mutual_type.b)
     foreign lpvm mutate(~%$rec#0:mutual_type.b, ?%$rec#1:mutual_type.b, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~bhead#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:mutual_type.b, ?%$#0:mutual_type.b, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~btail#0:mutual_type.a)
 b > public {inline} (12 calls)
-1: b(?bhead#0:wybe.int, ?btail#0:mutual_type.a, $#0:mutual_type.b, ?$$#0:wybe.bool):
+1: mutual_type.b.b<1>
+b(?bhead#0:wybe.int, ?btail#0:mutual_type.a, $#0:mutual_type.b, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -451,7 +464,8 @@ b > public {inline} (12 calls)
 
 
 bhead > public {inline} (0 calls)
-0: bhead($rec#0:mutual_type.b, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: mutual_type.b.bhead<0>
+bhead($rec#0:mutual_type.b, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -465,7 +479,8 @@ bhead > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 bhead > public {inline} (0 calls)
-1: bhead($rec#0:mutual_type.b, ?$rec#1:mutual_type.b, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: mutual_type.b.bhead<1>
+bhead($rec#0:mutual_type.b, ?$rec#1:mutual_type.b, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -481,7 +496,8 @@ bhead > public {inline} (0 calls)
 
 
 btail > public {inline} (0 calls)
-0: btail($rec#0:mutual_type.b, ?$#0:mutual_type.a, ?$$#0:wybe.bool):
+0: mutual_type.b.btail<0>
+btail($rec#0:mutual_type.b, ?$#0:mutual_type.a, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -495,7 +511,8 @@ btail > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 btail > public {inline} (0 calls)
-1: btail($rec#0:mutual_type.b, ?$rec#1:mutual_type.b, $field#0:mutual_type.a, ?$$#0:wybe.bool):
+1: mutual_type.b.btail<1>
+btail($rec#0:mutual_type.b, ?$rec#1:mutual_type.b, $field#0:mutual_type.a, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -511,7 +528,8 @@ btail > public {inline} (0 calls)
 
 
 no_b > public {inline} (0 calls)
-0: no_b(?$#0:mutual_type.b):
+0: mutual_type.b.no_b<0>
+no_b(?$#0:mutual_type.b):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(0:mutual_type.b, ?$#0:mutual_type.b)

--- a/test-cases/final-dump/mytree.exp
+++ b/test-cases/final-dump/mytree.exp
@@ -24,7 +24,8 @@ AFTER EVERYTHING:
   procs           : 
 
 printTree > public {inline} (0 calls)
-0: printTree(t#0:mytree.tree, io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: mytree.printTree<0>
+printTree(t#0:mytree.tree, io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     mytree.printTree1<0>(~t#0:mytree.tree, "{":wybe.string, ?%prefix#1:wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @mytree:nn:nn
@@ -32,7 +33,8 @@ printTree > public {inline} (0 calls)
 
 
 printTree1 > public (3 calls)
-0: printTree1(t#0:mytree.tree, prefix#0:wybe.string, ?prefix#3:wybe.string, io#0:wybe.phantom, ?io#4:wybe.phantom):
+0: mytree.printTree1<0>
+printTree1(t#0:mytree.tree, prefix#0:wybe.string, ?prefix#3:wybe.string, io#0:wybe.phantom, ?io#4:wybe.phantom):
  AliasPairs: [(prefix#0,prefix#3)]
  InterestingCallProperties: []
     foreign llvm icmp_ne(t#0:mytree.tree, 0:wybe.int, ?tmp$2#0:wybe.bool)
@@ -137,7 +139,8 @@ if.else:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:mytree.tree, $right#0:mytree.tree, ?$$#0:wybe.bool):
+0: mytree.tree./=<0>
+/=($left#0:mytree.tree, $right#0:mytree.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     mytree.tree.=<0>(~$left#0:mytree.tree, ~$right#0:mytree.tree, ?tmp$0#0:wybe.bool) #0
@@ -145,7 +148,8 @@ if.else:
 
 
 = > public (7 calls)
-0: =($left#0:mytree.tree, $right#0:mytree.tree, ?$$#0:wybe.bool):
+0: mytree.tree.=<0>
+=($left#0:mytree.tree, $right#0:mytree.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($left#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -186,14 +190,16 @@ if.else:
 
 
 empty > public {inline} (0 calls)
-0: empty(?$#0:mytree.tree):
+0: mytree.tree.empty<0>
+empty(?$#0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(0:mytree.tree, ?$#0:mytree.tree)
 
 
 key > public {inline} (0 calls)
-0: key($rec#0:mytree.tree, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: mytree.tree.key<0>
+key($rec#0:mytree.tree, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -207,7 +213,8 @@ key > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 key > public {inline} (0 calls)
-1: key($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: mytree.tree.key<1>
+key($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -223,7 +230,8 @@ key > public {inline} (0 calls)
 
 
 left > public {inline} (0 calls)
-0: left($rec#0:mytree.tree, ?$#0:mytree.tree, ?$$#0:wybe.bool):
+0: mytree.tree.left<0>
+left($rec#0:mytree.tree, ?$#0:mytree.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -237,7 +245,8 @@ left > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 left > public {inline} (0 calls)
-1: left($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:mytree.tree, ?$$#0:wybe.bool):
+1: mytree.tree.left<1>
+left($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:mytree.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -253,7 +262,8 @@ left > public {inline} (0 calls)
 
 
 node > public {inline} (0 calls)
-0: node(left#0:mytree.tree, key#0:wybe.int, right#0:mytree.tree, ?$#0:mytree.tree):
+0: mytree.tree.node<0>
+node(left#0:mytree.tree, key#0:wybe.int, right#0:mytree.tree, ?$#0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(24:wybe.int, ?$rec#0:mytree.tree)
@@ -261,7 +271,8 @@ node > public {inline} (0 calls)
     foreign lpvm mutate(~%$rec#1:mytree.tree, ?%$rec#2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key#0:wybe.int)
     foreign lpvm mutate(~%$rec#2:mytree.tree, ?%$#0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right#0:mytree.tree)
 node > public {inline} (16 calls)
-1: node(?left#0:mytree.tree, ?key#0:wybe.int, ?right#0:mytree.tree, $#0:mytree.tree, ?$$#0:wybe.bool):
+1: mytree.tree.node<1>
+node(?left#0:mytree.tree, ?key#0:wybe.int, ?right#0:mytree.tree, $#0:mytree.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -281,7 +292,8 @@ node > public {inline} (16 calls)
 
 
 right > public {inline} (0 calls)
-0: right($rec#0:mytree.tree, ?$#0:mytree.tree, ?$$#0:wybe.bool):
+0: mytree.tree.right<0>
+right($rec#0:mytree.tree, ?$#0:mytree.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -295,7 +307,8 @@ right > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 right > public {inline} (0 calls)
-1: right($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:mytree.tree, ?$$#0:wybe.bool):
+1: mytree.tree.right<1>
+right($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:mytree.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)

--- a/test-cases/final-dump/nested_if.exp
+++ b/test-cases/final-dump/nested_if.exp
@@ -10,7 +10,8 @@ AFTER EVERYTHING:
   procs           : 
 
 nested_if > public (0 calls)
-0: nested_if(i#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: nested_if.nested_if<0>
+nested_if(i#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_eq(i#0:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.bool) @int:nn:nn

--- a/test-cases/final-dump/nested_loop.exp
+++ b/test-cases/final-dump/nested_loop.exp
@@ -10,7 +10,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: nested_loop.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("Outer":wybe.string, ~io#0:wybe.phantom, ?tmp$1#0:wybe.phantom) @io:nn:nn
@@ -21,7 +22,8 @@ AFTER EVERYTHING:
 
 
 gen$1 > {inline} (1 calls)
-0: gen$1(io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: nested_loop.gen$1<0>
+gen$1(io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("Outer":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
@@ -32,7 +34,8 @@ gen$1 > {inline} (1 calls)
 
 
 gen$2 > {inline} (2 calls)
-0: gen$2(io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: nested_loop.gen$2<0>
+gen$2(io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("Inner":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn

--- a/test-cases/final-dump/numbers.exp
+++ b/test-cases/final-dump/numbers.exp
@@ -12,7 +12,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: numbers.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("Numbers has been initialised.":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
@@ -20,7 +21,8 @@ AFTER EVERYTHING:
 
 
 factorial > public (1 calls)
-0: factorial(n#0:wybe.int, ?$#0:wybe.int):
+0: numbers.factorial<0>
+factorial(n#0:wybe.int, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_sle(n#0:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.bool) @int:nn:nn
@@ -36,7 +38,8 @@ factorial > public (1 calls)
 
 
 toCelsius > public {inline} (0 calls)
-0: toCelsius(f#0:wybe.float, ?$#0:wybe.float):
+0: numbers.toCelsius<0>
+toCelsius(f#0:wybe.float, ?$#0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm fsub(~f#0:wybe.float, 32.0:wybe.float, ?tmp$1#0:wybe.float) @float:nn:nn

--- a/test-cases/final-dump/person1.exp
+++ b/test-cases/final-dump/person1.exp
@@ -20,7 +20,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: person1.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("Wang":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -70,7 +71,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:person1.person, $right#0:person1.person, ?$$#0:wybe.bool):
+0: person1.person./=<0>
+/=($left#0:person1.person, $right#0:person1.person, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.string)
@@ -92,7 +94,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:person1.person, $right#0:person1.person, ?$$#0:wybe.bool):
+0: person1.person.=<0>
+=($left#0:person1.person, $right#0:person1.person, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$firstname#0:wybe.string)
@@ -112,38 +115,44 @@ entry:
 
 
 firstname > public {inline} (0 calls)
-0: firstname($rec#0:person1.person, ?$#0:wybe.string):
+0: person1.person.firstname<0>
+firstname($rec#0:person1.person, ?$#0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.string)
 firstname > public {inline} (0 calls)
-1: firstname($rec#0:person1.person, ?$rec#1:person1.person, $field#0:wybe.string):
+1: person1.person.firstname<1>
+firstname($rec#0:person1.person, ?$rec#1:person1.person, $field#0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm mutate(~%$rec#0:person1.person, ?%$rec#1:person1.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.string)
 
 
 lastname > public {inline} (0 calls)
-0: lastname($rec#0:person1.person, ?$#0:wybe.string):
+0: person1.person.lastname<0>
+lastname($rec#0:person1.person, ?$#0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.string)
 lastname > public {inline} (0 calls)
-1: lastname($rec#0:person1.person, ?$rec#1:person1.person, $field#0:wybe.string):
+1: person1.person.lastname<1>
+lastname($rec#0:person1.person, ?$rec#1:person1.person, $field#0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm mutate(~%$rec#0:person1.person, ?%$rec#1:person1.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.string)
 
 
 person > public {inline} (0 calls)
-0: person(firstname#0:wybe.string, lastname#0:wybe.string, ?$#0:person1.person):
+0: person1.person.person<0>
+person(firstname#0:wybe.string, lastname#0:wybe.string, ?$#0:person1.person):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:person1.person)
     foreign lpvm mutate(~%$rec#0:person1.person, ?%$rec#1:person1.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname#0:wybe.string)
     foreign lpvm mutate(~%$rec#1:person1.person, ?%$#0:person1.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname#0:wybe.string)
 person > public {inline} (6 calls)
-1: person(?firstname#0:wybe.string, ?lastname#0:wybe.string, $#0:person1.person):
+1: person1.person.person<1>
+person(?firstname#0:wybe.string, ?lastname#0:wybe.string, $#0:person1.person):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname#0:wybe.string)

--- a/test-cases/final-dump/person2.exp
+++ b/test-cases/final-dump/person2.exp
@@ -20,7 +20,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: person2.<0>
+(io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("Smith":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -76,7 +77,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:person2.person, $right#0:person2.person, ?$$#0:wybe.bool):
+0: person2.person./=<0>
+/=($left#0:person2.person, $right#0:person2.person, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.string)
@@ -98,7 +100,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:person2.person, $right#0:person2.person, ?$$#0:wybe.bool):
+0: person2.person.=<0>
+=($left#0:person2.person, $right#0:person2.person, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$firstname#0:wybe.string)
@@ -118,38 +121,44 @@ entry:
 
 
 firstname > public {inline} (0 calls)
-0: firstname($rec#0:person2.person, ?$#0:wybe.string):
+0: person2.person.firstname<0>
+firstname($rec#0:person2.person, ?$#0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.string)
 firstname > public {inline} (0 calls)
-1: firstname($rec#0:person2.person, ?$rec#1:person2.person, $field#0:wybe.string):
+1: person2.person.firstname<1>
+firstname($rec#0:person2.person, ?$rec#1:person2.person, $field#0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm mutate(~%$rec#0:person2.person, ?%$rec#1:person2.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.string)
 
 
 lastname > public {inline} (0 calls)
-0: lastname($rec#0:person2.person, ?$#0:wybe.string):
+0: person2.person.lastname<0>
+lastname($rec#0:person2.person, ?$#0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.string)
 lastname > public {inline} (0 calls)
-1: lastname($rec#0:person2.person, ?$rec#1:person2.person, $field#0:wybe.string):
+1: person2.person.lastname<1>
+lastname($rec#0:person2.person, ?$rec#1:person2.person, $field#0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm mutate(~%$rec#0:person2.person, ?%$rec#1:person2.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.string)
 
 
 person > public {inline} (0 calls)
-0: person(firstname#0:wybe.string, lastname#0:wybe.string, ?$#0:person2.person):
+0: person2.person.person<0>
+person(firstname#0:wybe.string, lastname#0:wybe.string, ?$#0:person2.person):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:person2.person)
     foreign lpvm mutate(~%$rec#0:person2.person, ?%$rec#1:person2.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname#0:wybe.string)
     foreign lpvm mutate(~%$rec#1:person2.person, ?%$#0:person2.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname#0:wybe.string)
 person > public {inline} (6 calls)
-1: person(?firstname#0:wybe.string, ?lastname#0:wybe.string, $#0:person2.person):
+1: person2.person.person<1>
+person(?firstname#0:wybe.string, ?lastname#0:wybe.string, $#0:person2.person):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname#0:wybe.string)

--- a/test-cases/final-dump/person3.exp
+++ b/test-cases/final-dump/person3.exp
@@ -20,7 +20,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: person3.<0>
+(io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("Smith":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -76,7 +77,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:person3.person, $right#0:person3.person, ?$$#0:wybe.bool):
+0: person3.person./=<0>
+/=($left#0:person3.person, $right#0:person3.person, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.string)
@@ -98,7 +100,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:person3.person, $right#0:person3.person, ?$$#0:wybe.bool):
+0: person3.person.=<0>
+=($left#0:person3.person, $right#0:person3.person, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$firstname#0:wybe.string)
@@ -118,38 +121,44 @@ entry:
 
 
 firstname > public {inline} (0 calls)
-0: firstname($rec#0:person3.person, ?$#0:wybe.string):
+0: person3.person.firstname<0>
+firstname($rec#0:person3.person, ?$#0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.string)
 firstname > public {inline} (0 calls)
-1: firstname($rec#0:person3.person, ?$rec#1:person3.person, $field#0:wybe.string):
+1: person3.person.firstname<1>
+firstname($rec#0:person3.person, ?$rec#1:person3.person, $field#0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm mutate(~%$rec#0:person3.person, ?%$rec#1:person3.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.string)
 
 
 lastname > public {inline} (0 calls)
-0: lastname($rec#0:person3.person, ?$#0:wybe.string):
+0: person3.person.lastname<0>
+lastname($rec#0:person3.person, ?$#0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.string)
 lastname > public {inline} (0 calls)
-1: lastname($rec#0:person3.person, ?$rec#1:person3.person, $field#0:wybe.string):
+1: person3.person.lastname<1>
+lastname($rec#0:person3.person, ?$rec#1:person3.person, $field#0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm mutate(~%$rec#0:person3.person, ?%$rec#1:person3.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.string)
 
 
 person > public {inline} (0 calls)
-0: person(firstname#0:wybe.string, lastname#0:wybe.string, ?$#0:person3.person):
+0: person3.person.person<0>
+person(firstname#0:wybe.string, lastname#0:wybe.string, ?$#0:person3.person):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:person3.person)
     foreign lpvm mutate(~%$rec#0:person3.person, ?%$rec#1:person3.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname#0:wybe.string)
     foreign lpvm mutate(~%$rec#1:person3.person, ?%$#0:person3.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname#0:wybe.string)
 person > public {inline} (6 calls)
-1: person(?firstname#0:wybe.string, ?lastname#0:wybe.string, $#0:person3.person):
+1: person3.person.person<1>
+person(?firstname#0:wybe.string, ?lastname#0:wybe.string, $#0:person3.person):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname#0:wybe.string)

--- a/test-cases/final-dump/person4.exp
+++ b/test-cases/final-dump/person4.exp
@@ -20,7 +20,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: person4.<0>
+(io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("Wang":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -76,7 +77,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:person4.person, $right#0:person4.person, ?$$#0:wybe.bool):
+0: person4.person./=<0>
+/=($left#0:person4.person, $right#0:person4.person, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.string)
@@ -98,7 +100,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:person4.person, $right#0:person4.person, ?$$#0:wybe.bool):
+0: person4.person.=<0>
+=($left#0:person4.person, $right#0:person4.person, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$firstname#0:wybe.string)
@@ -118,38 +121,44 @@ entry:
 
 
 firstname > public {inline} (0 calls)
-0: firstname($rec#0:person4.person, ?$#0:wybe.string):
+0: person4.person.firstname<0>
+firstname($rec#0:person4.person, ?$#0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.string)
 firstname > public {inline} (0 calls)
-1: firstname($rec#0:person4.person, ?$rec#1:person4.person, $field#0:wybe.string):
+1: person4.person.firstname<1>
+firstname($rec#0:person4.person, ?$rec#1:person4.person, $field#0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm mutate(~%$rec#0:person4.person, ?%$rec#1:person4.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.string)
 
 
 lastname > public {inline} (0 calls)
-0: lastname($rec#0:person4.person, ?$#0:wybe.string):
+0: person4.person.lastname<0>
+lastname($rec#0:person4.person, ?$#0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.string)
 lastname > public {inline} (0 calls)
-1: lastname($rec#0:person4.person, ?$rec#1:person4.person, $field#0:wybe.string):
+1: person4.person.lastname<1>
+lastname($rec#0:person4.person, ?$rec#1:person4.person, $field#0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm mutate(~%$rec#0:person4.person, ?%$rec#1:person4.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.string)
 
 
 person > public {inline} (0 calls)
-0: person(firstname#0:wybe.string, lastname#0:wybe.string, ?$#0:person4.person):
+0: person4.person.person<0>
+person(firstname#0:wybe.string, lastname#0:wybe.string, ?$#0:person4.person):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:person4.person)
     foreign lpvm mutate(~%$rec#0:person4.person, ?%$rec#1:person4.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname#0:wybe.string)
     foreign lpvm mutate(~%$rec#1:person4.person, ?%$#0:person4.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname#0:wybe.string)
 person > public {inline} (6 calls)
-1: person(?firstname#0:wybe.string, ?lastname#0:wybe.string, $#0:person4.person):
+1: person4.person.person<1>
+person(?firstname#0:wybe.string, ?lastname#0:wybe.string, $#0:person4.person):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname#0:wybe.string)

--- a/test-cases/final-dump/person5.exp
+++ b/test-cases/final-dump/person5.exp
@@ -20,7 +20,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#3:wybe.phantom):
+0: person5.<0>
+(io#0:wybe.phantom, ?io#3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("Amy":wybe.string, ~#io#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
@@ -28,7 +29,8 @@ AFTER EVERYTHING:
 
 
 update_both > {inline} (1 calls)
-0: update_both(p1#0:person5.person, ?p1#1:person5.person, p2#0:person5.person, ?p2#1:person5.person, io#0:wybe.phantom, [?io#0:wybe.phantom]):
+0: person5.update_both<0>
+update_both(p1#0:person5.person, ?p1#1:person5.person, p2#0:person5.person, ?p2#1:person5.person, io#0:wybe.phantom, [?io#0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm mutate(~%p1#0:person5.person, ?%p1#1:person5.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, "Amy":wybe.string)
@@ -120,7 +122,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:person5.person, $right#0:person5.person, ?$$#0:wybe.bool):
+0: person5.person./=<0>
+/=($left#0:person5.person, $right#0:person5.person, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.string)
@@ -142,7 +145,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:person5.person, $right#0:person5.person, ?$$#0:wybe.bool):
+0: person5.person.=<0>
+=($left#0:person5.person, $right#0:person5.person, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$firstname#0:wybe.string)
@@ -162,38 +166,44 @@ entry:
 
 
 firstname > public {inline} (0 calls)
-0: firstname($rec#0:person5.person, ?$#0:wybe.string):
+0: person5.person.firstname<0>
+firstname($rec#0:person5.person, ?$#0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.string)
 firstname > public {inline} (0 calls)
-1: firstname($rec#0:person5.person, ?$rec#1:person5.person, $field#0:wybe.string):
+1: person5.person.firstname<1>
+firstname($rec#0:person5.person, ?$rec#1:person5.person, $field#0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm mutate(~%$rec#0:person5.person, ?%$rec#1:person5.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.string)
 
 
 lastname > public {inline} (0 calls)
-0: lastname($rec#0:person5.person, ?$#0:wybe.string):
+0: person5.person.lastname<0>
+lastname($rec#0:person5.person, ?$#0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.string)
 lastname > public {inline} (0 calls)
-1: lastname($rec#0:person5.person, ?$rec#1:person5.person, $field#0:wybe.string):
+1: person5.person.lastname<1>
+lastname($rec#0:person5.person, ?$rec#1:person5.person, $field#0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm mutate(~%$rec#0:person5.person, ?%$rec#1:person5.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.string)
 
 
 person > public {inline} (0 calls)
-0: person(firstname#0:wybe.string, lastname#0:wybe.string, ?$#0:person5.person):
+0: person5.person.person<0>
+person(firstname#0:wybe.string, lastname#0:wybe.string, ?$#0:person5.person):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:person5.person)
     foreign lpvm mutate(~%$rec#0:person5.person, ?%$rec#1:person5.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname#0:wybe.string)
     foreign lpvm mutate(~%$rec#1:person5.person, ?%$#0:person5.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname#0:wybe.string)
 person > public {inline} (6 calls)
-1: person(?firstname#0:wybe.string, ?lastname#0:wybe.string, $#0:person5.person):
+1: person5.person.person<1>
+person(?firstname#0:wybe.string, ?lastname#0:wybe.string, $#0:person5.person):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname#0:wybe.string)

--- a/test-cases/final-dump/position.exp
+++ b/test-cases/final-dump/position.exp
@@ -20,7 +20,8 @@ AFTER EVERYTHING:
   procs           : 
 
 printPosition > public (0 calls)
-0: printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+0: position.printPosition<0>
+printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -103,7 +104,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position./=<0>
+/=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -123,7 +125,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position.=<0>
+=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
@@ -141,14 +144,16 @@ entry:
 
 
 position > public {inline} (0 calls)
-0: position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+0: position.position.position<0>
+position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
     foreign lpvm mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:position.position, ?%$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
 position > public {inline} (6 calls)
-1: position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+1: position.position.position<1>
+position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
@@ -156,24 +161,28 @@ position > public {inline} (6 calls)
 
 
 x > public {inline} (0 calls)
-0: x($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.x<0>
+x($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 x > public {inline} (0 calls)
-1: x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.x<1>
+x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 y > public {inline} (0 calls)
-0: y($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.y<0>
+y($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 y > public {inline} (0 calls)
-1: y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.y<1>
+y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)

--- a/test-cases/final-dump/position1.exp
+++ b/test-cases/final-dump/position1.exp
@@ -20,7 +20,8 @@ AFTER EVERYTHING:
   procs           : 
 
 printPosition > public (0 calls)
-0: printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+0: position.printPosition<0>
+printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -103,7 +104,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position./=<0>
+/=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -123,7 +125,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position.=<0>
+=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
@@ -141,14 +144,16 @@ entry:
 
 
 position > public {inline} (0 calls)
-0: position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+0: position.position.position<0>
+position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
     foreign lpvm mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:position.position, ?%$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
 position > public {inline} (6 calls)
-1: position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+1: position.position.position<1>
+position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
@@ -156,24 +161,28 @@ position > public {inline} (6 calls)
 
 
 x > public {inline} (0 calls)
-0: x($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.x<0>
+x($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 x > public {inline} (0 calls)
-1: x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.x<1>
+x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 y > public {inline} (0 calls)
-0: y($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.y<0>
+y($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 y > public {inline} (0 calls)
-1: y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.y<1>
+y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
@@ -339,7 +348,8 @@ entry:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: position1.<0>
+(io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$4#0:position.position)

--- a/test-cases/final-dump/position2.exp
+++ b/test-cases/final-dump/position2.exp
@@ -20,7 +20,8 @@ AFTER EVERYTHING:
   procs           : 
 
 printPosition > public (0 calls)
-0: printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+0: position.printPosition<0>
+printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -103,7 +104,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position./=<0>
+/=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -123,7 +125,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+0: position.position.=<0>
+=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
@@ -141,14 +144,16 @@ entry:
 
 
 position > public {inline} (0 calls)
-0: position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+0: position.position.position<0>
+position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
     foreign lpvm mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:position.position, ?%$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
 position > public {inline} (6 calls)
-1: position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+1: position.position.position<1>
+position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
@@ -156,24 +161,28 @@ position > public {inline} (6 calls)
 
 
 x > public {inline} (0 calls)
-0: x($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.x<0>
+x($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 x > public {inline} (0 calls)
-1: x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.x<1>
+x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 y > public {inline} (0 calls)
-0: y($rec#0:position.position, ?$#0:wybe.int):
+0: position.position.y<0>
+y($rec#0:position.position, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 y > public {inline} (0 calls)
-1: y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+1: position.position.y<1>
+y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position.position, ?%$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
@@ -339,7 +348,8 @@ entry:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#6:wybe.phantom):
+0: position2.<0>
+(io#0:wybe.phantom, ?io#6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$5#0:position.position)

--- a/test-cases/final-dump/position_float.exp
+++ b/test-cases/final-dump/position_float.exp
@@ -50,7 +50,8 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:position_float.position, $right#0:position_float.position, ?$$#0:wybe.bool):
+0: position_float.position./=<0>
+/=($left#0:position_float.position, $right#0:position_float.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.float)
@@ -70,7 +71,8 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 
 = > public {inline} (1 calls)
-0: =($left#0:position_float.position, $right#0:position_float.position, ?$$#0:wybe.bool):
+0: position_float.position.=<0>
+=($left#0:position_float.position, $right#0:position_float.position, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.float)
@@ -88,14 +90,16 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 
 position > public {inline} (0 calls)
-0: position(x#0:wybe.float, y#0:wybe.float, ?$#0:position_float.position):
+0: position_float.position.position<0>
+position(x#0:wybe.float, y#0:wybe.float, ?$#0:position_float.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:position_float.position)
     foreign lpvm mutate(~%$rec#0:position_float.position, ?%$rec#1:position_float.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.float)
     foreign lpvm mutate(~%$rec#1:position_float.position, ?%$#0:position_float.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.float)
 position > public {inline} (6 calls)
-1: position(?x#0:wybe.float, ?y#0:wybe.float, $#0:position_float.position):
+1: position_float.position.position<1>
+position(?x#0:wybe.float, ?y#0:wybe.float, $#0:position_float.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.float)
@@ -103,24 +107,28 @@ position > public {inline} (6 calls)
 
 
 x > public {inline} (0 calls)
-0: x($rec#0:position_float.position, ?$#0:wybe.float):
+0: position_float.position.x<0>
+x($rec#0:position_float.position, ?$#0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.float)
 x > public {inline} (0 calls)
-1: x($rec#0:position_float.position, ?$rec#1:position_float.position, $field#0:wybe.float):
+1: position_float.position.x<1>
+x($rec#0:position_float.position, ?$rec#1:position_float.position, $field#0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position_float.position, ?%$rec#1:position_float.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.float)
 
 
 y > public {inline} (0 calls)
-0: y($rec#0:position_float.position, ?$#0:wybe.float):
+0: position_float.position.y<0>
+y($rec#0:position_float.position, ?$#0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.float)
 y > public {inline} (0 calls)
-1: y($rec#0:position_float.position, ?$rec#1:position_float.position, $field#0:wybe.float):
+1: position_float.position.y<1>
+y($rec#0:position_float.position, ?$rec#1:position_float.position, $field#0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:position_float.position, ?%$rec#1:position_float.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.float)

--- a/test-cases/final-dump/proc_allin.exp
+++ b/test-cases/final-dump/proc_allin.exp
@@ -10,7 +10,8 @@ AFTER EVERYTHING:
   procs           : 
 
 nada > public {inline} (0 calls)
-0: nada([x#0:wybe.int], [y#0:wybe.int]):
+0: proc_allin.nada<0>
+nada([x#0:wybe.int], [y#0:wybe.int]):
  AliasPairs: []
  InterestingCallProperties: []
 

--- a/test-cases/final-dump/proc_beer.exp
+++ b/test-cases/final-dump/proc_beer.exp
@@ -11,21 +11,24 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: proc_beer.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     proc_beer.gen$1<0>(99:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #1 @proc_beer:nn:nn
 
 
 beer99 > public {inline} (1 calls)
-0: beer99(io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: proc_beer.beer99<0>
+beer99(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     proc_beer.gen$1<0>(99:wybe.int, ~io#0:wybe.phantom, ?io#1:wybe.phantom) #0 @proc_beer:nn:nn
 
 
 gen$1 > (2 calls)
-0: gen$1(count#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: proc_beer.gen$1<0>
+gen$1(count#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_sge(count#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
@@ -43,7 +46,8 @@ gen$1 > (2 calls)
 
 
 gen$2 > {inline} (1 calls)
-0: gen$2(count#0:wybe.int, io#0:wybe.phantom, ?io#3:wybe.phantom):
+0: proc_beer.gen$2<0>
+gen$2(count#0:wybe.int, io#0:wybe.phantom, ?io#3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_int(count#0:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn

--- a/test-cases/final-dump/proc_factorial.exp
+++ b/test-cases/final-dump/proc_factorial.exp
@@ -11,7 +11,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: proc_factorial.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     proc_factorial.gen$1<0>(5:wybe.int, 1:wybe.int, ?tmp$0#0:wybe.int) #2 @proc_factorial:nn:nn
@@ -20,14 +21,16 @@ AFTER EVERYTHING:
 
 
 factorial > public {inline} (1 calls)
-0: factorial(n#0:wybe.int, ?result#1:wybe.int):
+0: proc_factorial.factorial<0>
+factorial(n#0:wybe.int, ?result#1:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     proc_factorial.gen$1<0>(~n#0:wybe.int, 1:wybe.int, ?result#1:wybe.int) #0 @proc_factorial:nn:nn
 
 
 gen$1 > (2 calls)
-0: gen$1(n#0:wybe.int, result#0:wybe.int, ?result#1:wybe.int):
+0: proc_factorial.gen$1<0>
+gen$1(n#0:wybe.int, result#0:wybe.int, ?result#1:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_sgt(n#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.bool) @int:nn:nn
@@ -43,7 +46,8 @@ gen$1 > (2 calls)
 
 
 gen$2 > {inline} (1 calls)
-0: gen$2(n#0:wybe.int, result#0:wybe.int, ?result#2:wybe.int):
+0: proc_factorial.gen$2<0>
+gen$2(n#0:wybe.int, result#0:wybe.int, ?result#2:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm mul(n#0:wybe.int, ~result#0:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn

--- a/test-cases/final-dump/proc_gcd.exp
+++ b/test-cases/final-dump/proc_gcd.exp
@@ -12,7 +12,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: proc_gcd.<0>
+(io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     proc_gcd.gen$1<0>(18:wybe.int, 24:wybe.int, ~#io#0:wybe.phantom, _:wybe.int, 18:wybe.int, 24:wybe.int, ?r#0:wybe.int, ?#io#1:wybe.phantom) #2 @proc_gcd:nn:nn
@@ -20,14 +21,16 @@ AFTER EVERYTHING:
 
 
 gcd > public {inline} (1 calls)
-0: gcd(a#0:wybe.int, b#0:wybe.int, ?r#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: proc_gcd.gcd<0>
+gcd(a#0:wybe.int, b#0:wybe.int, ?r#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     proc_gcd.gen$1<0>(~a#0:wybe.int, ~b#0:wybe.int, ~io#0:wybe.phantom, _:wybe.int, ~a#0:wybe.int, ~b#0:wybe.int, ?r#0:wybe.int, ?io#1:wybe.phantom) #0 @proc_gcd:nn:nn
 
 
 gen$1 > (2 calls)
-0: gen$1(a#0:wybe.int, b#0:wybe.int, io#0:wybe.phantom, [t#0:wybe.int], x#0:wybe.int, y#0:wybe.int, ?r#0:wybe.int, ?io#1:wybe.phantom):
+0: proc_gcd.gen$1<0>
+gen$1(a#0:wybe.int, b#0:wybe.int, io#0:wybe.phantom, [t#0:wybe.int], x#0:wybe.int, y#0:wybe.int, ?r#0:wybe.int, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(y#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
@@ -43,7 +46,8 @@ gen$1 > (2 calls)
 
 
 gen$2 > {inline} (1 calls)
-0: gen$2(a#0:wybe.int, b#0:wybe.int, io#0:wybe.phantom, [t#0:wybe.int], x#0:wybe.int, y#0:wybe.int, ?r#0:wybe.int, ?io#2:wybe.phantom):
+0: proc_gcd.gen$2<0>
+gen$2(a#0:wybe.int, b#0:wybe.int, io#0:wybe.phantom, [t#0:wybe.int], x#0:wybe.int, y#0:wybe.int, ?r#0:wybe.int, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     proc_gcd.mod<0>(~x#0:wybe.int, y#0:wybe.int, ?y#1:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @proc_gcd:nn:nn
@@ -51,7 +55,8 @@ gen$2 > {inline} (1 calls)
 
 
 mod > public (1 calls)
-0: mod(x#0:wybe.int, y#0:wybe.int, ?r#0:wybe.int, io#0:wybe.phantom, ?io#5:wybe.phantom):
+0: proc_gcd.mod<0>
+mod(x#0:wybe.int, y#0:wybe.int, ?r#0:wybe.int, io#0:wybe.phantom, ?io#5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c putchar('x':wybe.char, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn

--- a/test-cases/final-dump/proc_hello.exp
+++ b/test-cases/final-dump/proc_hello.exp
@@ -10,7 +10,8 @@ AFTER EVERYTHING:
   procs           : 
 
 print2 > public {inline} (0 calls)
-0: print2([x#0:wybe.int], [y#0:wybe.int], io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: proc_hello.print2<0>
+print2([x#0:wybe.int], [y#0:wybe.int], io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("hello, world":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn

--- a/test-cases/final-dump/proc_print2.exp
+++ b/test-cases/final-dump/proc_print2.exp
@@ -10,7 +10,8 @@ AFTER EVERYTHING:
   procs           : 
 
 print2 > public {inline} (0 calls)
-0: print2(x#0:wybe.int, y#0:wybe.int, io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: proc_print2.print2<0>
+print2(x#0:wybe.int, y#0:wybe.int, io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_int(~x#0:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn

--- a/test-cases/final-dump/proc_yorn.exp
+++ b/test-cases/final-dump/proc_yorn.exp
@@ -11,7 +11,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: proc_yorn.<0>
+(io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     proc_yorn.gen$1<0>(~#io#0:wybe.phantom, "Well, yes or no?":wybe.string, ?r#0:wybe.bool, ?#io#1:wybe.phantom) #2 @proc_yorn:nn:nn
@@ -20,7 +21,8 @@ AFTER EVERYTHING:
 
 
 gen$1 > (2 calls)
-0: gen$1(io#0:wybe.phantom, prompt#0:wybe.string, ?result#1:wybe.bool, ?io#5:wybe.phantom):
+0: proc_yorn.gen$1<0>
+gen$1(io#0:wybe.phantom, prompt#0:wybe.string, ?result#1:wybe.bool, ?io#5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(prompt#0:wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -44,7 +46,8 @@ gen$1 > (2 calls)
 
 
 is_yes > {inline} (4 calls)
-0: is_yes(ch#0:wybe.char, ?$#0:wybe.bool):
+0: proc_yorn.is_yes<0>
+is_yes(ch#0:wybe.char, ?$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(ch#0:wybe.char, 'y':wybe.char, ?tmp$2#0:wybe.bool) @char:nn:nn
@@ -54,7 +57,8 @@ is_yes > {inline} (4 calls)
 
 
 is_yes_or_no > (3 calls)
-0: is_yes_or_no(ch#0:wybe.char, ?$#0:wybe.bool):
+0: proc_yorn.is_yes_or_no<0>
+is_yes_or_no(ch#0:wybe.char, ?$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(ch#0:wybe.char, 'y':wybe.char, ?tmp$6#0:wybe.bool) @char:nn:nn
@@ -68,7 +72,8 @@ is_yes_or_no > (3 calls)
 
 
 yorn > public {inline} (1 calls)
-0: yorn(prompt#0:wybe.string, ?result#0:wybe.bool, io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: proc_yorn.yorn<0>
+yorn(prompt#0:wybe.string, ?result#0:wybe.bool, io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     proc_yorn.gen$1<0>(~io#0:wybe.phantom, ~prompt#0:wybe.string, ?result#0:wybe.bool, ?io#1:wybe.phantom) #0 @proc_yorn:nn:nn

--- a/test-cases/final-dump/proc_yorn2.exp
+++ b/test-cases/final-dump/proc_yorn2.exp
@@ -10,7 +10,8 @@ AFTER EVERYTHING:
   procs           : 
 
 gen$1 > (2 calls)
-0: gen$1(io#0:wybe.phantom, prompt#0:wybe.string, ?result#1:wybe.bool, ?io#5:wybe.phantom):
+0: proc_yorn2.gen$1<0>
+gen$1(io#0:wybe.phantom, prompt#0:wybe.string, ?result#1:wybe.bool, ?io#5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(prompt#0:wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -38,7 +39,8 @@ gen$1 > (2 calls)
 
 
 yorn > public {inline} (0 calls)
-0: yorn(prompt#0:wybe.string, ?result#0:wybe.bool, io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: proc_yorn2.yorn<0>
+yorn(prompt#0:wybe.string, ?result#0:wybe.bool, io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     proc_yorn2.gen$1<0>(~io#0:wybe.phantom, ~prompt#0:wybe.string, ?result#0:wybe.bool, ?io#1:wybe.phantom) #0 @proc_yorn2:2:5

--- a/test-cases/final-dump/representation.exp
+++ b/test-cases/final-dump/representation.exp
@@ -10,7 +10,8 @@ AFTER EVERYTHING:
   procs           : 
 
 + > public {inline} (0 calls)
-0: +(x#0:representation, y#0:representation, ?$#0:representation):
+0: representation.+<0>
++(x#0:representation, y#0:representation, ?$#0:representation):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm add(~x#0:representation, ~y#0:representation, ?$#0:representation) @representation:nn:nn

--- a/test-cases/final-dump/simple_loop.exp
+++ b/test-cases/final-dump/simple_loop.exp
@@ -10,14 +10,16 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: simple_loop.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     simple_loop.gen$1<0>(~io#0:wybe.phantom, ?io#1:wybe.phantom) #0 @simple_loop:nn:nn
 
 
 gen$1 > (2 calls)
-0: gen$1(io#0:wybe.phantom, ?io#3:wybe.phantom):
+0: simple_loop.gen$1<0>
+gen$1(io#0:wybe.phantom, ?io#3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c read_char(?c#0:wybe.char, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn

--- a/test-cases/final-dump/sister_module.exp
+++ b/test-cases/final-dump/sister_module.exp
@@ -13,14 +13,16 @@ AFTER EVERYTHING:
   procs           : 
 
 baz > {inline} (0 calls)
-0: baz(i#0:wybe.int, ?j#0:wybe.int):
+0: sister_module.baz<0>
+baz(i#0:wybe.int, ?j#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     sister_module.m1.foo<0>(~i#0:wybe.int, ?j#0:wybe.int) #0 @sister_module:nn:nn
 
 
 buzz > {inline} (0 calls)
-0: buzz(i#0:wybe.int, ?j#0:wybe.int):
+0: sister_module.buzz<0>
+buzz(i#0:wybe.int, ?j#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     sister_module.m2.bar<0>(~i#0:wybe.int, ?j#0:wybe.int) #0 @sister_module:nn:nn
@@ -63,7 +65,8 @@ entry:
   procs           : 
 
 foo > public {inline} (0 calls)
-0: foo(i#0:wybe.int, ?j#0:wybe.int):
+0: sister_module.m1.foo<0>
+foo(i#0:wybe.int, ?j#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm add(~i#0:wybe.int, 1:wybe.int, ?j#0:wybe.int) @int:nn:nn
@@ -99,7 +102,8 @@ entry:
   procs           : 
 
 bar > public {inline} (0 calls)
-0: bar(i#0:wybe.int, ?j#0:wybe.int):
+0: sister_module.m2.bar<0>
+bar(i#0:wybe.int, ?j#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm add(~i#0:wybe.int, 1:wybe.int, ?k#0:wybe.int) @int:nn:nn

--- a/test-cases/final-dump/stmt_if.exp
+++ b/test-cases/final-dump/stmt_if.exp
@@ -23,7 +23,8 @@ AFTER EVERYTHING:
   procs           : 
 
 foobar > (0 calls)
-0: foobar(io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: stmt_if.foobar<0>
+foobar(io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(24:wybe.int, ?tmp$8#0:stmt_if.tree)
@@ -45,7 +46,8 @@ foobar > (0 calls)
 
 
 gen$1 > (2 calls)
-0: gen$1(io#0:wybe.phantom, [tmp$0#0:stmt_if.tree], [tmp$1#0:stmt_if.tree], [tmp$2#0:stmt_if.tree], tr#0:stmt_if.tree, ?io#1:wybe.phantom):
+0: stmt_if.gen$1<0>
+gen$1(io#0:wybe.phantom, [tmp$0#0:stmt_if.tree], [tmp$1#0:stmt_if.tree], [tmp$2#0:stmt_if.tree], tr#0:stmt_if.tree, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     stmt_if.lookup<0>(3:wybe.int, ~tr#0:stmt_if.tree, ?tmp$3#0:wybe.bool) #0 @stmt_if:nn:nn
@@ -61,7 +63,8 @@ gen$1 > (2 calls)
 
 
 lookup > public (8 calls)
-0: lookup(key#0:wybe.int, tree#0:stmt_if.tree, ?result#0:wybe.bool):
+0: stmt_if.lookup<0>
+lookup(key#0:wybe.int, tree#0:stmt_if.tree, ?result#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(tree#0:stmt_if.tree, 0:wybe.int, ?tmp$6#0:wybe.bool)
@@ -226,7 +229,8 @@ if.else2:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:stmt_if.tree, $right#0:stmt_if.tree, ?$$#0:wybe.bool):
+0: stmt_if.tree./=<0>
+/=($left#0:stmt_if.tree, $right#0:stmt_if.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     stmt_if.tree.=<0>(~$left#0:stmt_if.tree, ~$right#0:stmt_if.tree, ?tmp$0#0:wybe.bool) #0
@@ -234,7 +238,8 @@ if.else2:
 
 
 = > public (7 calls)
-0: =($left#0:stmt_if.tree, $right#0:stmt_if.tree, ?$$#0:wybe.bool):
+0: stmt_if.tree.=<0>
+=($left#0:stmt_if.tree, $right#0:stmt_if.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($left#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -275,14 +280,16 @@ if.else2:
 
 
 empty > public {inline} (0 calls)
-0: empty(?$#0:stmt_if.tree):
+0: stmt_if.tree.empty<0>
+empty(?$#0:stmt_if.tree):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(0:stmt_if.tree, ?$#0:stmt_if.tree)
 
 
 key > public {inline} (0 calls)
-0: key($rec#0:stmt_if.tree, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: stmt_if.tree.key<0>
+key($rec#0:stmt_if.tree, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -296,7 +303,8 @@ key > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 key > public {inline} (0 calls)
-1: key($rec#0:stmt_if.tree, ?$rec#1:stmt_if.tree, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: stmt_if.tree.key<1>
+key($rec#0:stmt_if.tree, ?$rec#1:stmt_if.tree, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -312,7 +320,8 @@ key > public {inline} (0 calls)
 
 
 left > public {inline} (0 calls)
-0: left($rec#0:stmt_if.tree, ?$#0:stmt_if.tree, ?$$#0:wybe.bool):
+0: stmt_if.tree.left<0>
+left($rec#0:stmt_if.tree, ?$#0:stmt_if.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -326,7 +335,8 @@ left > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 left > public {inline} (0 calls)
-1: left($rec#0:stmt_if.tree, ?$rec#1:stmt_if.tree, $field#0:stmt_if.tree, ?$$#0:wybe.bool):
+1: stmt_if.tree.left<1>
+left($rec#0:stmt_if.tree, ?$rec#1:stmt_if.tree, $field#0:stmt_if.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -342,7 +352,8 @@ left > public {inline} (0 calls)
 
 
 node > public {inline} (0 calls)
-0: node(left#0:stmt_if.tree, key#0:wybe.int, right#0:stmt_if.tree, ?$#0:stmt_if.tree):
+0: stmt_if.tree.node<0>
+node(left#0:stmt_if.tree, key#0:wybe.int, right#0:stmt_if.tree, ?$#0:stmt_if.tree):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(24:wybe.int, ?$rec#0:stmt_if.tree)
@@ -350,7 +361,8 @@ node > public {inline} (0 calls)
     foreign lpvm mutate(~%$rec#1:stmt_if.tree, ?%$rec#2:stmt_if.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key#0:wybe.int)
     foreign lpvm mutate(~%$rec#2:stmt_if.tree, ?%$#0:stmt_if.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right#0:stmt_if.tree)
 node > public {inline} (16 calls)
-1: node(?left#0:stmt_if.tree, ?key#0:wybe.int, ?right#0:stmt_if.tree, $#0:stmt_if.tree, ?$$#0:wybe.bool):
+1: stmt_if.tree.node<1>
+node(?left#0:stmt_if.tree, ?key#0:wybe.int, ?right#0:stmt_if.tree, $#0:stmt_if.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -370,7 +382,8 @@ node > public {inline} (16 calls)
 
 
 right > public {inline} (0 calls)
-0: right($rec#0:stmt_if.tree, ?$#0:stmt_if.tree, ?$$#0:wybe.bool):
+0: stmt_if.tree.right<0>
+right($rec#0:stmt_if.tree, ?$#0:stmt_if.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -384,7 +397,8 @@ right > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 right > public {inline} (0 calls)
-1: right($rec#0:stmt_if.tree, ?$rec#1:stmt_if.tree, $field#0:stmt_if.tree, ?$$#0:wybe.bool):
+1: stmt_if.tree.right<1>
+right($rec#0:stmt_if.tree, ?$rec#1:stmt_if.tree, $field#0:stmt_if.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)

--- a/test-cases/final-dump/stmt_if2.exp
+++ b/test-cases/final-dump/stmt_if2.exp
@@ -24,7 +24,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: stmt_if2.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(24:wybe.int, ?tmp$7#0:stmt_if2.tree)
@@ -42,14 +43,16 @@ AFTER EVERYTHING:
 
 
 gen$1 > {inline} (3 calls)
-0: gen$1([k#0:wybe.int], [key#0:wybe.int], [l#0:stmt_if2.tree], [r#0:stmt_if2.tree], tmp$4#0:wybe.bool, [tree#0:stmt_if2.tree], ?$#0:wybe.bool):
+0: stmt_if2.gen$1<0>
+gen$1([k#0:wybe.int], [key#0:wybe.int], [l#0:stmt_if2.tree], [r#0:stmt_if2.tree], tmp$4#0:wybe.bool, [tree#0:stmt_if2.tree], ?$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(~tmp$4#0:wybe.bool, ?$#0:wybe.bool) @stmt_if2:5:5
 
 
 lookup > public (5 calls)
-0: lookup(key#0:wybe.int, tree#0:stmt_if2.tree, ?$#0:wybe.bool):
+0: stmt_if2.lookup<0>
+lookup(key#0:wybe.int, tree#0:stmt_if2.tree, ?$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     stmt_if2.tree.=<0>(tree#0:stmt_if2.tree, 0:stmt_if2.tree, ?tmp$13#0:wybe.bool) #1 @stmt_if2:6:8
@@ -197,7 +200,8 @@ if.else3:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:stmt_if2.tree, $right#0:stmt_if2.tree, ?$$#0:wybe.bool):
+0: stmt_if2.tree./=<0>
+/=($left#0:stmt_if2.tree, $right#0:stmt_if2.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     stmt_if2.tree.=<0>(~$left#0:stmt_if2.tree, ~$right#0:stmt_if2.tree, ?tmp$0#0:wybe.bool) #0
@@ -205,7 +209,8 @@ if.else3:
 
 
 = > public (7 calls)
-0: =($left#0:stmt_if2.tree, $right#0:stmt_if2.tree, ?$$#0:wybe.bool):
+0: stmt_if2.tree.=<0>
+=($left#0:stmt_if2.tree, $right#0:stmt_if2.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($left#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -246,14 +251,16 @@ if.else3:
 
 
 empty > public {inline} (0 calls)
-0: empty(?$#0:stmt_if2.tree):
+0: stmt_if2.tree.empty<0>
+empty(?$#0:stmt_if2.tree):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(0:stmt_if2.tree, ?$#0:stmt_if2.tree)
 
 
 key > public {inline} (0 calls)
-0: key($rec#0:stmt_if2.tree, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: stmt_if2.tree.key<0>
+key($rec#0:stmt_if2.tree, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -267,7 +274,8 @@ key > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 key > public {inline} (0 calls)
-1: key($rec#0:stmt_if2.tree, ?$rec#1:stmt_if2.tree, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: stmt_if2.tree.key<1>
+key($rec#0:stmt_if2.tree, ?$rec#1:stmt_if2.tree, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -283,7 +291,8 @@ key > public {inline} (0 calls)
 
 
 left > public {inline} (0 calls)
-0: left($rec#0:stmt_if2.tree, ?$#0:stmt_if2.tree, ?$$#0:wybe.bool):
+0: stmt_if2.tree.left<0>
+left($rec#0:stmt_if2.tree, ?$#0:stmt_if2.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -297,7 +306,8 @@ left > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 left > public {inline} (0 calls)
-1: left($rec#0:stmt_if2.tree, ?$rec#1:stmt_if2.tree, $field#0:stmt_if2.tree, ?$$#0:wybe.bool):
+1: stmt_if2.tree.left<1>
+left($rec#0:stmt_if2.tree, ?$rec#1:stmt_if2.tree, $field#0:stmt_if2.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -313,7 +323,8 @@ left > public {inline} (0 calls)
 
 
 node > public {inline} (0 calls)
-0: node(left#0:stmt_if2.tree, key#0:wybe.int, right#0:stmt_if2.tree, ?$#0:stmt_if2.tree):
+0: stmt_if2.tree.node<0>
+node(left#0:stmt_if2.tree, key#0:wybe.int, right#0:stmt_if2.tree, ?$#0:stmt_if2.tree):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(24:wybe.int, ?$rec#0:stmt_if2.tree)
@@ -321,7 +332,8 @@ node > public {inline} (0 calls)
     foreign lpvm mutate(~%$rec#1:stmt_if2.tree, ?%$rec#2:stmt_if2.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key#0:wybe.int)
     foreign lpvm mutate(~%$rec#2:stmt_if2.tree, ?%$#0:stmt_if2.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right#0:stmt_if2.tree)
 node > public {inline} (16 calls)
-1: node(?left#0:stmt_if2.tree, ?key#0:wybe.int, ?right#0:stmt_if2.tree, $#0:stmt_if2.tree, ?$$#0:wybe.bool):
+1: stmt_if2.tree.node<1>
+node(?left#0:stmt_if2.tree, ?key#0:wybe.int, ?right#0:stmt_if2.tree, $#0:stmt_if2.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -341,7 +353,8 @@ node > public {inline} (16 calls)
 
 
 right > public {inline} (0 calls)
-0: right($rec#0:stmt_if2.tree, ?$#0:stmt_if2.tree, ?$$#0:wybe.bool):
+0: stmt_if2.tree.right<0>
+right($rec#0:stmt_if2.tree, ?$#0:stmt_if2.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -355,7 +368,8 @@ right > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 right > public {inline} (0 calls)
-1: right($rec#0:stmt_if2.tree, ?$rec#1:stmt_if2.tree, $field#0:stmt_if2.tree, ?$$#0:wybe.bool):
+1: stmt_if2.tree.right<1>
+right($rec#0:stmt_if2.tree, ?$rec#1:stmt_if2.tree, $field#0:stmt_if2.tree, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)

--- a/test-cases/final-dump/stmt_nop.exp
+++ b/test-cases/final-dump/stmt_nop.exp
@@ -10,7 +10,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, [?io#0:wybe.phantom]):
+0: stmt_nop.<0>
+(io#0:wybe.phantom, [?io#0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
 

--- a/test-cases/final-dump/stmt_unless.exp
+++ b/test-cases/final-dump/stmt_unless.exp
@@ -11,14 +11,16 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: stmt_unless.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     stmt_unless.gen$1<0>(~io#0:wybe.phantom, 10:wybe.int, ?io#1:wybe.phantom) #0 @stmt_unless:nn:nn
 
 
 gen$1 > (3 calls)
-0: gen$1(io#0:wybe.phantom, n#0:wybe.int, ?io#1:wybe.phantom):
+0: stmt_unless.gen$1<0>
+gen$1(io#0:wybe.phantom, n#0:wybe.int, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_sgt(n#0:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.bool) @int:nn:nn
@@ -32,7 +34,8 @@ gen$1 > (3 calls)
 
 
 gen$2 > (1 calls)
-0: gen$2(io#0:wybe.phantom, n#0:wybe.int, ?io#2:wybe.phantom):
+0: stmt_unless.gen$2<0>
+gen$2(io#0:wybe.phantom, n#0:wybe.int, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm sub(~n#0:wybe.int, 1:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn
@@ -50,7 +53,8 @@ gen$2 > (1 calls)
 
 
 mod > public {inline} (3 calls)
-0: mod(x#0:wybe.int, y#0:wybe.int, ?$#0:wybe.int):
+0: stmt_unless.mod<0>
+mod(x#0:wybe.int, y#0:wybe.int, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm urem(~x#0:wybe.int, ~y#0:wybe.int, ?$#0:wybe.int) @stmt_unless:nn:nn

--- a/test-cases/final-dump/stmt_until.exp
+++ b/test-cases/final-dump/stmt_until.exp
@@ -10,14 +10,16 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: stmt_until.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     stmt_until.gen$1<0>(~io#0:wybe.phantom, 10:wybe.int, ?io#1:wybe.phantom) #0 @stmt_until:nn:nn
 
 
 gen$1 > (2 calls)
-0: gen$1(io#0:wybe.phantom, n#0:wybe.int, ?io#1:wybe.phantom):
+0: stmt_until.gen$1<0>
+gen$1(io#0:wybe.phantom, n#0:wybe.int, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_slt(n#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
@@ -34,7 +36,8 @@ gen$1 > (2 calls)
 
 
 gen$2 > {inline} (1 calls)
-0: gen$2(io#0:wybe.phantom, n#0:wybe.int, ?io#2:wybe.phantom):
+0: stmt_until.gen$2<0>
+gen$2(io#0:wybe.phantom, n#0:wybe.int, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm sub(~n#0:wybe.int, 1:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn

--- a/test-cases/final-dump/stmt_when.exp
+++ b/test-cases/final-dump/stmt_when.exp
@@ -11,14 +11,16 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: stmt_when.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     stmt_when.gen$1<0>(~io#0:wybe.phantom, 10:wybe.int, ?io#1:wybe.phantom) #0 @stmt_when:nn:nn
 
 
 gen$1 > (3 calls)
-0: gen$1(io#0:wybe.phantom, n#0:wybe.int, ?io#1:wybe.phantom):
+0: stmt_when.gen$1<0>
+gen$1(io#0:wybe.phantom, n#0:wybe.int, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_sgt(n#0:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.bool) @int:nn:nn
@@ -32,7 +34,8 @@ gen$1 > (3 calls)
 
 
 gen$2 > (1 calls)
-0: gen$2(io#0:wybe.phantom, n#0:wybe.int, ?io#2:wybe.phantom):
+0: stmt_when.gen$2<0>
+gen$2(io#0:wybe.phantom, n#0:wybe.int, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm sub(~n#0:wybe.int, 1:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn
@@ -50,7 +53,8 @@ gen$2 > (1 calls)
 
 
 mod > public {inline} (3 calls)
-0: mod(x#0:wybe.int, y#0:wybe.int, ?$#0:wybe.int):
+0: stmt_when.mod<0>
+mod(x#0:wybe.int, y#0:wybe.int, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm urem(~x#0:wybe.int, ~y#0:wybe.int, ?$#0:wybe.int) @stmt_when:nn:nn

--- a/test-cases/final-dump/stmt_while.exp
+++ b/test-cases/final-dump/stmt_while.exp
@@ -10,14 +10,16 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: stmt_while.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     stmt_while.gen$1<0>(~io#0:wybe.phantom, 10:wybe.int, ?io#1:wybe.phantom) #0 @stmt_while:nn:nn
 
 
 gen$1 > (2 calls)
-0: gen$1(io#0:wybe.phantom, n#0:wybe.int, ?io#1:wybe.phantom):
+0: stmt_while.gen$1<0>
+gen$1(io#0:wybe.phantom, n#0:wybe.int, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_sgt(n#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
@@ -34,7 +36,8 @@ gen$1 > (2 calls)
 
 
 gen$2 > {inline} (1 calls)
-0: gen$2(io#0:wybe.phantom, n#0:wybe.int, ?io#2:wybe.phantom):
+0: stmt_while.gen$2<0>
+gen$2(io#0:wybe.phantom, n#0:wybe.int, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm sub(~n#0:wybe.int, 1:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn

--- a/test-cases/final-dump/student.exp
+++ b/test-cases/final-dump/student.exp
@@ -31,7 +31,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: student.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp$4#0:student.course)
@@ -44,7 +45,8 @@ AFTER EVERYTHING:
 
 
 printStudent > public (1 calls)
-0: printStudent(stu#0:student.student, io#0:wybe.phantom, ?io#6:wybe.phantom):
+0: student.printStudent<0>
+printStudent(stu#0:student.student, io#0:wybe.phantom, ?io#6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("student id: ":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -173,7 +175,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:student.course, $right#0:student.course, ?$$#0:wybe.bool):
+0: student.course./=<0>
+/=($left#0:student.course, $right#0:student.course, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -194,7 +197,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:student.course, $right#0:student.course, ?$$#0:wybe.bool):
+0: student.course.=<0>
+=($left#0:student.course, $right#0:student.course, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$code#0:wybe.int)
@@ -213,26 +217,30 @@ entry:
 
 
 code > public {inline} (0 calls)
-0: code($rec#0:student.course, ?$#0:wybe.int):
+0: student.course.code<0>
+code($rec#0:student.course, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 code > public {inline} (0 calls)
-1: code($rec#0:student.course, ?$rec#1:student.course, $field#0:wybe.int):
+1: student.course.code<1>
+code($rec#0:student.course, ?$rec#1:student.course, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm mutate(~%$rec#0:student.course, ?%$rec#1:student.course, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 course > public {inline} (0 calls)
-0: course(code#0:wybe.int, name#0:wybe.string, ?$#0:student.course):
+0: student.course.course<0>
+course(code#0:wybe.int, name#0:wybe.string, ?$#0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:student.course)
     foreign lpvm mutate(~%$rec#0:student.course, ?%$rec#1:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~code#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:student.course, ?%$#0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~name#0:wybe.string)
 course > public {inline} (6 calls)
-1: course(?code#0:wybe.int, ?name#0:wybe.string, $#0:student.course):
+1: student.course.course<1>
+course(?code#0:wybe.int, ?name#0:wybe.string, $#0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?code#0:wybe.int)
@@ -240,12 +248,14 @@ course > public {inline} (6 calls)
 
 
 name > public {inline} (0 calls)
-0: name($rec#0:student.course, ?$#0:wybe.string):
+0: student.course.name<0>
+name($rec#0:student.course, ?$#0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.string)
 name > public {inline} (0 calls)
-1: name($rec#0:student.course, ?$rec#1:student.course, $field#0:wybe.string):
+1: student.course.name<1>
+name($rec#0:student.course, ?$rec#1:student.course, $field#0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:student.course, ?%$rec#1:student.course, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.string)
@@ -423,7 +433,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:student.student, $right#0:student.student, ?$$#0:wybe.bool):
+0: student.student./=<0>
+/=($left#0:student.student, $right#0:student.student, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -456,7 +467,8 @@ entry:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:student.student, $right#0:student.student, ?$$#0:wybe.bool):
+0: student.student.=<0>
+=($left#0:student.student, $right#0:student.student, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$id#0:wybe.int)
@@ -486,38 +498,44 @@ entry:
 
 
 id > public {inline} (0 calls)
-0: id($rec#0:student.student, ?$#0:wybe.int):
+0: student.student.id<0>
+id($rec#0:student.student, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 id > public {inline} (0 calls)
-1: id($rec#0:student.student, ?$rec#1:student.student, $field#0:wybe.int):
+1: student.student.id<1>
+id($rec#0:student.student, ?$rec#1:student.student, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm mutate(~%$rec#0:student.student, ?%$rec#1:student.student, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 major > public {inline} (0 calls)
-0: major($rec#0:student.student, ?$#0:student.course):
+0: student.student.major<0>
+major($rec#0:student.student, ?$#0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:student.course)
 major > public {inline} (0 calls)
-1: major($rec#0:student.student, ?$rec#1:student.student, $field#0:student.course):
+1: student.student.major<1>
+major($rec#0:student.student, ?$rec#1:student.student, $field#0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:student.student, ?%$rec#1:student.student, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:student.course)
 
 
 student > public {inline} (0 calls)
-0: student(id#0:wybe.int, major#0:student.course, ?$#0:student.student):
+0: student.student.student<0>
+student(id#0:wybe.int, major#0:student.course, ?$#0:student.student):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:student.student)
     foreign lpvm mutate(~%$rec#0:student.student, ?%$rec#1:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~id#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:student.student, ?%$#0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~major#0:student.course)
 student > public {inline} (6 calls)
-1: student(?id#0:wybe.int, ?major#0:student.course, $#0:student.student):
+1: student.student.student<1>
+student(?id#0:wybe.int, ?major#0:student.course, $#0:student.student):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?id#0:wybe.int)

--- a/test-cases/final-dump/submodule.exp
+++ b/test-cases/final-dump/submodule.exp
@@ -37,14 +37,16 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
   procs           : 
 
 hidden > {inline} (0 calls)
-0: hidden(io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: submodule.privatetest.hidden<0>
+hidden(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("private proc in a private module":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
 
 
 semi_hidden > public {inline} (0 calls)
-0: semi_hidden(io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: submodule.privatetest.semi_hidden<0>
+semi_hidden(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("public proc in a private module":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
@@ -98,14 +100,16 @@ entry:
   procs           : 
 
 semi_visible > {inline} (0 calls)
-0: semi_visible(io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: submodule.publictest.semi_visible<0>
+semi_visible(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("private proc in a public module":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
 
 
 visible > public {inline} (0 calls)
-0: visible(io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: submodule.publictest.visible<0>
+visible(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("public proc in a public module":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn

--- a/test-cases/final-dump/test_loop.exp
+++ b/test-cases/final-dump/test_loop.exp
@@ -23,7 +23,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public {inline} (0 calls)
-0: (io#0:wybe.phantom, ?io#2:wybe.phantom):
+0: test_loop.<0>
+(io#0:wybe.phantom, ?io#2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     test_loop.find_test<0>(3:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @test_loop:nn:nn
@@ -31,14 +32,16 @@ AFTER EVERYTHING:
 
 
 find_modulo > {inline} (3 calls)
-0: find_modulo(seq#0:test_loop.int_seq, modulus#0:wybe.int, ?i#0:wybe.int, ?$$#0:wybe.bool):
+0: test_loop.find_modulo<0>
+find_modulo(seq#0:test_loop.int_seq, modulus#0:wybe.int, ?i#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     test_loop.gen$1<0>(~modulus#0:wybe.int, ~seq#0:test_loop.int_seq, ?i#0:wybe.int, ?$$#0:wybe.bool) #0 @test_loop:nn:nn
 
 
 find_test > (2 calls)
-0: find_test(modulus#0:wybe.int, io#0:wybe.phantom, ?io#4:wybe.phantom):
+0: test_loop.find_test<0>
+find_test(modulus#0:wybe.int, io#0:wybe.phantom, ?io#4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(9,(test_loop.gen$1<0>,fromList [NonAliasedParamCond 1 []]))]
@@ -63,7 +66,8 @@ find_test > (2 calls)
 
 
 gen$1 > (2 calls)
-0: gen$1(modulus#0:wybe.int, seq#0:test_loop.int_seq, ?i#1:wybe.int, ?$$#0:wybe.bool):
+0: test_loop.gen$1<0>[6dacb8fd25]
+gen$1(modulus#0:wybe.int, seq#0:test_loop.int_seq, ?i#1:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 1]
  MultiSpeczDepInfo: [(0,(test_loop.int_seq.seq_next<0>,fromList [NonAliasedParamCond 0 [1]])),(3,(test_loop.gen$1<0>,fromList [NonAliasedParamCond 1 [1]]))]
@@ -272,7 +276,8 @@ if.else1:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:test_loop.int_seq, $right#0:test_loop.int_seq, ?$$#0:wybe.bool):
+0: test_loop.int_seq./=<0>
+/=($left#0:test_loop.int_seq, $right#0:test_loop.int_seq, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
@@ -302,7 +307,8 @@ if.else1:
 
 
 = > public {inline} (1 calls)
-0: =($left#0:test_loop.int_seq, $right#0:test_loop.int_seq, ?$$#0:wybe.bool):
+0: test_loop.int_seq.=<0>
+=($left#0:test_loop.int_seq, $right#0:test_loop.int_seq, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($left#0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$low#0:wybe.int)
@@ -329,19 +335,22 @@ if.else1:
 
 
 high > public {inline} (0 calls)
-0: high($rec#0:test_loop.int_seq, ?$#0:wybe.int):
+0: test_loop.int_seq.high<0>
+high($rec#0:test_loop.int_seq, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 high > public {inline} (0 calls)
-1: high($rec#0:test_loop.int_seq, ?$rec#1:test_loop.int_seq, $field#0:wybe.int):
+1: test_loop.int_seq.high<1>
+high($rec#0:test_loop.int_seq, ?$rec#1:test_loop.int_seq, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:test_loop.int_seq, ?%$rec#1:test_loop.int_seq, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 int_seq > public {inline} (0 calls)
-0: int_seq(low#0:wybe.int, step#0:wybe.int, high#0:wybe.int, ?$#0:test_loop.int_seq):
+0: test_loop.int_seq.int_seq<0>
+int_seq(low#0:wybe.int, step#0:wybe.int, high#0:wybe.int, ?$#0:test_loop.int_seq):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(24:wybe.int, ?$rec#0:test_loop.int_seq)
@@ -349,7 +358,8 @@ int_seq > public {inline} (0 calls)
     foreign lpvm mutate(~%$rec#1:test_loop.int_seq, ?%$rec#2:test_loop.int_seq, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~step#0:wybe.int)
     foreign lpvm mutate(~%$rec#2:test_loop.int_seq, ?%$#0:test_loop.int_seq, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~high#0:wybe.int)
 int_seq > public {inline} (13 calls)
-1: int_seq(?low#0:wybe.int, ?step#0:wybe.int, ?high#0:wybe.int, $#0:test_loop.int_seq):
+1: test_loop.int_seq.int_seq<1>
+int_seq(?low#0:wybe.int, ?step#0:wybe.int, ?high#0:wybe.int, $#0:test_loop.int_seq):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access($#0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?low#0:wybe.int)
@@ -358,19 +368,22 @@ int_seq > public {inline} (13 calls)
 
 
 low > public {inline} (0 calls)
-0: low($rec#0:test_loop.int_seq, ?$#0:wybe.int):
+0: test_loop.int_seq.low<0>
+low($rec#0:test_loop.int_seq, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 low > public {inline} (1 calls)
-1: low($rec#0:test_loop.int_seq, ?$rec#1:test_loop.int_seq, $field#0:wybe.int):
+1: test_loop.int_seq.low<1>
+low($rec#0:test_loop.int_seq, ?$rec#1:test_loop.int_seq, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:test_loop.int_seq, ?%$rec#1:test_loop.int_seq, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
 
 
 seq_next > public (0 calls)
-0: seq_next(seq#0:test_loop.int_seq, ?seq#1:test_loop.int_seq, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: test_loop.int_seq.seq_next<0>[410bae77d3]
+seq_next(seq#0:test_loop.int_seq, ?seq#1:test_loop.int_seq, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: [(seq#0,seq#1)]
  InterestingCallProperties: [InterestingUnaliased 0]
     foreign lpvm access(seq#0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?elt#0:wybe.int)
@@ -409,12 +422,14 @@ seq_next > public (0 calls)
 
 
 step > public {inline} (0 calls)
-0: step($rec#0:test_loop.int_seq, ?$#0:wybe.int):
+0: test_loop.int_seq.step<0>
+step($rec#0:test_loop.int_seq, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(~$rec#0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:wybe.int)
 step > public {inline} (0 calls)
-1: step($rec#0:test_loop.int_seq, ?$rec#1:test_loop.int_seq, $field#0:wybe.int):
+1: test_loop.int_seq.step<1>
+step($rec#0:test_loop.int_seq, ?$rec#1:test_loop.int_seq, $field#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm {noalias} mutate(~%$rec#0:test_loop.int_seq, ?%$rec#1:test_loop.int_seq, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field#0:wybe.int)

--- a/test-cases/final-dump/tests.exp
+++ b/test-cases/final-dump/tests.exp
@@ -28,7 +28,8 @@ AFTER EVERYTHING:
   procs           : 
 
 lookup > public (6 calls)
-0: lookup(key#0:wybe.int, map#0:tests.map, ?result#0:wybe.int, ?$$#0:wybe.bool):
+0: tests.lookup<0>
+lookup(key#0:wybe.int, map#0:tests.map, ?result#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(map#0:tests.map, 0:wybe.int, ?tmp$15#0:wybe.bool)
@@ -61,7 +62,8 @@ lookup > public (6 calls)
 
 
 lt > public (1 calls)
-0: lt(x#0:wybe.int, y#0:wybe.int, ?$$#0:wybe.bool):
+0: tests.lt<0>
+lt(x#0:wybe.int, y#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_slt(~x#0:wybe.int, ~y#0:wybe.int, ?tmp$3#0:wybe.bool) @int:nn:nn
@@ -75,14 +77,16 @@ lt > public (1 calls)
 
 
 lt2 > public {inline} (1 calls)
-0: lt2(x#0:wybe.int, y#0:wybe.int, ?res#0:wybe.bool):
+0: tests.lt2<0>
+lt2(x#0:wybe.int, y#0:wybe.int, ?res#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     tests.lt<0>(~x#0:wybe.int, ~y#0:wybe.int, ?res#0:wybe.bool) #0 @tests:nn:nn
 
 
 lt3 > public {inline} (0 calls)
-0: lt3(x#0:wybe.int, y#0:wybe.int, ?$$#0:wybe.bool):
+0: tests.lt3<0>
+lt3(x#0:wybe.int, y#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     tests.lt<0>(~y#0:wybe.int, ~x#0:wybe.int, ?$$#0:wybe.bool) #1 @tests:nn:nn
@@ -198,7 +202,8 @@ entry:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:tests.map, $right#0:tests.map, ?$$#0:wybe.bool):
+0: tests.map./=<0>
+/=($left#0:tests.map, $right#0:tests.map, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     tests.map.=<0>(~$left#0:tests.map, ~$right#0:tests.map, ?tmp$0#0:wybe.bool) #0
@@ -206,7 +211,8 @@ entry:
 
 
 = > public (9 calls)
-0: =($left#0:tests.map, $right#0:tests.map, ?$$#0:wybe.bool):
+0: tests.map.=<0>
+=($left#0:tests.map, $right#0:tests.map, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($left#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -256,14 +262,16 @@ entry:
 
 
 empty > public {inline} (0 calls)
-0: empty(?$#0:tests.map):
+0: tests.map.empty<0>
+empty(?$#0:tests.map):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(0:tests.map, ?$#0:tests.map)
 
 
 key > public {inline} (0 calls)
-0: key($rec#0:tests.map, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: tests.map.key<0>
+key($rec#0:tests.map, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -277,7 +285,8 @@ key > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 key > public {inline} (0 calls)
-1: key($rec#0:tests.map, ?$rec#1:tests.map, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: tests.map.key<1>
+key($rec#0:tests.map, ?$rec#1:tests.map, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -293,7 +302,8 @@ key > public {inline} (0 calls)
 
 
 left > public {inline} (0 calls)
-0: left($rec#0:tests.map, ?$#0:tests.map, ?$$#0:wybe.bool):
+0: tests.map.left<0>
+left($rec#0:tests.map, ?$#0:tests.map, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -307,7 +317,8 @@ left > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 left > public {inline} (0 calls)
-1: left($rec#0:tests.map, ?$rec#1:tests.map, $field#0:tests.map, ?$$#0:wybe.bool):
+1: tests.map.left<1>
+left($rec#0:tests.map, ?$rec#1:tests.map, $field#0:tests.map, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -323,7 +334,8 @@ left > public {inline} (0 calls)
 
 
 node > public {inline} (0 calls)
-0: node(left#0:tests.map, key#0:wybe.int, value#0:wybe.int, right#0:tests.map, ?$#0:tests.map):
+0: tests.map.node<0>
+node(left#0:tests.map, key#0:wybe.int, value#0:wybe.int, right#0:tests.map, ?$#0:tests.map):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(32:wybe.int, ?$rec#0:tests.map)
@@ -332,7 +344,8 @@ node > public {inline} (0 calls)
     foreign lpvm mutate(~%$rec#2:tests.map, ?%$rec#3:tests.map, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~value#0:wybe.int)
     foreign lpvm mutate(~%$rec#3:tests.map, ?%$#0:tests.map, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~right#0:tests.map)
 node > public {inline} (20 calls)
-1: node(?left#0:tests.map, ?key#0:wybe.int, ?value#0:wybe.int, ?right#0:tests.map, $#0:tests.map, ?$$#0:wybe.bool):
+1: tests.map.node<1>
+node(?left#0:tests.map, ?key#0:wybe.int, ?value#0:wybe.int, ?right#0:tests.map, $#0:tests.map, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -354,7 +367,8 @@ node > public {inline} (20 calls)
 
 
 right > public {inline} (0 calls)
-0: right($rec#0:tests.map, ?$#0:tests.map, ?$$#0:wybe.bool):
+0: tests.map.right<0>
+right($rec#0:tests.map, ?$#0:tests.map, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -368,7 +382,8 @@ right > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 right > public {inline} (0 calls)
-1: right($rec#0:tests.map, ?$rec#1:tests.map, $field#0:tests.map, ?$$#0:wybe.bool):
+1: tests.map.right<1>
+right($rec#0:tests.map, ?$rec#1:tests.map, $field#0:tests.map, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -384,7 +399,8 @@ right > public {inline} (0 calls)
 
 
 value > public {inline} (0 calls)
-0: value($rec#0:tests.map, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: tests.map.value<0>
+value($rec#0:tests.map, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -398,7 +414,8 @@ value > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 value > public {inline} (0 calls)
-1: value($rec#0:tests.map, ?$rec#1:tests.map, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: tests.map.value<1>
+value($rec#0:tests.map, ?$rec#1:tests.map, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)

--- a/test-cases/final-dump/thistype.exp
+++ b/test-cases/final-dump/thistype.exp
@@ -21,7 +21,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: thistype.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(7,(thistype.concat<0>,fromList [NonAliasedParamCond 0 []]))]
@@ -47,7 +48,8 @@ AFTER EVERYTHING:
 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:thistype, $right#0:thistype, ?$$#0:wybe.bool):
+0: thistype./=<0>
+/=($left#0:thistype, $right#0:thistype, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     thistype.=<0>(~$left#0:thistype, ~$right#0:thistype, ?tmp$0#0:wybe.bool) #0
@@ -55,7 +57,8 @@ AFTER EVERYTHING:
 
 
 = > public (2 calls)
-0: =($left#0:thistype, $right#0:thistype, ?$$#0:wybe.bool):
+0: thistype.=<0>
+=($left#0:thistype, $right#0:thistype, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($left#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -87,7 +90,8 @@ AFTER EVERYTHING:
 
 
 concat > public (2 calls)
-0: concat(x#0:thistype, y#0:thistype, ?$#0:thistype):
+0: thistype.concat<0>[410bae77d3]
+concat(x#0:thistype, y#0:thistype, ?$#0:thistype):
  AliasPairs: [($#0,y#0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(thistype.concat<0>,fromList [NonAliasedParamCond 0 [0]]))]
@@ -118,14 +122,16 @@ concat > public (2 calls)
 
 
 cons > public {inline} (6 calls)
-0: cons(head#0:wybe.int, tail#0:thistype, ?$#0:thistype):
+0: thistype.cons<0>
+cons(head#0:wybe.int, tail#0:thistype, ?$#0:thistype):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:thistype)
     foreign lpvm mutate(~%$rec#0:thistype, ?%$rec#1:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:thistype, ?%$#0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail#0:thistype)
 cons > public {inline} (18 calls)
-1: cons(?head#0:wybe.int, ?tail#0:thistype, $#0:thistype, ?$$#0:wybe.bool):
+1: thistype.cons<1>
+cons(?head#0:wybe.int, ?tail#0:thistype, $#0:thistype, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -143,7 +149,8 @@ cons > public {inline} (18 calls)
 
 
 head > public {inline} (0 calls)
-0: head($rec#0:thistype, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: thistype.head<0>
+head($rec#0:thistype, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -157,7 +164,8 @@ head > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 head > public {inline} (0 calls)
-1: head($rec#0:thistype, ?$rec#1:thistype, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: thistype.head<1>
+head($rec#0:thistype, ?$rec#1:thistype, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -173,7 +181,8 @@ head > public {inline} (0 calls)
 
 
 length > public (2 calls)
-0: length(x#0:thistype, ?$#0:wybe.int):
+0: thistype.length<0>
+length(x#0:thistype, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(x#0:thistype, 0:wybe.int, ?tmp$5#0:wybe.bool)
@@ -189,14 +198,16 @@ length > public (2 calls)
 
 
 nil > public {inline} (2 calls)
-0: nil(?$#0:thistype):
+0: thistype.nil<0>
+nil(?$#0:thistype):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(0:thistype, ?$#0:thistype)
 
 
 tail > public {inline} (0 calls)
-0: tail($rec#0:thistype, ?$#0:thistype, ?$$#0:wybe.bool):
+0: thistype.tail<0>
+tail($rec#0:thistype, ?$#0:thistype, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -210,7 +221,8 @@ tail > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 tail > public {inline} (0 calls)
-1: tail($rec#0:thistype, ?$rec#1:thistype, $field#0:thistype, ?$$#0:wybe.bool):
+1: thistype.tail<1>
+tail($rec#0:thistype, ?$rec#1:thistype, $field#0:thistype, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)

--- a/test-cases/final-dump/type_enum.exp
+++ b/test-cases/final-dump/type_enum.exp
@@ -46,7 +46,8 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:type_enum.season, $right#0:type_enum.season, ?$$#0:wybe.bool):
+0: type_enum.season./=<0>
+/=($left#0:type_enum.season, $right#0:type_enum.season, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_eq(~$left#0:type_enum.season, ~$right#0:type_enum.season, ?tmp$0#0:wybe.bool)
@@ -54,35 +55,40 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 
 = > public {inline} (1 calls)
-0: =($left#0:type_enum.season, $right#0:type_enum.season, ?$$#0:wybe.bool):
+0: type_enum.season.=<0>
+=($left#0:type_enum.season, $right#0:type_enum.season, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_eq(~$left#0:type_enum.season, ~$right#0:type_enum.season, ?$$#0:!wybe.bool)
 
 
 autumn > public {inline} (0 calls)
-0: autumn(?$#0:type_enum.season):
+0: type_enum.season.autumn<0>
+autumn(?$#0:type_enum.season):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(3:type_enum.season, ?$#0:type_enum.season)
 
 
 spring > public {inline} (0 calls)
-0: spring(?$#0:type_enum.season):
+0: type_enum.season.spring<0>
+spring(?$#0:type_enum.season):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(1:type_enum.season, ?$#0:type_enum.season)
 
 
 summer > public {inline} (0 calls)
-0: summer(?$#0:type_enum.season):
+0: type_enum.season.summer<0>
+summer(?$#0:type_enum.season):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(2:type_enum.season, ?$#0:type_enum.season)
 
 
 winter > public {inline} (0 calls)
-0: winter(?$#0:type_enum.season):
+0: type_enum.season.winter<0>
+winter(?$#0:type_enum.season):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(0:type_enum.season, ?$#0:type_enum.season)

--- a/test-cases/final-dump/type_int.exp
+++ b/test-cases/final-dump/type_int.exp
@@ -62,90 +62,104 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
   procs           : 
 
 * > public {inline} (0 calls)
-0: *(x#0:type_int.myint, y#0:type_int.myint, ?$#0:type_int.myint):
+0: type_int.myint.*<0>
+*(x#0:type_int.myint, y#0:type_int.myint, ?$#0:type_int.myint):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm mul(~x#0:type_int.myint, ~y#0:type_int.myint, ?$#0:type_int.myint) @type_int:nn:nn
 
 
 + > public {inline} (0 calls)
-0: +(x#0:type_int.myint, y#0:type_int.myint, ?$#0:type_int.myint):
+0: type_int.myint.+<0>
++(x#0:type_int.myint, y#0:type_int.myint, ?$#0:type_int.myint):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm add(~x#0:type_int.myint, ~y#0:type_int.myint, ?$#0:type_int.myint) @type_int:nn:nn
 + > public {inline} (0 calls)
-1: +(?x#0:type_int.myint, y#0:type_int.myint, z#0:type_int.myint):
+1: type_int.myint.+<1>
++(?x#0:type_int.myint, y#0:type_int.myint, z#0:type_int.myint):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm sub(~z#0:type_int.myint, ~y#0:type_int.myint, ?x#0:type_int.myint) @type_int:nn:nn
 + > public {inline} (0 calls)
-2: +(x#0:type_int.myint, ?y#0:type_int.myint, z#0:type_int.myint):
+2: type_int.myint.+<2>
++(x#0:type_int.myint, ?y#0:type_int.myint, z#0:type_int.myint):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm sub(~z#0:type_int.myint, ~x#0:type_int.myint, ?y#0:type_int.myint) @type_int:nn:nn
 
 
 - > public {inline} (0 calls)
-0: -(x#0:type_int.myint, y#0:type_int.myint, ?$#0:type_int.myint):
+0: type_int.myint.-<0>
+-(x#0:type_int.myint, y#0:type_int.myint, ?$#0:type_int.myint):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm sub(~x#0:type_int.myint, ~y#0:type_int.myint, ?$#0:type_int.myint) @type_int:nn:nn
 - > public {inline} (0 calls)
-1: -(?x#0:type_int.myint, y#0:type_int.myint, z#0:type_int.myint):
+1: type_int.myint.-<1>
+-(?x#0:type_int.myint, y#0:type_int.myint, z#0:type_int.myint):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm add(~y#0:type_int.myint, ~z#0:type_int.myint, ?x#0:type_int.myint) @type_int:nn:nn
 - > public {inline} (0 calls)
-2: -(x#0:type_int.myint, ?y#0:type_int.myint, z#0:type_int.myint):
+2: type_int.myint.-<2>
+-(x#0:type_int.myint, ?y#0:type_int.myint, z#0:type_int.myint):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm sub(~z#0:type_int.myint, ~x#0:type_int.myint, ?y#0:type_int.myint) @type_int:nn:nn
 
 
 / > public {inline} (0 calls)
-0: /(x#0:type_int.myint, y#0:type_int.myint, ?$#0:type_int.myint):
+0: type_int.myint./<0>
+/(x#0:type_int.myint, y#0:type_int.myint, ?$#0:type_int.myint):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm sdiv(~x#0:type_int.myint, ~y#0:type_int.myint, ?$#0:type_int.myint) @type_int:nn:nn
 
 
 /= > public {inline} (0 calls)
-0: /=(x#0:type_int.myint, y#0:type_int.myint, ?$#0:wybe.bool):
+0: type_int.myint./=<0>
+/=(x#0:type_int.myint, y#0:type_int.myint, ?$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(~x#0:type_int.myint, ~y#0:type_int.myint, ?$#0:wybe.bool) @type_int:nn:nn
 
 
 < > public {inline} (0 calls)
-0: <(x#0:type_int.myint, y#0:type_int.myint, ?$#0:wybe.bool):
+0: type_int.myint.<<0>
+<(x#0:type_int.myint, y#0:type_int.myint, ?$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_slt(~x#0:type_int.myint, ~y#0:type_int.myint, ?$#0:wybe.bool) @type_int:nn:nn
 
 
 <= > public {inline} (0 calls)
-0: <=(x#0:type_int.myint, y#0:type_int.myint, ?$#0:wybe.bool):
+0: type_int.myint.<=<0>
+<=(x#0:type_int.myint, y#0:type_int.myint, ?$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_sle(~x#0:type_int.myint, ~y#0:type_int.myint, ?$#0:wybe.bool) @type_int:nn:nn
 
 
 = > public {inline} (0 calls)
-0: =(x#0:type_int.myint, y#0:type_int.myint, ?$#0:wybe.bool):
+0: type_int.myint.=<0>
+=(x#0:type_int.myint, y#0:type_int.myint, ?$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_eq(~x#0:type_int.myint, ~y#0:type_int.myint, ?$#0:wybe.bool) @type_int:nn:nn
 
 
 > > public {inline} (0 calls)
-0: >(x#0:type_int.myint, y#0:type_int.myint, ?$#0:wybe.bool):
+0: type_int.myint.><0>
+>(x#0:type_int.myint, y#0:type_int.myint, ?$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_sgt(~x#0:type_int.myint, ~y#0:type_int.myint, ?$#0:wybe.bool) @type_int:nn:nn
 
 
 >= > public {inline} (0 calls)
-0: >=(x#0:type_int.myint, y#0:type_int.myint, ?$#0:wybe.bool):
+0: type_int.myint.>=<0>
+>=(x#0:type_int.myint, y#0:type_int.myint, ?$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_sge(~x#0:type_int.myint, ~y#0:type_int.myint, ?$#0:wybe.bool) @type_int:nn:nn

--- a/test-cases/final-dump/type_list.exp
+++ b/test-cases/final-dump/type_list.exp
@@ -23,7 +23,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: type_list.<0>
+(io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(7,(type_list.++<0>,fromList [NonAliasedParamCond 0 []]))]
@@ -48,7 +49,8 @@ AFTER EVERYTHING:
 
 
 ++ > public (2 calls)
-0: ++(x#0:type_list.intlist, y#0:type_list.intlist, ?$#0:type_list.intlist):
+0: type_list.++<0>[410bae77d3]
+++(x#0:type_list.intlist, y#0:type_list.intlist, ?$#0:type_list.intlist):
  AliasPairs: [($#0,y#0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(type_list.++<0>,fromList [NonAliasedParamCond 0 [0]]))]
@@ -79,7 +81,8 @@ AFTER EVERYTHING:
 
 
 length > public (2 calls)
-0: length(x#0:type_list.intlist, ?$#0:wybe.int):
+0: type_list.length<0>
+length(x#0:type_list.intlist, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(x#0:type_list.intlist, 0:wybe.int, ?tmp$5#0:wybe.bool)
@@ -253,7 +256,8 @@ if.else:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:type_list.intlist, $right#0:type_list.intlist, ?$$#0:wybe.bool):
+0: type_list.intlist./=<0>
+/=($left#0:type_list.intlist, $right#0:type_list.intlist, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     type_list.intlist.=<0>(~$left#0:type_list.intlist, ~$right#0:type_list.intlist, ?tmp$0#0:wybe.bool) #0
@@ -261,7 +265,8 @@ if.else:
 
 
 = > public (2 calls)
-0: =($left#0:type_list.intlist, $right#0:type_list.intlist, ?$$#0:wybe.bool):
+0: type_list.intlist.=<0>
+=($left#0:type_list.intlist, $right#0:type_list.intlist, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($left#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -293,21 +298,24 @@ if.else:
 
 
 [] > public {inline} (0 calls)
-0: [](?$#0:type_list.intlist):
+0: type_list.intlist.[]<0>
+[](?$#0:type_list.intlist):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(0:type_list.intlist, ?$#0:type_list.intlist)
 
 
 [|] > public {inline} (0 calls)
-0: [|](head#0:wybe.int, tail#0:type_list.intlist, ?$#0:type_list.intlist):
+0: type_list.intlist.[|]<0>
+[|](head#0:wybe.int, tail#0:type_list.intlist, ?$#0:type_list.intlist):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?$rec#0:type_list.intlist)
     foreign lpvm mutate(~%$rec#0:type_list.intlist, ?%$rec#1:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head#0:wybe.int)
     foreign lpvm mutate(~%$rec#1:type_list.intlist, ?%$#0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail#0:type_list.intlist)
 [|] > public {inline} (12 calls)
-1: [|](?head#0:wybe.int, ?tail#0:type_list.intlist, $#0:type_list.intlist, ?$$#0:wybe.bool):
+1: type_list.intlist.[|]<1>
+[|](?head#0:wybe.int, ?tail#0:type_list.intlist, $#0:type_list.intlist, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -325,7 +333,8 @@ if.else:
 
 
 head > public {inline} (0 calls)
-0: head($rec#0:type_list.intlist, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: type_list.intlist.head<0>
+head($rec#0:type_list.intlist, ?$#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -339,7 +348,8 @@ head > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 head > public {inline} (0 calls)
-1: head($rec#0:type_list.intlist, ?$rec#1:type_list.intlist, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: type_list.intlist.head<1>
+head($rec#0:type_list.intlist, ?$rec#1:type_list.intlist, $field#0:wybe.int, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -355,7 +365,8 @@ head > public {inline} (0 calls)
 
 
 tail > public {inline} (0 calls)
-0: tail($rec#0:type_list.intlist, ?$#0:type_list.intlist, ?$$#0:wybe.bool):
+0: type_list.intlist.tail<0>
+tail($rec#0:type_list.intlist, ?$#0:type_list.intlist, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
@@ -369,7 +380,8 @@ tail > public {inline} (0 calls)
         foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 tail > public {inline} (0 calls)
-1: tail($rec#0:type_list.intlist, ?$rec#1:type_list.intlist, $field#0:type_list.intlist, ?$$#0:wybe.bool):
+1: type_list.intlist.tail<1>
+tail($rec#0:type_list.intlist, ?$rec#1:type_list.intlist, $field#0:type_list.intlist, ?$$#0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)

--- a/test-cases/final-dump/unneeded.exp
+++ b/test-cases/final-dump/unneeded.exp
@@ -10,7 +10,8 @@ AFTER EVERYTHING:
   procs           : 
 
 unneeded > {inline} (0 calls)
-0: unneeded(x#0:wybe.int, [y#0:wybe.int], ?z#0:wybe.int, q#0:wybe.int, [?q#0:wybe.int]):
+0: unneeded.unneeded<0>
+unneeded(x#0:wybe.int, [y#0:wybe.int], ?z#0:wybe.int, q#0:wybe.int, [?q#0:wybe.int]):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm add(~x#0:wybe.int, 1:wybe.int, ?z#0:wybe.int) @int:nn:nn

--- a/test-cases/final-dump/update.exp
+++ b/test-cases/final-dump/update.exp
@@ -11,13 +11,15 @@ AFTER EVERYTHING:
   procs           : 
 
 inc2 > public {inline} (0 calls)
-0: inc2(x#0:wybe.int, ?$#0:wybe.int):
+0: update.inc2<0>
+inc2(x#0:wybe.int, ?$#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm add(~x#0:wybe.int, 1:wybe.int, ?tmp$1#0:wybe.int) @int:nn:nn
     foreign llvm add(~tmp$1#0:wybe.int, 1:wybe.int, ?$#0:wybe.int) @int:nn:nn
 inc2 > public {inline} (0 calls)
-1: inc2(?x#0:wybe.int, y#0:wybe.int):
+1: update.inc2<1>
+inc2(?x#0:wybe.int, y#0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm sub(~y#0:wybe.int, 1:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn

--- a/test-cases/final-dump/use_resource.exp
+++ b/test-cases/final-dump/use_resource.exp
@@ -10,7 +10,8 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (?count#2:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+0: use_resource.<0>
+(?count#2:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("Inner count (4): ":wybe.string, ~#io#0:wybe.phantom, ?tmp$6#0:wybe.phantom) @io:nn:nn
@@ -23,14 +24,16 @@ AFTER EVERYTHING:
 
 
 inc_count > {inline} (4 calls)
-0: inc_count(count#0:wybe.int, ?count#1:wybe.int):
+0: use_resource.inc_count<0>
+inc_count(count#0:wybe.int, ?count#1:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm add(~count#0:wybe.int, 1:wybe.int, ?count#1:wybe.int) @int:nn:nn
 
 
 use_test > {inline} (1 calls)
-0: use_test(count#0:wybe.int, ?count#5:wybe.int, io#0:wybe.phantom, ?io#4:wybe.phantom):
+0: use_resource.use_test<0>
+use_test(count#0:wybe.int, ?count#5:wybe.int, io#0:wybe.phantom, ?io#4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm add(~#count#0:wybe.int, 1:wybe.int, ?#count#1:wybe.int) @int:nn:nn


### PR DESCRIPTION
This make finding ProcSpec from ProcDef possible

This pull request will change some complex test result due to those test's expected output include a dump of the code.