### PR TITLE
Introduce local cache file which allows multiple specialization on read-only libs

### DIFF
--- a/src/Config.hs
+++ b/src/Config.hs
@@ -14,7 +14,8 @@ module Config (sourceExtension, objectExtension, executableExtension,
                wordSize, wordSizeBytes,
                availableTagBits, tagMask, smallestAllocatedAddress,
                magicVersion,
-               linkerDeadStripArgs, functionDefSection, removeLPVMSection)
+               linkerDeadStripArgs, functionDefSection, removeLPVMSection,
+               localCacheLibDir)
     where
 
 import Data.Word
@@ -24,6 +25,7 @@ import Foreign.Storable
 import System.Exit (ExitCode (..))
 import System.Process
 import System.FilePath
+import System.Directory.Extra (getHomeDirectory)
 
 -- |The file extension for source files.
 sourceExtension :: String
@@ -101,6 +103,12 @@ smallestAllocatedAddress = 65536 -- this is a pretty safe guess
 -- |Foreign shared library directory name
 sharedLibDirName :: String
 sharedLibDirName = "lib/"
+
+
+localCacheLibDir :: IO FilePath 
+localCacheLibDir = do 
+    homeDir <- getHomeDirectory
+    return $ homeDir </> ".wybe/cache"
 
 
 -- | Magic version number for the current iteration of LPVM.


### PR DESCRIPTION
By the default install config, wybemk doesn't have write permissions on object files of the stdlib. However, the multiple specialization framework needs to update those file. So now we have a problem #130.

This PR introduces "local cache file": if wybemk tries to write to a file that it doesn't have write permission, it will create a cache file under `~/.wybe/cache` and uses it instead. It also records the hash of the original file so the cache file will become invalid once the origincal file has changed. The whole thing is transparent to most parts of the compiler. 