### PR TITLE
Added missing `showStmt` pattern

### DIFF
--- a/src/AST.hs
+++ b/src/AST.hs
@@ -3169,6 +3169,7 @@ showStmt indent (UseResources resources stmts) =
     "use " ++ intercalate ", " (List.map show resources) ++ " in"
     ++ showBody (indent + 4) stmts
     ++ startLine indent ++ "}"
+showStmt _ Fail = "fail"
 showStmt _ Nop = "pass"
 showStmt indent (For generators body) =
   "for "


### PR DESCRIPTION
Fixes a compile warning of an incomplete pattern for `showStmt`.

```
warning: [-Wincomplete-patterns]
    Pattern match(es) are non-exhaustive
    In an equation for ‘showStmt’: Patterns not matched: _ Fail
     |
3132 | showStmt _ (ProcCall maybeMod name procID detism resourceful args) =
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
```
