### PR TITLE
fix for single-line comment at eof not parsing

### DIFF
--- a/src/Scanner.hs
+++ b/src/Scanner.hs
@@ -241,13 +241,13 @@ tokenise pos str@(c:cs)
                               multiCharTok name rest (TokIdent name pos) pos
                          (name,[]) ->
                              [TokError "Unclosed backquote beginning here" pos]
-                    '#' -> let  (target,trim) = case cs of
-                                    ('|':_) -> ("|#","|#")
-                                    _       -> ("\n","")
+                    '#' -> let  (target,trim,terminate) = case cs of
+                                    ('|':_) -> ("|#","|#",True)
+                                    _       -> ("\n","",False)
                                 (comment,rest) =
                                     breakList (target `isPrefixOf`) cs
                                 pos' = updatePosString pos (c:comment++trim)
-                            in if null rest
+                            in if terminate && null rest
                                then [TokError "Unterminated comment begins here"
                                               pos]
                                else tokenise pos' $ drop (length trim) rest


### PR DESCRIPTION
Example program that fails to parse:
```
!println("Wominjeka!")
#oops!
```
(with no terminal new line)

Output before fix:
```sh
% wybemk test
test.wybe:2:1: Syntax error: unexpected Unterminated comment begins here
expecting simple expression
```