### PR TITLE
Backtick

### DIFF
--- a/WYBE.md
+++ b/WYBE.md
@@ -506,6 +506,11 @@ Backquotes can also be used in function calls, so `` `+`(3,4)`` is semantically
 identical to `3 + 4`, regardless of which syntax was used to define the `+`
 function.
 
+Backquotes can also be used to make almost any sequence of characters act as a
+symbol.  The only characters that cannot appear between backquotes are newlines,
+other control characters (such as tabs and escape characters), the hash (#)
+character, and the backquote character itself.
+
 
 ##  <a name="reserved-words"></a>Reserved operators
 

--- a/src/AST.hs
+++ b/src/AST.hs
@@ -2879,7 +2879,7 @@ specialName2 front back = front ++ specialChar:back
 -- | The full name to give to a PrimVarName, including the variable number
 -- suffix.
 numberedVarName :: String -> Int -> String
-numberedVarName name number = name ++ "#" ++ show number
+numberedVarName name number = name ++ "##" ++ show number
 
 
 -- | The name to give to the output variable when converting a function to a

--- a/src/AST.hs
+++ b/src/AST.hs
@@ -2885,7 +2885,7 @@ numberedVarName name number = name ++ specialChar:specialChar:show number
 -- | The name to give to the output variable when converting a function to a
 -- proc.
 outputVariableName :: Ident
-outputVariableName = [specialChar]
+outputVariableName = specialName "result"
 
 
 -- | The name to give to the output status variable when converting a test proc to a Det proc.

--- a/src/AST.hs
+++ b/src/AST.hs
@@ -2890,7 +2890,7 @@ outputVariableName = specialName "result"
 
 -- | The name to give to the output status variable when converting a test proc to a Det proc.
 outputStatusName :: Ident
-outputStatusName = [specialChar,specialChar]
+outputStatusName = specialName "success"
 
 
 

--- a/src/AST.hs
+++ b/src/AST.hs
@@ -81,6 +81,7 @@ module AST (
   ProcModifiers(..), detModifiers, setDetism, setInline, setImpurity,
   showProcModifiers, Inlining(..), Impurity(..),
   addProc, addProcDef, lookupProc, publicProc, callTargets,
+  specialChar, specialName, specialName2, outputVariableName, outputStatusName,
   showBody, showPlacedPrims, showStmt, showBlock, showProcDef, showModSpec,
   showModSpecs, showResources, showOptPos, showProcDefs, showUse,
   shouldnt, nyi, checkError, checkValue, trustFromJust, trustFromJustM,
@@ -740,7 +741,7 @@ genProcName :: Compiler ProcName
 genProcName = do
   ctr <- getModule procCount
   updateModule (\mod -> mod {procCount = ctr + 1 })
-  return $ "gen$" ++ show (ctr + 1)
+  return $ specialName2 "gen" $ show (ctr + 1)
 
 -- |Apply the given function to the current module interface if the
 --  specified visibility is Public.
@@ -2110,7 +2111,7 @@ data LLTerm = TermNop
 
 -- |The variable name for the temporary variable whose number is given.
 mkTempName :: Int -> String
-mkTempName ctr = "tmp$" ++ show ctr
+mkTempName ctr = specialName2 "tmp" $ show ctr
 
 -- |Make a default LLBlock
 defaultBlock :: LLBlock
@@ -2853,6 +2854,39 @@ varsInPrimArg _ (ArgString _ _)         = Set.empty
 varsInPrimArg _ (ArgChar _ _)           = Set.empty
 varsInPrimArg _ (ArgUnneeded _ _)       = Set.empty
 varsInPrimArg _ (ArgUndef _)            = Set.empty
+
+
+----------------------------------------------------------------
+--                       Generating Symbols
+
+-- | The character we include in every generated identifier to prevent capturing
+-- a user identifier.  It should not be possible for the user to include this
+-- character in an identifier.
+specialChar :: Char
+specialChar = '$' -- for backward compatibility: replace with `
+
+
+-- | Construct a name can't be a valid Wybe symbol from one user string.
+specialName :: String -> String
+specialName = (specialChar:)
+
+
+-- | Construct a name that can't be a valid Wybe symbol from two user strings.
+specialName2 :: String -> String -> String
+specialName2 front back = front ++ specialChar:back
+
+
+-- | The name to give to the output variable when converting a function to a
+-- proc.
+outputVariableName :: Ident
+outputVariableName = [specialChar]
+
+
+-- | The name to give to the output status variable when converting a test proc to a Det proc.
+outputStatusName :: Ident
+outputStatusName = [specialChar,specialChar]
+
+
 
 
 ----------------------------------------------------------------

--- a/src/AST.hs
+++ b/src/AST.hs
@@ -2863,7 +2863,7 @@ varsInPrimArg _ (ArgUndef _)            = Set.empty
 -- a user identifier.  It should not be possible for the user to include this
 -- character in an identifier.
 specialChar :: Char
-specialChar = '$' -- for backward compatibility: replace with `
+specialChar = '#' -- note # is not allowed in backquoted strings
 
 
 -- | Construct a name can't be a valid Wybe symbol from one user string.
@@ -2877,9 +2877,9 @@ specialName2 front back = front ++ specialChar:back
 
 
 -- | The full name to give to a PrimVarName, including the variable number
--- suffix.
+-- suffix.  Use two specialChars to distinguish from special separator.
 numberedVarName :: String -> Int -> String
-numberedVarName name number = name ++ "##" ++ show number
+numberedVarName name number = name ++ specialChar:specialChar:show number
 
 
 -- | The name to give to the output variable when converting a function to a

--- a/src/AST.hs
+++ b/src/AST.hs
@@ -2876,6 +2876,12 @@ specialName2 :: String -> String -> String
 specialName2 front back = front ++ specialChar:back
 
 
+-- | The full name to give to a PrimVarName, including the variable number
+-- suffix.
+numberedVarName :: String -> Int -> String
+numberedVarName name number = name ++ "#" ++ show number
+
+
 -- | The name to give to the output variable when converting a function to a
 -- proc.
 outputVariableName :: Ident
@@ -3207,7 +3213,7 @@ showPrim _ (PrimForeign lang name flags args) =
 
 -- |Show a variable, with its suffix.
 instance Show PrimVarName where
-    show (PrimVarName var suffix) = var ++ "#" ++ show suffix
+    show (PrimVarName var suffix) = numberedVarName var suffix
 
 
 -- |Show a single statement.

--- a/src/Clause.hs
+++ b/src/Clause.hs
@@ -110,9 +110,9 @@ closingStmts detism params = do
     assigns <- mapM (\Param{paramName=nm,paramType=ty}
                     -> assign nm ty (ArgUndef ty))
                     undefs
-    tested <- Map.member "$$" <$> getCurrNumbering
+    tested <- Map.member outputStatusName <$> getCurrNumbering
     end <- if detism == SemiDet && not tested
-               then (:assigns) <$> assign "$$" boolType (ArgInt 1 boolType)
+               then (:assigns) <$> assign outputStatusName boolType (ArgInt 1 boolType)
                else return assigns
     logClause $ "Adding ending instructions: " ++ showPlacedPrims 4 end
     return end
@@ -208,7 +208,7 @@ compileBody stmts params detism = do
                                     ("compileBody for " ++ showStmt 4 call)
                                      procID) generalVersion)
                          (args' ++
-                          [ArgVar (PrimVarName "$$" 0) boolType FlowOut
+                          [ArgVar (PrimVarName outputStatusName 0) boolType FlowOut
                            (Implicit Nothing) False])
           return $ ProcBody (front++[final']) NoFork
 
@@ -289,11 +289,11 @@ compileSimpleStmt' (ForeignCall lang name flags args) = do
     return $ PrimForeign lang name flags args'
 compileSimpleStmt' (TestBool expr) =
     -- Only for handling a TestBool other than as the condition of a Cond:
-    compileSimpleStmt' $ content $ move (boolCast expr) (boolVarSet "$$")
+    compileSimpleStmt' $ content $ move (boolCast expr) (boolVarSet outputStatusName)
 compileSimpleStmt' Nop = 
-    compileSimpleStmt' $ content $ move boolTrue (boolVarSet "$$")
+    compileSimpleStmt' $ content $ move boolTrue (boolVarSet outputStatusName)
 compileSimpleStmt' Fail =
-    compileSimpleStmt' $ content $ move boolFalse (boolVarSet "$$")
+    compileSimpleStmt' $ content $ move boolFalse (boolVarSet outputStatusName)
 compileSimpleStmt' stmt =
     shouldnt $ "Normalisation left complex statement:\n" ++ showStmt 4 stmt
 
@@ -371,7 +371,7 @@ compileParam startVars endVars procName param@(Param name ty flow ftype) =
 
 -- |A synthetic output parameter carrying the test result
 testOutParam :: Param
-testOutParam = Param "$$" boolType ParamOut $ Implicit Nothing
+testOutParam = Param outputStatusName boolType ParamOut $ Implicit Nothing
 
 
 -- |Log a message, if we are logging clause generation.

--- a/src/Codegen.hs
+++ b/src/Codegen.hs
@@ -64,7 +64,8 @@ import qualified LLVM.AST.IntegerPredicate       as IP
 import           AST                             (Compiler, Prim, PrimProto,
                                                   TypeRepresentation,
                                                   getModuleSpec, logMsg,
-                                                  shouldnt, showModSpec)
+                                                  shouldnt, specialName2,
+                                                  showModSpec)
 import           LLVM.Context
 import           LLVM.Module
 import           Options                         (LogSelection (Blocks,Codegen))
@@ -448,7 +449,7 @@ namedInstr ty nm ins = do
     -- but llvm doesn't. So the block id is attached to the variable name to
     -- make it unique.
     blockId <- idx <$> current
-    let ref = Name $ fromString $ show blockId ++ "$" ++ nm
+    let ref = Name $ fromString $ specialName2 (show blockId) nm
     addInstr $ ref := ins
     return $ local ty ref
 

--- a/src/Resources.hs
+++ b/src/Resources.hs
@@ -286,10 +286,6 @@ resourceVar (ResourceSpec mod name) = do
     -- Always use resource name as variable name, regardless of module
     -- XXX This could cause collisions!
     return name
-    -- currMod <- getModuleSpec
-    -- if currMod == mod
-    -- then return name -- ensure we can use local resources in code
-    -- else return $ intercalate "." mod ++ "$" ++ name
 
 
 -- |Log a message, if we are logging resource transformation activity.

--- a/src/Scanner.hs
+++ b/src/Scanner.hs
@@ -470,10 +470,13 @@ tokeniseBackquote :: String -> SourcePos -> [Token]
 tokeniseBackquote cs pos =
     let pos'  = updatePosChar pos '`'  -- count the opening `
         pos'' = updatePosChar pos' '`' -- pre-count the closing `
-    in case break ((=='`') ||| (<' ')) cs of
+    in case break ((=='`') ||| (<' ') ||| (=='#')) cs of
+        ([],_)           -> [TokError "empty backquoted symbol" pos]
         (_,[])           -> [TokError "unclosed backquote" pos]
         (name,'`':rest)  -> multiCharTok name rest (TokIdent name pos) pos''
         (name,'\n':rest) -> [TokError "multiline backquoted symbol" pos]
+        (name,'#':rest)  -> [TokError "hash character (#) in backquoted symbol"
+                             pos]
         (name,_:rest)    ->
             [TokError "control character in a backquoted symbol" pos]
 

--- a/src/Unbranch.hs
+++ b/src/Unbranch.hs
@@ -143,23 +143,17 @@ unbranchBody loopinfo tmpCtr params detism body alt = do
 --                 Converting SemiDet procs to Det
 ----------------------------------------------------------------
 
-
--- |The name we give to the local variable holding the result of a
--- test (SemiDet) proc when we convert to a Det one.
-testVarName :: Ident
-testVarName = "$$"
-
 -- |A synthetic output parameter carrying the test result
 testOutParam :: Param
-testOutParam = Param testVarName boolType ParamOut $ Implicit Nothing
+testOutParam = Param outputStatusName boolType ParamOut $ Implicit Nothing
 
 -- |The output exp we use to hold the success/failure of a test proc.
 testOutExp :: Exp
-testOutExp = boolVarSet testVarName
+testOutExp = boolVarSet outputStatusName
 
 -- -- |The input exp we use to hold the success/failure of a test proc.
 -- testInExp :: Exp
--- testInExp = boolVarGet testVarName
+-- testInExp = boolVarGet outputStatusName
 
 
 ----------------------------------------------------------------

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -232,13 +232,13 @@ apply2way :: (a->b->c) -> (d->a) -> (d->b) -> d -> c
 apply2way combine f1 f2 input = combine (f1 input) (f2 input)
 
 -- | conjoin two functions
-infix 4 &&&
+infixl 4 &&&
 (&&&) :: (a->Bool) -> (a->Bool) -> a -> Bool
 (&&&) = apply2way (&&)
 
 
 -- | disjoin two functions
-infix 4 |||
+infixl 4 |||
 (|||) :: (a->Bool) -> (a->Bool) -> a -> Bool
 (|||) = apply2way (||)
 

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -13,7 +13,7 @@ module Util (sameLength, maybeNth, setMapInsert, showArguments,
              removeFromDS, connectedItemsInDS,
              mapDS, filterDS, dsToTransitivePairs,
              intersectMapIdentity, orElse,
-             apply2way, (&&&), zipWith3M, zipWith3M_,
+             apply2way, (&&&), (|||), zipWith3M, zipWith3M_,
              useLocalCacheFileIfPossible, createLocalCacheFile
              ) where
 
@@ -235,6 +235,12 @@ apply2way combine f1 f2 input = combine (f1 input) (f2 input)
 infix 4 &&&
 (&&&) :: (a->Bool) -> (a->Bool) -> a -> Bool
 (&&&) = apply2way (&&)
+
+
+-- | disjoin two functions
+infix 4 |||
+(|||) :: (a->Bool) -> (a->Bool) -> a -> Bool
+(|||) = apply2way (||)
 
 
 -- |zipWithM version for 3 lists.

--- a/test-cases/complex/exp/testcase_multi_specz-drone.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-drone.exp
@@ -273,14 +273,14 @@ do_action(d##0:drone.drone_info, ?d##2:drone.drone_info, action##0:wybe.char, ?s
 
 drone_init > (3 calls)
 0: drone.drone_init<0>
-drone_init(?###0:drone.drone_info):
+drone_init(?#result##0:drone.drone_info):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(32:wybe.int, ?tmp#5##0:drone.drone_info)
     foreign lpvm mutate(~tmp#5##0:drone.drone_info, ?tmp#6##0:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
     foreign lpvm mutate(~tmp#6##0:drone.drone_info, ?tmp#7##0:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
     foreign lpvm mutate(~tmp#7##0:drone.drone_info, ?tmp#8##0:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp#8##0:drone.drone_info, ?###0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp#8##0:drone.drone_info, ?#result##0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
 
 
 gen#1 > {inline} (2 calls)
@@ -458,10 +458,10 @@ LLVM code       : None
 
 count > public {inline} (0 calls)
 0: drone.drone_info.count<0>
-count(#rec##0:drone.drone_info, ?###0:wybe.int):
+count(#rec##0:drone.drone_info, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 count > public {inline} (0 calls)
 1: drone.drone_info.count<1>
 count(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
@@ -472,31 +472,31 @@ count(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
 
 drone_info > public {inline} (0 calls)
 0: drone.drone_info.drone_info<0>
-drone_info(x##0:wybe.int, y##0:wybe.int, z##0:wybe.int, count##0:wybe.int, ?###0:drone.drone_info):
+drone_info(x##0:wybe.int, y##0:wybe.int, z##0:wybe.int, count##0:wybe.int, ?#result##0:drone.drone_info):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(32:wybe.int, ?#rec##0:drone.drone_info)
     foreign lpvm mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~x##0:wybe.int)
     foreign lpvm mutate(~#rec##1:drone.drone_info, ?#rec##2:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~y##0:wybe.int)
     foreign lpvm mutate(~#rec##2:drone.drone_info, ?#rec##3:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~z##0:wybe.int)
-    foreign lpvm mutate(~#rec##3:drone.drone_info, ?###0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~count##0:wybe.int)
+    foreign lpvm mutate(~#rec##3:drone.drone_info, ?#result##0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~count##0:wybe.int)
 drone_info > public {inline} (14 calls)
 1: drone.drone_info.drone_info<1>
-drone_info(?x##0:wybe.int, ?y##0:wybe.int, ?z##0:wybe.int, ?count##0:wybe.int, ###0:drone.drone_info):
+drone_info(?x##0:wybe.int, ?y##0:wybe.int, ?z##0:wybe.int, ?count##0:wybe.int, #result##0:drone.drone_info):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(###0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?y##0:wybe.int)
-    foreign lpvm access(###0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?z##0:wybe.int)
-    foreign lpvm access(~###0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?count##0:wybe.int)
+    foreign lpvm access(#result##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(#result##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?z##0:wybe.int)
+    foreign lpvm access(~#result##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?count##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: drone.drone_info.x<0>
-x(#rec##0:drone.drone_info, ?###0:wybe.int):
+x(#rec##0:drone.drone_info, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 x > public {inline} (0 calls)
 1: drone.drone_info.x<1>
 x(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
@@ -507,10 +507,10 @@ x(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
 
 y > public {inline} (0 calls)
 0: drone.drone_info.y<0>
-y(#rec##0:drone.drone_info, ?###0:wybe.int):
+y(#rec##0:drone.drone_info, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 y > public {inline} (0 calls)
 1: drone.drone_info.y<1>
 y(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
@@ -521,10 +521,10 @@ y(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
 
 z > public {inline} (0 calls)
 0: drone.drone_info.z<0>
-z(#rec##0:drone.drone_info, ?###0:wybe.int):
+z(#rec##0:drone.drone_info, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 z > public {inline} (0 calls)
 1: drone.drone_info.z<1>
 z(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
@@ -931,14 +931,14 @@ do_action(d##0:drone.drone_info, ?d##2:drone.drone_info, action##0:wybe.char, ?s
 
 drone_init > (3 calls)
 0: drone.drone_init<0>
-drone_init(?###0:drone.drone_info):
+drone_init(?#result##0:drone.drone_info):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(32:wybe.int, ?tmp#5##0:drone.drone_info)
     foreign lpvm mutate(~tmp#5##0:drone.drone_info, ?tmp#6##0:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
     foreign lpvm mutate(~tmp#6##0:drone.drone_info, ?tmp#7##0:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
     foreign lpvm mutate(~tmp#7##0:drone.drone_info, ?tmp#8##0:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp#8##0:drone.drone_info, ?###0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp#8##0:drone.drone_info, ?#result##0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
 
 
 gen#1 > {inline} (2 calls)
@@ -1808,10 +1808,10 @@ entry:
 
 count > public {inline} (0 calls)
 0: drone.drone_info.count<0>
-count(#rec##0:drone.drone_info, ?###0:wybe.int):
+count(#rec##0:drone.drone_info, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 count > public {inline} (0 calls)
 1: drone.drone_info.count<1>
 count(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
@@ -1822,31 +1822,31 @@ count(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
 
 drone_info > public {inline} (0 calls)
 0: drone.drone_info.drone_info<0>
-drone_info(x##0:wybe.int, y##0:wybe.int, z##0:wybe.int, count##0:wybe.int, ?###0:drone.drone_info):
+drone_info(x##0:wybe.int, y##0:wybe.int, z##0:wybe.int, count##0:wybe.int, ?#result##0:drone.drone_info):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(32:wybe.int, ?#rec##0:drone.drone_info)
     foreign lpvm mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~x##0:wybe.int)
     foreign lpvm mutate(~#rec##1:drone.drone_info, ?#rec##2:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~y##0:wybe.int)
     foreign lpvm mutate(~#rec##2:drone.drone_info, ?#rec##3:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~z##0:wybe.int)
-    foreign lpvm mutate(~#rec##3:drone.drone_info, ?###0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~count##0:wybe.int)
+    foreign lpvm mutate(~#rec##3:drone.drone_info, ?#result##0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~count##0:wybe.int)
 drone_info > public {inline} (14 calls)
 1: drone.drone_info.drone_info<1>
-drone_info(?x##0:wybe.int, ?y##0:wybe.int, ?z##0:wybe.int, ?count##0:wybe.int, ###0:drone.drone_info):
+drone_info(?x##0:wybe.int, ?y##0:wybe.int, ?z##0:wybe.int, ?count##0:wybe.int, #result##0:drone.drone_info):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(###0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?y##0:wybe.int)
-    foreign lpvm access(###0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?z##0:wybe.int)
-    foreign lpvm access(~###0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?count##0:wybe.int)
+    foreign lpvm access(#result##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(#result##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?z##0:wybe.int)
+    foreign lpvm access(~#result##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?count##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: drone.drone_info.x<0>
-x(#rec##0:drone.drone_info, ?###0:wybe.int):
+x(#rec##0:drone.drone_info, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 x > public {inline} (0 calls)
 1: drone.drone_info.x<1>
 x(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
@@ -1857,10 +1857,10 @@ x(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
 
 y > public {inline} (0 calls)
 0: drone.drone_info.y<0>
-y(#rec##0:drone.drone_info, ?###0:wybe.int):
+y(#rec##0:drone.drone_info, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 y > public {inline} (0 calls)
 1: drone.drone_info.y<1>
 y(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
@@ -1871,10 +1871,10 @@ y(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
 
 z > public {inline} (0 calls)
 0: drone.drone_info.z<0>
-z(#rec##0:drone.drone_info, ?###0:wybe.int):
+z(#rec##0:drone.drone_info, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 z > public {inline} (0 calls)
 1: drone.drone_info.z<1>
 z(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
@@ -2040,20 +2040,20 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64, i64} @"drone.drone_info.drone_info<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64, i64, i64} @"drone.drone_info.drone_info<1>"(i64  %"#result##0")    {
 entry:
-  %58 = inttoptr i64 %"###0" to i64* 
+  %58 = inttoptr i64 %"#result##0" to i64* 
   %59 = getelementptr  i64, i64* %58, i64 0 
   %60 = load  i64, i64* %59 
-  %61 = add   i64 %"###0", 8 
+  %61 = add   i64 %"#result##0", 8 
   %62 = inttoptr i64 %61 to i64* 
   %63 = getelementptr  i64, i64* %62, i64 0 
   %64 = load  i64, i64* %63 
-  %65 = add   i64 %"###0", 16 
+  %65 = add   i64 %"#result##0", 16 
   %66 = inttoptr i64 %65 to i64* 
   %67 = getelementptr  i64, i64* %66, i64 0 
   %68 = load  i64, i64* %67 
-  %69 = add   i64 %"###0", 24 
+  %69 = add   i64 %"#result##0", 24 
   %70 = inttoptr i64 %69 to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
   %72 = load  i64, i64* %71 

--- a/test-cases/complex/exp/testcase_multi_specz-drone.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-drone.exp
@@ -72,11 +72,11 @@ LLVM code       : None
 (argc##0:wybe.int, [?argc##0:wybe.int], ?arguments##2:wybe.array(wybe.string), argv##0:wybe.array.raw_array(wybe.string), [?argv##0:wybe.array.raw_array(wybe.string)], ?command##2:wybe.string, ?exit_code##1:wybe.int, io##0:wybe.phantom, [?io##0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$9##0:wybe.array(?T))
-    foreign lpvm mutate(~tmp$9##0:wybe.array(?T), ?tmp$10##0:wybe.array(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
-    foreign lpvm mutate(~tmp$10##0:wybe.array(?T), ?tmp$1##0:wybe.array(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(?T))
-    wybe.array.[|]<0>(?command##2:?T, ?arguments##2:wybe.array(?T), ~tmp$1##0:wybe.array(?T), ?tmp$2##0:wybe.bool) #2 @command_line:nn:nn
-    case ~tmp$2##0:wybe.bool of
+    foreign lpvm alloc(16:wybe.int, ?tmp#9##0:wybe.array(?T))
+    foreign lpvm mutate(~tmp#9##0:wybe.array(?T), ?tmp#10##0:wybe.array(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
+    foreign lpvm mutate(~tmp#10##0:wybe.array(?T), ?tmp#1##0:wybe.array(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(?T))
+    wybe.array.[|]<0>(?command##2:?T, ?arguments##2:wybe.array(?T), ~tmp#1##0:wybe.array(?T), ?tmp#2##0:wybe.bool) #2 @command_line:nn:nn
+    case ~tmp#2##0:wybe.bool of
     0:
         foreign c {terminal,semipure} error_exit("command_line:17:10":wybe.string, "Erroneous program argument vector":wybe.string) @control:nn:nn
         foreign llvm move(0:wybe.int, ?exit_code##1:wybe.int)
@@ -175,23 +175,23 @@ entry:
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(4,(drone.loop<0>,fromList [NonAliasedParamCond 0 []]))]
-    drone.drone_init<0>(?tmp$0##0:drone.drone_info) #0 @drone:nn:nn
+    drone.drone_init<0>(?tmp#0##0:drone.drone_info) #0 @drone:nn:nn
     foreign c read_char(?ch##0:wybe.char, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm cast(-1:wybe.int, ?tmp$1##0:wybe.char) @io:nn:nn
-    foreign llvm icmp_ne(ch##0:wybe.char, ~tmp$1##0:wybe.char, ?tmp$2##0:wybe.bool) @char:nn:nn
-    case ~tmp$2##0:wybe.bool of
+    foreign lpvm cast(-1:wybe.int, ?tmp#1##0:wybe.char) @io:nn:nn
+    foreign llvm icmp_ne(ch##0:wybe.char, ~tmp#1##0:wybe.char, ?tmp#2##0:wybe.bool) @char:nn:nn
+    case ~tmp#2##0:wybe.bool of
     0:
-        foreign c {impure} malloc_count(?tmp$10##0:wybe.int) @memory_management:nn:nn
-        foreign c print_string("** malloc count: ":wybe.string, ~io##1:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
-        foreign c print_int(~tmp$10##0:wybe.int, ~tmp$11##0:wybe.phantom, ?tmp$12##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$12##0:wybe.phantom, ?io##3:wybe.phantom) @io:nn:nn
+        foreign c {impure} malloc_count(?tmp#10##0:wybe.int) @memory_management:nn:nn
+        foreign c print_string("** malloc count: ":wybe.string, ~io##1:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
+        foreign c print_int(~tmp#10##0:wybe.int, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#12##0:wybe.phantom, ?io##3:wybe.phantom) @io:nn:nn
 
     1:
-        drone.loop<0>[410bae77d3](~tmp$0##0:drone.drone_info, ~ch##0:wybe.char, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @drone:nn:nn
-        foreign c {impure} malloc_count(?tmp$10##0:wybe.int) @memory_management:nn:nn
-        foreign c print_string("** malloc count: ":wybe.string, ~io##2:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
-        foreign c print_int(~tmp$10##0:wybe.int, ~tmp$11##0:wybe.phantom, ?tmp$12##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$12##0:wybe.phantom, ?io##3:wybe.phantom) @io:nn:nn
+        drone.loop<0>[410bae77d3](~tmp#0##0:drone.drone_info, ~ch##0:wybe.char, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @drone:nn:nn
+        foreign c {impure} malloc_count(?tmp#10##0:wybe.int) @memory_management:nn:nn
+        foreign c print_string("** malloc count: ":wybe.string, ~io##2:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
+        foreign c print_int(~tmp#10##0:wybe.int, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#12##0:wybe.phantom, ?io##3:wybe.phantom) @io:nn:nn
 
 
 
@@ -200,103 +200,103 @@ do_action > (2 calls)
 do_action(d##0:drone.drone_info, ?d##2:drone.drone_info, action##0:wybe.char, ?success##2:wybe.bool):
  AliasPairs: [(d##0,d##2)]
  InterestingCallProperties: [InterestingUnaliased 0]
- MultiSpeczDepInfo: [(5,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(10,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(15,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(20,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(25,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(30,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(32,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 [0]]))]
-    foreign llvm icmp_eq(action##0:wybe.char, 'n':wybe.char, ?tmp$21##0:wybe.bool) @char:nn:nn
-    case ~tmp$21##0:wybe.bool of
+ MultiSpeczDepInfo: [(5,(drone.gen#2<0>,fromList [NonAliasedParamCond 1 []])),(10,(drone.gen#2<0>,fromList [NonAliasedParamCond 1 []])),(15,(drone.gen#2<0>,fromList [NonAliasedParamCond 1 []])),(20,(drone.gen#2<0>,fromList [NonAliasedParamCond 1 []])),(25,(drone.gen#2<0>,fromList [NonAliasedParamCond 1 []])),(30,(drone.gen#2<0>,fromList [NonAliasedParamCond 1 []])),(32,(drone.gen#2<0>,fromList [NonAliasedParamCond 1 [0]]))]
+    foreign llvm icmp_eq(action##0:wybe.char, 'n':wybe.char, ?tmp#21##0:wybe.bool) @char:nn:nn
+    case ~tmp#21##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(action##0:wybe.char, 's':wybe.char, ?tmp$20##0:wybe.bool) @char:nn:nn
-        case ~tmp$20##0:wybe.bool of
+        foreign llvm icmp_eq(action##0:wybe.char, 's':wybe.char, ?tmp#20##0:wybe.bool) @char:nn:nn
+        case ~tmp#20##0:wybe.bool of
         0:
-            foreign llvm icmp_eq(action##0:wybe.char, 'w':wybe.char, ?tmp$19##0:wybe.bool) @char:nn:nn
-            case ~tmp$19##0:wybe.bool of
+            foreign llvm icmp_eq(action##0:wybe.char, 'w':wybe.char, ?tmp#19##0:wybe.bool) @char:nn:nn
+            case ~tmp#19##0:wybe.bool of
             0:
-                foreign llvm icmp_eq(action##0:wybe.char, 'e':wybe.char, ?tmp$18##0:wybe.bool) @char:nn:nn
-                case ~tmp$18##0:wybe.bool of
+                foreign llvm icmp_eq(action##0:wybe.char, 'e':wybe.char, ?tmp#18##0:wybe.bool) @char:nn:nn
+                case ~tmp#18##0:wybe.bool of
                 0:
-                    foreign llvm icmp_eq(action##0:wybe.char, 'u':wybe.char, ?tmp$17##0:wybe.bool) @char:nn:nn
-                    case ~tmp$17##0:wybe.bool of
+                    foreign llvm icmp_eq(action##0:wybe.char, 'u':wybe.char, ?tmp#17##0:wybe.bool) @char:nn:nn
+                    case ~tmp#17##0:wybe.bool of
                     0:
-                        foreign llvm icmp_eq(~action##0:wybe.char, 'd':wybe.char, ?tmp$16##0:wybe.bool) @char:nn:nn
-                        case ~tmp$16##0:wybe.bool of
+                        foreign llvm icmp_eq(~action##0:wybe.char, 'd':wybe.char, ?tmp#16##0:wybe.bool) @char:nn:nn
+                        case ~tmp#16##0:wybe.bool of
                         0:
                             foreign llvm move(0:wybe.bool, ?success##2:wybe.bool) @drone:nn:nn
-                            drone.gen$2<0>(_:wybe.char, ~d##0:drone.drone_info, 0:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #32
+                            drone.gen#2<0>(_:wybe.char, ~d##0:drone.drone_info, 0:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #32
 
                         1:
-                            foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$12##0:wybe.int)
-                            foreign llvm sub(~tmp$12##0:wybe.int, 1:wybe.int, ?tmp$11##0:wybe.int) @int:nn:nn
-                            foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$11##0:wybe.int)
-                            drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #30
+                            foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#12##0:wybe.int)
+                            foreign llvm sub(~tmp#12##0:wybe.int, 1:wybe.int, ?tmp#11##0:wybe.int) @int:nn:nn
+                            foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#11##0:wybe.int)
+                            drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #30
                             foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
                     1:
-                        foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.int)
-                        foreign llvm add(~tmp$10##0:wybe.int, 1:wybe.int, ?tmp$9##0:wybe.int) @int:nn:nn
-                        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$9##0:wybe.int)
-                        drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #25
+                        foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int)
+                        foreign llvm add(~tmp#10##0:wybe.int, 1:wybe.int, ?tmp#9##0:wybe.int) @int:nn:nn
+                        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#9##0:wybe.int)
+                        drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #25
                         foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
                 1:
-                    foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
-                    foreign llvm add(~tmp$8##0:wybe.int, 1:wybe.int, ?tmp$7##0:wybe.int) @int:nn:nn
-                    foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$7##0:wybe.int)
-                    drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #20
+                    foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
+                    foreign llvm add(~tmp#8##0:wybe.int, 1:wybe.int, ?tmp#7##0:wybe.int) @int:nn:nn
+                    foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#7##0:wybe.int)
+                    drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #20
                     foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
             1:
-                foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-                foreign llvm sub(~tmp$6##0:wybe.int, 1:wybe.int, ?tmp$5##0:wybe.int) @int:nn:nn
-                foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$5##0:wybe.int)
-                drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #15
+                foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+                foreign llvm sub(~tmp#6##0:wybe.int, 1:wybe.int, ?tmp#5##0:wybe.int) @int:nn:nn
+                foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#5##0:wybe.int)
+                drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #15
                 foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
         1:
-            foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-            foreign llvm add(~tmp$4##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
-            foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$3##0:wybe.int)
-            drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #10
+            foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+            foreign llvm add(~tmp#4##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
+            foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int)
+            drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #10
             foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
     1:
-        foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm sub(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$1##0:wybe.int)
-        drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #5
+        foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm sub(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int)
+        drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #5
         foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
 
 drone_init > (3 calls)
 0: drone.drone_init<0>
-drone_init(?$##0:drone.drone_info):
+drone_init(?###0:drone.drone_info):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(32:wybe.int, ?tmp$5##0:drone.drone_info)
-    foreign lpvm mutate(~tmp$5##0:drone.drone_info, ?tmp$6##0:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$6##0:drone.drone_info, ?tmp$7##0:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$7##0:drone.drone_info, ?tmp$8##0:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$8##0:drone.drone_info, ?$##0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm alloc(32:wybe.int, ?tmp#5##0:drone.drone_info)
+    foreign lpvm mutate(~tmp#5##0:drone.drone_info, ?tmp#6##0:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp#6##0:drone.drone_info, ?tmp#7##0:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp#7##0:drone.drone_info, ?tmp#8##0:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp#8##0:drone.drone_info, ?###0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
 
 
-gen$1 > {inline} (2 calls)
-0: drone.gen$1<0>
-gen$1([ch##0:wybe.char], [d##0:drone.drone_info], io##0:wybe.phantom, [tmp$0##0:drone.drone_info], ?io##2:wybe.phantom):
+gen#1 > {inline} (2 calls)
+0: drone.gen#1<0>
+gen#1([ch##0:wybe.char], [d##0:drone.drone_info], io##0:wybe.phantom, [tmp#0##0:drone.drone_info], ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c {impure} malloc_count(?mc##0:wybe.int) @memory_management:nn:nn
     foreign c print_string("** malloc count: ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign c print_int(~mc##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$6##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$6##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_int(~mc##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
 
-gen$2 > (7 calls)
-0: drone.gen$2<0>
-gen$2([action##0:wybe.char], d##0:drone.drone_info, success##0:wybe.bool, [tmp$0##0:wybe.bool], ?d##1:drone.drone_info, [?success##0:wybe.bool]):
+gen#2 > (7 calls)
+0: drone.gen#2<0>
+gen#2([action##0:wybe.char], d##0:drone.drone_info, success##0:wybe.bool, [tmp#0##0:wybe.bool], ?d##1:drone.drone_info, [?success##0:wybe.bool]):
  AliasPairs: [(d##0,d##1)]
  InterestingCallProperties: [InterestingUnaliased 1]
     case success##0:wybe.bool of
@@ -304,22 +304,22 @@ gen$2([action##0:wybe.char], d##0:drone.drone_info, success##0:wybe.bool, [tmp$0
         foreign llvm move(~d##0:drone.drone_info, ?d##1:drone.drone_info)
 
     1:
-        foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$15##0:wybe.int)
-        foreign llvm add(~tmp$15##0:wybe.int, 1:wybe.int, ?tmp$14##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$14##0:wybe.int)
+        foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.int)
+        foreign llvm add(~tmp#15##0:wybe.int, 1:wybe.int, ?tmp#14##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#14##0:wybe.int)
 
 
 
-gen$3 > (4 calls)
-0: drone.gen$3<0>
-gen$3([ch##0:wybe.char], d##0:drone.drone_info, io##0:wybe.phantom, ?io##2:wybe.phantom):
+gen#3 > (4 calls)
+0: drone.gen#3<0>
+gen#3([ch##0:wybe.char], d##0:drone.drone_info, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 1]
  MultiSpeczDepInfo: [(3,(drone.loop<0>,fromList [NonAliasedParamCond 0 [1]]))]
     foreign c read_char(?ch##1:wybe.char, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm cast(-1:wybe.int, ?tmp$3##0:wybe.char) @io:nn:nn
-    foreign llvm icmp_ne(ch##1:wybe.char, ~tmp$3##0:wybe.char, ?tmp$4##0:wybe.bool) @char:nn:nn
-    case ~tmp$4##0:wybe.bool of
+    foreign lpvm cast(-1:wybe.int, ?tmp#3##0:wybe.char) @io:nn:nn
+    foreign llvm icmp_ne(ch##1:wybe.char, ~tmp#3##0:wybe.char, ?tmp#4##0:wybe.bool) @char:nn:nn
+    case ~tmp#4##0:wybe.bool of
     0:
         foreign llvm move(~io##1:wybe.phantom, ?io##2:wybe.phantom)
 
@@ -333,45 +333,45 @@ loop > (2 calls)
 loop(d##0:drone.drone_info, ch##0:wybe.char, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
- MultiSpeczDepInfo: [(5,(drone.gen$3<0>,fromList [NonAliasedParamCond 1 [0]])),(6,(drone.do_action<0>,fromList [NonAliasedParamCond 0 [0]])),(10,(drone.gen$3<0>,fromList [NonAliasedParamCond 1 [0]])),(11,(drone.gen$3<0>,fromList [NonAliasedParamCond 1 [0]])),(12,(drone.gen$3<0>,fromList [NonAliasedParamCond 1 [0]]))]
-    foreign llvm icmp_ne(ch##0:wybe.char, ' ':wybe.char, ?tmp$0##0:wybe.bool) @char:nn:nn
-    foreign llvm icmp_ne(ch##0:wybe.char, '\n':wybe.char, ?tmp$1##0:wybe.bool) @char:nn:nn
-    foreign llvm and(~tmp$0##0:wybe.bool, ~tmp$1##0:wybe.bool, ?tmp$7##0:wybe.bool) @bool:nn:nn
-    case ~tmp$7##0:wybe.bool of
+ MultiSpeczDepInfo: [(5,(drone.gen#3<0>,fromList [NonAliasedParamCond 1 [0]])),(6,(drone.do_action<0>,fromList [NonAliasedParamCond 0 [0]])),(10,(drone.gen#3<0>,fromList [NonAliasedParamCond 1 [0]])),(11,(drone.gen#3<0>,fromList [NonAliasedParamCond 1 [0]])),(12,(drone.gen#3<0>,fromList [NonAliasedParamCond 1 [0]]))]
+    foreign llvm icmp_ne(ch##0:wybe.char, ' ':wybe.char, ?tmp#0##0:wybe.bool) @char:nn:nn
+    foreign llvm icmp_ne(ch##0:wybe.char, '\n':wybe.char, ?tmp#1##0:wybe.bool) @char:nn:nn
+    foreign llvm and(~tmp#0##0:wybe.bool, ~tmp#1##0:wybe.bool, ?tmp#7##0:wybe.bool) @bool:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        drone.gen$3<0>(_:wybe.char, ~d##0:drone.drone_info, ~io##0:wybe.phantom, ?io##2:wybe.phantom) #12
+        drone.gen#3<0>(_:wybe.char, ~d##0:drone.drone_info, ~io##0:wybe.phantom, ?io##2:wybe.phantom) #12
 
     1:
-        foreign llvm icmp_eq(ch##0:wybe.char, 'p':wybe.char, ?tmp$6##0:wybe.bool) @char:nn:nn
-        case ~tmp$6##0:wybe.bool of
+        foreign llvm icmp_eq(ch##0:wybe.char, 'p':wybe.char, ?tmp#6##0:wybe.bool) @char:nn:nn
+        case ~tmp#6##0:wybe.bool of
         0:
             drone.do_action<0>(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, ~ch##0:wybe.char, ?success##0:wybe.bool) #6 @drone:nn:nn
-            foreign llvm icmp_eq(~success##0:wybe.bool, 0:wybe.bool, ?tmp$5##0:wybe.bool) @bool:nn:nn
-            case ~tmp$5##0:wybe.bool of
+            foreign llvm icmp_eq(~success##0:wybe.bool, 0:wybe.bool, ?tmp#5##0:wybe.bool) @bool:nn:nn
+            case ~tmp#5##0:wybe.bool of
             0:
-                drone.gen$3<0>(_:wybe.char, ~d##1:drone.drone_info, ~io##0:wybe.phantom, ?io##2:wybe.phantom) #11
+                drone.gen#3<0>(_:wybe.char, ~d##1:drone.drone_info, ~io##0:wybe.phantom, ?io##2:wybe.phantom) #11
 
             1:
-                foreign c print_string("invalid action!":wybe.string, ~#io##0:wybe.phantom, ?tmp$20##0:wybe.phantom) @io:nn:nn
-                foreign c putchar('\n':wybe.char, ~tmp$20##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-                drone.gen$3<0>(_:wybe.char, ~d##1:drone.drone_info, ~io##1:wybe.phantom, ?io##2:wybe.phantom) #10
+                foreign c print_string("invalid action!":wybe.string, ~#io##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @io:nn:nn
+                foreign c putchar('\n':wybe.char, ~tmp#20##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+                drone.gen#3<0>(_:wybe.char, ~d##1:drone.drone_info, ~io##1:wybe.phantom, ?io##2:wybe.phantom) #10
 
 
         1:
-            foreign c print_string("(":wybe.string, ~#io##0:wybe.phantom, ?tmp$18##0:wybe.phantom) @io:nn:nn
-            foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$19##0:wybe.int)
-            foreign c print_int(~tmp$19##0:wybe.int, ~tmp$18##0:wybe.phantom, ?tmp$20##0:wybe.phantom) @io:nn:nn
-            foreign c print_string(", ":wybe.string, ~tmp$20##0:wybe.phantom, ?tmp$21##0:wybe.phantom) @io:nn:nn
-            foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$22##0:wybe.int)
-            foreign c print_int(~tmp$22##0:wybe.int, ~tmp$21##0:wybe.phantom, ?tmp$23##0:wybe.phantom) @io:nn:nn
-            foreign c print_string(", ":wybe.string, ~tmp$23##0:wybe.phantom, ?tmp$24##0:wybe.phantom) @io:nn:nn
-            foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$25##0:wybe.int)
-            foreign c print_int(~tmp$25##0:wybe.int, ~tmp$24##0:wybe.phantom, ?tmp$26##0:wybe.phantom) @io:nn:nn
-            foreign c print_string(") #":wybe.string, ~tmp$26##0:wybe.phantom, ?tmp$27##0:wybe.phantom) @io:nn:nn
-            foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$28##0:wybe.int)
-            foreign c print_int(~tmp$28##0:wybe.int, ~tmp$27##0:wybe.phantom, ?tmp$29##0:wybe.phantom) @io:nn:nn
-            foreign c putchar('\n':wybe.char, ~tmp$29##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-            drone.gen$3<0>(_:wybe.char, ~d##0:drone.drone_info, ~io##1:wybe.phantom, ?io##2:wybe.phantom) #5
+            foreign c print_string("(":wybe.string, ~#io##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @io:nn:nn
+            foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#19##0:wybe.int)
+            foreign c print_int(~tmp#19##0:wybe.int, ~tmp#18##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @io:nn:nn
+            foreign c print_string(", ":wybe.string, ~tmp#20##0:wybe.phantom, ?tmp#21##0:wybe.phantom) @io:nn:nn
+            foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#22##0:wybe.int)
+            foreign c print_int(~tmp#22##0:wybe.int, ~tmp#21##0:wybe.phantom, ?tmp#23##0:wybe.phantom) @io:nn:nn
+            foreign c print_string(", ":wybe.string, ~tmp#23##0:wybe.phantom, ?tmp#24##0:wybe.phantom) @io:nn:nn
+            foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#25##0:wybe.int)
+            foreign c print_int(~tmp#25##0:wybe.int, ~tmp#24##0:wybe.phantom, ?tmp#26##0:wybe.phantom) @io:nn:nn
+            foreign c print_string(") #":wybe.string, ~tmp#26##0:wybe.phantom, ?tmp#27##0:wybe.phantom) @io:nn:nn
+            foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#28##0:wybe.int)
+            foreign c print_int(~tmp#28##0:wybe.int, ~tmp#27##0:wybe.phantom, ?tmp#29##0:wybe.phantom) @io:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#29##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+            drone.gen#3<0>(_:wybe.char, ~d##0:drone.drone_info, ~io##1:wybe.phantom, ?io##2:wybe.phantom) #5
 
 
 
@@ -382,17 +382,17 @@ print_info(d##0:drone.drone_info, io##0:wybe.phantom, ?io##9:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("(":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string(", ":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     foreign c print_string(", ":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
-    foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.int)
-    foreign c print_int(~tmp$2##0:wybe.int, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+    foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int)
+    foreign c print_int(~tmp#2##0:wybe.int, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
     foreign c print_string(") #":wybe.string, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign c print_int(~tmp$3##0:wybe.int, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign c print_int(~tmp#3##0:wybe.int, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~#io##8:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
 
 LLVM code       : None
@@ -421,36 +421,36 @@ LLVM code       : None
 
 = > public {inline} (1 calls)
 0: drone.drone_info.=<0>
-=($left##0:drone.drone_info, $right##0:drone.drone_info, ?$$##0:wybe.bool):
+=(#left##0:drone.drone_info, #right##0:drone.drone_info, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
-    foreign lpvm access($left##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
-    foreign lpvm access($left##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$z##0:wybe.int)
-    foreign lpvm access(~$left##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$count##0:wybe.int)
-    foreign lpvm access($right##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
-    foreign lpvm access($right##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
-    foreign lpvm access($right##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$z##0:wybe.int)
-    foreign lpvm access(~$right##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$count##0:wybe.int)
-    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
+    foreign lpvm access(#left##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
+    foreign lpvm access(#left##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#z##0:wybe.int)
+    foreign lpvm access(~#left##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#count##0:wybe.int)
+    foreign lpvm access(#right##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
+    foreign lpvm access(#right##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign lpvm access(#right##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#z##0:wybe.int)
+    foreign lpvm access(~#right##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#count##0:wybe.int)
+    foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?tmp$2##0:wybe.bool) @int:nn:nn
-        case ~tmp$2##0:wybe.bool of
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?tmp#2##0:wybe.bool) @int:nn:nn
+        case ~tmp#2##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~$left$z##0:wybe.int, ~$right$z##0:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
-            case ~tmp$3##0:wybe.bool of
+            foreign llvm icmp_eq(~#left#z##0:wybe.int, ~#right#z##0:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
+            case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
             1:
-                foreign llvm icmp_eq(~$left$count##0:wybe.int, ~$right$count##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+                foreign llvm icmp_eq(~#left#count##0:wybe.int, ~#right#count##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
@@ -458,117 +458,117 @@ LLVM code       : None
 
 count > public {inline} (0 calls)
 0: drone.drone_info.count<0>
-count($rec##0:drone.drone_info, ?$##0:wybe.int):
+count(#rec##0:drone.drone_info, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:wybe.int)
 count > public {inline} (0 calls)
 1: drone.drone_info.count<1>
-count($rec##0:drone.drone_info, ?$rec##1:drone.drone_info, $field##0:wybe.int):
+count(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:drone.drone_info, ?$rec##1:drone.drone_info, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 drone_info > public {inline} (0 calls)
 0: drone.drone_info.drone_info<0>
-drone_info(x##0:wybe.int, y##0:wybe.int, z##0:wybe.int, count##0:wybe.int, ?$##0:drone.drone_info):
+drone_info(x##0:wybe.int, y##0:wybe.int, z##0:wybe.int, count##0:wybe.int, ?###0:drone.drone_info):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(32:wybe.int, ?$rec##0:drone.drone_info)
-    foreign lpvm mutate(~$rec##0:drone.drone_info, ?$rec##1:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:drone.drone_info, ?$rec##2:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~y##0:wybe.int)
-    foreign lpvm mutate(~$rec##2:drone.drone_info, ?$rec##3:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~z##0:wybe.int)
-    foreign lpvm mutate(~$rec##3:drone.drone_info, ?$##0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~count##0:wybe.int)
+    foreign lpvm alloc(32:wybe.int, ?#rec##0:drone.drone_info)
+    foreign lpvm mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:drone.drone_info, ?#rec##2:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~#rec##2:drone.drone_info, ?#rec##3:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~z##0:wybe.int)
+    foreign lpvm mutate(~#rec##3:drone.drone_info, ?###0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~count##0:wybe.int)
 drone_info > public {inline} (14 calls)
 1: drone.drone_info.drone_info<1>
-drone_info(?x##0:wybe.int, ?y##0:wybe.int, ?z##0:wybe.int, ?count##0:wybe.int, $##0:drone.drone_info):
+drone_info(?x##0:wybe.int, ?y##0:wybe.int, ?z##0:wybe.int, ?count##0:wybe.int, ###0:drone.drone_info):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access($##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?y##0:wybe.int)
-    foreign lpvm access($##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?z##0:wybe.int)
-    foreign lpvm access(~$##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?count##0:wybe.int)
+    foreign lpvm access(###0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(###0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(###0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?z##0:wybe.int)
+    foreign lpvm access(~###0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?count##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: drone.drone_info.x<0>
-x($rec##0:drone.drone_info, ?$##0:wybe.int):
+x(#rec##0:drone.drone_info, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:wybe.int)
 x > public {inline} (0 calls)
 1: drone.drone_info.x<1>
-x($rec##0:drone.drone_info, ?$rec##1:drone.drone_info, $field##0:wybe.int):
+x(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:drone.drone_info, ?$rec##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: drone.drone_info.y<0>
-y($rec##0:drone.drone_info, ?$##0:wybe.int):
+y(#rec##0:drone.drone_info, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:wybe.int)
 y > public {inline} (0 calls)
 1: drone.drone_info.y<1>
-y($rec##0:drone.drone_info, ?$rec##1:drone.drone_info, $field##0:wybe.int):
+y(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:drone.drone_info, ?$rec##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 z > public {inline} (0 calls)
 0: drone.drone_info.z<0>
-z($rec##0:drone.drone_info, ?$##0:wybe.int):
+z(#rec##0:drone.drone_info, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:wybe.int)
 z > public {inline} (0 calls)
 1: drone.drone_info.z<1>
-z($rec##0:drone.drone_info, ?$rec##1:drone.drone_info, $field##0:wybe.int):
+z(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:drone.drone_info, ?$rec##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: drone.drone_info.~=<0>
-~=($left##0:drone.drone_info, $right##0:drone.drone_info, ?$$##0:wybe.bool):
+~=(#left##0:drone.drone_info, #right##0:drone.drone_info, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access($left##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($left##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$left##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign lpvm access($right##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.int)
-    foreign lpvm access($right##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
-    foreign lpvm access($right##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.int)
-    foreign lpvm access(~$right##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$7##0:wybe.int, ?tmp$11##0:wybe.bool) @int:nn:nn
-    case ~tmp$11##0:wybe.bool of
+    foreign lpvm access(#left##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(#left##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#left##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#left##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#right##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int)
+    foreign lpvm access(#right##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
+    foreign lpvm access(#right##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
+    foreign lpvm access(~#right##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#7##0:wybe.int, ?tmp#11##0:wybe.bool) @int:nn:nn
+    case ~tmp#11##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$8##0:wybe.int, ?tmp$12##0:wybe.bool) @int:nn:nn
-        case ~tmp$12##0:wybe.bool of
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#8##0:wybe.int, ?tmp#12##0:wybe.bool) @int:nn:nn
+        case ~tmp#12##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~tmp$5##0:wybe.int, ~tmp$9##0:wybe.int, ?tmp$13##0:wybe.bool) @int:nn:nn
-            case ~tmp$13##0:wybe.bool of
+            foreign llvm icmp_eq(~tmp#5##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#13##0:wybe.bool) @int:nn:nn
+            case ~tmp#13##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-                foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+                foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
             1:
-                foreign llvm icmp_eq(~tmp$10##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-                foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm icmp_eq(~tmp#10##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+                foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
 
@@ -661,11 +661,11 @@ entry:
 (argc##0:wybe.int, [?argc##0:wybe.int], ?arguments##2:wybe.array(wybe.string), argv##0:wybe.array.raw_array(wybe.string), [?argv##0:wybe.array.raw_array(wybe.string)], ?command##2:wybe.string, ?exit_code##1:wybe.int, io##0:wybe.phantom, [?io##0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$9##0:wybe.array(?T))
-    foreign lpvm mutate(~tmp$9##0:wybe.array(?T), ?tmp$10##0:wybe.array(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
-    foreign lpvm mutate(~tmp$10##0:wybe.array(?T), ?tmp$1##0:wybe.array(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(?T))
-    wybe.array.[|]<0>(?command##2:?T, ?arguments##2:wybe.array(?T), ~tmp$1##0:wybe.array(?T), ?tmp$2##0:wybe.bool) #2 @command_line:nn:nn
-    case ~tmp$2##0:wybe.bool of
+    foreign lpvm alloc(16:wybe.int, ?tmp#9##0:wybe.array(?T))
+    foreign lpvm mutate(~tmp#9##0:wybe.array(?T), ?tmp#10##0:wybe.array(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
+    foreign lpvm mutate(~tmp#10##0:wybe.array(?T), ?tmp#1##0:wybe.array(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(?T))
+    wybe.array.[|]<0>(?command##2:?T, ?arguments##2:wybe.array(?T), ~tmp#1##0:wybe.array(?T), ?tmp#2##0:wybe.bool) #2 @command_line:nn:nn
+    case ~tmp#2##0:wybe.bool of
     0:
         foreign c {terminal,semipure} error_exit("command_line:17:10":wybe.string, "Erroneous program argument vector":wybe.string) @control:nn:nn
         foreign llvm move(0:wybe.int, ?exit_code##1:wybe.int)
@@ -764,23 +764,23 @@ entry:
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(4,(drone.loop<0>,fromList [NonAliasedParamCond 0 []]))]
-    drone.drone_init<0>(?tmp$0##0:drone.drone_info) #0 @drone:nn:nn
+    drone.drone_init<0>(?tmp#0##0:drone.drone_info) #0 @drone:nn:nn
     foreign c read_char(?ch##0:wybe.char, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm cast(-1:wybe.int, ?tmp$1##0:wybe.char) @io:nn:nn
-    foreign llvm icmp_ne(ch##0:wybe.char, ~tmp$1##0:wybe.char, ?tmp$2##0:wybe.bool) @char:nn:nn
-    case ~tmp$2##0:wybe.bool of
+    foreign lpvm cast(-1:wybe.int, ?tmp#1##0:wybe.char) @io:nn:nn
+    foreign llvm icmp_ne(ch##0:wybe.char, ~tmp#1##0:wybe.char, ?tmp#2##0:wybe.bool) @char:nn:nn
+    case ~tmp#2##0:wybe.bool of
     0:
-        foreign c {impure} malloc_count(?tmp$10##0:wybe.int) @memory_management:nn:nn
-        foreign c print_string("** malloc count: ":wybe.string, ~io##1:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
-        foreign c print_int(~tmp$10##0:wybe.int, ~tmp$11##0:wybe.phantom, ?tmp$12##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$12##0:wybe.phantom, ?io##3:wybe.phantom) @io:nn:nn
+        foreign c {impure} malloc_count(?tmp#10##0:wybe.int) @memory_management:nn:nn
+        foreign c print_string("** malloc count: ":wybe.string, ~io##1:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
+        foreign c print_int(~tmp#10##0:wybe.int, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#12##0:wybe.phantom, ?io##3:wybe.phantom) @io:nn:nn
 
     1:
-        drone.loop<0>[410bae77d3](~tmp$0##0:drone.drone_info, ~ch##0:wybe.char, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @drone:nn:nn
-        foreign c {impure} malloc_count(?tmp$10##0:wybe.int) @memory_management:nn:nn
-        foreign c print_string("** malloc count: ":wybe.string, ~io##2:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
-        foreign c print_int(~tmp$10##0:wybe.int, ~tmp$11##0:wybe.phantom, ?tmp$12##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$12##0:wybe.phantom, ?io##3:wybe.phantom) @io:nn:nn
+        drone.loop<0>[410bae77d3](~tmp#0##0:drone.drone_info, ~ch##0:wybe.char, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @drone:nn:nn
+        foreign c {impure} malloc_count(?tmp#10##0:wybe.int) @memory_management:nn:nn
+        foreign c print_string("** malloc count: ":wybe.string, ~io##2:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
+        foreign c print_int(~tmp#10##0:wybe.int, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#12##0:wybe.phantom, ?io##3:wybe.phantom) @io:nn:nn
 
 
 
@@ -789,172 +789,172 @@ do_action > (2 calls)
 do_action(d##0:drone.drone_info, ?d##2:drone.drone_info, action##0:wybe.char, ?success##2:wybe.bool):
  AliasPairs: [(d##0,d##2)]
  InterestingCallProperties: [InterestingUnaliased 0]
- MultiSpeczDepInfo: [(5,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(10,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(15,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(20,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(25,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(30,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(32,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 [0]]))]
-    foreign llvm icmp_eq(action##0:wybe.char, 'n':wybe.char, ?tmp$21##0:wybe.bool) @char:nn:nn
-    case ~tmp$21##0:wybe.bool of
+ MultiSpeczDepInfo: [(5,(drone.gen#2<0>,fromList [NonAliasedParamCond 1 []])),(10,(drone.gen#2<0>,fromList [NonAliasedParamCond 1 []])),(15,(drone.gen#2<0>,fromList [NonAliasedParamCond 1 []])),(20,(drone.gen#2<0>,fromList [NonAliasedParamCond 1 []])),(25,(drone.gen#2<0>,fromList [NonAliasedParamCond 1 []])),(30,(drone.gen#2<0>,fromList [NonAliasedParamCond 1 []])),(32,(drone.gen#2<0>,fromList [NonAliasedParamCond 1 [0]]))]
+    foreign llvm icmp_eq(action##0:wybe.char, 'n':wybe.char, ?tmp#21##0:wybe.bool) @char:nn:nn
+    case ~tmp#21##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(action##0:wybe.char, 's':wybe.char, ?tmp$20##0:wybe.bool) @char:nn:nn
-        case ~tmp$20##0:wybe.bool of
+        foreign llvm icmp_eq(action##0:wybe.char, 's':wybe.char, ?tmp#20##0:wybe.bool) @char:nn:nn
+        case ~tmp#20##0:wybe.bool of
         0:
-            foreign llvm icmp_eq(action##0:wybe.char, 'w':wybe.char, ?tmp$19##0:wybe.bool) @char:nn:nn
-            case ~tmp$19##0:wybe.bool of
+            foreign llvm icmp_eq(action##0:wybe.char, 'w':wybe.char, ?tmp#19##0:wybe.bool) @char:nn:nn
+            case ~tmp#19##0:wybe.bool of
             0:
-                foreign llvm icmp_eq(action##0:wybe.char, 'e':wybe.char, ?tmp$18##0:wybe.bool) @char:nn:nn
-                case ~tmp$18##0:wybe.bool of
+                foreign llvm icmp_eq(action##0:wybe.char, 'e':wybe.char, ?tmp#18##0:wybe.bool) @char:nn:nn
+                case ~tmp#18##0:wybe.bool of
                 0:
-                    foreign llvm icmp_eq(action##0:wybe.char, 'u':wybe.char, ?tmp$17##0:wybe.bool) @char:nn:nn
-                    case ~tmp$17##0:wybe.bool of
+                    foreign llvm icmp_eq(action##0:wybe.char, 'u':wybe.char, ?tmp#17##0:wybe.bool) @char:nn:nn
+                    case ~tmp#17##0:wybe.bool of
                     0:
-                        foreign llvm icmp_eq(~action##0:wybe.char, 'd':wybe.char, ?tmp$16##0:wybe.bool) @char:nn:nn
-                        case ~tmp$16##0:wybe.bool of
+                        foreign llvm icmp_eq(~action##0:wybe.char, 'd':wybe.char, ?tmp#16##0:wybe.bool) @char:nn:nn
+                        case ~tmp#16##0:wybe.bool of
                         0:
                             foreign llvm move(0:wybe.bool, ?success##2:wybe.bool) @drone:nn:nn
-                            drone.gen$2<0>(_:wybe.char, ~d##0:drone.drone_info, 0:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #32
+                            drone.gen#2<0>(_:wybe.char, ~d##0:drone.drone_info, 0:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #32
 
                         1:
-                            foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$12##0:wybe.int)
-                            foreign llvm sub(~tmp$12##0:wybe.int, 1:wybe.int, ?tmp$11##0:wybe.int) @int:nn:nn
-                            foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$11##0:wybe.int)
-                            drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #30
+                            foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#12##0:wybe.int)
+                            foreign llvm sub(~tmp#12##0:wybe.int, 1:wybe.int, ?tmp#11##0:wybe.int) @int:nn:nn
+                            foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#11##0:wybe.int)
+                            drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #30
                             foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
                     1:
-                        foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.int)
-                        foreign llvm add(~tmp$10##0:wybe.int, 1:wybe.int, ?tmp$9##0:wybe.int) @int:nn:nn
-                        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$9##0:wybe.int)
-                        drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #25
+                        foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int)
+                        foreign llvm add(~tmp#10##0:wybe.int, 1:wybe.int, ?tmp#9##0:wybe.int) @int:nn:nn
+                        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#9##0:wybe.int)
+                        drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #25
                         foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
                 1:
-                    foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
-                    foreign llvm add(~tmp$8##0:wybe.int, 1:wybe.int, ?tmp$7##0:wybe.int) @int:nn:nn
-                    foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$7##0:wybe.int)
-                    drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #20
+                    foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
+                    foreign llvm add(~tmp#8##0:wybe.int, 1:wybe.int, ?tmp#7##0:wybe.int) @int:nn:nn
+                    foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#7##0:wybe.int)
+                    drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #20
                     foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
             1:
-                foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-                foreign llvm sub(~tmp$6##0:wybe.int, 1:wybe.int, ?tmp$5##0:wybe.int) @int:nn:nn
-                foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$5##0:wybe.int)
-                drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #15
+                foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+                foreign llvm sub(~tmp#6##0:wybe.int, 1:wybe.int, ?tmp#5##0:wybe.int) @int:nn:nn
+                foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#5##0:wybe.int)
+                drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #15
                 foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
         1:
-            foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-            foreign llvm add(~tmp$4##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
-            foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$3##0:wybe.int)
-            drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #10
+            foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+            foreign llvm add(~tmp#4##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
+            foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int)
+            drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #10
             foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
     1:
-        foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm sub(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$1##0:wybe.int)
-        drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #5
+        foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm sub(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int)
+        drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #5
         foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_eq(action##0:wybe.char, 'n':wybe.char, ?tmp$21##0:wybe.bool) @char:nn:nn
-    case ~tmp$21##0:wybe.bool of
+    foreign llvm icmp_eq(action##0:wybe.char, 'n':wybe.char, ?tmp#21##0:wybe.bool) @char:nn:nn
+    case ~tmp#21##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(action##0:wybe.char, 's':wybe.char, ?tmp$20##0:wybe.bool) @char:nn:nn
-        case ~tmp$20##0:wybe.bool of
+        foreign llvm icmp_eq(action##0:wybe.char, 's':wybe.char, ?tmp#20##0:wybe.bool) @char:nn:nn
+        case ~tmp#20##0:wybe.bool of
         0:
-            foreign llvm icmp_eq(action##0:wybe.char, 'w':wybe.char, ?tmp$19##0:wybe.bool) @char:nn:nn
-            case ~tmp$19##0:wybe.bool of
+            foreign llvm icmp_eq(action##0:wybe.char, 'w':wybe.char, ?tmp#19##0:wybe.bool) @char:nn:nn
+            case ~tmp#19##0:wybe.bool of
             0:
-                foreign llvm icmp_eq(action##0:wybe.char, 'e':wybe.char, ?tmp$18##0:wybe.bool) @char:nn:nn
-                case ~tmp$18##0:wybe.bool of
+                foreign llvm icmp_eq(action##0:wybe.char, 'e':wybe.char, ?tmp#18##0:wybe.bool) @char:nn:nn
+                case ~tmp#18##0:wybe.bool of
                 0:
-                    foreign llvm icmp_eq(action##0:wybe.char, 'u':wybe.char, ?tmp$17##0:wybe.bool) @char:nn:nn
-                    case ~tmp$17##0:wybe.bool of
+                    foreign llvm icmp_eq(action##0:wybe.char, 'u':wybe.char, ?tmp#17##0:wybe.bool) @char:nn:nn
+                    case ~tmp#17##0:wybe.bool of
                     0:
-                        foreign llvm icmp_eq(~action##0:wybe.char, 'd':wybe.char, ?tmp$16##0:wybe.bool) @char:nn:nn
-                        case ~tmp$16##0:wybe.bool of
+                        foreign llvm icmp_eq(~action##0:wybe.char, 'd':wybe.char, ?tmp#16##0:wybe.bool) @char:nn:nn
+                        case ~tmp#16##0:wybe.bool of
                         0:
                             foreign llvm move(0:wybe.bool, ?success##2:wybe.bool) @drone:nn:nn
-                            drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##0:drone.drone_info, 0:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #32
+                            drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##0:drone.drone_info, 0:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #32
 
                         1:
-                            foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$12##0:wybe.int)
-                            foreign llvm sub(~tmp$12##0:wybe.int, 1:wybe.int, ?tmp$11##0:wybe.int) @int:nn:nn
-                            foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$11##0:wybe.int)
-                            drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #30
+                            foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#12##0:wybe.int)
+                            foreign llvm sub(~tmp#12##0:wybe.int, 1:wybe.int, ?tmp#11##0:wybe.int) @int:nn:nn
+                            foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#11##0:wybe.int)
+                            drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #30
                             foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
                     1:
-                        foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.int)
-                        foreign llvm add(~tmp$10##0:wybe.int, 1:wybe.int, ?tmp$9##0:wybe.int) @int:nn:nn
-                        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$9##0:wybe.int)
-                        drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #25
+                        foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int)
+                        foreign llvm add(~tmp#10##0:wybe.int, 1:wybe.int, ?tmp#9##0:wybe.int) @int:nn:nn
+                        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#9##0:wybe.int)
+                        drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #25
                         foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
                 1:
-                    foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
-                    foreign llvm add(~tmp$8##0:wybe.int, 1:wybe.int, ?tmp$7##0:wybe.int) @int:nn:nn
-                    foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$7##0:wybe.int)
-                    drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #20
+                    foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
+                    foreign llvm add(~tmp#8##0:wybe.int, 1:wybe.int, ?tmp#7##0:wybe.int) @int:nn:nn
+                    foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#7##0:wybe.int)
+                    drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #20
                     foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
             1:
-                foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-                foreign llvm sub(~tmp$6##0:wybe.int, 1:wybe.int, ?tmp$5##0:wybe.int) @int:nn:nn
-                foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$5##0:wybe.int)
-                drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #15
+                foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+                foreign llvm sub(~tmp#6##0:wybe.int, 1:wybe.int, ?tmp#5##0:wybe.int) @int:nn:nn
+                foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#5##0:wybe.int)
+                drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #15
                 foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
         1:
-            foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-            foreign llvm add(~tmp$4##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
-            foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$3##0:wybe.int)
-            drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #10
+            foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+            foreign llvm add(~tmp#4##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
+            foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int)
+            drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #10
             foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
     1:
-        foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm sub(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$1##0:wybe.int)
-        drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #5
+        foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm sub(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int)
+        drone.gen#2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #5
         foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
 
 drone_init > (3 calls)
 0: drone.drone_init<0>
-drone_init(?$##0:drone.drone_info):
+drone_init(?###0:drone.drone_info):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(32:wybe.int, ?tmp$5##0:drone.drone_info)
-    foreign lpvm mutate(~tmp$5##0:drone.drone_info, ?tmp$6##0:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$6##0:drone.drone_info, ?tmp$7##0:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$7##0:drone.drone_info, ?tmp$8##0:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$8##0:drone.drone_info, ?$##0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm alloc(32:wybe.int, ?tmp#5##0:drone.drone_info)
+    foreign lpvm mutate(~tmp#5##0:drone.drone_info, ?tmp#6##0:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp#6##0:drone.drone_info, ?tmp#7##0:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp#7##0:drone.drone_info, ?tmp#8##0:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp#8##0:drone.drone_info, ?###0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
 
 
-gen$1 > {inline} (2 calls)
-0: drone.gen$1<0>
-gen$1([ch##0:wybe.char], [d##0:drone.drone_info], io##0:wybe.phantom, [tmp$0##0:drone.drone_info], ?io##2:wybe.phantom):
+gen#1 > {inline} (2 calls)
+0: drone.gen#1<0>
+gen#1([ch##0:wybe.char], [d##0:drone.drone_info], io##0:wybe.phantom, [tmp#0##0:drone.drone_info], ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c {impure} malloc_count(?mc##0:wybe.int) @memory_management:nn:nn
     foreign c print_string("** malloc count: ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign c print_int(~mc##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$6##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$6##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_int(~mc##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
 
-gen$2 > (7 calls)
-0: drone.gen$2<0>[6dacb8fd25]
-gen$2([action##0:wybe.char], d##0:drone.drone_info, success##0:wybe.bool, [tmp$0##0:wybe.bool], ?d##1:drone.drone_info, [?success##0:wybe.bool]):
+gen#2 > (7 calls)
+0: drone.gen#2<0>[6dacb8fd25]
+gen#2([action##0:wybe.char], d##0:drone.drone_info, success##0:wybe.bool, [tmp#0##0:wybe.bool], ?d##1:drone.drone_info, [?success##0:wybe.bool]):
  AliasPairs: [(d##0,d##1)]
  InterestingCallProperties: [InterestingUnaliased 1]
     case success##0:wybe.bool of
@@ -962,9 +962,9 @@ gen$2([action##0:wybe.char], d##0:drone.drone_info, success##0:wybe.bool, [tmp$0
         foreign llvm move(~d##0:drone.drone_info, ?d##1:drone.drone_info)
 
     1:
-        foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$15##0:wybe.int)
-        foreign llvm add(~tmp$15##0:wybe.int, 1:wybe.int, ?tmp$14##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$14##0:wybe.int)
+        foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.int)
+        foreign llvm add(~tmp#15##0:wybe.int, 1:wybe.int, ?tmp#14##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#14##0:wybe.int)
 
  [6dacb8fd25] [NonAliasedParam 1] :
     case success##0:wybe.bool of
@@ -972,22 +972,22 @@ gen$2([action##0:wybe.char], d##0:drone.drone_info, success##0:wybe.bool, [tmp$0
         foreign llvm move(~d##0:drone.drone_info, ?d##1:drone.drone_info)
 
     1:
-        foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$15##0:wybe.int)
-        foreign llvm add(~tmp$15##0:wybe.int, 1:wybe.int, ?tmp$14##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$14##0:wybe.int)
+        foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.int)
+        foreign llvm add(~tmp#15##0:wybe.int, 1:wybe.int, ?tmp#14##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp#14##0:wybe.int)
 
 
 
-gen$3 > (4 calls)
-0: drone.gen$3<0>[6dacb8fd25]
-gen$3([ch##0:wybe.char], d##0:drone.drone_info, io##0:wybe.phantom, ?io##2:wybe.phantom):
+gen#3 > (4 calls)
+0: drone.gen#3<0>[6dacb8fd25]
+gen#3([ch##0:wybe.char], d##0:drone.drone_info, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 1]
  MultiSpeczDepInfo: [(3,(drone.loop<0>,fromList [NonAliasedParamCond 0 [1]]))]
     foreign c read_char(?ch##1:wybe.char, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm cast(-1:wybe.int, ?tmp$3##0:wybe.char) @io:nn:nn
-    foreign llvm icmp_ne(ch##1:wybe.char, ~tmp$3##0:wybe.char, ?tmp$4##0:wybe.bool) @char:nn:nn
-    case ~tmp$4##0:wybe.bool of
+    foreign lpvm cast(-1:wybe.int, ?tmp#3##0:wybe.char) @io:nn:nn
+    foreign llvm icmp_ne(ch##1:wybe.char, ~tmp#3##0:wybe.char, ?tmp#4##0:wybe.bool) @char:nn:nn
+    case ~tmp#4##0:wybe.bool of
     0:
         foreign llvm move(~io##1:wybe.phantom, ?io##2:wybe.phantom)
 
@@ -996,9 +996,9 @@ gen$3([ch##0:wybe.char], d##0:drone.drone_info, io##0:wybe.phantom, ?io##2:wybe.
 
  [6dacb8fd25] [NonAliasedParam 1] :
     foreign c read_char(?ch##1:wybe.char, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm cast(-1:wybe.int, ?tmp$3##0:wybe.char) @io:nn:nn
-    foreign llvm icmp_ne(ch##1:wybe.char, ~tmp$3##0:wybe.char, ?tmp$4##0:wybe.bool) @char:nn:nn
-    case ~tmp$4##0:wybe.bool of
+    foreign lpvm cast(-1:wybe.int, ?tmp#3##0:wybe.char) @io:nn:nn
+    foreign llvm icmp_ne(ch##1:wybe.char, ~tmp#3##0:wybe.char, ?tmp#4##0:wybe.bool) @char:nn:nn
+    case ~tmp#4##0:wybe.bool of
     0:
         foreign llvm move(~io##1:wybe.phantom, ?io##2:wybe.phantom)
 
@@ -1012,86 +1012,86 @@ loop > (2 calls)
 loop(d##0:drone.drone_info, ch##0:wybe.char, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
- MultiSpeczDepInfo: [(5,(drone.gen$3<0>,fromList [NonAliasedParamCond 1 [0]])),(6,(drone.do_action<0>,fromList [NonAliasedParamCond 0 [0]])),(10,(drone.gen$3<0>,fromList [NonAliasedParamCond 1 [0]])),(11,(drone.gen$3<0>,fromList [NonAliasedParamCond 1 [0]])),(12,(drone.gen$3<0>,fromList [NonAliasedParamCond 1 [0]]))]
-    foreign llvm icmp_ne(ch##0:wybe.char, ' ':wybe.char, ?tmp$0##0:wybe.bool) @char:nn:nn
-    foreign llvm icmp_ne(ch##0:wybe.char, '\n':wybe.char, ?tmp$1##0:wybe.bool) @char:nn:nn
-    foreign llvm and(~tmp$0##0:wybe.bool, ~tmp$1##0:wybe.bool, ?tmp$7##0:wybe.bool) @bool:nn:nn
-    case ~tmp$7##0:wybe.bool of
+ MultiSpeczDepInfo: [(5,(drone.gen#3<0>,fromList [NonAliasedParamCond 1 [0]])),(6,(drone.do_action<0>,fromList [NonAliasedParamCond 0 [0]])),(10,(drone.gen#3<0>,fromList [NonAliasedParamCond 1 [0]])),(11,(drone.gen#3<0>,fromList [NonAliasedParamCond 1 [0]])),(12,(drone.gen#3<0>,fromList [NonAliasedParamCond 1 [0]]))]
+    foreign llvm icmp_ne(ch##0:wybe.char, ' ':wybe.char, ?tmp#0##0:wybe.bool) @char:nn:nn
+    foreign llvm icmp_ne(ch##0:wybe.char, '\n':wybe.char, ?tmp#1##0:wybe.bool) @char:nn:nn
+    foreign llvm and(~tmp#0##0:wybe.bool, ~tmp#1##0:wybe.bool, ?tmp#7##0:wybe.bool) @bool:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        drone.gen$3<0>(_:wybe.char, ~d##0:drone.drone_info, ~io##0:wybe.phantom, ?io##2:wybe.phantom) #12
+        drone.gen#3<0>(_:wybe.char, ~d##0:drone.drone_info, ~io##0:wybe.phantom, ?io##2:wybe.phantom) #12
 
     1:
-        foreign llvm icmp_eq(ch##0:wybe.char, 'p':wybe.char, ?tmp$6##0:wybe.bool) @char:nn:nn
-        case ~tmp$6##0:wybe.bool of
+        foreign llvm icmp_eq(ch##0:wybe.char, 'p':wybe.char, ?tmp#6##0:wybe.bool) @char:nn:nn
+        case ~tmp#6##0:wybe.bool of
         0:
             drone.do_action<0>(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, ~ch##0:wybe.char, ?success##0:wybe.bool) #6 @drone:nn:nn
-            foreign llvm icmp_eq(~success##0:wybe.bool, 0:wybe.bool, ?tmp$5##0:wybe.bool) @bool:nn:nn
-            case ~tmp$5##0:wybe.bool of
+            foreign llvm icmp_eq(~success##0:wybe.bool, 0:wybe.bool, ?tmp#5##0:wybe.bool) @bool:nn:nn
+            case ~tmp#5##0:wybe.bool of
             0:
-                drone.gen$3<0>(_:wybe.char, ~d##1:drone.drone_info, ~io##0:wybe.phantom, ?io##2:wybe.phantom) #11
+                drone.gen#3<0>(_:wybe.char, ~d##1:drone.drone_info, ~io##0:wybe.phantom, ?io##2:wybe.phantom) #11
 
             1:
-                foreign c print_string("invalid action!":wybe.string, ~#io##0:wybe.phantom, ?tmp$20##0:wybe.phantom) @io:nn:nn
-                foreign c putchar('\n':wybe.char, ~tmp$20##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-                drone.gen$3<0>(_:wybe.char, ~d##1:drone.drone_info, ~io##1:wybe.phantom, ?io##2:wybe.phantom) #10
+                foreign c print_string("invalid action!":wybe.string, ~#io##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @io:nn:nn
+                foreign c putchar('\n':wybe.char, ~tmp#20##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+                drone.gen#3<0>(_:wybe.char, ~d##1:drone.drone_info, ~io##1:wybe.phantom, ?io##2:wybe.phantom) #10
 
 
         1:
-            foreign c print_string("(":wybe.string, ~#io##0:wybe.phantom, ?tmp$18##0:wybe.phantom) @io:nn:nn
-            foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$19##0:wybe.int)
-            foreign c print_int(~tmp$19##0:wybe.int, ~tmp$18##0:wybe.phantom, ?tmp$20##0:wybe.phantom) @io:nn:nn
-            foreign c print_string(", ":wybe.string, ~tmp$20##0:wybe.phantom, ?tmp$21##0:wybe.phantom) @io:nn:nn
-            foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$22##0:wybe.int)
-            foreign c print_int(~tmp$22##0:wybe.int, ~tmp$21##0:wybe.phantom, ?tmp$23##0:wybe.phantom) @io:nn:nn
-            foreign c print_string(", ":wybe.string, ~tmp$23##0:wybe.phantom, ?tmp$24##0:wybe.phantom) @io:nn:nn
-            foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$25##0:wybe.int)
-            foreign c print_int(~tmp$25##0:wybe.int, ~tmp$24##0:wybe.phantom, ?tmp$26##0:wybe.phantom) @io:nn:nn
-            foreign c print_string(") #":wybe.string, ~tmp$26##0:wybe.phantom, ?tmp$27##0:wybe.phantom) @io:nn:nn
-            foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$28##0:wybe.int)
-            foreign c print_int(~tmp$28##0:wybe.int, ~tmp$27##0:wybe.phantom, ?tmp$29##0:wybe.phantom) @io:nn:nn
-            foreign c putchar('\n':wybe.char, ~tmp$29##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-            drone.gen$3<0>(_:wybe.char, ~d##0:drone.drone_info, ~io##1:wybe.phantom, ?io##2:wybe.phantom) #5
+            foreign c print_string("(":wybe.string, ~#io##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @io:nn:nn
+            foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#19##0:wybe.int)
+            foreign c print_int(~tmp#19##0:wybe.int, ~tmp#18##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @io:nn:nn
+            foreign c print_string(", ":wybe.string, ~tmp#20##0:wybe.phantom, ?tmp#21##0:wybe.phantom) @io:nn:nn
+            foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#22##0:wybe.int)
+            foreign c print_int(~tmp#22##0:wybe.int, ~tmp#21##0:wybe.phantom, ?tmp#23##0:wybe.phantom) @io:nn:nn
+            foreign c print_string(", ":wybe.string, ~tmp#23##0:wybe.phantom, ?tmp#24##0:wybe.phantom) @io:nn:nn
+            foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#25##0:wybe.int)
+            foreign c print_int(~tmp#25##0:wybe.int, ~tmp#24##0:wybe.phantom, ?tmp#26##0:wybe.phantom) @io:nn:nn
+            foreign c print_string(") #":wybe.string, ~tmp#26##0:wybe.phantom, ?tmp#27##0:wybe.phantom) @io:nn:nn
+            foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#28##0:wybe.int)
+            foreign c print_int(~tmp#28##0:wybe.int, ~tmp#27##0:wybe.phantom, ?tmp#29##0:wybe.phantom) @io:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#29##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+            drone.gen#3<0>(_:wybe.char, ~d##0:drone.drone_info, ~io##1:wybe.phantom, ?io##2:wybe.phantom) #5
 
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_ne(ch##0:wybe.char, ' ':wybe.char, ?tmp$0##0:wybe.bool) @char:nn:nn
-    foreign llvm icmp_ne(ch##0:wybe.char, '\n':wybe.char, ?tmp$1##0:wybe.bool) @char:nn:nn
-    foreign llvm and(~tmp$0##0:wybe.bool, ~tmp$1##0:wybe.bool, ?tmp$7##0:wybe.bool) @bool:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign llvm icmp_ne(ch##0:wybe.char, ' ':wybe.char, ?tmp#0##0:wybe.bool) @char:nn:nn
+    foreign llvm icmp_ne(ch##0:wybe.char, '\n':wybe.char, ?tmp#1##0:wybe.bool) @char:nn:nn
+    foreign llvm and(~tmp#0##0:wybe.bool, ~tmp#1##0:wybe.bool, ?tmp#7##0:wybe.bool) @bool:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        drone.gen$3<0>[6dacb8fd25](_:wybe.char, ~d##0:drone.drone_info, ~io##0:wybe.phantom, ?io##2:wybe.phantom) #12
+        drone.gen#3<0>[6dacb8fd25](_:wybe.char, ~d##0:drone.drone_info, ~io##0:wybe.phantom, ?io##2:wybe.phantom) #12
 
     1:
-        foreign llvm icmp_eq(ch##0:wybe.char, 'p':wybe.char, ?tmp$6##0:wybe.bool) @char:nn:nn
-        case ~tmp$6##0:wybe.bool of
+        foreign llvm icmp_eq(ch##0:wybe.char, 'p':wybe.char, ?tmp#6##0:wybe.bool) @char:nn:nn
+        case ~tmp#6##0:wybe.bool of
         0:
             drone.do_action<0>[410bae77d3](~%d##0:drone.drone_info, ?%d##1:drone.drone_info, ~ch##0:wybe.char, ?success##0:wybe.bool) #6 @drone:nn:nn
-            foreign llvm icmp_eq(~success##0:wybe.bool, 0:wybe.bool, ?tmp$5##0:wybe.bool) @bool:nn:nn
-            case ~tmp$5##0:wybe.bool of
+            foreign llvm icmp_eq(~success##0:wybe.bool, 0:wybe.bool, ?tmp#5##0:wybe.bool) @bool:nn:nn
+            case ~tmp#5##0:wybe.bool of
             0:
-                drone.gen$3<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, ~io##0:wybe.phantom, ?io##2:wybe.phantom) #11
+                drone.gen#3<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, ~io##0:wybe.phantom, ?io##2:wybe.phantom) #11
 
             1:
-                foreign c print_string("invalid action!":wybe.string, ~#io##0:wybe.phantom, ?tmp$20##0:wybe.phantom) @io:nn:nn
-                foreign c putchar('\n':wybe.char, ~tmp$20##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-                drone.gen$3<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, ~io##1:wybe.phantom, ?io##2:wybe.phantom) #10
+                foreign c print_string("invalid action!":wybe.string, ~#io##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @io:nn:nn
+                foreign c putchar('\n':wybe.char, ~tmp#20##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+                drone.gen#3<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, ~io##1:wybe.phantom, ?io##2:wybe.phantom) #10
 
 
         1:
-            foreign c print_string("(":wybe.string, ~#io##0:wybe.phantom, ?tmp$18##0:wybe.phantom) @io:nn:nn
-            foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$19##0:wybe.int)
-            foreign c print_int(~tmp$19##0:wybe.int, ~tmp$18##0:wybe.phantom, ?tmp$20##0:wybe.phantom) @io:nn:nn
-            foreign c print_string(", ":wybe.string, ~tmp$20##0:wybe.phantom, ?tmp$21##0:wybe.phantom) @io:nn:nn
-            foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$22##0:wybe.int)
-            foreign c print_int(~tmp$22##0:wybe.int, ~tmp$21##0:wybe.phantom, ?tmp$23##0:wybe.phantom) @io:nn:nn
-            foreign c print_string(", ":wybe.string, ~tmp$23##0:wybe.phantom, ?tmp$24##0:wybe.phantom) @io:nn:nn
-            foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$25##0:wybe.int)
-            foreign c print_int(~tmp$25##0:wybe.int, ~tmp$24##0:wybe.phantom, ?tmp$26##0:wybe.phantom) @io:nn:nn
-            foreign c print_string(") #":wybe.string, ~tmp$26##0:wybe.phantom, ?tmp$27##0:wybe.phantom) @io:nn:nn
-            foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$28##0:wybe.int)
-            foreign c print_int(~tmp$28##0:wybe.int, ~tmp$27##0:wybe.phantom, ?tmp$29##0:wybe.phantom) @io:nn:nn
-            foreign c putchar('\n':wybe.char, ~tmp$29##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-            drone.gen$3<0>[6dacb8fd25](_:wybe.char, ~d##0:drone.drone_info, ~io##1:wybe.phantom, ?io##2:wybe.phantom) #5
+            foreign c print_string("(":wybe.string, ~#io##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @io:nn:nn
+            foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#19##0:wybe.int)
+            foreign c print_int(~tmp#19##0:wybe.int, ~tmp#18##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @io:nn:nn
+            foreign c print_string(", ":wybe.string, ~tmp#20##0:wybe.phantom, ?tmp#21##0:wybe.phantom) @io:nn:nn
+            foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#22##0:wybe.int)
+            foreign c print_int(~tmp#22##0:wybe.int, ~tmp#21##0:wybe.phantom, ?tmp#23##0:wybe.phantom) @io:nn:nn
+            foreign c print_string(", ":wybe.string, ~tmp#23##0:wybe.phantom, ?tmp#24##0:wybe.phantom) @io:nn:nn
+            foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#25##0:wybe.int)
+            foreign c print_int(~tmp#25##0:wybe.int, ~tmp#24##0:wybe.phantom, ?tmp#26##0:wybe.phantom) @io:nn:nn
+            foreign c print_string(") #":wybe.string, ~tmp#26##0:wybe.phantom, ?tmp#27##0:wybe.phantom) @io:nn:nn
+            foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#28##0:wybe.int)
+            foreign c print_int(~tmp#28##0:wybe.int, ~tmp#27##0:wybe.phantom, ?tmp#29##0:wybe.phantom) @io:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#29##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+            drone.gen#3<0>[6dacb8fd25](_:wybe.char, ~d##0:drone.drone_info, ~io##1:wybe.phantom, ?io##2:wybe.phantom) #5
 
 
 
@@ -1102,17 +1102,17 @@ print_info(d##0:drone.drone_info, io##0:wybe.phantom, ?io##9:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("(":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string(", ":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     foreign c print_string(", ":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
-    foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.int)
-    foreign c print_int(~tmp$2##0:wybe.int, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+    foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int)
+    foreign c print_int(~tmp#2##0:wybe.int, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
     foreign c print_string(") #":wybe.string, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign c print_int(~tmp$3##0:wybe.int, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign c print_int(~tmp#3##0:wybe.int, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~#io##8:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
 
   LLVM code       :
@@ -1197,27 +1197,27 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"drone.<0>"()    {
 entry:
-  %"1$tmp$0##0" = tail call fastcc  i64  @"drone.drone_init<0>"()  
-  %"1$ch##0" = tail call ccc  i8  @read_char()  
+  %"1#tmp#0##0" = tail call fastcc  i64  @"drone.drone_init<0>"()  
+  %"1#ch##0" = tail call ccc  i8  @read_char()  
   %1 = alloca i64 
   store  i64 -1, i64* %1 
   %2 = load  i64, i64* %1 
   %3 = trunc i64 %2 to i8  
-  %"1$tmp$2##0" = icmp ne i8 %"1$ch##0", %3 
-  br i1 %"1$tmp$2##0", label %if.then, label %if.else 
+  %"1#tmp#2##0" = icmp ne i8 %"1#ch##0", %3 
+  br i1 %"1#tmp#2##0", label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"drone.loop<0>[410bae77d3]"(i64  %"1$tmp$0##0", i8  %"1$ch##0")  
-  %"2$tmp$10##0" = tail call ccc  i64  @malloc_count()  
+  tail call fastcc  void  @"drone.loop<0>[410bae77d3]"(i64  %"1#tmp#0##0", i8  %"1#ch##0")  
+  %"2#tmp#10##0" = tail call ccc  i64  @malloc_count()  
   %5 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @drone.4, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %5)  
-  tail call ccc  void  @print_int(i64  %"2$tmp$10##0")  
+  tail call ccc  void  @print_int(i64  %"2#tmp#10##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else:
-  %"3$tmp$10##0" = tail call ccc  i64  @malloc_count()  
+  %"3#tmp#10##0" = tail call ccc  i64  @malloc_count()  
   %7 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @drone.6, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %7)  
-  tail call ccc  void  @print_int(i64  %"3$tmp$10##0")  
+  tail call ccc  void  @print_int(i64  %"3#tmp#10##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -1225,14 +1225,14 @@ if.else:
 
 define external fastcc  {i64, i1} @"drone.do_action<0>"(i64  %"d##0", i8  %"action##0")    {
 entry:
-  %"1$tmp$21##0" = icmp eq i8 %"action##0", 110 
-  br i1 %"1$tmp$21##0", label %if.then, label %if.else 
+  %"1#tmp#21##0" = icmp eq i8 %"action##0", 110 
+  br i1 %"1#tmp#21##0", label %if.then, label %if.else 
 if.then:
   %8 = add   i64 %"d##0", 8 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
-  %"2$tmp$1##0" = sub   i64 %11, 1 
+  %"2#tmp#1##0" = sub   i64 %11, 1 
   %12 = trunc i64 32 to i32  
   %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
   %14 = ptrtoint i8* %13 to i64 
@@ -1243,20 +1243,20 @@ if.then:
   %18 = add   i64 %14, 8 
   %19 = inttoptr i64 %18 to i64* 
   %20 = getelementptr  i64, i64* %19, i64 0 
-  store  i64 %"2$tmp$1##0", i64* %20 
-  %"2$d##2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %14, i1  1)  
-  %21 = insertvalue {i64, i1} undef, i64 %"2$d##2", 0 
+  store  i64 %"2#tmp#1##0", i64* %20 
+  %"2#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %14, i1  1)  
+  %21 = insertvalue {i64, i1} undef, i64 %"2#d##2", 0 
   %22 = insertvalue {i64, i1} %21, i1 1, 1 
   ret {i64, i1} %22 
 if.else:
-  %"3$tmp$20##0" = icmp eq i8 %"action##0", 115 
-  br i1 %"3$tmp$20##0", label %if.then1, label %if.else1 
+  %"3#tmp#20##0" = icmp eq i8 %"action##0", 115 
+  br i1 %"3#tmp#20##0", label %if.then1, label %if.else1 
 if.then1:
   %23 = add   i64 %"d##0", 8 
   %24 = inttoptr i64 %23 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
   %26 = load  i64, i64* %25 
-  %"4$tmp$3##0" = add   i64 %26, 1 
+  %"4#tmp#3##0" = add   i64 %26, 1 
   %27 = trunc i64 32 to i32  
   %28 = tail call ccc  i8*  @wybe_malloc(i32  %27)  
   %29 = ptrtoint i8* %28 to i64 
@@ -1267,19 +1267,19 @@ if.then1:
   %33 = add   i64 %29, 8 
   %34 = inttoptr i64 %33 to i64* 
   %35 = getelementptr  i64, i64* %34, i64 0 
-  store  i64 %"4$tmp$3##0", i64* %35 
-  %"4$d##2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %29, i1  1)  
-  %36 = insertvalue {i64, i1} undef, i64 %"4$d##2", 0 
+  store  i64 %"4#tmp#3##0", i64* %35 
+  %"4#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %29, i1  1)  
+  %36 = insertvalue {i64, i1} undef, i64 %"4#d##2", 0 
   %37 = insertvalue {i64, i1} %36, i1 1, 1 
   ret {i64, i1} %37 
 if.else1:
-  %"5$tmp$19##0" = icmp eq i8 %"action##0", 119 
-  br i1 %"5$tmp$19##0", label %if.then2, label %if.else2 
+  %"5#tmp#19##0" = icmp eq i8 %"action##0", 119 
+  br i1 %"5#tmp#19##0", label %if.then2, label %if.else2 
 if.then2:
   %38 = inttoptr i64 %"d##0" to i64* 
   %39 = getelementptr  i64, i64* %38, i64 0 
   %40 = load  i64, i64* %39 
-  %"6$tmp$5##0" = sub   i64 %40, 1 
+  %"6#tmp#5##0" = sub   i64 %40, 1 
   %41 = trunc i64 32 to i32  
   %42 = tail call ccc  i8*  @wybe_malloc(i32  %41)  
   %43 = ptrtoint i8* %42 to i64 
@@ -1289,19 +1289,19 @@ if.then2:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %44, i8*  %45, i32  %46, i32  8, i1  0)  
   %47 = inttoptr i64 %43 to i64* 
   %48 = getelementptr  i64, i64* %47, i64 0 
-  store  i64 %"6$tmp$5##0", i64* %48 
-  %"6$d##2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %43, i1  1)  
-  %49 = insertvalue {i64, i1} undef, i64 %"6$d##2", 0 
+  store  i64 %"6#tmp#5##0", i64* %48 
+  %"6#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %43, i1  1)  
+  %49 = insertvalue {i64, i1} undef, i64 %"6#d##2", 0 
   %50 = insertvalue {i64, i1} %49, i1 1, 1 
   ret {i64, i1} %50 
 if.else2:
-  %"7$tmp$18##0" = icmp eq i8 %"action##0", 101 
-  br i1 %"7$tmp$18##0", label %if.then3, label %if.else3 
+  %"7#tmp#18##0" = icmp eq i8 %"action##0", 101 
+  br i1 %"7#tmp#18##0", label %if.then3, label %if.else3 
 if.then3:
   %51 = inttoptr i64 %"d##0" to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
   %53 = load  i64, i64* %52 
-  %"8$tmp$7##0" = add   i64 %53, 1 
+  %"8#tmp#7##0" = add   i64 %53, 1 
   %54 = trunc i64 32 to i32  
   %55 = tail call ccc  i8*  @wybe_malloc(i32  %54)  
   %56 = ptrtoint i8* %55 to i64 
@@ -1311,20 +1311,20 @@ if.then3:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %57, i8*  %58, i32  %59, i32  8, i1  0)  
   %60 = inttoptr i64 %56 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
-  store  i64 %"8$tmp$7##0", i64* %61 
-  %"8$d##2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %56, i1  1)  
-  %62 = insertvalue {i64, i1} undef, i64 %"8$d##2", 0 
+  store  i64 %"8#tmp#7##0", i64* %61 
+  %"8#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %56, i1  1)  
+  %62 = insertvalue {i64, i1} undef, i64 %"8#d##2", 0 
   %63 = insertvalue {i64, i1} %62, i1 1, 1 
   ret {i64, i1} %63 
 if.else3:
-  %"9$tmp$17##0" = icmp eq i8 %"action##0", 117 
-  br i1 %"9$tmp$17##0", label %if.then4, label %if.else4 
+  %"9#tmp#17##0" = icmp eq i8 %"action##0", 117 
+  br i1 %"9#tmp#17##0", label %if.then4, label %if.else4 
 if.then4:
   %64 = add   i64 %"d##0", 16 
   %65 = inttoptr i64 %64 to i64* 
   %66 = getelementptr  i64, i64* %65, i64 0 
   %67 = load  i64, i64* %66 
-  %"10$tmp$9##0" = add   i64 %67, 1 
+  %"10#tmp#9##0" = add   i64 %67, 1 
   %68 = trunc i64 32 to i32  
   %69 = tail call ccc  i8*  @wybe_malloc(i32  %68)  
   %70 = ptrtoint i8* %69 to i64 
@@ -1335,20 +1335,20 @@ if.then4:
   %74 = add   i64 %70, 16 
   %75 = inttoptr i64 %74 to i64* 
   %76 = getelementptr  i64, i64* %75, i64 0 
-  store  i64 %"10$tmp$9##0", i64* %76 
-  %"10$d##2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %70, i1  1)  
-  %77 = insertvalue {i64, i1} undef, i64 %"10$d##2", 0 
+  store  i64 %"10#tmp#9##0", i64* %76 
+  %"10#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %70, i1  1)  
+  %77 = insertvalue {i64, i1} undef, i64 %"10#d##2", 0 
   %78 = insertvalue {i64, i1} %77, i1 1, 1 
   ret {i64, i1} %78 
 if.else4:
-  %"11$tmp$16##0" = icmp eq i8 %"action##0", 100 
-  br i1 %"11$tmp$16##0", label %if.then5, label %if.else5 
+  %"11#tmp#16##0" = icmp eq i8 %"action##0", 100 
+  br i1 %"11#tmp#16##0", label %if.then5, label %if.else5 
 if.then5:
   %79 = add   i64 %"d##0", 16 
   %80 = inttoptr i64 %79 to i64* 
   %81 = getelementptr  i64, i64* %80, i64 0 
   %82 = load  i64, i64* %81 
-  %"12$tmp$11##0" = sub   i64 %82, 1 
+  %"12#tmp#11##0" = sub   i64 %82, 1 
   %83 = trunc i64 32 to i32  
   %84 = tail call ccc  i8*  @wybe_malloc(i32  %83)  
   %85 = ptrtoint i8* %84 to i64 
@@ -1359,14 +1359,14 @@ if.then5:
   %89 = add   i64 %85, 16 
   %90 = inttoptr i64 %89 to i64* 
   %91 = getelementptr  i64, i64* %90, i64 0 
-  store  i64 %"12$tmp$11##0", i64* %91 
-  %"12$d##2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %85, i1  1)  
-  %92 = insertvalue {i64, i1} undef, i64 %"12$d##2", 0 
+  store  i64 %"12#tmp#11##0", i64* %91 
+  %"12#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %85, i1  1)  
+  %92 = insertvalue {i64, i1} undef, i64 %"12#d##2", 0 
   %93 = insertvalue {i64, i1} %92, i1 1, 1 
   ret {i64, i1} %93 
 if.else5:
-  %"13$d##2" = tail call fastcc  i64  @"drone.gen$2<0>"(i64  %"d##0", i1  0)  
-  %94 = insertvalue {i64, i1} undef, i64 %"13$d##2", 0 
+  %"13#d##2" = tail call fastcc  i64  @"drone.gen#2<0>"(i64  %"d##0", i1  0)  
+  %94 = insertvalue {i64, i1} undef, i64 %"13#d##2", 0 
   %95 = insertvalue {i64, i1} %94, i1 0, 1 
   ret {i64, i1} %95 
 }
@@ -1374,106 +1374,106 @@ if.else5:
 
 define external fastcc  {i64, i1} @"drone.do_action<0>[410bae77d3]"(i64  %"d##0", i8  %"action##0")    {
 entry:
-  %"1$tmp$21##0" = icmp eq i8 %"action##0", 110 
-  br i1 %"1$tmp$21##0", label %if.then, label %if.else 
+  %"1#tmp#21##0" = icmp eq i8 %"action##0", 110 
+  br i1 %"1#tmp#21##0", label %if.then, label %if.else 
 if.then:
   %96 = add   i64 %"d##0", 8 
   %97 = inttoptr i64 %96 to i64* 
   %98 = getelementptr  i64, i64* %97, i64 0 
   %99 = load  i64, i64* %98 
-  %"2$tmp$1##0" = sub   i64 %99, 1 
+  %"2#tmp#1##0" = sub   i64 %99, 1 
   %100 = add   i64 %"d##0", 8 
   %101 = inttoptr i64 %100 to i64* 
   %102 = getelementptr  i64, i64* %101, i64 0 
-  store  i64 %"2$tmp$1##0", i64* %102 
-  %"2$d##2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
-  %103 = insertvalue {i64, i1} undef, i64 %"2$d##2", 0 
+  store  i64 %"2#tmp#1##0", i64* %102 
+  %"2#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
+  %103 = insertvalue {i64, i1} undef, i64 %"2#d##2", 0 
   %104 = insertvalue {i64, i1} %103, i1 1, 1 
   ret {i64, i1} %104 
 if.else:
-  %"3$tmp$20##0" = icmp eq i8 %"action##0", 115 
-  br i1 %"3$tmp$20##0", label %if.then1, label %if.else1 
+  %"3#tmp#20##0" = icmp eq i8 %"action##0", 115 
+  br i1 %"3#tmp#20##0", label %if.then1, label %if.else1 
 if.then1:
   %105 = add   i64 %"d##0", 8 
   %106 = inttoptr i64 %105 to i64* 
   %107 = getelementptr  i64, i64* %106, i64 0 
   %108 = load  i64, i64* %107 
-  %"4$tmp$3##0" = add   i64 %108, 1 
+  %"4#tmp#3##0" = add   i64 %108, 1 
   %109 = add   i64 %"d##0", 8 
   %110 = inttoptr i64 %109 to i64* 
   %111 = getelementptr  i64, i64* %110, i64 0 
-  store  i64 %"4$tmp$3##0", i64* %111 
-  %"4$d##2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
-  %112 = insertvalue {i64, i1} undef, i64 %"4$d##2", 0 
+  store  i64 %"4#tmp#3##0", i64* %111 
+  %"4#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
+  %112 = insertvalue {i64, i1} undef, i64 %"4#d##2", 0 
   %113 = insertvalue {i64, i1} %112, i1 1, 1 
   ret {i64, i1} %113 
 if.else1:
-  %"5$tmp$19##0" = icmp eq i8 %"action##0", 119 
-  br i1 %"5$tmp$19##0", label %if.then2, label %if.else2 
+  %"5#tmp#19##0" = icmp eq i8 %"action##0", 119 
+  br i1 %"5#tmp#19##0", label %if.then2, label %if.else2 
 if.then2:
   %114 = inttoptr i64 %"d##0" to i64* 
   %115 = getelementptr  i64, i64* %114, i64 0 
   %116 = load  i64, i64* %115 
-  %"6$tmp$5##0" = sub   i64 %116, 1 
+  %"6#tmp#5##0" = sub   i64 %116, 1 
   %117 = inttoptr i64 %"d##0" to i64* 
   %118 = getelementptr  i64, i64* %117, i64 0 
-  store  i64 %"6$tmp$5##0", i64* %118 
-  %"6$d##2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
-  %119 = insertvalue {i64, i1} undef, i64 %"6$d##2", 0 
+  store  i64 %"6#tmp#5##0", i64* %118 
+  %"6#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
+  %119 = insertvalue {i64, i1} undef, i64 %"6#d##2", 0 
   %120 = insertvalue {i64, i1} %119, i1 1, 1 
   ret {i64, i1} %120 
 if.else2:
-  %"7$tmp$18##0" = icmp eq i8 %"action##0", 101 
-  br i1 %"7$tmp$18##0", label %if.then3, label %if.else3 
+  %"7#tmp#18##0" = icmp eq i8 %"action##0", 101 
+  br i1 %"7#tmp#18##0", label %if.then3, label %if.else3 
 if.then3:
   %121 = inttoptr i64 %"d##0" to i64* 
   %122 = getelementptr  i64, i64* %121, i64 0 
   %123 = load  i64, i64* %122 
-  %"8$tmp$7##0" = add   i64 %123, 1 
+  %"8#tmp#7##0" = add   i64 %123, 1 
   %124 = inttoptr i64 %"d##0" to i64* 
   %125 = getelementptr  i64, i64* %124, i64 0 
-  store  i64 %"8$tmp$7##0", i64* %125 
-  %"8$d##2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
-  %126 = insertvalue {i64, i1} undef, i64 %"8$d##2", 0 
+  store  i64 %"8#tmp#7##0", i64* %125 
+  %"8#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
+  %126 = insertvalue {i64, i1} undef, i64 %"8#d##2", 0 
   %127 = insertvalue {i64, i1} %126, i1 1, 1 
   ret {i64, i1} %127 
 if.else3:
-  %"9$tmp$17##0" = icmp eq i8 %"action##0", 117 
-  br i1 %"9$tmp$17##0", label %if.then4, label %if.else4 
+  %"9#tmp#17##0" = icmp eq i8 %"action##0", 117 
+  br i1 %"9#tmp#17##0", label %if.then4, label %if.else4 
 if.then4:
   %128 = add   i64 %"d##0", 16 
   %129 = inttoptr i64 %128 to i64* 
   %130 = getelementptr  i64, i64* %129, i64 0 
   %131 = load  i64, i64* %130 
-  %"10$tmp$9##0" = add   i64 %131, 1 
+  %"10#tmp#9##0" = add   i64 %131, 1 
   %132 = add   i64 %"d##0", 16 
   %133 = inttoptr i64 %132 to i64* 
   %134 = getelementptr  i64, i64* %133, i64 0 
-  store  i64 %"10$tmp$9##0", i64* %134 
-  %"10$d##2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
-  %135 = insertvalue {i64, i1} undef, i64 %"10$d##2", 0 
+  store  i64 %"10#tmp#9##0", i64* %134 
+  %"10#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
+  %135 = insertvalue {i64, i1} undef, i64 %"10#d##2", 0 
   %136 = insertvalue {i64, i1} %135, i1 1, 1 
   ret {i64, i1} %136 
 if.else4:
-  %"11$tmp$16##0" = icmp eq i8 %"action##0", 100 
-  br i1 %"11$tmp$16##0", label %if.then5, label %if.else5 
+  %"11#tmp#16##0" = icmp eq i8 %"action##0", 100 
+  br i1 %"11#tmp#16##0", label %if.then5, label %if.else5 
 if.then5:
   %137 = add   i64 %"d##0", 16 
   %138 = inttoptr i64 %137 to i64* 
   %139 = getelementptr  i64, i64* %138, i64 0 
   %140 = load  i64, i64* %139 
-  %"12$tmp$11##0" = sub   i64 %140, 1 
+  %"12#tmp#11##0" = sub   i64 %140, 1 
   %141 = add   i64 %"d##0", 16 
   %142 = inttoptr i64 %141 to i64* 
   %143 = getelementptr  i64, i64* %142, i64 0 
-  store  i64 %"12$tmp$11##0", i64* %143 
-  %"12$d##2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
-  %144 = insertvalue {i64, i1} undef, i64 %"12$d##2", 0 
+  store  i64 %"12#tmp#11##0", i64* %143 
+  %"12#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
+  %144 = insertvalue {i64, i1} undef, i64 %"12#d##2", 0 
   %145 = insertvalue {i64, i1} %144, i1 1, 1 
   ret {i64, i1} %145 
 if.else5:
-  %"13$d##2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %"d##0", i1  0)  
-  %146 = insertvalue {i64, i1} undef, i64 %"13$d##2", 0 
+  %"13#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  0)  
+  %146 = insertvalue {i64, i1} undef, i64 %"13#d##2", 0 
   %147 = insertvalue {i64, i1} %146, i1 0, 1 
   ret {i64, i1} %147 
 }
@@ -1503,18 +1503,18 @@ entry:
 }
 
 
-define external fastcc  void @"drone.gen$1<0>"()    {
+define external fastcc  void @"drone.gen#1<0>"()    {
 entry:
-  %"1$mc##0" = tail call ccc  i64  @malloc_count()  
+  %"1#mc##0" = tail call ccc  i64  @malloc_count()  
   %163 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @drone.162, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %163)  
-  tail call ccc  void  @print_int(i64  %"1$mc##0")  
+  tail call ccc  void  @print_int(i64  %"1#mc##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  i64 @"drone.gen$2<0>"(i64  %"d##0", i1  %"success##0")    {
+define external fastcc  i64 @"drone.gen#2<0>"(i64  %"d##0", i1  %"success##0")    {
 entry:
   br i1 %"success##0", label %if.then, label %if.else 
 if.then:
@@ -1522,7 +1522,7 @@ if.then:
   %165 = inttoptr i64 %164 to i64* 
   %166 = getelementptr  i64, i64* %165, i64 0 
   %167 = load  i64, i64* %166 
-  %"2$tmp$14##0" = add   i64 %167, 1 
+  %"2#tmp#14##0" = add   i64 %167, 1 
   %168 = trunc i64 32 to i32  
   %169 = tail call ccc  i8*  @wybe_malloc(i32  %168)  
   %170 = ptrtoint i8* %169 to i64 
@@ -1533,14 +1533,14 @@ if.then:
   %174 = add   i64 %170, 24 
   %175 = inttoptr i64 %174 to i64* 
   %176 = getelementptr  i64, i64* %175, i64 0 
-  store  i64 %"2$tmp$14##0", i64* %176 
+  store  i64 %"2#tmp#14##0", i64* %176 
   ret i64 %170 
 if.else:
   ret i64 %"d##0" 
 }
 
 
-define external fastcc  i64 @"drone.gen$2<0>[6dacb8fd25]"(i64  %"d##0", i1  %"success##0")    {
+define external fastcc  i64 @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  %"success##0")    {
 entry:
   br i1 %"success##0", label %if.then, label %if.else 
 if.then:
@@ -1548,45 +1548,45 @@ if.then:
   %178 = inttoptr i64 %177 to i64* 
   %179 = getelementptr  i64, i64* %178, i64 0 
   %180 = load  i64, i64* %179 
-  %"2$tmp$14##0" = add   i64 %180, 1 
+  %"2#tmp#14##0" = add   i64 %180, 1 
   %181 = add   i64 %"d##0", 24 
   %182 = inttoptr i64 %181 to i64* 
   %183 = getelementptr  i64, i64* %182, i64 0 
-  store  i64 %"2$tmp$14##0", i64* %183 
+  store  i64 %"2#tmp#14##0", i64* %183 
   ret i64 %"d##0" 
 if.else:
   ret i64 %"d##0" 
 }
 
 
-define external fastcc  void @"drone.gen$3<0>"(i64  %"d##0")    {
+define external fastcc  void @"drone.gen#3<0>"(i64  %"d##0")    {
 entry:
-  %"1$ch##1" = tail call ccc  i8  @read_char()  
+  %"1#ch##1" = tail call ccc  i8  @read_char()  
   %184 = alloca i64 
   store  i64 -1, i64* %184 
   %185 = load  i64, i64* %184 
   %186 = trunc i64 %185 to i8  
-  %"1$tmp$4##0" = icmp ne i8 %"1$ch##1", %186 
-  br i1 %"1$tmp$4##0", label %if.then, label %if.else 
+  %"1#tmp#4##0" = icmp ne i8 %"1#ch##1", %186 
+  br i1 %"1#tmp#4##0", label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"drone.loop<0>"(i64  %"d##0", i8  %"1$ch##1")  
+  tail call fastcc  void  @"drone.loop<0>"(i64  %"d##0", i8  %"1#ch##1")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"drone.gen$3<0>[6dacb8fd25]"(i64  %"d##0")    {
+define external fastcc  void @"drone.gen#3<0>[6dacb8fd25]"(i64  %"d##0")    {
 entry:
-  %"1$ch##1" = tail call ccc  i8  @read_char()  
+  %"1#ch##1" = tail call ccc  i8  @read_char()  
   %187 = alloca i64 
   store  i64 -1, i64* %187 
   %188 = load  i64, i64* %187 
   %189 = trunc i64 %188 to i8  
-  %"1$tmp$4##0" = icmp ne i8 %"1$ch##1", %189 
-  br i1 %"1$tmp$4##0", label %if.then, label %if.else 
+  %"1#tmp#4##0" = icmp ne i8 %"1#ch##1", %189 
+  br i1 %"1#tmp#4##0", label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"drone.loop<0>[410bae77d3]"(i64  %"d##0", i8  %"1$ch##1")  
+  tail call fastcc  void  @"drone.loop<0>[410bae77d3]"(i64  %"d##0", i8  %"1#ch##1")  
   ret void 
 if.else:
   ret void 
@@ -1595,15 +1595,15 @@ if.else:
 
 define external fastcc  void @"drone.loop<0>"(i64  %"d##0", i8  %"ch##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i8 %"ch##0", 32 
-  %"1$tmp$1##0" = icmp ne i8 %"ch##0", 10 
-  %"1$tmp$7##0" = and i1 %"1$tmp$0##0", %"1$tmp$1##0" 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i8 %"ch##0", 32 
+  %"1#tmp#1##0" = icmp ne i8 %"ch##0", 10 
+  %"1#tmp#7##0" = and i1 %"1#tmp#0##0", %"1#tmp#1##0" 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$6##0" = icmp eq i8 %"ch##0", 112 
-  br i1 %"2$tmp$6##0", label %if.then1, label %if.else1 
+  %"2#tmp#6##0" = icmp eq i8 %"ch##0", 112 
+  br i1 %"2#tmp#6##0", label %if.then1, label %if.else1 
 if.else:
-  tail call fastcc  void  @"drone.gen$3<0>"(i64  %"d##0")  
+  tail call fastcc  void  @"drone.gen#3<0>"(i64  %"d##0")  
   ret void 
 if.then1:
   %191 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @drone.190, i32 0, i32 0) to i64 
@@ -1634,37 +1634,37 @@ if.then1:
   %212 = load  i64, i64* %211 
   tail call ccc  void  @print_int(i64  %212)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"drone.gen$3<0>"(i64  %"d##0")  
+  tail call fastcc  void  @"drone.gen#3<0>"(i64  %"d##0")  
   ret void 
 if.else1:
   %213 = tail call fastcc  {i64, i1}  @"drone.do_action<0>"(i64  %"d##0", i8  %"ch##0")  
   %214 = extractvalue {i64, i1} %213, 0 
   %215 = extractvalue {i64, i1} %213, 1 
-  %"5$tmp$5##0" = icmp eq i1 %215, 0 
-  br i1 %"5$tmp$5##0", label %if.then2, label %if.else2 
+  %"5#tmp#5##0" = icmp eq i1 %215, 0 
+  br i1 %"5#tmp#5##0", label %if.then2, label %if.else2 
 if.then2:
   %217 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @drone.216, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %217)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"drone.gen$3<0>"(i64  %214)  
+  tail call fastcc  void  @"drone.gen#3<0>"(i64  %214)  
   ret void 
 if.else2:
-  tail call fastcc  void  @"drone.gen$3<0>"(i64  %214)  
+  tail call fastcc  void  @"drone.gen#3<0>"(i64  %214)  
   ret void 
 }
 
 
 define external fastcc  void @"drone.loop<0>[410bae77d3]"(i64  %"d##0", i8  %"ch##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i8 %"ch##0", 32 
-  %"1$tmp$1##0" = icmp ne i8 %"ch##0", 10 
-  %"1$tmp$7##0" = and i1 %"1$tmp$0##0", %"1$tmp$1##0" 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i8 %"ch##0", 32 
+  %"1#tmp#1##0" = icmp ne i8 %"ch##0", 10 
+  %"1#tmp#7##0" = and i1 %"1#tmp#0##0", %"1#tmp#1##0" 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$6##0" = icmp eq i8 %"ch##0", 112 
-  br i1 %"2$tmp$6##0", label %if.then1, label %if.else1 
+  %"2#tmp#6##0" = icmp eq i8 %"ch##0", 112 
+  br i1 %"2#tmp#6##0", label %if.then1, label %if.else1 
 if.else:
-  tail call fastcc  void  @"drone.gen$3<0>[6dacb8fd25]"(i64  %"d##0")  
+  tail call fastcc  void  @"drone.gen#3<0>[6dacb8fd25]"(i64  %"d##0")  
   ret void 
 if.then1:
   %219 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @drone.218, i32 0, i32 0) to i64 
@@ -1695,22 +1695,22 @@ if.then1:
   %240 = load  i64, i64* %239 
   tail call ccc  void  @print_int(i64  %240)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"drone.gen$3<0>[6dacb8fd25]"(i64  %"d##0")  
+  tail call fastcc  void  @"drone.gen#3<0>[6dacb8fd25]"(i64  %"d##0")  
   ret void 
 if.else1:
   %241 = tail call fastcc  {i64, i1}  @"drone.do_action<0>[410bae77d3]"(i64  %"d##0", i8  %"ch##0")  
   %242 = extractvalue {i64, i1} %241, 0 
   %243 = extractvalue {i64, i1} %241, 1 
-  %"5$tmp$5##0" = icmp eq i1 %243, 0 
-  br i1 %"5$tmp$5##0", label %if.then2, label %if.else2 
+  %"5#tmp#5##0" = icmp eq i1 %243, 0 
+  br i1 %"5#tmp#5##0", label %if.then2, label %if.else2 
 if.then2:
   %245 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @drone.244, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %245)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"drone.gen$3<0>[6dacb8fd25]"(i64  %242)  
+  tail call fastcc  void  @"drone.gen#3<0>[6dacb8fd25]"(i64  %242)  
   ret void 
 if.else2:
-  tail call fastcc  void  @"drone.gen$3<0>[6dacb8fd25]"(i64  %242)  
+  tail call fastcc  void  @"drone.gen#3<0>[6dacb8fd25]"(i64  %242)  
   ret void 
 }
 
@@ -1771,36 +1771,36 @@ entry:
 
 = > public {inline} (1 calls)
 0: drone.drone_info.=<0>
-=($left##0:drone.drone_info, $right##0:drone.drone_info, ?$$##0:wybe.bool):
+=(#left##0:drone.drone_info, #right##0:drone.drone_info, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
-    foreign lpvm access($left##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
-    foreign lpvm access($left##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$z##0:wybe.int)
-    foreign lpvm access(~$left##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$count##0:wybe.int)
-    foreign lpvm access($right##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
-    foreign lpvm access($right##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
-    foreign lpvm access($right##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$z##0:wybe.int)
-    foreign lpvm access(~$right##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$count##0:wybe.int)
-    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
+    foreign lpvm access(#left##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
+    foreign lpvm access(#left##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#z##0:wybe.int)
+    foreign lpvm access(~#left##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#count##0:wybe.int)
+    foreign lpvm access(#right##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
+    foreign lpvm access(#right##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign lpvm access(#right##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#z##0:wybe.int)
+    foreign lpvm access(~#right##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#count##0:wybe.int)
+    foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?tmp$2##0:wybe.bool) @int:nn:nn
-        case ~tmp$2##0:wybe.bool of
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?tmp#2##0:wybe.bool) @int:nn:nn
+        case ~tmp#2##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~$left$z##0:wybe.int, ~$right$z##0:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
-            case ~tmp$3##0:wybe.bool of
+            foreign llvm icmp_eq(~#left#z##0:wybe.int, ~#right#z##0:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
+            case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
             1:
-                foreign llvm icmp_eq(~$left$count##0:wybe.int, ~$right$count##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+                foreign llvm icmp_eq(~#left#count##0:wybe.int, ~#right#count##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
@@ -1808,117 +1808,117 @@ entry:
 
 count > public {inline} (0 calls)
 0: drone.drone_info.count<0>
-count($rec##0:drone.drone_info, ?$##0:wybe.int):
+count(#rec##0:drone.drone_info, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:wybe.int)
 count > public {inline} (0 calls)
 1: drone.drone_info.count<1>
-count($rec##0:drone.drone_info, ?$rec##1:drone.drone_info, $field##0:wybe.int):
+count(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:drone.drone_info, ?$rec##1:drone.drone_info, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 drone_info > public {inline} (0 calls)
 0: drone.drone_info.drone_info<0>
-drone_info(x##0:wybe.int, y##0:wybe.int, z##0:wybe.int, count##0:wybe.int, ?$##0:drone.drone_info):
+drone_info(x##0:wybe.int, y##0:wybe.int, z##0:wybe.int, count##0:wybe.int, ?###0:drone.drone_info):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(32:wybe.int, ?$rec##0:drone.drone_info)
-    foreign lpvm mutate(~$rec##0:drone.drone_info, ?$rec##1:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:drone.drone_info, ?$rec##2:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~y##0:wybe.int)
-    foreign lpvm mutate(~$rec##2:drone.drone_info, ?$rec##3:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~z##0:wybe.int)
-    foreign lpvm mutate(~$rec##3:drone.drone_info, ?$##0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~count##0:wybe.int)
+    foreign lpvm alloc(32:wybe.int, ?#rec##0:drone.drone_info)
+    foreign lpvm mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:drone.drone_info, ?#rec##2:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~#rec##2:drone.drone_info, ?#rec##3:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~z##0:wybe.int)
+    foreign lpvm mutate(~#rec##3:drone.drone_info, ?###0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~count##0:wybe.int)
 drone_info > public {inline} (14 calls)
 1: drone.drone_info.drone_info<1>
-drone_info(?x##0:wybe.int, ?y##0:wybe.int, ?z##0:wybe.int, ?count##0:wybe.int, $##0:drone.drone_info):
+drone_info(?x##0:wybe.int, ?y##0:wybe.int, ?z##0:wybe.int, ?count##0:wybe.int, ###0:drone.drone_info):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access($##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?y##0:wybe.int)
-    foreign lpvm access($##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?z##0:wybe.int)
-    foreign lpvm access(~$##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?count##0:wybe.int)
+    foreign lpvm access(###0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(###0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(###0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?z##0:wybe.int)
+    foreign lpvm access(~###0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?count##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: drone.drone_info.x<0>
-x($rec##0:drone.drone_info, ?$##0:wybe.int):
+x(#rec##0:drone.drone_info, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:wybe.int)
 x > public {inline} (0 calls)
 1: drone.drone_info.x<1>
-x($rec##0:drone.drone_info, ?$rec##1:drone.drone_info, $field##0:wybe.int):
+x(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:drone.drone_info, ?$rec##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: drone.drone_info.y<0>
-y($rec##0:drone.drone_info, ?$##0:wybe.int):
+y(#rec##0:drone.drone_info, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:wybe.int)
 y > public {inline} (0 calls)
 1: drone.drone_info.y<1>
-y($rec##0:drone.drone_info, ?$rec##1:drone.drone_info, $field##0:wybe.int):
+y(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:drone.drone_info, ?$rec##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 z > public {inline} (0 calls)
 0: drone.drone_info.z<0>
-z($rec##0:drone.drone_info, ?$##0:wybe.int):
+z(#rec##0:drone.drone_info, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:wybe.int)
 z > public {inline} (0 calls)
 1: drone.drone_info.z<1>
-z($rec##0:drone.drone_info, ?$rec##1:drone.drone_info, $field##0:wybe.int):
+z(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:drone.drone_info, ?$rec##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: drone.drone_info.~=<0>
-~=($left##0:drone.drone_info, $right##0:drone.drone_info, ?$$##0:wybe.bool):
+~=(#left##0:drone.drone_info, #right##0:drone.drone_info, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access($left##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($left##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$left##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign lpvm access($right##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.int)
-    foreign lpvm access($right##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
-    foreign lpvm access($right##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.int)
-    foreign lpvm access(~$right##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$7##0:wybe.int, ?tmp$11##0:wybe.bool) @int:nn:nn
-    case ~tmp$11##0:wybe.bool of
+    foreign lpvm access(#left##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(#left##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#left##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#left##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#right##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int)
+    foreign lpvm access(#right##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
+    foreign lpvm access(#right##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
+    foreign lpvm access(~#right##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#7##0:wybe.int, ?tmp#11##0:wybe.bool) @int:nn:nn
+    case ~tmp#11##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$8##0:wybe.int, ?tmp$12##0:wybe.bool) @int:nn:nn
-        case ~tmp$12##0:wybe.bool of
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#8##0:wybe.int, ?tmp#12##0:wybe.bool) @int:nn:nn
+        case ~tmp#12##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~tmp$5##0:wybe.int, ~tmp$9##0:wybe.int, ?tmp$13##0:wybe.bool) @int:nn:nn
-            case ~tmp$13##0:wybe.bool of
+            foreign llvm icmp_eq(~tmp#5##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#13##0:wybe.bool) @int:nn:nn
+            case ~tmp#13##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-                foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+                foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
             1:
-                foreign llvm icmp_eq(~tmp$10##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-                foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm icmp_eq(~tmp#10##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+                foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
 
@@ -1937,61 +1937,61 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"drone.drone_info.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"drone.drone_info.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = add   i64 %"$left##0", 16 
+  %8 = add   i64 %"#left##0", 16 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
-  %12 = add   i64 %"$left##0", 24 
+  %12 = add   i64 %"#left##0", 24 
   %13 = inttoptr i64 %12 to i64* 
   %14 = getelementptr  i64, i64* %13, i64 0 
   %15 = load  i64, i64* %14 
-  %16 = inttoptr i64 %"$right##0" to i64* 
+  %16 = inttoptr i64 %"#right##0" to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
-  %19 = add   i64 %"$right##0", 8 
+  %19 = add   i64 %"#right##0", 8 
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %23 = add   i64 %"$right##0", 16 
+  %23 = add   i64 %"#right##0", 16 
   %24 = inttoptr i64 %23 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
   %26 = load  i64, i64* %25 
-  %27 = add   i64 %"$right##0", 24 
+  %27 = add   i64 %"#right##0", 24 
   %28 = inttoptr i64 %27 to i64* 
   %29 = getelementptr  i64, i64* %28, i64 0 
   %30 = load  i64, i64* %29 
-  %"1$tmp$1##0" = icmp eq i64 %3, %18 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %18 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = icmp eq i64 %7, %22 
-  br i1 %"2$tmp$2##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = icmp eq i64 %7, %22 
+  br i1 %"2#tmp#2##0", label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %"4$tmp$3##0" = icmp eq i64 %11, %26 
-  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
+  %"4#tmp#3##0" = icmp eq i64 %11, %26 
+  br i1 %"4#tmp#3##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$$$##0" = icmp eq i64 %15, %30 
-  ret i1 %"6$$$##0" 
+  %"6#####0" = icmp eq i64 %15, %30 
+  ret i1 %"6#####0" 
 if.else2:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"drone.drone_info.count<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"drone.drone_info.count<0>"(i64  %"#rec##0")    {
 entry:
-  %31 = add   i64 %"$rec##0", 24 
+  %31 = add   i64 %"#rec##0", 24 
   %32 = inttoptr i64 %31 to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
@@ -1999,19 +1999,19 @@ entry:
 }
 
 
-define external fastcc  i64 @"drone.drone_info.count<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"drone.drone_info.count<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %35 = trunc i64 32 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec##0" to i8* 
+  %39 = inttoptr i64 %"#rec##0" to i8* 
   %40 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = add   i64 %37, 24 
   %42 = inttoptr i64 %41 to i64* 
   %43 = getelementptr  i64, i64* %42, i64 0 
-  store  i64 %"$field##0", i64* %43 
+  store  i64 %"#field##0", i64* %43 
   ret i64 %37 
 }
 
@@ -2040,20 +2040,20 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64, i64} @"drone.drone_info.drone_info<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64, i64, i64} @"drone.drone_info.drone_info<1>"(i64  %"###0")    {
 entry:
-  %58 = inttoptr i64 %"$##0" to i64* 
+  %58 = inttoptr i64 %"###0" to i64* 
   %59 = getelementptr  i64, i64* %58, i64 0 
   %60 = load  i64, i64* %59 
-  %61 = add   i64 %"$##0", 8 
+  %61 = add   i64 %"###0", 8 
   %62 = inttoptr i64 %61 to i64* 
   %63 = getelementptr  i64, i64* %62, i64 0 
   %64 = load  i64, i64* %63 
-  %65 = add   i64 %"$##0", 16 
+  %65 = add   i64 %"###0", 16 
   %66 = inttoptr i64 %65 to i64* 
   %67 = getelementptr  i64, i64* %66, i64 0 
   %68 = load  i64, i64* %67 
-  %69 = add   i64 %"$##0", 24 
+  %69 = add   i64 %"###0", 24 
   %70 = inttoptr i64 %69 to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
   %72 = load  i64, i64* %71 
@@ -2065,34 +2065,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"drone.drone_info.x<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"drone.drone_info.x<0>"(i64  %"#rec##0")    {
 entry:
-  %77 = inttoptr i64 %"$rec##0" to i64* 
+  %77 = inttoptr i64 %"#rec##0" to i64* 
   %78 = getelementptr  i64, i64* %77, i64 0 
   %79 = load  i64, i64* %78 
   ret i64 %79 
 }
 
 
-define external fastcc  i64 @"drone.drone_info.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"drone.drone_info.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %80 = trunc i64 32 to i32  
   %81 = tail call ccc  i8*  @wybe_malloc(i32  %80)  
   %82 = ptrtoint i8* %81 to i64 
   %83 = inttoptr i64 %82 to i8* 
-  %84 = inttoptr i64 %"$rec##0" to i8* 
+  %84 = inttoptr i64 %"#rec##0" to i8* 
   %85 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %83, i8*  %84, i32  %85, i32  8, i1  0)  
   %86 = inttoptr i64 %82 to i64* 
   %87 = getelementptr  i64, i64* %86, i64 0 
-  store  i64 %"$field##0", i64* %87 
+  store  i64 %"#field##0", i64* %87 
   ret i64 %82 
 }
 
 
-define external fastcc  i64 @"drone.drone_info.y<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"drone.drone_info.y<0>"(i64  %"#rec##0")    {
 entry:
-  %88 = add   i64 %"$rec##0", 8 
+  %88 = add   i64 %"#rec##0", 8 
   %89 = inttoptr i64 %88 to i64* 
   %90 = getelementptr  i64, i64* %89, i64 0 
   %91 = load  i64, i64* %90 
@@ -2100,26 +2100,26 @@ entry:
 }
 
 
-define external fastcc  i64 @"drone.drone_info.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"drone.drone_info.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %92 = trunc i64 32 to i32  
   %93 = tail call ccc  i8*  @wybe_malloc(i32  %92)  
   %94 = ptrtoint i8* %93 to i64 
   %95 = inttoptr i64 %94 to i8* 
-  %96 = inttoptr i64 %"$rec##0" to i8* 
+  %96 = inttoptr i64 %"#rec##0" to i8* 
   %97 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %95, i8*  %96, i32  %97, i32  8, i1  0)  
   %98 = add   i64 %94, 8 
   %99 = inttoptr i64 %98 to i64* 
   %100 = getelementptr  i64, i64* %99, i64 0 
-  store  i64 %"$field##0", i64* %100 
+  store  i64 %"#field##0", i64* %100 
   ret i64 %94 
 }
 
 
-define external fastcc  i64 @"drone.drone_info.z<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"drone.drone_info.z<0>"(i64  %"#rec##0")    {
 entry:
-  %101 = add   i64 %"$rec##0", 16 
+  %101 = add   i64 %"#rec##0", 16 
   %102 = inttoptr i64 %101 to i64* 
   %103 = getelementptr  i64, i64* %102, i64 0 
   %104 = load  i64, i64* %103 
@@ -2127,76 +2127,76 @@ entry:
 }
 
 
-define external fastcc  i64 @"drone.drone_info.z<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"drone.drone_info.z<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %105 = trunc i64 32 to i32  
   %106 = tail call ccc  i8*  @wybe_malloc(i32  %105)  
   %107 = ptrtoint i8* %106 to i64 
   %108 = inttoptr i64 %107 to i8* 
-  %109 = inttoptr i64 %"$rec##0" to i8* 
+  %109 = inttoptr i64 %"#rec##0" to i8* 
   %110 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %108, i8*  %109, i32  %110, i32  8, i1  0)  
   %111 = add   i64 %107, 16 
   %112 = inttoptr i64 %111 to i64* 
   %113 = getelementptr  i64, i64* %112, i64 0 
-  store  i64 %"$field##0", i64* %113 
+  store  i64 %"#field##0", i64* %113 
   ret i64 %107 
 }
 
 
-define external fastcc  i1 @"drone.drone_info.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"drone.drone_info.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %114 = inttoptr i64 %"$left##0" to i64* 
+  %114 = inttoptr i64 %"#left##0" to i64* 
   %115 = getelementptr  i64, i64* %114, i64 0 
   %116 = load  i64, i64* %115 
-  %117 = add   i64 %"$left##0", 8 
+  %117 = add   i64 %"#left##0", 8 
   %118 = inttoptr i64 %117 to i64* 
   %119 = getelementptr  i64, i64* %118, i64 0 
   %120 = load  i64, i64* %119 
-  %121 = add   i64 %"$left##0", 16 
+  %121 = add   i64 %"#left##0", 16 
   %122 = inttoptr i64 %121 to i64* 
   %123 = getelementptr  i64, i64* %122, i64 0 
   %124 = load  i64, i64* %123 
-  %125 = add   i64 %"$left##0", 24 
+  %125 = add   i64 %"#left##0", 24 
   %126 = inttoptr i64 %125 to i64* 
   %127 = getelementptr  i64, i64* %126, i64 0 
   %128 = load  i64, i64* %127 
-  %129 = inttoptr i64 %"$right##0" to i64* 
+  %129 = inttoptr i64 %"#right##0" to i64* 
   %130 = getelementptr  i64, i64* %129, i64 0 
   %131 = load  i64, i64* %130 
-  %132 = add   i64 %"$right##0", 8 
+  %132 = add   i64 %"#right##0", 8 
   %133 = inttoptr i64 %132 to i64* 
   %134 = getelementptr  i64, i64* %133, i64 0 
   %135 = load  i64, i64* %134 
-  %136 = add   i64 %"$right##0", 16 
+  %136 = add   i64 %"#right##0", 16 
   %137 = inttoptr i64 %136 to i64* 
   %138 = getelementptr  i64, i64* %137, i64 0 
   %139 = load  i64, i64* %138 
-  %140 = add   i64 %"$right##0", 24 
+  %140 = add   i64 %"#right##0", 24 
   %141 = inttoptr i64 %140 to i64* 
   %142 = getelementptr  i64, i64* %141, i64 0 
   %143 = load  i64, i64* %142 
-  %"1$tmp$11##0" = icmp eq i64 %116, %131 
-  br i1 %"1$tmp$11##0", label %if.then, label %if.else 
+  %"1#tmp#11##0" = icmp eq i64 %116, %131 
+  br i1 %"1#tmp#11##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$12##0" = icmp eq i64 %120, %135 
-  br i1 %"2$tmp$12##0", label %if.then1, label %if.else1 
+  %"2#tmp#12##0" = icmp eq i64 %120, %135 
+  br i1 %"2#tmp#12##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 if.then1:
-  %"4$tmp$13##0" = icmp eq i64 %124, %139 
-  br i1 %"4$tmp$13##0", label %if.then2, label %if.else2 
+  %"4#tmp#13##0" = icmp eq i64 %124, %139 
+  br i1 %"4#tmp#13##0", label %if.then2, label %if.else2 
 if.else1:
-  %"5$$$##0" = xor i1 0, 1 
-  ret i1 %"5$$$##0" 
+  %"5#####0" = xor i1 0, 1 
+  ret i1 %"5#####0" 
 if.then2:
-  %"6$tmp$0##0" = icmp eq i64 %143, %128 
-  %"6$$$##0" = xor i1 %"6$tmp$0##0", 1 
-  ret i1 %"6$$$##0" 
+  %"6#tmp#0##0" = icmp eq i64 %143, %128 
+  %"6#####0" = xor i1 %"6#tmp#0##0", 1 
+  ret i1 %"6#####0" 
 if.else2:
-  %"7$$$##0" = xor i1 0, 1 
-  ret i1 %"7$$$##0" 
+  %"7#####0" = xor i1 0, 1 
+  ret i1 %"7#####0" 
 }
 
 ----------------------------------------------------------------------

--- a/test-cases/complex/exp/testcase_multi_specz-drone.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-drone.exp
@@ -38,13 +38,13 @@ AFTER BUILDING MAIN:
 
 *main* > {inline} (0 calls)
 0: .<0>
-(argc#0:wybe.int, argv#0:wybe.array.raw_array(wybe.string), ?exit_code#0:wybe.int, ?io#2:wybe.phantom):
+(argc##0:wybe.int, argv##0:wybe.array.raw_array(wybe.string), ?exit_code##0:wybe.int, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c {semipure} gc_init @memory_management:nn:nn
-    command_line.<0>(~#argc#0:wybe.int, ?_:wybe.int, ?#arguments#0:wybe.array(wybe.string), ~#argv#0:wybe.array.raw_array(wybe.string), ?_:wybe.array.raw_array(wybe.string), ?#command#0:wybe.string, ?#exit_code#0:wybe.int, 0:wybe.phantom, ?_:wybe.phantom) #2
-    drone.<0>(0:wybe.phantom, ?#io#2:wybe.phantom) #3
-    foreign c {semipure,terminal} exit(exit_code#0:wybe.int)
+    command_line.<0>(~#argc##0:wybe.int, ?_:wybe.int, ?#arguments##0:wybe.array(wybe.string), ~#argv##0:wybe.array.raw_array(wybe.string), ?_:wybe.array.raw_array(wybe.string), ?#command##0:wybe.string, ?#exit_code##0:wybe.int, 0:wybe.phantom, ?_:wybe.phantom) #2
+    drone.<0>(0:wybe.phantom, ?#io##2:wybe.phantom) #3
+    foreign c {semipure,terminal} exit(exit_code##0:wybe.int)
 
 LLVM code       : None
 
@@ -69,29 +69,29 @@ LLVM code       : None
 
 *main* > public (0 calls)
 0: command_line.<0>
-(argc#0:wybe.int, [?argc#0:wybe.int], ?arguments#2:wybe.array(wybe.string), argv#0:wybe.array.raw_array(wybe.string), [?argv#0:wybe.array.raw_array(wybe.string)], ?command#2:wybe.string, ?exit_code#1:wybe.int, io#0:wybe.phantom, [?io#0:wybe.phantom]):
+(argc##0:wybe.int, [?argc##0:wybe.int], ?arguments##2:wybe.array(wybe.string), argv##0:wybe.array.raw_array(wybe.string), [?argv##0:wybe.array.raw_array(wybe.string)], ?command##2:wybe.string, ?exit_code##1:wybe.int, io##0:wybe.phantom, [?io##0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$9#0:wybe.array(?T))
-    foreign lpvm mutate(~tmp$9#0:wybe.array(?T), ?tmp$10#0:wybe.array(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc#0:wybe.int)
-    foreign lpvm mutate(~tmp$10#0:wybe.array(?T), ?tmp$1#0:wybe.array(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv#0:wybe.array.raw_array(?T))
-    wybe.array.[|]<0>(?command#2:?T, ?arguments#2:wybe.array(?T), ~tmp$1#0:wybe.array(?T), ?tmp$2#0:wybe.bool) #2 @command_line:nn:nn
-    case ~tmp$2#0:wybe.bool of
+    foreign lpvm alloc(16:wybe.int, ?tmp$9##0:wybe.array(?T))
+    foreign lpvm mutate(~tmp$9##0:wybe.array(?T), ?tmp$10##0:wybe.array(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
+    foreign lpvm mutate(~tmp$10##0:wybe.array(?T), ?tmp$1##0:wybe.array(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(?T))
+    wybe.array.[|]<0>(?command##2:?T, ?arguments##2:wybe.array(?T), ~tmp$1##0:wybe.array(?T), ?tmp$2##0:wybe.bool) #2 @command_line:nn:nn
+    case ~tmp$2##0:wybe.bool of
     0:
         foreign c {terminal,semipure} error_exit("command_line:17:10":wybe.string, "Erroneous program argument vector":wybe.string) @control:nn:nn
-        foreign llvm move(0:wybe.int, ?exit_code#1:wybe.int)
+        foreign llvm move(0:wybe.int, ?exit_code##1:wybe.int)
 
     1:
-        foreign llvm move(0:wybe.int, ?exit_code#1:wybe.int) @command_line:nn:nn
+        foreign llvm move(0:wybe.int, ?exit_code##1:wybe.int) @command_line:nn:nn
 
 
 
 set_exit_code > public {inline} (0 calls)
 0: command_line.set_exit_code<0>
-set_exit_code(code#0:wybe.int, [exit_code#0:wybe.int], ?exit_code#1:wybe.int):
+set_exit_code(code##0:wybe.int, [exit_code##0:wybe.int], ?exit_code##1:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(~code#0:wybe.int, ?exit_code#1:wybe.int) @command_line:nn:nn
+    foreign llvm move(~code##0:wybe.int, ?exit_code##1:wybe.int) @command_line:nn:nn
 
   LLVM code       :
 
@@ -119,18 +119,18 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  {i64, i64, i64} @"command_line.<0>"(i64  %"argc#0", i64  %"argv#0")    {
+define external fastcc  {i64, i64, i64} @"command_line.<0>"(i64  %"argc##0", i64  %"argv##0")    {
 entry:
   %1 = trunc i64 16 to i32  
   %2 = tail call ccc  i8*  @wybe_malloc(i32  %1)  
   %3 = ptrtoint i8* %2 to i64 
   %4 = inttoptr i64 %3 to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
-  store  i64 %"argc#0", i64* %5 
+  store  i64 %"argc##0", i64* %5 
   %6 = add   i64 %3, 8 
   %7 = inttoptr i64 %6 to i64* 
   %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"argv#0", i64* %8 
+  store  i64 %"argv##0", i64* %8 
   %9 = tail call fastcc  {i64, i64, i1}  @"wybe.array.[|]<0>"(i64  %3)  
   %10 = extractvalue {i64, i64, i1} %9, 0 
   %11 = extractvalue {i64, i64, i1} %9, 1 
@@ -152,9 +152,9 @@ if.else:
 }
 
 
-define external fastcc  i64 @"command_line.set_exit_code<0>"(i64  %"code#0")    {
+define external fastcc  i64 @"command_line.set_exit_code<0>"(i64  %"code##0")    {
 entry:
-  ret i64 %"code#0" 
+  ret i64 %"code##0" 
 }
 --------------------------------------------------
  Module drone
@@ -171,229 +171,229 @@ entry:
 
 *main* > public (0 calls)
 0: drone.<0>
-(io#0:wybe.phantom, ?io#3:wybe.phantom):
+(io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(4,(drone.loop<0>,fromList [NonAliasedParamCond 0 []]))]
-    drone.drone_init<0>(?tmp$0#0:drone.drone_info) #0 @drone:nn:nn
-    foreign c read_char(?ch#0:wybe.char, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm cast(-1:wybe.int, ?tmp$1#0:wybe.char) @io:nn:nn
-    foreign llvm icmp_ne(ch#0:wybe.char, ~tmp$1#0:wybe.char, ?tmp$2#0:wybe.bool) @char:nn:nn
-    case ~tmp$2#0:wybe.bool of
+    drone.drone_init<0>(?tmp$0##0:drone.drone_info) #0 @drone:nn:nn
+    foreign c read_char(?ch##0:wybe.char, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm cast(-1:wybe.int, ?tmp$1##0:wybe.char) @io:nn:nn
+    foreign llvm icmp_ne(ch##0:wybe.char, ~tmp$1##0:wybe.char, ?tmp$2##0:wybe.bool) @char:nn:nn
+    case ~tmp$2##0:wybe.bool of
     0:
-        foreign c {impure} malloc_count(?tmp$10#0:wybe.int) @memory_management:nn:nn
-        foreign c print_string("** malloc count: ":wybe.string, ~io#1:wybe.phantom, ?tmp$11#0:wybe.phantom) @io:nn:nn
-        foreign c print_int(~tmp$10#0:wybe.int, ~tmp$11#0:wybe.phantom, ?tmp$12#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$12#0:wybe.phantom, ?io#3:wybe.phantom) @io:nn:nn
+        foreign c {impure} malloc_count(?tmp$10##0:wybe.int) @memory_management:nn:nn
+        foreign c print_string("** malloc count: ":wybe.string, ~io##1:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
+        foreign c print_int(~tmp$10##0:wybe.int, ~tmp$11##0:wybe.phantom, ?tmp$12##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$12##0:wybe.phantom, ?io##3:wybe.phantom) @io:nn:nn
 
     1:
-        drone.loop<0>[410bae77d3](~tmp$0#0:drone.drone_info, ~ch#0:wybe.char, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #4 @drone:nn:nn
-        foreign c {impure} malloc_count(?tmp$10#0:wybe.int) @memory_management:nn:nn
-        foreign c print_string("** malloc count: ":wybe.string, ~io#2:wybe.phantom, ?tmp$11#0:wybe.phantom) @io:nn:nn
-        foreign c print_int(~tmp$10#0:wybe.int, ~tmp$11#0:wybe.phantom, ?tmp$12#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$12#0:wybe.phantom, ?io#3:wybe.phantom) @io:nn:nn
+        drone.loop<0>[410bae77d3](~tmp$0##0:drone.drone_info, ~ch##0:wybe.char, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @drone:nn:nn
+        foreign c {impure} malloc_count(?tmp$10##0:wybe.int) @memory_management:nn:nn
+        foreign c print_string("** malloc count: ":wybe.string, ~io##2:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
+        foreign c print_int(~tmp$10##0:wybe.int, ~tmp$11##0:wybe.phantom, ?tmp$12##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$12##0:wybe.phantom, ?io##3:wybe.phantom) @io:nn:nn
 
 
 
 do_action > (2 calls)
 0: drone.do_action<0>
-do_action(d#0:drone.drone_info, ?d#2:drone.drone_info, action#0:wybe.char, ?success#2:wybe.bool):
- AliasPairs: [(d#0,d#2)]
+do_action(d##0:drone.drone_info, ?d##2:drone.drone_info, action##0:wybe.char, ?success##2:wybe.bool):
+ AliasPairs: [(d##0,d##2)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(5,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(10,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(15,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(20,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(25,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(30,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(32,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 [0]]))]
-    foreign llvm icmp_eq(action#0:wybe.char, 'n':wybe.char, ?tmp$21#0:wybe.bool) @char:nn:nn
-    case ~tmp$21#0:wybe.bool of
+    foreign llvm icmp_eq(action##0:wybe.char, 'n':wybe.char, ?tmp$21##0:wybe.bool) @char:nn:nn
+    case ~tmp$21##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(action#0:wybe.char, 's':wybe.char, ?tmp$20#0:wybe.bool) @char:nn:nn
-        case ~tmp$20#0:wybe.bool of
+        foreign llvm icmp_eq(action##0:wybe.char, 's':wybe.char, ?tmp$20##0:wybe.bool) @char:nn:nn
+        case ~tmp$20##0:wybe.bool of
         0:
-            foreign llvm icmp_eq(action#0:wybe.char, 'w':wybe.char, ?tmp$19#0:wybe.bool) @char:nn:nn
-            case ~tmp$19#0:wybe.bool of
+            foreign llvm icmp_eq(action##0:wybe.char, 'w':wybe.char, ?tmp$19##0:wybe.bool) @char:nn:nn
+            case ~tmp$19##0:wybe.bool of
             0:
-                foreign llvm icmp_eq(action#0:wybe.char, 'e':wybe.char, ?tmp$18#0:wybe.bool) @char:nn:nn
-                case ~tmp$18#0:wybe.bool of
+                foreign llvm icmp_eq(action##0:wybe.char, 'e':wybe.char, ?tmp$18##0:wybe.bool) @char:nn:nn
+                case ~tmp$18##0:wybe.bool of
                 0:
-                    foreign llvm icmp_eq(action#0:wybe.char, 'u':wybe.char, ?tmp$17#0:wybe.bool) @char:nn:nn
-                    case ~tmp$17#0:wybe.bool of
+                    foreign llvm icmp_eq(action##0:wybe.char, 'u':wybe.char, ?tmp$17##0:wybe.bool) @char:nn:nn
+                    case ~tmp$17##0:wybe.bool of
                     0:
-                        foreign llvm icmp_eq(~action#0:wybe.char, 'd':wybe.char, ?tmp$16#0:wybe.bool) @char:nn:nn
-                        case ~tmp$16#0:wybe.bool of
+                        foreign llvm icmp_eq(~action##0:wybe.char, 'd':wybe.char, ?tmp$16##0:wybe.bool) @char:nn:nn
+                        case ~tmp$16##0:wybe.bool of
                         0:
-                            foreign llvm move(0:wybe.bool, ?success#2:wybe.bool) @drone:nn:nn
-                            drone.gen$2<0>(_:wybe.char, ~d#0:drone.drone_info, 0:wybe.bool, _:wybe.bool, ?d#2:drone.drone_info, ?_:wybe.bool) #32
+                            foreign llvm move(0:wybe.bool, ?success##2:wybe.bool) @drone:nn:nn
+                            drone.gen$2<0>(_:wybe.char, ~d##0:drone.drone_info, 0:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #32
 
                         1:
-                            foreign lpvm access(d#0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$12#0:wybe.int)
-                            foreign llvm sub(~tmp$12#0:wybe.int, 1:wybe.int, ?tmp$11#0:wybe.int) @int:nn:nn
-                            foreign lpvm {noalias} mutate(~%d#0:drone.drone_info, ?%d#1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$11#0:wybe.int)
-                            drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d#1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d#2:drone.drone_info, ?_:wybe.bool) #30
-                            foreign llvm move(1:wybe.bool, ?success#2:wybe.bool)
+                            foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$12##0:wybe.int)
+                            foreign llvm sub(~tmp$12##0:wybe.int, 1:wybe.int, ?tmp$11##0:wybe.int) @int:nn:nn
+                            foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$11##0:wybe.int)
+                            drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #30
+                            foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
                     1:
-                        foreign lpvm access(d#0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.int)
-                        foreign llvm add(~tmp$10#0:wybe.int, 1:wybe.int, ?tmp$9#0:wybe.int) @int:nn:nn
-                        foreign lpvm {noalias} mutate(~%d#0:drone.drone_info, ?%d#1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$9#0:wybe.int)
-                        drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d#1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d#2:drone.drone_info, ?_:wybe.bool) #25
-                        foreign llvm move(1:wybe.bool, ?success#2:wybe.bool)
+                        foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.int)
+                        foreign llvm add(~tmp$10##0:wybe.int, 1:wybe.int, ?tmp$9##0:wybe.int) @int:nn:nn
+                        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$9##0:wybe.int)
+                        drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #25
+                        foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
                 1:
-                    foreign lpvm access(d#0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.int)
-                    foreign llvm add(~tmp$8#0:wybe.int, 1:wybe.int, ?tmp$7#0:wybe.int) @int:nn:nn
-                    foreign lpvm {noalias} mutate(~%d#0:drone.drone_info, ?%d#1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$7#0:wybe.int)
-                    drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d#1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d#2:drone.drone_info, ?_:wybe.bool) #20
-                    foreign llvm move(1:wybe.bool, ?success#2:wybe.bool)
+                    foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
+                    foreign llvm add(~tmp$8##0:wybe.int, 1:wybe.int, ?tmp$7##0:wybe.int) @int:nn:nn
+                    foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$7##0:wybe.int)
+                    drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #20
+                    foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
             1:
-                foreign lpvm access(d#0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-                foreign llvm sub(~tmp$6#0:wybe.int, 1:wybe.int, ?tmp$5#0:wybe.int) @int:nn:nn
-                foreign lpvm {noalias} mutate(~%d#0:drone.drone_info, ?%d#1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$5#0:wybe.int)
-                drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d#1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d#2:drone.drone_info, ?_:wybe.bool) #15
-                foreign llvm move(1:wybe.bool, ?success#2:wybe.bool)
+                foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+                foreign llvm sub(~tmp$6##0:wybe.int, 1:wybe.int, ?tmp$5##0:wybe.int) @int:nn:nn
+                foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$5##0:wybe.int)
+                drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #15
+                foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
         1:
-            foreign lpvm access(d#0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-            foreign llvm add(~tmp$4#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.int) @int:nn:nn
-            foreign lpvm {noalias} mutate(~%d#0:drone.drone_info, ?%d#1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$3#0:wybe.int)
-            drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d#1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d#2:drone.drone_info, ?_:wybe.bool) #10
-            foreign llvm move(1:wybe.bool, ?success#2:wybe.bool)
+            foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+            foreign llvm add(~tmp$4##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
+            foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$3##0:wybe.int)
+            drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #10
+            foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
     1:
-        foreign lpvm access(d#0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm sub(~tmp$2#0:wybe.int, 1:wybe.int, ?tmp$1#0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%d#0:drone.drone_info, ?%d#1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$1#0:wybe.int)
-        drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d#1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d#2:drone.drone_info, ?_:wybe.bool) #5
-        foreign llvm move(1:wybe.bool, ?success#2:wybe.bool)
+        foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm sub(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$1##0:wybe.int)
+        drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #5
+        foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
 
 drone_init > (3 calls)
 0: drone.drone_init<0>
-drone_init(?$#0:drone.drone_info):
+drone_init(?$##0:drone.drone_info):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(32:wybe.int, ?tmp$5#0:drone.drone_info)
-    foreign lpvm mutate(~tmp$5#0:drone.drone_info, ?tmp$6#0:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$6#0:drone.drone_info, ?tmp$7#0:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$7#0:drone.drone_info, ?tmp$8#0:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$8#0:drone.drone_info, ?$#0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm alloc(32:wybe.int, ?tmp$5##0:drone.drone_info)
+    foreign lpvm mutate(~tmp$5##0:drone.drone_info, ?tmp$6##0:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp$6##0:drone.drone_info, ?tmp$7##0:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp$7##0:drone.drone_info, ?tmp$8##0:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp$8##0:drone.drone_info, ?$##0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
 
 
 gen$1 > {inline} (2 calls)
 0: drone.gen$1<0>
-gen$1([ch#0:wybe.char], [d#0:drone.drone_info], io#0:wybe.phantom, [tmp$0#0:drone.drone_info], ?io#2:wybe.phantom):
+gen$1([ch##0:wybe.char], [d##0:drone.drone_info], io##0:wybe.phantom, [tmp$0##0:drone.drone_info], ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c {impure} malloc_count(?mc#0:wybe.int) @memory_management:nn:nn
-    foreign c print_string("** malloc count: ":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_int(~mc#0:wybe.int, ~#io#1:wybe.phantom, ?tmp$6#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$6#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
+    foreign c {impure} malloc_count(?mc##0:wybe.int) @memory_management:nn:nn
+    foreign c print_string("** malloc count: ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~mc##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$6##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$6##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
 
 gen$2 > (7 calls)
 0: drone.gen$2<0>
-gen$2([action#0:wybe.char], d#0:drone.drone_info, success#0:wybe.bool, [tmp$0#0:wybe.bool], ?d#1:drone.drone_info, [?success#0:wybe.bool]):
- AliasPairs: [(d#0,d#1)]
+gen$2([action##0:wybe.char], d##0:drone.drone_info, success##0:wybe.bool, [tmp$0##0:wybe.bool], ?d##1:drone.drone_info, [?success##0:wybe.bool]):
+ AliasPairs: [(d##0,d##1)]
  InterestingCallProperties: [InterestingUnaliased 1]
-    case success#0:wybe.bool of
+    case success##0:wybe.bool of
     0:
-        foreign llvm move(~d#0:drone.drone_info, ?d#1:drone.drone_info)
+        foreign llvm move(~d##0:drone.drone_info, ?d##1:drone.drone_info)
 
     1:
-        foreign lpvm access(d#0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$15#0:wybe.int)
-        foreign llvm add(~tmp$15#0:wybe.int, 1:wybe.int, ?tmp$14#0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%d#0:drone.drone_info, ?%d#1:drone.drone_info, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$14#0:wybe.int)
+        foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$15##0:wybe.int)
+        foreign llvm add(~tmp$15##0:wybe.int, 1:wybe.int, ?tmp$14##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$14##0:wybe.int)
 
 
 
 gen$3 > (4 calls)
 0: drone.gen$3<0>
-gen$3([ch#0:wybe.char], d#0:drone.drone_info, io#0:wybe.phantom, ?io#2:wybe.phantom):
+gen$3([ch##0:wybe.char], d##0:drone.drone_info, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 1]
  MultiSpeczDepInfo: [(3,(drone.loop<0>,fromList [NonAliasedParamCond 0 [1]]))]
-    foreign c read_char(?ch#1:wybe.char, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm cast(-1:wybe.int, ?tmp$3#0:wybe.char) @io:nn:nn
-    foreign llvm icmp_ne(ch#1:wybe.char, ~tmp$3#0:wybe.char, ?tmp$4#0:wybe.bool) @char:nn:nn
-    case ~tmp$4#0:wybe.bool of
+    foreign c read_char(?ch##1:wybe.char, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm cast(-1:wybe.int, ?tmp$3##0:wybe.char) @io:nn:nn
+    foreign llvm icmp_ne(ch##1:wybe.char, ~tmp$3##0:wybe.char, ?tmp$4##0:wybe.bool) @char:nn:nn
+    case ~tmp$4##0:wybe.bool of
     0:
-        foreign llvm move(~io#1:wybe.phantom, ?io#2:wybe.phantom)
+        foreign llvm move(~io##1:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        drone.loop<0>(~d#0:drone.drone_info, ~ch#1:wybe.char, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #3 @drone:nn:nn
+        drone.loop<0>(~d##0:drone.drone_info, ~ch##1:wybe.char, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #3 @drone:nn:nn
 
 
 
 loop > (2 calls)
 0: drone.loop<0>
-loop(d#0:drone.drone_info, ch#0:wybe.char, io#0:wybe.phantom, ?io#2:wybe.phantom):
+loop(d##0:drone.drone_info, ch##0:wybe.char, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(5,(drone.gen$3<0>,fromList [NonAliasedParamCond 1 [0]])),(6,(drone.do_action<0>,fromList [NonAliasedParamCond 0 [0]])),(10,(drone.gen$3<0>,fromList [NonAliasedParamCond 1 [0]])),(11,(drone.gen$3<0>,fromList [NonAliasedParamCond 1 [0]])),(12,(drone.gen$3<0>,fromList [NonAliasedParamCond 1 [0]]))]
-    foreign llvm icmp_ne(ch#0:wybe.char, ' ':wybe.char, ?tmp$0#0:wybe.bool) @char:nn:nn
-    foreign llvm icmp_ne(ch#0:wybe.char, '\n':wybe.char, ?tmp$1#0:wybe.bool) @char:nn:nn
-    foreign llvm and(~tmp$0#0:wybe.bool, ~tmp$1#0:wybe.bool, ?tmp$7#0:wybe.bool) @bool:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign llvm icmp_ne(ch##0:wybe.char, ' ':wybe.char, ?tmp$0##0:wybe.bool) @char:nn:nn
+    foreign llvm icmp_ne(ch##0:wybe.char, '\n':wybe.char, ?tmp$1##0:wybe.bool) @char:nn:nn
+    foreign llvm and(~tmp$0##0:wybe.bool, ~tmp$1##0:wybe.bool, ?tmp$7##0:wybe.bool) @bool:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        drone.gen$3<0>(_:wybe.char, ~d#0:drone.drone_info, ~io#0:wybe.phantom, ?io#2:wybe.phantom) #12
+        drone.gen$3<0>(_:wybe.char, ~d##0:drone.drone_info, ~io##0:wybe.phantom, ?io##2:wybe.phantom) #12
 
     1:
-        foreign llvm icmp_eq(ch#0:wybe.char, 'p':wybe.char, ?tmp$6#0:wybe.bool) @char:nn:nn
-        case ~tmp$6#0:wybe.bool of
+        foreign llvm icmp_eq(ch##0:wybe.char, 'p':wybe.char, ?tmp$6##0:wybe.bool) @char:nn:nn
+        case ~tmp$6##0:wybe.bool of
         0:
-            drone.do_action<0>(~%d#0:drone.drone_info, ?%d#1:drone.drone_info, ~ch#0:wybe.char, ?success#0:wybe.bool) #6 @drone:nn:nn
-            foreign llvm icmp_eq(~success#0:wybe.bool, 0:wybe.bool, ?tmp$5#0:wybe.bool) @bool:nn:nn
-            case ~tmp$5#0:wybe.bool of
+            drone.do_action<0>(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, ~ch##0:wybe.char, ?success##0:wybe.bool) #6 @drone:nn:nn
+            foreign llvm icmp_eq(~success##0:wybe.bool, 0:wybe.bool, ?tmp$5##0:wybe.bool) @bool:nn:nn
+            case ~tmp$5##0:wybe.bool of
             0:
-                drone.gen$3<0>(_:wybe.char, ~d#1:drone.drone_info, ~io#0:wybe.phantom, ?io#2:wybe.phantom) #11
+                drone.gen$3<0>(_:wybe.char, ~d##1:drone.drone_info, ~io##0:wybe.phantom, ?io##2:wybe.phantom) #11
 
             1:
-                foreign c print_string("invalid action!":wybe.string, ~#io#0:wybe.phantom, ?tmp$20#0:wybe.phantom) @io:nn:nn
-                foreign c putchar('\n':wybe.char, ~tmp$20#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-                drone.gen$3<0>(_:wybe.char, ~d#1:drone.drone_info, ~io#1:wybe.phantom, ?io#2:wybe.phantom) #10
+                foreign c print_string("invalid action!":wybe.string, ~#io##0:wybe.phantom, ?tmp$20##0:wybe.phantom) @io:nn:nn
+                foreign c putchar('\n':wybe.char, ~tmp$20##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+                drone.gen$3<0>(_:wybe.char, ~d##1:drone.drone_info, ~io##1:wybe.phantom, ?io##2:wybe.phantom) #10
 
 
         1:
-            foreign c print_string("(":wybe.string, ~#io#0:wybe.phantom, ?tmp$18#0:wybe.phantom) @io:nn:nn
-            foreign lpvm access(d#0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$19#0:wybe.int)
-            foreign c print_int(~tmp$19#0:wybe.int, ~tmp$18#0:wybe.phantom, ?tmp$20#0:wybe.phantom) @io:nn:nn
-            foreign c print_string(", ":wybe.string, ~tmp$20#0:wybe.phantom, ?tmp$21#0:wybe.phantom) @io:nn:nn
-            foreign lpvm access(d#0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$22#0:wybe.int)
-            foreign c print_int(~tmp$22#0:wybe.int, ~tmp$21#0:wybe.phantom, ?tmp$23#0:wybe.phantom) @io:nn:nn
-            foreign c print_string(", ":wybe.string, ~tmp$23#0:wybe.phantom, ?tmp$24#0:wybe.phantom) @io:nn:nn
-            foreign lpvm access(d#0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$25#0:wybe.int)
-            foreign c print_int(~tmp$25#0:wybe.int, ~tmp$24#0:wybe.phantom, ?tmp$26#0:wybe.phantom) @io:nn:nn
-            foreign c print_string(") #":wybe.string, ~tmp$26#0:wybe.phantom, ?tmp$27#0:wybe.phantom) @io:nn:nn
-            foreign lpvm access(d#0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$28#0:wybe.int)
-            foreign c print_int(~tmp$28#0:wybe.int, ~tmp$27#0:wybe.phantom, ?tmp$29#0:wybe.phantom) @io:nn:nn
-            foreign c putchar('\n':wybe.char, ~tmp$29#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-            drone.gen$3<0>(_:wybe.char, ~d#0:drone.drone_info, ~io#1:wybe.phantom, ?io#2:wybe.phantom) #5
+            foreign c print_string("(":wybe.string, ~#io##0:wybe.phantom, ?tmp$18##0:wybe.phantom) @io:nn:nn
+            foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$19##0:wybe.int)
+            foreign c print_int(~tmp$19##0:wybe.int, ~tmp$18##0:wybe.phantom, ?tmp$20##0:wybe.phantom) @io:nn:nn
+            foreign c print_string(", ":wybe.string, ~tmp$20##0:wybe.phantom, ?tmp$21##0:wybe.phantom) @io:nn:nn
+            foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$22##0:wybe.int)
+            foreign c print_int(~tmp$22##0:wybe.int, ~tmp$21##0:wybe.phantom, ?tmp$23##0:wybe.phantom) @io:nn:nn
+            foreign c print_string(", ":wybe.string, ~tmp$23##0:wybe.phantom, ?tmp$24##0:wybe.phantom) @io:nn:nn
+            foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$25##0:wybe.int)
+            foreign c print_int(~tmp$25##0:wybe.int, ~tmp$24##0:wybe.phantom, ?tmp$26##0:wybe.phantom) @io:nn:nn
+            foreign c print_string(") #":wybe.string, ~tmp$26##0:wybe.phantom, ?tmp$27##0:wybe.phantom) @io:nn:nn
+            foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$28##0:wybe.int)
+            foreign c print_int(~tmp$28##0:wybe.int, ~tmp$27##0:wybe.phantom, ?tmp$29##0:wybe.phantom) @io:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp$29##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+            drone.gen$3<0>(_:wybe.char, ~d##0:drone.drone_info, ~io##1:wybe.phantom, ?io##2:wybe.phantom) #5
 
 
 
 
 print_info > {inline} (1 calls)
 0: drone.print_info<0>
-print_info(d#0:drone.drone_info, io#0:wybe.phantom, ?io#9:wybe.phantom):
+print_info(d##0:drone.drone_info, io##0:wybe.phantom, ?io##9:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("(":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(d#0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string(", ":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(d#0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_string(", ":wybe.string, ~#io#4:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-    foreign lpvm access(d#0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$2#0:wybe.int)
-    foreign c print_int(~tmp$2#0:wybe.int, ~#io#5:wybe.phantom, ?#io#6:wybe.phantom) @io:nn:nn
-    foreign c print_string(") #":wybe.string, ~#io#6:wybe.phantom, ?#io#7:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~d#0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign c print_int(~tmp$3#0:wybe.int, ~#io#7:wybe.phantom, ?#io#8:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~#io#8:wybe.phantom, ?#io#9:wybe.phantom) @io:nn:nn
+    foreign c print_string("(":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(", ":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(", ":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.int)
+    foreign c print_int(~tmp$2##0:wybe.int, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+    foreign c print_string(") #":wybe.string, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign c print_int(~tmp$3##0:wybe.int, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~#io##8:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
 
 LLVM code       : None
 
@@ -421,36 +421,36 @@ LLVM code       : None
 
 = > public {inline} (1 calls)
 0: drone.drone_info.=<0>
-=($left#0:drone.drone_info, $right#0:drone.drone_info, ?$$#0:wybe.bool):
+=($left##0:drone.drone_info, $right##0:drone.drone_info, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
-    foreign lpvm access($left#0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$y#0:wybe.int)
-    foreign lpvm access($left#0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$z#0:wybe.int)
-    foreign lpvm access(~$left#0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$count#0:wybe.int)
-    foreign lpvm access($right#0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$x#0:wybe.int)
-    foreign lpvm access($right#0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$y#0:wybe.int)
-    foreign lpvm access($right#0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$z#0:wybe.int)
-    foreign lpvm access(~$right#0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$count#0:wybe.int)
-    foreign llvm icmp_eq(~$left$x#0:wybe.int, ~$right$x#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
+    foreign lpvm access($left##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
+    foreign lpvm access($left##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$z##0:wybe.int)
+    foreign lpvm access(~$left##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$count##0:wybe.int)
+    foreign lpvm access($right##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
+    foreign lpvm access($right##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
+    foreign lpvm access($right##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$z##0:wybe.int)
+    foreign lpvm access(~$right##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$count##0:wybe.int)
+    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y#0:wybe.int, ~$right$y#0:wybe.int, ?tmp$2#0:wybe.bool) @int:nn:nn
-        case ~tmp$2#0:wybe.bool of
+        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?tmp$2##0:wybe.bool) @int:nn:nn
+        case ~tmp$2##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~$left$z#0:wybe.int, ~$right$z#0:wybe.int, ?tmp$3#0:wybe.bool) @int:nn:nn
-            case ~tmp$3#0:wybe.bool of
+            foreign llvm icmp_eq(~$left$z##0:wybe.int, ~$right$z##0:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
+            case ~tmp$3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                foreign llvm icmp_eq(~$left$count#0:wybe.int, ~$right$count#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+                foreign llvm icmp_eq(~$left$count##0:wybe.int, ~$right$count##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
@@ -458,117 +458,117 @@ LLVM code       : None
 
 count > public {inline} (0 calls)
 0: drone.drone_info.count<0>
-count($rec#0:drone.drone_info, ?$#0:wybe.int):
+count($rec##0:drone.drone_info, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 count > public {inline} (0 calls)
 1: drone.drone_info.count<1>
-count($rec#0:drone.drone_info, ?$rec#1:drone.drone_info, $field#0:wybe.int):
+count($rec##0:drone.drone_info, ?$rec##1:drone.drone_info, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:drone.drone_info, ?$rec#1:drone.drone_info, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:drone.drone_info, ?$rec##1:drone.drone_info, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 drone_info > public {inline} (0 calls)
 0: drone.drone_info.drone_info<0>
-drone_info(x#0:wybe.int, y#0:wybe.int, z#0:wybe.int, count#0:wybe.int, ?$#0:drone.drone_info):
+drone_info(x##0:wybe.int, y##0:wybe.int, z##0:wybe.int, count##0:wybe.int, ?$##0:drone.drone_info):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(32:wybe.int, ?$rec#0:drone.drone_info)
-    foreign lpvm mutate(~$rec#0:drone.drone_info, ?$rec#1:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~x#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:drone.drone_info, ?$rec#2:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~y#0:wybe.int)
-    foreign lpvm mutate(~$rec#2:drone.drone_info, ?$rec#3:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~z#0:wybe.int)
-    foreign lpvm mutate(~$rec#3:drone.drone_info, ?$#0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~count#0:wybe.int)
+    foreign lpvm alloc(32:wybe.int, ?$rec##0:drone.drone_info)
+    foreign lpvm mutate(~$rec##0:drone.drone_info, ?$rec##1:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:drone.drone_info, ?$rec##2:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~$rec##2:drone.drone_info, ?$rec##3:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~z##0:wybe.int)
+    foreign lpvm mutate(~$rec##3:drone.drone_info, ?$##0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~count##0:wybe.int)
 drone_info > public {inline} (14 calls)
 1: drone.drone_info.drone_info<1>
-drone_info(?x#0:wybe.int, ?y#0:wybe.int, ?z#0:wybe.int, ?count#0:wybe.int, $#0:drone.drone_info):
+drone_info(?x##0:wybe.int, ?y##0:wybe.int, ?z##0:wybe.int, ?count##0:wybe.int, $##0:drone.drone_info):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?x#0:wybe.int)
-    foreign lpvm access($#0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?y#0:wybe.int)
-    foreign lpvm access($#0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?z#0:wybe.int)
-    foreign lpvm access(~$#0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?count#0:wybe.int)
+    foreign lpvm access($##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access($##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access($##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?z##0:wybe.int)
+    foreign lpvm access(~$##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?count##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: drone.drone_info.x<0>
-x($rec#0:drone.drone_info, ?$#0:wybe.int):
+x($rec##0:drone.drone_info, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 x > public {inline} (0 calls)
 1: drone.drone_info.x<1>
-x($rec#0:drone.drone_info, ?$rec#1:drone.drone_info, $field#0:wybe.int):
+x($rec##0:drone.drone_info, ?$rec##1:drone.drone_info, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:drone.drone_info, ?$rec#1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:drone.drone_info, ?$rec##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: drone.drone_info.y<0>
-y($rec#0:drone.drone_info, ?$#0:wybe.int):
+y($rec##0:drone.drone_info, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 y > public {inline} (0 calls)
 1: drone.drone_info.y<1>
-y($rec#0:drone.drone_info, ?$rec#1:drone.drone_info, $field#0:wybe.int):
+y($rec##0:drone.drone_info, ?$rec##1:drone.drone_info, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:drone.drone_info, ?$rec#1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:drone.drone_info, ?$rec##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 z > public {inline} (0 calls)
 0: drone.drone_info.z<0>
-z($rec#0:drone.drone_info, ?$#0:wybe.int):
+z($rec##0:drone.drone_info, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 z > public {inline} (0 calls)
 1: drone.drone_info.z<1>
-z($rec#0:drone.drone_info, ?$rec#1:drone.drone_info, $field#0:wybe.int):
+z($rec##0:drone.drone_info, ?$rec##1:drone.drone_info, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:drone.drone_info, ?$rec#1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:drone.drone_info, ?$rec##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: drone.drone_info.~=<0>
-~=($left#0:drone.drone_info, $right#0:drone.drone_info, ?$$#0:wybe.bool):
+~=($left##0:drone.drone_info, $right##0:drone.drone_info, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access($left#0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($left#0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$left#0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign lpvm access($right#0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$7#0:wybe.int)
-    foreign lpvm access($right#0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.int)
-    foreign lpvm access($right#0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.int)
-    foreign lpvm access(~$right#0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$7#0:wybe.int, ?tmp$11#0:wybe.bool) @int:nn:nn
-    case ~tmp$11#0:wybe.bool of
+    foreign lpvm access($left##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access($left##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($left##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$left##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign lpvm access($right##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.int)
+    foreign lpvm access($right##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
+    foreign lpvm access($right##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.int)
+    foreign lpvm access(~$right##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$7##0:wybe.int, ?tmp$11##0:wybe.bool) @int:nn:nn
+    case ~tmp$11##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$8#0:wybe.int, ?tmp$12#0:wybe.bool) @int:nn:nn
-        case ~tmp$12#0:wybe.bool of
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$8##0:wybe.int, ?tmp$12##0:wybe.bool) @int:nn:nn
+        case ~tmp$12##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-            foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~tmp$5#0:wybe.int, ~tmp$9#0:wybe.int, ?tmp$13#0:wybe.bool) @int:nn:nn
-            case ~tmp$13#0:wybe.bool of
+            foreign llvm icmp_eq(~tmp$5##0:wybe.int, ~tmp$9##0:wybe.int, ?tmp$13##0:wybe.bool) @int:nn:nn
+            case ~tmp$13##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-                foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+                foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                foreign llvm icmp_eq(~tmp$10#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-                foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm icmp_eq(~tmp$10##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+                foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
@@ -592,13 +592,13 @@ AFTER EVERYTHING:
 
 *main* > {inline} (0 calls)
 0: .<0>
-(argc#0:wybe.int, argv#0:wybe.array.raw_array(wybe.string), ?exit_code#0:wybe.int, ?io#2:wybe.phantom):
+(argc##0:wybe.int, argv##0:wybe.array.raw_array(wybe.string), ?exit_code##0:wybe.int, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c {semipure} gc_init @memory_management:nn:nn
-    command_line.<0>(~#argc#0:wybe.int, ?_:wybe.int, ?#arguments#0:wybe.array(wybe.string), ~#argv#0:wybe.array.raw_array(wybe.string), ?_:wybe.array.raw_array(wybe.string), ?#command#0:wybe.string, ?#exit_code#0:wybe.int, 0:wybe.phantom, ?_:wybe.phantom) #2
-    drone.<0>(0:wybe.phantom, ?#io#2:wybe.phantom) #3
-    foreign c {semipure,terminal} exit(exit_code#0:wybe.int)
+    command_line.<0>(~#argc##0:wybe.int, ?_:wybe.int, ?#arguments##0:wybe.array(wybe.string), ~#argv##0:wybe.array.raw_array(wybe.string), ?_:wybe.array.raw_array(wybe.string), ?#command##0:wybe.string, ?#exit_code##0:wybe.int, 0:wybe.phantom, ?_:wybe.phantom) #2
+    drone.<0>(0:wybe.phantom, ?#io##2:wybe.phantom) #3
+    foreign c {semipure,terminal} exit(exit_code##0:wybe.int)
 
   LLVM code       :
 
@@ -626,10 +626,10 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external ccc  i32 @main(i64  %"argc#0", i64  %"argv#0")    {
+define external ccc  i32 @main(i64  %"argc##0", i64  %"argv##0")    {
 entry:
   tail call ccc  void  @gc_init()  
-  %1 = tail call fastcc  {i64, i64, i64}  @"command_line.<0>"(i64  %"argc#0", i64  %"argv#0")  
+  %1 = tail call fastcc  {i64, i64, i64}  @"command_line.<0>"(i64  %"argc##0", i64  %"argv##0")  
   %2 = extractvalue {i64, i64, i64} %1, 0 
   %3 = extractvalue {i64, i64, i64} %1, 1 
   %4 = extractvalue {i64, i64, i64} %1, 2 
@@ -658,29 +658,29 @@ entry:
 
 *main* > public (0 calls)
 0: command_line.<0>
-(argc#0:wybe.int, [?argc#0:wybe.int], ?arguments#2:wybe.array(wybe.string), argv#0:wybe.array.raw_array(wybe.string), [?argv#0:wybe.array.raw_array(wybe.string)], ?command#2:wybe.string, ?exit_code#1:wybe.int, io#0:wybe.phantom, [?io#0:wybe.phantom]):
+(argc##0:wybe.int, [?argc##0:wybe.int], ?arguments##2:wybe.array(wybe.string), argv##0:wybe.array.raw_array(wybe.string), [?argv##0:wybe.array.raw_array(wybe.string)], ?command##2:wybe.string, ?exit_code##1:wybe.int, io##0:wybe.phantom, [?io##0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$9#0:wybe.array(?T))
-    foreign lpvm mutate(~tmp$9#0:wybe.array(?T), ?tmp$10#0:wybe.array(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc#0:wybe.int)
-    foreign lpvm mutate(~tmp$10#0:wybe.array(?T), ?tmp$1#0:wybe.array(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv#0:wybe.array.raw_array(?T))
-    wybe.array.[|]<0>(?command#2:?T, ?arguments#2:wybe.array(?T), ~tmp$1#0:wybe.array(?T), ?tmp$2#0:wybe.bool) #2 @command_line:nn:nn
-    case ~tmp$2#0:wybe.bool of
+    foreign lpvm alloc(16:wybe.int, ?tmp$9##0:wybe.array(?T))
+    foreign lpvm mutate(~tmp$9##0:wybe.array(?T), ?tmp$10##0:wybe.array(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
+    foreign lpvm mutate(~tmp$10##0:wybe.array(?T), ?tmp$1##0:wybe.array(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(?T))
+    wybe.array.[|]<0>(?command##2:?T, ?arguments##2:wybe.array(?T), ~tmp$1##0:wybe.array(?T), ?tmp$2##0:wybe.bool) #2 @command_line:nn:nn
+    case ~tmp$2##0:wybe.bool of
     0:
         foreign c {terminal,semipure} error_exit("command_line:17:10":wybe.string, "Erroneous program argument vector":wybe.string) @control:nn:nn
-        foreign llvm move(0:wybe.int, ?exit_code#1:wybe.int)
+        foreign llvm move(0:wybe.int, ?exit_code##1:wybe.int)
 
     1:
-        foreign llvm move(0:wybe.int, ?exit_code#1:wybe.int) @command_line:nn:nn
+        foreign llvm move(0:wybe.int, ?exit_code##1:wybe.int) @command_line:nn:nn
 
 
 
 set_exit_code > public {inline} (0 calls)
 0: command_line.set_exit_code<0>
-set_exit_code(code#0:wybe.int, [exit_code#0:wybe.int], ?exit_code#1:wybe.int):
+set_exit_code(code##0:wybe.int, [exit_code##0:wybe.int], ?exit_code##1:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(~code#0:wybe.int, ?exit_code#1:wybe.int) @command_line:nn:nn
+    foreign llvm move(~code##0:wybe.int, ?exit_code##1:wybe.int) @command_line:nn:nn
 
   LLVM code       :
 
@@ -708,18 +708,18 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  {i64, i64, i64} @"command_line.<0>"(i64  %"argc#0", i64  %"argv#0")    {
+define external fastcc  {i64, i64, i64} @"command_line.<0>"(i64  %"argc##0", i64  %"argv##0")    {
 entry:
   %1 = trunc i64 16 to i32  
   %2 = tail call ccc  i8*  @wybe_malloc(i32  %1)  
   %3 = ptrtoint i8* %2 to i64 
   %4 = inttoptr i64 %3 to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
-  store  i64 %"argc#0", i64* %5 
+  store  i64 %"argc##0", i64* %5 
   %6 = add   i64 %3, 8 
   %7 = inttoptr i64 %6 to i64* 
   %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"argv#0", i64* %8 
+  store  i64 %"argv##0", i64* %8 
   %9 = tail call fastcc  {i64, i64, i1}  @"wybe.array.[|]<0>"(i64  %3)  
   %10 = extractvalue {i64, i64, i1} %9, 0 
   %11 = extractvalue {i64, i64, i1} %9, 1 
@@ -741,9 +741,9 @@ if.else:
 }
 
 
-define external fastcc  i64 @"command_line.set_exit_code<0>"(i64  %"code#0")    {
+define external fastcc  i64 @"command_line.set_exit_code<0>"(i64  %"code##0")    {
 entry:
-  ret i64 %"code#0" 
+  ret i64 %"code##0" 
 }
 --------------------------------------------------
  Module drone
@@ -760,360 +760,360 @@ entry:
 
 *main* > public (0 calls)
 0: drone.<0>
-(io#0:wybe.phantom, ?io#3:wybe.phantom):
+(io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(4,(drone.loop<0>,fromList [NonAliasedParamCond 0 []]))]
-    drone.drone_init<0>(?tmp$0#0:drone.drone_info) #0 @drone:nn:nn
-    foreign c read_char(?ch#0:wybe.char, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm cast(-1:wybe.int, ?tmp$1#0:wybe.char) @io:nn:nn
-    foreign llvm icmp_ne(ch#0:wybe.char, ~tmp$1#0:wybe.char, ?tmp$2#0:wybe.bool) @char:nn:nn
-    case ~tmp$2#0:wybe.bool of
+    drone.drone_init<0>(?tmp$0##0:drone.drone_info) #0 @drone:nn:nn
+    foreign c read_char(?ch##0:wybe.char, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm cast(-1:wybe.int, ?tmp$1##0:wybe.char) @io:nn:nn
+    foreign llvm icmp_ne(ch##0:wybe.char, ~tmp$1##0:wybe.char, ?tmp$2##0:wybe.bool) @char:nn:nn
+    case ~tmp$2##0:wybe.bool of
     0:
-        foreign c {impure} malloc_count(?tmp$10#0:wybe.int) @memory_management:nn:nn
-        foreign c print_string("** malloc count: ":wybe.string, ~io#1:wybe.phantom, ?tmp$11#0:wybe.phantom) @io:nn:nn
-        foreign c print_int(~tmp$10#0:wybe.int, ~tmp$11#0:wybe.phantom, ?tmp$12#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$12#0:wybe.phantom, ?io#3:wybe.phantom) @io:nn:nn
+        foreign c {impure} malloc_count(?tmp$10##0:wybe.int) @memory_management:nn:nn
+        foreign c print_string("** malloc count: ":wybe.string, ~io##1:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
+        foreign c print_int(~tmp$10##0:wybe.int, ~tmp$11##0:wybe.phantom, ?tmp$12##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$12##0:wybe.phantom, ?io##3:wybe.phantom) @io:nn:nn
 
     1:
-        drone.loop<0>[410bae77d3](~tmp$0#0:drone.drone_info, ~ch#0:wybe.char, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #4 @drone:nn:nn
-        foreign c {impure} malloc_count(?tmp$10#0:wybe.int) @memory_management:nn:nn
-        foreign c print_string("** malloc count: ":wybe.string, ~io#2:wybe.phantom, ?tmp$11#0:wybe.phantom) @io:nn:nn
-        foreign c print_int(~tmp$10#0:wybe.int, ~tmp$11#0:wybe.phantom, ?tmp$12#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$12#0:wybe.phantom, ?io#3:wybe.phantom) @io:nn:nn
+        drone.loop<0>[410bae77d3](~tmp$0##0:drone.drone_info, ~ch##0:wybe.char, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @drone:nn:nn
+        foreign c {impure} malloc_count(?tmp$10##0:wybe.int) @memory_management:nn:nn
+        foreign c print_string("** malloc count: ":wybe.string, ~io##2:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
+        foreign c print_int(~tmp$10##0:wybe.int, ~tmp$11##0:wybe.phantom, ?tmp$12##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$12##0:wybe.phantom, ?io##3:wybe.phantom) @io:nn:nn
 
 
 
 do_action > (2 calls)
 0: drone.do_action<0>[410bae77d3]
-do_action(d#0:drone.drone_info, ?d#2:drone.drone_info, action#0:wybe.char, ?success#2:wybe.bool):
- AliasPairs: [(d#0,d#2)]
+do_action(d##0:drone.drone_info, ?d##2:drone.drone_info, action##0:wybe.char, ?success##2:wybe.bool):
+ AliasPairs: [(d##0,d##2)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(5,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(10,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(15,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(20,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(25,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(30,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 []])),(32,(drone.gen$2<0>,fromList [NonAliasedParamCond 1 [0]]))]
-    foreign llvm icmp_eq(action#0:wybe.char, 'n':wybe.char, ?tmp$21#0:wybe.bool) @char:nn:nn
-    case ~tmp$21#0:wybe.bool of
+    foreign llvm icmp_eq(action##0:wybe.char, 'n':wybe.char, ?tmp$21##0:wybe.bool) @char:nn:nn
+    case ~tmp$21##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(action#0:wybe.char, 's':wybe.char, ?tmp$20#0:wybe.bool) @char:nn:nn
-        case ~tmp$20#0:wybe.bool of
+        foreign llvm icmp_eq(action##0:wybe.char, 's':wybe.char, ?tmp$20##0:wybe.bool) @char:nn:nn
+        case ~tmp$20##0:wybe.bool of
         0:
-            foreign llvm icmp_eq(action#0:wybe.char, 'w':wybe.char, ?tmp$19#0:wybe.bool) @char:nn:nn
-            case ~tmp$19#0:wybe.bool of
+            foreign llvm icmp_eq(action##0:wybe.char, 'w':wybe.char, ?tmp$19##0:wybe.bool) @char:nn:nn
+            case ~tmp$19##0:wybe.bool of
             0:
-                foreign llvm icmp_eq(action#0:wybe.char, 'e':wybe.char, ?tmp$18#0:wybe.bool) @char:nn:nn
-                case ~tmp$18#0:wybe.bool of
+                foreign llvm icmp_eq(action##0:wybe.char, 'e':wybe.char, ?tmp$18##0:wybe.bool) @char:nn:nn
+                case ~tmp$18##0:wybe.bool of
                 0:
-                    foreign llvm icmp_eq(action#0:wybe.char, 'u':wybe.char, ?tmp$17#0:wybe.bool) @char:nn:nn
-                    case ~tmp$17#0:wybe.bool of
+                    foreign llvm icmp_eq(action##0:wybe.char, 'u':wybe.char, ?tmp$17##0:wybe.bool) @char:nn:nn
+                    case ~tmp$17##0:wybe.bool of
                     0:
-                        foreign llvm icmp_eq(~action#0:wybe.char, 'd':wybe.char, ?tmp$16#0:wybe.bool) @char:nn:nn
-                        case ~tmp$16#0:wybe.bool of
+                        foreign llvm icmp_eq(~action##0:wybe.char, 'd':wybe.char, ?tmp$16##0:wybe.bool) @char:nn:nn
+                        case ~tmp$16##0:wybe.bool of
                         0:
-                            foreign llvm move(0:wybe.bool, ?success#2:wybe.bool) @drone:nn:nn
-                            drone.gen$2<0>(_:wybe.char, ~d#0:drone.drone_info, 0:wybe.bool, _:wybe.bool, ?d#2:drone.drone_info, ?_:wybe.bool) #32
+                            foreign llvm move(0:wybe.bool, ?success##2:wybe.bool) @drone:nn:nn
+                            drone.gen$2<0>(_:wybe.char, ~d##0:drone.drone_info, 0:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #32
 
                         1:
-                            foreign lpvm access(d#0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$12#0:wybe.int)
-                            foreign llvm sub(~tmp$12#0:wybe.int, 1:wybe.int, ?tmp$11#0:wybe.int) @int:nn:nn
-                            foreign lpvm {noalias} mutate(~%d#0:drone.drone_info, ?%d#1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$11#0:wybe.int)
-                            drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d#1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d#2:drone.drone_info, ?_:wybe.bool) #30
-                            foreign llvm move(1:wybe.bool, ?success#2:wybe.bool)
+                            foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$12##0:wybe.int)
+                            foreign llvm sub(~tmp$12##0:wybe.int, 1:wybe.int, ?tmp$11##0:wybe.int) @int:nn:nn
+                            foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$11##0:wybe.int)
+                            drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #30
+                            foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
                     1:
-                        foreign lpvm access(d#0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.int)
-                        foreign llvm add(~tmp$10#0:wybe.int, 1:wybe.int, ?tmp$9#0:wybe.int) @int:nn:nn
-                        foreign lpvm {noalias} mutate(~%d#0:drone.drone_info, ?%d#1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$9#0:wybe.int)
-                        drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d#1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d#2:drone.drone_info, ?_:wybe.bool) #25
-                        foreign llvm move(1:wybe.bool, ?success#2:wybe.bool)
+                        foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.int)
+                        foreign llvm add(~tmp$10##0:wybe.int, 1:wybe.int, ?tmp$9##0:wybe.int) @int:nn:nn
+                        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$9##0:wybe.int)
+                        drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #25
+                        foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
                 1:
-                    foreign lpvm access(d#0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.int)
-                    foreign llvm add(~tmp$8#0:wybe.int, 1:wybe.int, ?tmp$7#0:wybe.int) @int:nn:nn
-                    foreign lpvm {noalias} mutate(~%d#0:drone.drone_info, ?%d#1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$7#0:wybe.int)
-                    drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d#1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d#2:drone.drone_info, ?_:wybe.bool) #20
-                    foreign llvm move(1:wybe.bool, ?success#2:wybe.bool)
+                    foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
+                    foreign llvm add(~tmp$8##0:wybe.int, 1:wybe.int, ?tmp$7##0:wybe.int) @int:nn:nn
+                    foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$7##0:wybe.int)
+                    drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #20
+                    foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
             1:
-                foreign lpvm access(d#0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-                foreign llvm sub(~tmp$6#0:wybe.int, 1:wybe.int, ?tmp$5#0:wybe.int) @int:nn:nn
-                foreign lpvm {noalias} mutate(~%d#0:drone.drone_info, ?%d#1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$5#0:wybe.int)
-                drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d#1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d#2:drone.drone_info, ?_:wybe.bool) #15
-                foreign llvm move(1:wybe.bool, ?success#2:wybe.bool)
+                foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+                foreign llvm sub(~tmp$6##0:wybe.int, 1:wybe.int, ?tmp$5##0:wybe.int) @int:nn:nn
+                foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$5##0:wybe.int)
+                drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #15
+                foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
         1:
-            foreign lpvm access(d#0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-            foreign llvm add(~tmp$4#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.int) @int:nn:nn
-            foreign lpvm {noalias} mutate(~%d#0:drone.drone_info, ?%d#1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$3#0:wybe.int)
-            drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d#1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d#2:drone.drone_info, ?_:wybe.bool) #10
-            foreign llvm move(1:wybe.bool, ?success#2:wybe.bool)
+            foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+            foreign llvm add(~tmp$4##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
+            foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$3##0:wybe.int)
+            drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #10
+            foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
     1:
-        foreign lpvm access(d#0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm sub(~tmp$2#0:wybe.int, 1:wybe.int, ?tmp$1#0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%d#0:drone.drone_info, ?%d#1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$1#0:wybe.int)
-        drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d#1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d#2:drone.drone_info, ?_:wybe.bool) #5
-        foreign llvm move(1:wybe.bool, ?success#2:wybe.bool)
+        foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm sub(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$1##0:wybe.int)
+        drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #5
+        foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_eq(action#0:wybe.char, 'n':wybe.char, ?tmp$21#0:wybe.bool) @char:nn:nn
-    case ~tmp$21#0:wybe.bool of
+    foreign llvm icmp_eq(action##0:wybe.char, 'n':wybe.char, ?tmp$21##0:wybe.bool) @char:nn:nn
+    case ~tmp$21##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(action#0:wybe.char, 's':wybe.char, ?tmp$20#0:wybe.bool) @char:nn:nn
-        case ~tmp$20#0:wybe.bool of
+        foreign llvm icmp_eq(action##0:wybe.char, 's':wybe.char, ?tmp$20##0:wybe.bool) @char:nn:nn
+        case ~tmp$20##0:wybe.bool of
         0:
-            foreign llvm icmp_eq(action#0:wybe.char, 'w':wybe.char, ?tmp$19#0:wybe.bool) @char:nn:nn
-            case ~tmp$19#0:wybe.bool of
+            foreign llvm icmp_eq(action##0:wybe.char, 'w':wybe.char, ?tmp$19##0:wybe.bool) @char:nn:nn
+            case ~tmp$19##0:wybe.bool of
             0:
-                foreign llvm icmp_eq(action#0:wybe.char, 'e':wybe.char, ?tmp$18#0:wybe.bool) @char:nn:nn
-                case ~tmp$18#0:wybe.bool of
+                foreign llvm icmp_eq(action##0:wybe.char, 'e':wybe.char, ?tmp$18##0:wybe.bool) @char:nn:nn
+                case ~tmp$18##0:wybe.bool of
                 0:
-                    foreign llvm icmp_eq(action#0:wybe.char, 'u':wybe.char, ?tmp$17#0:wybe.bool) @char:nn:nn
-                    case ~tmp$17#0:wybe.bool of
+                    foreign llvm icmp_eq(action##0:wybe.char, 'u':wybe.char, ?tmp$17##0:wybe.bool) @char:nn:nn
+                    case ~tmp$17##0:wybe.bool of
                     0:
-                        foreign llvm icmp_eq(~action#0:wybe.char, 'd':wybe.char, ?tmp$16#0:wybe.bool) @char:nn:nn
-                        case ~tmp$16#0:wybe.bool of
+                        foreign llvm icmp_eq(~action##0:wybe.char, 'd':wybe.char, ?tmp$16##0:wybe.bool) @char:nn:nn
+                        case ~tmp$16##0:wybe.bool of
                         0:
-                            foreign llvm move(0:wybe.bool, ?success#2:wybe.bool) @drone:nn:nn
-                            drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d#0:drone.drone_info, 0:wybe.bool, _:wybe.bool, ?d#2:drone.drone_info, ?_:wybe.bool) #32
+                            foreign llvm move(0:wybe.bool, ?success##2:wybe.bool) @drone:nn:nn
+                            drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##0:drone.drone_info, 0:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #32
 
                         1:
-                            foreign lpvm access(d#0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$12#0:wybe.int)
-                            foreign llvm sub(~tmp$12#0:wybe.int, 1:wybe.int, ?tmp$11#0:wybe.int) @int:nn:nn
-                            foreign lpvm {noalias} mutate(~%d#0:drone.drone_info, ?%d#1:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$11#0:wybe.int)
-                            drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d#1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d#2:drone.drone_info, ?_:wybe.bool) #30
-                            foreign llvm move(1:wybe.bool, ?success#2:wybe.bool)
+                            foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$12##0:wybe.int)
+                            foreign llvm sub(~tmp$12##0:wybe.int, 1:wybe.int, ?tmp$11##0:wybe.int) @int:nn:nn
+                            foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$11##0:wybe.int)
+                            drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #30
+                            foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
                     1:
-                        foreign lpvm access(d#0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.int)
-                        foreign llvm add(~tmp$10#0:wybe.int, 1:wybe.int, ?tmp$9#0:wybe.int) @int:nn:nn
-                        foreign lpvm {noalias} mutate(~%d#0:drone.drone_info, ?%d#1:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$9#0:wybe.int)
-                        drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d#1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d#2:drone.drone_info, ?_:wybe.bool) #25
-                        foreign llvm move(1:wybe.bool, ?success#2:wybe.bool)
+                        foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.int)
+                        foreign llvm add(~tmp$10##0:wybe.int, 1:wybe.int, ?tmp$9##0:wybe.int) @int:nn:nn
+                        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$9##0:wybe.int)
+                        drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #25
+                        foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
                 1:
-                    foreign lpvm access(d#0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.int)
-                    foreign llvm add(~tmp$8#0:wybe.int, 1:wybe.int, ?tmp$7#0:wybe.int) @int:nn:nn
-                    foreign lpvm {noalias} mutate(~%d#0:drone.drone_info, ?%d#1:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$7#0:wybe.int)
-                    drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d#1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d#2:drone.drone_info, ?_:wybe.bool) #20
-                    foreign llvm move(1:wybe.bool, ?success#2:wybe.bool)
+                    foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
+                    foreign llvm add(~tmp$8##0:wybe.int, 1:wybe.int, ?tmp$7##0:wybe.int) @int:nn:nn
+                    foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$7##0:wybe.int)
+                    drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #20
+                    foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
             1:
-                foreign lpvm access(d#0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-                foreign llvm sub(~tmp$6#0:wybe.int, 1:wybe.int, ?tmp$5#0:wybe.int) @int:nn:nn
-                foreign lpvm {noalias} mutate(~%d#0:drone.drone_info, ?%d#1:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$5#0:wybe.int)
-                drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d#1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d#2:drone.drone_info, ?_:wybe.bool) #15
-                foreign llvm move(1:wybe.bool, ?success#2:wybe.bool)
+                foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+                foreign llvm sub(~tmp$6##0:wybe.int, 1:wybe.int, ?tmp$5##0:wybe.int) @int:nn:nn
+                foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$5##0:wybe.int)
+                drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #15
+                foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
         1:
-            foreign lpvm access(d#0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-            foreign llvm add(~tmp$4#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.int) @int:nn:nn
-            foreign lpvm {noalias} mutate(~%d#0:drone.drone_info, ?%d#1:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$3#0:wybe.int)
-            drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d#1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d#2:drone.drone_info, ?_:wybe.bool) #10
-            foreign llvm move(1:wybe.bool, ?success#2:wybe.bool)
+            foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+            foreign llvm add(~tmp$4##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
+            foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$3##0:wybe.int)
+            drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #10
+            foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
     1:
-        foreign lpvm access(d#0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm sub(~tmp$2#0:wybe.int, 1:wybe.int, ?tmp$1#0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%d#0:drone.drone_info, ?%d#1:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$1#0:wybe.int)
-        drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d#1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d#2:drone.drone_info, ?_:wybe.bool) #5
-        foreign llvm move(1:wybe.bool, ?success#2:wybe.bool)
+        foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm sub(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$1##0:wybe.int)
+        drone.gen$2<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, 1:wybe.bool, _:wybe.bool, ?d##2:drone.drone_info, ?_:wybe.bool) #5
+        foreign llvm move(1:wybe.bool, ?success##2:wybe.bool)
 
 
 
 drone_init > (3 calls)
 0: drone.drone_init<0>
-drone_init(?$#0:drone.drone_info):
+drone_init(?$##0:drone.drone_info):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(32:wybe.int, ?tmp$5#0:drone.drone_info)
-    foreign lpvm mutate(~tmp$5#0:drone.drone_info, ?tmp$6#0:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$6#0:drone.drone_info, ?tmp$7#0:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$7#0:drone.drone_info, ?tmp$8#0:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$8#0:drone.drone_info, ?$#0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm alloc(32:wybe.int, ?tmp$5##0:drone.drone_info)
+    foreign lpvm mutate(~tmp$5##0:drone.drone_info, ?tmp$6##0:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp$6##0:drone.drone_info, ?tmp$7##0:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp$7##0:drone.drone_info, ?tmp$8##0:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp$8##0:drone.drone_info, ?$##0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 0:wybe.int)
 
 
 gen$1 > {inline} (2 calls)
 0: drone.gen$1<0>
-gen$1([ch#0:wybe.char], [d#0:drone.drone_info], io#0:wybe.phantom, [tmp$0#0:drone.drone_info], ?io#2:wybe.phantom):
+gen$1([ch##0:wybe.char], [d##0:drone.drone_info], io##0:wybe.phantom, [tmp$0##0:drone.drone_info], ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c {impure} malloc_count(?mc#0:wybe.int) @memory_management:nn:nn
-    foreign c print_string("** malloc count: ":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_int(~mc#0:wybe.int, ~#io#1:wybe.phantom, ?tmp$6#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$6#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
+    foreign c {impure} malloc_count(?mc##0:wybe.int) @memory_management:nn:nn
+    foreign c print_string("** malloc count: ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~mc##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$6##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$6##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
 
 gen$2 > (7 calls)
 0: drone.gen$2<0>[6dacb8fd25]
-gen$2([action#0:wybe.char], d#0:drone.drone_info, success#0:wybe.bool, [tmp$0#0:wybe.bool], ?d#1:drone.drone_info, [?success#0:wybe.bool]):
- AliasPairs: [(d#0,d#1)]
+gen$2([action##0:wybe.char], d##0:drone.drone_info, success##0:wybe.bool, [tmp$0##0:wybe.bool], ?d##1:drone.drone_info, [?success##0:wybe.bool]):
+ AliasPairs: [(d##0,d##1)]
  InterestingCallProperties: [InterestingUnaliased 1]
-    case success#0:wybe.bool of
+    case success##0:wybe.bool of
     0:
-        foreign llvm move(~d#0:drone.drone_info, ?d#1:drone.drone_info)
+        foreign llvm move(~d##0:drone.drone_info, ?d##1:drone.drone_info)
 
     1:
-        foreign lpvm access(d#0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$15#0:wybe.int)
-        foreign llvm add(~tmp$15#0:wybe.int, 1:wybe.int, ?tmp$14#0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%d#0:drone.drone_info, ?%d#1:drone.drone_info, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$14#0:wybe.int)
+        foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$15##0:wybe.int)
+        foreign llvm add(~tmp$15##0:wybe.int, 1:wybe.int, ?tmp$14##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$14##0:wybe.int)
 
  [6dacb8fd25] [NonAliasedParam 1] :
-    case success#0:wybe.bool of
+    case success##0:wybe.bool of
     0:
-        foreign llvm move(~d#0:drone.drone_info, ?d#1:drone.drone_info)
+        foreign llvm move(~d##0:drone.drone_info, ?d##1:drone.drone_info)
 
     1:
-        foreign lpvm access(d#0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$15#0:wybe.int)
-        foreign llvm add(~tmp$15#0:wybe.int, 1:wybe.int, ?tmp$14#0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%d#0:drone.drone_info, ?%d#1:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$14#0:wybe.int)
+        foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$15##0:wybe.int)
+        foreign llvm add(~tmp$15##0:wybe.int, 1:wybe.int, ?tmp$14##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~tmp$14##0:wybe.int)
 
 
 
 gen$3 > (4 calls)
 0: drone.gen$3<0>[6dacb8fd25]
-gen$3([ch#0:wybe.char], d#0:drone.drone_info, io#0:wybe.phantom, ?io#2:wybe.phantom):
+gen$3([ch##0:wybe.char], d##0:drone.drone_info, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 1]
  MultiSpeczDepInfo: [(3,(drone.loop<0>,fromList [NonAliasedParamCond 0 [1]]))]
-    foreign c read_char(?ch#1:wybe.char, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm cast(-1:wybe.int, ?tmp$3#0:wybe.char) @io:nn:nn
-    foreign llvm icmp_ne(ch#1:wybe.char, ~tmp$3#0:wybe.char, ?tmp$4#0:wybe.bool) @char:nn:nn
-    case ~tmp$4#0:wybe.bool of
+    foreign c read_char(?ch##1:wybe.char, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm cast(-1:wybe.int, ?tmp$3##0:wybe.char) @io:nn:nn
+    foreign llvm icmp_ne(ch##1:wybe.char, ~tmp$3##0:wybe.char, ?tmp$4##0:wybe.bool) @char:nn:nn
+    case ~tmp$4##0:wybe.bool of
     0:
-        foreign llvm move(~io#1:wybe.phantom, ?io#2:wybe.phantom)
+        foreign llvm move(~io##1:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        drone.loop<0>(~d#0:drone.drone_info, ~ch#1:wybe.char, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #3 @drone:nn:nn
+        drone.loop<0>(~d##0:drone.drone_info, ~ch##1:wybe.char, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #3 @drone:nn:nn
 
  [6dacb8fd25] [NonAliasedParam 1] :
-    foreign c read_char(?ch#1:wybe.char, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm cast(-1:wybe.int, ?tmp$3#0:wybe.char) @io:nn:nn
-    foreign llvm icmp_ne(ch#1:wybe.char, ~tmp$3#0:wybe.char, ?tmp$4#0:wybe.bool) @char:nn:nn
-    case ~tmp$4#0:wybe.bool of
+    foreign c read_char(?ch##1:wybe.char, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm cast(-1:wybe.int, ?tmp$3##0:wybe.char) @io:nn:nn
+    foreign llvm icmp_ne(ch##1:wybe.char, ~tmp$3##0:wybe.char, ?tmp$4##0:wybe.bool) @char:nn:nn
+    case ~tmp$4##0:wybe.bool of
     0:
-        foreign llvm move(~io#1:wybe.phantom, ?io#2:wybe.phantom)
+        foreign llvm move(~io##1:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        drone.loop<0>[410bae77d3](~d#0:drone.drone_info, ~ch#1:wybe.char, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #3 @drone:nn:nn
+        drone.loop<0>[410bae77d3](~d##0:drone.drone_info, ~ch##1:wybe.char, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #3 @drone:nn:nn
 
 
 
 loop > (2 calls)
 0: drone.loop<0>[410bae77d3]
-loop(d#0:drone.drone_info, ch#0:wybe.char, io#0:wybe.phantom, ?io#2:wybe.phantom):
+loop(d##0:drone.drone_info, ch##0:wybe.char, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(5,(drone.gen$3<0>,fromList [NonAliasedParamCond 1 [0]])),(6,(drone.do_action<0>,fromList [NonAliasedParamCond 0 [0]])),(10,(drone.gen$3<0>,fromList [NonAliasedParamCond 1 [0]])),(11,(drone.gen$3<0>,fromList [NonAliasedParamCond 1 [0]])),(12,(drone.gen$3<0>,fromList [NonAliasedParamCond 1 [0]]))]
-    foreign llvm icmp_ne(ch#0:wybe.char, ' ':wybe.char, ?tmp$0#0:wybe.bool) @char:nn:nn
-    foreign llvm icmp_ne(ch#0:wybe.char, '\n':wybe.char, ?tmp$1#0:wybe.bool) @char:nn:nn
-    foreign llvm and(~tmp$0#0:wybe.bool, ~tmp$1#0:wybe.bool, ?tmp$7#0:wybe.bool) @bool:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign llvm icmp_ne(ch##0:wybe.char, ' ':wybe.char, ?tmp$0##0:wybe.bool) @char:nn:nn
+    foreign llvm icmp_ne(ch##0:wybe.char, '\n':wybe.char, ?tmp$1##0:wybe.bool) @char:nn:nn
+    foreign llvm and(~tmp$0##0:wybe.bool, ~tmp$1##0:wybe.bool, ?tmp$7##0:wybe.bool) @bool:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        drone.gen$3<0>(_:wybe.char, ~d#0:drone.drone_info, ~io#0:wybe.phantom, ?io#2:wybe.phantom) #12
+        drone.gen$3<0>(_:wybe.char, ~d##0:drone.drone_info, ~io##0:wybe.phantom, ?io##2:wybe.phantom) #12
 
     1:
-        foreign llvm icmp_eq(ch#0:wybe.char, 'p':wybe.char, ?tmp$6#0:wybe.bool) @char:nn:nn
-        case ~tmp$6#0:wybe.bool of
+        foreign llvm icmp_eq(ch##0:wybe.char, 'p':wybe.char, ?tmp$6##0:wybe.bool) @char:nn:nn
+        case ~tmp$6##0:wybe.bool of
         0:
-            drone.do_action<0>(~%d#0:drone.drone_info, ?%d#1:drone.drone_info, ~ch#0:wybe.char, ?success#0:wybe.bool) #6 @drone:nn:nn
-            foreign llvm icmp_eq(~success#0:wybe.bool, 0:wybe.bool, ?tmp$5#0:wybe.bool) @bool:nn:nn
-            case ~tmp$5#0:wybe.bool of
+            drone.do_action<0>(~%d##0:drone.drone_info, ?%d##1:drone.drone_info, ~ch##0:wybe.char, ?success##0:wybe.bool) #6 @drone:nn:nn
+            foreign llvm icmp_eq(~success##0:wybe.bool, 0:wybe.bool, ?tmp$5##0:wybe.bool) @bool:nn:nn
+            case ~tmp$5##0:wybe.bool of
             0:
-                drone.gen$3<0>(_:wybe.char, ~d#1:drone.drone_info, ~io#0:wybe.phantom, ?io#2:wybe.phantom) #11
+                drone.gen$3<0>(_:wybe.char, ~d##1:drone.drone_info, ~io##0:wybe.phantom, ?io##2:wybe.phantom) #11
 
             1:
-                foreign c print_string("invalid action!":wybe.string, ~#io#0:wybe.phantom, ?tmp$20#0:wybe.phantom) @io:nn:nn
-                foreign c putchar('\n':wybe.char, ~tmp$20#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-                drone.gen$3<0>(_:wybe.char, ~d#1:drone.drone_info, ~io#1:wybe.phantom, ?io#2:wybe.phantom) #10
+                foreign c print_string("invalid action!":wybe.string, ~#io##0:wybe.phantom, ?tmp$20##0:wybe.phantom) @io:nn:nn
+                foreign c putchar('\n':wybe.char, ~tmp$20##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+                drone.gen$3<0>(_:wybe.char, ~d##1:drone.drone_info, ~io##1:wybe.phantom, ?io##2:wybe.phantom) #10
 
 
         1:
-            foreign c print_string("(":wybe.string, ~#io#0:wybe.phantom, ?tmp$18#0:wybe.phantom) @io:nn:nn
-            foreign lpvm access(d#0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$19#0:wybe.int)
-            foreign c print_int(~tmp$19#0:wybe.int, ~tmp$18#0:wybe.phantom, ?tmp$20#0:wybe.phantom) @io:nn:nn
-            foreign c print_string(", ":wybe.string, ~tmp$20#0:wybe.phantom, ?tmp$21#0:wybe.phantom) @io:nn:nn
-            foreign lpvm access(d#0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$22#0:wybe.int)
-            foreign c print_int(~tmp$22#0:wybe.int, ~tmp$21#0:wybe.phantom, ?tmp$23#0:wybe.phantom) @io:nn:nn
-            foreign c print_string(", ":wybe.string, ~tmp$23#0:wybe.phantom, ?tmp$24#0:wybe.phantom) @io:nn:nn
-            foreign lpvm access(d#0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$25#0:wybe.int)
-            foreign c print_int(~tmp$25#0:wybe.int, ~tmp$24#0:wybe.phantom, ?tmp$26#0:wybe.phantom) @io:nn:nn
-            foreign c print_string(") #":wybe.string, ~tmp$26#0:wybe.phantom, ?tmp$27#0:wybe.phantom) @io:nn:nn
-            foreign lpvm access(d#0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$28#0:wybe.int)
-            foreign c print_int(~tmp$28#0:wybe.int, ~tmp$27#0:wybe.phantom, ?tmp$29#0:wybe.phantom) @io:nn:nn
-            foreign c putchar('\n':wybe.char, ~tmp$29#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-            drone.gen$3<0>(_:wybe.char, ~d#0:drone.drone_info, ~io#1:wybe.phantom, ?io#2:wybe.phantom) #5
+            foreign c print_string("(":wybe.string, ~#io##0:wybe.phantom, ?tmp$18##0:wybe.phantom) @io:nn:nn
+            foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$19##0:wybe.int)
+            foreign c print_int(~tmp$19##0:wybe.int, ~tmp$18##0:wybe.phantom, ?tmp$20##0:wybe.phantom) @io:nn:nn
+            foreign c print_string(", ":wybe.string, ~tmp$20##0:wybe.phantom, ?tmp$21##0:wybe.phantom) @io:nn:nn
+            foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$22##0:wybe.int)
+            foreign c print_int(~tmp$22##0:wybe.int, ~tmp$21##0:wybe.phantom, ?tmp$23##0:wybe.phantom) @io:nn:nn
+            foreign c print_string(", ":wybe.string, ~tmp$23##0:wybe.phantom, ?tmp$24##0:wybe.phantom) @io:nn:nn
+            foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$25##0:wybe.int)
+            foreign c print_int(~tmp$25##0:wybe.int, ~tmp$24##0:wybe.phantom, ?tmp$26##0:wybe.phantom) @io:nn:nn
+            foreign c print_string(") #":wybe.string, ~tmp$26##0:wybe.phantom, ?tmp$27##0:wybe.phantom) @io:nn:nn
+            foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$28##0:wybe.int)
+            foreign c print_int(~tmp$28##0:wybe.int, ~tmp$27##0:wybe.phantom, ?tmp$29##0:wybe.phantom) @io:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp$29##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+            drone.gen$3<0>(_:wybe.char, ~d##0:drone.drone_info, ~io##1:wybe.phantom, ?io##2:wybe.phantom) #5
 
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_ne(ch#0:wybe.char, ' ':wybe.char, ?tmp$0#0:wybe.bool) @char:nn:nn
-    foreign llvm icmp_ne(ch#0:wybe.char, '\n':wybe.char, ?tmp$1#0:wybe.bool) @char:nn:nn
-    foreign llvm and(~tmp$0#0:wybe.bool, ~tmp$1#0:wybe.bool, ?tmp$7#0:wybe.bool) @bool:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign llvm icmp_ne(ch##0:wybe.char, ' ':wybe.char, ?tmp$0##0:wybe.bool) @char:nn:nn
+    foreign llvm icmp_ne(ch##0:wybe.char, '\n':wybe.char, ?tmp$1##0:wybe.bool) @char:nn:nn
+    foreign llvm and(~tmp$0##0:wybe.bool, ~tmp$1##0:wybe.bool, ?tmp$7##0:wybe.bool) @bool:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        drone.gen$3<0>[6dacb8fd25](_:wybe.char, ~d#0:drone.drone_info, ~io#0:wybe.phantom, ?io#2:wybe.phantom) #12
+        drone.gen$3<0>[6dacb8fd25](_:wybe.char, ~d##0:drone.drone_info, ~io##0:wybe.phantom, ?io##2:wybe.phantom) #12
 
     1:
-        foreign llvm icmp_eq(ch#0:wybe.char, 'p':wybe.char, ?tmp$6#0:wybe.bool) @char:nn:nn
-        case ~tmp$6#0:wybe.bool of
+        foreign llvm icmp_eq(ch##0:wybe.char, 'p':wybe.char, ?tmp$6##0:wybe.bool) @char:nn:nn
+        case ~tmp$6##0:wybe.bool of
         0:
-            drone.do_action<0>[410bae77d3](~%d#0:drone.drone_info, ?%d#1:drone.drone_info, ~ch#0:wybe.char, ?success#0:wybe.bool) #6 @drone:nn:nn
-            foreign llvm icmp_eq(~success#0:wybe.bool, 0:wybe.bool, ?tmp$5#0:wybe.bool) @bool:nn:nn
-            case ~tmp$5#0:wybe.bool of
+            drone.do_action<0>[410bae77d3](~%d##0:drone.drone_info, ?%d##1:drone.drone_info, ~ch##0:wybe.char, ?success##0:wybe.bool) #6 @drone:nn:nn
+            foreign llvm icmp_eq(~success##0:wybe.bool, 0:wybe.bool, ?tmp$5##0:wybe.bool) @bool:nn:nn
+            case ~tmp$5##0:wybe.bool of
             0:
-                drone.gen$3<0>[6dacb8fd25](_:wybe.char, ~d#1:drone.drone_info, ~io#0:wybe.phantom, ?io#2:wybe.phantom) #11
+                drone.gen$3<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, ~io##0:wybe.phantom, ?io##2:wybe.phantom) #11
 
             1:
-                foreign c print_string("invalid action!":wybe.string, ~#io#0:wybe.phantom, ?tmp$20#0:wybe.phantom) @io:nn:nn
-                foreign c putchar('\n':wybe.char, ~tmp$20#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-                drone.gen$3<0>[6dacb8fd25](_:wybe.char, ~d#1:drone.drone_info, ~io#1:wybe.phantom, ?io#2:wybe.phantom) #10
+                foreign c print_string("invalid action!":wybe.string, ~#io##0:wybe.phantom, ?tmp$20##0:wybe.phantom) @io:nn:nn
+                foreign c putchar('\n':wybe.char, ~tmp$20##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+                drone.gen$3<0>[6dacb8fd25](_:wybe.char, ~d##1:drone.drone_info, ~io##1:wybe.phantom, ?io##2:wybe.phantom) #10
 
 
         1:
-            foreign c print_string("(":wybe.string, ~#io#0:wybe.phantom, ?tmp$18#0:wybe.phantom) @io:nn:nn
-            foreign lpvm access(d#0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$19#0:wybe.int)
-            foreign c print_int(~tmp$19#0:wybe.int, ~tmp$18#0:wybe.phantom, ?tmp$20#0:wybe.phantom) @io:nn:nn
-            foreign c print_string(", ":wybe.string, ~tmp$20#0:wybe.phantom, ?tmp$21#0:wybe.phantom) @io:nn:nn
-            foreign lpvm access(d#0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$22#0:wybe.int)
-            foreign c print_int(~tmp$22#0:wybe.int, ~tmp$21#0:wybe.phantom, ?tmp$23#0:wybe.phantom) @io:nn:nn
-            foreign c print_string(", ":wybe.string, ~tmp$23#0:wybe.phantom, ?tmp$24#0:wybe.phantom) @io:nn:nn
-            foreign lpvm access(d#0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$25#0:wybe.int)
-            foreign c print_int(~tmp$25#0:wybe.int, ~tmp$24#0:wybe.phantom, ?tmp$26#0:wybe.phantom) @io:nn:nn
-            foreign c print_string(") #":wybe.string, ~tmp$26#0:wybe.phantom, ?tmp$27#0:wybe.phantom) @io:nn:nn
-            foreign lpvm access(d#0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$28#0:wybe.int)
-            foreign c print_int(~tmp$28#0:wybe.int, ~tmp$27#0:wybe.phantom, ?tmp$29#0:wybe.phantom) @io:nn:nn
-            foreign c putchar('\n':wybe.char, ~tmp$29#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-            drone.gen$3<0>[6dacb8fd25](_:wybe.char, ~d#0:drone.drone_info, ~io#1:wybe.phantom, ?io#2:wybe.phantom) #5
+            foreign c print_string("(":wybe.string, ~#io##0:wybe.phantom, ?tmp$18##0:wybe.phantom) @io:nn:nn
+            foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$19##0:wybe.int)
+            foreign c print_int(~tmp$19##0:wybe.int, ~tmp$18##0:wybe.phantom, ?tmp$20##0:wybe.phantom) @io:nn:nn
+            foreign c print_string(", ":wybe.string, ~tmp$20##0:wybe.phantom, ?tmp$21##0:wybe.phantom) @io:nn:nn
+            foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$22##0:wybe.int)
+            foreign c print_int(~tmp$22##0:wybe.int, ~tmp$21##0:wybe.phantom, ?tmp$23##0:wybe.phantom) @io:nn:nn
+            foreign c print_string(", ":wybe.string, ~tmp$23##0:wybe.phantom, ?tmp$24##0:wybe.phantom) @io:nn:nn
+            foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$25##0:wybe.int)
+            foreign c print_int(~tmp$25##0:wybe.int, ~tmp$24##0:wybe.phantom, ?tmp$26##0:wybe.phantom) @io:nn:nn
+            foreign c print_string(") #":wybe.string, ~tmp$26##0:wybe.phantom, ?tmp$27##0:wybe.phantom) @io:nn:nn
+            foreign lpvm access(d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$28##0:wybe.int)
+            foreign c print_int(~tmp$28##0:wybe.int, ~tmp$27##0:wybe.phantom, ?tmp$29##0:wybe.phantom) @io:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp$29##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+            drone.gen$3<0>[6dacb8fd25](_:wybe.char, ~d##0:drone.drone_info, ~io##1:wybe.phantom, ?io##2:wybe.phantom) #5
 
 
 
 
 print_info > {inline} (1 calls)
 0: drone.print_info<0>
-print_info(d#0:drone.drone_info, io#0:wybe.phantom, ?io#9:wybe.phantom):
+print_info(d##0:drone.drone_info, io##0:wybe.phantom, ?io##9:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("(":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(d#0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string(", ":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(d#0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_string(", ":wybe.string, ~#io#4:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-    foreign lpvm access(d#0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$2#0:wybe.int)
-    foreign c print_int(~tmp$2#0:wybe.int, ~#io#5:wybe.phantom, ?#io#6:wybe.phantom) @io:nn:nn
-    foreign c print_string(") #":wybe.string, ~#io#6:wybe.phantom, ?#io#7:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~d#0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign c print_int(~tmp$3#0:wybe.int, ~#io#7:wybe.phantom, ?#io#8:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~#io#8:wybe.phantom, ?#io#9:wybe.phantom) @io:nn:nn
+    foreign c print_string("(":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(d##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(", ":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign lpvm access(d##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(", ":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign lpvm access(d##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.int)
+    foreign c print_int(~tmp$2##0:wybe.int, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+    foreign c print_string(") #":wybe.string, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~d##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign c print_int(~tmp$3##0:wybe.int, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~#io##8:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -1197,283 +1197,283 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"drone.<0>"()    {
 entry:
-  %"1$tmp$0#0" = tail call fastcc  i64  @"drone.drone_init<0>"()  
-  %"1$ch#0" = tail call ccc  i8  @read_char()  
+  %"1$tmp$0##0" = tail call fastcc  i64  @"drone.drone_init<0>"()  
+  %"1$ch##0" = tail call ccc  i8  @read_char()  
   %1 = alloca i64 
   store  i64 -1, i64* %1 
   %2 = load  i64, i64* %1 
   %3 = trunc i64 %2 to i8  
-  %"1$tmp$2#0" = icmp ne i8 %"1$ch#0", %3 
-  br i1 %"1$tmp$2#0", label %if.then, label %if.else 
+  %"1$tmp$2##0" = icmp ne i8 %"1$ch##0", %3 
+  br i1 %"1$tmp$2##0", label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"drone.loop<0>[410bae77d3]"(i64  %"1$tmp$0#0", i8  %"1$ch#0")  
-  %"2$tmp$10#0" = tail call ccc  i64  @malloc_count()  
+  tail call fastcc  void  @"drone.loop<0>[410bae77d3]"(i64  %"1$tmp$0##0", i8  %"1$ch##0")  
+  %"2$tmp$10##0" = tail call ccc  i64  @malloc_count()  
   %5 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @drone.4, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %5)  
-  tail call ccc  void  @print_int(i64  %"2$tmp$10#0")  
+  tail call ccc  void  @print_int(i64  %"2$tmp$10##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else:
-  %"3$tmp$10#0" = tail call ccc  i64  @malloc_count()  
+  %"3$tmp$10##0" = tail call ccc  i64  @malloc_count()  
   %7 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @drone.6, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %7)  
-  tail call ccc  void  @print_int(i64  %"3$tmp$10#0")  
+  tail call ccc  void  @print_int(i64  %"3$tmp$10##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  {i64, i1} @"drone.do_action<0>"(i64  %"d#0", i8  %"action#0")    {
+define external fastcc  {i64, i1} @"drone.do_action<0>"(i64  %"d##0", i8  %"action##0")    {
 entry:
-  %"1$tmp$21#0" = icmp eq i8 %"action#0", 110 
-  br i1 %"1$tmp$21#0", label %if.then, label %if.else 
+  %"1$tmp$21##0" = icmp eq i8 %"action##0", 110 
+  br i1 %"1$tmp$21##0", label %if.then, label %if.else 
 if.then:
-  %8 = add   i64 %"d#0", 8 
+  %8 = add   i64 %"d##0", 8 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
-  %"2$tmp$1#0" = sub   i64 %11, 1 
+  %"2$tmp$1##0" = sub   i64 %11, 1 
   %12 = trunc i64 32 to i32  
   %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
   %14 = ptrtoint i8* %13 to i64 
   %15 = inttoptr i64 %14 to i8* 
-  %16 = inttoptr i64 %"d#0" to i8* 
+  %16 = inttoptr i64 %"d##0" to i8* 
   %17 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %15, i8*  %16, i32  %17, i32  8, i1  0)  
   %18 = add   i64 %14, 8 
   %19 = inttoptr i64 %18 to i64* 
   %20 = getelementptr  i64, i64* %19, i64 0 
-  store  i64 %"2$tmp$1#0", i64* %20 
-  %"2$d#2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %14, i1  1)  
-  %21 = insertvalue {i64, i1} undef, i64 %"2$d#2", 0 
+  store  i64 %"2$tmp$1##0", i64* %20 
+  %"2$d##2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %14, i1  1)  
+  %21 = insertvalue {i64, i1} undef, i64 %"2$d##2", 0 
   %22 = insertvalue {i64, i1} %21, i1 1, 1 
   ret {i64, i1} %22 
 if.else:
-  %"3$tmp$20#0" = icmp eq i8 %"action#0", 115 
-  br i1 %"3$tmp$20#0", label %if.then1, label %if.else1 
+  %"3$tmp$20##0" = icmp eq i8 %"action##0", 115 
+  br i1 %"3$tmp$20##0", label %if.then1, label %if.else1 
 if.then1:
-  %23 = add   i64 %"d#0", 8 
+  %23 = add   i64 %"d##0", 8 
   %24 = inttoptr i64 %23 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
   %26 = load  i64, i64* %25 
-  %"4$tmp$3#0" = add   i64 %26, 1 
+  %"4$tmp$3##0" = add   i64 %26, 1 
   %27 = trunc i64 32 to i32  
   %28 = tail call ccc  i8*  @wybe_malloc(i32  %27)  
   %29 = ptrtoint i8* %28 to i64 
   %30 = inttoptr i64 %29 to i8* 
-  %31 = inttoptr i64 %"d#0" to i8* 
+  %31 = inttoptr i64 %"d##0" to i8* 
   %32 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %30, i8*  %31, i32  %32, i32  8, i1  0)  
   %33 = add   i64 %29, 8 
   %34 = inttoptr i64 %33 to i64* 
   %35 = getelementptr  i64, i64* %34, i64 0 
-  store  i64 %"4$tmp$3#0", i64* %35 
-  %"4$d#2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %29, i1  1)  
-  %36 = insertvalue {i64, i1} undef, i64 %"4$d#2", 0 
+  store  i64 %"4$tmp$3##0", i64* %35 
+  %"4$d##2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %29, i1  1)  
+  %36 = insertvalue {i64, i1} undef, i64 %"4$d##2", 0 
   %37 = insertvalue {i64, i1} %36, i1 1, 1 
   ret {i64, i1} %37 
 if.else1:
-  %"5$tmp$19#0" = icmp eq i8 %"action#0", 119 
-  br i1 %"5$tmp$19#0", label %if.then2, label %if.else2 
+  %"5$tmp$19##0" = icmp eq i8 %"action##0", 119 
+  br i1 %"5$tmp$19##0", label %if.then2, label %if.else2 
 if.then2:
-  %38 = inttoptr i64 %"d#0" to i64* 
+  %38 = inttoptr i64 %"d##0" to i64* 
   %39 = getelementptr  i64, i64* %38, i64 0 
   %40 = load  i64, i64* %39 
-  %"6$tmp$5#0" = sub   i64 %40, 1 
+  %"6$tmp$5##0" = sub   i64 %40, 1 
   %41 = trunc i64 32 to i32  
   %42 = tail call ccc  i8*  @wybe_malloc(i32  %41)  
   %43 = ptrtoint i8* %42 to i64 
   %44 = inttoptr i64 %43 to i8* 
-  %45 = inttoptr i64 %"d#0" to i8* 
+  %45 = inttoptr i64 %"d##0" to i8* 
   %46 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %44, i8*  %45, i32  %46, i32  8, i1  0)  
   %47 = inttoptr i64 %43 to i64* 
   %48 = getelementptr  i64, i64* %47, i64 0 
-  store  i64 %"6$tmp$5#0", i64* %48 
-  %"6$d#2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %43, i1  1)  
-  %49 = insertvalue {i64, i1} undef, i64 %"6$d#2", 0 
+  store  i64 %"6$tmp$5##0", i64* %48 
+  %"6$d##2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %43, i1  1)  
+  %49 = insertvalue {i64, i1} undef, i64 %"6$d##2", 0 
   %50 = insertvalue {i64, i1} %49, i1 1, 1 
   ret {i64, i1} %50 
 if.else2:
-  %"7$tmp$18#0" = icmp eq i8 %"action#0", 101 
-  br i1 %"7$tmp$18#0", label %if.then3, label %if.else3 
+  %"7$tmp$18##0" = icmp eq i8 %"action##0", 101 
+  br i1 %"7$tmp$18##0", label %if.then3, label %if.else3 
 if.then3:
-  %51 = inttoptr i64 %"d#0" to i64* 
+  %51 = inttoptr i64 %"d##0" to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
   %53 = load  i64, i64* %52 
-  %"8$tmp$7#0" = add   i64 %53, 1 
+  %"8$tmp$7##0" = add   i64 %53, 1 
   %54 = trunc i64 32 to i32  
   %55 = tail call ccc  i8*  @wybe_malloc(i32  %54)  
   %56 = ptrtoint i8* %55 to i64 
   %57 = inttoptr i64 %56 to i8* 
-  %58 = inttoptr i64 %"d#0" to i8* 
+  %58 = inttoptr i64 %"d##0" to i8* 
   %59 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %57, i8*  %58, i32  %59, i32  8, i1  0)  
   %60 = inttoptr i64 %56 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
-  store  i64 %"8$tmp$7#0", i64* %61 
-  %"8$d#2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %56, i1  1)  
-  %62 = insertvalue {i64, i1} undef, i64 %"8$d#2", 0 
+  store  i64 %"8$tmp$7##0", i64* %61 
+  %"8$d##2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %56, i1  1)  
+  %62 = insertvalue {i64, i1} undef, i64 %"8$d##2", 0 
   %63 = insertvalue {i64, i1} %62, i1 1, 1 
   ret {i64, i1} %63 
 if.else3:
-  %"9$tmp$17#0" = icmp eq i8 %"action#0", 117 
-  br i1 %"9$tmp$17#0", label %if.then4, label %if.else4 
+  %"9$tmp$17##0" = icmp eq i8 %"action##0", 117 
+  br i1 %"9$tmp$17##0", label %if.then4, label %if.else4 
 if.then4:
-  %64 = add   i64 %"d#0", 16 
+  %64 = add   i64 %"d##0", 16 
   %65 = inttoptr i64 %64 to i64* 
   %66 = getelementptr  i64, i64* %65, i64 0 
   %67 = load  i64, i64* %66 
-  %"10$tmp$9#0" = add   i64 %67, 1 
+  %"10$tmp$9##0" = add   i64 %67, 1 
   %68 = trunc i64 32 to i32  
   %69 = tail call ccc  i8*  @wybe_malloc(i32  %68)  
   %70 = ptrtoint i8* %69 to i64 
   %71 = inttoptr i64 %70 to i8* 
-  %72 = inttoptr i64 %"d#0" to i8* 
+  %72 = inttoptr i64 %"d##0" to i8* 
   %73 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %71, i8*  %72, i32  %73, i32  8, i1  0)  
   %74 = add   i64 %70, 16 
   %75 = inttoptr i64 %74 to i64* 
   %76 = getelementptr  i64, i64* %75, i64 0 
-  store  i64 %"10$tmp$9#0", i64* %76 
-  %"10$d#2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %70, i1  1)  
-  %77 = insertvalue {i64, i1} undef, i64 %"10$d#2", 0 
+  store  i64 %"10$tmp$9##0", i64* %76 
+  %"10$d##2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %70, i1  1)  
+  %77 = insertvalue {i64, i1} undef, i64 %"10$d##2", 0 
   %78 = insertvalue {i64, i1} %77, i1 1, 1 
   ret {i64, i1} %78 
 if.else4:
-  %"11$tmp$16#0" = icmp eq i8 %"action#0", 100 
-  br i1 %"11$tmp$16#0", label %if.then5, label %if.else5 
+  %"11$tmp$16##0" = icmp eq i8 %"action##0", 100 
+  br i1 %"11$tmp$16##0", label %if.then5, label %if.else5 
 if.then5:
-  %79 = add   i64 %"d#0", 16 
+  %79 = add   i64 %"d##0", 16 
   %80 = inttoptr i64 %79 to i64* 
   %81 = getelementptr  i64, i64* %80, i64 0 
   %82 = load  i64, i64* %81 
-  %"12$tmp$11#0" = sub   i64 %82, 1 
+  %"12$tmp$11##0" = sub   i64 %82, 1 
   %83 = trunc i64 32 to i32  
   %84 = tail call ccc  i8*  @wybe_malloc(i32  %83)  
   %85 = ptrtoint i8* %84 to i64 
   %86 = inttoptr i64 %85 to i8* 
-  %87 = inttoptr i64 %"d#0" to i8* 
+  %87 = inttoptr i64 %"d##0" to i8* 
   %88 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %86, i8*  %87, i32  %88, i32  8, i1  0)  
   %89 = add   i64 %85, 16 
   %90 = inttoptr i64 %89 to i64* 
   %91 = getelementptr  i64, i64* %90, i64 0 
-  store  i64 %"12$tmp$11#0", i64* %91 
-  %"12$d#2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %85, i1  1)  
-  %92 = insertvalue {i64, i1} undef, i64 %"12$d#2", 0 
+  store  i64 %"12$tmp$11##0", i64* %91 
+  %"12$d##2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %85, i1  1)  
+  %92 = insertvalue {i64, i1} undef, i64 %"12$d##2", 0 
   %93 = insertvalue {i64, i1} %92, i1 1, 1 
   ret {i64, i1} %93 
 if.else5:
-  %"13$d#2" = tail call fastcc  i64  @"drone.gen$2<0>"(i64  %"d#0", i1  0)  
-  %94 = insertvalue {i64, i1} undef, i64 %"13$d#2", 0 
+  %"13$d##2" = tail call fastcc  i64  @"drone.gen$2<0>"(i64  %"d##0", i1  0)  
+  %94 = insertvalue {i64, i1} undef, i64 %"13$d##2", 0 
   %95 = insertvalue {i64, i1} %94, i1 0, 1 
   ret {i64, i1} %95 
 }
 
 
-define external fastcc  {i64, i1} @"drone.do_action<0>[410bae77d3]"(i64  %"d#0", i8  %"action#0")    {
+define external fastcc  {i64, i1} @"drone.do_action<0>[410bae77d3]"(i64  %"d##0", i8  %"action##0")    {
 entry:
-  %"1$tmp$21#0" = icmp eq i8 %"action#0", 110 
-  br i1 %"1$tmp$21#0", label %if.then, label %if.else 
+  %"1$tmp$21##0" = icmp eq i8 %"action##0", 110 
+  br i1 %"1$tmp$21##0", label %if.then, label %if.else 
 if.then:
-  %96 = add   i64 %"d#0", 8 
+  %96 = add   i64 %"d##0", 8 
   %97 = inttoptr i64 %96 to i64* 
   %98 = getelementptr  i64, i64* %97, i64 0 
   %99 = load  i64, i64* %98 
-  %"2$tmp$1#0" = sub   i64 %99, 1 
-  %100 = add   i64 %"d#0", 8 
+  %"2$tmp$1##0" = sub   i64 %99, 1 
+  %100 = add   i64 %"d##0", 8 
   %101 = inttoptr i64 %100 to i64* 
   %102 = getelementptr  i64, i64* %101, i64 0 
-  store  i64 %"2$tmp$1#0", i64* %102 
-  %"2$d#2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %"d#0", i1  1)  
-  %103 = insertvalue {i64, i1} undef, i64 %"2$d#2", 0 
+  store  i64 %"2$tmp$1##0", i64* %102 
+  %"2$d##2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
+  %103 = insertvalue {i64, i1} undef, i64 %"2$d##2", 0 
   %104 = insertvalue {i64, i1} %103, i1 1, 1 
   ret {i64, i1} %104 
 if.else:
-  %"3$tmp$20#0" = icmp eq i8 %"action#0", 115 
-  br i1 %"3$tmp$20#0", label %if.then1, label %if.else1 
+  %"3$tmp$20##0" = icmp eq i8 %"action##0", 115 
+  br i1 %"3$tmp$20##0", label %if.then1, label %if.else1 
 if.then1:
-  %105 = add   i64 %"d#0", 8 
+  %105 = add   i64 %"d##0", 8 
   %106 = inttoptr i64 %105 to i64* 
   %107 = getelementptr  i64, i64* %106, i64 0 
   %108 = load  i64, i64* %107 
-  %"4$tmp$3#0" = add   i64 %108, 1 
-  %109 = add   i64 %"d#0", 8 
+  %"4$tmp$3##0" = add   i64 %108, 1 
+  %109 = add   i64 %"d##0", 8 
   %110 = inttoptr i64 %109 to i64* 
   %111 = getelementptr  i64, i64* %110, i64 0 
-  store  i64 %"4$tmp$3#0", i64* %111 
-  %"4$d#2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %"d#0", i1  1)  
-  %112 = insertvalue {i64, i1} undef, i64 %"4$d#2", 0 
+  store  i64 %"4$tmp$3##0", i64* %111 
+  %"4$d##2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
+  %112 = insertvalue {i64, i1} undef, i64 %"4$d##2", 0 
   %113 = insertvalue {i64, i1} %112, i1 1, 1 
   ret {i64, i1} %113 
 if.else1:
-  %"5$tmp$19#0" = icmp eq i8 %"action#0", 119 
-  br i1 %"5$tmp$19#0", label %if.then2, label %if.else2 
+  %"5$tmp$19##0" = icmp eq i8 %"action##0", 119 
+  br i1 %"5$tmp$19##0", label %if.then2, label %if.else2 
 if.then2:
-  %114 = inttoptr i64 %"d#0" to i64* 
+  %114 = inttoptr i64 %"d##0" to i64* 
   %115 = getelementptr  i64, i64* %114, i64 0 
   %116 = load  i64, i64* %115 
-  %"6$tmp$5#0" = sub   i64 %116, 1 
-  %117 = inttoptr i64 %"d#0" to i64* 
+  %"6$tmp$5##0" = sub   i64 %116, 1 
+  %117 = inttoptr i64 %"d##0" to i64* 
   %118 = getelementptr  i64, i64* %117, i64 0 
-  store  i64 %"6$tmp$5#0", i64* %118 
-  %"6$d#2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %"d#0", i1  1)  
-  %119 = insertvalue {i64, i1} undef, i64 %"6$d#2", 0 
+  store  i64 %"6$tmp$5##0", i64* %118 
+  %"6$d##2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
+  %119 = insertvalue {i64, i1} undef, i64 %"6$d##2", 0 
   %120 = insertvalue {i64, i1} %119, i1 1, 1 
   ret {i64, i1} %120 
 if.else2:
-  %"7$tmp$18#0" = icmp eq i8 %"action#0", 101 
-  br i1 %"7$tmp$18#0", label %if.then3, label %if.else3 
+  %"7$tmp$18##0" = icmp eq i8 %"action##0", 101 
+  br i1 %"7$tmp$18##0", label %if.then3, label %if.else3 
 if.then3:
-  %121 = inttoptr i64 %"d#0" to i64* 
+  %121 = inttoptr i64 %"d##0" to i64* 
   %122 = getelementptr  i64, i64* %121, i64 0 
   %123 = load  i64, i64* %122 
-  %"8$tmp$7#0" = add   i64 %123, 1 
-  %124 = inttoptr i64 %"d#0" to i64* 
+  %"8$tmp$7##0" = add   i64 %123, 1 
+  %124 = inttoptr i64 %"d##0" to i64* 
   %125 = getelementptr  i64, i64* %124, i64 0 
-  store  i64 %"8$tmp$7#0", i64* %125 
-  %"8$d#2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %"d#0", i1  1)  
-  %126 = insertvalue {i64, i1} undef, i64 %"8$d#2", 0 
+  store  i64 %"8$tmp$7##0", i64* %125 
+  %"8$d##2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
+  %126 = insertvalue {i64, i1} undef, i64 %"8$d##2", 0 
   %127 = insertvalue {i64, i1} %126, i1 1, 1 
   ret {i64, i1} %127 
 if.else3:
-  %"9$tmp$17#0" = icmp eq i8 %"action#0", 117 
-  br i1 %"9$tmp$17#0", label %if.then4, label %if.else4 
+  %"9$tmp$17##0" = icmp eq i8 %"action##0", 117 
+  br i1 %"9$tmp$17##0", label %if.then4, label %if.else4 
 if.then4:
-  %128 = add   i64 %"d#0", 16 
+  %128 = add   i64 %"d##0", 16 
   %129 = inttoptr i64 %128 to i64* 
   %130 = getelementptr  i64, i64* %129, i64 0 
   %131 = load  i64, i64* %130 
-  %"10$tmp$9#0" = add   i64 %131, 1 
-  %132 = add   i64 %"d#0", 16 
+  %"10$tmp$9##0" = add   i64 %131, 1 
+  %132 = add   i64 %"d##0", 16 
   %133 = inttoptr i64 %132 to i64* 
   %134 = getelementptr  i64, i64* %133, i64 0 
-  store  i64 %"10$tmp$9#0", i64* %134 
-  %"10$d#2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %"d#0", i1  1)  
-  %135 = insertvalue {i64, i1} undef, i64 %"10$d#2", 0 
+  store  i64 %"10$tmp$9##0", i64* %134 
+  %"10$d##2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
+  %135 = insertvalue {i64, i1} undef, i64 %"10$d##2", 0 
   %136 = insertvalue {i64, i1} %135, i1 1, 1 
   ret {i64, i1} %136 
 if.else4:
-  %"11$tmp$16#0" = icmp eq i8 %"action#0", 100 
-  br i1 %"11$tmp$16#0", label %if.then5, label %if.else5 
+  %"11$tmp$16##0" = icmp eq i8 %"action##0", 100 
+  br i1 %"11$tmp$16##0", label %if.then5, label %if.else5 
 if.then5:
-  %137 = add   i64 %"d#0", 16 
+  %137 = add   i64 %"d##0", 16 
   %138 = inttoptr i64 %137 to i64* 
   %139 = getelementptr  i64, i64* %138, i64 0 
   %140 = load  i64, i64* %139 
-  %"12$tmp$11#0" = sub   i64 %140, 1 
-  %141 = add   i64 %"d#0", 16 
+  %"12$tmp$11##0" = sub   i64 %140, 1 
+  %141 = add   i64 %"d##0", 16 
   %142 = inttoptr i64 %141 to i64* 
   %143 = getelementptr  i64, i64* %142, i64 0 
-  store  i64 %"12$tmp$11#0", i64* %143 
-  %"12$d#2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %"d#0", i1  1)  
-  %144 = insertvalue {i64, i1} undef, i64 %"12$d#2", 0 
+  store  i64 %"12$tmp$11##0", i64* %143 
+  %"12$d##2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
+  %144 = insertvalue {i64, i1} undef, i64 %"12$d##2", 0 
   %145 = insertvalue {i64, i1} %144, i1 1, 1 
   ret {i64, i1} %145 
 if.else5:
-  %"13$d#2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %"d#0", i1  0)  
-  %146 = insertvalue {i64, i1} undef, i64 %"13$d#2", 0 
+  %"13$d##2" = tail call fastcc  i64  @"drone.gen$2<0>[6dacb8fd25]"(i64  %"d##0", i1  0)  
+  %146 = insertvalue {i64, i1} undef, i64 %"13$d##2", 0 
   %147 = insertvalue {i64, i1} %146, i1 0, 1 
   ret {i64, i1} %147 
 }
@@ -1505,143 +1505,143 @@ entry:
 
 define external fastcc  void @"drone.gen$1<0>"()    {
 entry:
-  %"1$mc#0" = tail call ccc  i64  @malloc_count()  
+  %"1$mc##0" = tail call ccc  i64  @malloc_count()  
   %163 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @drone.162, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %163)  
-  tail call ccc  void  @print_int(i64  %"1$mc#0")  
+  tail call ccc  void  @print_int(i64  %"1$mc##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  i64 @"drone.gen$2<0>"(i64  %"d#0", i1  %"success#0")    {
+define external fastcc  i64 @"drone.gen$2<0>"(i64  %"d##0", i1  %"success##0")    {
 entry:
-  br i1 %"success#0", label %if.then, label %if.else 
+  br i1 %"success##0", label %if.then, label %if.else 
 if.then:
-  %164 = add   i64 %"d#0", 24 
+  %164 = add   i64 %"d##0", 24 
   %165 = inttoptr i64 %164 to i64* 
   %166 = getelementptr  i64, i64* %165, i64 0 
   %167 = load  i64, i64* %166 
-  %"2$tmp$14#0" = add   i64 %167, 1 
+  %"2$tmp$14##0" = add   i64 %167, 1 
   %168 = trunc i64 32 to i32  
   %169 = tail call ccc  i8*  @wybe_malloc(i32  %168)  
   %170 = ptrtoint i8* %169 to i64 
   %171 = inttoptr i64 %170 to i8* 
-  %172 = inttoptr i64 %"d#0" to i8* 
+  %172 = inttoptr i64 %"d##0" to i8* 
   %173 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %171, i8*  %172, i32  %173, i32  8, i1  0)  
   %174 = add   i64 %170, 24 
   %175 = inttoptr i64 %174 to i64* 
   %176 = getelementptr  i64, i64* %175, i64 0 
-  store  i64 %"2$tmp$14#0", i64* %176 
+  store  i64 %"2$tmp$14##0", i64* %176 
   ret i64 %170 
 if.else:
-  ret i64 %"d#0" 
+  ret i64 %"d##0" 
 }
 
 
-define external fastcc  i64 @"drone.gen$2<0>[6dacb8fd25]"(i64  %"d#0", i1  %"success#0")    {
+define external fastcc  i64 @"drone.gen$2<0>[6dacb8fd25]"(i64  %"d##0", i1  %"success##0")    {
 entry:
-  br i1 %"success#0", label %if.then, label %if.else 
+  br i1 %"success##0", label %if.then, label %if.else 
 if.then:
-  %177 = add   i64 %"d#0", 24 
+  %177 = add   i64 %"d##0", 24 
   %178 = inttoptr i64 %177 to i64* 
   %179 = getelementptr  i64, i64* %178, i64 0 
   %180 = load  i64, i64* %179 
-  %"2$tmp$14#0" = add   i64 %180, 1 
-  %181 = add   i64 %"d#0", 24 
+  %"2$tmp$14##0" = add   i64 %180, 1 
+  %181 = add   i64 %"d##0", 24 
   %182 = inttoptr i64 %181 to i64* 
   %183 = getelementptr  i64, i64* %182, i64 0 
-  store  i64 %"2$tmp$14#0", i64* %183 
-  ret i64 %"d#0" 
+  store  i64 %"2$tmp$14##0", i64* %183 
+  ret i64 %"d##0" 
 if.else:
-  ret i64 %"d#0" 
+  ret i64 %"d##0" 
 }
 
 
-define external fastcc  void @"drone.gen$3<0>"(i64  %"d#0")    {
+define external fastcc  void @"drone.gen$3<0>"(i64  %"d##0")    {
 entry:
-  %"1$ch#1" = tail call ccc  i8  @read_char()  
+  %"1$ch##1" = tail call ccc  i8  @read_char()  
   %184 = alloca i64 
   store  i64 -1, i64* %184 
   %185 = load  i64, i64* %184 
   %186 = trunc i64 %185 to i8  
-  %"1$tmp$4#0" = icmp ne i8 %"1$ch#1", %186 
-  br i1 %"1$tmp$4#0", label %if.then, label %if.else 
+  %"1$tmp$4##0" = icmp ne i8 %"1$ch##1", %186 
+  br i1 %"1$tmp$4##0", label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"drone.loop<0>"(i64  %"d#0", i8  %"1$ch#1")  
+  tail call fastcc  void  @"drone.loop<0>"(i64  %"d##0", i8  %"1$ch##1")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"drone.gen$3<0>[6dacb8fd25]"(i64  %"d#0")    {
+define external fastcc  void @"drone.gen$3<0>[6dacb8fd25]"(i64  %"d##0")    {
 entry:
-  %"1$ch#1" = tail call ccc  i8  @read_char()  
+  %"1$ch##1" = tail call ccc  i8  @read_char()  
   %187 = alloca i64 
   store  i64 -1, i64* %187 
   %188 = load  i64, i64* %187 
   %189 = trunc i64 %188 to i8  
-  %"1$tmp$4#0" = icmp ne i8 %"1$ch#1", %189 
-  br i1 %"1$tmp$4#0", label %if.then, label %if.else 
+  %"1$tmp$4##0" = icmp ne i8 %"1$ch##1", %189 
+  br i1 %"1$tmp$4##0", label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"drone.loop<0>[410bae77d3]"(i64  %"d#0", i8  %"1$ch#1")  
+  tail call fastcc  void  @"drone.loop<0>[410bae77d3]"(i64  %"d##0", i8  %"1$ch##1")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"drone.loop<0>"(i64  %"d#0", i8  %"ch#0")    {
+define external fastcc  void @"drone.loop<0>"(i64  %"d##0", i8  %"ch##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i8 %"ch#0", 32 
-  %"1$tmp$1#0" = icmp ne i8 %"ch#0", 10 
-  %"1$tmp$7#0" = and i1 %"1$tmp$0#0", %"1$tmp$1#0" 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i8 %"ch##0", 32 
+  %"1$tmp$1##0" = icmp ne i8 %"ch##0", 10 
+  %"1$tmp$7##0" = and i1 %"1$tmp$0##0", %"1$tmp$1##0" 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$6#0" = icmp eq i8 %"ch#0", 112 
-  br i1 %"2$tmp$6#0", label %if.then1, label %if.else1 
+  %"2$tmp$6##0" = icmp eq i8 %"ch##0", 112 
+  br i1 %"2$tmp$6##0", label %if.then1, label %if.else1 
 if.else:
-  tail call fastcc  void  @"drone.gen$3<0>"(i64  %"d#0")  
+  tail call fastcc  void  @"drone.gen$3<0>"(i64  %"d##0")  
   ret void 
 if.then1:
   %191 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @drone.190, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %191)  
-  %192 = inttoptr i64 %"d#0" to i64* 
+  %192 = inttoptr i64 %"d##0" to i64* 
   %193 = getelementptr  i64, i64* %192, i64 0 
   %194 = load  i64, i64* %193 
   tail call ccc  void  @print_int(i64  %194)  
   %196 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @drone.195, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %196)  
-  %197 = add   i64 %"d#0", 8 
+  %197 = add   i64 %"d##0", 8 
   %198 = inttoptr i64 %197 to i64* 
   %199 = getelementptr  i64, i64* %198, i64 0 
   %200 = load  i64, i64* %199 
   tail call ccc  void  @print_int(i64  %200)  
   %202 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @drone.201, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %202)  
-  %203 = add   i64 %"d#0", 16 
+  %203 = add   i64 %"d##0", 16 
   %204 = inttoptr i64 %203 to i64* 
   %205 = getelementptr  i64, i64* %204, i64 0 
   %206 = load  i64, i64* %205 
   tail call ccc  void  @print_int(i64  %206)  
   %208 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @drone.207, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %208)  
-  %209 = add   i64 %"d#0", 24 
+  %209 = add   i64 %"d##0", 24 
   %210 = inttoptr i64 %209 to i64* 
   %211 = getelementptr  i64, i64* %210, i64 0 
   %212 = load  i64, i64* %211 
   tail call ccc  void  @print_int(i64  %212)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"drone.gen$3<0>"(i64  %"d#0")  
+  tail call fastcc  void  @"drone.gen$3<0>"(i64  %"d##0")  
   ret void 
 if.else1:
-  %213 = tail call fastcc  {i64, i1}  @"drone.do_action<0>"(i64  %"d#0", i8  %"ch#0")  
+  %213 = tail call fastcc  {i64, i1}  @"drone.do_action<0>"(i64  %"d##0", i8  %"ch##0")  
   %214 = extractvalue {i64, i1} %213, 0 
   %215 = extractvalue {i64, i1} %213, 1 
-  %"5$tmp$5#0" = icmp eq i1 %215, 0 
-  br i1 %"5$tmp$5#0", label %if.then2, label %if.else2 
+  %"5$tmp$5##0" = icmp eq i1 %215, 0 
+  br i1 %"5$tmp$5##0", label %if.then2, label %if.else2 
 if.then2:
   %217 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @drone.216, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %217)  
@@ -1654,55 +1654,55 @@ if.else2:
 }
 
 
-define external fastcc  void @"drone.loop<0>[410bae77d3]"(i64  %"d#0", i8  %"ch#0")    {
+define external fastcc  void @"drone.loop<0>[410bae77d3]"(i64  %"d##0", i8  %"ch##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i8 %"ch#0", 32 
-  %"1$tmp$1#0" = icmp ne i8 %"ch#0", 10 
-  %"1$tmp$7#0" = and i1 %"1$tmp$0#0", %"1$tmp$1#0" 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i8 %"ch##0", 32 
+  %"1$tmp$1##0" = icmp ne i8 %"ch##0", 10 
+  %"1$tmp$7##0" = and i1 %"1$tmp$0##0", %"1$tmp$1##0" 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$6#0" = icmp eq i8 %"ch#0", 112 
-  br i1 %"2$tmp$6#0", label %if.then1, label %if.else1 
+  %"2$tmp$6##0" = icmp eq i8 %"ch##0", 112 
+  br i1 %"2$tmp$6##0", label %if.then1, label %if.else1 
 if.else:
-  tail call fastcc  void  @"drone.gen$3<0>[6dacb8fd25]"(i64  %"d#0")  
+  tail call fastcc  void  @"drone.gen$3<0>[6dacb8fd25]"(i64  %"d##0")  
   ret void 
 if.then1:
   %219 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @drone.218, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %219)  
-  %220 = inttoptr i64 %"d#0" to i64* 
+  %220 = inttoptr i64 %"d##0" to i64* 
   %221 = getelementptr  i64, i64* %220, i64 0 
   %222 = load  i64, i64* %221 
   tail call ccc  void  @print_int(i64  %222)  
   %224 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @drone.223, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %224)  
-  %225 = add   i64 %"d#0", 8 
+  %225 = add   i64 %"d##0", 8 
   %226 = inttoptr i64 %225 to i64* 
   %227 = getelementptr  i64, i64* %226, i64 0 
   %228 = load  i64, i64* %227 
   tail call ccc  void  @print_int(i64  %228)  
   %230 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @drone.229, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %230)  
-  %231 = add   i64 %"d#0", 16 
+  %231 = add   i64 %"d##0", 16 
   %232 = inttoptr i64 %231 to i64* 
   %233 = getelementptr  i64, i64* %232, i64 0 
   %234 = load  i64, i64* %233 
   tail call ccc  void  @print_int(i64  %234)  
   %236 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @drone.235, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %236)  
-  %237 = add   i64 %"d#0", 24 
+  %237 = add   i64 %"d##0", 24 
   %238 = inttoptr i64 %237 to i64* 
   %239 = getelementptr  i64, i64* %238, i64 0 
   %240 = load  i64, i64* %239 
   tail call ccc  void  @print_int(i64  %240)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"drone.gen$3<0>[6dacb8fd25]"(i64  %"d#0")  
+  tail call fastcc  void  @"drone.gen$3<0>[6dacb8fd25]"(i64  %"d##0")  
   ret void 
 if.else1:
-  %241 = tail call fastcc  {i64, i1}  @"drone.do_action<0>[410bae77d3]"(i64  %"d#0", i8  %"ch#0")  
+  %241 = tail call fastcc  {i64, i1}  @"drone.do_action<0>[410bae77d3]"(i64  %"d##0", i8  %"ch##0")  
   %242 = extractvalue {i64, i1} %241, 0 
   %243 = extractvalue {i64, i1} %241, 1 
-  %"5$tmp$5#0" = icmp eq i1 %243, 0 
-  br i1 %"5$tmp$5#0", label %if.then2, label %if.else2 
+  %"5$tmp$5##0" = icmp eq i1 %243, 0 
+  br i1 %"5$tmp$5##0", label %if.then2, label %if.else2 
 if.then2:
   %245 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @drone.244, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %245)  
@@ -1715,31 +1715,31 @@ if.else2:
 }
 
 
-define external fastcc  void @"drone.print_info<0>"(i64  %"d#0")    {
+define external fastcc  void @"drone.print_info<0>"(i64  %"d##0")    {
 entry:
   %247 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @drone.246, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %247)  
-  %248 = inttoptr i64 %"d#0" to i64* 
+  %248 = inttoptr i64 %"d##0" to i64* 
   %249 = getelementptr  i64, i64* %248, i64 0 
   %250 = load  i64, i64* %249 
   tail call ccc  void  @print_int(i64  %250)  
   %252 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @drone.251, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %252)  
-  %253 = add   i64 %"d#0", 8 
+  %253 = add   i64 %"d##0", 8 
   %254 = inttoptr i64 %253 to i64* 
   %255 = getelementptr  i64, i64* %254, i64 0 
   %256 = load  i64, i64* %255 
   tail call ccc  void  @print_int(i64  %256)  
   %258 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @drone.257, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %258)  
-  %259 = add   i64 %"d#0", 16 
+  %259 = add   i64 %"d##0", 16 
   %260 = inttoptr i64 %259 to i64* 
   %261 = getelementptr  i64, i64* %260, i64 0 
   %262 = load  i64, i64* %261 
   tail call ccc  void  @print_int(i64  %262)  
   %264 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @drone.263, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %264)  
-  %265 = add   i64 %"d#0", 24 
+  %265 = add   i64 %"d##0", 24 
   %266 = inttoptr i64 %265 to i64* 
   %267 = getelementptr  i64, i64* %266, i64 0 
   %268 = load  i64, i64* %267 
@@ -1771,36 +1771,36 @@ entry:
 
 = > public {inline} (1 calls)
 0: drone.drone_info.=<0>
-=($left#0:drone.drone_info, $right#0:drone.drone_info, ?$$#0:wybe.bool):
+=($left##0:drone.drone_info, $right##0:drone.drone_info, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
-    foreign lpvm access($left#0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$y#0:wybe.int)
-    foreign lpvm access($left#0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$z#0:wybe.int)
-    foreign lpvm access(~$left#0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$count#0:wybe.int)
-    foreign lpvm access($right#0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$x#0:wybe.int)
-    foreign lpvm access($right#0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$y#0:wybe.int)
-    foreign lpvm access($right#0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$z#0:wybe.int)
-    foreign lpvm access(~$right#0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$count#0:wybe.int)
-    foreign llvm icmp_eq(~$left$x#0:wybe.int, ~$right$x#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
+    foreign lpvm access($left##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
+    foreign lpvm access($left##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$z##0:wybe.int)
+    foreign lpvm access(~$left##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$count##0:wybe.int)
+    foreign lpvm access($right##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
+    foreign lpvm access($right##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
+    foreign lpvm access($right##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$z##0:wybe.int)
+    foreign lpvm access(~$right##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$count##0:wybe.int)
+    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y#0:wybe.int, ~$right$y#0:wybe.int, ?tmp$2#0:wybe.bool) @int:nn:nn
-        case ~tmp$2#0:wybe.bool of
+        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?tmp$2##0:wybe.bool) @int:nn:nn
+        case ~tmp$2##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~$left$z#0:wybe.int, ~$right$z#0:wybe.int, ?tmp$3#0:wybe.bool) @int:nn:nn
-            case ~tmp$3#0:wybe.bool of
+            foreign llvm icmp_eq(~$left$z##0:wybe.int, ~$right$z##0:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
+            case ~tmp$3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                foreign llvm icmp_eq(~$left$count#0:wybe.int, ~$right$count#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+                foreign llvm icmp_eq(~$left$count##0:wybe.int, ~$right$count##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
@@ -1808,117 +1808,117 @@ entry:
 
 count > public {inline} (0 calls)
 0: drone.drone_info.count<0>
-count($rec#0:drone.drone_info, ?$#0:wybe.int):
+count($rec##0:drone.drone_info, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 count > public {inline} (0 calls)
 1: drone.drone_info.count<1>
-count($rec#0:drone.drone_info, ?$rec#1:drone.drone_info, $field#0:wybe.int):
+count($rec##0:drone.drone_info, ?$rec##1:drone.drone_info, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:drone.drone_info, ?$rec#1:drone.drone_info, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:drone.drone_info, ?$rec##1:drone.drone_info, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 drone_info > public {inline} (0 calls)
 0: drone.drone_info.drone_info<0>
-drone_info(x#0:wybe.int, y#0:wybe.int, z#0:wybe.int, count#0:wybe.int, ?$#0:drone.drone_info):
+drone_info(x##0:wybe.int, y##0:wybe.int, z##0:wybe.int, count##0:wybe.int, ?$##0:drone.drone_info):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(32:wybe.int, ?$rec#0:drone.drone_info)
-    foreign lpvm mutate(~$rec#0:drone.drone_info, ?$rec#1:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~x#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:drone.drone_info, ?$rec#2:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~y#0:wybe.int)
-    foreign lpvm mutate(~$rec#2:drone.drone_info, ?$rec#3:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~z#0:wybe.int)
-    foreign lpvm mutate(~$rec#3:drone.drone_info, ?$#0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~count#0:wybe.int)
+    foreign lpvm alloc(32:wybe.int, ?$rec##0:drone.drone_info)
+    foreign lpvm mutate(~$rec##0:drone.drone_info, ?$rec##1:drone.drone_info, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:drone.drone_info, ?$rec##2:drone.drone_info, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~$rec##2:drone.drone_info, ?$rec##3:drone.drone_info, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~z##0:wybe.int)
+    foreign lpvm mutate(~$rec##3:drone.drone_info, ?$##0:drone.drone_info, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~count##0:wybe.int)
 drone_info > public {inline} (14 calls)
 1: drone.drone_info.drone_info<1>
-drone_info(?x#0:wybe.int, ?y#0:wybe.int, ?z#0:wybe.int, ?count#0:wybe.int, $#0:drone.drone_info):
+drone_info(?x##0:wybe.int, ?y##0:wybe.int, ?z##0:wybe.int, ?count##0:wybe.int, $##0:drone.drone_info):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?x#0:wybe.int)
-    foreign lpvm access($#0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?y#0:wybe.int)
-    foreign lpvm access($#0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?z#0:wybe.int)
-    foreign lpvm access(~$#0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?count#0:wybe.int)
+    foreign lpvm access($##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access($##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access($##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?z##0:wybe.int)
+    foreign lpvm access(~$##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?count##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: drone.drone_info.x<0>
-x($rec#0:drone.drone_info, ?$#0:wybe.int):
+x($rec##0:drone.drone_info, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 x > public {inline} (0 calls)
 1: drone.drone_info.x<1>
-x($rec#0:drone.drone_info, ?$rec#1:drone.drone_info, $field#0:wybe.int):
+x($rec##0:drone.drone_info, ?$rec##1:drone.drone_info, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:drone.drone_info, ?$rec#1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:drone.drone_info, ?$rec##1:drone.drone_info, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: drone.drone_info.y<0>
-y($rec#0:drone.drone_info, ?$#0:wybe.int):
+y($rec##0:drone.drone_info, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 y > public {inline} (0 calls)
 1: drone.drone_info.y<1>
-y($rec#0:drone.drone_info, ?$rec#1:drone.drone_info, $field#0:wybe.int):
+y($rec##0:drone.drone_info, ?$rec##1:drone.drone_info, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:drone.drone_info, ?$rec#1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:drone.drone_info, ?$rec##1:drone.drone_info, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 z > public {inline} (0 calls)
 0: drone.drone_info.z<0>
-z($rec#0:drone.drone_info, ?$#0:wybe.int):
+z($rec##0:drone.drone_info, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 z > public {inline} (0 calls)
 1: drone.drone_info.z<1>
-z($rec#0:drone.drone_info, ?$rec#1:drone.drone_info, $field#0:wybe.int):
+z($rec##0:drone.drone_info, ?$rec##1:drone.drone_info, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:drone.drone_info, ?$rec#1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:drone.drone_info, ?$rec##1:drone.drone_info, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: drone.drone_info.~=<0>
-~=($left#0:drone.drone_info, $right#0:drone.drone_info, ?$$#0:wybe.bool):
+~=($left##0:drone.drone_info, $right##0:drone.drone_info, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access($left#0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($left#0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$left#0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign lpvm access($right#0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$7#0:wybe.int)
-    foreign lpvm access($right#0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.int)
-    foreign lpvm access($right#0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.int)
-    foreign lpvm access(~$right#0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$7#0:wybe.int, ?tmp$11#0:wybe.bool) @int:nn:nn
-    case ~tmp$11#0:wybe.bool of
+    foreign lpvm access($left##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access($left##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($left##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$left##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign lpvm access($right##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.int)
+    foreign lpvm access($right##0:drone.drone_info, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
+    foreign lpvm access($right##0:drone.drone_info, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.int)
+    foreign lpvm access(~$right##0:drone.drone_info, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$7##0:wybe.int, ?tmp$11##0:wybe.bool) @int:nn:nn
+    case ~tmp$11##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$8#0:wybe.int, ?tmp$12#0:wybe.bool) @int:nn:nn
-        case ~tmp$12#0:wybe.bool of
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$8##0:wybe.int, ?tmp$12##0:wybe.bool) @int:nn:nn
+        case ~tmp$12##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-            foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~tmp$5#0:wybe.int, ~tmp$9#0:wybe.int, ?tmp$13#0:wybe.bool) @int:nn:nn
-            case ~tmp$13#0:wybe.bool of
+            foreign llvm icmp_eq(~tmp$5##0:wybe.int, ~tmp$9##0:wybe.int, ?tmp$13##0:wybe.bool) @int:nn:nn
+            case ~tmp$13##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-                foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+                foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                foreign llvm icmp_eq(~tmp$10#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-                foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm icmp_eq(~tmp$10##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+                foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
@@ -1937,61 +1937,61 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"drone.drone_info.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"drone.drone_info.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = add   i64 %"$left#0", 16 
+  %8 = add   i64 %"$left##0", 16 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
-  %12 = add   i64 %"$left#0", 24 
+  %12 = add   i64 %"$left##0", 24 
   %13 = inttoptr i64 %12 to i64* 
   %14 = getelementptr  i64, i64* %13, i64 0 
   %15 = load  i64, i64* %14 
-  %16 = inttoptr i64 %"$right#0" to i64* 
+  %16 = inttoptr i64 %"$right##0" to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
-  %19 = add   i64 %"$right#0", 8 
+  %19 = add   i64 %"$right##0", 8 
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %23 = add   i64 %"$right#0", 16 
+  %23 = add   i64 %"$right##0", 16 
   %24 = inttoptr i64 %23 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
   %26 = load  i64, i64* %25 
-  %27 = add   i64 %"$right#0", 24 
+  %27 = add   i64 %"$right##0", 24 
   %28 = inttoptr i64 %27 to i64* 
   %29 = getelementptr  i64, i64* %28, i64 0 
   %30 = load  i64, i64* %29 
-  %"1$tmp$1#0" = icmp eq i64 %3, %18 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %18 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = icmp eq i64 %7, %22 
-  br i1 %"2$tmp$2#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = icmp eq i64 %7, %22 
+  br i1 %"2$tmp$2##0", label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %"4$tmp$3#0" = icmp eq i64 %11, %26 
-  br i1 %"4$tmp$3#0", label %if.then2, label %if.else2 
+  %"4$tmp$3##0" = icmp eq i64 %11, %26 
+  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$$$#0" = icmp eq i64 %15, %30 
-  ret i1 %"6$$$#0" 
+  %"6$$$##0" = icmp eq i64 %15, %30 
+  ret i1 %"6$$$##0" 
 if.else2:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"drone.drone_info.count<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"drone.drone_info.count<0>"(i64  %"$rec##0")    {
 entry:
-  %31 = add   i64 %"$rec#0", 24 
+  %31 = add   i64 %"$rec##0", 24 
   %32 = inttoptr i64 %31 to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
@@ -1999,61 +1999,61 @@ entry:
 }
 
 
-define external fastcc  i64 @"drone.drone_info.count<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"drone.drone_info.count<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %35 = trunc i64 32 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec#0" to i8* 
+  %39 = inttoptr i64 %"$rec##0" to i8* 
   %40 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = add   i64 %37, 24 
   %42 = inttoptr i64 %41 to i64* 
   %43 = getelementptr  i64, i64* %42, i64 0 
-  store  i64 %"$field#0", i64* %43 
+  store  i64 %"$field##0", i64* %43 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"drone.drone_info.drone_info<0>"(i64  %"x#0", i64  %"y#0", i64  %"z#0", i64  %"count#0")    {
+define external fastcc  i64 @"drone.drone_info.drone_info<0>"(i64  %"x##0", i64  %"y##0", i64  %"z##0", i64  %"count##0")    {
 entry:
   %44 = trunc i64 32 to i32  
   %45 = tail call ccc  i8*  @wybe_malloc(i32  %44)  
   %46 = ptrtoint i8* %45 to i64 
   %47 = inttoptr i64 %46 to i64* 
   %48 = getelementptr  i64, i64* %47, i64 0 
-  store  i64 %"x#0", i64* %48 
+  store  i64 %"x##0", i64* %48 
   %49 = add   i64 %46, 8 
   %50 = inttoptr i64 %49 to i64* 
   %51 = getelementptr  i64, i64* %50, i64 0 
-  store  i64 %"y#0", i64* %51 
+  store  i64 %"y##0", i64* %51 
   %52 = add   i64 %46, 16 
   %53 = inttoptr i64 %52 to i64* 
   %54 = getelementptr  i64, i64* %53, i64 0 
-  store  i64 %"z#0", i64* %54 
+  store  i64 %"z##0", i64* %54 
   %55 = add   i64 %46, 24 
   %56 = inttoptr i64 %55 to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
-  store  i64 %"count#0", i64* %57 
+  store  i64 %"count##0", i64* %57 
   ret i64 %46 
 }
 
 
-define external fastcc  {i64, i64, i64, i64} @"drone.drone_info.drone_info<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64, i64, i64} @"drone.drone_info.drone_info<1>"(i64  %"$##0")    {
 entry:
-  %58 = inttoptr i64 %"$#0" to i64* 
+  %58 = inttoptr i64 %"$##0" to i64* 
   %59 = getelementptr  i64, i64* %58, i64 0 
   %60 = load  i64, i64* %59 
-  %61 = add   i64 %"$#0", 8 
+  %61 = add   i64 %"$##0", 8 
   %62 = inttoptr i64 %61 to i64* 
   %63 = getelementptr  i64, i64* %62, i64 0 
   %64 = load  i64, i64* %63 
-  %65 = add   i64 %"$#0", 16 
+  %65 = add   i64 %"$##0", 16 
   %66 = inttoptr i64 %65 to i64* 
   %67 = getelementptr  i64, i64* %66, i64 0 
   %68 = load  i64, i64* %67 
-  %69 = add   i64 %"$#0", 24 
+  %69 = add   i64 %"$##0", 24 
   %70 = inttoptr i64 %69 to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
   %72 = load  i64, i64* %71 
@@ -2065,34 +2065,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"drone.drone_info.x<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"drone.drone_info.x<0>"(i64  %"$rec##0")    {
 entry:
-  %77 = inttoptr i64 %"$rec#0" to i64* 
+  %77 = inttoptr i64 %"$rec##0" to i64* 
   %78 = getelementptr  i64, i64* %77, i64 0 
   %79 = load  i64, i64* %78 
   ret i64 %79 
 }
 
 
-define external fastcc  i64 @"drone.drone_info.x<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"drone.drone_info.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %80 = trunc i64 32 to i32  
   %81 = tail call ccc  i8*  @wybe_malloc(i32  %80)  
   %82 = ptrtoint i8* %81 to i64 
   %83 = inttoptr i64 %82 to i8* 
-  %84 = inttoptr i64 %"$rec#0" to i8* 
+  %84 = inttoptr i64 %"$rec##0" to i8* 
   %85 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %83, i8*  %84, i32  %85, i32  8, i1  0)  
   %86 = inttoptr i64 %82 to i64* 
   %87 = getelementptr  i64, i64* %86, i64 0 
-  store  i64 %"$field#0", i64* %87 
+  store  i64 %"$field##0", i64* %87 
   ret i64 %82 
 }
 
 
-define external fastcc  i64 @"drone.drone_info.y<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"drone.drone_info.y<0>"(i64  %"$rec##0")    {
 entry:
-  %88 = add   i64 %"$rec#0", 8 
+  %88 = add   i64 %"$rec##0", 8 
   %89 = inttoptr i64 %88 to i64* 
   %90 = getelementptr  i64, i64* %89, i64 0 
   %91 = load  i64, i64* %90 
@@ -2100,26 +2100,26 @@ entry:
 }
 
 
-define external fastcc  i64 @"drone.drone_info.y<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"drone.drone_info.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %92 = trunc i64 32 to i32  
   %93 = tail call ccc  i8*  @wybe_malloc(i32  %92)  
   %94 = ptrtoint i8* %93 to i64 
   %95 = inttoptr i64 %94 to i8* 
-  %96 = inttoptr i64 %"$rec#0" to i8* 
+  %96 = inttoptr i64 %"$rec##0" to i8* 
   %97 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %95, i8*  %96, i32  %97, i32  8, i1  0)  
   %98 = add   i64 %94, 8 
   %99 = inttoptr i64 %98 to i64* 
   %100 = getelementptr  i64, i64* %99, i64 0 
-  store  i64 %"$field#0", i64* %100 
+  store  i64 %"$field##0", i64* %100 
   ret i64 %94 
 }
 
 
-define external fastcc  i64 @"drone.drone_info.z<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"drone.drone_info.z<0>"(i64  %"$rec##0")    {
 entry:
-  %101 = add   i64 %"$rec#0", 16 
+  %101 = add   i64 %"$rec##0", 16 
   %102 = inttoptr i64 %101 to i64* 
   %103 = getelementptr  i64, i64* %102, i64 0 
   %104 = load  i64, i64* %103 
@@ -2127,76 +2127,76 @@ entry:
 }
 
 
-define external fastcc  i64 @"drone.drone_info.z<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"drone.drone_info.z<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %105 = trunc i64 32 to i32  
   %106 = tail call ccc  i8*  @wybe_malloc(i32  %105)  
   %107 = ptrtoint i8* %106 to i64 
   %108 = inttoptr i64 %107 to i8* 
-  %109 = inttoptr i64 %"$rec#0" to i8* 
+  %109 = inttoptr i64 %"$rec##0" to i8* 
   %110 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %108, i8*  %109, i32  %110, i32  8, i1  0)  
   %111 = add   i64 %107, 16 
   %112 = inttoptr i64 %111 to i64* 
   %113 = getelementptr  i64, i64* %112, i64 0 
-  store  i64 %"$field#0", i64* %113 
+  store  i64 %"$field##0", i64* %113 
   ret i64 %107 
 }
 
 
-define external fastcc  i1 @"drone.drone_info.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"drone.drone_info.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %114 = inttoptr i64 %"$left#0" to i64* 
+  %114 = inttoptr i64 %"$left##0" to i64* 
   %115 = getelementptr  i64, i64* %114, i64 0 
   %116 = load  i64, i64* %115 
-  %117 = add   i64 %"$left#0", 8 
+  %117 = add   i64 %"$left##0", 8 
   %118 = inttoptr i64 %117 to i64* 
   %119 = getelementptr  i64, i64* %118, i64 0 
   %120 = load  i64, i64* %119 
-  %121 = add   i64 %"$left#0", 16 
+  %121 = add   i64 %"$left##0", 16 
   %122 = inttoptr i64 %121 to i64* 
   %123 = getelementptr  i64, i64* %122, i64 0 
   %124 = load  i64, i64* %123 
-  %125 = add   i64 %"$left#0", 24 
+  %125 = add   i64 %"$left##0", 24 
   %126 = inttoptr i64 %125 to i64* 
   %127 = getelementptr  i64, i64* %126, i64 0 
   %128 = load  i64, i64* %127 
-  %129 = inttoptr i64 %"$right#0" to i64* 
+  %129 = inttoptr i64 %"$right##0" to i64* 
   %130 = getelementptr  i64, i64* %129, i64 0 
   %131 = load  i64, i64* %130 
-  %132 = add   i64 %"$right#0", 8 
+  %132 = add   i64 %"$right##0", 8 
   %133 = inttoptr i64 %132 to i64* 
   %134 = getelementptr  i64, i64* %133, i64 0 
   %135 = load  i64, i64* %134 
-  %136 = add   i64 %"$right#0", 16 
+  %136 = add   i64 %"$right##0", 16 
   %137 = inttoptr i64 %136 to i64* 
   %138 = getelementptr  i64, i64* %137, i64 0 
   %139 = load  i64, i64* %138 
-  %140 = add   i64 %"$right#0", 24 
+  %140 = add   i64 %"$right##0", 24 
   %141 = inttoptr i64 %140 to i64* 
   %142 = getelementptr  i64, i64* %141, i64 0 
   %143 = load  i64, i64* %142 
-  %"1$tmp$11#0" = icmp eq i64 %116, %131 
-  br i1 %"1$tmp$11#0", label %if.then, label %if.else 
+  %"1$tmp$11##0" = icmp eq i64 %116, %131 
+  br i1 %"1$tmp$11##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$12#0" = icmp eq i64 %120, %135 
-  br i1 %"2$tmp$12#0", label %if.then1, label %if.else1 
+  %"2$tmp$12##0" = icmp eq i64 %120, %135 
+  br i1 %"2$tmp$12##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 if.then1:
-  %"4$tmp$13#0" = icmp eq i64 %124, %139 
-  br i1 %"4$tmp$13#0", label %if.then2, label %if.else2 
+  %"4$tmp$13##0" = icmp eq i64 %124, %139 
+  br i1 %"4$tmp$13##0", label %if.then2, label %if.else2 
 if.else1:
-  %"5$$$#0" = xor i1 0, 1 
-  ret i1 %"5$$$#0" 
+  %"5$$$##0" = xor i1 0, 1 
+  ret i1 %"5$$$##0" 
 if.then2:
-  %"6$tmp$0#0" = icmp eq i64 %143, %128 
-  %"6$$$#0" = xor i1 %"6$tmp$0#0", 1 
-  ret i1 %"6$$$#0" 
+  %"6$tmp$0##0" = icmp eq i64 %143, %128 
+  %"6$$$##0" = xor i1 %"6$tmp$0##0", 1 
+  ret i1 %"6$$$##0" 
 if.else2:
-  %"7$$$#0" = xor i1 0, 1 
-  ret i1 %"7$$$#0" 
+  %"7$$$##0" = xor i1 0, 1 
+  ret i1 %"7$$$##0" 
 }
 
 ----------------------------------------------------------------------

--- a/test-cases/complex/exp/testcase_multi_specz-drone.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-drone.exp
@@ -421,7 +421,7 @@ LLVM code       : None
 
 = > public {inline} (1 calls)
 0: drone.drone_info.=<0>
-=(#left##0:drone.drone_info, #right##0:drone.drone_info, ?####0:wybe.bool):
+=(#left##0:drone.drone_info, #right##0:drone.drone_info, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
@@ -435,22 +435,22 @@ LLVM code       : None
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?tmp#2##0:wybe.bool) @int:nn:nn
         case ~tmp#2##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign llvm icmp_eq(~#left#z##0:wybe.int, ~#right#z##0:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
             case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
-                foreign llvm icmp_eq(~#left#count##0:wybe.int, ~#right#count##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+                foreign llvm icmp_eq(~#left#count##0:wybe.int, ~#right#count##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -535,7 +535,7 @@ z(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
 
 ~= > public {inline} (0 calls)
 0: drone.drone_info.~=<0>
-~=(#left##0:drone.drone_info, #right##0:drone.drone_info, ?####0:wybe.bool):
+~=(#left##0:drone.drone_info, #right##0:drone.drone_info, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -550,25 +550,25 @@ z(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
     case ~tmp#11##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#8##0:wybe.int, ?tmp#12##0:wybe.bool) @int:nn:nn
         case ~tmp#12##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign llvm icmp_eq(~tmp#5##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#13##0:wybe.bool) @int:nn:nn
             case ~tmp#13##0:wybe.bool of
             0:
                 foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-                foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
             1:
                 foreign llvm icmp_eq(~tmp#10##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-                foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -1771,7 +1771,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: drone.drone_info.=<0>
-=(#left##0:drone.drone_info, #right##0:drone.drone_info, ?####0:wybe.bool):
+=(#left##0:drone.drone_info, #right##0:drone.drone_info, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
@@ -1785,22 +1785,22 @@ entry:
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?tmp#2##0:wybe.bool) @int:nn:nn
         case ~tmp#2##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign llvm icmp_eq(~#left#z##0:wybe.int, ~#right#z##0:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
             case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
-                foreign llvm icmp_eq(~#left#count##0:wybe.int, ~#right#count##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+                foreign llvm icmp_eq(~#left#count##0:wybe.int, ~#right#count##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -1885,7 +1885,7 @@ z(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
 
 ~= > public {inline} (0 calls)
 0: drone.drone_info.~=<0>
-~=(#left##0:drone.drone_info, #right##0:drone.drone_info, ?####0:wybe.bool):
+~=(#left##0:drone.drone_info, #right##0:drone.drone_info, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:drone.drone_info, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -1900,25 +1900,25 @@ z(#rec##0:drone.drone_info, ?#rec##1:drone.drone_info, #field##0:wybe.int):
     case ~tmp#11##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#8##0:wybe.int, ?tmp#12##0:wybe.bool) @int:nn:nn
         case ~tmp#12##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign llvm icmp_eq(~tmp#5##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#13##0:wybe.bool) @int:nn:nn
             case ~tmp#13##0:wybe.bool of
             0:
                 foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-                foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
             1:
                 foreign llvm icmp_eq(~tmp#10##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-                foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -1982,8 +1982,8 @@ if.then1:
 if.else1:
   ret i1 0 
 if.then2:
-  %"6#####0" = icmp eq i64 %15, %30 
-  ret i1 %"6#####0" 
+  %"6##success##0" = icmp eq i64 %15, %30 
+  ret i1 %"6##success##0" 
 if.else2:
   ret i1 0 
 }
@@ -2182,21 +2182,21 @@ if.then:
   %"2#tmp#12##0" = icmp eq i64 %120, %135 
   br i1 %"2#tmp#12##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 if.then1:
   %"4#tmp#13##0" = icmp eq i64 %124, %139 
   br i1 %"4#tmp#13##0", label %if.then2, label %if.else2 
 if.else1:
-  %"5#####0" = xor i1 0, 1 
-  ret i1 %"5#####0" 
+  %"5##success##0" = xor i1 0, 1 
+  ret i1 %"5##success##0" 
 if.then2:
   %"6#tmp#0##0" = icmp eq i64 %143, %128 
-  %"6#####0" = xor i1 %"6#tmp#0##0", 1 
-  ret i1 %"6#####0" 
+  %"6##success##0" = xor i1 %"6#tmp#0##0", 1 
+  ret i1 %"6##success##0" 
 if.else2:
-  %"7#####0" = xor i1 0, 1 
-  ret i1 %"7#####0" 
+  %"7##success##0" = xor i1 0, 1 
+  ret i1 %"7##success##0" 
 }
 
 ----------------------------------------------------------------------

--- a/test-cases/complex/exp/testcase_multi_specz-int_list.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-int_list.exp
@@ -644,13 +644,13 @@ LLVM code       : None
 
 = > public (2 calls)
 0: int_list.int_list.=<0>
-=(#left##0:int_list.int_list, #right##0:int_list.int_list, ?####0:wybe.bool):
+=(#left##0:int_list.int_list, #right##0:int_list.int_list, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~#left##0:int_list.int_list, ~#right##0:int_list.int_list, ?####0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:int_list.int_list, ~#right##0:int_list.int_list, ?#success##0:wybe.bool)
 
     1:
         foreign lpvm access(#left##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#head##0:wybe.int)
@@ -658,7 +658,7 @@ LLVM code       : None
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
         case ~tmp#9##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign lpvm access(#right##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#head##0:wybe.int)
@@ -666,10 +666,10 @@ LLVM code       : None
             foreign llvm icmp_eq(~#left#head##0:wybe.int, ~#right#head##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
             case ~tmp#4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
-                int_list.int_list.=<0>(~#left#tail##0:int_list.int_list, ~#right#tail##0:int_list.int_list, ?####0:wybe.bool) #3
+                int_list.int_list.=<0>(~#left#tail##0:int_list.int_list, ~#right#tail##0:int_list.int_list, ?#success##0:wybe.bool) #3
 
 
 
@@ -685,52 +685,52 @@ cons(head##0:wybe.int, tail##0:int_list.int_list, ?#result##0:int_list.int_list)
     foreign lpvm mutate(~#rec##1:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:int_list.int_list)
 cons > public {inline} (12 calls)
 1: int_list.int_list.cons<1>
-cons(?head##0:wybe.int, ?tail##0:int_list.int_list, #result##0:int_list.int_list, ?####0:wybe.bool):
+cons(?head##0:wybe.int, ?tail##0:int_list.int_list, #result##0:int_list.int_list, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?head##0:wybe.int)
         foreign llvm move(undef:int_list.int_list, ?tail##0:int_list.int_list)
 
     1:
         foreign lpvm access(#result##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
         foreign lpvm access(~#result##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:int_list.int_list)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 head > public {inline} (0 calls)
 0: int_list.int_list.head<0>
-head(#rec##0:int_list.int_list, ?#result##0:wybe.int, ?####0:wybe.bool):
+head(#rec##0:int_list.int_list, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign lpvm access(~#rec##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 head > public {inline} (0 calls)
 1: int_list.int_list.head<1>
-head(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:wybe.int, ?####0:wybe.bool):
+head(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list)
 
     1:
         foreign lpvm mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -744,43 +744,43 @@ nil(?#result##0:int_list.int_list):
 
 tail > public {inline} (0 calls)
 0: int_list.int_list.tail<0>
-tail(#rec##0:int_list.int_list, ?#result##0:int_list.int_list, ?####0:wybe.bool):
+tail(#rec##0:int_list.int_list, ?#result##0:int_list.int_list, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:int_list.int_list, ?#result##0:int_list.int_list)
 
     1:
         foreign lpvm access(~#rec##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:int_list.int_list)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 tail > public {inline} (0 calls)
 1: int_list.int_list.tail<1>
-tail(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:int_list.int_list, ?####0:wybe.bool):
+tail(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:int_list.int_list, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list)
 
     1:
         foreign lpvm {noalias} mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:int_list.int_list)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: int_list.int_list.~=<0>
-~=(#left##0:int_list.int_list, #right##0:int_list.int_list, ?####0:wybe.bool):
+~=(#left##0:int_list.int_list, #right##0:int_list.int_list, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     int_list.int_list.=<0>(~#left##0:int_list.int_list, ~#right##0:int_list.int_list, ?tmp#0##0:wybe.bool) #0
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 LLVM code       : None
 
@@ -2306,13 +2306,13 @@ if.else:
 
 = > public (2 calls)
 0: int_list.int_list.=<0>
-=(#left##0:int_list.int_list, #right##0:int_list.int_list, ?####0:wybe.bool):
+=(#left##0:int_list.int_list, #right##0:int_list.int_list, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~#left##0:int_list.int_list, ~#right##0:int_list.int_list, ?####0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:int_list.int_list, ~#right##0:int_list.int_list, ?#success##0:wybe.bool)
 
     1:
         foreign lpvm access(#left##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#head##0:wybe.int)
@@ -2320,7 +2320,7 @@ if.else:
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
         case ~tmp#9##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign lpvm access(#right##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#head##0:wybe.int)
@@ -2328,10 +2328,10 @@ if.else:
             foreign llvm icmp_eq(~#left#head##0:wybe.int, ~#right#head##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
             case ~tmp#4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
-                int_list.int_list.=<0>(~#left#tail##0:int_list.int_list, ~#right#tail##0:int_list.int_list, ?####0:wybe.bool) #3
+                int_list.int_list.=<0>(~#left#tail##0:int_list.int_list, ~#right#tail##0:int_list.int_list, ?#success##0:wybe.bool) #3
 
 
 
@@ -2347,52 +2347,52 @@ cons(head##0:wybe.int, tail##0:int_list.int_list, ?#result##0:int_list.int_list)
     foreign lpvm mutate(~#rec##1:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:int_list.int_list)
 cons > public {inline} (12 calls)
 1: int_list.int_list.cons<1>
-cons(?head##0:wybe.int, ?tail##0:int_list.int_list, #result##0:int_list.int_list, ?####0:wybe.bool):
+cons(?head##0:wybe.int, ?tail##0:int_list.int_list, #result##0:int_list.int_list, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?head##0:wybe.int)
         foreign llvm move(undef:int_list.int_list, ?tail##0:int_list.int_list)
 
     1:
         foreign lpvm access(#result##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
         foreign lpvm access(~#result##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:int_list.int_list)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 head > public {inline} (0 calls)
 0: int_list.int_list.head<0>
-head(#rec##0:int_list.int_list, ?#result##0:wybe.int, ?####0:wybe.bool):
+head(#rec##0:int_list.int_list, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign lpvm access(~#rec##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 head > public {inline} (0 calls)
 1: int_list.int_list.head<1>
-head(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:wybe.int, ?####0:wybe.bool):
+head(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list)
 
     1:
         foreign lpvm mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -2406,43 +2406,43 @@ nil(?#result##0:int_list.int_list):
 
 tail > public {inline} (0 calls)
 0: int_list.int_list.tail<0>
-tail(#rec##0:int_list.int_list, ?#result##0:int_list.int_list, ?####0:wybe.bool):
+tail(#rec##0:int_list.int_list, ?#result##0:int_list.int_list, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:int_list.int_list, ?#result##0:int_list.int_list)
 
     1:
         foreign lpvm access(~#rec##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:int_list.int_list)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 tail > public {inline} (0 calls)
 1: int_list.int_list.tail<1>
-tail(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:int_list.int_list, ?####0:wybe.bool):
+tail(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:int_list.int_list, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list)
 
     1:
         foreign lpvm {noalias} mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:int_list.int_list)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: int_list.int_list.~=<0>
-~=(#left##0:int_list.int_list, #right##0:int_list.int_list, ?####0:wybe.bool):
+~=(#left##0:int_list.int_list, #right##0:int_list.int_list, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     int_list.int_list.=<0>(~#left##0:int_list.int_list, ~#right##0:int_list.int_list, ?tmp#0##0:wybe.bool) #0
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 
@@ -2473,8 +2473,8 @@ if.then:
   %"2#tmp#9##0" = icmp ne i64 %"#right##0", 0 
   br i1 %"2#tmp#9##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %"3#####0" 
+  %"3##success##0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3##success##0" 
 if.then1:
   %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
@@ -2488,8 +2488,8 @@ if.then1:
 if.else1:
   ret i1 0 
 if.then2:
-  %"6#####0" = tail call fastcc  i1  @"int_list.int_list.=<0>"(i64  %7, i64  %14)  
-  ret i1 %"6#####0" 
+  %"6##success##0" = tail call fastcc  i1  @"int_list.int_list.=<0>"(i64  %7, i64  %14)  
+  ret i1 %"6##success##0" 
 if.else2:
   ret i1 0 
 }
@@ -2632,8 +2632,8 @@ if.else:
 define external fastcc  i1 @"int_list.int_list.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %"1#tmp#0##0" = tail call fastcc  i1  @"int_list.int_list.=<0>"(i64  %"#left##0", i64  %"#right##0")  
-  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
-  ret i1 %"1#####0" 
+  %"1##success##0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1##success##0" 
 }
 --------------------------------------------------
  Module int_list_test

--- a/test-cases/complex/exp/testcase_multi_specz-int_list.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-int_list.exp
@@ -258,25 +258,25 @@ entry:
 
 append > public (0 calls)
 0: int_list.append<0>
-append(lst##0:int_list.int_list, v##0:wybe.int, ?###0:int_list.int_list):
+append(lst##0:int_list.int_list, v##0:wybe.int, ?#result##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.extend<0>,fromList [NonAliasedParamCond 0 [0]]))]
     foreign lpvm alloc(16:wybe.int, ?tmp#5##0:int_list.int_list)
     foreign lpvm mutate(~tmp#5##0:int_list.int_list, ?tmp#6##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
     foreign lpvm mutate(~tmp#6##0:int_list.int_list, ?tmp#7##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:int_list.int_list)
-    int_list.extend<0>(~lst##0:int_list.int_list, ~tmp#7##0:int_list.int_list, ?###0:int_list.int_list) #2 @int_list:nn:nn
+    int_list.extend<0>(~lst##0:int_list.int_list, ~tmp#7##0:int_list.int_list, ?#result##0:int_list.int_list) #2 @int_list:nn:nn
 
 
 count > public (3 calls)
 0: int_list.count<0>
-count(lst##0:int_list.int_list, x##0:wybe.int, ?###0:wybe.int):
+count(lst##0:int_list.int_list, x##0:wybe.int, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.bool)
     case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.int, ?###0:wybe.int) @int_list:nn:nn
+        foreign llvm move(0:wybe.int, ?#result##0:wybe.int) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
@@ -285,24 +285,24 @@ count(lst##0:int_list.int_list, x##0:wybe.int, ?###0:wybe.int):
         foreign llvm icmp_eq(~h##0:wybe.int, ~x##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
         case ~tmp#4##0:wybe.bool of
         0:
-            foreign llvm move(~tmp#2##0:wybe.int, ?###0:wybe.int) @int:nn:nn
+            foreign llvm move(~tmp#2##0:wybe.int, ?#result##0:wybe.int) @int:nn:nn
 
         1:
-            foreign llvm add(~tmp#2##0:wybe.int, 1:wybe.int, ?###0:wybe.int) @int:nn:nn
+            foreign llvm add(~tmp#2##0:wybe.int, 1:wybe.int, ?#result##0:wybe.int) @int:nn:nn
 
 
 
 
 extend > public (3 calls)
 0: int_list.extend<0>[410bae77d3]
-extend(lst1##0:int_list.int_list, lst2##0:int_list.int_list, ?###0:int_list.int_list):
- AliasPairs: [(###0,lst2##0)]
+extend(lst1##0:int_list.int_list, lst2##0:int_list.int_list, ?#result##0:int_list.int_list):
+ AliasPairs: [(#result##0,lst2##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(int_list.extend<0>,fromList [NonAliasedParamCond 0 [0]]))]
     foreign llvm icmp_ne(lst1##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
     case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~lst2##0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(~lst2##0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst1##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
@@ -310,16 +310,16 @@ extend(lst1##0:int_list.int_list, lst2##0:int_list.int_list, ?###0:int_list.int_
         int_list.extend<0>(~t##0:int_list.int_list, ~lst2##0:int_list.int_list, ?tmp#2##0:int_list.int_list) #1 @int_list:nn:nn
         foreign lpvm alloc(16:wybe.int, ?tmp#8##0:int_list.int_list)
         foreign lpvm mutate(~tmp#8##0:int_list.int_list, ?tmp#9##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-        foreign lpvm mutate(~tmp#9##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:int_list.int_list)
+        foreign lpvm mutate(~tmp#9##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:int_list.int_list)
 
 
 
 gen#1 > {inline} (2 calls)
 0: int_list.gen#1<0>
-gen#1([h##0:wybe.int], [lst##0:int_list.int_list], [t##0:int_list.int_list], tmp#2##0:wybe.int, tmp#3##0:wybe.int, [x##0:wybe.int], ?###0:wybe.int):
+gen#1([h##0:wybe.int], [lst##0:int_list.int_list], [t##0:int_list.int_list], tmp#2##0:wybe.int, tmp#3##0:wybe.int, [x##0:wybe.int], ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~tmp#2##0:wybe.int, ~tmp#3##0:wybe.int, ?###0:wybe.int) @int:nn:nn
+    foreign llvm add(~tmp#2##0:wybe.int, ~tmp#3##0:wybe.int, ?#result##0:wybe.int) @int:nn:nn
 
 
 gen#2 > (2 calls)
@@ -356,14 +356,14 @@ gen#3(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, stop##0:
 
 greater > (3 calls)
 0: int_list.greater<0>
-greater(lst##0:int_list.int_list, v##0:wybe.int, ?###0:int_list.int_list):
+greater(lst##0:int_list.int_list, v##0:wybe.int, ?#result##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.greater<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.greater<0>,fromList [NonAliasedParamCond 0 [0]]))]
     foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
     case ~tmp#9##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
@@ -371,34 +371,34 @@ greater(lst##0:int_list.int_list, v##0:wybe.int, ?###0:int_list.int_list):
         foreign llvm icmp_sge(h##0:wybe.int, v##0:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
         case ~tmp#6##0:wybe.bool of
         0:
-            int_list.greater<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?###0:int_list.int_list) #4 @int_list:nn:nn
+            int_list.greater<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?#result##0:int_list.int_list) #4 @int_list:nn:nn
 
         1:
             int_list.greater<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp#3##0:int_list.int_list) #2 @int_list:nn:nn
             foreign lpvm alloc(16:wybe.int, ?tmp#14##0:int_list.int_list)
             foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-            foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
+            foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
 
 
 
 
 index > public {inline} (0 calls)
 0: int_list.index<0>
-index(lst##0:int_list.int_list, x##0:wybe.int, ?###0:wybe.int):
+index(lst##0:int_list.int_list, x##0:wybe.int, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    int_list.index_helper<0>(~lst##0:int_list.int_list, 0:wybe.int, ~x##0:wybe.int, ?###0:wybe.int) #0 @int_list:nn:nn
+    int_list.index_helper<0>(~lst##0:int_list.int_list, 0:wybe.int, ~x##0:wybe.int, ?#result##0:wybe.int) #0 @int_list:nn:nn
 
 
 index_helper > (2 calls)
 0: int_list.index_helper<0>
-index_helper(lst##0:int_list.int_list, idx##0:wybe.int, x##0:wybe.int, ?###0:wybe.int):
+index_helper(lst##0:int_list.int_list, idx##0:wybe.int, x##0:wybe.int, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.bool)
     case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(-1:wybe.int, ?###0:wybe.int) @int_list:nn:nn
+        foreign llvm move(-1:wybe.int, ?#result##0:wybe.int) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
@@ -407,18 +407,18 @@ index_helper(lst##0:int_list.int_list, idx##0:wybe.int, x##0:wybe.int, ?###0:wyb
         case ~tmp#4##0:wybe.bool of
         0:
             foreign llvm add(~idx##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
-            int_list.index_helper<0>(~t##0:int_list.int_list, ~tmp#3##0:wybe.int, ~x##0:wybe.int, ?###0:wybe.int) #3 @int_list:nn:nn
+            int_list.index_helper<0>(~t##0:int_list.int_list, ~tmp#3##0:wybe.int, ~x##0:wybe.int, ?#result##0:wybe.int) #3 @int_list:nn:nn
 
         1:
-            foreign llvm move(~idx##0:wybe.int, ?###0:wybe.int) @int_list:nn:nn
+            foreign llvm move(~idx##0:wybe.int, ?#result##0:wybe.int) @int_list:nn:nn
 
 
 
 
 insert > public (2 calls)
 0: int_list.insert<0>[410bae77d3]
-insert(lst##0:int_list.int_list, idx##0:wybe.int, v##0:wybe.int, ?###0:int_list.int_list):
- AliasPairs: [(###0,lst##0)]
+insert(lst##0:int_list.int_list, idx##0:wybe.int, v##0:wybe.int, ?#result##0:int_list.int_list):
+ AliasPairs: [(#result##0,lst##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(4,(int_list.insert<0>,fromList [NonAliasedParamCond 0 [0]])),(7,(int_list.insert<0>,fromList [NonAliasedParamCond 0 [0]]))]
     foreign llvm icmp_eq(idx##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool) @int:nn:nn
@@ -428,7 +428,7 @@ insert(lst##0:int_list.int_list, idx##0:wybe.int, v##0:wybe.int, ?###0:int_list.
         case ~tmp#13##0:wybe.bool of
         0:
             foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp#7##0:wybe.int) @int:nn:nn
-            int_list.insert<0>(~lst##0:int_list.int_list, ~tmp#7##0:wybe.int, ~v##0:wybe.int, ?###0:int_list.int_list) #7 @int_list:nn:nn
+            int_list.insert<0>(~lst##0:int_list.int_list, ~tmp#7##0:wybe.int, ~v##0:wybe.int, ?#result##0:int_list.int_list) #7 @int_list:nn:nn
 
         1:
             foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
@@ -437,26 +437,26 @@ insert(lst##0:int_list.int_list, idx##0:wybe.int, v##0:wybe.int, ?###0:int_list.
             int_list.insert<0>(~t##0:int_list.int_list, ~tmp#5##0:wybe.int, ~v##0:wybe.int, ?tmp#4##0:int_list.int_list) #4 @int_list:nn:nn
             foreign lpvm alloc(16:wybe.int, ?tmp#18##0:int_list.int_list)
             foreign lpvm mutate(~tmp#18##0:int_list.int_list, ?tmp#19##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-            foreign lpvm mutate(~tmp#19##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#4##0:int_list.int_list)
+            foreign lpvm mutate(~tmp#19##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#4##0:int_list.int_list)
 
 
     1:
         foreign lpvm alloc(16:wybe.int, ?tmp#14##0:int_list.int_list)
         foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
-        foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lst##0:int_list.int_list)
+        foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lst##0:int_list.int_list)
 
 
 
 lesser > (3 calls)
 0: int_list.lesser<0>
-lesser(lst##0:int_list.int_list, v##0:wybe.int, ?###0:int_list.int_list):
+lesser(lst##0:int_list.int_list, v##0:wybe.int, ?#result##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.lesser<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.lesser<0>,fromList [NonAliasedParamCond 0 [0]]))]
     foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
     case ~tmp#9##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
@@ -464,27 +464,27 @@ lesser(lst##0:int_list.int_list, v##0:wybe.int, ?###0:int_list.int_list):
         foreign llvm icmp_slt(h##0:wybe.int, v##0:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
         case ~tmp#6##0:wybe.bool of
         0:
-            int_list.lesser<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?###0:int_list.int_list) #4 @int_list:nn:nn
+            int_list.lesser<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?#result##0:int_list.int_list) #4 @int_list:nn:nn
 
         1:
             int_list.lesser<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp#3##0:int_list.int_list) #2 @int_list:nn:nn
             foreign lpvm alloc(16:wybe.int, ?tmp#14##0:int_list.int_list)
             foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-            foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
+            foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
 
 
 
 
 pop > public (1 calls)
 0: int_list.pop<0>[410bae77d3]
-pop(lst##0:int_list.int_list, idx##0:wybe.int, ?###0:int_list.int_list):
- AliasPairs: [(###0,lst##0)]
+pop(lst##0:int_list.int_list, idx##0:wybe.int, ?#result##0:int_list.int_list):
+ AliasPairs: [(#result##0,lst##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(3,(int_list.pop<0>,fromList [NonAliasedParamCond 0 [0]]))]
     foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
     case ~tmp#9##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
@@ -496,10 +496,10 @@ pop(lst##0:int_list.int_list, idx##0:wybe.int, ?###0:int_list.int_list):
             int_list.pop<0>(~t##0:int_list.int_list, ~tmp#4##0:wybe.int, ?tmp#3##0:int_list.int_list) #3 @int_list:nn:nn
             foreign lpvm alloc(16:wybe.int, ?tmp#16##0:int_list.int_list)
             foreign lpvm mutate(~tmp#16##0:int_list.int_list, ?tmp#17##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-            foreign lpvm mutate(~tmp#17##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
+            foreign lpvm mutate(~tmp#17##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
 
         1:
-            foreign llvm move(~t##0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
+            foreign llvm move(~t##0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
 
 
@@ -542,14 +542,14 @@ range(start##0:wybe.int, stop##0:wybe.int, step##0:wybe.int, ?result##1:int_list
 
 remove > public (1 calls)
 0: int_list.remove<0>[410bae77d3]
-remove(lst##0:int_list.int_list, v##0:wybe.int, ?###0:int_list.int_list):
- AliasPairs: [(###0,lst##0)]
+remove(lst##0:int_list.int_list, v##0:wybe.int, ?#result##0:int_list.int_list):
+ AliasPairs: [(#result##0,lst##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.remove<0>,fromList [NonAliasedParamCond 0 [0]]))]
     foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool)
     case ~tmp#8##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
@@ -560,32 +560,32 @@ remove(lst##0:int_list.int_list, v##0:wybe.int, ?###0:int_list.int_list):
             int_list.remove<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp#3##0:int_list.int_list) #2 @int_list:nn:nn
             foreign lpvm alloc(16:wybe.int, ?tmp#13##0:int_list.int_list)
             foreign lpvm mutate(~tmp#13##0:int_list.int_list, ?tmp#14##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-            foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
+            foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
 
         1:
-            foreign llvm move(~t##0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
+            foreign llvm move(~t##0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
 
 
 
 reverse > public {inline} (1 calls)
 0: int_list.reverse<0>
-reverse(lst##0:int_list.int_list, ?###0:int_list.int_list):
+reverse(lst##0:int_list.int_list, ?#result##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    int_list.reverse_helper<0>(~lst##0:int_list.int_list, 0:int_list.int_list, ?###0:int_list.int_list) #1 @int_list:nn:nn
+    int_list.reverse_helper<0>(~lst##0:int_list.int_list, 0:int_list.int_list, ?#result##0:int_list.int_list) #1 @int_list:nn:nn
 
 
 reverse_helper > (2 calls)
 0: int_list.reverse_helper<0>
-reverse_helper(lst##0:int_list.int_list, acc##0:int_list.int_list, ?###0:int_list.int_list):
- AliasPairs: [(###0,acc##0)]
+reverse_helper(lst##0:int_list.int_list, acc##0:int_list.int_list, ?#result##0:int_list.int_list):
+ AliasPairs: [(#result##0,acc##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]]))]
     foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
     case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~acc##0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(~acc##0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
@@ -593,20 +593,20 @@ reverse_helper(lst##0:int_list.int_list, acc##0:int_list.int_list, ?###0:int_lis
         foreign lpvm alloc(16:wybe.int, ?tmp#8##0:int_list.int_list)
         foreign lpvm mutate(~tmp#8##0:int_list.int_list, ?tmp#9##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
         foreign lpvm mutate(~tmp#9##0:int_list.int_list, ?tmp#10##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~acc##0:int_list.int_list)
-        int_list.reverse_helper<0>(~t##0:int_list.int_list, ~tmp#10##0:int_list.int_list, ?###0:int_list.int_list) #2 @int_list:nn:nn
+        int_list.reverse_helper<0>(~t##0:int_list.int_list, ~tmp#10##0:int_list.int_list, ?#result##0:int_list.int_list) #2 @int_list:nn:nn
 
 
 
 sort > public (2 calls)
 0: int_list.sort<0>[410bae77d3]
-sort(lst##0:int_list.int_list, ?###0:int_list.int_list):
+sort(lst##0:int_list.int_list, ?#result##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.sort<0>,fromList [NonAliasedParamCond 0 []])),(3,(int_list.greater<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.sort<0>,fromList [NonAliasedParamCond 0 []])),(6,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []]))]
     foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
     case ~tmp#10##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
@@ -618,7 +618,7 @@ sort(lst##0:int_list.int_list, ?###0:int_list.int_list):
         foreign lpvm alloc(16:wybe.int, ?tmp#13##0:int_list.int_list)
         foreign lpvm mutate(~tmp#13##0:int_list.int_list, ?tmp#14##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
         foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##0:int_list.int_list)
-        int_list.extend<0>[410bae77d3](~tmp#2##0:int_list.int_list, ~tmp#15##0:int_list.int_list, ?###0:int_list.int_list) #6 @int_list:nn:nn
+        int_list.extend<0>[410bae77d3](~tmp#2##0:int_list.int_list, ~tmp#15##0:int_list.int_list, ?#result##0:int_list.int_list) #6 @int_list:nn:nn
 
 
 LLVM code       : None
@@ -677,18 +677,18 @@ LLVM code       : None
 
 cons > public {inline} (0 calls)
 0: int_list.int_list.cons<0>
-cons(head##0:wybe.int, tail##0:int_list.int_list, ?###0:int_list.int_list):
+cons(head##0:wybe.int, tail##0:int_list.int_list, ?#result##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:int_list.int_list)
     foreign lpvm mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:int_list.int_list)
+    foreign lpvm mutate(~#rec##1:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:int_list.int_list)
 cons > public {inline} (12 calls)
 1: int_list.int_list.cons<1>
-cons(?head##0:wybe.int, ?tail##0:int_list.int_list, ###0:int_list.int_list, ?####0:wybe.bool):
+cons(?head##0:wybe.int, ?tail##0:int_list.int_list, #result##0:int_list.int_list, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
@@ -696,25 +696,25 @@ cons(?head##0:wybe.int, ?tail##0:int_list.int_list, ###0:int_list.int_list, ?###
         foreign llvm move(undef:int_list.int_list, ?tail##0:int_list.int_list)
 
     1:
-        foreign lpvm access(###0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
-        foreign lpvm access(~###0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:int_list.int_list)
+        foreign lpvm access(#result##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
+        foreign lpvm access(~#result##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:int_list.int_list)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 head > public {inline} (0 calls)
 0: int_list.int_list.head<0>
-head(#rec##0:int_list.int_list, ?###0:wybe.int, ?####0:wybe.bool):
+head(#rec##0:int_list.int_list, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign lpvm access(~#rec##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 head > public {inline} (0 calls)
@@ -736,25 +736,25 @@ head(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:wybe.int, 
 
 nil > public {inline} (0 calls)
 0: int_list.int_list.nil<0>
-nil(?###0:int_list.int_list):
+nil(?#result##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:int_list.int_list, ?###0:int_list.int_list)
+    foreign llvm move(0:int_list.int_list, ?#result##0:int_list.int_list)
 
 
 tail > public {inline} (0 calls)
 0: int_list.int_list.tail<0>
-tail(#rec##0:int_list.int_list, ?###0:int_list.int_list, ?####0:wybe.bool):
+tail(#rec##0:int_list.int_list, ?#result##0:int_list.int_list, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:int_list.int_list, ?###0:int_list.int_list)
+        foreign llvm move(undef:int_list.int_list, ?#result##0:int_list.int_list)
 
     1:
-        foreign lpvm access(~#rec##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:int_list.int_list)
+        foreign lpvm access(~#rec##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:int_list.int_list)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 tail > public {inline} (0 calls)
@@ -1097,30 +1097,30 @@ entry:
 
 append > public (0 calls)
 0: int_list.append<0>[410bae77d3]
-append(lst##0:int_list.int_list, v##0:wybe.int, ?###0:int_list.int_list):
+append(lst##0:int_list.int_list, v##0:wybe.int, ?#result##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.extend<0>,fromList [NonAliasedParamCond 0 [0]]))]
     foreign lpvm alloc(16:wybe.int, ?tmp#5##0:int_list.int_list)
     foreign lpvm mutate(~tmp#5##0:int_list.int_list, ?tmp#6##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
     foreign lpvm mutate(~tmp#6##0:int_list.int_list, ?tmp#7##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:int_list.int_list)
-    int_list.extend<0>(~lst##0:int_list.int_list, ~tmp#7##0:int_list.int_list, ?###0:int_list.int_list) #2 @int_list:nn:nn
+    int_list.extend<0>(~lst##0:int_list.int_list, ~tmp#7##0:int_list.int_list, ?#result##0:int_list.int_list) #2 @int_list:nn:nn
  [410bae77d3] [NonAliasedParam 0] :
     foreign lpvm alloc(16:wybe.int, ?tmp#5##0:int_list.int_list)
     foreign lpvm mutate(~tmp#5##0:int_list.int_list, ?tmp#6##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
     foreign lpvm mutate(~tmp#6##0:int_list.int_list, ?tmp#7##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:int_list.int_list)
-    int_list.extend<0>[410bae77d3](~lst##0:int_list.int_list, ~tmp#7##0:int_list.int_list, ?###0:int_list.int_list) #2 @int_list:nn:nn
+    int_list.extend<0>[410bae77d3](~lst##0:int_list.int_list, ~tmp#7##0:int_list.int_list, ?#result##0:int_list.int_list) #2 @int_list:nn:nn
 
 
 count > public (3 calls)
 0: int_list.count<0>
-count(lst##0:int_list.int_list, x##0:wybe.int, ?###0:wybe.int):
+count(lst##0:int_list.int_list, x##0:wybe.int, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.bool)
     case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.int, ?###0:wybe.int) @int_list:nn:nn
+        foreign llvm move(0:wybe.int, ?#result##0:wybe.int) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
@@ -1129,24 +1129,24 @@ count(lst##0:int_list.int_list, x##0:wybe.int, ?###0:wybe.int):
         foreign llvm icmp_eq(~h##0:wybe.int, ~x##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
         case ~tmp#4##0:wybe.bool of
         0:
-            foreign llvm move(~tmp#2##0:wybe.int, ?###0:wybe.int) @int:nn:nn
+            foreign llvm move(~tmp#2##0:wybe.int, ?#result##0:wybe.int) @int:nn:nn
 
         1:
-            foreign llvm add(~tmp#2##0:wybe.int, 1:wybe.int, ?###0:wybe.int) @int:nn:nn
+            foreign llvm add(~tmp#2##0:wybe.int, 1:wybe.int, ?#result##0:wybe.int) @int:nn:nn
 
 
 
 
 extend > public (3 calls)
 0: int_list.extend<0>[410bae77d3]
-extend(lst1##0:int_list.int_list, lst2##0:int_list.int_list, ?###0:int_list.int_list):
- AliasPairs: [(###0,lst2##0)]
+extend(lst1##0:int_list.int_list, lst2##0:int_list.int_list, ?#result##0:int_list.int_list):
+ AliasPairs: [(#result##0,lst2##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(int_list.extend<0>,fromList [NonAliasedParamCond 0 [0]]))]
     foreign llvm icmp_ne(lst1##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
     case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~lst2##0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(~lst2##0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst1##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
@@ -1154,27 +1154,27 @@ extend(lst1##0:int_list.int_list, lst2##0:int_list.int_list, ?###0:int_list.int_
         int_list.extend<0>(~t##0:int_list.int_list, ~lst2##0:int_list.int_list, ?tmp#2##0:int_list.int_list) #1 @int_list:nn:nn
         foreign lpvm alloc(16:wybe.int, ?tmp#8##0:int_list.int_list)
         foreign lpvm mutate(~tmp#8##0:int_list.int_list, ?tmp#9##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-        foreign lpvm mutate(~tmp#9##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:int_list.int_list)
+        foreign lpvm mutate(~tmp#9##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:int_list.int_list)
 
  [410bae77d3] [NonAliasedParam 0] :
     foreign llvm icmp_ne(lst1##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
     case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~lst2##0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(~lst2##0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst1##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
         int_list.extend<0>[410bae77d3](~t##0:int_list.int_list, ~lst2##0:int_list.int_list, ?tmp#2##0:int_list.int_list) #1 @int_list:nn:nn
-        foreign lpvm mutate(~lst1##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:int_list.int_list)
+        foreign lpvm mutate(~lst1##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:int_list.int_list)
 
 
 
 gen#1 > {inline} (2 calls)
 0: int_list.gen#1<0>
-gen#1([h##0:wybe.int], [lst##0:int_list.int_list], [t##0:int_list.int_list], tmp#2##0:wybe.int, tmp#3##0:wybe.int, [x##0:wybe.int], ?###0:wybe.int):
+gen#1([h##0:wybe.int], [lst##0:int_list.int_list], [t##0:int_list.int_list], tmp#2##0:wybe.int, tmp#3##0:wybe.int, [x##0:wybe.int], ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~tmp#2##0:wybe.int, ~tmp#3##0:wybe.int, ?###0:wybe.int) @int:nn:nn
+    foreign llvm add(~tmp#2##0:wybe.int, ~tmp#3##0:wybe.int, ?#result##0:wybe.int) @int:nn:nn
 
 
 gen#2 > (2 calls)
@@ -1224,14 +1224,14 @@ gen#3(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, stop##0:
 
 greater > (3 calls)
 0: int_list.greater<0>[410bae77d3]
-greater(lst##0:int_list.int_list, v##0:wybe.int, ?###0:int_list.int_list):
+greater(lst##0:int_list.int_list, v##0:wybe.int, ?#result##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.greater<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.greater<0>,fromList [NonAliasedParamCond 0 [0]]))]
     foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
     case ~tmp#9##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
@@ -1239,20 +1239,20 @@ greater(lst##0:int_list.int_list, v##0:wybe.int, ?###0:int_list.int_list):
         foreign llvm icmp_sge(h##0:wybe.int, v##0:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
         case ~tmp#6##0:wybe.bool of
         0:
-            int_list.greater<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?###0:int_list.int_list) #4 @int_list:nn:nn
+            int_list.greater<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?#result##0:int_list.int_list) #4 @int_list:nn:nn
 
         1:
             int_list.greater<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp#3##0:int_list.int_list) #2 @int_list:nn:nn
             foreign lpvm alloc(16:wybe.int, ?tmp#14##0:int_list.int_list)
             foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-            foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
+            foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
 
 
  [410bae77d3] [NonAliasedParam 0] :
     foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
     case ~tmp#9##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
@@ -1260,32 +1260,32 @@ greater(lst##0:int_list.int_list, v##0:wybe.int, ?###0:int_list.int_list):
         foreign llvm icmp_sge(~h##0:wybe.int, v##0:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
         case ~tmp#6##0:wybe.bool of
         0:
-            int_list.greater<0>[410bae77d3](~t##0:int_list.int_list, ~v##0:wybe.int, ?###0:int_list.int_list) #4 @int_list:nn:nn
+            int_list.greater<0>[410bae77d3](~t##0:int_list.int_list, ~v##0:wybe.int, ?#result##0:int_list.int_list) #4 @int_list:nn:nn
 
         1:
             int_list.greater<0>[410bae77d3](~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp#3##0:int_list.int_list) #2 @int_list:nn:nn
-            foreign lpvm mutate(~lst##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
+            foreign lpvm mutate(~lst##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
 
 
 
 
 index > public {inline} (0 calls)
 0: int_list.index<0>
-index(lst##0:int_list.int_list, x##0:wybe.int, ?###0:wybe.int):
+index(lst##0:int_list.int_list, x##0:wybe.int, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    int_list.index_helper<0>(~lst##0:int_list.int_list, 0:wybe.int, ~x##0:wybe.int, ?###0:wybe.int) #0 @int_list:nn:nn
+    int_list.index_helper<0>(~lst##0:int_list.int_list, 0:wybe.int, ~x##0:wybe.int, ?#result##0:wybe.int) #0 @int_list:nn:nn
 
 
 index_helper > (2 calls)
 0: int_list.index_helper<0>
-index_helper(lst##0:int_list.int_list, idx##0:wybe.int, x##0:wybe.int, ?###0:wybe.int):
+index_helper(lst##0:int_list.int_list, idx##0:wybe.int, x##0:wybe.int, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.bool)
     case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(-1:wybe.int, ?###0:wybe.int) @int_list:nn:nn
+        foreign llvm move(-1:wybe.int, ?#result##0:wybe.int) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
@@ -1294,18 +1294,18 @@ index_helper(lst##0:int_list.int_list, idx##0:wybe.int, x##0:wybe.int, ?###0:wyb
         case ~tmp#4##0:wybe.bool of
         0:
             foreign llvm add(~idx##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
-            int_list.index_helper<0>(~t##0:int_list.int_list, ~tmp#3##0:wybe.int, ~x##0:wybe.int, ?###0:wybe.int) #3 @int_list:nn:nn
+            int_list.index_helper<0>(~t##0:int_list.int_list, ~tmp#3##0:wybe.int, ~x##0:wybe.int, ?#result##0:wybe.int) #3 @int_list:nn:nn
 
         1:
-            foreign llvm move(~idx##0:wybe.int, ?###0:wybe.int) @int_list:nn:nn
+            foreign llvm move(~idx##0:wybe.int, ?#result##0:wybe.int) @int_list:nn:nn
 
 
 
 
 insert > public (2 calls)
 0: int_list.insert<0>[410bae77d3]
-insert(lst##0:int_list.int_list, idx##0:wybe.int, v##0:wybe.int, ?###0:int_list.int_list):
- AliasPairs: [(###0,lst##0)]
+insert(lst##0:int_list.int_list, idx##0:wybe.int, v##0:wybe.int, ?#result##0:int_list.int_list):
+ AliasPairs: [(#result##0,lst##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(4,(int_list.insert<0>,fromList [NonAliasedParamCond 0 [0]])),(7,(int_list.insert<0>,fromList [NonAliasedParamCond 0 [0]]))]
     foreign llvm icmp_eq(idx##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool) @int:nn:nn
@@ -1315,7 +1315,7 @@ insert(lst##0:int_list.int_list, idx##0:wybe.int, v##0:wybe.int, ?###0:int_list.
         case ~tmp#13##0:wybe.bool of
         0:
             foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp#7##0:wybe.int) @int:nn:nn
-            int_list.insert<0>(~lst##0:int_list.int_list, ~tmp#7##0:wybe.int, ~v##0:wybe.int, ?###0:int_list.int_list) #7 @int_list:nn:nn
+            int_list.insert<0>(~lst##0:int_list.int_list, ~tmp#7##0:wybe.int, ~v##0:wybe.int, ?#result##0:int_list.int_list) #7 @int_list:nn:nn
 
         1:
             foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
@@ -1324,13 +1324,13 @@ insert(lst##0:int_list.int_list, idx##0:wybe.int, v##0:wybe.int, ?###0:int_list.
             int_list.insert<0>(~t##0:int_list.int_list, ~tmp#5##0:wybe.int, ~v##0:wybe.int, ?tmp#4##0:int_list.int_list) #4 @int_list:nn:nn
             foreign lpvm alloc(16:wybe.int, ?tmp#18##0:int_list.int_list)
             foreign lpvm mutate(~tmp#18##0:int_list.int_list, ?tmp#19##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-            foreign lpvm mutate(~tmp#19##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#4##0:int_list.int_list)
+            foreign lpvm mutate(~tmp#19##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#4##0:int_list.int_list)
 
 
     1:
         foreign lpvm alloc(16:wybe.int, ?tmp#14##0:int_list.int_list)
         foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
-        foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lst##0:int_list.int_list)
+        foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lst##0:int_list.int_list)
 
  [410bae77d3] [NonAliasedParam 0] :
     foreign llvm icmp_eq(idx##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool) @int:nn:nn
@@ -1340,32 +1340,32 @@ insert(lst##0:int_list.int_list, idx##0:wybe.int, v##0:wybe.int, ?###0:int_list.
         case ~tmp#13##0:wybe.bool of
         0:
             foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp#7##0:wybe.int) @int:nn:nn
-            int_list.insert<0>[410bae77d3](~lst##0:int_list.int_list, ~tmp#7##0:wybe.int, ~v##0:wybe.int, ?###0:int_list.int_list) #7 @int_list:nn:nn
+            int_list.insert<0>[410bae77d3](~lst##0:int_list.int_list, ~tmp#7##0:wybe.int, ~v##0:wybe.int, ?#result##0:int_list.int_list) #7 @int_list:nn:nn
 
         1:
             foreign lpvm access(lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
             foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp#5##0:wybe.int) @int:nn:nn
             int_list.insert<0>[410bae77d3](~t##0:int_list.int_list, ~tmp#5##0:wybe.int, ~v##0:wybe.int, ?tmp#4##0:int_list.int_list) #4 @int_list:nn:nn
-            foreign lpvm mutate(~lst##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#4##0:int_list.int_list)
+            foreign lpvm mutate(~lst##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#4##0:int_list.int_list)
 
 
     1:
         foreign lpvm alloc(16:wybe.int, ?tmp#14##0:int_list.int_list)
         foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
-        foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lst##0:int_list.int_list)
+        foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lst##0:int_list.int_list)
 
 
 
 lesser > (3 calls)
 0: int_list.lesser<0>
-lesser(lst##0:int_list.int_list, v##0:wybe.int, ?###0:int_list.int_list):
+lesser(lst##0:int_list.int_list, v##0:wybe.int, ?#result##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.lesser<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.lesser<0>,fromList [NonAliasedParamCond 0 [0]]))]
     foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
     case ~tmp#9##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
@@ -1373,27 +1373,27 @@ lesser(lst##0:int_list.int_list, v##0:wybe.int, ?###0:int_list.int_list):
         foreign llvm icmp_slt(h##0:wybe.int, v##0:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
         case ~tmp#6##0:wybe.bool of
         0:
-            int_list.lesser<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?###0:int_list.int_list) #4 @int_list:nn:nn
+            int_list.lesser<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?#result##0:int_list.int_list) #4 @int_list:nn:nn
 
         1:
             int_list.lesser<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp#3##0:int_list.int_list) #2 @int_list:nn:nn
             foreign lpvm alloc(16:wybe.int, ?tmp#14##0:int_list.int_list)
             foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-            foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
+            foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
 
 
 
 
 pop > public (1 calls)
 0: int_list.pop<0>[410bae77d3]
-pop(lst##0:int_list.int_list, idx##0:wybe.int, ?###0:int_list.int_list):
- AliasPairs: [(###0,lst##0)]
+pop(lst##0:int_list.int_list, idx##0:wybe.int, ?#result##0:int_list.int_list):
+ AliasPairs: [(#result##0,lst##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(3,(int_list.pop<0>,fromList [NonAliasedParamCond 0 [0]]))]
     foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
     case ~tmp#9##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
@@ -1405,17 +1405,17 @@ pop(lst##0:int_list.int_list, idx##0:wybe.int, ?###0:int_list.int_list):
             int_list.pop<0>(~t##0:int_list.int_list, ~tmp#4##0:wybe.int, ?tmp#3##0:int_list.int_list) #3 @int_list:nn:nn
             foreign lpvm alloc(16:wybe.int, ?tmp#16##0:int_list.int_list)
             foreign lpvm mutate(~tmp#16##0:int_list.int_list, ?tmp#17##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-            foreign lpvm mutate(~tmp#17##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
+            foreign lpvm mutate(~tmp#17##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
 
         1:
-            foreign llvm move(~t##0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
+            foreign llvm move(~t##0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
 
  [410bae77d3] [NonAliasedParam 0] :
     foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
     case ~tmp#9##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
@@ -1424,10 +1424,10 @@ pop(lst##0:int_list.int_list, idx##0:wybe.int, ?###0:int_list.int_list):
         0:
             foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp#4##0:wybe.int) @int:nn:nn
             int_list.pop<0>[410bae77d3](~t##0:int_list.int_list, ~tmp#4##0:wybe.int, ?tmp#3##0:int_list.int_list) #3 @int_list:nn:nn
-            foreign lpvm mutate(~lst##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
+            foreign lpvm mutate(~lst##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
 
         1:
-            foreign llvm move(~t##0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
+            foreign llvm move(~t##0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
 
 
@@ -1470,14 +1470,14 @@ range(start##0:wybe.int, stop##0:wybe.int, step##0:wybe.int, ?result##1:int_list
 
 remove > public (1 calls)
 0: int_list.remove<0>[410bae77d3]
-remove(lst##0:int_list.int_list, v##0:wybe.int, ?###0:int_list.int_list):
- AliasPairs: [(###0,lst##0)]
+remove(lst##0:int_list.int_list, v##0:wybe.int, ?#result##0:int_list.int_list):
+ AliasPairs: [(#result##0,lst##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.remove<0>,fromList [NonAliasedParamCond 0 [0]]))]
     foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool)
     case ~tmp#8##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
@@ -1488,17 +1488,17 @@ remove(lst##0:int_list.int_list, v##0:wybe.int, ?###0:int_list.int_list):
             int_list.remove<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp#3##0:int_list.int_list) #2 @int_list:nn:nn
             foreign lpvm alloc(16:wybe.int, ?tmp#13##0:int_list.int_list)
             foreign lpvm mutate(~tmp#13##0:int_list.int_list, ?tmp#14##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-            foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
+            foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
 
         1:
-            foreign llvm move(~t##0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
+            foreign llvm move(~t##0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
 
  [410bae77d3] [NonAliasedParam 0] :
     foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool)
     case ~tmp#8##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
@@ -1507,32 +1507,32 @@ remove(lst##0:int_list.int_list, v##0:wybe.int, ?###0:int_list.int_list):
         case ~tmp#5##0:wybe.bool of
         0:
             int_list.remove<0>[410bae77d3](~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp#3##0:int_list.int_list) #2 @int_list:nn:nn
-            foreign lpvm mutate(~lst##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
+            foreign lpvm mutate(~lst##0:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
 
         1:
-            foreign llvm move(~t##0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
+            foreign llvm move(~t##0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
 
 
 
 reverse > public {inline} (1 calls)
 0: int_list.reverse<0>
-reverse(lst##0:int_list.int_list, ?###0:int_list.int_list):
+reverse(lst##0:int_list.int_list, ?#result##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    int_list.reverse_helper<0>(~lst##0:int_list.int_list, 0:int_list.int_list, ?###0:int_list.int_list) #1 @int_list:nn:nn
+    int_list.reverse_helper<0>(~lst##0:int_list.int_list, 0:int_list.int_list, ?#result##0:int_list.int_list) #1 @int_list:nn:nn
 
 
 reverse_helper > (2 calls)
 0: int_list.reverse_helper<0>[410bae77d3]
-reverse_helper(lst##0:int_list.int_list, acc##0:int_list.int_list, ?###0:int_list.int_list):
- AliasPairs: [(###0,acc##0)]
+reverse_helper(lst##0:int_list.int_list, acc##0:int_list.int_list, ?#result##0:int_list.int_list):
+ AliasPairs: [(#result##0,acc##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]]))]
     foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
     case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~acc##0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(~acc##0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
@@ -1540,31 +1540,31 @@ reverse_helper(lst##0:int_list.int_list, acc##0:int_list.int_list, ?###0:int_lis
         foreign lpvm alloc(16:wybe.int, ?tmp#8##0:int_list.int_list)
         foreign lpvm mutate(~tmp#8##0:int_list.int_list, ?tmp#9##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
         foreign lpvm mutate(~tmp#9##0:int_list.int_list, ?tmp#10##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~acc##0:int_list.int_list)
-        int_list.reverse_helper<0>(~t##0:int_list.int_list, ~tmp#10##0:int_list.int_list, ?###0:int_list.int_list) #2 @int_list:nn:nn
+        int_list.reverse_helper<0>(~t##0:int_list.int_list, ~tmp#10##0:int_list.int_list, ?#result##0:int_list.int_list) #2 @int_list:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
     foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
     case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~acc##0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(~acc##0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
         foreign lpvm mutate(~lst##0:int_list.int_list, ?tmp#10##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~acc##0:int_list.int_list)
-        int_list.reverse_helper<0>[410bae77d3](~t##0:int_list.int_list, ~tmp#10##0:int_list.int_list, ?###0:int_list.int_list) #2 @int_list:nn:nn
+        int_list.reverse_helper<0>[410bae77d3](~t##0:int_list.int_list, ~tmp#10##0:int_list.int_list, ?#result##0:int_list.int_list) #2 @int_list:nn:nn
 
 
 
 sort > public (2 calls)
 0: int_list.sort<0>[410bae77d3]
-sort(lst##0:int_list.int_list, ?###0:int_list.int_list):
+sort(lst##0:int_list.int_list, ?#result##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.sort<0>,fromList [NonAliasedParamCond 0 []])),(3,(int_list.greater<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.sort<0>,fromList [NonAliasedParamCond 0 []])),(6,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []]))]
     foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
     case ~tmp#10##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
@@ -1576,13 +1576,13 @@ sort(lst##0:int_list.int_list, ?###0:int_list.int_list):
         foreign lpvm alloc(16:wybe.int, ?tmp#13##0:int_list.int_list)
         foreign lpvm mutate(~tmp#13##0:int_list.int_list, ?tmp#14##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
         foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##0:int_list.int_list)
-        int_list.extend<0>[410bae77d3](~tmp#2##0:int_list.int_list, ~tmp#15##0:int_list.int_list, ?###0:int_list.int_list) #6 @int_list:nn:nn
+        int_list.extend<0>[410bae77d3](~tmp#2##0:int_list.int_list, ~tmp#15##0:int_list.int_list, ?#result##0:int_list.int_list) #6 @int_list:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
     foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
     case ~tmp#10##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?#result##0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
@@ -1592,7 +1592,7 @@ sort(lst##0:int_list.int_list, ?###0:int_list.int_list):
         int_list.greater<0>[410bae77d3](~t##0:int_list.int_list, ~h##0:wybe.int, ?tmp#6##0:int_list.int_list) #3 @int_list:nn:nn
         int_list.sort<0>[410bae77d3](~tmp#6##0:int_list.int_list, ?tmp#5##0:int_list.int_list) #4 @int_list:nn:nn
         foreign lpvm mutate(~lst##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##0:int_list.int_list)
-        int_list.extend<0>[410bae77d3](~tmp#2##0:int_list.int_list, ~tmp#15##0:int_list.int_list, ?###0:int_list.int_list) #6 @int_list:nn:nn
+        int_list.extend<0>[410bae77d3](~tmp#2##0:int_list.int_list, ~tmp#15##0:int_list.int_list, ?#result##0:int_list.int_list) #6 @int_list:nn:nn
 
 
   LLVM code       :
@@ -1627,8 +1627,8 @@ entry:
   %7 = inttoptr i64 %6 to i64* 
   %8 = getelementptr  i64, i64* %7, i64 0 
   store  i64 0, i64* %8 
-  %"1####0" = tail call fastcc  i64  @"int_list.extend<0>"(i64  %"lst##0", i64  %3)  
-  ret i64 %"1####0" 
+  %"1##result##0" = tail call fastcc  i64  @"int_list.extend<0>"(i64  %"lst##0", i64  %3)  
+  ret i64 %"1##result##0" 
 }
 
 
@@ -1644,8 +1644,8 @@ entry:
   %15 = inttoptr i64 %14 to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
   store  i64 0, i64* %16 
-  %"1####0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"lst##0", i64  %11)  
-  ret i64 %"1####0" 
+  %"1##result##0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"lst##0", i64  %11)  
+  ret i64 %"1##result##0" 
 }
 
 
@@ -1667,8 +1667,8 @@ if.then:
 if.else:
   ret i64 0 
 if.then1:
-  %"4####0" = add   i64 %"2#tmp#2##0", 1 
-  ret i64 %"4####0" 
+  %"4##result##0" = add   i64 %"2#tmp#2##0", 1 
+  ret i64 %"4##result##0" 
 if.else1:
   ret i64 %"2#tmp#2##0" 
 }
@@ -1725,8 +1725,8 @@ if.else:
 
 define external fastcc  i64 @"int_list.gen#1<0>"(i64  %"tmp#2##0", i64  %"tmp#3##0")    {
 entry:
-  %"1####0" = add   i64 %"tmp#2##0", %"tmp#3##0" 
-  ret i64 %"1####0" 
+  %"1##result##0" = add   i64 %"tmp#2##0", %"tmp#3##0" 
+  ret i64 %"1##result##0" 
 }
 
 
@@ -1826,8 +1826,8 @@ if.then1:
   store  i64 %"4#tmp#3##0", i64* %84 
   ret i64 %79 
 if.else1:
-  %"5####0" = tail call fastcc  i64  @"int_list.greater<0>"(i64  %76, i64  %"v##0")  
-  ret i64 %"5####0" 
+  %"5##result##0" = tail call fastcc  i64  @"int_list.greater<0>"(i64  %76, i64  %"v##0")  
+  ret i64 %"5##result##0" 
 }
 
 
@@ -1855,15 +1855,15 @@ if.then1:
   store  i64 %"4#tmp#3##0", i64* %94 
   ret i64 %"lst##0" 
 if.else1:
-  %"5####0" = tail call fastcc  i64  @"int_list.greater<0>[410bae77d3]"(i64  %91, i64  %"v##0")  
-  ret i64 %"5####0" 
+  %"5##result##0" = tail call fastcc  i64  @"int_list.greater<0>[410bae77d3]"(i64  %91, i64  %"v##0")  
+  ret i64 %"5##result##0" 
 }
 
 
 define external fastcc  i64 @"int_list.index<0>"(i64  %"lst##0", i64  %"x##0")    {
 entry:
-  %"1####0" = tail call fastcc  i64  @"int_list.index_helper<0>"(i64  %"lst##0", i64  0, i64  %"x##0")  
-  ret i64 %"1####0" 
+  %"1##result##0" = tail call fastcc  i64  @"int_list.index_helper<0>"(i64  %"lst##0", i64  0, i64  %"x##0")  
+  ret i64 %"1##result##0" 
 }
 
 
@@ -1887,8 +1887,8 @@ if.then1:
   ret i64 %"idx##0" 
 if.else1:
   %"5#tmp#3##0" = add   i64 %"idx##0", 1 
-  %"5####0" = tail call fastcc  i64  @"int_list.index_helper<0>"(i64  %101, i64  %"5#tmp#3##0", i64  %"x##0")  
-  ret i64 %"5####0" 
+  %"5##result##0" = tail call fastcc  i64  @"int_list.index_helper<0>"(i64  %101, i64  %"5#tmp#3##0", i64  %"x##0")  
+  ret i64 %"5##result##0" 
 }
 
 
@@ -1934,8 +1934,8 @@ if.then1:
   ret i64 %119 
 if.else1:
   %"5#tmp#7##0" = sub   i64 %"idx##0", 1 
-  %"5####0" = tail call fastcc  i64  @"int_list.insert<0>"(i64  %"lst##0", i64  %"5#tmp#7##0", i64  %"v##0")  
-  ret i64 %"5####0" 
+  %"5##result##0" = tail call fastcc  i64  @"int_list.insert<0>"(i64  %"lst##0", i64  %"5#tmp#7##0", i64  %"v##0")  
+  ret i64 %"5##result##0" 
 }
 
 
@@ -1972,8 +1972,8 @@ if.then1:
   ret i64 %"lst##0" 
 if.else1:
   %"5#tmp#7##0" = sub   i64 %"idx##0", 1 
-  %"5####0" = tail call fastcc  i64  @"int_list.insert<0>[410bae77d3]"(i64  %"lst##0", i64  %"5#tmp#7##0", i64  %"v##0")  
-  ret i64 %"5####0" 
+  %"5##result##0" = tail call fastcc  i64  @"int_list.insert<0>[410bae77d3]"(i64  %"lst##0", i64  %"5#tmp#7##0", i64  %"v##0")  
+  ret i64 %"5##result##0" 
 }
 
 
@@ -2007,8 +2007,8 @@ if.then1:
   store  i64 %"4#tmp#3##0", i64* %154 
   ret i64 %149 
 if.else1:
-  %"5####0" = tail call fastcc  i64  @"int_list.lesser<0>"(i64  %146, i64  %"v##0")  
-  ret i64 %"5####0" 
+  %"5##result##0" = tail call fastcc  i64  @"int_list.lesser<0>"(i64  %146, i64  %"v##0")  
+  ret i64 %"5##result##0" 
 }
 
 
@@ -2173,8 +2173,8 @@ if.else1:
 
 define external fastcc  i64 @"int_list.reverse<0>"(i64  %"lst##0")    {
 entry:
-  %"1####0" = tail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %"lst##0", i64  0)  
-  ret i64 %"1####0" 
+  %"1##result##0" = tail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %"lst##0", i64  0)  
+  ret i64 %"1##result##0" 
 }
 
 
@@ -2200,8 +2200,8 @@ if.then:
   %222 = inttoptr i64 %221 to i64* 
   %223 = getelementptr  i64, i64* %222, i64 0 
   store  i64 %"acc##0", i64* %223 
-  %"2####0" = tail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %215, i64  %218)  
-  ret i64 %"2####0" 
+  %"2##result##0" = tail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %215, i64  %218)  
+  ret i64 %"2##result##0" 
 if.else:
   ret i64 %"acc##0" 
 }
@@ -2220,8 +2220,8 @@ if.then:
   %229 = inttoptr i64 %228 to i64* 
   %230 = getelementptr  i64, i64* %229, i64 0 
   store  i64 %"acc##0", i64* %230 
-  %"2####0" = tail call fastcc  i64  @"int_list.reverse_helper<0>[410bae77d3]"(i64  %227, i64  %"lst##0")  
-  ret i64 %"2####0" 
+  %"2##result##0" = tail call fastcc  i64  @"int_list.reverse_helper<0>[410bae77d3]"(i64  %227, i64  %"lst##0")  
+  ret i64 %"2##result##0" 
 if.else:
   ret i64 %"acc##0" 
 }
@@ -2253,8 +2253,8 @@ if.then:
   %244 = inttoptr i64 %243 to i64* 
   %245 = getelementptr  i64, i64* %244, i64 0 
   store  i64 %"2#tmp#5##0", i64* %245 
-  %"2####0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"2#tmp#2##0", i64  %240)  
-  ret i64 %"2####0" 
+  %"2##result##0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"2#tmp#2##0", i64  %240)  
+  ret i64 %"2##result##0" 
 if.else:
   ret i64 0 
 }
@@ -2280,8 +2280,8 @@ if.then:
   %254 = inttoptr i64 %253 to i64* 
   %255 = getelementptr  i64, i64* %254, i64 0 
   store  i64 %"2#tmp#5##0", i64* %255 
-  %"2####0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"2#tmp#2##0", i64  %"lst##0")  
-  ret i64 %"2####0" 
+  %"2##result##0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"2#tmp#2##0", i64  %"lst##0")  
+  ret i64 %"2##result##0" 
 if.else:
   ret i64 0 
 }
@@ -2339,18 +2339,18 @@ if.else:
 
 cons > public {inline} (0 calls)
 0: int_list.int_list.cons<0>
-cons(head##0:wybe.int, tail##0:int_list.int_list, ?###0:int_list.int_list):
+cons(head##0:wybe.int, tail##0:int_list.int_list, ?#result##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:int_list.int_list)
     foreign lpvm mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:int_list.int_list)
+    foreign lpvm mutate(~#rec##1:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:int_list.int_list)
 cons > public {inline} (12 calls)
 1: int_list.int_list.cons<1>
-cons(?head##0:wybe.int, ?tail##0:int_list.int_list, ###0:int_list.int_list, ?####0:wybe.bool):
+cons(?head##0:wybe.int, ?tail##0:int_list.int_list, #result##0:int_list.int_list, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
@@ -2358,25 +2358,25 @@ cons(?head##0:wybe.int, ?tail##0:int_list.int_list, ###0:int_list.int_list, ?###
         foreign llvm move(undef:int_list.int_list, ?tail##0:int_list.int_list)
 
     1:
-        foreign lpvm access(###0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
-        foreign lpvm access(~###0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:int_list.int_list)
+        foreign lpvm access(#result##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
+        foreign lpvm access(~#result##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:int_list.int_list)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 head > public {inline} (0 calls)
 0: int_list.int_list.head<0>
-head(#rec##0:int_list.int_list, ?###0:wybe.int, ?####0:wybe.bool):
+head(#rec##0:int_list.int_list, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign lpvm access(~#rec##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 head > public {inline} (0 calls)
@@ -2398,25 +2398,25 @@ head(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:wybe.int, 
 
 nil > public {inline} (0 calls)
 0: int_list.int_list.nil<0>
-nil(?###0:int_list.int_list):
+nil(?#result##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:int_list.int_list, ?###0:int_list.int_list)
+    foreign llvm move(0:int_list.int_list, ?#result##0:int_list.int_list)
 
 
 tail > public {inline} (0 calls)
 0: int_list.int_list.tail<0>
-tail(#rec##0:int_list.int_list, ?###0:int_list.int_list, ?####0:wybe.bool):
+tail(#rec##0:int_list.int_list, ?#result##0:int_list.int_list, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:int_list.int_list, ?###0:int_list.int_list)
+        foreign llvm move(undef:int_list.int_list, ?#result##0:int_list.int_list)
 
     1:
-        foreign lpvm access(~#rec##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:int_list.int_list)
+        foreign lpvm access(~#rec##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:int_list.int_list)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 tail > public {inline} (0 calls)
@@ -2511,15 +2511,15 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"int_list.int_list.cons<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64, i1} @"int_list.int_list.cons<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  %"1#tmp#0##0" = icmp ne i64 %"#result##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 

--- a/test-cases/complex/exp/testcase_multi_specz-int_list.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-int_list.exp
@@ -106,13 +106,13 @@ AFTER BUILDING MAIN:
 
 *main* > {inline} (0 calls)
 0: .<0>
-(argc#0:wybe.int, argv#0:wybe.array.raw_array(wybe.string), ?exit_code#0:wybe.int, ?io#2:wybe.phantom):
+(argc##0:wybe.int, argv##0:wybe.array.raw_array(wybe.string), ?exit_code##0:wybe.int, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c {semipure} gc_init @memory_management:nn:nn
-    command_line.<0>(~#argc#0:wybe.int, ?_:wybe.int, ?#arguments#0:wybe.array(wybe.string), ~#argv#0:wybe.array.raw_array(wybe.string), ?_:wybe.array.raw_array(wybe.string), ?#command#0:wybe.string, ?#exit_code#0:wybe.int, 0:wybe.phantom, ?_:wybe.phantom) #2
-    int_list_test.<0>(0:wybe.phantom, ?#io#2:wybe.phantom) #3
-    foreign c {semipure,terminal} exit(exit_code#0:wybe.int)
+    command_line.<0>(~#argc##0:wybe.int, ?_:wybe.int, ?#arguments##0:wybe.array(wybe.string), ~#argv##0:wybe.array.raw_array(wybe.string), ?_:wybe.array.raw_array(wybe.string), ?#command##0:wybe.string, ?#exit_code##0:wybe.int, 0:wybe.phantom, ?_:wybe.phantom) #2
+    int_list_test.<0>(0:wybe.phantom, ?#io##2:wybe.phantom) #3
+    foreign c {semipure,terminal} exit(exit_code##0:wybe.int)
 
 LLVM code       : None
 
@@ -137,29 +137,29 @@ LLVM code       : None
 
 *main* > public (0 calls)
 0: command_line.<0>
-(argc#0:wybe.int, [?argc#0:wybe.int], ?arguments#2:wybe.array(wybe.string), argv#0:wybe.array.raw_array(wybe.string), [?argv#0:wybe.array.raw_array(wybe.string)], ?command#2:wybe.string, ?exit_code#1:wybe.int, io#0:wybe.phantom, [?io#0:wybe.phantom]):
+(argc##0:wybe.int, [?argc##0:wybe.int], ?arguments##2:wybe.array(wybe.string), argv##0:wybe.array.raw_array(wybe.string), [?argv##0:wybe.array.raw_array(wybe.string)], ?command##2:wybe.string, ?exit_code##1:wybe.int, io##0:wybe.phantom, [?io##0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$9#0:wybe.array(?T))
-    foreign lpvm mutate(~tmp$9#0:wybe.array(?T), ?tmp$10#0:wybe.array(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc#0:wybe.int)
-    foreign lpvm mutate(~tmp$10#0:wybe.array(?T), ?tmp$1#0:wybe.array(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv#0:wybe.array.raw_array(?T))
-    wybe.array.[|]<0>(?command#2:?T, ?arguments#2:wybe.array(?T), ~tmp$1#0:wybe.array(?T), ?tmp$2#0:wybe.bool) #2 @command_line:nn:nn
-    case ~tmp$2#0:wybe.bool of
+    foreign lpvm alloc(16:wybe.int, ?tmp$9##0:wybe.array(?T))
+    foreign lpvm mutate(~tmp$9##0:wybe.array(?T), ?tmp$10##0:wybe.array(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
+    foreign lpvm mutate(~tmp$10##0:wybe.array(?T), ?tmp$1##0:wybe.array(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(?T))
+    wybe.array.[|]<0>(?command##2:?T, ?arguments##2:wybe.array(?T), ~tmp$1##0:wybe.array(?T), ?tmp$2##0:wybe.bool) #2 @command_line:nn:nn
+    case ~tmp$2##0:wybe.bool of
     0:
         foreign c {terminal,semipure} error_exit("command_line:17:10":wybe.string, "Erroneous program argument vector":wybe.string) @control:nn:nn
-        foreign llvm move(0:wybe.int, ?exit_code#1:wybe.int)
+        foreign llvm move(0:wybe.int, ?exit_code##1:wybe.int)
 
     1:
-        foreign llvm move(0:wybe.int, ?exit_code#1:wybe.int) @command_line:nn:nn
+        foreign llvm move(0:wybe.int, ?exit_code##1:wybe.int) @command_line:nn:nn
 
 
 
 set_exit_code > public {inline} (0 calls)
 0: command_line.set_exit_code<0>
-set_exit_code(code#0:wybe.int, [exit_code#0:wybe.int], ?exit_code#1:wybe.int):
+set_exit_code(code##0:wybe.int, [exit_code##0:wybe.int], ?exit_code##1:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(~code#0:wybe.int, ?exit_code#1:wybe.int) @command_line:nn:nn
+    foreign llvm move(~code##0:wybe.int, ?exit_code##1:wybe.int) @command_line:nn:nn
 
   LLVM code       :
 
@@ -187,18 +187,18 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  {i64, i64, i64} @"command_line.<0>"(i64  %"argc#0", i64  %"argv#0")    {
+define external fastcc  {i64, i64, i64} @"command_line.<0>"(i64  %"argc##0", i64  %"argv##0")    {
 entry:
   %1 = trunc i64 16 to i32  
   %2 = tail call ccc  i8*  @wybe_malloc(i32  %1)  
   %3 = ptrtoint i8* %2 to i64 
   %4 = inttoptr i64 %3 to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
-  store  i64 %"argc#0", i64* %5 
+  store  i64 %"argc##0", i64* %5 
   %6 = add   i64 %3, 8 
   %7 = inttoptr i64 %6 to i64* 
   %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"argv#0", i64* %8 
+  store  i64 %"argv##0", i64* %8 
   %9 = tail call fastcc  {i64, i64, i1}  @"wybe.array.[|]<0>"(i64  %3)  
   %10 = extractvalue {i64, i64, i1} %9, 0 
   %11 = extractvalue {i64, i64, i1} %9, 1 
@@ -220,9 +220,9 @@ if.else:
 }
 
 
-define external fastcc  i64 @"command_line.set_exit_code<0>"(i64  %"code#0")    {
+define external fastcc  i64 @"command_line.set_exit_code<0>"(i64  %"code##0")    {
 entry:
-  ret i64 %"code#0" 
+  ret i64 %"code##0" 
 }
 --------------------------------------------------
  Module int_list
@@ -258,367 +258,367 @@ entry:
 
 append > public (0 calls)
 0: int_list.append<0>
-append(lst#0:int_list.int_list, v#0:wybe.int, ?$#0:int_list.int_list):
+append(lst##0:int_list.int_list, v##0:wybe.int, ?$##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.extend<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign lpvm alloc(16:wybe.int, ?tmp$5#0:int_list.int_list)
-    foreign lpvm mutate(~tmp$5#0:int_list.int_list, ?tmp$6#0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v#0:wybe.int)
-    foreign lpvm mutate(~tmp$6#0:int_list.int_list, ?tmp$7#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:int_list.int_list)
-    int_list.extend<0>(~lst#0:int_list.int_list, ~tmp$7#0:int_list.int_list, ?$#0:int_list.int_list) #2 @int_list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$5##0:int_list.int_list)
+    foreign lpvm mutate(~tmp$5##0:int_list.int_list, ?tmp$6##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
+    foreign lpvm mutate(~tmp$6##0:int_list.int_list, ?tmp$7##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:int_list.int_list)
+    int_list.extend<0>(~lst##0:int_list.int_list, ~tmp$7##0:int_list.int_list, ?$##0:int_list.int_list) #2 @int_list:nn:nn
 
 
 count > public (3 calls)
 0: int_list.count<0>
-count(lst#0:int_list.int_list, x#0:wybe.int, ?$#0:wybe.int):
+count(lst##0:int_list.int_list, x##0:wybe.int, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(lst#0:wybe.int, 0:wybe.int, ?tmp$7#0:wybe.bool)
-    case ~tmp$7#0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.bool)
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.int, ?$#0:wybe.int) @int_list:nn:nn
+        foreign llvm move(0:wybe.int, ?$##0:wybe.int) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:wybe.int)
-        foreign lpvm access(~lst#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:int_list.int_list)
-        int_list.count<0>(~t#0:int_list.int_list, x#0:wybe.int, ?tmp$2#0:wybe.int) #1 @int_list:nn:nn
-        foreign llvm icmp_eq(~h#0:wybe.int, ~x#0:wybe.int, ?tmp$4#0:wybe.bool) @int:nn:nn
-        case ~tmp$4#0:wybe.bool of
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        int_list.count<0>(~t##0:int_list.int_list, x##0:wybe.int, ?tmp$2##0:wybe.int) #1 @int_list:nn:nn
+        foreign llvm icmp_eq(~h##0:wybe.int, ~x##0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
+        case ~tmp$4##0:wybe.bool of
         0:
-            foreign llvm move(~tmp$2#0:wybe.int, ?$#0:wybe.int) @int:nn:nn
+            foreign llvm move(~tmp$2##0:wybe.int, ?$##0:wybe.int) @int:nn:nn
 
         1:
-            foreign llvm add(~tmp$2#0:wybe.int, 1:wybe.int, ?$#0:wybe.int) @int:nn:nn
+            foreign llvm add(~tmp$2##0:wybe.int, 1:wybe.int, ?$##0:wybe.int) @int:nn:nn
 
 
 
 
 extend > public (3 calls)
 0: int_list.extend<0>[410bae77d3]
-extend(lst1#0:int_list.int_list, lst2#0:int_list.int_list, ?$#0:int_list.int_list):
- AliasPairs: [($#0,lst2#0)]
+extend(lst1##0:int_list.int_list, lst2##0:int_list.int_list, ?$##0:int_list.int_list):
+ AliasPairs: [($##0,lst2##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(int_list.extend<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(lst1#0:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.bool)
-    case ~tmp$5#0:wybe.bool of
+    foreign llvm icmp_ne(lst1##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
+    case ~tmp$5##0:wybe.bool of
     0:
-        foreign llvm move(~lst2#0:int_list.int_list, ?$#0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(~lst2##0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst1#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:wybe.int)
-        foreign lpvm access(~lst1#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:int_list.int_list)
-        int_list.extend<0>(~t#0:int_list.int_list, ~lst2#0:int_list.int_list, ?tmp$2#0:int_list.int_list) #1 @int_list:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$8#0:int_list.int_list)
-        foreign lpvm mutate(~tmp$8#0:int_list.int_list, ?tmp$9#0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h#0:wybe.int)
-        foreign lpvm mutate(~tmp$9#0:int_list.int_list, ?$#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:int_list.int_list)
+        foreign lpvm access(lst1##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+        foreign lpvm access(~lst1##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        int_list.extend<0>(~t##0:int_list.int_list, ~lst2##0:int_list.int_list, ?tmp$2##0:int_list.int_list) #1 @int_list:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp$8##0:int_list.int_list)
+        foreign lpvm mutate(~tmp$8##0:int_list.int_list, ?tmp$9##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+        foreign lpvm mutate(~tmp$9##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:int_list.int_list)
 
 
 
 gen$1 > {inline} (2 calls)
 0: int_list.gen$1<0>
-gen$1([h#0:wybe.int], [lst#0:int_list.int_list], [t#0:int_list.int_list], tmp$2#0:wybe.int, tmp$3#0:wybe.int, [x#0:wybe.int], ?$#0:wybe.int):
+gen$1([h##0:wybe.int], [lst##0:int_list.int_list], [t##0:int_list.int_list], tmp$2##0:wybe.int, tmp$3##0:wybe.int, [x##0:wybe.int], ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~tmp$2#0:wybe.int, ~tmp$3#0:wybe.int, ?$#0:wybe.int) @int:nn:nn
+    foreign llvm add(~tmp$2##0:wybe.int, ~tmp$3##0:wybe.int, ?$##0:wybe.int) @int:nn:nn
 
 
 gen$2 > (2 calls)
 0: int_list.gen$2<0>[410bae77d3]
-gen$2(result#0:int_list.int_list, start#0:wybe.int, step#0:wybe.int, stop#0:wybe.int, tmp$0#0:int_list.int_list, ?result#1:int_list.int_list):
+gen$2(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, stop##0:wybe.int, tmp$0##0:int_list.int_list, ?result##1:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(3,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.gen$2<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_slt(start#0:wybe.int, stop#0:wybe.int, ?tmp$3#0:wybe.bool) @int:nn:nn
-    case ~tmp$3#0:wybe.bool of
+    foreign llvm icmp_slt(start##0:wybe.int, stop##0:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
+    case ~tmp$3##0:wybe.bool of
     0:
-        int_list.reverse_helper<0>(~result#0:int_list.int_list, 0:int_list.int_list, ?result#1:int_list.int_list) #3 @int_list:nn:nn
+        int_list.reverse_helper<0>(~result##0:int_list.int_list, 0:int_list.int_list, ?result##1:int_list.int_list) #3 @int_list:nn:nn
 
     1:
-        foreign lpvm alloc(16:wybe.int, ?tmp$12#0:int_list.int_list)
-        foreign lpvm mutate(~tmp$12#0:int_list.int_list, ?tmp$13#0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start#0:wybe.int)
-        foreign lpvm mutate(~tmp$13#0:int_list.int_list, ?tmp$14#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result#0:int_list.int_list)
-        foreign llvm add(~start#0:wybe.int, step#0:wybe.int, ?tmp$15#0:wybe.int) @int:nn:nn
-        int_list.gen$2<0>(~tmp$14#0:int_list.int_list, ~tmp$15#0:wybe.int, ~step#0:wybe.int, ~stop#0:wybe.int, ~tmp$0#0:int_list.int_list, ?result#1:int_list.int_list) #4 @int_list:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp$12##0:int_list.int_list)
+        foreign lpvm mutate(~tmp$12##0:int_list.int_list, ?tmp$13##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int)
+        foreign lpvm mutate(~tmp$13##0:int_list.int_list, ?tmp$14##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list)
+        foreign llvm add(~start##0:wybe.int, step##0:wybe.int, ?tmp$15##0:wybe.int) @int:nn:nn
+        int_list.gen$2<0>(~tmp$14##0:int_list.int_list, ~tmp$15##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ~tmp$0##0:int_list.int_list, ?result##1:int_list.int_list) #4 @int_list:nn:nn
 
 
 
 gen$3 > {inline} (1 calls)
 0: int_list.gen$3<0>
-gen$3(result#0:int_list.int_list, start#0:wybe.int, step#0:wybe.int, stop#0:wybe.int, tmp$0#0:int_list.int_list, ?result#2:int_list.int_list):
+gen$3(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, stop##0:wybe.int, tmp$0##0:int_list.int_list, ?result##2:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$5#0:int_list.int_list)
-    foreign lpvm mutate(~tmp$5#0:int_list.int_list, ?tmp$6#0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start#0:wybe.int)
-    foreign lpvm mutate(~tmp$6#0:int_list.int_list, ?tmp$7#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result#0:int_list.int_list)
-    foreign llvm add(~start#0:wybe.int, step#0:wybe.int, ?tmp$2#0:wybe.int) @int:nn:nn
-    int_list.gen$2<0>(~tmp$7#0:int_list.int_list, ~tmp$2#0:wybe.int, ~step#0:wybe.int, ~stop#0:wybe.int, ~tmp$0#0:int_list.int_list, ?result#2:int_list.int_list) #2 @int_list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$5##0:int_list.int_list)
+    foreign lpvm mutate(~tmp$5##0:int_list.int_list, ?tmp$6##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int)
+    foreign lpvm mutate(~tmp$6##0:int_list.int_list, ?tmp$7##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list)
+    foreign llvm add(~start##0:wybe.int, step##0:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
+    int_list.gen$2<0>(~tmp$7##0:int_list.int_list, ~tmp$2##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ~tmp$0##0:int_list.int_list, ?result##2:int_list.int_list) #2 @int_list:nn:nn
 
 
 greater > (3 calls)
 0: int_list.greater<0>
-greater(lst#0:int_list.int_list, v#0:wybe.int, ?$#0:int_list.int_list):
+greater(lst##0:int_list.int_list, v##0:wybe.int, ?$##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.greater<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.greater<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(lst#0:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.bool)
-    case ~tmp$9#0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
+    case ~tmp$9##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?$#0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:wybe.int)
-        foreign lpvm access(~lst#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:int_list.int_list)
-        foreign llvm icmp_sge(h#0:wybe.int, v#0:wybe.int, ?tmp$6#0:wybe.bool) @int:nn:nn
-        case ~tmp$6#0:wybe.bool of
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign llvm icmp_sge(h##0:wybe.int, v##0:wybe.int, ?tmp$6##0:wybe.bool) @int:nn:nn
+        case ~tmp$6##0:wybe.bool of
         0:
-            int_list.greater<0>(~t#0:int_list.int_list, ~v#0:wybe.int, ?$#0:int_list.int_list) #4 @int_list:nn:nn
+            int_list.greater<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?$##0:int_list.int_list) #4 @int_list:nn:nn
 
         1:
-            int_list.greater<0>(~t#0:int_list.int_list, ~v#0:wybe.int, ?tmp$3#0:int_list.int_list) #2 @int_list:nn:nn
-            foreign lpvm alloc(16:wybe.int, ?tmp$14#0:int_list.int_list)
-            foreign lpvm mutate(~tmp$14#0:int_list.int_list, ?tmp$15#0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h#0:wybe.int)
-            foreign lpvm mutate(~tmp$15#0:int_list.int_list, ?$#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3#0:int_list.int_list)
+            int_list.greater<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp$3##0:int_list.int_list) #2 @int_list:nn:nn
+            foreign lpvm alloc(16:wybe.int, ?tmp$14##0:int_list.int_list)
+            foreign lpvm mutate(~tmp$14##0:int_list.int_list, ?tmp$15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+            foreign lpvm mutate(~tmp$15##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:int_list.int_list)
 
 
 
 
 index > public {inline} (0 calls)
 0: int_list.index<0>
-index(lst#0:int_list.int_list, x#0:wybe.int, ?$#0:wybe.int):
+index(lst##0:int_list.int_list, x##0:wybe.int, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    int_list.index_helper<0>(~lst#0:int_list.int_list, 0:wybe.int, ~x#0:wybe.int, ?$#0:wybe.int) #0 @int_list:nn:nn
+    int_list.index_helper<0>(~lst##0:int_list.int_list, 0:wybe.int, ~x##0:wybe.int, ?$##0:wybe.int) #0 @int_list:nn:nn
 
 
 index_helper > (2 calls)
 0: int_list.index_helper<0>
-index_helper(lst#0:int_list.int_list, idx#0:wybe.int, x#0:wybe.int, ?$#0:wybe.int):
+index_helper(lst##0:int_list.int_list, idx##0:wybe.int, x##0:wybe.int, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(lst#0:wybe.int, 0:wybe.int, ?tmp$7#0:wybe.bool)
-    case ~tmp$7#0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.bool)
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(-1:wybe.int, ?$#0:wybe.int) @int_list:nn:nn
+        foreign llvm move(-1:wybe.int, ?$##0:wybe.int) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:wybe.int)
-        foreign lpvm access(~lst#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:int_list.int_list)
-        foreign llvm icmp_eq(~h#0:wybe.int, x#0:wybe.int, ?tmp$4#0:wybe.bool) @int:nn:nn
-        case ~tmp$4#0:wybe.bool of
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign llvm icmp_eq(~h##0:wybe.int, x##0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
+        case ~tmp$4##0:wybe.bool of
         0:
-            foreign llvm add(~idx#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.int) @int:nn:nn
-            int_list.index_helper<0>(~t#0:int_list.int_list, ~tmp$3#0:wybe.int, ~x#0:wybe.int, ?$#0:wybe.int) #3 @int_list:nn:nn
+            foreign llvm add(~idx##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
+            int_list.index_helper<0>(~t##0:int_list.int_list, ~tmp$3##0:wybe.int, ~x##0:wybe.int, ?$##0:wybe.int) #3 @int_list:nn:nn
 
         1:
-            foreign llvm move(~idx#0:wybe.int, ?$#0:wybe.int) @int_list:nn:nn
+            foreign llvm move(~idx##0:wybe.int, ?$##0:wybe.int) @int_list:nn:nn
 
 
 
 
 insert > public (2 calls)
 0: int_list.insert<0>[410bae77d3]
-insert(lst#0:int_list.int_list, idx#0:wybe.int, v#0:wybe.int, ?$#0:int_list.int_list):
- AliasPairs: [($#0,lst#0)]
+insert(lst##0:int_list.int_list, idx##0:wybe.int, v##0:wybe.int, ?$##0:int_list.int_list):
+ AliasPairs: [($##0,lst##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(4,(int_list.insert<0>,fromList [NonAliasedParamCond 0 [0]])),(7,(int_list.insert<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_eq(idx#0:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.bool) @int:nn:nn
-    case ~tmp$9#0:wybe.bool of
+    foreign llvm icmp_eq(idx##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool) @int:nn:nn
+    case ~tmp$9##0:wybe.bool of
     0:
-        foreign llvm icmp_ne(lst#0:wybe.int, 0:wybe.int, ?tmp$13#0:wybe.bool)
-        case ~tmp$13#0:wybe.bool of
+        foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$13##0:wybe.bool)
+        case ~tmp$13##0:wybe.bool of
         0:
-            foreign llvm sub(~idx#0:wybe.int, 1:wybe.int, ?tmp$7#0:wybe.int) @int:nn:nn
-            int_list.insert<0>(~lst#0:int_list.int_list, ~tmp$7#0:wybe.int, ~v#0:wybe.int, ?$#0:int_list.int_list) #7 @int_list:nn:nn
+            foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp$7##0:wybe.int) @int:nn:nn
+            int_list.insert<0>(~lst##0:int_list.int_list, ~tmp$7##0:wybe.int, ~v##0:wybe.int, ?$##0:int_list.int_list) #7 @int_list:nn:nn
 
         1:
-            foreign lpvm access(lst#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:wybe.int)
-            foreign lpvm access(~lst#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:int_list.int_list)
-            foreign llvm sub(~idx#0:wybe.int, 1:wybe.int, ?tmp$5#0:wybe.int) @int:nn:nn
-            int_list.insert<0>(~t#0:int_list.int_list, ~tmp$5#0:wybe.int, ~v#0:wybe.int, ?tmp$4#0:int_list.int_list) #4 @int_list:nn:nn
-            foreign lpvm alloc(16:wybe.int, ?tmp$18#0:int_list.int_list)
-            foreign lpvm mutate(~tmp$18#0:int_list.int_list, ?tmp$19#0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h#0:wybe.int)
-            foreign lpvm mutate(~tmp$19#0:int_list.int_list, ?$#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$4#0:int_list.int_list)
+            foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+            foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+            foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp$5##0:wybe.int) @int:nn:nn
+            int_list.insert<0>(~t##0:int_list.int_list, ~tmp$5##0:wybe.int, ~v##0:wybe.int, ?tmp$4##0:int_list.int_list) #4 @int_list:nn:nn
+            foreign lpvm alloc(16:wybe.int, ?tmp$18##0:int_list.int_list)
+            foreign lpvm mutate(~tmp$18##0:int_list.int_list, ?tmp$19##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+            foreign lpvm mutate(~tmp$19##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$4##0:int_list.int_list)
 
 
     1:
-        foreign lpvm alloc(16:wybe.int, ?tmp$14#0:int_list.int_list)
-        foreign lpvm mutate(~tmp$14#0:int_list.int_list, ?tmp$15#0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v#0:wybe.int)
-        foreign lpvm mutate(~tmp$15#0:int_list.int_list, ?$#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lst#0:int_list.int_list)
+        foreign lpvm alloc(16:wybe.int, ?tmp$14##0:int_list.int_list)
+        foreign lpvm mutate(~tmp$14##0:int_list.int_list, ?tmp$15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
+        foreign lpvm mutate(~tmp$15##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lst##0:int_list.int_list)
 
 
 
 lesser > (3 calls)
 0: int_list.lesser<0>
-lesser(lst#0:int_list.int_list, v#0:wybe.int, ?$#0:int_list.int_list):
+lesser(lst##0:int_list.int_list, v##0:wybe.int, ?$##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.lesser<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.lesser<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(lst#0:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.bool)
-    case ~tmp$9#0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
+    case ~tmp$9##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?$#0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:wybe.int)
-        foreign lpvm access(~lst#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:int_list.int_list)
-        foreign llvm icmp_slt(h#0:wybe.int, v#0:wybe.int, ?tmp$6#0:wybe.bool) @int:nn:nn
-        case ~tmp$6#0:wybe.bool of
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign llvm icmp_slt(h##0:wybe.int, v##0:wybe.int, ?tmp$6##0:wybe.bool) @int:nn:nn
+        case ~tmp$6##0:wybe.bool of
         0:
-            int_list.lesser<0>(~t#0:int_list.int_list, ~v#0:wybe.int, ?$#0:int_list.int_list) #4 @int_list:nn:nn
+            int_list.lesser<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?$##0:int_list.int_list) #4 @int_list:nn:nn
 
         1:
-            int_list.lesser<0>(~t#0:int_list.int_list, ~v#0:wybe.int, ?tmp$3#0:int_list.int_list) #2 @int_list:nn:nn
-            foreign lpvm alloc(16:wybe.int, ?tmp$14#0:int_list.int_list)
-            foreign lpvm mutate(~tmp$14#0:int_list.int_list, ?tmp$15#0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h#0:wybe.int)
-            foreign lpvm mutate(~tmp$15#0:int_list.int_list, ?$#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3#0:int_list.int_list)
+            int_list.lesser<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp$3##0:int_list.int_list) #2 @int_list:nn:nn
+            foreign lpvm alloc(16:wybe.int, ?tmp$14##0:int_list.int_list)
+            foreign lpvm mutate(~tmp$14##0:int_list.int_list, ?tmp$15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+            foreign lpvm mutate(~tmp$15##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:int_list.int_list)
 
 
 
 
 pop > public (1 calls)
 0: int_list.pop<0>[410bae77d3]
-pop(lst#0:int_list.int_list, idx#0:wybe.int, ?$#0:int_list.int_list):
- AliasPairs: [($#0,lst#0)]
+pop(lst##0:int_list.int_list, idx##0:wybe.int, ?$##0:int_list.int_list):
+ AliasPairs: [($##0,lst##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(3,(int_list.pop<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(lst#0:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.bool)
-    case ~tmp$9#0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
+    case ~tmp$9##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?$#0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:wybe.int)
-        foreign lpvm access(~lst#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:int_list.int_list)
-        foreign llvm icmp_eq(idx#0:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.bool) @int:nn:nn
-        case ~tmp$6#0:wybe.bool of
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign llvm icmp_eq(idx##0:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.bool) @int:nn:nn
+        case ~tmp$6##0:wybe.bool of
         0:
-            foreign llvm sub(~idx#0:wybe.int, 1:wybe.int, ?tmp$4#0:wybe.int) @int:nn:nn
-            int_list.pop<0>(~t#0:int_list.int_list, ~tmp$4#0:wybe.int, ?tmp$3#0:int_list.int_list) #3 @int_list:nn:nn
-            foreign lpvm alloc(16:wybe.int, ?tmp$16#0:int_list.int_list)
-            foreign lpvm mutate(~tmp$16#0:int_list.int_list, ?tmp$17#0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h#0:wybe.int)
-            foreign lpvm mutate(~tmp$17#0:int_list.int_list, ?$#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3#0:int_list.int_list)
+            foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp$4##0:wybe.int) @int:nn:nn
+            int_list.pop<0>(~t##0:int_list.int_list, ~tmp$4##0:wybe.int, ?tmp$3##0:int_list.int_list) #3 @int_list:nn:nn
+            foreign lpvm alloc(16:wybe.int, ?tmp$16##0:int_list.int_list)
+            foreign lpvm mutate(~tmp$16##0:int_list.int_list, ?tmp$17##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+            foreign lpvm mutate(~tmp$17##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:int_list.int_list)
 
         1:
-            foreign llvm move(~t#0:int_list.int_list, ?$#0:int_list.int_list) @int_list:nn:nn
+            foreign llvm move(~t##0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
 
 
 
 
 print > public (2 calls)
 0: int_list.print<0>
-print(x#0:int_list.int_list, io#0:wybe.phantom, ?io#3:wybe.phantom):
+print(x##0:int_list.int_list, io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(x#0:wybe.int, 0:wybe.int, ?tmp$2#0:wybe.bool)
-    case ~tmp$2#0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.bool)
+    case ~tmp$2##0:wybe.bool of
     0:
-        foreign llvm move(~io#0:wybe.phantom, ?io#3:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##3:wybe.phantom)
 
     1:
-        foreign lpvm access(x#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:wybe.int)
-        foreign lpvm access(~x#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:int_list.int_list)
-        foreign c print_int(~h#0:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        foreign c putchar(' ':wybe.char, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-        int_list.print<0>(~t#0:int_list.int_list, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) #3 @int_list:nn:nn
+        foreign lpvm access(x##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+        foreign lpvm access(~x##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign c print_int(~h##0:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        foreign c putchar(' ':wybe.char, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+        int_list.print<0>(~t##0:int_list.int_list, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @int_list:nn:nn
 
 
 
 println > public {inline} (0 calls)
 0: int_list.println<0>
-println(x#0:int_list.int_list, io#0:wybe.phantom, ?io#2:wybe.phantom):
+println(x##0:int_list.int_list, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    int_list.print<0>(~x#0:int_list.int_list, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
+    int_list.print<0>(~x##0:int_list.int_list, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
 
 range > public {inline} (0 calls)
 0: int_list.range<0>
-range(start#0:wybe.int, stop#0:wybe.int, step#0:wybe.int, ?result#1:int_list.int_list):
+range(start##0:wybe.int, stop##0:wybe.int, step##0:wybe.int, ?result##1:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    int_list.gen$2<0>(0:int_list.int_list, ~start#0:wybe.int, ~step#0:wybe.int, ~stop#0:wybe.int, 0:int_list.int_list, ?result#1:int_list.int_list) #1 @int_list:nn:nn
+    int_list.gen$2<0>(0:int_list.int_list, ~start##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, 0:int_list.int_list, ?result##1:int_list.int_list) #1 @int_list:nn:nn
 
 
 remove > public (1 calls)
 0: int_list.remove<0>[410bae77d3]
-remove(lst#0:int_list.int_list, v#0:wybe.int, ?$#0:int_list.int_list):
- AliasPairs: [($#0,lst#0)]
+remove(lst##0:int_list.int_list, v##0:wybe.int, ?$##0:int_list.int_list):
+ AliasPairs: [($##0,lst##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.remove<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(lst#0:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.bool)
-    case ~tmp$8#0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.bool)
+    case ~tmp$8##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?$#0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:wybe.int)
-        foreign lpvm access(~lst#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:int_list.int_list)
-        foreign llvm icmp_eq(h#0:wybe.int, v#0:wybe.int, ?tmp$5#0:wybe.bool) @int:nn:nn
-        case ~tmp$5#0:wybe.bool of
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign llvm icmp_eq(h##0:wybe.int, v##0:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
+        case ~tmp$5##0:wybe.bool of
         0:
-            int_list.remove<0>(~t#0:int_list.int_list, ~v#0:wybe.int, ?tmp$3#0:int_list.int_list) #2 @int_list:nn:nn
-            foreign lpvm alloc(16:wybe.int, ?tmp$13#0:int_list.int_list)
-            foreign lpvm mutate(~tmp$13#0:int_list.int_list, ?tmp$14#0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h#0:wybe.int)
-            foreign lpvm mutate(~tmp$14#0:int_list.int_list, ?$#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3#0:int_list.int_list)
+            int_list.remove<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp$3##0:int_list.int_list) #2 @int_list:nn:nn
+            foreign lpvm alloc(16:wybe.int, ?tmp$13##0:int_list.int_list)
+            foreign lpvm mutate(~tmp$13##0:int_list.int_list, ?tmp$14##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+            foreign lpvm mutate(~tmp$14##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:int_list.int_list)
 
         1:
-            foreign llvm move(~t#0:int_list.int_list, ?$#0:int_list.int_list) @int_list:nn:nn
+            foreign llvm move(~t##0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
 
 
 
 
 reverse > public {inline} (1 calls)
 0: int_list.reverse<0>
-reverse(lst#0:int_list.int_list, ?$#0:int_list.int_list):
+reverse(lst##0:int_list.int_list, ?$##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    int_list.reverse_helper<0>(~lst#0:int_list.int_list, 0:int_list.int_list, ?$#0:int_list.int_list) #1 @int_list:nn:nn
+    int_list.reverse_helper<0>(~lst##0:int_list.int_list, 0:int_list.int_list, ?$##0:int_list.int_list) #1 @int_list:nn:nn
 
 
 reverse_helper > (2 calls)
 0: int_list.reverse_helper<0>
-reverse_helper(lst#0:int_list.int_list, acc#0:int_list.int_list, ?$#0:int_list.int_list):
- AliasPairs: [($#0,acc#0)]
+reverse_helper(lst##0:int_list.int_list, acc##0:int_list.int_list, ?$##0:int_list.int_list):
+ AliasPairs: [($##0,acc##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(lst#0:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.bool)
-    case ~tmp$5#0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
+    case ~tmp$5##0:wybe.bool of
     0:
-        foreign llvm move(~acc#0:int_list.int_list, ?$#0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(~acc##0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:wybe.int)
-        foreign lpvm access(~lst#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:int_list.int_list)
-        foreign lpvm alloc(16:wybe.int, ?tmp$8#0:int_list.int_list)
-        foreign lpvm mutate(~tmp$8#0:int_list.int_list, ?tmp$9#0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h#0:wybe.int)
-        foreign lpvm mutate(~tmp$9#0:int_list.int_list, ?tmp$10#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~acc#0:int_list.int_list)
-        int_list.reverse_helper<0>(~t#0:int_list.int_list, ~tmp$10#0:int_list.int_list, ?$#0:int_list.int_list) #2 @int_list:nn:nn
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign lpvm alloc(16:wybe.int, ?tmp$8##0:int_list.int_list)
+        foreign lpvm mutate(~tmp$8##0:int_list.int_list, ?tmp$9##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+        foreign lpvm mutate(~tmp$9##0:int_list.int_list, ?tmp$10##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~acc##0:int_list.int_list)
+        int_list.reverse_helper<0>(~t##0:int_list.int_list, ~tmp$10##0:int_list.int_list, ?$##0:int_list.int_list) #2 @int_list:nn:nn
 
 
 
 sort > public (2 calls)
 0: int_list.sort<0>[410bae77d3]
-sort(lst#0:int_list.int_list, ?$#0:int_list.int_list):
+sort(lst##0:int_list.int_list, ?$##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.sort<0>,fromList [NonAliasedParamCond 0 []])),(3,(int_list.greater<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.sort<0>,fromList [NonAliasedParamCond 0 []])),(6,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign llvm icmp_ne(lst#0:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.bool)
-    case ~tmp$10#0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.bool)
+    case ~tmp$10##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?$#0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:wybe.int)
-        foreign lpvm access(~lst#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:int_list.int_list)
-        int_list.lesser<0>(t#0:int_list.int_list, h#0:wybe.int, ?tmp$3#0:int_list.int_list) #1 @int_list:nn:nn
-        int_list.sort<0>[410bae77d3](~tmp$3#0:int_list.int_list, ?tmp$2#0:int_list.int_list) #2 @int_list:nn:nn
-        int_list.greater<0>(~t#0:int_list.int_list, h#0:wybe.int, ?tmp$6#0:int_list.int_list) #3 @int_list:nn:nn
-        int_list.sort<0>[410bae77d3](~tmp$6#0:int_list.int_list, ?tmp$5#0:int_list.int_list) #4 @int_list:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$13#0:int_list.int_list)
-        foreign lpvm mutate(~tmp$13#0:int_list.int_list, ?tmp$14#0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h#0:wybe.int)
-        foreign lpvm mutate(~tmp$14#0:int_list.int_list, ?tmp$15#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$5#0:int_list.int_list)
-        int_list.extend<0>[410bae77d3](~tmp$2#0:int_list.int_list, ~tmp$15#0:int_list.int_list, ?$#0:int_list.int_list) #6 @int_list:nn:nn
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        int_list.lesser<0>(t##0:int_list.int_list, h##0:wybe.int, ?tmp$3##0:int_list.int_list) #1 @int_list:nn:nn
+        int_list.sort<0>[410bae77d3](~tmp$3##0:int_list.int_list, ?tmp$2##0:int_list.int_list) #2 @int_list:nn:nn
+        int_list.greater<0>(~t##0:int_list.int_list, h##0:wybe.int, ?tmp$6##0:int_list.int_list) #3 @int_list:nn:nn
+        int_list.sort<0>[410bae77d3](~tmp$6##0:int_list.int_list, ?tmp$5##0:int_list.int_list) #4 @int_list:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp$13##0:int_list.int_list)
+        foreign lpvm mutate(~tmp$13##0:int_list.int_list, ?tmp$14##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+        foreign lpvm mutate(~tmp$14##0:int_list.int_list, ?tmp$15##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$5##0:int_list.int_list)
+        int_list.extend<0>[410bae77d3](~tmp$2##0:int_list.int_list, ~tmp$15##0:int_list.int_list, ?$##0:int_list.int_list) #6 @int_list:nn:nn
 
 
 LLVM code       : None
@@ -644,32 +644,32 @@ LLVM code       : None
 
 = > public (2 calls)
 0: int_list.int_list.=<0>
-=($left#0:int_list.int_list, $right#0:int_list.int_list, ?$$#0:wybe.bool):
+=($left##0:int_list.int_list, $right##0:int_list.int_list, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left#0:int_list.int_list, ~$right#0:int_list.int_list, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~$left##0:int_list.int_list, ~$right##0:int_list.int_list, ?$$##0:wybe.bool)
 
     1:
-        foreign lpvm access($left#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$head#0:wybe.int)
-        foreign lpvm access(~$left#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$tail#0:int_list.int_list)
-        foreign llvm icmp_ne($right#0:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.bool)
-        case ~tmp$9#0:wybe.bool of
+        foreign lpvm access($left##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$head##0:wybe.int)
+        foreign lpvm access(~$left##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$tail##0:int_list.int_list)
+        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
+        case ~tmp$9##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign lpvm access($right#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$head#0:wybe.int)
-            foreign lpvm access(~$right#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$tail#0:int_list.int_list)
-            foreign llvm icmp_eq(~$left$head#0:wybe.int, ~$right$head#0:wybe.int, ?tmp$4#0:wybe.bool) @int:nn:nn
-            case ~tmp$4#0:wybe.bool of
+            foreign lpvm access($right##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$head##0:wybe.int)
+            foreign lpvm access(~$right##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$tail##0:int_list.int_list)
+            foreign llvm icmp_eq(~$left$head##0:wybe.int, ~$right$head##0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
+            case ~tmp$4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                int_list.int_list.=<0>(~$left$tail#0:int_list.int_list, ~$right$tail#0:int_list.int_list, ?$$#0:wybe.bool) #3
+                int_list.int_list.=<0>(~$left$tail##0:int_list.int_list, ~$right$tail##0:int_list.int_list, ?$$##0:wybe.bool) #3
 
 
 
@@ -677,110 +677,110 @@ LLVM code       : None
 
 cons > public {inline} (0 calls)
 0: int_list.int_list.cons<0>
-cons(head#0:wybe.int, tail#0:int_list.int_list, ?$#0:int_list.int_list):
+cons(head##0:wybe.int, tail##0:int_list.int_list, ?$##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:int_list.int_list)
-    foreign lpvm mutate(~$rec#0:int_list.int_list, ?$rec#1:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:int_list.int_list, ?$#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail#0:int_list.int_list)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:int_list.int_list)
+    foreign lpvm mutate(~$rec##0:int_list.int_list, ?$rec##1:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:int_list.int_list)
 cons > public {inline} (12 calls)
 1: int_list.int_list.cons<1>
-cons(?head#0:wybe.int, ?tail#0:int_list.int_list, $#0:int_list.int_list, ?$$#0:wybe.bool):
+cons(?head##0:wybe.int, ?tail##0:int_list.int_list, $##0:int_list.int_list, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?head#0:wybe.int)
-        foreign llvm move(undef:int_list.int_list, ?tail#0:int_list.int_list)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?head##0:wybe.int)
+        foreign llvm move(undef:int_list.int_list, ?tail##0:int_list.int_list)
 
     1:
-        foreign lpvm access($#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head#0:wybe.int)
-        foreign lpvm access(~$#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail#0:int_list.int_list)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access($##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
+        foreign lpvm access(~$##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:int_list.int_list)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 head > public {inline} (0 calls)
 0: int_list.int_list.head<0>
-head($rec#0:int_list.int_list, ?$#0:wybe.int, ?$$#0:wybe.bool):
+head($rec##0:int_list.int_list, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 head > public {inline} (0 calls)
 1: int_list.int_list.head<1>
-head($rec#0:int_list.int_list, ?$rec#1:int_list.int_list, $field#0:wybe.int, ?$$#0:wybe.bool):
+head($rec##0:int_list.int_list, ?$rec##1:int_list.int_list, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:int_list.int_list, ?$rec#1:int_list.int_list)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:int_list.int_list, ?$rec##1:int_list.int_list)
 
     1:
-        foreign lpvm mutate(~$rec#0:int_list.int_list, ?$rec#1:int_list.int_list, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~$rec##0:int_list.int_list, ?$rec##1:int_list.int_list, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 nil > public {inline} (0 calls)
 0: int_list.int_list.nil<0>
-nil(?$#0:int_list.int_list):
+nil(?$##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:int_list.int_list, ?$#0:int_list.int_list)
+    foreign llvm move(0:int_list.int_list, ?$##0:int_list.int_list)
 
 
 tail > public {inline} (0 calls)
 0: int_list.int_list.tail<0>
-tail($rec#0:int_list.int_list, ?$#0:int_list.int_list, ?$$#0:wybe.bool):
+tail($rec##0:int_list.int_list, ?$##0:int_list.int_list, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:int_list.int_list, ?$#0:int_list.int_list)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:int_list.int_list, ?$##0:int_list.int_list)
 
     1:
-        foreign lpvm access(~$rec#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:int_list.int_list)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:int_list.int_list)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 tail > public {inline} (0 calls)
 1: int_list.int_list.tail<1>
-tail($rec#0:int_list.int_list, ?$rec#1:int_list.int_list, $field#0:int_list.int_list, ?$$#0:wybe.bool):
+tail($rec##0:int_list.int_list, ?$rec##1:int_list.int_list, $field##0:int_list.int_list, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:int_list.int_list, ?$rec#1:int_list.int_list)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:int_list.int_list, ?$rec##1:int_list.int_list)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec#0:int_list.int_list, ?$rec#1:int_list.int_list, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:int_list.int_list)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm {noalias} mutate(~$rec##0:int_list.int_list, ?$rec##1:int_list.int_list, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:int_list.int_list)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: int_list.int_list.~=<0>
-~=($left#0:int_list.int_list, $right#0:int_list.int_list, ?$$#0:wybe.bool):
+~=($left##0:int_list.int_list, $right##0:int_list.int_list, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    int_list.int_list.=<0>(~$left#0:int_list.int_list, ~$right#0:int_list.int_list, ?tmp$0#0:wybe.bool) #0
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    int_list.int_list.=<0>(~$left##0:int_list.int_list, ~$right##0:int_list.int_list, ?tmp$0##0:wybe.bool) #0
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 LLVM code       : None
 
@@ -798,98 +798,98 @@ LLVM code       : None
 
 *main* > public (0 calls)
 0: int_list_test.<0>
-(io#0:wybe.phantom, ?io#22:wybe.phantom):
+(io##0:wybe.phantom, ?io##22:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(24,(int_list_test.test_int_list<0>,fromList [NonAliasedParamCond 0 [],NonAliasedParamCond 1 [],NonAliasedParamCond 2 []])),(34,(int_list.gen$2<0>,fromList [NonAliasedParamCond 0 []])),(35,(int_list.gen$2<0>,fromList [NonAliasedParamCond 0 []])),(36,(int_list.gen$2<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign c {impure} malloc_count(?mc1#0:wybe.int) @memory_management:nn:nn
-    int_list.gen$2<0>[410bae77d3](0:int_list.int_list, 1:wybe.int, 1:wybe.int, 10:wybe.int, 0:int_list.int_list, ?tmp$0#0:int_list.int_list) #34 @int_list:nn:nn
-    int_list.gen$2<0>[410bae77d3](0:int_list.int_list, 2:wybe.int, 2:wybe.int, 20:wybe.int, 0:int_list.int_list, ?tmp$1#0:int_list.int_list) #35 @int_list:nn:nn
-    int_list.gen$2<0>[410bae77d3](0:int_list.int_list, 3:wybe.int, 3:wybe.int, 30:wybe.int, 0:int_list.int_list, ?tmp$2#0:int_list.int_list) #36 @int_list:nn:nn
-    foreign c print_string("x y z:":wybe.string, ~#io#0:wybe.phantom, ?tmp$17#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$17#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$0#0:int_list.int_list, ~#io#1:wybe.phantom, ?tmp$20#0:wybe.phantom) #37 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$20#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$1#0:int_list.int_list, ~#io#2:wybe.phantom, ?tmp$23#0:wybe.phantom) #38 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$23#0:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$2#0:int_list.int_list, ~#io#3:wybe.phantom, ?tmp$26#0:wybe.phantom) #39 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$26#0:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c {impure} malloc_count(?mc2#0:wybe.int) @memory_management:nn:nn
-    foreign llvm sub(~mc2#0:wybe.int, ~mc1#0:wybe.int, ?tmp$3#0:wybe.int) @int:nn:nn
-    foreign c print_string("--------------------":wybe.string, ~#io#4:wybe.phantom, ?tmp$31#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$31#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-    foreign c print_string("tests with alias":wybe.string, ~#io#5:wybe.phantom, ?tmp$34#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$34#0:wybe.phantom, ?#io#6:wybe.phantom) @io:nn:nn
-    foreign c {impure} malloc_count(?mc1#1:wybe.int) @memory_management:nn:nn
-    int_list_test.test_int_list<0>(tmp$0#0:int_list.int_list, tmp$1#0:int_list.int_list, tmp$2#0:int_list.int_list, ~#io#6:wybe.phantom, ?#io#7:wybe.phantom) #13 @int_list_test:nn:nn
-    foreign c {impure} malloc_count(?mc2#1:wybe.int) @memory_management:nn:nn
-    foreign llvm sub(~mc2#1:wybe.int, ~mc1#1:wybe.int, ?tmp$4#0:wybe.int) @int:nn:nn
-    foreign c print_string("original x y z:":wybe.string, ~#io#7:wybe.phantom, ?tmp$39#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$39#0:wybe.phantom, ?#io#8:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$0#0:int_list.int_list, ~#io#8:wybe.phantom, ?tmp$42#0:wybe.phantom) #40 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$42#0:wybe.phantom, ?#io#9:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$1#0:int_list.int_list, ~#io#9:wybe.phantom, ?tmp$45#0:wybe.phantom) #41 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$45#0:wybe.phantom, ?#io#10:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$2#0:int_list.int_list, ~#io#10:wybe.phantom, ?tmp$48#0:wybe.phantom) #42 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$48#0:wybe.phantom, ?#io#11:wybe.phantom) @io:nn:nn
-    foreign c print_string("--------------------":wybe.string, ~#io#11:wybe.phantom, ?tmp$51#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$51#0:wybe.phantom, ?#io#12:wybe.phantom) @io:nn:nn
-    foreign c print_string("--------------------":wybe.string, ~#io#12:wybe.phantom, ?tmp$54#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$54#0:wybe.phantom, ?#io#13:wybe.phantom) @io:nn:nn
-    foreign c print_string("tests without alias":wybe.string, ~#io#13:wybe.phantom, ?tmp$57#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$57#0:wybe.phantom, ?#io#14:wybe.phantom) @io:nn:nn
-    foreign c {impure} malloc_count(?mc1#2:wybe.int) @memory_management:nn:nn
-    int_list_test.test_int_list<0>[9e35cb823b](~tmp$0#0:int_list.int_list, ~tmp$1#0:int_list.int_list, ~tmp$2#0:int_list.int_list, ~#io#14:wybe.phantom, ?#io#15:wybe.phantom) #24 @int_list_test:nn:nn
-    foreign c {impure} malloc_count(?mc2#2:wybe.int) @memory_management:nn:nn
-    foreign llvm sub(~mc2#2:wybe.int, ~mc1#2:wybe.int, ?tmp$5#0:wybe.int) @int:nn:nn
-    foreign c print_string("--------------------":wybe.string, ~#io#15:wybe.phantom, ?tmp$62#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$62#0:wybe.phantom, ?#io#16:wybe.phantom) @io:nn:nn
-    foreign c print_string(" ** malloc count of building lists: ":wybe.string, ~#io#16:wybe.phantom, ?#io#17:wybe.phantom) @io:nn:nn
-    foreign c print_int(~tmp$3#0:wybe.int, ~#io#17:wybe.phantom, ?tmp$67#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$67#0:wybe.phantom, ?#io#18:wybe.phantom) @io:nn:nn
-    foreign c print_string(" ** malloc count of test(aliased): ":wybe.string, ~#io#18:wybe.phantom, ?#io#19:wybe.phantom) @io:nn:nn
-    foreign c print_int(~tmp$4#0:wybe.int, ~#io#19:wybe.phantom, ?tmp$72#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$72#0:wybe.phantom, ?#io#20:wybe.phantom) @io:nn:nn
-    foreign c print_string(" ** malloc count of test(non-aliased): ":wybe.string, ~#io#20:wybe.phantom, ?#io#21:wybe.phantom) @io:nn:nn
-    foreign c print_int(~tmp$5#0:wybe.int, ~#io#21:wybe.phantom, ?tmp$77#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$77#0:wybe.phantom, ?#io#22:wybe.phantom) @io:nn:nn
+    foreign c {impure} malloc_count(?mc1##0:wybe.int) @memory_management:nn:nn
+    int_list.gen$2<0>[410bae77d3](0:int_list.int_list, 1:wybe.int, 1:wybe.int, 10:wybe.int, 0:int_list.int_list, ?tmp$0##0:int_list.int_list) #34 @int_list:nn:nn
+    int_list.gen$2<0>[410bae77d3](0:int_list.int_list, 2:wybe.int, 2:wybe.int, 20:wybe.int, 0:int_list.int_list, ?tmp$1##0:int_list.int_list) #35 @int_list:nn:nn
+    int_list.gen$2<0>[410bae77d3](0:int_list.int_list, 3:wybe.int, 3:wybe.int, 30:wybe.int, 0:int_list.int_list, ?tmp$2##0:int_list.int_list) #36 @int_list:nn:nn
+    foreign c print_string("x y z:":wybe.string, ~#io##0:wybe.phantom, ?tmp$17##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$17##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp$0##0:int_list.int_list, ~#io##1:wybe.phantom, ?tmp$20##0:wybe.phantom) #37 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$20##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp$1##0:int_list.int_list, ~#io##2:wybe.phantom, ?tmp$23##0:wybe.phantom) #38 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$23##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp$2##0:int_list.int_list, ~#io##3:wybe.phantom, ?tmp$26##0:wybe.phantom) #39 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$26##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c {impure} malloc_count(?mc2##0:wybe.int) @memory_management:nn:nn
+    foreign llvm sub(~mc2##0:wybe.int, ~mc1##0:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
+    foreign c print_string("--------------------":wybe.string, ~#io##4:wybe.phantom, ?tmp$31##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$31##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign c print_string("tests with alias":wybe.string, ~#io##5:wybe.phantom, ?tmp$34##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$34##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+    foreign c {impure} malloc_count(?mc1##1:wybe.int) @memory_management:nn:nn
+    int_list_test.test_int_list<0>(tmp$0##0:int_list.int_list, tmp$1##0:int_list.int_list, tmp$2##0:int_list.int_list, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) #13 @int_list_test:nn:nn
+    foreign c {impure} malloc_count(?mc2##1:wybe.int) @memory_management:nn:nn
+    foreign llvm sub(~mc2##1:wybe.int, ~mc1##1:wybe.int, ?tmp$4##0:wybe.int) @int:nn:nn
+    foreign c print_string("original x y z:":wybe.string, ~#io##7:wybe.phantom, ?tmp$39##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$39##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp$0##0:int_list.int_list, ~#io##8:wybe.phantom, ?tmp$42##0:wybe.phantom) #40 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$42##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp$1##0:int_list.int_list, ~#io##9:wybe.phantom, ?tmp$45##0:wybe.phantom) #41 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$45##0:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp$2##0:int_list.int_list, ~#io##10:wybe.phantom, ?tmp$48##0:wybe.phantom) #42 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$48##0:wybe.phantom, ?#io##11:wybe.phantom) @io:nn:nn
+    foreign c print_string("--------------------":wybe.string, ~#io##11:wybe.phantom, ?tmp$51##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$51##0:wybe.phantom, ?#io##12:wybe.phantom) @io:nn:nn
+    foreign c print_string("--------------------":wybe.string, ~#io##12:wybe.phantom, ?tmp$54##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$54##0:wybe.phantom, ?#io##13:wybe.phantom) @io:nn:nn
+    foreign c print_string("tests without alias":wybe.string, ~#io##13:wybe.phantom, ?tmp$57##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$57##0:wybe.phantom, ?#io##14:wybe.phantom) @io:nn:nn
+    foreign c {impure} malloc_count(?mc1##2:wybe.int) @memory_management:nn:nn
+    int_list_test.test_int_list<0>[9e35cb823b](~tmp$0##0:int_list.int_list, ~tmp$1##0:int_list.int_list, ~tmp$2##0:int_list.int_list, ~#io##14:wybe.phantom, ?#io##15:wybe.phantom) #24 @int_list_test:nn:nn
+    foreign c {impure} malloc_count(?mc2##2:wybe.int) @memory_management:nn:nn
+    foreign llvm sub(~mc2##2:wybe.int, ~mc1##2:wybe.int, ?tmp$5##0:wybe.int) @int:nn:nn
+    foreign c print_string("--------------------":wybe.string, ~#io##15:wybe.phantom, ?tmp$62##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$62##0:wybe.phantom, ?#io##16:wybe.phantom) @io:nn:nn
+    foreign c print_string(" ** malloc count of building lists: ":wybe.string, ~#io##16:wybe.phantom, ?#io##17:wybe.phantom) @io:nn:nn
+    foreign c print_int(~tmp$3##0:wybe.int, ~#io##17:wybe.phantom, ?tmp$67##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$67##0:wybe.phantom, ?#io##18:wybe.phantom) @io:nn:nn
+    foreign c print_string(" ** malloc count of test(aliased): ":wybe.string, ~#io##18:wybe.phantom, ?#io##19:wybe.phantom) @io:nn:nn
+    foreign c print_int(~tmp$4##0:wybe.int, ~#io##19:wybe.phantom, ?tmp$72##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$72##0:wybe.phantom, ?#io##20:wybe.phantom) @io:nn:nn
+    foreign c print_string(" ** malloc count of test(non-aliased): ":wybe.string, ~#io##20:wybe.phantom, ?#io##21:wybe.phantom) @io:nn:nn
+    foreign c print_int(~tmp$5##0:wybe.int, ~#io##21:wybe.phantom, ?tmp$77##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$77##0:wybe.phantom, ?#io##22:wybe.phantom) @io:nn:nn
 
 
 test_int_list > (2 calls)
 0: int_list_test.test_int_list<0>
-test_int_list(x#0:int_list.int_list, y#0:int_list.int_list, z#0:int_list.int_list, io#0:wybe.phantom, ?io#10:wybe.phantom):
+test_int_list(x##0:int_list.int_list, y##0:int_list.int_list, z##0:int_list.int_list, io##0:wybe.phantom, ?io##10:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0,InterestingUnaliased 1,InterestingUnaliased 2]
  MultiSpeczDepInfo: [(2,(int_list.append<0>,fromList [NonAliasedParamCond 0 [1]])),(7,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []])),(8,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []])),(11,(int_list.insert<0>,fromList [NonAliasedParamCond 0 []])),(12,(int_list.pop<0>,fromList [NonAliasedParamCond 0 []])),(13,(int_list.remove<0>,fromList [NonAliasedParamCond 0 []])),(16,(int_list.sort<0>,fromList [NonAliasedParamCond 0 []])),(19,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]])),(20,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [2]]))]
-    int_list.reverse_helper<0>(~x#0:int_list.int_list, 0:int_list.int_list, ?x#1:int_list.int_list) #19 @int_list:nn:nn
-    int_list.reverse_helper<0>(~z#0:int_list.int_list, 0:int_list.int_list, ?z#1:int_list.int_list) #20 @int_list:nn:nn
-    int_list.append<0>(~y#0:int_list.int_list, 99:wybe.int, ?tmp$0#0:int_list.int_list) #2 @int_list_test:nn:nn
-    foreign c print_string("-":wybe.string, ~#io#0:wybe.phantom, ?tmp$10#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$10#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    int_list.print<0>(x#1:int_list.int_list, ~#io#1:wybe.phantom, ?tmp$13#0:wybe.phantom) #21 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$13#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$0#0:int_list.int_list, ~#io#2:wybe.phantom, ?tmp$16#0:wybe.phantom) #22 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$16#0:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    int_list.print<0>(z#1:int_list.int_list, ~#io#3:wybe.phantom, ?tmp$19#0:wybe.phantom) #23 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$19#0:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    int_list.extend<0>[410bae77d3](~x#1:int_list.int_list, ~tmp$0#0:int_list.int_list, ?tmp$1#0:int_list.int_list) #7 @int_list_test:nn:nn
-    int_list.extend<0>[410bae77d3](~tmp$1#0:int_list.int_list, ~z#1:int_list.int_list, ?tmp$2#0:int_list.int_list) #8 @int_list_test:nn:nn
-    foreign c print_string("-":wybe.string, ~#io#4:wybe.phantom, ?tmp$22#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$22#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$2#0:int_list.int_list, ~#io#5:wybe.phantom, ?tmp$25#0:wybe.phantom) #24 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$25#0:wybe.phantom, ?#io#6:wybe.phantom) @io:nn:nn
-    int_list.insert<0>[410bae77d3](~tmp$2#0:int_list.int_list, 4:wybe.int, 78:wybe.int, ?tmp$3#0:int_list.int_list) #11 @int_list_test:nn:nn
-    int_list.pop<0>[410bae77d3](~tmp$3#0:int_list.int_list, 20:wybe.int, ?tmp$4#0:int_list.int_list) #12 @int_list_test:nn:nn
-    int_list.remove<0>[410bae77d3](~tmp$4#0:int_list.int_list, 2:wybe.int, ?tmp$5#0:int_list.int_list) #13 @int_list_test:nn:nn
-    foreign c print_string("-":wybe.string, ~#io#6:wybe.phantom, ?tmp$28#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$28#0:wybe.phantom, ?#io#7:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$5#0:int_list.int_list, ~#io#7:wybe.phantom, ?tmp$31#0:wybe.phantom) #25 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$31#0:wybe.phantom, ?#io#8:wybe.phantom) @io:nn:nn
-    int_list.sort<0>[410bae77d3](~tmp$5#0:int_list.int_list, ?l#5:int_list.int_list) #16 @int_list_test:nn:nn
-    foreign c print_string("-":wybe.string, ~#io#8:wybe.phantom, ?tmp$34#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$34#0:wybe.phantom, ?#io#9:wybe.phantom) @io:nn:nn
-    int_list.print<0>(~l#5:int_list.int_list, ~#io#9:wybe.phantom, ?tmp$37#0:wybe.phantom) #26 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$37#0:wybe.phantom, ?#io#10:wybe.phantom) @io:nn:nn
+    int_list.reverse_helper<0>(~x##0:int_list.int_list, 0:int_list.int_list, ?x##1:int_list.int_list) #19 @int_list:nn:nn
+    int_list.reverse_helper<0>(~z##0:int_list.int_list, 0:int_list.int_list, ?z##1:int_list.int_list) #20 @int_list:nn:nn
+    int_list.append<0>(~y##0:int_list.int_list, 99:wybe.int, ?tmp$0##0:int_list.int_list) #2 @int_list_test:nn:nn
+    foreign c print_string("-":wybe.string, ~#io##0:wybe.phantom, ?tmp$10##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    int_list.print<0>(x##1:int_list.int_list, ~#io##1:wybe.phantom, ?tmp$13##0:wybe.phantom) #21 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$13##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp$0##0:int_list.int_list, ~#io##2:wybe.phantom, ?tmp$16##0:wybe.phantom) #22 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$16##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    int_list.print<0>(z##1:int_list.int_list, ~#io##3:wybe.phantom, ?tmp$19##0:wybe.phantom) #23 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$19##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    int_list.extend<0>[410bae77d3](~x##1:int_list.int_list, ~tmp$0##0:int_list.int_list, ?tmp$1##0:int_list.int_list) #7 @int_list_test:nn:nn
+    int_list.extend<0>[410bae77d3](~tmp$1##0:int_list.int_list, ~z##1:int_list.int_list, ?tmp$2##0:int_list.int_list) #8 @int_list_test:nn:nn
+    foreign c print_string("-":wybe.string, ~#io##4:wybe.phantom, ?tmp$22##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$22##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp$2##0:int_list.int_list, ~#io##5:wybe.phantom, ?tmp$25##0:wybe.phantom) #24 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$25##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+    int_list.insert<0>[410bae77d3](~tmp$2##0:int_list.int_list, 4:wybe.int, 78:wybe.int, ?tmp$3##0:int_list.int_list) #11 @int_list_test:nn:nn
+    int_list.pop<0>[410bae77d3](~tmp$3##0:int_list.int_list, 20:wybe.int, ?tmp$4##0:int_list.int_list) #12 @int_list_test:nn:nn
+    int_list.remove<0>[410bae77d3](~tmp$4##0:int_list.int_list, 2:wybe.int, ?tmp$5##0:int_list.int_list) #13 @int_list_test:nn:nn
+    foreign c print_string("-":wybe.string, ~#io##6:wybe.phantom, ?tmp$28##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$28##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp$5##0:int_list.int_list, ~#io##7:wybe.phantom, ?tmp$31##0:wybe.phantom) #25 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$31##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
+    int_list.sort<0>[410bae77d3](~tmp$5##0:int_list.int_list, ?l##5:int_list.int_list) #16 @int_list_test:nn:nn
+    foreign c print_string("-":wybe.string, ~#io##8:wybe.phantom, ?tmp$34##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$34##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
+    int_list.print<0>(~l##5:int_list.int_list, ~#io##9:wybe.phantom, ?tmp$37##0:wybe.phantom) #26 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$37##0:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
 
 LLVM code       : None
 
@@ -910,13 +910,13 @@ AFTER EVERYTHING:
 
 *main* > {inline} (0 calls)
 0: .<0>
-(argc#0:wybe.int, argv#0:wybe.array.raw_array(wybe.string), ?exit_code#0:wybe.int, ?io#2:wybe.phantom):
+(argc##0:wybe.int, argv##0:wybe.array.raw_array(wybe.string), ?exit_code##0:wybe.int, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c {semipure} gc_init @memory_management:nn:nn
-    command_line.<0>(~#argc#0:wybe.int, ?_:wybe.int, ?#arguments#0:wybe.array(wybe.string), ~#argv#0:wybe.array.raw_array(wybe.string), ?_:wybe.array.raw_array(wybe.string), ?#command#0:wybe.string, ?#exit_code#0:wybe.int, 0:wybe.phantom, ?_:wybe.phantom) #2
-    int_list_test.<0>(0:wybe.phantom, ?#io#2:wybe.phantom) #3
-    foreign c {semipure,terminal} exit(exit_code#0:wybe.int)
+    command_line.<0>(~#argc##0:wybe.int, ?_:wybe.int, ?#arguments##0:wybe.array(wybe.string), ~#argv##0:wybe.array.raw_array(wybe.string), ?_:wybe.array.raw_array(wybe.string), ?#command##0:wybe.string, ?#exit_code##0:wybe.int, 0:wybe.phantom, ?_:wybe.phantom) #2
+    int_list_test.<0>(0:wybe.phantom, ?#io##2:wybe.phantom) #3
+    foreign c {semipure,terminal} exit(exit_code##0:wybe.int)
 
   LLVM code       :
 
@@ -944,10 +944,10 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external ccc  i32 @main(i64  %"argc#0", i64  %"argv#0")    {
+define external ccc  i32 @main(i64  %"argc##0", i64  %"argv##0")    {
 entry:
   tail call ccc  void  @gc_init()  
-  %1 = tail call fastcc  {i64, i64, i64}  @"command_line.<0>"(i64  %"argc#0", i64  %"argv#0")  
+  %1 = tail call fastcc  {i64, i64, i64}  @"command_line.<0>"(i64  %"argc##0", i64  %"argv##0")  
   %2 = extractvalue {i64, i64, i64} %1, 0 
   %3 = extractvalue {i64, i64, i64} %1, 1 
   %4 = extractvalue {i64, i64, i64} %1, 2 
@@ -976,29 +976,29 @@ entry:
 
 *main* > public (0 calls)
 0: command_line.<0>
-(argc#0:wybe.int, [?argc#0:wybe.int], ?arguments#2:wybe.array(wybe.string), argv#0:wybe.array.raw_array(wybe.string), [?argv#0:wybe.array.raw_array(wybe.string)], ?command#2:wybe.string, ?exit_code#1:wybe.int, io#0:wybe.phantom, [?io#0:wybe.phantom]):
+(argc##0:wybe.int, [?argc##0:wybe.int], ?arguments##2:wybe.array(wybe.string), argv##0:wybe.array.raw_array(wybe.string), [?argv##0:wybe.array.raw_array(wybe.string)], ?command##2:wybe.string, ?exit_code##1:wybe.int, io##0:wybe.phantom, [?io##0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$9#0:wybe.array(?T))
-    foreign lpvm mutate(~tmp$9#0:wybe.array(?T), ?tmp$10#0:wybe.array(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc#0:wybe.int)
-    foreign lpvm mutate(~tmp$10#0:wybe.array(?T), ?tmp$1#0:wybe.array(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv#0:wybe.array.raw_array(?T))
-    wybe.array.[|]<0>(?command#2:?T, ?arguments#2:wybe.array(?T), ~tmp$1#0:wybe.array(?T), ?tmp$2#0:wybe.bool) #2 @command_line:nn:nn
-    case ~tmp$2#0:wybe.bool of
+    foreign lpvm alloc(16:wybe.int, ?tmp$9##0:wybe.array(?T))
+    foreign lpvm mutate(~tmp$9##0:wybe.array(?T), ?tmp$10##0:wybe.array(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
+    foreign lpvm mutate(~tmp$10##0:wybe.array(?T), ?tmp$1##0:wybe.array(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(?T))
+    wybe.array.[|]<0>(?command##2:?T, ?arguments##2:wybe.array(?T), ~tmp$1##0:wybe.array(?T), ?tmp$2##0:wybe.bool) #2 @command_line:nn:nn
+    case ~tmp$2##0:wybe.bool of
     0:
         foreign c {terminal,semipure} error_exit("command_line:17:10":wybe.string, "Erroneous program argument vector":wybe.string) @control:nn:nn
-        foreign llvm move(0:wybe.int, ?exit_code#1:wybe.int)
+        foreign llvm move(0:wybe.int, ?exit_code##1:wybe.int)
 
     1:
-        foreign llvm move(0:wybe.int, ?exit_code#1:wybe.int) @command_line:nn:nn
+        foreign llvm move(0:wybe.int, ?exit_code##1:wybe.int) @command_line:nn:nn
 
 
 
 set_exit_code > public {inline} (0 calls)
 0: command_line.set_exit_code<0>
-set_exit_code(code#0:wybe.int, [exit_code#0:wybe.int], ?exit_code#1:wybe.int):
+set_exit_code(code##0:wybe.int, [exit_code##0:wybe.int], ?exit_code##1:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(~code#0:wybe.int, ?exit_code#1:wybe.int) @command_line:nn:nn
+    foreign llvm move(~code##0:wybe.int, ?exit_code##1:wybe.int) @command_line:nn:nn
 
   LLVM code       :
 
@@ -1026,18 +1026,18 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  {i64, i64, i64} @"command_line.<0>"(i64  %"argc#0", i64  %"argv#0")    {
+define external fastcc  {i64, i64, i64} @"command_line.<0>"(i64  %"argc##0", i64  %"argv##0")    {
 entry:
   %1 = trunc i64 16 to i32  
   %2 = tail call ccc  i8*  @wybe_malloc(i32  %1)  
   %3 = ptrtoint i8* %2 to i64 
   %4 = inttoptr i64 %3 to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
-  store  i64 %"argc#0", i64* %5 
+  store  i64 %"argc##0", i64* %5 
   %6 = add   i64 %3, 8 
   %7 = inttoptr i64 %6 to i64* 
   %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"argv#0", i64* %8 
+  store  i64 %"argv##0", i64* %8 
   %9 = tail call fastcc  {i64, i64, i1}  @"wybe.array.[|]<0>"(i64  %3)  
   %10 = extractvalue {i64, i64, i1} %9, 0 
   %11 = extractvalue {i64, i64, i1} %9, 1 
@@ -1059,9 +1059,9 @@ if.else:
 }
 
 
-define external fastcc  i64 @"command_line.set_exit_code<0>"(i64  %"code#0")    {
+define external fastcc  i64 @"command_line.set_exit_code<0>"(i64  %"code##0")    {
 entry:
-  ret i64 %"code#0" 
+  ret i64 %"code##0" 
 }
 --------------------------------------------------
  Module int_list
@@ -1097,502 +1097,502 @@ entry:
 
 append > public (0 calls)
 0: int_list.append<0>[410bae77d3]
-append(lst#0:int_list.int_list, v#0:wybe.int, ?$#0:int_list.int_list):
+append(lst##0:int_list.int_list, v##0:wybe.int, ?$##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.extend<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign lpvm alloc(16:wybe.int, ?tmp$5#0:int_list.int_list)
-    foreign lpvm mutate(~tmp$5#0:int_list.int_list, ?tmp$6#0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v#0:wybe.int)
-    foreign lpvm mutate(~tmp$6#0:int_list.int_list, ?tmp$7#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:int_list.int_list)
-    int_list.extend<0>(~lst#0:int_list.int_list, ~tmp$7#0:int_list.int_list, ?$#0:int_list.int_list) #2 @int_list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$5##0:int_list.int_list)
+    foreign lpvm mutate(~tmp$5##0:int_list.int_list, ?tmp$6##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
+    foreign lpvm mutate(~tmp$6##0:int_list.int_list, ?tmp$7##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:int_list.int_list)
+    int_list.extend<0>(~lst##0:int_list.int_list, ~tmp$7##0:int_list.int_list, ?$##0:int_list.int_list) #2 @int_list:nn:nn
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm alloc(16:wybe.int, ?tmp$5#0:int_list.int_list)
-    foreign lpvm mutate(~tmp$5#0:int_list.int_list, ?tmp$6#0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v#0:wybe.int)
-    foreign lpvm mutate(~tmp$6#0:int_list.int_list, ?tmp$7#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:int_list.int_list)
-    int_list.extend<0>[410bae77d3](~lst#0:int_list.int_list, ~tmp$7#0:int_list.int_list, ?$#0:int_list.int_list) #2 @int_list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$5##0:int_list.int_list)
+    foreign lpvm mutate(~tmp$5##0:int_list.int_list, ?tmp$6##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
+    foreign lpvm mutate(~tmp$6##0:int_list.int_list, ?tmp$7##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:int_list.int_list)
+    int_list.extend<0>[410bae77d3](~lst##0:int_list.int_list, ~tmp$7##0:int_list.int_list, ?$##0:int_list.int_list) #2 @int_list:nn:nn
 
 
 count > public (3 calls)
 0: int_list.count<0>
-count(lst#0:int_list.int_list, x#0:wybe.int, ?$#0:wybe.int):
+count(lst##0:int_list.int_list, x##0:wybe.int, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(lst#0:wybe.int, 0:wybe.int, ?tmp$7#0:wybe.bool)
-    case ~tmp$7#0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.bool)
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.int, ?$#0:wybe.int) @int_list:nn:nn
+        foreign llvm move(0:wybe.int, ?$##0:wybe.int) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:wybe.int)
-        foreign lpvm access(~lst#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:int_list.int_list)
-        int_list.count<0>(~t#0:int_list.int_list, x#0:wybe.int, ?tmp$2#0:wybe.int) #1 @int_list:nn:nn
-        foreign llvm icmp_eq(~h#0:wybe.int, ~x#0:wybe.int, ?tmp$4#0:wybe.bool) @int:nn:nn
-        case ~tmp$4#0:wybe.bool of
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        int_list.count<0>(~t##0:int_list.int_list, x##0:wybe.int, ?tmp$2##0:wybe.int) #1 @int_list:nn:nn
+        foreign llvm icmp_eq(~h##0:wybe.int, ~x##0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
+        case ~tmp$4##0:wybe.bool of
         0:
-            foreign llvm move(~tmp$2#0:wybe.int, ?$#0:wybe.int) @int:nn:nn
+            foreign llvm move(~tmp$2##0:wybe.int, ?$##0:wybe.int) @int:nn:nn
 
         1:
-            foreign llvm add(~tmp$2#0:wybe.int, 1:wybe.int, ?$#0:wybe.int) @int:nn:nn
+            foreign llvm add(~tmp$2##0:wybe.int, 1:wybe.int, ?$##0:wybe.int) @int:nn:nn
 
 
 
 
 extend > public (3 calls)
 0: int_list.extend<0>[410bae77d3]
-extend(lst1#0:int_list.int_list, lst2#0:int_list.int_list, ?$#0:int_list.int_list):
- AliasPairs: [($#0,lst2#0)]
+extend(lst1##0:int_list.int_list, lst2##0:int_list.int_list, ?$##0:int_list.int_list):
+ AliasPairs: [($##0,lst2##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(int_list.extend<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(lst1#0:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.bool)
-    case ~tmp$5#0:wybe.bool of
+    foreign llvm icmp_ne(lst1##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
+    case ~tmp$5##0:wybe.bool of
     0:
-        foreign llvm move(~lst2#0:int_list.int_list, ?$#0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(~lst2##0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst1#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:wybe.int)
-        foreign lpvm access(~lst1#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:int_list.int_list)
-        int_list.extend<0>(~t#0:int_list.int_list, ~lst2#0:int_list.int_list, ?tmp$2#0:int_list.int_list) #1 @int_list:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$8#0:int_list.int_list)
-        foreign lpvm mutate(~tmp$8#0:int_list.int_list, ?tmp$9#0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h#0:wybe.int)
-        foreign lpvm mutate(~tmp$9#0:int_list.int_list, ?$#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:int_list.int_list)
+        foreign lpvm access(lst1##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+        foreign lpvm access(~lst1##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        int_list.extend<0>(~t##0:int_list.int_list, ~lst2##0:int_list.int_list, ?tmp$2##0:int_list.int_list) #1 @int_list:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp$8##0:int_list.int_list)
+        foreign lpvm mutate(~tmp$8##0:int_list.int_list, ?tmp$9##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+        foreign lpvm mutate(~tmp$9##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:int_list.int_list)
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_ne(lst1#0:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.bool)
-    case ~tmp$5#0:wybe.bool of
+    foreign llvm icmp_ne(lst1##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
+    case ~tmp$5##0:wybe.bool of
     0:
-        foreign llvm move(~lst2#0:int_list.int_list, ?$#0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(~lst2##0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst1#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:int_list.int_list)
-        int_list.extend<0>[410bae77d3](~t#0:int_list.int_list, ~lst2#0:int_list.int_list, ?tmp$2#0:int_list.int_list) #1 @int_list:nn:nn
-        foreign lpvm mutate(~lst1#0:int_list.int_list, ?$#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:int_list.int_list)
+        foreign lpvm access(lst1##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        int_list.extend<0>[410bae77d3](~t##0:int_list.int_list, ~lst2##0:int_list.int_list, ?tmp$2##0:int_list.int_list) #1 @int_list:nn:nn
+        foreign lpvm mutate(~lst1##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:int_list.int_list)
 
 
 
 gen$1 > {inline} (2 calls)
 0: int_list.gen$1<0>
-gen$1([h#0:wybe.int], [lst#0:int_list.int_list], [t#0:int_list.int_list], tmp$2#0:wybe.int, tmp$3#0:wybe.int, [x#0:wybe.int], ?$#0:wybe.int):
+gen$1([h##0:wybe.int], [lst##0:int_list.int_list], [t##0:int_list.int_list], tmp$2##0:wybe.int, tmp$3##0:wybe.int, [x##0:wybe.int], ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~tmp$2#0:wybe.int, ~tmp$3#0:wybe.int, ?$#0:wybe.int) @int:nn:nn
+    foreign llvm add(~tmp$2##0:wybe.int, ~tmp$3##0:wybe.int, ?$##0:wybe.int) @int:nn:nn
 
 
 gen$2 > (2 calls)
 0: int_list.gen$2<0>
-gen$2(result#0:int_list.int_list, start#0:wybe.int, step#0:wybe.int, stop#0:wybe.int, tmp$0#0:int_list.int_list, ?result#1:int_list.int_list):
+gen$2(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, stop##0:wybe.int, tmp$0##0:int_list.int_list, ?result##1:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(3,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.gen$2<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_slt(start#0:wybe.int, stop#0:wybe.int, ?tmp$3#0:wybe.bool) @int:nn:nn
-    case ~tmp$3#0:wybe.bool of
+    foreign llvm icmp_slt(start##0:wybe.int, stop##0:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
+    case ~tmp$3##0:wybe.bool of
     0:
-        int_list.reverse_helper<0>(~result#0:int_list.int_list, 0:int_list.int_list, ?result#1:int_list.int_list) #3 @int_list:nn:nn
+        int_list.reverse_helper<0>(~result##0:int_list.int_list, 0:int_list.int_list, ?result##1:int_list.int_list) #3 @int_list:nn:nn
 
     1:
-        foreign lpvm alloc(16:wybe.int, ?tmp$12#0:int_list.int_list)
-        foreign lpvm mutate(~tmp$12#0:int_list.int_list, ?tmp$13#0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start#0:wybe.int)
-        foreign lpvm mutate(~tmp$13#0:int_list.int_list, ?tmp$14#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result#0:int_list.int_list)
-        foreign llvm add(~start#0:wybe.int, step#0:wybe.int, ?tmp$15#0:wybe.int) @int:nn:nn
-        int_list.gen$2<0>(~tmp$14#0:int_list.int_list, ~tmp$15#0:wybe.int, ~step#0:wybe.int, ~stop#0:wybe.int, ~tmp$0#0:int_list.int_list, ?result#1:int_list.int_list) #4 @int_list:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp$12##0:int_list.int_list)
+        foreign lpvm mutate(~tmp$12##0:int_list.int_list, ?tmp$13##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int)
+        foreign lpvm mutate(~tmp$13##0:int_list.int_list, ?tmp$14##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list)
+        foreign llvm add(~start##0:wybe.int, step##0:wybe.int, ?tmp$15##0:wybe.int) @int:nn:nn
+        int_list.gen$2<0>(~tmp$14##0:int_list.int_list, ~tmp$15##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ~tmp$0##0:int_list.int_list, ?result##1:int_list.int_list) #4 @int_list:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_slt(start#0:wybe.int, stop#0:wybe.int, ?tmp$3#0:wybe.bool) @int:nn:nn
-    case ~tmp$3#0:wybe.bool of
+    foreign llvm icmp_slt(start##0:wybe.int, stop##0:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
+    case ~tmp$3##0:wybe.bool of
     0:
-        int_list.reverse_helper<0>[410bae77d3](~result#0:int_list.int_list, 0:int_list.int_list, ?result#1:int_list.int_list) #3 @int_list:nn:nn
+        int_list.reverse_helper<0>[410bae77d3](~result##0:int_list.int_list, 0:int_list.int_list, ?result##1:int_list.int_list) #3 @int_list:nn:nn
 
     1:
-        foreign lpvm alloc(16:wybe.int, ?tmp$12#0:int_list.int_list)
-        foreign lpvm mutate(~tmp$12#0:int_list.int_list, ?tmp$13#0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start#0:wybe.int)
-        foreign lpvm mutate(~tmp$13#0:int_list.int_list, ?tmp$14#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result#0:int_list.int_list)
-        foreign llvm add(~start#0:wybe.int, step#0:wybe.int, ?tmp$15#0:wybe.int) @int:nn:nn
-        int_list.gen$2<0>[410bae77d3](~tmp$14#0:int_list.int_list, ~tmp$15#0:wybe.int, ~step#0:wybe.int, ~stop#0:wybe.int, ~tmp$0#0:int_list.int_list, ?result#1:int_list.int_list) #4 @int_list:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp$12##0:int_list.int_list)
+        foreign lpvm mutate(~tmp$12##0:int_list.int_list, ?tmp$13##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int)
+        foreign lpvm mutate(~tmp$13##0:int_list.int_list, ?tmp$14##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list)
+        foreign llvm add(~start##0:wybe.int, step##0:wybe.int, ?tmp$15##0:wybe.int) @int:nn:nn
+        int_list.gen$2<0>[410bae77d3](~tmp$14##0:int_list.int_list, ~tmp$15##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ~tmp$0##0:int_list.int_list, ?result##1:int_list.int_list) #4 @int_list:nn:nn
 
 
 
 gen$3 > {inline} (1 calls)
 0: int_list.gen$3<0>
-gen$3(result#0:int_list.int_list, start#0:wybe.int, step#0:wybe.int, stop#0:wybe.int, tmp$0#0:int_list.int_list, ?result#2:int_list.int_list):
+gen$3(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, stop##0:wybe.int, tmp$0##0:int_list.int_list, ?result##2:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$5#0:int_list.int_list)
-    foreign lpvm mutate(~tmp$5#0:int_list.int_list, ?tmp$6#0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start#0:wybe.int)
-    foreign lpvm mutate(~tmp$6#0:int_list.int_list, ?tmp$7#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result#0:int_list.int_list)
-    foreign llvm add(~start#0:wybe.int, step#0:wybe.int, ?tmp$2#0:wybe.int) @int:nn:nn
-    int_list.gen$2<0>(~tmp$7#0:int_list.int_list, ~tmp$2#0:wybe.int, ~step#0:wybe.int, ~stop#0:wybe.int, ~tmp$0#0:int_list.int_list, ?result#2:int_list.int_list) #2 @int_list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$5##0:int_list.int_list)
+    foreign lpvm mutate(~tmp$5##0:int_list.int_list, ?tmp$6##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int)
+    foreign lpvm mutate(~tmp$6##0:int_list.int_list, ?tmp$7##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list)
+    foreign llvm add(~start##0:wybe.int, step##0:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
+    int_list.gen$2<0>(~tmp$7##0:int_list.int_list, ~tmp$2##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ~tmp$0##0:int_list.int_list, ?result##2:int_list.int_list) #2 @int_list:nn:nn
 
 
 greater > (3 calls)
 0: int_list.greater<0>[410bae77d3]
-greater(lst#0:int_list.int_list, v#0:wybe.int, ?$#0:int_list.int_list):
+greater(lst##0:int_list.int_list, v##0:wybe.int, ?$##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.greater<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.greater<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(lst#0:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.bool)
-    case ~tmp$9#0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
+    case ~tmp$9##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?$#0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:wybe.int)
-        foreign lpvm access(~lst#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:int_list.int_list)
-        foreign llvm icmp_sge(h#0:wybe.int, v#0:wybe.int, ?tmp$6#0:wybe.bool) @int:nn:nn
-        case ~tmp$6#0:wybe.bool of
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign llvm icmp_sge(h##0:wybe.int, v##0:wybe.int, ?tmp$6##0:wybe.bool) @int:nn:nn
+        case ~tmp$6##0:wybe.bool of
         0:
-            int_list.greater<0>(~t#0:int_list.int_list, ~v#0:wybe.int, ?$#0:int_list.int_list) #4 @int_list:nn:nn
+            int_list.greater<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?$##0:int_list.int_list) #4 @int_list:nn:nn
 
         1:
-            int_list.greater<0>(~t#0:int_list.int_list, ~v#0:wybe.int, ?tmp$3#0:int_list.int_list) #2 @int_list:nn:nn
-            foreign lpvm alloc(16:wybe.int, ?tmp$14#0:int_list.int_list)
-            foreign lpvm mutate(~tmp$14#0:int_list.int_list, ?tmp$15#0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h#0:wybe.int)
-            foreign lpvm mutate(~tmp$15#0:int_list.int_list, ?$#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3#0:int_list.int_list)
+            int_list.greater<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp$3##0:int_list.int_list) #2 @int_list:nn:nn
+            foreign lpvm alloc(16:wybe.int, ?tmp$14##0:int_list.int_list)
+            foreign lpvm mutate(~tmp$14##0:int_list.int_list, ?tmp$15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+            foreign lpvm mutate(~tmp$15##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:int_list.int_list)
 
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_ne(lst#0:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.bool)
-    case ~tmp$9#0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
+    case ~tmp$9##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?$#0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:wybe.int)
-        foreign lpvm access(lst#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:int_list.int_list)
-        foreign llvm icmp_sge(~h#0:wybe.int, v#0:wybe.int, ?tmp$6#0:wybe.bool) @int:nn:nn
-        case ~tmp$6#0:wybe.bool of
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+        foreign lpvm access(lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign llvm icmp_sge(~h##0:wybe.int, v##0:wybe.int, ?tmp$6##0:wybe.bool) @int:nn:nn
+        case ~tmp$6##0:wybe.bool of
         0:
-            int_list.greater<0>[410bae77d3](~t#0:int_list.int_list, ~v#0:wybe.int, ?$#0:int_list.int_list) #4 @int_list:nn:nn
+            int_list.greater<0>[410bae77d3](~t##0:int_list.int_list, ~v##0:wybe.int, ?$##0:int_list.int_list) #4 @int_list:nn:nn
 
         1:
-            int_list.greater<0>[410bae77d3](~t#0:int_list.int_list, ~v#0:wybe.int, ?tmp$3#0:int_list.int_list) #2 @int_list:nn:nn
-            foreign lpvm mutate(~lst#0:int_list.int_list, ?$#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3#0:int_list.int_list)
+            int_list.greater<0>[410bae77d3](~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp$3##0:int_list.int_list) #2 @int_list:nn:nn
+            foreign lpvm mutate(~lst##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:int_list.int_list)
 
 
 
 
 index > public {inline} (0 calls)
 0: int_list.index<0>
-index(lst#0:int_list.int_list, x#0:wybe.int, ?$#0:wybe.int):
+index(lst##0:int_list.int_list, x##0:wybe.int, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    int_list.index_helper<0>(~lst#0:int_list.int_list, 0:wybe.int, ~x#0:wybe.int, ?$#0:wybe.int) #0 @int_list:nn:nn
+    int_list.index_helper<0>(~lst##0:int_list.int_list, 0:wybe.int, ~x##0:wybe.int, ?$##0:wybe.int) #0 @int_list:nn:nn
 
 
 index_helper > (2 calls)
 0: int_list.index_helper<0>
-index_helper(lst#0:int_list.int_list, idx#0:wybe.int, x#0:wybe.int, ?$#0:wybe.int):
+index_helper(lst##0:int_list.int_list, idx##0:wybe.int, x##0:wybe.int, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(lst#0:wybe.int, 0:wybe.int, ?tmp$7#0:wybe.bool)
-    case ~tmp$7#0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.bool)
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(-1:wybe.int, ?$#0:wybe.int) @int_list:nn:nn
+        foreign llvm move(-1:wybe.int, ?$##0:wybe.int) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:wybe.int)
-        foreign lpvm access(~lst#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:int_list.int_list)
-        foreign llvm icmp_eq(~h#0:wybe.int, x#0:wybe.int, ?tmp$4#0:wybe.bool) @int:nn:nn
-        case ~tmp$4#0:wybe.bool of
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign llvm icmp_eq(~h##0:wybe.int, x##0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
+        case ~tmp$4##0:wybe.bool of
         0:
-            foreign llvm add(~idx#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.int) @int:nn:nn
-            int_list.index_helper<0>(~t#0:int_list.int_list, ~tmp$3#0:wybe.int, ~x#0:wybe.int, ?$#0:wybe.int) #3 @int_list:nn:nn
+            foreign llvm add(~idx##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
+            int_list.index_helper<0>(~t##0:int_list.int_list, ~tmp$3##0:wybe.int, ~x##0:wybe.int, ?$##0:wybe.int) #3 @int_list:nn:nn
 
         1:
-            foreign llvm move(~idx#0:wybe.int, ?$#0:wybe.int) @int_list:nn:nn
+            foreign llvm move(~idx##0:wybe.int, ?$##0:wybe.int) @int_list:nn:nn
 
 
 
 
 insert > public (2 calls)
 0: int_list.insert<0>[410bae77d3]
-insert(lst#0:int_list.int_list, idx#0:wybe.int, v#0:wybe.int, ?$#0:int_list.int_list):
- AliasPairs: [($#0,lst#0)]
+insert(lst##0:int_list.int_list, idx##0:wybe.int, v##0:wybe.int, ?$##0:int_list.int_list):
+ AliasPairs: [($##0,lst##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(4,(int_list.insert<0>,fromList [NonAliasedParamCond 0 [0]])),(7,(int_list.insert<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_eq(idx#0:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.bool) @int:nn:nn
-    case ~tmp$9#0:wybe.bool of
+    foreign llvm icmp_eq(idx##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool) @int:nn:nn
+    case ~tmp$9##0:wybe.bool of
     0:
-        foreign llvm icmp_ne(lst#0:wybe.int, 0:wybe.int, ?tmp$13#0:wybe.bool)
-        case ~tmp$13#0:wybe.bool of
+        foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$13##0:wybe.bool)
+        case ~tmp$13##0:wybe.bool of
         0:
-            foreign llvm sub(~idx#0:wybe.int, 1:wybe.int, ?tmp$7#0:wybe.int) @int:nn:nn
-            int_list.insert<0>(~lst#0:int_list.int_list, ~tmp$7#0:wybe.int, ~v#0:wybe.int, ?$#0:int_list.int_list) #7 @int_list:nn:nn
+            foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp$7##0:wybe.int) @int:nn:nn
+            int_list.insert<0>(~lst##0:int_list.int_list, ~tmp$7##0:wybe.int, ~v##0:wybe.int, ?$##0:int_list.int_list) #7 @int_list:nn:nn
 
         1:
-            foreign lpvm access(lst#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:wybe.int)
-            foreign lpvm access(~lst#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:int_list.int_list)
-            foreign llvm sub(~idx#0:wybe.int, 1:wybe.int, ?tmp$5#0:wybe.int) @int:nn:nn
-            int_list.insert<0>(~t#0:int_list.int_list, ~tmp$5#0:wybe.int, ~v#0:wybe.int, ?tmp$4#0:int_list.int_list) #4 @int_list:nn:nn
-            foreign lpvm alloc(16:wybe.int, ?tmp$18#0:int_list.int_list)
-            foreign lpvm mutate(~tmp$18#0:int_list.int_list, ?tmp$19#0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h#0:wybe.int)
-            foreign lpvm mutate(~tmp$19#0:int_list.int_list, ?$#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$4#0:int_list.int_list)
+            foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+            foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+            foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp$5##0:wybe.int) @int:nn:nn
+            int_list.insert<0>(~t##0:int_list.int_list, ~tmp$5##0:wybe.int, ~v##0:wybe.int, ?tmp$4##0:int_list.int_list) #4 @int_list:nn:nn
+            foreign lpvm alloc(16:wybe.int, ?tmp$18##0:int_list.int_list)
+            foreign lpvm mutate(~tmp$18##0:int_list.int_list, ?tmp$19##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+            foreign lpvm mutate(~tmp$19##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$4##0:int_list.int_list)
 
 
     1:
-        foreign lpvm alloc(16:wybe.int, ?tmp$14#0:int_list.int_list)
-        foreign lpvm mutate(~tmp$14#0:int_list.int_list, ?tmp$15#0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v#0:wybe.int)
-        foreign lpvm mutate(~tmp$15#0:int_list.int_list, ?$#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lst#0:int_list.int_list)
+        foreign lpvm alloc(16:wybe.int, ?tmp$14##0:int_list.int_list)
+        foreign lpvm mutate(~tmp$14##0:int_list.int_list, ?tmp$15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
+        foreign lpvm mutate(~tmp$15##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lst##0:int_list.int_list)
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_eq(idx#0:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.bool) @int:nn:nn
-    case ~tmp$9#0:wybe.bool of
+    foreign llvm icmp_eq(idx##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool) @int:nn:nn
+    case ~tmp$9##0:wybe.bool of
     0:
-        foreign llvm icmp_ne(lst#0:wybe.int, 0:wybe.int, ?tmp$13#0:wybe.bool)
-        case ~tmp$13#0:wybe.bool of
+        foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$13##0:wybe.bool)
+        case ~tmp$13##0:wybe.bool of
         0:
-            foreign llvm sub(~idx#0:wybe.int, 1:wybe.int, ?tmp$7#0:wybe.int) @int:nn:nn
-            int_list.insert<0>[410bae77d3](~lst#0:int_list.int_list, ~tmp$7#0:wybe.int, ~v#0:wybe.int, ?$#0:int_list.int_list) #7 @int_list:nn:nn
+            foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp$7##0:wybe.int) @int:nn:nn
+            int_list.insert<0>[410bae77d3](~lst##0:int_list.int_list, ~tmp$7##0:wybe.int, ~v##0:wybe.int, ?$##0:int_list.int_list) #7 @int_list:nn:nn
 
         1:
-            foreign lpvm access(lst#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:int_list.int_list)
-            foreign llvm sub(~idx#0:wybe.int, 1:wybe.int, ?tmp$5#0:wybe.int) @int:nn:nn
-            int_list.insert<0>[410bae77d3](~t#0:int_list.int_list, ~tmp$5#0:wybe.int, ~v#0:wybe.int, ?tmp$4#0:int_list.int_list) #4 @int_list:nn:nn
-            foreign lpvm mutate(~lst#0:int_list.int_list, ?$#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$4#0:int_list.int_list)
+            foreign lpvm access(lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+            foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp$5##0:wybe.int) @int:nn:nn
+            int_list.insert<0>[410bae77d3](~t##0:int_list.int_list, ~tmp$5##0:wybe.int, ~v##0:wybe.int, ?tmp$4##0:int_list.int_list) #4 @int_list:nn:nn
+            foreign lpvm mutate(~lst##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$4##0:int_list.int_list)
 
 
     1:
-        foreign lpvm alloc(16:wybe.int, ?tmp$14#0:int_list.int_list)
-        foreign lpvm mutate(~tmp$14#0:int_list.int_list, ?tmp$15#0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v#0:wybe.int)
-        foreign lpvm mutate(~tmp$15#0:int_list.int_list, ?$#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lst#0:int_list.int_list)
+        foreign lpvm alloc(16:wybe.int, ?tmp$14##0:int_list.int_list)
+        foreign lpvm mutate(~tmp$14##0:int_list.int_list, ?tmp$15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
+        foreign lpvm mutate(~tmp$15##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lst##0:int_list.int_list)
 
 
 
 lesser > (3 calls)
 0: int_list.lesser<0>
-lesser(lst#0:int_list.int_list, v#0:wybe.int, ?$#0:int_list.int_list):
+lesser(lst##0:int_list.int_list, v##0:wybe.int, ?$##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.lesser<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.lesser<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(lst#0:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.bool)
-    case ~tmp$9#0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
+    case ~tmp$9##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?$#0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:wybe.int)
-        foreign lpvm access(~lst#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:int_list.int_list)
-        foreign llvm icmp_slt(h#0:wybe.int, v#0:wybe.int, ?tmp$6#0:wybe.bool) @int:nn:nn
-        case ~tmp$6#0:wybe.bool of
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign llvm icmp_slt(h##0:wybe.int, v##0:wybe.int, ?tmp$6##0:wybe.bool) @int:nn:nn
+        case ~tmp$6##0:wybe.bool of
         0:
-            int_list.lesser<0>(~t#0:int_list.int_list, ~v#0:wybe.int, ?$#0:int_list.int_list) #4 @int_list:nn:nn
+            int_list.lesser<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?$##0:int_list.int_list) #4 @int_list:nn:nn
 
         1:
-            int_list.lesser<0>(~t#0:int_list.int_list, ~v#0:wybe.int, ?tmp$3#0:int_list.int_list) #2 @int_list:nn:nn
-            foreign lpvm alloc(16:wybe.int, ?tmp$14#0:int_list.int_list)
-            foreign lpvm mutate(~tmp$14#0:int_list.int_list, ?tmp$15#0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h#0:wybe.int)
-            foreign lpvm mutate(~tmp$15#0:int_list.int_list, ?$#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3#0:int_list.int_list)
+            int_list.lesser<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp$3##0:int_list.int_list) #2 @int_list:nn:nn
+            foreign lpvm alloc(16:wybe.int, ?tmp$14##0:int_list.int_list)
+            foreign lpvm mutate(~tmp$14##0:int_list.int_list, ?tmp$15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+            foreign lpvm mutate(~tmp$15##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:int_list.int_list)
 
 
 
 
 pop > public (1 calls)
 0: int_list.pop<0>[410bae77d3]
-pop(lst#0:int_list.int_list, idx#0:wybe.int, ?$#0:int_list.int_list):
- AliasPairs: [($#0,lst#0)]
+pop(lst##0:int_list.int_list, idx##0:wybe.int, ?$##0:int_list.int_list):
+ AliasPairs: [($##0,lst##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(3,(int_list.pop<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(lst#0:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.bool)
-    case ~tmp$9#0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
+    case ~tmp$9##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?$#0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:wybe.int)
-        foreign lpvm access(~lst#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:int_list.int_list)
-        foreign llvm icmp_eq(idx#0:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.bool) @int:nn:nn
-        case ~tmp$6#0:wybe.bool of
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign llvm icmp_eq(idx##0:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.bool) @int:nn:nn
+        case ~tmp$6##0:wybe.bool of
         0:
-            foreign llvm sub(~idx#0:wybe.int, 1:wybe.int, ?tmp$4#0:wybe.int) @int:nn:nn
-            int_list.pop<0>(~t#0:int_list.int_list, ~tmp$4#0:wybe.int, ?tmp$3#0:int_list.int_list) #3 @int_list:nn:nn
-            foreign lpvm alloc(16:wybe.int, ?tmp$16#0:int_list.int_list)
-            foreign lpvm mutate(~tmp$16#0:int_list.int_list, ?tmp$17#0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h#0:wybe.int)
-            foreign lpvm mutate(~tmp$17#0:int_list.int_list, ?$#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3#0:int_list.int_list)
+            foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp$4##0:wybe.int) @int:nn:nn
+            int_list.pop<0>(~t##0:int_list.int_list, ~tmp$4##0:wybe.int, ?tmp$3##0:int_list.int_list) #3 @int_list:nn:nn
+            foreign lpvm alloc(16:wybe.int, ?tmp$16##0:int_list.int_list)
+            foreign lpvm mutate(~tmp$16##0:int_list.int_list, ?tmp$17##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+            foreign lpvm mutate(~tmp$17##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:int_list.int_list)
 
         1:
-            foreign llvm move(~t#0:int_list.int_list, ?$#0:int_list.int_list) @int_list:nn:nn
+            foreign llvm move(~t##0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
 
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_ne(lst#0:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.bool)
-    case ~tmp$9#0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
+    case ~tmp$9##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?$#0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:int_list.int_list)
-        foreign llvm icmp_eq(idx#0:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.bool) @int:nn:nn
-        case ~tmp$6#0:wybe.bool of
+        foreign lpvm access(lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign llvm icmp_eq(idx##0:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.bool) @int:nn:nn
+        case ~tmp$6##0:wybe.bool of
         0:
-            foreign llvm sub(~idx#0:wybe.int, 1:wybe.int, ?tmp$4#0:wybe.int) @int:nn:nn
-            int_list.pop<0>[410bae77d3](~t#0:int_list.int_list, ~tmp$4#0:wybe.int, ?tmp$3#0:int_list.int_list) #3 @int_list:nn:nn
-            foreign lpvm mutate(~lst#0:int_list.int_list, ?$#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3#0:int_list.int_list)
+            foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp$4##0:wybe.int) @int:nn:nn
+            int_list.pop<0>[410bae77d3](~t##0:int_list.int_list, ~tmp$4##0:wybe.int, ?tmp$3##0:int_list.int_list) #3 @int_list:nn:nn
+            foreign lpvm mutate(~lst##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:int_list.int_list)
 
         1:
-            foreign llvm move(~t#0:int_list.int_list, ?$#0:int_list.int_list) @int_list:nn:nn
+            foreign llvm move(~t##0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
 
 
 
 
 print > public (2 calls)
 0: int_list.print<0>
-print(x#0:int_list.int_list, io#0:wybe.phantom, ?io#3:wybe.phantom):
+print(x##0:int_list.int_list, io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(x#0:wybe.int, 0:wybe.int, ?tmp$2#0:wybe.bool)
-    case ~tmp$2#0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.bool)
+    case ~tmp$2##0:wybe.bool of
     0:
-        foreign llvm move(~io#0:wybe.phantom, ?io#3:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##3:wybe.phantom)
 
     1:
-        foreign lpvm access(x#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:wybe.int)
-        foreign lpvm access(~x#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:int_list.int_list)
-        foreign c print_int(~h#0:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        foreign c putchar(' ':wybe.char, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-        int_list.print<0>(~t#0:int_list.int_list, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) #3 @int_list:nn:nn
+        foreign lpvm access(x##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+        foreign lpvm access(~x##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign c print_int(~h##0:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        foreign c putchar(' ':wybe.char, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+        int_list.print<0>(~t##0:int_list.int_list, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @int_list:nn:nn
 
 
 
 println > public {inline} (0 calls)
 0: int_list.println<0>
-println(x#0:int_list.int_list, io#0:wybe.phantom, ?io#2:wybe.phantom):
+println(x##0:int_list.int_list, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    int_list.print<0>(~x#0:int_list.int_list, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
+    int_list.print<0>(~x##0:int_list.int_list, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
 
 range > public {inline} (0 calls)
 0: int_list.range<0>
-range(start#0:wybe.int, stop#0:wybe.int, step#0:wybe.int, ?result#1:int_list.int_list):
+range(start##0:wybe.int, stop##0:wybe.int, step##0:wybe.int, ?result##1:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    int_list.gen$2<0>(0:int_list.int_list, ~start#0:wybe.int, ~step#0:wybe.int, ~stop#0:wybe.int, 0:int_list.int_list, ?result#1:int_list.int_list) #1 @int_list:nn:nn
+    int_list.gen$2<0>(0:int_list.int_list, ~start##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, 0:int_list.int_list, ?result##1:int_list.int_list) #1 @int_list:nn:nn
 
 
 remove > public (1 calls)
 0: int_list.remove<0>[410bae77d3]
-remove(lst#0:int_list.int_list, v#0:wybe.int, ?$#0:int_list.int_list):
- AliasPairs: [($#0,lst#0)]
+remove(lst##0:int_list.int_list, v##0:wybe.int, ?$##0:int_list.int_list):
+ AliasPairs: [($##0,lst##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.remove<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(lst#0:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.bool)
-    case ~tmp$8#0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.bool)
+    case ~tmp$8##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?$#0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:wybe.int)
-        foreign lpvm access(~lst#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:int_list.int_list)
-        foreign llvm icmp_eq(h#0:wybe.int, v#0:wybe.int, ?tmp$5#0:wybe.bool) @int:nn:nn
-        case ~tmp$5#0:wybe.bool of
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign llvm icmp_eq(h##0:wybe.int, v##0:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
+        case ~tmp$5##0:wybe.bool of
         0:
-            int_list.remove<0>(~t#0:int_list.int_list, ~v#0:wybe.int, ?tmp$3#0:int_list.int_list) #2 @int_list:nn:nn
-            foreign lpvm alloc(16:wybe.int, ?tmp$13#0:int_list.int_list)
-            foreign lpvm mutate(~tmp$13#0:int_list.int_list, ?tmp$14#0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h#0:wybe.int)
-            foreign lpvm mutate(~tmp$14#0:int_list.int_list, ?$#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3#0:int_list.int_list)
+            int_list.remove<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp$3##0:int_list.int_list) #2 @int_list:nn:nn
+            foreign lpvm alloc(16:wybe.int, ?tmp$13##0:int_list.int_list)
+            foreign lpvm mutate(~tmp$13##0:int_list.int_list, ?tmp$14##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+            foreign lpvm mutate(~tmp$14##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:int_list.int_list)
 
         1:
-            foreign llvm move(~t#0:int_list.int_list, ?$#0:int_list.int_list) @int_list:nn:nn
+            foreign llvm move(~t##0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
 
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_ne(lst#0:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.bool)
-    case ~tmp$8#0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.bool)
+    case ~tmp$8##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?$#0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:wybe.int)
-        foreign lpvm access(lst#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:int_list.int_list)
-        foreign llvm icmp_eq(~h#0:wybe.int, v#0:wybe.int, ?tmp$5#0:wybe.bool) @int:nn:nn
-        case ~tmp$5#0:wybe.bool of
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+        foreign lpvm access(lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign llvm icmp_eq(~h##0:wybe.int, v##0:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
+        case ~tmp$5##0:wybe.bool of
         0:
-            int_list.remove<0>[410bae77d3](~t#0:int_list.int_list, ~v#0:wybe.int, ?tmp$3#0:int_list.int_list) #2 @int_list:nn:nn
-            foreign lpvm mutate(~lst#0:int_list.int_list, ?$#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3#0:int_list.int_list)
+            int_list.remove<0>[410bae77d3](~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp$3##0:int_list.int_list) #2 @int_list:nn:nn
+            foreign lpvm mutate(~lst##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:int_list.int_list)
 
         1:
-            foreign llvm move(~t#0:int_list.int_list, ?$#0:int_list.int_list) @int_list:nn:nn
+            foreign llvm move(~t##0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
 
 
 
 
 reverse > public {inline} (1 calls)
 0: int_list.reverse<0>
-reverse(lst#0:int_list.int_list, ?$#0:int_list.int_list):
+reverse(lst##0:int_list.int_list, ?$##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    int_list.reverse_helper<0>(~lst#0:int_list.int_list, 0:int_list.int_list, ?$#0:int_list.int_list) #1 @int_list:nn:nn
+    int_list.reverse_helper<0>(~lst##0:int_list.int_list, 0:int_list.int_list, ?$##0:int_list.int_list) #1 @int_list:nn:nn
 
 
 reverse_helper > (2 calls)
 0: int_list.reverse_helper<0>[410bae77d3]
-reverse_helper(lst#0:int_list.int_list, acc#0:int_list.int_list, ?$#0:int_list.int_list):
- AliasPairs: [($#0,acc#0)]
+reverse_helper(lst##0:int_list.int_list, acc##0:int_list.int_list, ?$##0:int_list.int_list):
+ AliasPairs: [($##0,acc##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(lst#0:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.bool)
-    case ~tmp$5#0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
+    case ~tmp$5##0:wybe.bool of
     0:
-        foreign llvm move(~acc#0:int_list.int_list, ?$#0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(~acc##0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:wybe.int)
-        foreign lpvm access(~lst#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:int_list.int_list)
-        foreign lpvm alloc(16:wybe.int, ?tmp$8#0:int_list.int_list)
-        foreign lpvm mutate(~tmp$8#0:int_list.int_list, ?tmp$9#0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h#0:wybe.int)
-        foreign lpvm mutate(~tmp$9#0:int_list.int_list, ?tmp$10#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~acc#0:int_list.int_list)
-        int_list.reverse_helper<0>(~t#0:int_list.int_list, ~tmp$10#0:int_list.int_list, ?$#0:int_list.int_list) #2 @int_list:nn:nn
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign lpvm alloc(16:wybe.int, ?tmp$8##0:int_list.int_list)
+        foreign lpvm mutate(~tmp$8##0:int_list.int_list, ?tmp$9##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+        foreign lpvm mutate(~tmp$9##0:int_list.int_list, ?tmp$10##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~acc##0:int_list.int_list)
+        int_list.reverse_helper<0>(~t##0:int_list.int_list, ~tmp$10##0:int_list.int_list, ?$##0:int_list.int_list) #2 @int_list:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_ne(lst#0:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.bool)
-    case ~tmp$5#0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
+    case ~tmp$5##0:wybe.bool of
     0:
-        foreign llvm move(~acc#0:int_list.int_list, ?$#0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(~acc##0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:int_list.int_list)
-        foreign lpvm mutate(~lst#0:int_list.int_list, ?tmp$10#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~acc#0:int_list.int_list)
-        int_list.reverse_helper<0>[410bae77d3](~t#0:int_list.int_list, ~tmp$10#0:int_list.int_list, ?$#0:int_list.int_list) #2 @int_list:nn:nn
+        foreign lpvm access(lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign lpvm mutate(~lst##0:int_list.int_list, ?tmp$10##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~acc##0:int_list.int_list)
+        int_list.reverse_helper<0>[410bae77d3](~t##0:int_list.int_list, ~tmp$10##0:int_list.int_list, ?$##0:int_list.int_list) #2 @int_list:nn:nn
 
 
 
 sort > public (2 calls)
 0: int_list.sort<0>[410bae77d3]
-sort(lst#0:int_list.int_list, ?$#0:int_list.int_list):
+sort(lst##0:int_list.int_list, ?$##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.sort<0>,fromList [NonAliasedParamCond 0 []])),(3,(int_list.greater<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.sort<0>,fromList [NonAliasedParamCond 0 []])),(6,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign llvm icmp_ne(lst#0:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.bool)
-    case ~tmp$10#0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.bool)
+    case ~tmp$10##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?$#0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:wybe.int)
-        foreign lpvm access(~lst#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:int_list.int_list)
-        int_list.lesser<0>(t#0:int_list.int_list, h#0:wybe.int, ?tmp$3#0:int_list.int_list) #1 @int_list:nn:nn
-        int_list.sort<0>[410bae77d3](~tmp$3#0:int_list.int_list, ?tmp$2#0:int_list.int_list) #2 @int_list:nn:nn
-        int_list.greater<0>(~t#0:int_list.int_list, h#0:wybe.int, ?tmp$6#0:int_list.int_list) #3 @int_list:nn:nn
-        int_list.sort<0>[410bae77d3](~tmp$6#0:int_list.int_list, ?tmp$5#0:int_list.int_list) #4 @int_list:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$13#0:int_list.int_list)
-        foreign lpvm mutate(~tmp$13#0:int_list.int_list, ?tmp$14#0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h#0:wybe.int)
-        foreign lpvm mutate(~tmp$14#0:int_list.int_list, ?tmp$15#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$5#0:int_list.int_list)
-        int_list.extend<0>[410bae77d3](~tmp$2#0:int_list.int_list, ~tmp$15#0:int_list.int_list, ?$#0:int_list.int_list) #6 @int_list:nn:nn
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+        foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        int_list.lesser<0>(t##0:int_list.int_list, h##0:wybe.int, ?tmp$3##0:int_list.int_list) #1 @int_list:nn:nn
+        int_list.sort<0>[410bae77d3](~tmp$3##0:int_list.int_list, ?tmp$2##0:int_list.int_list) #2 @int_list:nn:nn
+        int_list.greater<0>(~t##0:int_list.int_list, h##0:wybe.int, ?tmp$6##0:int_list.int_list) #3 @int_list:nn:nn
+        int_list.sort<0>[410bae77d3](~tmp$6##0:int_list.int_list, ?tmp$5##0:int_list.int_list) #4 @int_list:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp$13##0:int_list.int_list)
+        foreign lpvm mutate(~tmp$13##0:int_list.int_list, ?tmp$14##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+        foreign lpvm mutate(~tmp$14##0:int_list.int_list, ?tmp$15##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$5##0:int_list.int_list)
+        int_list.extend<0>[410bae77d3](~tmp$2##0:int_list.int_list, ~tmp$15##0:int_list.int_list, ?$##0:int_list.int_list) #6 @int_list:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_ne(lst#0:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.bool)
-    case ~tmp$10#0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.bool)
+    case ~tmp$10##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?$#0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
 
     1:
-        foreign lpvm access(lst#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:wybe.int)
-        foreign lpvm access(lst#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:int_list.int_list)
-        int_list.lesser<0>(t#0:int_list.int_list, h#0:wybe.int, ?tmp$3#0:int_list.int_list) #1 @int_list:nn:nn
-        int_list.sort<0>[410bae77d3](~tmp$3#0:int_list.int_list, ?tmp$2#0:int_list.int_list) #2 @int_list:nn:nn
-        int_list.greater<0>[410bae77d3](~t#0:int_list.int_list, ~h#0:wybe.int, ?tmp$6#0:int_list.int_list) #3 @int_list:nn:nn
-        int_list.sort<0>[410bae77d3](~tmp$6#0:int_list.int_list, ?tmp$5#0:int_list.int_list) #4 @int_list:nn:nn
-        foreign lpvm mutate(~lst#0:int_list.int_list, ?tmp$15#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$5#0:int_list.int_list)
-        int_list.extend<0>[410bae77d3](~tmp$2#0:int_list.int_list, ~tmp$15#0:int_list.int_list, ?$#0:int_list.int_list) #6 @int_list:nn:nn
+        foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+        foreign lpvm access(lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        int_list.lesser<0>(t##0:int_list.int_list, h##0:wybe.int, ?tmp$3##0:int_list.int_list) #1 @int_list:nn:nn
+        int_list.sort<0>[410bae77d3](~tmp$3##0:int_list.int_list, ?tmp$2##0:int_list.int_list) #2 @int_list:nn:nn
+        int_list.greater<0>[410bae77d3](~t##0:int_list.int_list, ~h##0:wybe.int, ?tmp$6##0:int_list.int_list) #3 @int_list:nn:nn
+        int_list.sort<0>[410bae77d3](~tmp$6##0:int_list.int_list, ?tmp$5##0:int_list.int_list) #4 @int_list:nn:nn
+        foreign lpvm mutate(~lst##0:int_list.int_list, ?tmp$15##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$5##0:int_list.int_list)
+        int_list.extend<0>[410bae77d3](~tmp$2##0:int_list.int_list, ~tmp$15##0:int_list.int_list, ?$##0:int_list.int_list) #6 @int_list:nn:nn
 
 
   LLVM code       :
@@ -1615,78 +1615,78 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i64 @"int_list.append<0>"(i64  %"lst#0", i64  %"v#0")    {
+define external fastcc  i64 @"int_list.append<0>"(i64  %"lst##0", i64  %"v##0")    {
 entry:
   %1 = trunc i64 16 to i32  
   %2 = tail call ccc  i8*  @wybe_malloc(i32  %1)  
   %3 = ptrtoint i8* %2 to i64 
   %4 = inttoptr i64 %3 to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
-  store  i64 %"v#0", i64* %5 
+  store  i64 %"v##0", i64* %5 
   %6 = add   i64 %3, 8 
   %7 = inttoptr i64 %6 to i64* 
   %8 = getelementptr  i64, i64* %7, i64 0 
   store  i64 0, i64* %8 
-  %"1$$#0" = tail call fastcc  i64  @"int_list.extend<0>"(i64  %"lst#0", i64  %3)  
-  ret i64 %"1$$#0" 
+  %"1$$##0" = tail call fastcc  i64  @"int_list.extend<0>"(i64  %"lst##0", i64  %3)  
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  i64 @"int_list.append<0>[410bae77d3]"(i64  %"lst#0", i64  %"v#0")    {
+define external fastcc  i64 @"int_list.append<0>[410bae77d3]"(i64  %"lst##0", i64  %"v##0")    {
 entry:
   %9 = trunc i64 16 to i32  
   %10 = tail call ccc  i8*  @wybe_malloc(i32  %9)  
   %11 = ptrtoint i8* %10 to i64 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 %"v#0", i64* %13 
+  store  i64 %"v##0", i64* %13 
   %14 = add   i64 %11, 8 
   %15 = inttoptr i64 %14 to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
   store  i64 0, i64* %16 
-  %"1$$#0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"lst#0", i64  %11)  
-  ret i64 %"1$$#0" 
+  %"1$$##0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"lst##0", i64  %11)  
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  i64 @"int_list.count<0>"(i64  %"lst#0", i64  %"x#0")    {
+define external fastcc  i64 @"int_list.count<0>"(i64  %"lst##0", i64  %"x##0")    {
 entry:
-  %"1$tmp$7#0" = icmp ne i64 %"lst#0", 0 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %17 = inttoptr i64 %"lst#0" to i64* 
+  %17 = inttoptr i64 %"lst##0" to i64* 
   %18 = getelementptr  i64, i64* %17, i64 0 
   %19 = load  i64, i64* %18 
-  %20 = add   i64 %"lst#0", 8 
+  %20 = add   i64 %"lst##0", 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
   %23 = load  i64, i64* %22 
-  %"2$tmp$2#0" = tail call fastcc  i64  @"int_list.count<0>"(i64  %23, i64  %"x#0")  
-  %"2$tmp$4#0" = icmp eq i64 %19, %"x#0" 
-  br i1 %"2$tmp$4#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = tail call fastcc  i64  @"int_list.count<0>"(i64  %23, i64  %"x##0")  
+  %"2$tmp$4##0" = icmp eq i64 %19, %"x##0" 
+  br i1 %"2$tmp$4##0", label %if.then1, label %if.else1 
 if.else:
   ret i64 0 
 if.then1:
-  %"4$$#0" = add   i64 %"2$tmp$2#0", 1 
-  ret i64 %"4$$#0" 
+  %"4$$##0" = add   i64 %"2$tmp$2##0", 1 
+  ret i64 %"4$$##0" 
 if.else1:
-  ret i64 %"2$tmp$2#0" 
+  ret i64 %"2$tmp$2##0" 
 }
 
 
-define external fastcc  i64 @"int_list.extend<0>"(i64  %"lst1#0", i64  %"lst2#0")    {
+define external fastcc  i64 @"int_list.extend<0>"(i64  %"lst1##0", i64  %"lst2##0")    {
 entry:
-  %"1$tmp$5#0" = icmp ne i64 %"lst1#0", 0 
-  br i1 %"1$tmp$5#0", label %if.then, label %if.else 
+  %"1$tmp$5##0" = icmp ne i64 %"lst1##0", 0 
+  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
 if.then:
-  %24 = inttoptr i64 %"lst1#0" to i64* 
+  %24 = inttoptr i64 %"lst1##0" to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
   %26 = load  i64, i64* %25 
-  %27 = add   i64 %"lst1#0", 8 
+  %27 = add   i64 %"lst1##0", 8 
   %28 = inttoptr i64 %27 to i64* 
   %29 = getelementptr  i64, i64* %28, i64 0 
   %30 = load  i64, i64* %29 
-  %"2$tmp$2#0" = tail call fastcc  i64  @"int_list.extend<0>"(i64  %30, i64  %"lst2#0")  
+  %"2$tmp$2##0" = tail call fastcc  i64  @"int_list.extend<0>"(i64  %30, i64  %"lst2##0")  
   %31 = trunc i64 16 to i32  
   %32 = tail call ccc  i8*  @wybe_malloc(i32  %31)  
   %33 = ptrtoint i8* %32 to i64 
@@ -1696,124 +1696,124 @@ if.then:
   %36 = add   i64 %33, 8 
   %37 = inttoptr i64 %36 to i64* 
   %38 = getelementptr  i64, i64* %37, i64 0 
-  store  i64 %"2$tmp$2#0", i64* %38 
+  store  i64 %"2$tmp$2##0", i64* %38 
   ret i64 %33 
 if.else:
-  ret i64 %"lst2#0" 
+  ret i64 %"lst2##0" 
 }
 
 
-define external fastcc  i64 @"int_list.extend<0>[410bae77d3]"(i64  %"lst1#0", i64  %"lst2#0")    {
+define external fastcc  i64 @"int_list.extend<0>[410bae77d3]"(i64  %"lst1##0", i64  %"lst2##0")    {
 entry:
-  %"1$tmp$5#0" = icmp ne i64 %"lst1#0", 0 
-  br i1 %"1$tmp$5#0", label %if.then, label %if.else 
+  %"1$tmp$5##0" = icmp ne i64 %"lst1##0", 0 
+  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
 if.then:
-  %39 = add   i64 %"lst1#0", 8 
+  %39 = add   i64 %"lst1##0", 8 
   %40 = inttoptr i64 %39 to i64* 
   %41 = getelementptr  i64, i64* %40, i64 0 
   %42 = load  i64, i64* %41 
-  %"2$tmp$2#0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %42, i64  %"lst2#0")  
-  %43 = add   i64 %"lst1#0", 8 
+  %"2$tmp$2##0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %42, i64  %"lst2##0")  
+  %43 = add   i64 %"lst1##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
-  store  i64 %"2$tmp$2#0", i64* %45 
-  ret i64 %"lst1#0" 
+  store  i64 %"2$tmp$2##0", i64* %45 
+  ret i64 %"lst1##0" 
 if.else:
-  ret i64 %"lst2#0" 
+  ret i64 %"lst2##0" 
 }
 
 
-define external fastcc  i64 @"int_list.gen$1<0>"(i64  %"tmp$2#0", i64  %"tmp$3#0")    {
+define external fastcc  i64 @"int_list.gen$1<0>"(i64  %"tmp$2##0", i64  %"tmp$3##0")    {
 entry:
-  %"1$$#0" = add   i64 %"tmp$2#0", %"tmp$3#0" 
-  ret i64 %"1$$#0" 
+  %"1$$##0" = add   i64 %"tmp$2##0", %"tmp$3##0" 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  i64 @"int_list.gen$2<0>"(i64  %"result#0", i64  %"start#0", i64  %"step#0", i64  %"stop#0", i64  %"tmp$0#0")    {
+define external fastcc  i64 @"int_list.gen$2<0>"(i64  %"result##0", i64  %"start##0", i64  %"step##0", i64  %"stop##0", i64  %"tmp$0##0")    {
 entry:
-  %"1$tmp$3#0" = icmp slt i64 %"start#0", %"stop#0" 
-  br i1 %"1$tmp$3#0", label %if.then, label %if.else 
+  %"1$tmp$3##0" = icmp slt i64 %"start##0", %"stop##0" 
+  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
 if.then:
   %46 = trunc i64 16 to i32  
   %47 = tail call ccc  i8*  @wybe_malloc(i32  %46)  
   %48 = ptrtoint i8* %47 to i64 
   %49 = inttoptr i64 %48 to i64* 
   %50 = getelementptr  i64, i64* %49, i64 0 
-  store  i64 %"start#0", i64* %50 
+  store  i64 %"start##0", i64* %50 
   %51 = add   i64 %48, 8 
   %52 = inttoptr i64 %51 to i64* 
   %53 = getelementptr  i64, i64* %52, i64 0 
-  store  i64 %"result#0", i64* %53 
-  %"2$tmp$15#0" = add   i64 %"start#0", %"step#0" 
-  %"2$result#1" = tail call fastcc  i64  @"int_list.gen$2<0>"(i64  %48, i64  %"2$tmp$15#0", i64  %"step#0", i64  %"stop#0", i64  %"tmp$0#0")  
-  ret i64 %"2$result#1" 
+  store  i64 %"result##0", i64* %53 
+  %"2$tmp$15##0" = add   i64 %"start##0", %"step##0" 
+  %"2$result##1" = tail call fastcc  i64  @"int_list.gen$2<0>"(i64  %48, i64  %"2$tmp$15##0", i64  %"step##0", i64  %"stop##0", i64  %"tmp$0##0")  
+  ret i64 %"2$result##1" 
 if.else:
-  %"3$result#1" = tail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %"result#0", i64  0)  
-  ret i64 %"3$result#1" 
+  %"3$result##1" = tail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %"result##0", i64  0)  
+  ret i64 %"3$result##1" 
 }
 
 
-define external fastcc  i64 @"int_list.gen$2<0>[410bae77d3]"(i64  %"result#0", i64  %"start#0", i64  %"step#0", i64  %"stop#0", i64  %"tmp$0#0")    {
+define external fastcc  i64 @"int_list.gen$2<0>[410bae77d3]"(i64  %"result##0", i64  %"start##0", i64  %"step##0", i64  %"stop##0", i64  %"tmp$0##0")    {
 entry:
-  %"1$tmp$3#0" = icmp slt i64 %"start#0", %"stop#0" 
-  br i1 %"1$tmp$3#0", label %if.then, label %if.else 
+  %"1$tmp$3##0" = icmp slt i64 %"start##0", %"stop##0" 
+  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
 if.then:
   %54 = trunc i64 16 to i32  
   %55 = tail call ccc  i8*  @wybe_malloc(i32  %54)  
   %56 = ptrtoint i8* %55 to i64 
   %57 = inttoptr i64 %56 to i64* 
   %58 = getelementptr  i64, i64* %57, i64 0 
-  store  i64 %"start#0", i64* %58 
+  store  i64 %"start##0", i64* %58 
   %59 = add   i64 %56, 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
-  store  i64 %"result#0", i64* %61 
-  %"2$tmp$15#0" = add   i64 %"start#0", %"step#0" 
-  %"2$result#1" = tail call fastcc  i64  @"int_list.gen$2<0>[410bae77d3]"(i64  %56, i64  %"2$tmp$15#0", i64  %"step#0", i64  %"stop#0", i64  %"tmp$0#0")  
-  ret i64 %"2$result#1" 
+  store  i64 %"result##0", i64* %61 
+  %"2$tmp$15##0" = add   i64 %"start##0", %"step##0" 
+  %"2$result##1" = tail call fastcc  i64  @"int_list.gen$2<0>[410bae77d3]"(i64  %56, i64  %"2$tmp$15##0", i64  %"step##0", i64  %"stop##0", i64  %"tmp$0##0")  
+  ret i64 %"2$result##1" 
 if.else:
-  %"3$result#1" = tail call fastcc  i64  @"int_list.reverse_helper<0>[410bae77d3]"(i64  %"result#0", i64  0)  
-  ret i64 %"3$result#1" 
+  %"3$result##1" = tail call fastcc  i64  @"int_list.reverse_helper<0>[410bae77d3]"(i64  %"result##0", i64  0)  
+  ret i64 %"3$result##1" 
 }
 
 
-define external fastcc  i64 @"int_list.gen$3<0>"(i64  %"result#0", i64  %"start#0", i64  %"step#0", i64  %"stop#0", i64  %"tmp$0#0")    {
+define external fastcc  i64 @"int_list.gen$3<0>"(i64  %"result##0", i64  %"start##0", i64  %"step##0", i64  %"stop##0", i64  %"tmp$0##0")    {
 entry:
   %62 = trunc i64 16 to i32  
   %63 = tail call ccc  i8*  @wybe_malloc(i32  %62)  
   %64 = ptrtoint i8* %63 to i64 
   %65 = inttoptr i64 %64 to i64* 
   %66 = getelementptr  i64, i64* %65, i64 0 
-  store  i64 %"start#0", i64* %66 
+  store  i64 %"start##0", i64* %66 
   %67 = add   i64 %64, 8 
   %68 = inttoptr i64 %67 to i64* 
   %69 = getelementptr  i64, i64* %68, i64 0 
-  store  i64 %"result#0", i64* %69 
-  %"1$tmp$2#0" = add   i64 %"start#0", %"step#0" 
-  %"1$result#2" = tail call fastcc  i64  @"int_list.gen$2<0>"(i64  %64, i64  %"1$tmp$2#0", i64  %"step#0", i64  %"stop#0", i64  %"tmp$0#0")  
-  ret i64 %"1$result#2" 
+  store  i64 %"result##0", i64* %69 
+  %"1$tmp$2##0" = add   i64 %"start##0", %"step##0" 
+  %"1$result##2" = tail call fastcc  i64  @"int_list.gen$2<0>"(i64  %64, i64  %"1$tmp$2##0", i64  %"step##0", i64  %"stop##0", i64  %"tmp$0##0")  
+  ret i64 %"1$result##2" 
 }
 
 
-define external fastcc  i64 @"int_list.greater<0>"(i64  %"lst#0", i64  %"v#0")    {
+define external fastcc  i64 @"int_list.greater<0>"(i64  %"lst##0", i64  %"v##0")    {
 entry:
-  %"1$tmp$9#0" = icmp ne i64 %"lst#0", 0 
-  br i1 %"1$tmp$9#0", label %if.then, label %if.else 
+  %"1$tmp$9##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1$tmp$9##0", label %if.then, label %if.else 
 if.then:
-  %70 = inttoptr i64 %"lst#0" to i64* 
+  %70 = inttoptr i64 %"lst##0" to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
   %72 = load  i64, i64* %71 
-  %73 = add   i64 %"lst#0", 8 
+  %73 = add   i64 %"lst##0", 8 
   %74 = inttoptr i64 %73 to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
   %76 = load  i64, i64* %75 
-  %"2$tmp$6#0" = icmp sge i64 %72, %"v#0" 
-  br i1 %"2$tmp$6#0", label %if.then1, label %if.else1 
+  %"2$tmp$6##0" = icmp sge i64 %72, %"v##0" 
+  br i1 %"2$tmp$6##0", label %if.then1, label %if.else1 
 if.else:
   ret i64 0 
 if.then1:
-  %"4$tmp$3#0" = tail call fastcc  i64  @"int_list.greater<0>"(i64  %76, i64  %"v#0")  
+  %"4$tmp$3##0" = tail call fastcc  i64  @"int_list.greater<0>"(i64  %76, i64  %"v##0")  
   %77 = trunc i64 16 to i32  
   %78 = tail call ccc  i8*  @wybe_malloc(i32  %77)  
   %79 = ptrtoint i8* %78 to i64 
@@ -1823,104 +1823,104 @@ if.then1:
   %82 = add   i64 %79, 8 
   %83 = inttoptr i64 %82 to i64* 
   %84 = getelementptr  i64, i64* %83, i64 0 
-  store  i64 %"4$tmp$3#0", i64* %84 
+  store  i64 %"4$tmp$3##0", i64* %84 
   ret i64 %79 
 if.else1:
-  %"5$$#0" = tail call fastcc  i64  @"int_list.greater<0>"(i64  %76, i64  %"v#0")  
-  ret i64 %"5$$#0" 
+  %"5$$##0" = tail call fastcc  i64  @"int_list.greater<0>"(i64  %76, i64  %"v##0")  
+  ret i64 %"5$$##0" 
 }
 
 
-define external fastcc  i64 @"int_list.greater<0>[410bae77d3]"(i64  %"lst#0", i64  %"v#0")    {
+define external fastcc  i64 @"int_list.greater<0>[410bae77d3]"(i64  %"lst##0", i64  %"v##0")    {
 entry:
-  %"1$tmp$9#0" = icmp ne i64 %"lst#0", 0 
-  br i1 %"1$tmp$9#0", label %if.then, label %if.else 
+  %"1$tmp$9##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1$tmp$9##0", label %if.then, label %if.else 
 if.then:
-  %85 = inttoptr i64 %"lst#0" to i64* 
+  %85 = inttoptr i64 %"lst##0" to i64* 
   %86 = getelementptr  i64, i64* %85, i64 0 
   %87 = load  i64, i64* %86 
-  %88 = add   i64 %"lst#0", 8 
+  %88 = add   i64 %"lst##0", 8 
   %89 = inttoptr i64 %88 to i64* 
   %90 = getelementptr  i64, i64* %89, i64 0 
   %91 = load  i64, i64* %90 
-  %"2$tmp$6#0" = icmp sge i64 %87, %"v#0" 
-  br i1 %"2$tmp$6#0", label %if.then1, label %if.else1 
+  %"2$tmp$6##0" = icmp sge i64 %87, %"v##0" 
+  br i1 %"2$tmp$6##0", label %if.then1, label %if.else1 
 if.else:
   ret i64 0 
 if.then1:
-  %"4$tmp$3#0" = tail call fastcc  i64  @"int_list.greater<0>[410bae77d3]"(i64  %91, i64  %"v#0")  
-  %92 = add   i64 %"lst#0", 8 
+  %"4$tmp$3##0" = tail call fastcc  i64  @"int_list.greater<0>[410bae77d3]"(i64  %91, i64  %"v##0")  
+  %92 = add   i64 %"lst##0", 8 
   %93 = inttoptr i64 %92 to i64* 
   %94 = getelementptr  i64, i64* %93, i64 0 
-  store  i64 %"4$tmp$3#0", i64* %94 
-  ret i64 %"lst#0" 
+  store  i64 %"4$tmp$3##0", i64* %94 
+  ret i64 %"lst##0" 
 if.else1:
-  %"5$$#0" = tail call fastcc  i64  @"int_list.greater<0>[410bae77d3]"(i64  %91, i64  %"v#0")  
-  ret i64 %"5$$#0" 
+  %"5$$##0" = tail call fastcc  i64  @"int_list.greater<0>[410bae77d3]"(i64  %91, i64  %"v##0")  
+  ret i64 %"5$$##0" 
 }
 
 
-define external fastcc  i64 @"int_list.index<0>"(i64  %"lst#0", i64  %"x#0")    {
+define external fastcc  i64 @"int_list.index<0>"(i64  %"lst##0", i64  %"x##0")    {
 entry:
-  %"1$$#0" = tail call fastcc  i64  @"int_list.index_helper<0>"(i64  %"lst#0", i64  0, i64  %"x#0")  
-  ret i64 %"1$$#0" 
+  %"1$$##0" = tail call fastcc  i64  @"int_list.index_helper<0>"(i64  %"lst##0", i64  0, i64  %"x##0")  
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  i64 @"int_list.index_helper<0>"(i64  %"lst#0", i64  %"idx#0", i64  %"x#0")    {
+define external fastcc  i64 @"int_list.index_helper<0>"(i64  %"lst##0", i64  %"idx##0", i64  %"x##0")    {
 entry:
-  %"1$tmp$7#0" = icmp ne i64 %"lst#0", 0 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %95 = inttoptr i64 %"lst#0" to i64* 
+  %95 = inttoptr i64 %"lst##0" to i64* 
   %96 = getelementptr  i64, i64* %95, i64 0 
   %97 = load  i64, i64* %96 
-  %98 = add   i64 %"lst#0", 8 
+  %98 = add   i64 %"lst##0", 8 
   %99 = inttoptr i64 %98 to i64* 
   %100 = getelementptr  i64, i64* %99, i64 0 
   %101 = load  i64, i64* %100 
-  %"2$tmp$4#0" = icmp eq i64 %97, %"x#0" 
-  br i1 %"2$tmp$4#0", label %if.then1, label %if.else1 
+  %"2$tmp$4##0" = icmp eq i64 %97, %"x##0" 
+  br i1 %"2$tmp$4##0", label %if.then1, label %if.else1 
 if.else:
   ret i64 -1 
 if.then1:
-  ret i64 %"idx#0" 
+  ret i64 %"idx##0" 
 if.else1:
-  %"5$tmp$3#0" = add   i64 %"idx#0", 1 
-  %"5$$#0" = tail call fastcc  i64  @"int_list.index_helper<0>"(i64  %101, i64  %"5$tmp$3#0", i64  %"x#0")  
-  ret i64 %"5$$#0" 
+  %"5$tmp$3##0" = add   i64 %"idx##0", 1 
+  %"5$$##0" = tail call fastcc  i64  @"int_list.index_helper<0>"(i64  %101, i64  %"5$tmp$3##0", i64  %"x##0")  
+  ret i64 %"5$$##0" 
 }
 
 
-define external fastcc  i64 @"int_list.insert<0>"(i64  %"lst#0", i64  %"idx#0", i64  %"v#0")    {
+define external fastcc  i64 @"int_list.insert<0>"(i64  %"lst##0", i64  %"idx##0", i64  %"v##0")    {
 entry:
-  %"1$tmp$9#0" = icmp eq i64 %"idx#0", 0 
-  br i1 %"1$tmp$9#0", label %if.then, label %if.else 
+  %"1$tmp$9##0" = icmp eq i64 %"idx##0", 0 
+  br i1 %"1$tmp$9##0", label %if.then, label %if.else 
 if.then:
   %102 = trunc i64 16 to i32  
   %103 = tail call ccc  i8*  @wybe_malloc(i32  %102)  
   %104 = ptrtoint i8* %103 to i64 
   %105 = inttoptr i64 %104 to i64* 
   %106 = getelementptr  i64, i64* %105, i64 0 
-  store  i64 %"v#0", i64* %106 
+  store  i64 %"v##0", i64* %106 
   %107 = add   i64 %104, 8 
   %108 = inttoptr i64 %107 to i64* 
   %109 = getelementptr  i64, i64* %108, i64 0 
-  store  i64 %"lst#0", i64* %109 
+  store  i64 %"lst##0", i64* %109 
   ret i64 %104 
 if.else:
-  %"3$tmp$13#0" = icmp ne i64 %"lst#0", 0 
-  br i1 %"3$tmp$13#0", label %if.then1, label %if.else1 
+  %"3$tmp$13##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"3$tmp$13##0", label %if.then1, label %if.else1 
 if.then1:
-  %110 = inttoptr i64 %"lst#0" to i64* 
+  %110 = inttoptr i64 %"lst##0" to i64* 
   %111 = getelementptr  i64, i64* %110, i64 0 
   %112 = load  i64, i64* %111 
-  %113 = add   i64 %"lst#0", 8 
+  %113 = add   i64 %"lst##0", 8 
   %114 = inttoptr i64 %113 to i64* 
   %115 = getelementptr  i64, i64* %114, i64 0 
   %116 = load  i64, i64* %115 
-  %"4$tmp$5#0" = sub   i64 %"idx#0", 1 
-  %"4$tmp$4#0" = tail call fastcc  i64  @"int_list.insert<0>"(i64  %116, i64  %"4$tmp$5#0", i64  %"v#0")  
+  %"4$tmp$5##0" = sub   i64 %"idx##0", 1 
+  %"4$tmp$4##0" = tail call fastcc  i64  @"int_list.insert<0>"(i64  %116, i64  %"4$tmp$5##0", i64  %"v##0")  
   %117 = trunc i64 16 to i32  
   %118 = tail call ccc  i8*  @wybe_malloc(i32  %117)  
   %119 = ptrtoint i8* %118 to i64 
@@ -1930,71 +1930,71 @@ if.then1:
   %122 = add   i64 %119, 8 
   %123 = inttoptr i64 %122 to i64* 
   %124 = getelementptr  i64, i64* %123, i64 0 
-  store  i64 %"4$tmp$4#0", i64* %124 
+  store  i64 %"4$tmp$4##0", i64* %124 
   ret i64 %119 
 if.else1:
-  %"5$tmp$7#0" = sub   i64 %"idx#0", 1 
-  %"5$$#0" = tail call fastcc  i64  @"int_list.insert<0>"(i64  %"lst#0", i64  %"5$tmp$7#0", i64  %"v#0")  
-  ret i64 %"5$$#0" 
+  %"5$tmp$7##0" = sub   i64 %"idx##0", 1 
+  %"5$$##0" = tail call fastcc  i64  @"int_list.insert<0>"(i64  %"lst##0", i64  %"5$tmp$7##0", i64  %"v##0")  
+  ret i64 %"5$$##0" 
 }
 
 
-define external fastcc  i64 @"int_list.insert<0>[410bae77d3]"(i64  %"lst#0", i64  %"idx#0", i64  %"v#0")    {
+define external fastcc  i64 @"int_list.insert<0>[410bae77d3]"(i64  %"lst##0", i64  %"idx##0", i64  %"v##0")    {
 entry:
-  %"1$tmp$9#0" = icmp eq i64 %"idx#0", 0 
-  br i1 %"1$tmp$9#0", label %if.then, label %if.else 
+  %"1$tmp$9##0" = icmp eq i64 %"idx##0", 0 
+  br i1 %"1$tmp$9##0", label %if.then, label %if.else 
 if.then:
   %125 = trunc i64 16 to i32  
   %126 = tail call ccc  i8*  @wybe_malloc(i32  %125)  
   %127 = ptrtoint i8* %126 to i64 
   %128 = inttoptr i64 %127 to i64* 
   %129 = getelementptr  i64, i64* %128, i64 0 
-  store  i64 %"v#0", i64* %129 
+  store  i64 %"v##0", i64* %129 
   %130 = add   i64 %127, 8 
   %131 = inttoptr i64 %130 to i64* 
   %132 = getelementptr  i64, i64* %131, i64 0 
-  store  i64 %"lst#0", i64* %132 
+  store  i64 %"lst##0", i64* %132 
   ret i64 %127 
 if.else:
-  %"3$tmp$13#0" = icmp ne i64 %"lst#0", 0 
-  br i1 %"3$tmp$13#0", label %if.then1, label %if.else1 
+  %"3$tmp$13##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"3$tmp$13##0", label %if.then1, label %if.else1 
 if.then1:
-  %133 = add   i64 %"lst#0", 8 
+  %133 = add   i64 %"lst##0", 8 
   %134 = inttoptr i64 %133 to i64* 
   %135 = getelementptr  i64, i64* %134, i64 0 
   %136 = load  i64, i64* %135 
-  %"4$tmp$5#0" = sub   i64 %"idx#0", 1 
-  %"4$tmp$4#0" = tail call fastcc  i64  @"int_list.insert<0>[410bae77d3]"(i64  %136, i64  %"4$tmp$5#0", i64  %"v#0")  
-  %137 = add   i64 %"lst#0", 8 
+  %"4$tmp$5##0" = sub   i64 %"idx##0", 1 
+  %"4$tmp$4##0" = tail call fastcc  i64  @"int_list.insert<0>[410bae77d3]"(i64  %136, i64  %"4$tmp$5##0", i64  %"v##0")  
+  %137 = add   i64 %"lst##0", 8 
   %138 = inttoptr i64 %137 to i64* 
   %139 = getelementptr  i64, i64* %138, i64 0 
-  store  i64 %"4$tmp$4#0", i64* %139 
-  ret i64 %"lst#0" 
+  store  i64 %"4$tmp$4##0", i64* %139 
+  ret i64 %"lst##0" 
 if.else1:
-  %"5$tmp$7#0" = sub   i64 %"idx#0", 1 
-  %"5$$#0" = tail call fastcc  i64  @"int_list.insert<0>[410bae77d3]"(i64  %"lst#0", i64  %"5$tmp$7#0", i64  %"v#0")  
-  ret i64 %"5$$#0" 
+  %"5$tmp$7##0" = sub   i64 %"idx##0", 1 
+  %"5$$##0" = tail call fastcc  i64  @"int_list.insert<0>[410bae77d3]"(i64  %"lst##0", i64  %"5$tmp$7##0", i64  %"v##0")  
+  ret i64 %"5$$##0" 
 }
 
 
-define external fastcc  i64 @"int_list.lesser<0>"(i64  %"lst#0", i64  %"v#0")    {
+define external fastcc  i64 @"int_list.lesser<0>"(i64  %"lst##0", i64  %"v##0")    {
 entry:
-  %"1$tmp$9#0" = icmp ne i64 %"lst#0", 0 
-  br i1 %"1$tmp$9#0", label %if.then, label %if.else 
+  %"1$tmp$9##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1$tmp$9##0", label %if.then, label %if.else 
 if.then:
-  %140 = inttoptr i64 %"lst#0" to i64* 
+  %140 = inttoptr i64 %"lst##0" to i64* 
   %141 = getelementptr  i64, i64* %140, i64 0 
   %142 = load  i64, i64* %141 
-  %143 = add   i64 %"lst#0", 8 
+  %143 = add   i64 %"lst##0", 8 
   %144 = inttoptr i64 %143 to i64* 
   %145 = getelementptr  i64, i64* %144, i64 0 
   %146 = load  i64, i64* %145 
-  %"2$tmp$6#0" = icmp slt i64 %142, %"v#0" 
-  br i1 %"2$tmp$6#0", label %if.then1, label %if.else1 
+  %"2$tmp$6##0" = icmp slt i64 %142, %"v##0" 
+  br i1 %"2$tmp$6##0", label %if.then1, label %if.else1 
 if.else:
   ret i64 0 
 if.then1:
-  %"4$tmp$3#0" = tail call fastcc  i64  @"int_list.lesser<0>"(i64  %146, i64  %"v#0")  
+  %"4$tmp$3##0" = tail call fastcc  i64  @"int_list.lesser<0>"(i64  %146, i64  %"v##0")  
   %147 = trunc i64 16 to i32  
   %148 = tail call ccc  i8*  @wybe_malloc(i32  %147)  
   %149 = ptrtoint i8* %148 to i64 
@@ -2004,35 +2004,35 @@ if.then1:
   %152 = add   i64 %149, 8 
   %153 = inttoptr i64 %152 to i64* 
   %154 = getelementptr  i64, i64* %153, i64 0 
-  store  i64 %"4$tmp$3#0", i64* %154 
+  store  i64 %"4$tmp$3##0", i64* %154 
   ret i64 %149 
 if.else1:
-  %"5$$#0" = tail call fastcc  i64  @"int_list.lesser<0>"(i64  %146, i64  %"v#0")  
-  ret i64 %"5$$#0" 
+  %"5$$##0" = tail call fastcc  i64  @"int_list.lesser<0>"(i64  %146, i64  %"v##0")  
+  ret i64 %"5$$##0" 
 }
 
 
-define external fastcc  i64 @"int_list.pop<0>"(i64  %"lst#0", i64  %"idx#0")    {
+define external fastcc  i64 @"int_list.pop<0>"(i64  %"lst##0", i64  %"idx##0")    {
 entry:
-  %"1$tmp$9#0" = icmp ne i64 %"lst#0", 0 
-  br i1 %"1$tmp$9#0", label %if.then, label %if.else 
+  %"1$tmp$9##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1$tmp$9##0", label %if.then, label %if.else 
 if.then:
-  %155 = inttoptr i64 %"lst#0" to i64* 
+  %155 = inttoptr i64 %"lst##0" to i64* 
   %156 = getelementptr  i64, i64* %155, i64 0 
   %157 = load  i64, i64* %156 
-  %158 = add   i64 %"lst#0", 8 
+  %158 = add   i64 %"lst##0", 8 
   %159 = inttoptr i64 %158 to i64* 
   %160 = getelementptr  i64, i64* %159, i64 0 
   %161 = load  i64, i64* %160 
-  %"2$tmp$6#0" = icmp eq i64 %"idx#0", 0 
-  br i1 %"2$tmp$6#0", label %if.then1, label %if.else1 
+  %"2$tmp$6##0" = icmp eq i64 %"idx##0", 0 
+  br i1 %"2$tmp$6##0", label %if.then1, label %if.else1 
 if.else:
   ret i64 0 
 if.then1:
   ret i64 %161 
 if.else1:
-  %"5$tmp$4#0" = sub   i64 %"idx#0", 1 
-  %"5$tmp$3#0" = tail call fastcc  i64  @"int_list.pop<0>"(i64  %161, i64  %"5$tmp$4#0")  
+  %"5$tmp$4##0" = sub   i64 %"idx##0", 1 
+  %"5$tmp$3##0" = tail call fastcc  i64  @"int_list.pop<0>"(i64  %161, i64  %"5$tmp$4##0")  
   %162 = trunc i64 16 to i32  
   %163 = tail call ccc  i8*  @wybe_malloc(i32  %162)  
   %164 = ptrtoint i8* %163 to i64 
@@ -2042,46 +2042,46 @@ if.else1:
   %167 = add   i64 %164, 8 
   %168 = inttoptr i64 %167 to i64* 
   %169 = getelementptr  i64, i64* %168, i64 0 
-  store  i64 %"5$tmp$3#0", i64* %169 
+  store  i64 %"5$tmp$3##0", i64* %169 
   ret i64 %164 
 }
 
 
-define external fastcc  i64 @"int_list.pop<0>[410bae77d3]"(i64  %"lst#0", i64  %"idx#0")    {
+define external fastcc  i64 @"int_list.pop<0>[410bae77d3]"(i64  %"lst##0", i64  %"idx##0")    {
 entry:
-  %"1$tmp$9#0" = icmp ne i64 %"lst#0", 0 
-  br i1 %"1$tmp$9#0", label %if.then, label %if.else 
+  %"1$tmp$9##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1$tmp$9##0", label %if.then, label %if.else 
 if.then:
-  %170 = add   i64 %"lst#0", 8 
+  %170 = add   i64 %"lst##0", 8 
   %171 = inttoptr i64 %170 to i64* 
   %172 = getelementptr  i64, i64* %171, i64 0 
   %173 = load  i64, i64* %172 
-  %"2$tmp$6#0" = icmp eq i64 %"idx#0", 0 
-  br i1 %"2$tmp$6#0", label %if.then1, label %if.else1 
+  %"2$tmp$6##0" = icmp eq i64 %"idx##0", 0 
+  br i1 %"2$tmp$6##0", label %if.then1, label %if.else1 
 if.else:
   ret i64 0 
 if.then1:
   ret i64 %173 
 if.else1:
-  %"5$tmp$4#0" = sub   i64 %"idx#0", 1 
-  %"5$tmp$3#0" = tail call fastcc  i64  @"int_list.pop<0>[410bae77d3]"(i64  %173, i64  %"5$tmp$4#0")  
-  %174 = add   i64 %"lst#0", 8 
+  %"5$tmp$4##0" = sub   i64 %"idx##0", 1 
+  %"5$tmp$3##0" = tail call fastcc  i64  @"int_list.pop<0>[410bae77d3]"(i64  %173, i64  %"5$tmp$4##0")  
+  %174 = add   i64 %"lst##0", 8 
   %175 = inttoptr i64 %174 to i64* 
   %176 = getelementptr  i64, i64* %175, i64 0 
-  store  i64 %"5$tmp$3#0", i64* %176 
-  ret i64 %"lst#0" 
+  store  i64 %"5$tmp$3##0", i64* %176 
+  ret i64 %"lst##0" 
 }
 
 
-define external fastcc  void @"int_list.print<0>"(i64  %"x#0")    {
+define external fastcc  void @"int_list.print<0>"(i64  %"x##0")    {
 entry:
-  %"1$tmp$2#0" = icmp ne i64 %"x#0", 0 
-  br i1 %"1$tmp$2#0", label %if.then, label %if.else 
+  %"1$tmp$2##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1$tmp$2##0", label %if.then, label %if.else 
 if.then:
-  %177 = inttoptr i64 %"x#0" to i64* 
+  %177 = inttoptr i64 %"x##0" to i64* 
   %178 = getelementptr  i64, i64* %177, i64 0 
   %179 = load  i64, i64* %178 
-  %180 = add   i64 %"x#0", 8 
+  %180 = add   i64 %"x##0", 8 
   %181 = inttoptr i64 %180 to i64* 
   %182 = getelementptr  i64, i64* %181, i64 0 
   %183 = load  i64, i64* %182 
@@ -2094,41 +2094,41 @@ if.else:
 }
 
 
-define external fastcc  void @"int_list.println<0>"(i64  %"x#0")    {
+define external fastcc  void @"int_list.println<0>"(i64  %"x##0")    {
 entry:
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"x#0")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"x##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  i64 @"int_list.range<0>"(i64  %"start#0", i64  %"stop#0", i64  %"step#0")    {
+define external fastcc  i64 @"int_list.range<0>"(i64  %"start##0", i64  %"stop##0", i64  %"step##0")    {
 entry:
-  %"1$result#1" = tail call fastcc  i64  @"int_list.gen$2<0>"(i64  0, i64  %"start#0", i64  %"step#0", i64  %"stop#0", i64  0)  
-  ret i64 %"1$result#1" 
+  %"1$result##1" = tail call fastcc  i64  @"int_list.gen$2<0>"(i64  0, i64  %"start##0", i64  %"step##0", i64  %"stop##0", i64  0)  
+  ret i64 %"1$result##1" 
 }
 
 
-define external fastcc  i64 @"int_list.remove<0>"(i64  %"lst#0", i64  %"v#0")    {
+define external fastcc  i64 @"int_list.remove<0>"(i64  %"lst##0", i64  %"v##0")    {
 entry:
-  %"1$tmp$8#0" = icmp ne i64 %"lst#0", 0 
-  br i1 %"1$tmp$8#0", label %if.then, label %if.else 
+  %"1$tmp$8##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1$tmp$8##0", label %if.then, label %if.else 
 if.then:
-  %184 = inttoptr i64 %"lst#0" to i64* 
+  %184 = inttoptr i64 %"lst##0" to i64* 
   %185 = getelementptr  i64, i64* %184, i64 0 
   %186 = load  i64, i64* %185 
-  %187 = add   i64 %"lst#0", 8 
+  %187 = add   i64 %"lst##0", 8 
   %188 = inttoptr i64 %187 to i64* 
   %189 = getelementptr  i64, i64* %188, i64 0 
   %190 = load  i64, i64* %189 
-  %"2$tmp$5#0" = icmp eq i64 %186, %"v#0" 
-  br i1 %"2$tmp$5#0", label %if.then1, label %if.else1 
+  %"2$tmp$5##0" = icmp eq i64 %186, %"v##0" 
+  br i1 %"2$tmp$5##0", label %if.then1, label %if.else1 
 if.else:
   ret i64 0 
 if.then1:
   ret i64 %190 
 if.else1:
-  %"5$tmp$3#0" = tail call fastcc  i64  @"int_list.remove<0>"(i64  %190, i64  %"v#0")  
+  %"5$tmp$3##0" = tail call fastcc  i64  @"int_list.remove<0>"(i64  %190, i64  %"v##0")  
   %191 = trunc i64 16 to i32  
   %192 = tail call ccc  i8*  @wybe_malloc(i32  %191)  
   %193 = ptrtoint i8* %192 to i64 
@@ -2138,55 +2138,55 @@ if.else1:
   %196 = add   i64 %193, 8 
   %197 = inttoptr i64 %196 to i64* 
   %198 = getelementptr  i64, i64* %197, i64 0 
-  store  i64 %"5$tmp$3#0", i64* %198 
+  store  i64 %"5$tmp$3##0", i64* %198 
   ret i64 %193 
 }
 
 
-define external fastcc  i64 @"int_list.remove<0>[410bae77d3]"(i64  %"lst#0", i64  %"v#0")    {
+define external fastcc  i64 @"int_list.remove<0>[410bae77d3]"(i64  %"lst##0", i64  %"v##0")    {
 entry:
-  %"1$tmp$8#0" = icmp ne i64 %"lst#0", 0 
-  br i1 %"1$tmp$8#0", label %if.then, label %if.else 
+  %"1$tmp$8##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1$tmp$8##0", label %if.then, label %if.else 
 if.then:
-  %199 = inttoptr i64 %"lst#0" to i64* 
+  %199 = inttoptr i64 %"lst##0" to i64* 
   %200 = getelementptr  i64, i64* %199, i64 0 
   %201 = load  i64, i64* %200 
-  %202 = add   i64 %"lst#0", 8 
+  %202 = add   i64 %"lst##0", 8 
   %203 = inttoptr i64 %202 to i64* 
   %204 = getelementptr  i64, i64* %203, i64 0 
   %205 = load  i64, i64* %204 
-  %"2$tmp$5#0" = icmp eq i64 %201, %"v#0" 
-  br i1 %"2$tmp$5#0", label %if.then1, label %if.else1 
+  %"2$tmp$5##0" = icmp eq i64 %201, %"v##0" 
+  br i1 %"2$tmp$5##0", label %if.then1, label %if.else1 
 if.else:
   ret i64 0 
 if.then1:
   ret i64 %205 
 if.else1:
-  %"5$tmp$3#0" = tail call fastcc  i64  @"int_list.remove<0>[410bae77d3]"(i64  %205, i64  %"v#0")  
-  %206 = add   i64 %"lst#0", 8 
+  %"5$tmp$3##0" = tail call fastcc  i64  @"int_list.remove<0>[410bae77d3]"(i64  %205, i64  %"v##0")  
+  %206 = add   i64 %"lst##0", 8 
   %207 = inttoptr i64 %206 to i64* 
   %208 = getelementptr  i64, i64* %207, i64 0 
-  store  i64 %"5$tmp$3#0", i64* %208 
-  ret i64 %"lst#0" 
+  store  i64 %"5$tmp$3##0", i64* %208 
+  ret i64 %"lst##0" 
 }
 
 
-define external fastcc  i64 @"int_list.reverse<0>"(i64  %"lst#0")    {
+define external fastcc  i64 @"int_list.reverse<0>"(i64  %"lst##0")    {
 entry:
-  %"1$$#0" = tail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %"lst#0", i64  0)  
-  ret i64 %"1$$#0" 
+  %"1$$##0" = tail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %"lst##0", i64  0)  
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  i64 @"int_list.reverse_helper<0>"(i64  %"lst#0", i64  %"acc#0")    {
+define external fastcc  i64 @"int_list.reverse_helper<0>"(i64  %"lst##0", i64  %"acc##0")    {
 entry:
-  %"1$tmp$5#0" = icmp ne i64 %"lst#0", 0 
-  br i1 %"1$tmp$5#0", label %if.then, label %if.else 
+  %"1$tmp$5##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
 if.then:
-  %209 = inttoptr i64 %"lst#0" to i64* 
+  %209 = inttoptr i64 %"lst##0" to i64* 
   %210 = getelementptr  i64, i64* %209, i64 0 
   %211 = load  i64, i64* %210 
-  %212 = add   i64 %"lst#0", 8 
+  %212 = add   i64 %"lst##0", 8 
   %213 = inttoptr i64 %212 to i64* 
   %214 = getelementptr  i64, i64* %213, i64 0 
   %215 = load  i64, i64* %214 
@@ -2199,50 +2199,50 @@ if.then:
   %221 = add   i64 %218, 8 
   %222 = inttoptr i64 %221 to i64* 
   %223 = getelementptr  i64, i64* %222, i64 0 
-  store  i64 %"acc#0", i64* %223 
-  %"2$$#0" = tail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %215, i64  %218)  
-  ret i64 %"2$$#0" 
+  store  i64 %"acc##0", i64* %223 
+  %"2$$##0" = tail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %215, i64  %218)  
+  ret i64 %"2$$##0" 
 if.else:
-  ret i64 %"acc#0" 
+  ret i64 %"acc##0" 
 }
 
 
-define external fastcc  i64 @"int_list.reverse_helper<0>[410bae77d3]"(i64  %"lst#0", i64  %"acc#0")    {
+define external fastcc  i64 @"int_list.reverse_helper<0>[410bae77d3]"(i64  %"lst##0", i64  %"acc##0")    {
 entry:
-  %"1$tmp$5#0" = icmp ne i64 %"lst#0", 0 
-  br i1 %"1$tmp$5#0", label %if.then, label %if.else 
+  %"1$tmp$5##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
 if.then:
-  %224 = add   i64 %"lst#0", 8 
+  %224 = add   i64 %"lst##0", 8 
   %225 = inttoptr i64 %224 to i64* 
   %226 = getelementptr  i64, i64* %225, i64 0 
   %227 = load  i64, i64* %226 
-  %228 = add   i64 %"lst#0", 8 
+  %228 = add   i64 %"lst##0", 8 
   %229 = inttoptr i64 %228 to i64* 
   %230 = getelementptr  i64, i64* %229, i64 0 
-  store  i64 %"acc#0", i64* %230 
-  %"2$$#0" = tail call fastcc  i64  @"int_list.reverse_helper<0>[410bae77d3]"(i64  %227, i64  %"lst#0")  
-  ret i64 %"2$$#0" 
+  store  i64 %"acc##0", i64* %230 
+  %"2$$##0" = tail call fastcc  i64  @"int_list.reverse_helper<0>[410bae77d3]"(i64  %227, i64  %"lst##0")  
+  ret i64 %"2$$##0" 
 if.else:
-  ret i64 %"acc#0" 
+  ret i64 %"acc##0" 
 }
 
 
-define external fastcc  i64 @"int_list.sort<0>"(i64  %"lst#0")    {
+define external fastcc  i64 @"int_list.sort<0>"(i64  %"lst##0")    {
 entry:
-  %"1$tmp$10#0" = icmp ne i64 %"lst#0", 0 
-  br i1 %"1$tmp$10#0", label %if.then, label %if.else 
+  %"1$tmp$10##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1$tmp$10##0", label %if.then, label %if.else 
 if.then:
-  %231 = inttoptr i64 %"lst#0" to i64* 
+  %231 = inttoptr i64 %"lst##0" to i64* 
   %232 = getelementptr  i64, i64* %231, i64 0 
   %233 = load  i64, i64* %232 
-  %234 = add   i64 %"lst#0", 8 
+  %234 = add   i64 %"lst##0", 8 
   %235 = inttoptr i64 %234 to i64* 
   %236 = getelementptr  i64, i64* %235, i64 0 
   %237 = load  i64, i64* %236 
-  %"2$tmp$3#0" = tail call fastcc  i64  @"int_list.lesser<0>"(i64  %237, i64  %233)  
-  %"2$tmp$2#0" = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %"2$tmp$3#0")  
-  %"2$tmp$6#0" = tail call fastcc  i64  @"int_list.greater<0>"(i64  %237, i64  %233)  
-  %"2$tmp$5#0" = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %"2$tmp$6#0")  
+  %"2$tmp$3##0" = tail call fastcc  i64  @"int_list.lesser<0>"(i64  %237, i64  %233)  
+  %"2$tmp$2##0" = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %"2$tmp$3##0")  
+  %"2$tmp$6##0" = tail call fastcc  i64  @"int_list.greater<0>"(i64  %237, i64  %233)  
+  %"2$tmp$5##0" = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %"2$tmp$6##0")  
   %238 = trunc i64 16 to i32  
   %239 = tail call ccc  i8*  @wybe_malloc(i32  %238)  
   %240 = ptrtoint i8* %239 to i64 
@@ -2252,36 +2252,36 @@ if.then:
   %243 = add   i64 %240, 8 
   %244 = inttoptr i64 %243 to i64* 
   %245 = getelementptr  i64, i64* %244, i64 0 
-  store  i64 %"2$tmp$5#0", i64* %245 
-  %"2$$#0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"2$tmp$2#0", i64  %240)  
-  ret i64 %"2$$#0" 
+  store  i64 %"2$tmp$5##0", i64* %245 
+  %"2$$##0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"2$tmp$2##0", i64  %240)  
+  ret i64 %"2$$##0" 
 if.else:
   ret i64 0 
 }
 
 
-define external fastcc  i64 @"int_list.sort<0>[410bae77d3]"(i64  %"lst#0")    {
+define external fastcc  i64 @"int_list.sort<0>[410bae77d3]"(i64  %"lst##0")    {
 entry:
-  %"1$tmp$10#0" = icmp ne i64 %"lst#0", 0 
-  br i1 %"1$tmp$10#0", label %if.then, label %if.else 
+  %"1$tmp$10##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1$tmp$10##0", label %if.then, label %if.else 
 if.then:
-  %246 = inttoptr i64 %"lst#0" to i64* 
+  %246 = inttoptr i64 %"lst##0" to i64* 
   %247 = getelementptr  i64, i64* %246, i64 0 
   %248 = load  i64, i64* %247 
-  %249 = add   i64 %"lst#0", 8 
+  %249 = add   i64 %"lst##0", 8 
   %250 = inttoptr i64 %249 to i64* 
   %251 = getelementptr  i64, i64* %250, i64 0 
   %252 = load  i64, i64* %251 
-  %"2$tmp$3#0" = tail call fastcc  i64  @"int_list.lesser<0>"(i64  %252, i64  %248)  
-  %"2$tmp$2#0" = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %"2$tmp$3#0")  
-  %"2$tmp$6#0" = tail call fastcc  i64  @"int_list.greater<0>[410bae77d3]"(i64  %252, i64  %248)  
-  %"2$tmp$5#0" = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %"2$tmp$6#0")  
-  %253 = add   i64 %"lst#0", 8 
+  %"2$tmp$3##0" = tail call fastcc  i64  @"int_list.lesser<0>"(i64  %252, i64  %248)  
+  %"2$tmp$2##0" = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %"2$tmp$3##0")  
+  %"2$tmp$6##0" = tail call fastcc  i64  @"int_list.greater<0>[410bae77d3]"(i64  %252, i64  %248)  
+  %"2$tmp$5##0" = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %"2$tmp$6##0")  
+  %253 = add   i64 %"lst##0", 8 
   %254 = inttoptr i64 %253 to i64* 
   %255 = getelementptr  i64, i64* %254, i64 0 
-  store  i64 %"2$tmp$5#0", i64* %255 
-  %"2$$#0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"2$tmp$2#0", i64  %"lst#0")  
-  ret i64 %"2$$#0" 
+  store  i64 %"2$tmp$5##0", i64* %255 
+  %"2$$##0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"2$tmp$2##0", i64  %"lst##0")  
+  ret i64 %"2$$##0" 
 if.else:
   ret i64 0 
 }
@@ -2306,32 +2306,32 @@ if.else:
 
 = > public (2 calls)
 0: int_list.int_list.=<0>
-=($left#0:int_list.int_list, $right#0:int_list.int_list, ?$$#0:wybe.bool):
+=($left##0:int_list.int_list, $right##0:int_list.int_list, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left#0:int_list.int_list, ~$right#0:int_list.int_list, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~$left##0:int_list.int_list, ~$right##0:int_list.int_list, ?$$##0:wybe.bool)
 
     1:
-        foreign lpvm access($left#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$head#0:wybe.int)
-        foreign lpvm access(~$left#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$tail#0:int_list.int_list)
-        foreign llvm icmp_ne($right#0:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.bool)
-        case ~tmp$9#0:wybe.bool of
+        foreign lpvm access($left##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$head##0:wybe.int)
+        foreign lpvm access(~$left##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$tail##0:int_list.int_list)
+        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
+        case ~tmp$9##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign lpvm access($right#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$head#0:wybe.int)
-            foreign lpvm access(~$right#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$tail#0:int_list.int_list)
-            foreign llvm icmp_eq(~$left$head#0:wybe.int, ~$right$head#0:wybe.int, ?tmp$4#0:wybe.bool) @int:nn:nn
-            case ~tmp$4#0:wybe.bool of
+            foreign lpvm access($right##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$head##0:wybe.int)
+            foreign lpvm access(~$right##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$tail##0:int_list.int_list)
+            foreign llvm icmp_eq(~$left$head##0:wybe.int, ~$right$head##0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
+            case ~tmp$4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                int_list.int_list.=<0>(~$left$tail#0:int_list.int_list, ~$right$tail#0:int_list.int_list, ?$$#0:wybe.bool) #3
+                int_list.int_list.=<0>(~$left$tail##0:int_list.int_list, ~$right$tail##0:int_list.int_list, ?$$##0:wybe.bool) #3
 
 
 
@@ -2339,110 +2339,110 @@ if.else:
 
 cons > public {inline} (0 calls)
 0: int_list.int_list.cons<0>
-cons(head#0:wybe.int, tail#0:int_list.int_list, ?$#0:int_list.int_list):
+cons(head##0:wybe.int, tail##0:int_list.int_list, ?$##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:int_list.int_list)
-    foreign lpvm mutate(~$rec#0:int_list.int_list, ?$rec#1:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:int_list.int_list, ?$#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail#0:int_list.int_list)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:int_list.int_list)
+    foreign lpvm mutate(~$rec##0:int_list.int_list, ?$rec##1:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:int_list.int_list)
 cons > public {inline} (12 calls)
 1: int_list.int_list.cons<1>
-cons(?head#0:wybe.int, ?tail#0:int_list.int_list, $#0:int_list.int_list, ?$$#0:wybe.bool):
+cons(?head##0:wybe.int, ?tail##0:int_list.int_list, $##0:int_list.int_list, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?head#0:wybe.int)
-        foreign llvm move(undef:int_list.int_list, ?tail#0:int_list.int_list)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?head##0:wybe.int)
+        foreign llvm move(undef:int_list.int_list, ?tail##0:int_list.int_list)
 
     1:
-        foreign lpvm access($#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head#0:wybe.int)
-        foreign lpvm access(~$#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail#0:int_list.int_list)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access($##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
+        foreign lpvm access(~$##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:int_list.int_list)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 head > public {inline} (0 calls)
 0: int_list.int_list.head<0>
-head($rec#0:int_list.int_list, ?$#0:wybe.int, ?$$#0:wybe.bool):
+head($rec##0:int_list.int_list, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 head > public {inline} (0 calls)
 1: int_list.int_list.head<1>
-head($rec#0:int_list.int_list, ?$rec#1:int_list.int_list, $field#0:wybe.int, ?$$#0:wybe.bool):
+head($rec##0:int_list.int_list, ?$rec##1:int_list.int_list, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:int_list.int_list, ?$rec#1:int_list.int_list)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:int_list.int_list, ?$rec##1:int_list.int_list)
 
     1:
-        foreign lpvm mutate(~$rec#0:int_list.int_list, ?$rec#1:int_list.int_list, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~$rec##0:int_list.int_list, ?$rec##1:int_list.int_list, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 nil > public {inline} (0 calls)
 0: int_list.int_list.nil<0>
-nil(?$#0:int_list.int_list):
+nil(?$##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:int_list.int_list, ?$#0:int_list.int_list)
+    foreign llvm move(0:int_list.int_list, ?$##0:int_list.int_list)
 
 
 tail > public {inline} (0 calls)
 0: int_list.int_list.tail<0>
-tail($rec#0:int_list.int_list, ?$#0:int_list.int_list, ?$$#0:wybe.bool):
+tail($rec##0:int_list.int_list, ?$##0:int_list.int_list, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:int_list.int_list, ?$#0:int_list.int_list)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:int_list.int_list, ?$##0:int_list.int_list)
 
     1:
-        foreign lpvm access(~$rec#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:int_list.int_list)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:int_list.int_list)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 tail > public {inline} (0 calls)
 1: int_list.int_list.tail<1>
-tail($rec#0:int_list.int_list, ?$rec#1:int_list.int_list, $field#0:int_list.int_list, ?$$#0:wybe.bool):
+tail($rec##0:int_list.int_list, ?$rec##1:int_list.int_list, $field##0:int_list.int_list, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:int_list.int_list, ?$rec#1:int_list.int_list)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:int_list.int_list, ?$rec##1:int_list.int_list)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec#0:int_list.int_list, ?$rec#1:int_list.int_list, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:int_list.int_list)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm {noalias} mutate(~$rec##0:int_list.int_list, ?$rec##1:int_list.int_list, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:int_list.int_list)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: int_list.int_list.~=<0>
-~=($left#0:int_list.int_list, $right#0:int_list.int_list, ?$$#0:wybe.bool):
+~=($left##0:int_list.int_list, $right##0:int_list.int_list, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    int_list.int_list.=<0>(~$left#0:int_list.int_list, ~$right#0:int_list.int_list, ?tmp$0#0:wybe.bool) #0
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    int_list.int_list.=<0>(~$left##0:int_list.int_list, ~$right##0:int_list.int_list, ?tmp$0##0:wybe.bool) #0
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
   LLVM code       :
 
@@ -2458,68 +2458,68 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"int_list.int_list.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"int_list.int_list.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$left#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %"2$tmp$9#0" = icmp ne i64 %"$right#0", 0 
-  br i1 %"2$tmp$9#0", label %if.then1, label %if.else1 
+  %"2$tmp$9##0" = icmp ne i64 %"$right##0", 0 
+  br i1 %"2$tmp$9##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = icmp eq i64 %"$left#0", %"$right#0" 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
+  ret i1 %"3$$$##0" 
 if.then1:
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"4$tmp$4#0" = icmp eq i64 %3, %10 
-  br i1 %"4$tmp$4#0", label %if.then2, label %if.else2 
+  %"4$tmp$4##0" = icmp eq i64 %3, %10 
+  br i1 %"4$tmp$4##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$$$#0" = tail call fastcc  i1  @"int_list.int_list.=<0>"(i64  %7, i64  %14)  
-  ret i1 %"6$$$#0" 
+  %"6$$$##0" = tail call fastcc  i1  @"int_list.int_list.=<0>"(i64  %7, i64  %14)  
+  ret i1 %"6$$$##0" 
 if.else2:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"int_list.int_list.cons<0>"(i64  %"head#0", i64  %"tail#0")    {
+define external fastcc  i64 @"int_list.int_list.cons<0>"(i64  %"head##0", i64  %"tail##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"head#0", i64* %19 
+  store  i64 %"head##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"tail#0", i64* %22 
+  store  i64 %"tail##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64, i1} @"int_list.int_list.cons<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64, i1} @"int_list.int_list.cons<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -2535,12 +2535,12 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"int_list.int_list.head<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"int_list.int_list.head<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %36 = inttoptr i64 %"$rec#0" to i64* 
+  %36 = inttoptr i64 %"$rec##0" to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
   %39 = insertvalue {i64, i1} undef, i64 %38, 0 
@@ -2553,26 +2553,26 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"int_list.int_list.head<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"int_list.int_list.head<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %43 = trunc i64 16 to i32  
   %44 = tail call ccc  i8*  @wybe_malloc(i32  %43)  
   %45 = ptrtoint i8* %44 to i64 
   %46 = inttoptr i64 %45 to i8* 
-  %47 = inttoptr i64 %"$rec#0" to i8* 
+  %47 = inttoptr i64 %"$rec##0" to i8* 
   %48 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %46, i8*  %47, i32  %48, i32  8, i1  0)  
   %49 = inttoptr i64 %45 to i64* 
   %50 = getelementptr  i64, i64* %49, i64 0 
-  store  i64 %"$field#0", i64* %50 
+  store  i64 %"$field##0", i64* %50 
   %51 = insertvalue {i64, i1} undef, i64 %45, 0 
   %52 = insertvalue {i64, i1} %51, i1 1, 1 
   ret {i64, i1} %52 
 if.else:
-  %53 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %53 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %54 = insertvalue {i64, i1} %53, i1 0, 1 
   ret {i64, i1} %54 
 }
@@ -2584,12 +2584,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"int_list.int_list.tail<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"int_list.int_list.tail<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %55 = add   i64 %"$rec#0", 8 
+  %55 = add   i64 %"$rec##0", 8 
   %56 = inttoptr i64 %55 to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
@@ -2603,37 +2603,37 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"int_list.int_list.tail<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"int_list.int_list.tail<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %63 = trunc i64 16 to i32  
   %64 = tail call ccc  i8*  @wybe_malloc(i32  %63)  
   %65 = ptrtoint i8* %64 to i64 
   %66 = inttoptr i64 %65 to i8* 
-  %67 = inttoptr i64 %"$rec#0" to i8* 
+  %67 = inttoptr i64 %"$rec##0" to i8* 
   %68 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %66, i8*  %67, i32  %68, i32  8, i1  0)  
   %69 = add   i64 %65, 8 
   %70 = inttoptr i64 %69 to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
-  store  i64 %"$field#0", i64* %71 
+  store  i64 %"$field##0", i64* %71 
   %72 = insertvalue {i64, i1} undef, i64 %65, 0 
   %73 = insertvalue {i64, i1} %72, i1 1, 1 
   ret {i64, i1} %73 
 if.else:
-  %74 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %74 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %75 = insertvalue {i64, i1} %74, i1 0, 1 
   ret {i64, i1} %75 
 }
 
 
-define external fastcc  i1 @"int_list.int_list.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"int_list.int_list.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = tail call fastcc  i1  @"int_list.int_list.=<0>"(i64  %"$left#0", i64  %"$right#0")  
-  %"1$$$#0" = xor i1 %"1$tmp$0#0", 1 
-  ret i1 %"1$$$#0" 
+  %"1$tmp$0##0" = tail call fastcc  i1  @"int_list.int_list.=<0>"(i64  %"$left##0", i64  %"$right##0")  
+  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
+  ret i1 %"1$$$##0" 
 }
 --------------------------------------------------
  Module int_list_test
@@ -2649,128 +2649,128 @@ entry:
 
 *main* > public (0 calls)
 0: int_list_test.<0>
-(io#0:wybe.phantom, ?io#22:wybe.phantom):
+(io##0:wybe.phantom, ?io##22:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(24,(int_list_test.test_int_list<0>,fromList [NonAliasedParamCond 0 [],NonAliasedParamCond 1 [],NonAliasedParamCond 2 []])),(34,(int_list.gen$2<0>,fromList [NonAliasedParamCond 0 []])),(35,(int_list.gen$2<0>,fromList [NonAliasedParamCond 0 []])),(36,(int_list.gen$2<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign c {impure} malloc_count(?mc1#0:wybe.int) @memory_management:nn:nn
-    int_list.gen$2<0>[410bae77d3](0:int_list.int_list, 1:wybe.int, 1:wybe.int, 10:wybe.int, 0:int_list.int_list, ?tmp$0#0:int_list.int_list) #34 @int_list:nn:nn
-    int_list.gen$2<0>[410bae77d3](0:int_list.int_list, 2:wybe.int, 2:wybe.int, 20:wybe.int, 0:int_list.int_list, ?tmp$1#0:int_list.int_list) #35 @int_list:nn:nn
-    int_list.gen$2<0>[410bae77d3](0:int_list.int_list, 3:wybe.int, 3:wybe.int, 30:wybe.int, 0:int_list.int_list, ?tmp$2#0:int_list.int_list) #36 @int_list:nn:nn
-    foreign c print_string("x y z:":wybe.string, ~#io#0:wybe.phantom, ?tmp$17#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$17#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$0#0:int_list.int_list, ~#io#1:wybe.phantom, ?tmp$20#0:wybe.phantom) #37 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$20#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$1#0:int_list.int_list, ~#io#2:wybe.phantom, ?tmp$23#0:wybe.phantom) #38 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$23#0:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$2#0:int_list.int_list, ~#io#3:wybe.phantom, ?tmp$26#0:wybe.phantom) #39 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$26#0:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c {impure} malloc_count(?mc2#0:wybe.int) @memory_management:nn:nn
-    foreign llvm sub(~mc2#0:wybe.int, ~mc1#0:wybe.int, ?tmp$3#0:wybe.int) @int:nn:nn
-    foreign c print_string("--------------------":wybe.string, ~#io#4:wybe.phantom, ?tmp$31#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$31#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-    foreign c print_string("tests with alias":wybe.string, ~#io#5:wybe.phantom, ?tmp$34#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$34#0:wybe.phantom, ?#io#6:wybe.phantom) @io:nn:nn
-    foreign c {impure} malloc_count(?mc1#1:wybe.int) @memory_management:nn:nn
-    int_list_test.test_int_list<0>(tmp$0#0:int_list.int_list, tmp$1#0:int_list.int_list, tmp$2#0:int_list.int_list, ~#io#6:wybe.phantom, ?#io#7:wybe.phantom) #13 @int_list_test:nn:nn
-    foreign c {impure} malloc_count(?mc2#1:wybe.int) @memory_management:nn:nn
-    foreign llvm sub(~mc2#1:wybe.int, ~mc1#1:wybe.int, ?tmp$4#0:wybe.int) @int:nn:nn
-    foreign c print_string("original x y z:":wybe.string, ~#io#7:wybe.phantom, ?tmp$39#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$39#0:wybe.phantom, ?#io#8:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$0#0:int_list.int_list, ~#io#8:wybe.phantom, ?tmp$42#0:wybe.phantom) #40 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$42#0:wybe.phantom, ?#io#9:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$1#0:int_list.int_list, ~#io#9:wybe.phantom, ?tmp$45#0:wybe.phantom) #41 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$45#0:wybe.phantom, ?#io#10:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$2#0:int_list.int_list, ~#io#10:wybe.phantom, ?tmp$48#0:wybe.phantom) #42 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$48#0:wybe.phantom, ?#io#11:wybe.phantom) @io:nn:nn
-    foreign c print_string("--------------------":wybe.string, ~#io#11:wybe.phantom, ?tmp$51#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$51#0:wybe.phantom, ?#io#12:wybe.phantom) @io:nn:nn
-    foreign c print_string("--------------------":wybe.string, ~#io#12:wybe.phantom, ?tmp$54#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$54#0:wybe.phantom, ?#io#13:wybe.phantom) @io:nn:nn
-    foreign c print_string("tests without alias":wybe.string, ~#io#13:wybe.phantom, ?tmp$57#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$57#0:wybe.phantom, ?#io#14:wybe.phantom) @io:nn:nn
-    foreign c {impure} malloc_count(?mc1#2:wybe.int) @memory_management:nn:nn
-    int_list_test.test_int_list<0>[9e35cb823b](~tmp$0#0:int_list.int_list, ~tmp$1#0:int_list.int_list, ~tmp$2#0:int_list.int_list, ~#io#14:wybe.phantom, ?#io#15:wybe.phantom) #24 @int_list_test:nn:nn
-    foreign c {impure} malloc_count(?mc2#2:wybe.int) @memory_management:nn:nn
-    foreign llvm sub(~mc2#2:wybe.int, ~mc1#2:wybe.int, ?tmp$5#0:wybe.int) @int:nn:nn
-    foreign c print_string("--------------------":wybe.string, ~#io#15:wybe.phantom, ?tmp$62#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$62#0:wybe.phantom, ?#io#16:wybe.phantom) @io:nn:nn
-    foreign c print_string(" ** malloc count of building lists: ":wybe.string, ~#io#16:wybe.phantom, ?#io#17:wybe.phantom) @io:nn:nn
-    foreign c print_int(~tmp$3#0:wybe.int, ~#io#17:wybe.phantom, ?tmp$67#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$67#0:wybe.phantom, ?#io#18:wybe.phantom) @io:nn:nn
-    foreign c print_string(" ** malloc count of test(aliased): ":wybe.string, ~#io#18:wybe.phantom, ?#io#19:wybe.phantom) @io:nn:nn
-    foreign c print_int(~tmp$4#0:wybe.int, ~#io#19:wybe.phantom, ?tmp$72#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$72#0:wybe.phantom, ?#io#20:wybe.phantom) @io:nn:nn
-    foreign c print_string(" ** malloc count of test(non-aliased): ":wybe.string, ~#io#20:wybe.phantom, ?#io#21:wybe.phantom) @io:nn:nn
-    foreign c print_int(~tmp$5#0:wybe.int, ~#io#21:wybe.phantom, ?tmp$77#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$77#0:wybe.phantom, ?#io#22:wybe.phantom) @io:nn:nn
+    foreign c {impure} malloc_count(?mc1##0:wybe.int) @memory_management:nn:nn
+    int_list.gen$2<0>[410bae77d3](0:int_list.int_list, 1:wybe.int, 1:wybe.int, 10:wybe.int, 0:int_list.int_list, ?tmp$0##0:int_list.int_list) #34 @int_list:nn:nn
+    int_list.gen$2<0>[410bae77d3](0:int_list.int_list, 2:wybe.int, 2:wybe.int, 20:wybe.int, 0:int_list.int_list, ?tmp$1##0:int_list.int_list) #35 @int_list:nn:nn
+    int_list.gen$2<0>[410bae77d3](0:int_list.int_list, 3:wybe.int, 3:wybe.int, 30:wybe.int, 0:int_list.int_list, ?tmp$2##0:int_list.int_list) #36 @int_list:nn:nn
+    foreign c print_string("x y z:":wybe.string, ~#io##0:wybe.phantom, ?tmp$17##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$17##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp$0##0:int_list.int_list, ~#io##1:wybe.phantom, ?tmp$20##0:wybe.phantom) #37 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$20##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp$1##0:int_list.int_list, ~#io##2:wybe.phantom, ?tmp$23##0:wybe.phantom) #38 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$23##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp$2##0:int_list.int_list, ~#io##3:wybe.phantom, ?tmp$26##0:wybe.phantom) #39 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$26##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c {impure} malloc_count(?mc2##0:wybe.int) @memory_management:nn:nn
+    foreign llvm sub(~mc2##0:wybe.int, ~mc1##0:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
+    foreign c print_string("--------------------":wybe.string, ~#io##4:wybe.phantom, ?tmp$31##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$31##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign c print_string("tests with alias":wybe.string, ~#io##5:wybe.phantom, ?tmp$34##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$34##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+    foreign c {impure} malloc_count(?mc1##1:wybe.int) @memory_management:nn:nn
+    int_list_test.test_int_list<0>(tmp$0##0:int_list.int_list, tmp$1##0:int_list.int_list, tmp$2##0:int_list.int_list, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) #13 @int_list_test:nn:nn
+    foreign c {impure} malloc_count(?mc2##1:wybe.int) @memory_management:nn:nn
+    foreign llvm sub(~mc2##1:wybe.int, ~mc1##1:wybe.int, ?tmp$4##0:wybe.int) @int:nn:nn
+    foreign c print_string("original x y z:":wybe.string, ~#io##7:wybe.phantom, ?tmp$39##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$39##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp$0##0:int_list.int_list, ~#io##8:wybe.phantom, ?tmp$42##0:wybe.phantom) #40 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$42##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp$1##0:int_list.int_list, ~#io##9:wybe.phantom, ?tmp$45##0:wybe.phantom) #41 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$45##0:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp$2##0:int_list.int_list, ~#io##10:wybe.phantom, ?tmp$48##0:wybe.phantom) #42 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$48##0:wybe.phantom, ?#io##11:wybe.phantom) @io:nn:nn
+    foreign c print_string("--------------------":wybe.string, ~#io##11:wybe.phantom, ?tmp$51##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$51##0:wybe.phantom, ?#io##12:wybe.phantom) @io:nn:nn
+    foreign c print_string("--------------------":wybe.string, ~#io##12:wybe.phantom, ?tmp$54##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$54##0:wybe.phantom, ?#io##13:wybe.phantom) @io:nn:nn
+    foreign c print_string("tests without alias":wybe.string, ~#io##13:wybe.phantom, ?tmp$57##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$57##0:wybe.phantom, ?#io##14:wybe.phantom) @io:nn:nn
+    foreign c {impure} malloc_count(?mc1##2:wybe.int) @memory_management:nn:nn
+    int_list_test.test_int_list<0>[9e35cb823b](~tmp$0##0:int_list.int_list, ~tmp$1##0:int_list.int_list, ~tmp$2##0:int_list.int_list, ~#io##14:wybe.phantom, ?#io##15:wybe.phantom) #24 @int_list_test:nn:nn
+    foreign c {impure} malloc_count(?mc2##2:wybe.int) @memory_management:nn:nn
+    foreign llvm sub(~mc2##2:wybe.int, ~mc1##2:wybe.int, ?tmp$5##0:wybe.int) @int:nn:nn
+    foreign c print_string("--------------------":wybe.string, ~#io##15:wybe.phantom, ?tmp$62##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$62##0:wybe.phantom, ?#io##16:wybe.phantom) @io:nn:nn
+    foreign c print_string(" ** malloc count of building lists: ":wybe.string, ~#io##16:wybe.phantom, ?#io##17:wybe.phantom) @io:nn:nn
+    foreign c print_int(~tmp$3##0:wybe.int, ~#io##17:wybe.phantom, ?tmp$67##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$67##0:wybe.phantom, ?#io##18:wybe.phantom) @io:nn:nn
+    foreign c print_string(" ** malloc count of test(aliased): ":wybe.string, ~#io##18:wybe.phantom, ?#io##19:wybe.phantom) @io:nn:nn
+    foreign c print_int(~tmp$4##0:wybe.int, ~#io##19:wybe.phantom, ?tmp$72##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$72##0:wybe.phantom, ?#io##20:wybe.phantom) @io:nn:nn
+    foreign c print_string(" ** malloc count of test(non-aliased): ":wybe.string, ~#io##20:wybe.phantom, ?#io##21:wybe.phantom) @io:nn:nn
+    foreign c print_int(~tmp$5##0:wybe.int, ~#io##21:wybe.phantom, ?tmp$77##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$77##0:wybe.phantom, ?#io##22:wybe.phantom) @io:nn:nn
 
 
 test_int_list > (2 calls)
 0: int_list_test.test_int_list<0>[9e35cb823b]
-test_int_list(x#0:int_list.int_list, y#0:int_list.int_list, z#0:int_list.int_list, io#0:wybe.phantom, ?io#10:wybe.phantom):
+test_int_list(x##0:int_list.int_list, y##0:int_list.int_list, z##0:int_list.int_list, io##0:wybe.phantom, ?io##10:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0,InterestingUnaliased 1,InterestingUnaliased 2]
  MultiSpeczDepInfo: [(2,(int_list.append<0>,fromList [NonAliasedParamCond 0 [1]])),(7,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []])),(8,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []])),(11,(int_list.insert<0>,fromList [NonAliasedParamCond 0 []])),(12,(int_list.pop<0>,fromList [NonAliasedParamCond 0 []])),(13,(int_list.remove<0>,fromList [NonAliasedParamCond 0 []])),(16,(int_list.sort<0>,fromList [NonAliasedParamCond 0 []])),(19,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]])),(20,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [2]]))]
-    int_list.reverse_helper<0>(~x#0:int_list.int_list, 0:int_list.int_list, ?x#1:int_list.int_list) #19 @int_list:nn:nn
-    int_list.reverse_helper<0>(~z#0:int_list.int_list, 0:int_list.int_list, ?z#1:int_list.int_list) #20 @int_list:nn:nn
-    int_list.append<0>(~y#0:int_list.int_list, 99:wybe.int, ?tmp$0#0:int_list.int_list) #2 @int_list_test:nn:nn
-    foreign c print_string("-":wybe.string, ~#io#0:wybe.phantom, ?tmp$10#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$10#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    int_list.print<0>(x#1:int_list.int_list, ~#io#1:wybe.phantom, ?tmp$13#0:wybe.phantom) #21 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$13#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$0#0:int_list.int_list, ~#io#2:wybe.phantom, ?tmp$16#0:wybe.phantom) #22 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$16#0:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    int_list.print<0>(z#1:int_list.int_list, ~#io#3:wybe.phantom, ?tmp$19#0:wybe.phantom) #23 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$19#0:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    int_list.extend<0>[410bae77d3](~x#1:int_list.int_list, ~tmp$0#0:int_list.int_list, ?tmp$1#0:int_list.int_list) #7 @int_list_test:nn:nn
-    int_list.extend<0>[410bae77d3](~tmp$1#0:int_list.int_list, ~z#1:int_list.int_list, ?tmp$2#0:int_list.int_list) #8 @int_list_test:nn:nn
-    foreign c print_string("-":wybe.string, ~#io#4:wybe.phantom, ?tmp$22#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$22#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$2#0:int_list.int_list, ~#io#5:wybe.phantom, ?tmp$25#0:wybe.phantom) #24 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$25#0:wybe.phantom, ?#io#6:wybe.phantom) @io:nn:nn
-    int_list.insert<0>[410bae77d3](~tmp$2#0:int_list.int_list, 4:wybe.int, 78:wybe.int, ?tmp$3#0:int_list.int_list) #11 @int_list_test:nn:nn
-    int_list.pop<0>[410bae77d3](~tmp$3#0:int_list.int_list, 20:wybe.int, ?tmp$4#0:int_list.int_list) #12 @int_list_test:nn:nn
-    int_list.remove<0>[410bae77d3](~tmp$4#0:int_list.int_list, 2:wybe.int, ?tmp$5#0:int_list.int_list) #13 @int_list_test:nn:nn
-    foreign c print_string("-":wybe.string, ~#io#6:wybe.phantom, ?tmp$28#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$28#0:wybe.phantom, ?#io#7:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$5#0:int_list.int_list, ~#io#7:wybe.phantom, ?tmp$31#0:wybe.phantom) #25 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$31#0:wybe.phantom, ?#io#8:wybe.phantom) @io:nn:nn
-    int_list.sort<0>[410bae77d3](~tmp$5#0:int_list.int_list, ?l#5:int_list.int_list) #16 @int_list_test:nn:nn
-    foreign c print_string("-":wybe.string, ~#io#8:wybe.phantom, ?tmp$34#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$34#0:wybe.phantom, ?#io#9:wybe.phantom) @io:nn:nn
-    int_list.print<0>(~l#5:int_list.int_list, ~#io#9:wybe.phantom, ?tmp$37#0:wybe.phantom) #26 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$37#0:wybe.phantom, ?#io#10:wybe.phantom) @io:nn:nn
+    int_list.reverse_helper<0>(~x##0:int_list.int_list, 0:int_list.int_list, ?x##1:int_list.int_list) #19 @int_list:nn:nn
+    int_list.reverse_helper<0>(~z##0:int_list.int_list, 0:int_list.int_list, ?z##1:int_list.int_list) #20 @int_list:nn:nn
+    int_list.append<0>(~y##0:int_list.int_list, 99:wybe.int, ?tmp$0##0:int_list.int_list) #2 @int_list_test:nn:nn
+    foreign c print_string("-":wybe.string, ~#io##0:wybe.phantom, ?tmp$10##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    int_list.print<0>(x##1:int_list.int_list, ~#io##1:wybe.phantom, ?tmp$13##0:wybe.phantom) #21 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$13##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp$0##0:int_list.int_list, ~#io##2:wybe.phantom, ?tmp$16##0:wybe.phantom) #22 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$16##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    int_list.print<0>(z##1:int_list.int_list, ~#io##3:wybe.phantom, ?tmp$19##0:wybe.phantom) #23 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$19##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    int_list.extend<0>[410bae77d3](~x##1:int_list.int_list, ~tmp$0##0:int_list.int_list, ?tmp$1##0:int_list.int_list) #7 @int_list_test:nn:nn
+    int_list.extend<0>[410bae77d3](~tmp$1##0:int_list.int_list, ~z##1:int_list.int_list, ?tmp$2##0:int_list.int_list) #8 @int_list_test:nn:nn
+    foreign c print_string("-":wybe.string, ~#io##4:wybe.phantom, ?tmp$22##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$22##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp$2##0:int_list.int_list, ~#io##5:wybe.phantom, ?tmp$25##0:wybe.phantom) #24 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$25##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+    int_list.insert<0>[410bae77d3](~tmp$2##0:int_list.int_list, 4:wybe.int, 78:wybe.int, ?tmp$3##0:int_list.int_list) #11 @int_list_test:nn:nn
+    int_list.pop<0>[410bae77d3](~tmp$3##0:int_list.int_list, 20:wybe.int, ?tmp$4##0:int_list.int_list) #12 @int_list_test:nn:nn
+    int_list.remove<0>[410bae77d3](~tmp$4##0:int_list.int_list, 2:wybe.int, ?tmp$5##0:int_list.int_list) #13 @int_list_test:nn:nn
+    foreign c print_string("-":wybe.string, ~#io##6:wybe.phantom, ?tmp$28##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$28##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp$5##0:int_list.int_list, ~#io##7:wybe.phantom, ?tmp$31##0:wybe.phantom) #25 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$31##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
+    int_list.sort<0>[410bae77d3](~tmp$5##0:int_list.int_list, ?l##5:int_list.int_list) #16 @int_list_test:nn:nn
+    foreign c print_string("-":wybe.string, ~#io##8:wybe.phantom, ?tmp$34##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$34##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
+    int_list.print<0>(~l##5:int_list.int_list, ~#io##9:wybe.phantom, ?tmp$37##0:wybe.phantom) #26 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$37##0:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
  [9e35cb823b] [NonAliasedParam 0,NonAliasedParam 1,NonAliasedParam 2] :
-    int_list.reverse_helper<0>[410bae77d3](~x#0:int_list.int_list, 0:int_list.int_list, ?x#1:int_list.int_list) #19 @int_list:nn:nn
-    int_list.reverse_helper<0>[410bae77d3](~z#0:int_list.int_list, 0:int_list.int_list, ?z#1:int_list.int_list) #20 @int_list:nn:nn
-    int_list.append<0>[410bae77d3](~y#0:int_list.int_list, 99:wybe.int, ?tmp$0#0:int_list.int_list) #2 @int_list_test:nn:nn
-    foreign c print_string("-":wybe.string, ~#io#0:wybe.phantom, ?tmp$10#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$10#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    int_list.print<0>(x#1:int_list.int_list, ~#io#1:wybe.phantom, ?tmp$13#0:wybe.phantom) #21 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$13#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$0#0:int_list.int_list, ~#io#2:wybe.phantom, ?tmp$16#0:wybe.phantom) #22 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$16#0:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    int_list.print<0>(z#1:int_list.int_list, ~#io#3:wybe.phantom, ?tmp$19#0:wybe.phantom) #23 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$19#0:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    int_list.extend<0>[410bae77d3](~x#1:int_list.int_list, ~tmp$0#0:int_list.int_list, ?tmp$1#0:int_list.int_list) #7 @int_list_test:nn:nn
-    int_list.extend<0>[410bae77d3](~tmp$1#0:int_list.int_list, ~z#1:int_list.int_list, ?tmp$2#0:int_list.int_list) #8 @int_list_test:nn:nn
-    foreign c print_string("-":wybe.string, ~#io#4:wybe.phantom, ?tmp$22#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$22#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$2#0:int_list.int_list, ~#io#5:wybe.phantom, ?tmp$25#0:wybe.phantom) #24 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$25#0:wybe.phantom, ?#io#6:wybe.phantom) @io:nn:nn
-    int_list.insert<0>[410bae77d3](~tmp$2#0:int_list.int_list, 4:wybe.int, 78:wybe.int, ?tmp$3#0:int_list.int_list) #11 @int_list_test:nn:nn
-    int_list.pop<0>[410bae77d3](~tmp$3#0:int_list.int_list, 20:wybe.int, ?tmp$4#0:int_list.int_list) #12 @int_list_test:nn:nn
-    int_list.remove<0>[410bae77d3](~tmp$4#0:int_list.int_list, 2:wybe.int, ?tmp$5#0:int_list.int_list) #13 @int_list_test:nn:nn
-    foreign c print_string("-":wybe.string, ~#io#6:wybe.phantom, ?tmp$28#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$28#0:wybe.phantom, ?#io#7:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$5#0:int_list.int_list, ~#io#7:wybe.phantom, ?tmp$31#0:wybe.phantom) #25 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$31#0:wybe.phantom, ?#io#8:wybe.phantom) @io:nn:nn
-    int_list.sort<0>[410bae77d3](~tmp$5#0:int_list.int_list, ?l#5:int_list.int_list) #16 @int_list_test:nn:nn
-    foreign c print_string("-":wybe.string, ~#io#8:wybe.phantom, ?tmp$34#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$34#0:wybe.phantom, ?#io#9:wybe.phantom) @io:nn:nn
-    int_list.print<0>(~l#5:int_list.int_list, ~#io#9:wybe.phantom, ?tmp$37#0:wybe.phantom) #26 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$37#0:wybe.phantom, ?#io#10:wybe.phantom) @io:nn:nn
+    int_list.reverse_helper<0>[410bae77d3](~x##0:int_list.int_list, 0:int_list.int_list, ?x##1:int_list.int_list) #19 @int_list:nn:nn
+    int_list.reverse_helper<0>[410bae77d3](~z##0:int_list.int_list, 0:int_list.int_list, ?z##1:int_list.int_list) #20 @int_list:nn:nn
+    int_list.append<0>[410bae77d3](~y##0:int_list.int_list, 99:wybe.int, ?tmp$0##0:int_list.int_list) #2 @int_list_test:nn:nn
+    foreign c print_string("-":wybe.string, ~#io##0:wybe.phantom, ?tmp$10##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    int_list.print<0>(x##1:int_list.int_list, ~#io##1:wybe.phantom, ?tmp$13##0:wybe.phantom) #21 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$13##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp$0##0:int_list.int_list, ~#io##2:wybe.phantom, ?tmp$16##0:wybe.phantom) #22 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$16##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    int_list.print<0>(z##1:int_list.int_list, ~#io##3:wybe.phantom, ?tmp$19##0:wybe.phantom) #23 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$19##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    int_list.extend<0>[410bae77d3](~x##1:int_list.int_list, ~tmp$0##0:int_list.int_list, ?tmp$1##0:int_list.int_list) #7 @int_list_test:nn:nn
+    int_list.extend<0>[410bae77d3](~tmp$1##0:int_list.int_list, ~z##1:int_list.int_list, ?tmp$2##0:int_list.int_list) #8 @int_list_test:nn:nn
+    foreign c print_string("-":wybe.string, ~#io##4:wybe.phantom, ?tmp$22##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$22##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp$2##0:int_list.int_list, ~#io##5:wybe.phantom, ?tmp$25##0:wybe.phantom) #24 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$25##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+    int_list.insert<0>[410bae77d3](~tmp$2##0:int_list.int_list, 4:wybe.int, 78:wybe.int, ?tmp$3##0:int_list.int_list) #11 @int_list_test:nn:nn
+    int_list.pop<0>[410bae77d3](~tmp$3##0:int_list.int_list, 20:wybe.int, ?tmp$4##0:int_list.int_list) #12 @int_list_test:nn:nn
+    int_list.remove<0>[410bae77d3](~tmp$4##0:int_list.int_list, 2:wybe.int, ?tmp$5##0:int_list.int_list) #13 @int_list_test:nn:nn
+    foreign c print_string("-":wybe.string, ~#io##6:wybe.phantom, ?tmp$28##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$28##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp$5##0:int_list.int_list, ~#io##7:wybe.phantom, ?tmp$31##0:wybe.phantom) #25 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$31##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
+    int_list.sort<0>[410bae77d3](~tmp$5##0:int_list.int_list, ?l##5:int_list.int_list) #16 @int_list_test:nn:nn
+    foreign c print_string("-":wybe.string, ~#io##8:wybe.phantom, ?tmp$34##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$34##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
+    int_list.print<0>(~l##5:int_list.int_list, ~#io##9:wybe.phantom, ?tmp$37##0:wybe.phantom) #26 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$37##0:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -2890,39 +2890,39 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"int_list_test.<0>"()    {
 entry:
-  %"1$mc1#0" = tail call ccc  i64  @malloc_count()  
-  %"1$tmp$0#0" = tail call fastcc  i64  @"int_list.gen$2<0>[410bae77d3]"(i64  0, i64  1, i64  1, i64  10, i64  0)  
-  %"1$tmp$1#0" = tail call fastcc  i64  @"int_list.gen$2<0>[410bae77d3]"(i64  0, i64  2, i64  2, i64  20, i64  0)  
-  %"1$tmp$2#0" = tail call fastcc  i64  @"int_list.gen$2<0>[410bae77d3]"(i64  0, i64  3, i64  3, i64  30, i64  0)  
+  %"1$mc1##0" = tail call ccc  i64  @malloc_count()  
+  %"1$tmp$0##0" = tail call fastcc  i64  @"int_list.gen$2<0>[410bae77d3]"(i64  0, i64  1, i64  1, i64  10, i64  0)  
+  %"1$tmp$1##0" = tail call fastcc  i64  @"int_list.gen$2<0>[410bae77d3]"(i64  0, i64  2, i64  2, i64  20, i64  0)  
+  %"1$tmp$2##0" = tail call fastcc  i64  @"int_list.gen$2<0>[410bae77d3]"(i64  0, i64  3, i64  3, i64  30, i64  0)  
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$0#0")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$0##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$1#0")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$1##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$2#0")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$2##0")  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$mc2#0" = tail call ccc  i64  @malloc_count()  
-  %"1$tmp$3#0" = sub   i64 %"1$mc2#0", %"1$mc1#0" 
+  %"1$mc2##0" = tail call ccc  i64  @malloc_count()  
+  %"1$tmp$3##0" = sub   i64 %"1$mc2##0", %"1$mc1##0" 
   %4 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.3, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %4)  
   tail call ccc  void  @putchar(i8  10)  
   %6 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.5, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %6)  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$mc1#1" = tail call ccc  i64  @malloc_count()  
-  tail call fastcc  void  @"int_list_test.test_int_list<0>"(i64  %"1$tmp$0#0", i64  %"1$tmp$1#0", i64  %"1$tmp$2#0")  
-  %"1$mc2#1" = tail call ccc  i64  @malloc_count()  
-  %"1$tmp$4#0" = sub   i64 %"1$mc2#1", %"1$mc1#1" 
+  %"1$mc1##1" = tail call ccc  i64  @malloc_count()  
+  tail call fastcc  void  @"int_list_test.test_int_list<0>"(i64  %"1$tmp$0##0", i64  %"1$tmp$1##0", i64  %"1$tmp$2##0")  
+  %"1$mc2##1" = tail call ccc  i64  @malloc_count()  
+  %"1$tmp$4##0" = sub   i64 %"1$mc2##1", %"1$mc1##1" 
   %8 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.7, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %8)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$0#0")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$0##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$1#0")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$1##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$2#0")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$2##0")  
   tail call ccc  void  @putchar(i8  10)  
   %10 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.9, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %10)  
@@ -2933,102 +2933,102 @@ entry:
   %14 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.13, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %14)  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$mc1#2" = tail call ccc  i64  @malloc_count()  
-  tail call fastcc  void  @"int_list_test.test_int_list<0>[9e35cb823b]"(i64  %"1$tmp$0#0", i64  %"1$tmp$1#0", i64  %"1$tmp$2#0")  
-  %"1$mc2#2" = tail call ccc  i64  @malloc_count()  
-  %"1$tmp$5#0" = sub   i64 %"1$mc2#2", %"1$mc1#2" 
+  %"1$mc1##2" = tail call ccc  i64  @malloc_count()  
+  tail call fastcc  void  @"int_list_test.test_int_list<0>[9e35cb823b]"(i64  %"1$tmp$0##0", i64  %"1$tmp$1##0", i64  %"1$tmp$2##0")  
+  %"1$mc2##2" = tail call ccc  i64  @malloc_count()  
+  %"1$tmp$5##0" = sub   i64 %"1$mc2##2", %"1$mc1##2" 
   %16 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.15, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %16)  
   tail call ccc  void  @putchar(i8  10)  
   %18 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.17, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %18)  
-  tail call ccc  void  @print_int(i64  %"1$tmp$3#0")  
+  tail call ccc  void  @print_int(i64  %"1$tmp$3##0")  
   tail call ccc  void  @putchar(i8  10)  
   %20 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.19, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %20)  
-  tail call ccc  void  @print_int(i64  %"1$tmp$4#0")  
+  tail call ccc  void  @print_int(i64  %"1$tmp$4##0")  
   tail call ccc  void  @putchar(i8  10)  
   %22 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.21, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %22)  
-  tail call ccc  void  @print_int(i64  %"1$tmp$5#0")  
+  tail call ccc  void  @print_int(i64  %"1$tmp$5##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  void @"int_list_test.test_int_list<0>"(i64  %"x#0", i64  %"y#0", i64  %"z#0")    {
+define external fastcc  void @"int_list_test.test_int_list<0>"(i64  %"x##0", i64  %"y##0", i64  %"z##0")    {
 entry:
-  %"1$x#1" = tail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %"x#0", i64  0)  
-  %"1$z#1" = tail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %"z#0", i64  0)  
-  %"1$tmp$0#0" = tail call fastcc  i64  @"int_list.append<0>"(i64  %"y#0", i64  99)  
+  %"1$x##1" = tail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %"x##0", i64  0)  
+  %"1$z##1" = tail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %"z##0", i64  0)  
+  %"1$tmp$0##0" = tail call fastcc  i64  @"int_list.append<0>"(i64  %"y##0", i64  99)  
   %24 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.23, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %24)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$x#1")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$x##1")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$0#0")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$0##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$z#1")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$z##1")  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$tmp$1#0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"1$x#1", i64  %"1$tmp$0#0")  
-  %"1$tmp$2#0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"1$tmp$1#0", i64  %"1$z#1")  
+  %"1$tmp$1##0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"1$x##1", i64  %"1$tmp$0##0")  
+  %"1$tmp$2##0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"1$tmp$1##0", i64  %"1$z##1")  
   %26 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.25, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %26)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$2#0")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$2##0")  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$tmp$3#0" = tail call fastcc  i64  @"int_list.insert<0>[410bae77d3]"(i64  %"1$tmp$2#0", i64  4, i64  78)  
-  %"1$tmp$4#0" = tail call fastcc  i64  @"int_list.pop<0>[410bae77d3]"(i64  %"1$tmp$3#0", i64  20)  
-  %"1$tmp$5#0" = tail call fastcc  i64  @"int_list.remove<0>[410bae77d3]"(i64  %"1$tmp$4#0", i64  2)  
+  %"1$tmp$3##0" = tail call fastcc  i64  @"int_list.insert<0>[410bae77d3]"(i64  %"1$tmp$2##0", i64  4, i64  78)  
+  %"1$tmp$4##0" = tail call fastcc  i64  @"int_list.pop<0>[410bae77d3]"(i64  %"1$tmp$3##0", i64  20)  
+  %"1$tmp$5##0" = tail call fastcc  i64  @"int_list.remove<0>[410bae77d3]"(i64  %"1$tmp$4##0", i64  2)  
   %28 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.27, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %28)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$5#0")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$5##0")  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$l#5" = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %"1$tmp$5#0")  
+  %"1$l##5" = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %"1$tmp$5##0")  
   %30 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.29, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %30)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$l#5")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$l##5")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  void @"int_list_test.test_int_list<0>[9e35cb823b]"(i64  %"x#0", i64  %"y#0", i64  %"z#0")    {
+define external fastcc  void @"int_list_test.test_int_list<0>[9e35cb823b]"(i64  %"x##0", i64  %"y##0", i64  %"z##0")    {
 entry:
-  %"1$x#1" = tail call fastcc  i64  @"int_list.reverse_helper<0>[410bae77d3]"(i64  %"x#0", i64  0)  
-  %"1$z#1" = tail call fastcc  i64  @"int_list.reverse_helper<0>[410bae77d3]"(i64  %"z#0", i64  0)  
-  %"1$tmp$0#0" = tail call fastcc  i64  @"int_list.append<0>[410bae77d3]"(i64  %"y#0", i64  99)  
+  %"1$x##1" = tail call fastcc  i64  @"int_list.reverse_helper<0>[410bae77d3]"(i64  %"x##0", i64  0)  
+  %"1$z##1" = tail call fastcc  i64  @"int_list.reverse_helper<0>[410bae77d3]"(i64  %"z##0", i64  0)  
+  %"1$tmp$0##0" = tail call fastcc  i64  @"int_list.append<0>[410bae77d3]"(i64  %"y##0", i64  99)  
   %32 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.31, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %32)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$x#1")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$x##1")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$0#0")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$0##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$z#1")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$z##1")  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$tmp$1#0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"1$x#1", i64  %"1$tmp$0#0")  
-  %"1$tmp$2#0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"1$tmp$1#0", i64  %"1$z#1")  
+  %"1$tmp$1##0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"1$x##1", i64  %"1$tmp$0##0")  
+  %"1$tmp$2##0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"1$tmp$1##0", i64  %"1$z##1")  
   %34 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.33, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %34)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$2#0")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$2##0")  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$tmp$3#0" = tail call fastcc  i64  @"int_list.insert<0>[410bae77d3]"(i64  %"1$tmp$2#0", i64  4, i64  78)  
-  %"1$tmp$4#0" = tail call fastcc  i64  @"int_list.pop<0>[410bae77d3]"(i64  %"1$tmp$3#0", i64  20)  
-  %"1$tmp$5#0" = tail call fastcc  i64  @"int_list.remove<0>[410bae77d3]"(i64  %"1$tmp$4#0", i64  2)  
+  %"1$tmp$3##0" = tail call fastcc  i64  @"int_list.insert<0>[410bae77d3]"(i64  %"1$tmp$2##0", i64  4, i64  78)  
+  %"1$tmp$4##0" = tail call fastcc  i64  @"int_list.pop<0>[410bae77d3]"(i64  %"1$tmp$3##0", i64  20)  
+  %"1$tmp$5##0" = tail call fastcc  i64  @"int_list.remove<0>[410bae77d3]"(i64  %"1$tmp$4##0", i64  2)  
   %36 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.35, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %36)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$5#0")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$5##0")  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$l#5" = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %"1$tmp$5#0")  
+  %"1$l##5" = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %"1$tmp$5##0")  
   %38 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.37, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %38)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$l#5")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$l##5")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/complex/exp/testcase_multi_specz-int_list.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-int_list.exp
@@ -140,11 +140,11 @@ LLVM code       : None
 (argc##0:wybe.int, [?argc##0:wybe.int], ?arguments##2:wybe.array(wybe.string), argv##0:wybe.array.raw_array(wybe.string), [?argv##0:wybe.array.raw_array(wybe.string)], ?command##2:wybe.string, ?exit_code##1:wybe.int, io##0:wybe.phantom, [?io##0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$9##0:wybe.array(?T))
-    foreign lpvm mutate(~tmp$9##0:wybe.array(?T), ?tmp$10##0:wybe.array(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
-    foreign lpvm mutate(~tmp$10##0:wybe.array(?T), ?tmp$1##0:wybe.array(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(?T))
-    wybe.array.[|]<0>(?command##2:?T, ?arguments##2:wybe.array(?T), ~tmp$1##0:wybe.array(?T), ?tmp$2##0:wybe.bool) #2 @command_line:nn:nn
-    case ~tmp$2##0:wybe.bool of
+    foreign lpvm alloc(16:wybe.int, ?tmp#9##0:wybe.array(?T))
+    foreign lpvm mutate(~tmp#9##0:wybe.array(?T), ?tmp#10##0:wybe.array(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
+    foreign lpvm mutate(~tmp#10##0:wybe.array(?T), ?tmp#1##0:wybe.array(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(?T))
+    wybe.array.[|]<0>(?command##2:?T, ?arguments##2:wybe.array(?T), ~tmp#1##0:wybe.array(?T), ?tmp#2##0:wybe.bool) #2 @command_line:nn:nn
+    case ~tmp#2##0:wybe.bool of
     0:
         foreign c {terminal,semipure} error_exit("command_line:17:10":wybe.string, "Erroneous program argument vector":wybe.string) @control:nn:nn
         foreign llvm move(0:wybe.int, ?exit_code##1:wybe.int)
@@ -258,248 +258,248 @@ entry:
 
 append > public (0 calls)
 0: int_list.append<0>
-append(lst##0:int_list.int_list, v##0:wybe.int, ?$##0:int_list.int_list):
+append(lst##0:int_list.int_list, v##0:wybe.int, ?###0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.extend<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign lpvm alloc(16:wybe.int, ?tmp$5##0:int_list.int_list)
-    foreign lpvm mutate(~tmp$5##0:int_list.int_list, ?tmp$6##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
-    foreign lpvm mutate(~tmp$6##0:int_list.int_list, ?tmp$7##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:int_list.int_list)
-    int_list.extend<0>(~lst##0:int_list.int_list, ~tmp$7##0:int_list.int_list, ?$##0:int_list.int_list) #2 @int_list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:int_list.int_list)
+    foreign lpvm mutate(~tmp#5##0:int_list.int_list, ?tmp#6##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
+    foreign lpvm mutate(~tmp#6##0:int_list.int_list, ?tmp#7##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:int_list.int_list)
+    int_list.extend<0>(~lst##0:int_list.int_list, ~tmp#7##0:int_list.int_list, ?###0:int_list.int_list) #2 @int_list:nn:nn
 
 
 count > public (3 calls)
 0: int_list.count<0>
-count(lst##0:int_list.int_list, x##0:wybe.int, ?$##0:wybe.int):
+count(lst##0:int_list.int_list, x##0:wybe.int, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.bool)
-    case ~tmp$7##0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.bool)
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.int, ?$##0:wybe.int) @int_list:nn:nn
+        foreign llvm move(0:wybe.int, ?###0:wybe.int) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
         foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
-        int_list.count<0>(~t##0:int_list.int_list, x##0:wybe.int, ?tmp$2##0:wybe.int) #1 @int_list:nn:nn
-        foreign llvm icmp_eq(~h##0:wybe.int, ~x##0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
-        case ~tmp$4##0:wybe.bool of
+        int_list.count<0>(~t##0:int_list.int_list, x##0:wybe.int, ?tmp#2##0:wybe.int) #1 @int_list:nn:nn
+        foreign llvm icmp_eq(~h##0:wybe.int, ~x##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
+        case ~tmp#4##0:wybe.bool of
         0:
-            foreign llvm move(~tmp$2##0:wybe.int, ?$##0:wybe.int) @int:nn:nn
+            foreign llvm move(~tmp#2##0:wybe.int, ?###0:wybe.int) @int:nn:nn
 
         1:
-            foreign llvm add(~tmp$2##0:wybe.int, 1:wybe.int, ?$##0:wybe.int) @int:nn:nn
+            foreign llvm add(~tmp#2##0:wybe.int, 1:wybe.int, ?###0:wybe.int) @int:nn:nn
 
 
 
 
 extend > public (3 calls)
 0: int_list.extend<0>[410bae77d3]
-extend(lst1##0:int_list.int_list, lst2##0:int_list.int_list, ?$##0:int_list.int_list):
- AliasPairs: [($##0,lst2##0)]
+extend(lst1##0:int_list.int_list, lst2##0:int_list.int_list, ?###0:int_list.int_list):
+ AliasPairs: [(###0,lst2##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(int_list.extend<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(lst1##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
-    case ~tmp$5##0:wybe.bool of
+    foreign llvm icmp_ne(lst1##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
+    case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~lst2##0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(~lst2##0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst1##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
         foreign lpvm access(~lst1##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
-        int_list.extend<0>(~t##0:int_list.int_list, ~lst2##0:int_list.int_list, ?tmp$2##0:int_list.int_list) #1 @int_list:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$8##0:int_list.int_list)
-        foreign lpvm mutate(~tmp$8##0:int_list.int_list, ?tmp$9##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-        foreign lpvm mutate(~tmp$9##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:int_list.int_list)
+        int_list.extend<0>(~t##0:int_list.int_list, ~lst2##0:int_list.int_list, ?tmp#2##0:int_list.int_list) #1 @int_list:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:int_list.int_list)
+        foreign lpvm mutate(~tmp#8##0:int_list.int_list, ?tmp#9##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+        foreign lpvm mutate(~tmp#9##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:int_list.int_list)
 
 
 
-gen$1 > {inline} (2 calls)
-0: int_list.gen$1<0>
-gen$1([h##0:wybe.int], [lst##0:int_list.int_list], [t##0:int_list.int_list], tmp$2##0:wybe.int, tmp$3##0:wybe.int, [x##0:wybe.int], ?$##0:wybe.int):
+gen#1 > {inline} (2 calls)
+0: int_list.gen#1<0>
+gen#1([h##0:wybe.int], [lst##0:int_list.int_list], [t##0:int_list.int_list], tmp#2##0:wybe.int, tmp#3##0:wybe.int, [x##0:wybe.int], ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~tmp$2##0:wybe.int, ~tmp$3##0:wybe.int, ?$##0:wybe.int) @int:nn:nn
+    foreign llvm add(~tmp#2##0:wybe.int, ~tmp#3##0:wybe.int, ?###0:wybe.int) @int:nn:nn
 
 
-gen$2 > (2 calls)
-0: int_list.gen$2<0>[410bae77d3]
-gen$2(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, stop##0:wybe.int, tmp$0##0:int_list.int_list, ?result##1:int_list.int_list):
+gen#2 > (2 calls)
+0: int_list.gen#2<0>[410bae77d3]
+gen#2(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, stop##0:wybe.int, tmp#0##0:int_list.int_list, ?result##1:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
- MultiSpeczDepInfo: [(3,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.gen$2<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_slt(start##0:wybe.int, stop##0:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
-    case ~tmp$3##0:wybe.bool of
+ MultiSpeczDepInfo: [(3,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.gen#2<0>,fromList [NonAliasedParamCond 0 [0]]))]
+    foreign llvm icmp_slt(start##0:wybe.int, stop##0:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
+    case ~tmp#3##0:wybe.bool of
     0:
         int_list.reverse_helper<0>(~result##0:int_list.int_list, 0:int_list.int_list, ?result##1:int_list.int_list) #3 @int_list:nn:nn
 
     1:
-        foreign lpvm alloc(16:wybe.int, ?tmp$12##0:int_list.int_list)
-        foreign lpvm mutate(~tmp$12##0:int_list.int_list, ?tmp$13##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int)
-        foreign lpvm mutate(~tmp$13##0:int_list.int_list, ?tmp$14##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list)
-        foreign llvm add(~start##0:wybe.int, step##0:wybe.int, ?tmp$15##0:wybe.int) @int:nn:nn
-        int_list.gen$2<0>(~tmp$14##0:int_list.int_list, ~tmp$15##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ~tmp$0##0:int_list.int_list, ?result##1:int_list.int_list) #4 @int_list:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#12##0:int_list.int_list)
+        foreign lpvm mutate(~tmp#12##0:int_list.int_list, ?tmp#13##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int)
+        foreign lpvm mutate(~tmp#13##0:int_list.int_list, ?tmp#14##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list)
+        foreign llvm add(~start##0:wybe.int, step##0:wybe.int, ?tmp#15##0:wybe.int) @int:nn:nn
+        int_list.gen#2<0>(~tmp#14##0:int_list.int_list, ~tmp#15##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ~tmp#0##0:int_list.int_list, ?result##1:int_list.int_list) #4 @int_list:nn:nn
 
 
 
-gen$3 > {inline} (1 calls)
-0: int_list.gen$3<0>
-gen$3(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, stop##0:wybe.int, tmp$0##0:int_list.int_list, ?result##2:int_list.int_list):
+gen#3 > {inline} (1 calls)
+0: int_list.gen#3<0>
+gen#3(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, stop##0:wybe.int, tmp#0##0:int_list.int_list, ?result##2:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$5##0:int_list.int_list)
-    foreign lpvm mutate(~tmp$5##0:int_list.int_list, ?tmp$6##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int)
-    foreign lpvm mutate(~tmp$6##0:int_list.int_list, ?tmp$7##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list)
-    foreign llvm add(~start##0:wybe.int, step##0:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
-    int_list.gen$2<0>(~tmp$7##0:int_list.int_list, ~tmp$2##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ~tmp$0##0:int_list.int_list, ?result##2:int_list.int_list) #2 @int_list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:int_list.int_list)
+    foreign lpvm mutate(~tmp#5##0:int_list.int_list, ?tmp#6##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int)
+    foreign lpvm mutate(~tmp#6##0:int_list.int_list, ?tmp#7##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list)
+    foreign llvm add(~start##0:wybe.int, step##0:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
+    int_list.gen#2<0>(~tmp#7##0:int_list.int_list, ~tmp#2##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ~tmp#0##0:int_list.int_list, ?result##2:int_list.int_list) #2 @int_list:nn:nn
 
 
 greater > (3 calls)
 0: int_list.greater<0>
-greater(lst##0:int_list.int_list, v##0:wybe.int, ?$##0:int_list.int_list):
+greater(lst##0:int_list.int_list, v##0:wybe.int, ?###0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.greater<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.greater<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
-    case ~tmp$9##0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
+    case ~tmp#9##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
         foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
-        foreign llvm icmp_sge(h##0:wybe.int, v##0:wybe.int, ?tmp$6##0:wybe.bool) @int:nn:nn
-        case ~tmp$6##0:wybe.bool of
+        foreign llvm icmp_sge(h##0:wybe.int, v##0:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
+        case ~tmp#6##0:wybe.bool of
         0:
-            int_list.greater<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?$##0:int_list.int_list) #4 @int_list:nn:nn
+            int_list.greater<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?###0:int_list.int_list) #4 @int_list:nn:nn
 
         1:
-            int_list.greater<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp$3##0:int_list.int_list) #2 @int_list:nn:nn
-            foreign lpvm alloc(16:wybe.int, ?tmp$14##0:int_list.int_list)
-            foreign lpvm mutate(~tmp$14##0:int_list.int_list, ?tmp$15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-            foreign lpvm mutate(~tmp$15##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:int_list.int_list)
+            int_list.greater<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp#3##0:int_list.int_list) #2 @int_list:nn:nn
+            foreign lpvm alloc(16:wybe.int, ?tmp#14##0:int_list.int_list)
+            foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+            foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
 
 
 
 
 index > public {inline} (0 calls)
 0: int_list.index<0>
-index(lst##0:int_list.int_list, x##0:wybe.int, ?$##0:wybe.int):
+index(lst##0:int_list.int_list, x##0:wybe.int, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    int_list.index_helper<0>(~lst##0:int_list.int_list, 0:wybe.int, ~x##0:wybe.int, ?$##0:wybe.int) #0 @int_list:nn:nn
+    int_list.index_helper<0>(~lst##0:int_list.int_list, 0:wybe.int, ~x##0:wybe.int, ?###0:wybe.int) #0 @int_list:nn:nn
 
 
 index_helper > (2 calls)
 0: int_list.index_helper<0>
-index_helper(lst##0:int_list.int_list, idx##0:wybe.int, x##0:wybe.int, ?$##0:wybe.int):
+index_helper(lst##0:int_list.int_list, idx##0:wybe.int, x##0:wybe.int, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.bool)
-    case ~tmp$7##0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.bool)
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(-1:wybe.int, ?$##0:wybe.int) @int_list:nn:nn
+        foreign llvm move(-1:wybe.int, ?###0:wybe.int) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
         foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
-        foreign llvm icmp_eq(~h##0:wybe.int, x##0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
-        case ~tmp$4##0:wybe.bool of
+        foreign llvm icmp_eq(~h##0:wybe.int, x##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
+        case ~tmp#4##0:wybe.bool of
         0:
-            foreign llvm add(~idx##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
-            int_list.index_helper<0>(~t##0:int_list.int_list, ~tmp$3##0:wybe.int, ~x##0:wybe.int, ?$##0:wybe.int) #3 @int_list:nn:nn
+            foreign llvm add(~idx##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
+            int_list.index_helper<0>(~t##0:int_list.int_list, ~tmp#3##0:wybe.int, ~x##0:wybe.int, ?###0:wybe.int) #3 @int_list:nn:nn
 
         1:
-            foreign llvm move(~idx##0:wybe.int, ?$##0:wybe.int) @int_list:nn:nn
+            foreign llvm move(~idx##0:wybe.int, ?###0:wybe.int) @int_list:nn:nn
 
 
 
 
 insert > public (2 calls)
 0: int_list.insert<0>[410bae77d3]
-insert(lst##0:int_list.int_list, idx##0:wybe.int, v##0:wybe.int, ?$##0:int_list.int_list):
- AliasPairs: [($##0,lst##0)]
+insert(lst##0:int_list.int_list, idx##0:wybe.int, v##0:wybe.int, ?###0:int_list.int_list):
+ AliasPairs: [(###0,lst##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(4,(int_list.insert<0>,fromList [NonAliasedParamCond 0 [0]])),(7,(int_list.insert<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_eq(idx##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool) @int:nn:nn
-    case ~tmp$9##0:wybe.bool of
+    foreign llvm icmp_eq(idx##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool) @int:nn:nn
+    case ~tmp#9##0:wybe.bool of
     0:
-        foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$13##0:wybe.bool)
-        case ~tmp$13##0:wybe.bool of
+        foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#13##0:wybe.bool)
+        case ~tmp#13##0:wybe.bool of
         0:
-            foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp$7##0:wybe.int) @int:nn:nn
-            int_list.insert<0>(~lst##0:int_list.int_list, ~tmp$7##0:wybe.int, ~v##0:wybe.int, ?$##0:int_list.int_list) #7 @int_list:nn:nn
+            foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp#7##0:wybe.int) @int:nn:nn
+            int_list.insert<0>(~lst##0:int_list.int_list, ~tmp#7##0:wybe.int, ~v##0:wybe.int, ?###0:int_list.int_list) #7 @int_list:nn:nn
 
         1:
             foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
             foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
-            foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp$5##0:wybe.int) @int:nn:nn
-            int_list.insert<0>(~t##0:int_list.int_list, ~tmp$5##0:wybe.int, ~v##0:wybe.int, ?tmp$4##0:int_list.int_list) #4 @int_list:nn:nn
-            foreign lpvm alloc(16:wybe.int, ?tmp$18##0:int_list.int_list)
-            foreign lpvm mutate(~tmp$18##0:int_list.int_list, ?tmp$19##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-            foreign lpvm mutate(~tmp$19##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$4##0:int_list.int_list)
+            foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp#5##0:wybe.int) @int:nn:nn
+            int_list.insert<0>(~t##0:int_list.int_list, ~tmp#5##0:wybe.int, ~v##0:wybe.int, ?tmp#4##0:int_list.int_list) #4 @int_list:nn:nn
+            foreign lpvm alloc(16:wybe.int, ?tmp#18##0:int_list.int_list)
+            foreign lpvm mutate(~tmp#18##0:int_list.int_list, ?tmp#19##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+            foreign lpvm mutate(~tmp#19##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#4##0:int_list.int_list)
 
 
     1:
-        foreign lpvm alloc(16:wybe.int, ?tmp$14##0:int_list.int_list)
-        foreign lpvm mutate(~tmp$14##0:int_list.int_list, ?tmp$15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
-        foreign lpvm mutate(~tmp$15##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lst##0:int_list.int_list)
+        foreign lpvm alloc(16:wybe.int, ?tmp#14##0:int_list.int_list)
+        foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
+        foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lst##0:int_list.int_list)
 
 
 
 lesser > (3 calls)
 0: int_list.lesser<0>
-lesser(lst##0:int_list.int_list, v##0:wybe.int, ?$##0:int_list.int_list):
+lesser(lst##0:int_list.int_list, v##0:wybe.int, ?###0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.lesser<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.lesser<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
-    case ~tmp$9##0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
+    case ~tmp#9##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
         foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
-        foreign llvm icmp_slt(h##0:wybe.int, v##0:wybe.int, ?tmp$6##0:wybe.bool) @int:nn:nn
-        case ~tmp$6##0:wybe.bool of
+        foreign llvm icmp_slt(h##0:wybe.int, v##0:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
+        case ~tmp#6##0:wybe.bool of
         0:
-            int_list.lesser<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?$##0:int_list.int_list) #4 @int_list:nn:nn
+            int_list.lesser<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?###0:int_list.int_list) #4 @int_list:nn:nn
 
         1:
-            int_list.lesser<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp$3##0:int_list.int_list) #2 @int_list:nn:nn
-            foreign lpvm alloc(16:wybe.int, ?tmp$14##0:int_list.int_list)
-            foreign lpvm mutate(~tmp$14##0:int_list.int_list, ?tmp$15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-            foreign lpvm mutate(~tmp$15##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:int_list.int_list)
+            int_list.lesser<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp#3##0:int_list.int_list) #2 @int_list:nn:nn
+            foreign lpvm alloc(16:wybe.int, ?tmp#14##0:int_list.int_list)
+            foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+            foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
 
 
 
 
 pop > public (1 calls)
 0: int_list.pop<0>[410bae77d3]
-pop(lst##0:int_list.int_list, idx##0:wybe.int, ?$##0:int_list.int_list):
- AliasPairs: [($##0,lst##0)]
+pop(lst##0:int_list.int_list, idx##0:wybe.int, ?###0:int_list.int_list):
+ AliasPairs: [(###0,lst##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(3,(int_list.pop<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
-    case ~tmp$9##0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
+    case ~tmp#9##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
         foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
-        foreign llvm icmp_eq(idx##0:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.bool) @int:nn:nn
-        case ~tmp$6##0:wybe.bool of
+        foreign llvm icmp_eq(idx##0:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
+        case ~tmp#6##0:wybe.bool of
         0:
-            foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp$4##0:wybe.int) @int:nn:nn
-            int_list.pop<0>(~t##0:int_list.int_list, ~tmp$4##0:wybe.int, ?tmp$3##0:int_list.int_list) #3 @int_list:nn:nn
-            foreign lpvm alloc(16:wybe.int, ?tmp$16##0:int_list.int_list)
-            foreign lpvm mutate(~tmp$16##0:int_list.int_list, ?tmp$17##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-            foreign lpvm mutate(~tmp$17##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:int_list.int_list)
+            foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp#4##0:wybe.int) @int:nn:nn
+            int_list.pop<0>(~t##0:int_list.int_list, ~tmp#4##0:wybe.int, ?tmp#3##0:int_list.int_list) #3 @int_list:nn:nn
+            foreign lpvm alloc(16:wybe.int, ?tmp#16##0:int_list.int_list)
+            foreign lpvm mutate(~tmp#16##0:int_list.int_list, ?tmp#17##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+            foreign lpvm mutate(~tmp#17##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
 
         1:
-            foreign llvm move(~t##0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
+            foreign llvm move(~t##0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
 
 
 
@@ -509,8 +509,8 @@ print > public (2 calls)
 print(x##0:int_list.int_list, io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.bool)
-    case ~tmp$2##0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.bool)
+    case ~tmp#2##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##3:wybe.phantom)
 
@@ -537,88 +537,88 @@ range > public {inline} (0 calls)
 range(start##0:wybe.int, stop##0:wybe.int, step##0:wybe.int, ?result##1:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    int_list.gen$2<0>(0:int_list.int_list, ~start##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, 0:int_list.int_list, ?result##1:int_list.int_list) #1 @int_list:nn:nn
+    int_list.gen#2<0>(0:int_list.int_list, ~start##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, 0:int_list.int_list, ?result##1:int_list.int_list) #1 @int_list:nn:nn
 
 
 remove > public (1 calls)
 0: int_list.remove<0>[410bae77d3]
-remove(lst##0:int_list.int_list, v##0:wybe.int, ?$##0:int_list.int_list):
- AliasPairs: [($##0,lst##0)]
+remove(lst##0:int_list.int_list, v##0:wybe.int, ?###0:int_list.int_list):
+ AliasPairs: [(###0,lst##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.remove<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.bool)
-    case ~tmp$8##0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool)
+    case ~tmp#8##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
         foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
-        foreign llvm icmp_eq(h##0:wybe.int, v##0:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
-        case ~tmp$5##0:wybe.bool of
+        foreign llvm icmp_eq(h##0:wybe.int, v##0:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
+        case ~tmp#5##0:wybe.bool of
         0:
-            int_list.remove<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp$3##0:int_list.int_list) #2 @int_list:nn:nn
-            foreign lpvm alloc(16:wybe.int, ?tmp$13##0:int_list.int_list)
-            foreign lpvm mutate(~tmp$13##0:int_list.int_list, ?tmp$14##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-            foreign lpvm mutate(~tmp$14##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:int_list.int_list)
+            int_list.remove<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp#3##0:int_list.int_list) #2 @int_list:nn:nn
+            foreign lpvm alloc(16:wybe.int, ?tmp#13##0:int_list.int_list)
+            foreign lpvm mutate(~tmp#13##0:int_list.int_list, ?tmp#14##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+            foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
 
         1:
-            foreign llvm move(~t##0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
+            foreign llvm move(~t##0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
 
 
 
 
 reverse > public {inline} (1 calls)
 0: int_list.reverse<0>
-reverse(lst##0:int_list.int_list, ?$##0:int_list.int_list):
+reverse(lst##0:int_list.int_list, ?###0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    int_list.reverse_helper<0>(~lst##0:int_list.int_list, 0:int_list.int_list, ?$##0:int_list.int_list) #1 @int_list:nn:nn
+    int_list.reverse_helper<0>(~lst##0:int_list.int_list, 0:int_list.int_list, ?###0:int_list.int_list) #1 @int_list:nn:nn
 
 
 reverse_helper > (2 calls)
 0: int_list.reverse_helper<0>
-reverse_helper(lst##0:int_list.int_list, acc##0:int_list.int_list, ?$##0:int_list.int_list):
- AliasPairs: [($##0,acc##0)]
+reverse_helper(lst##0:int_list.int_list, acc##0:int_list.int_list, ?###0:int_list.int_list):
+ AliasPairs: [(###0,acc##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
-    case ~tmp$5##0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
+    case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~acc##0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(~acc##0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
         foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
-        foreign lpvm alloc(16:wybe.int, ?tmp$8##0:int_list.int_list)
-        foreign lpvm mutate(~tmp$8##0:int_list.int_list, ?tmp$9##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-        foreign lpvm mutate(~tmp$9##0:int_list.int_list, ?tmp$10##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~acc##0:int_list.int_list)
-        int_list.reverse_helper<0>(~t##0:int_list.int_list, ~tmp$10##0:int_list.int_list, ?$##0:int_list.int_list) #2 @int_list:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:int_list.int_list)
+        foreign lpvm mutate(~tmp#8##0:int_list.int_list, ?tmp#9##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+        foreign lpvm mutate(~tmp#9##0:int_list.int_list, ?tmp#10##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~acc##0:int_list.int_list)
+        int_list.reverse_helper<0>(~t##0:int_list.int_list, ~tmp#10##0:int_list.int_list, ?###0:int_list.int_list) #2 @int_list:nn:nn
 
 
 
 sort > public (2 calls)
 0: int_list.sort<0>[410bae77d3]
-sort(lst##0:int_list.int_list, ?$##0:int_list.int_list):
+sort(lst##0:int_list.int_list, ?###0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.sort<0>,fromList [NonAliasedParamCond 0 []])),(3,(int_list.greater<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.sort<0>,fromList [NonAliasedParamCond 0 []])),(6,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.bool)
-    case ~tmp$10##0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
+    case ~tmp#10##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
         foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
-        int_list.lesser<0>(t##0:int_list.int_list, h##0:wybe.int, ?tmp$3##0:int_list.int_list) #1 @int_list:nn:nn
-        int_list.sort<0>[410bae77d3](~tmp$3##0:int_list.int_list, ?tmp$2##0:int_list.int_list) #2 @int_list:nn:nn
-        int_list.greater<0>(~t##0:int_list.int_list, h##0:wybe.int, ?tmp$6##0:int_list.int_list) #3 @int_list:nn:nn
-        int_list.sort<0>[410bae77d3](~tmp$6##0:int_list.int_list, ?tmp$5##0:int_list.int_list) #4 @int_list:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$13##0:int_list.int_list)
-        foreign lpvm mutate(~tmp$13##0:int_list.int_list, ?tmp$14##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-        foreign lpvm mutate(~tmp$14##0:int_list.int_list, ?tmp$15##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$5##0:int_list.int_list)
-        int_list.extend<0>[410bae77d3](~tmp$2##0:int_list.int_list, ~tmp$15##0:int_list.int_list, ?$##0:int_list.int_list) #6 @int_list:nn:nn
+        int_list.lesser<0>(t##0:int_list.int_list, h##0:wybe.int, ?tmp#3##0:int_list.int_list) #1 @int_list:nn:nn
+        int_list.sort<0>[410bae77d3](~tmp#3##0:int_list.int_list, ?tmp#2##0:int_list.int_list) #2 @int_list:nn:nn
+        int_list.greater<0>(~t##0:int_list.int_list, h##0:wybe.int, ?tmp#6##0:int_list.int_list) #3 @int_list:nn:nn
+        int_list.sort<0>[410bae77d3](~tmp#6##0:int_list.int_list, ?tmp#5##0:int_list.int_list) #4 @int_list:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#13##0:int_list.int_list)
+        foreign lpvm mutate(~tmp#13##0:int_list.int_list, ?tmp#14##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+        foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##0:int_list.int_list)
+        int_list.extend<0>[410bae77d3](~tmp#2##0:int_list.int_list, ~tmp#15##0:int_list.int_list, ?###0:int_list.int_list) #6 @int_list:nn:nn
 
 
 LLVM code       : None
@@ -644,32 +644,32 @@ LLVM code       : None
 
 = > public (2 calls)
 0: int_list.int_list.=<0>
-=($left##0:int_list.int_list, $right##0:int_list.int_list, ?$$##0:wybe.bool):
+=(#left##0:int_list.int_list, #right##0:int_list.int_list, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left##0:int_list.int_list, ~$right##0:int_list.int_list, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:int_list.int_list, ~#right##0:int_list.int_list, ?####0:wybe.bool)
 
     1:
-        foreign lpvm access($left##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$head##0:wybe.int)
-        foreign lpvm access(~$left##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$tail##0:int_list.int_list)
-        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
-        case ~tmp$9##0:wybe.bool of
+        foreign lpvm access(#left##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#head##0:wybe.int)
+        foreign lpvm access(~#left##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#tail##0:int_list.int_list)
+        foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
+        case ~tmp#9##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign lpvm access($right##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$head##0:wybe.int)
-            foreign lpvm access(~$right##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$tail##0:int_list.int_list)
-            foreign llvm icmp_eq(~$left$head##0:wybe.int, ~$right$head##0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
-            case ~tmp$4##0:wybe.bool of
+            foreign lpvm access(#right##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#head##0:wybe.int)
+            foreign lpvm access(~#right##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#tail##0:int_list.int_list)
+            foreign llvm icmp_eq(~#left#head##0:wybe.int, ~#right#head##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
+            case ~tmp#4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
             1:
-                int_list.int_list.=<0>(~$left$tail##0:int_list.int_list, ~$right$tail##0:int_list.int_list, ?$$##0:wybe.bool) #3
+                int_list.int_list.=<0>(~#left#tail##0:int_list.int_list, ~#right#tail##0:int_list.int_list, ?####0:wybe.bool) #3
 
 
 
@@ -677,110 +677,110 @@ LLVM code       : None
 
 cons > public {inline} (0 calls)
 0: int_list.int_list.cons<0>
-cons(head##0:wybe.int, tail##0:int_list.int_list, ?$##0:int_list.int_list):
+cons(head##0:wybe.int, tail##0:int_list.int_list, ?###0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:int_list.int_list)
-    foreign lpvm mutate(~$rec##0:int_list.int_list, ?$rec##1:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:int_list.int_list)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:int_list.int_list)
+    foreign lpvm mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:int_list.int_list)
 cons > public {inline} (12 calls)
 1: int_list.int_list.cons<1>
-cons(?head##0:wybe.int, ?tail##0:int_list.int_list, $##0:int_list.int_list, ?$$##0:wybe.bool):
+cons(?head##0:wybe.int, ?tail##0:int_list.int_list, ###0:int_list.int_list, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?head##0:wybe.int)
         foreign llvm move(undef:int_list.int_list, ?tail##0:int_list.int_list)
 
     1:
-        foreign lpvm access($##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
-        foreign lpvm access(~$##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:int_list.int_list)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(###0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
+        foreign lpvm access(~###0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:int_list.int_list)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 head > public {inline} (0 calls)
 0: int_list.int_list.head<0>
-head($rec##0:int_list.int_list, ?$##0:wybe.int, ?$$##0:wybe.bool):
+head(#rec##0:int_list.int_list, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 head > public {inline} (0 calls)
 1: int_list.int_list.head<1>
-head($rec##0:int_list.int_list, ?$rec##1:int_list.int_list, $field##0:wybe.int, ?$$##0:wybe.bool):
+head(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:int_list.int_list, ?$rec##1:int_list.int_list)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list)
 
     1:
-        foreign lpvm mutate(~$rec##0:int_list.int_list, ?$rec##1:int_list.int_list, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 nil > public {inline} (0 calls)
 0: int_list.int_list.nil<0>
-nil(?$##0:int_list.int_list):
+nil(?###0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:int_list.int_list, ?$##0:int_list.int_list)
+    foreign llvm move(0:int_list.int_list, ?###0:int_list.int_list)
 
 
 tail > public {inline} (0 calls)
 0: int_list.int_list.tail<0>
-tail($rec##0:int_list.int_list, ?$##0:int_list.int_list, ?$$##0:wybe.bool):
+tail(#rec##0:int_list.int_list, ?###0:int_list.int_list, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:int_list.int_list, ?$##0:int_list.int_list)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:int_list.int_list, ?###0:int_list.int_list)
 
     1:
-        foreign lpvm access(~$rec##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:int_list.int_list)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:int_list.int_list)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 tail > public {inline} (0 calls)
 1: int_list.int_list.tail<1>
-tail($rec##0:int_list.int_list, ?$rec##1:int_list.int_list, $field##0:int_list.int_list, ?$$##0:wybe.bool):
+tail(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:int_list.int_list, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:int_list.int_list, ?$rec##1:int_list.int_list)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec##0:int_list.int_list, ?$rec##1:int_list.int_list, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:int_list.int_list)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm {noalias} mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:int_list.int_list)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: int_list.int_list.~=<0>
-~=($left##0:int_list.int_list, $right##0:int_list.int_list, ?$$##0:wybe.bool):
+~=(#left##0:int_list.int_list, #right##0:int_list.int_list, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    int_list.int_list.=<0>(~$left##0:int_list.int_list, ~$right##0:int_list.int_list, ?tmp$0##0:wybe.bool) #0
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    int_list.int_list.=<0>(~#left##0:int_list.int_list, ~#right##0:int_list.int_list, ?tmp#0##0:wybe.bool) #0
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 LLVM code       : None
 
@@ -801,58 +801,58 @@ LLVM code       : None
 (io##0:wybe.phantom, ?io##22:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
- MultiSpeczDepInfo: [(24,(int_list_test.test_int_list<0>,fromList [NonAliasedParamCond 0 [],NonAliasedParamCond 1 [],NonAliasedParamCond 2 []])),(34,(int_list.gen$2<0>,fromList [NonAliasedParamCond 0 []])),(35,(int_list.gen$2<0>,fromList [NonAliasedParamCond 0 []])),(36,(int_list.gen$2<0>,fromList [NonAliasedParamCond 0 []]))]
+ MultiSpeczDepInfo: [(24,(int_list_test.test_int_list<0>,fromList [NonAliasedParamCond 0 [],NonAliasedParamCond 1 [],NonAliasedParamCond 2 []])),(34,(int_list.gen#2<0>,fromList [NonAliasedParamCond 0 []])),(35,(int_list.gen#2<0>,fromList [NonAliasedParamCond 0 []])),(36,(int_list.gen#2<0>,fromList [NonAliasedParamCond 0 []]))]
     foreign c {impure} malloc_count(?mc1##0:wybe.int) @memory_management:nn:nn
-    int_list.gen$2<0>[410bae77d3](0:int_list.int_list, 1:wybe.int, 1:wybe.int, 10:wybe.int, 0:int_list.int_list, ?tmp$0##0:int_list.int_list) #34 @int_list:nn:nn
-    int_list.gen$2<0>[410bae77d3](0:int_list.int_list, 2:wybe.int, 2:wybe.int, 20:wybe.int, 0:int_list.int_list, ?tmp$1##0:int_list.int_list) #35 @int_list:nn:nn
-    int_list.gen$2<0>[410bae77d3](0:int_list.int_list, 3:wybe.int, 3:wybe.int, 30:wybe.int, 0:int_list.int_list, ?tmp$2##0:int_list.int_list) #36 @int_list:nn:nn
-    foreign c print_string("x y z:":wybe.string, ~#io##0:wybe.phantom, ?tmp$17##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$17##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$0##0:int_list.int_list, ~#io##1:wybe.phantom, ?tmp$20##0:wybe.phantom) #37 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$20##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$1##0:int_list.int_list, ~#io##2:wybe.phantom, ?tmp$23##0:wybe.phantom) #38 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$23##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$2##0:int_list.int_list, ~#io##3:wybe.phantom, ?tmp$26##0:wybe.phantom) #39 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$26##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    int_list.gen#2<0>[410bae77d3](0:int_list.int_list, 1:wybe.int, 1:wybe.int, 10:wybe.int, 0:int_list.int_list, ?tmp#0##0:int_list.int_list) #34 @int_list:nn:nn
+    int_list.gen#2<0>[410bae77d3](0:int_list.int_list, 2:wybe.int, 2:wybe.int, 20:wybe.int, 0:int_list.int_list, ?tmp#1##0:int_list.int_list) #35 @int_list:nn:nn
+    int_list.gen#2<0>[410bae77d3](0:int_list.int_list, 3:wybe.int, 3:wybe.int, 30:wybe.int, 0:int_list.int_list, ?tmp#2##0:int_list.int_list) #36 @int_list:nn:nn
+    foreign c print_string("x y z:":wybe.string, ~#io##0:wybe.phantom, ?tmp#17##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#17##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp#0##0:int_list.int_list, ~#io##1:wybe.phantom, ?tmp#20##0:wybe.phantom) #37 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#20##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp#1##0:int_list.int_list, ~#io##2:wybe.phantom, ?tmp#23##0:wybe.phantom) #38 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#23##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp#2##0:int_list.int_list, ~#io##3:wybe.phantom, ?tmp#26##0:wybe.phantom) #39 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#26##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     foreign c {impure} malloc_count(?mc2##0:wybe.int) @memory_management:nn:nn
-    foreign llvm sub(~mc2##0:wybe.int, ~mc1##0:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
-    foreign c print_string("--------------------":wybe.string, ~#io##4:wybe.phantom, ?tmp$31##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$31##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
-    foreign c print_string("tests with alias":wybe.string, ~#io##5:wybe.phantom, ?tmp$34##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$34##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+    foreign llvm sub(~mc2##0:wybe.int, ~mc1##0:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
+    foreign c print_string("--------------------":wybe.string, ~#io##4:wybe.phantom, ?tmp#31##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#31##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign c print_string("tests with alias":wybe.string, ~#io##5:wybe.phantom, ?tmp#34##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#34##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
     foreign c {impure} malloc_count(?mc1##1:wybe.int) @memory_management:nn:nn
-    int_list_test.test_int_list<0>(tmp$0##0:int_list.int_list, tmp$1##0:int_list.int_list, tmp$2##0:int_list.int_list, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) #13 @int_list_test:nn:nn
+    int_list_test.test_int_list<0>(tmp#0##0:int_list.int_list, tmp#1##0:int_list.int_list, tmp#2##0:int_list.int_list, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) #13 @int_list_test:nn:nn
     foreign c {impure} malloc_count(?mc2##1:wybe.int) @memory_management:nn:nn
-    foreign llvm sub(~mc2##1:wybe.int, ~mc1##1:wybe.int, ?tmp$4##0:wybe.int) @int:nn:nn
-    foreign c print_string("original x y z:":wybe.string, ~#io##7:wybe.phantom, ?tmp$39##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$39##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$0##0:int_list.int_list, ~#io##8:wybe.phantom, ?tmp$42##0:wybe.phantom) #40 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$42##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$1##0:int_list.int_list, ~#io##9:wybe.phantom, ?tmp$45##0:wybe.phantom) #41 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$45##0:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$2##0:int_list.int_list, ~#io##10:wybe.phantom, ?tmp$48##0:wybe.phantom) #42 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$48##0:wybe.phantom, ?#io##11:wybe.phantom) @io:nn:nn
-    foreign c print_string("--------------------":wybe.string, ~#io##11:wybe.phantom, ?tmp$51##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$51##0:wybe.phantom, ?#io##12:wybe.phantom) @io:nn:nn
-    foreign c print_string("--------------------":wybe.string, ~#io##12:wybe.phantom, ?tmp$54##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$54##0:wybe.phantom, ?#io##13:wybe.phantom) @io:nn:nn
-    foreign c print_string("tests without alias":wybe.string, ~#io##13:wybe.phantom, ?tmp$57##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$57##0:wybe.phantom, ?#io##14:wybe.phantom) @io:nn:nn
+    foreign llvm sub(~mc2##1:wybe.int, ~mc1##1:wybe.int, ?tmp#4##0:wybe.int) @int:nn:nn
+    foreign c print_string("original x y z:":wybe.string, ~#io##7:wybe.phantom, ?tmp#39##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#39##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp#0##0:int_list.int_list, ~#io##8:wybe.phantom, ?tmp#42##0:wybe.phantom) #40 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#42##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp#1##0:int_list.int_list, ~#io##9:wybe.phantom, ?tmp#45##0:wybe.phantom) #41 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#45##0:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp#2##0:int_list.int_list, ~#io##10:wybe.phantom, ?tmp#48##0:wybe.phantom) #42 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#48##0:wybe.phantom, ?#io##11:wybe.phantom) @io:nn:nn
+    foreign c print_string("--------------------":wybe.string, ~#io##11:wybe.phantom, ?tmp#51##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#51##0:wybe.phantom, ?#io##12:wybe.phantom) @io:nn:nn
+    foreign c print_string("--------------------":wybe.string, ~#io##12:wybe.phantom, ?tmp#54##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#54##0:wybe.phantom, ?#io##13:wybe.phantom) @io:nn:nn
+    foreign c print_string("tests without alias":wybe.string, ~#io##13:wybe.phantom, ?tmp#57##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#57##0:wybe.phantom, ?#io##14:wybe.phantom) @io:nn:nn
     foreign c {impure} malloc_count(?mc1##2:wybe.int) @memory_management:nn:nn
-    int_list_test.test_int_list<0>[9e35cb823b](~tmp$0##0:int_list.int_list, ~tmp$1##0:int_list.int_list, ~tmp$2##0:int_list.int_list, ~#io##14:wybe.phantom, ?#io##15:wybe.phantom) #24 @int_list_test:nn:nn
+    int_list_test.test_int_list<0>[9e35cb823b](~tmp#0##0:int_list.int_list, ~tmp#1##0:int_list.int_list, ~tmp#2##0:int_list.int_list, ~#io##14:wybe.phantom, ?#io##15:wybe.phantom) #24 @int_list_test:nn:nn
     foreign c {impure} malloc_count(?mc2##2:wybe.int) @memory_management:nn:nn
-    foreign llvm sub(~mc2##2:wybe.int, ~mc1##2:wybe.int, ?tmp$5##0:wybe.int) @int:nn:nn
-    foreign c print_string("--------------------":wybe.string, ~#io##15:wybe.phantom, ?tmp$62##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$62##0:wybe.phantom, ?#io##16:wybe.phantom) @io:nn:nn
+    foreign llvm sub(~mc2##2:wybe.int, ~mc1##2:wybe.int, ?tmp#5##0:wybe.int) @int:nn:nn
+    foreign c print_string("--------------------":wybe.string, ~#io##15:wybe.phantom, ?tmp#62##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#62##0:wybe.phantom, ?#io##16:wybe.phantom) @io:nn:nn
     foreign c print_string(" ** malloc count of building lists: ":wybe.string, ~#io##16:wybe.phantom, ?#io##17:wybe.phantom) @io:nn:nn
-    foreign c print_int(~tmp$3##0:wybe.int, ~#io##17:wybe.phantom, ?tmp$67##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$67##0:wybe.phantom, ?#io##18:wybe.phantom) @io:nn:nn
+    foreign c print_int(~tmp#3##0:wybe.int, ~#io##17:wybe.phantom, ?tmp#67##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#67##0:wybe.phantom, ?#io##18:wybe.phantom) @io:nn:nn
     foreign c print_string(" ** malloc count of test(aliased): ":wybe.string, ~#io##18:wybe.phantom, ?#io##19:wybe.phantom) @io:nn:nn
-    foreign c print_int(~tmp$4##0:wybe.int, ~#io##19:wybe.phantom, ?tmp$72##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$72##0:wybe.phantom, ?#io##20:wybe.phantom) @io:nn:nn
+    foreign c print_int(~tmp#4##0:wybe.int, ~#io##19:wybe.phantom, ?tmp#72##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#72##0:wybe.phantom, ?#io##20:wybe.phantom) @io:nn:nn
     foreign c print_string(" ** malloc count of test(non-aliased): ":wybe.string, ~#io##20:wybe.phantom, ?#io##21:wybe.phantom) @io:nn:nn
-    foreign c print_int(~tmp$5##0:wybe.int, ~#io##21:wybe.phantom, ?tmp$77##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$77##0:wybe.phantom, ?#io##22:wybe.phantom) @io:nn:nn
+    foreign c print_int(~tmp#5##0:wybe.int, ~#io##21:wybe.phantom, ?tmp#77##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#77##0:wybe.phantom, ?#io##22:wybe.phantom) @io:nn:nn
 
 
 test_int_list > (2 calls)
@@ -863,33 +863,33 @@ test_int_list(x##0:int_list.int_list, y##0:int_list.int_list, z##0:int_list.int_
  MultiSpeczDepInfo: [(2,(int_list.append<0>,fromList [NonAliasedParamCond 0 [1]])),(7,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []])),(8,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []])),(11,(int_list.insert<0>,fromList [NonAliasedParamCond 0 []])),(12,(int_list.pop<0>,fromList [NonAliasedParamCond 0 []])),(13,(int_list.remove<0>,fromList [NonAliasedParamCond 0 []])),(16,(int_list.sort<0>,fromList [NonAliasedParamCond 0 []])),(19,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]])),(20,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [2]]))]
     int_list.reverse_helper<0>(~x##0:int_list.int_list, 0:int_list.int_list, ?x##1:int_list.int_list) #19 @int_list:nn:nn
     int_list.reverse_helper<0>(~z##0:int_list.int_list, 0:int_list.int_list, ?z##1:int_list.int_list) #20 @int_list:nn:nn
-    int_list.append<0>(~y##0:int_list.int_list, 99:wybe.int, ?tmp$0##0:int_list.int_list) #2 @int_list_test:nn:nn
-    foreign c print_string("-":wybe.string, ~#io##0:wybe.phantom, ?tmp$10##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    int_list.print<0>(x##1:int_list.int_list, ~#io##1:wybe.phantom, ?tmp$13##0:wybe.phantom) #21 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$13##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$0##0:int_list.int_list, ~#io##2:wybe.phantom, ?tmp$16##0:wybe.phantom) #22 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$16##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    int_list.print<0>(z##1:int_list.int_list, ~#io##3:wybe.phantom, ?tmp$19##0:wybe.phantom) #23 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$19##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    int_list.extend<0>[410bae77d3](~x##1:int_list.int_list, ~tmp$0##0:int_list.int_list, ?tmp$1##0:int_list.int_list) #7 @int_list_test:nn:nn
-    int_list.extend<0>[410bae77d3](~tmp$1##0:int_list.int_list, ~z##1:int_list.int_list, ?tmp$2##0:int_list.int_list) #8 @int_list_test:nn:nn
-    foreign c print_string("-":wybe.string, ~#io##4:wybe.phantom, ?tmp$22##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$22##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$2##0:int_list.int_list, ~#io##5:wybe.phantom, ?tmp$25##0:wybe.phantom) #24 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$25##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
-    int_list.insert<0>[410bae77d3](~tmp$2##0:int_list.int_list, 4:wybe.int, 78:wybe.int, ?tmp$3##0:int_list.int_list) #11 @int_list_test:nn:nn
-    int_list.pop<0>[410bae77d3](~tmp$3##0:int_list.int_list, 20:wybe.int, ?tmp$4##0:int_list.int_list) #12 @int_list_test:nn:nn
-    int_list.remove<0>[410bae77d3](~tmp$4##0:int_list.int_list, 2:wybe.int, ?tmp$5##0:int_list.int_list) #13 @int_list_test:nn:nn
-    foreign c print_string("-":wybe.string, ~#io##6:wybe.phantom, ?tmp$28##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$28##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$5##0:int_list.int_list, ~#io##7:wybe.phantom, ?tmp$31##0:wybe.phantom) #25 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$31##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
-    int_list.sort<0>[410bae77d3](~tmp$5##0:int_list.int_list, ?l##5:int_list.int_list) #16 @int_list_test:nn:nn
-    foreign c print_string("-":wybe.string, ~#io##8:wybe.phantom, ?tmp$34##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$34##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
-    int_list.print<0>(~l##5:int_list.int_list, ~#io##9:wybe.phantom, ?tmp$37##0:wybe.phantom) #26 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$37##0:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
+    int_list.append<0>(~y##0:int_list.int_list, 99:wybe.int, ?tmp#0##0:int_list.int_list) #2 @int_list_test:nn:nn
+    foreign c print_string("-":wybe.string, ~#io##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    int_list.print<0>(x##1:int_list.int_list, ~#io##1:wybe.phantom, ?tmp#13##0:wybe.phantom) #21 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp#0##0:int_list.int_list, ~#io##2:wybe.phantom, ?tmp#16##0:wybe.phantom) #22 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    int_list.print<0>(z##1:int_list.int_list, ~#io##3:wybe.phantom, ?tmp#19##0:wybe.phantom) #23 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#19##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    int_list.extend<0>[410bae77d3](~x##1:int_list.int_list, ~tmp#0##0:int_list.int_list, ?tmp#1##0:int_list.int_list) #7 @int_list_test:nn:nn
+    int_list.extend<0>[410bae77d3](~tmp#1##0:int_list.int_list, ~z##1:int_list.int_list, ?tmp#2##0:int_list.int_list) #8 @int_list_test:nn:nn
+    foreign c print_string("-":wybe.string, ~#io##4:wybe.phantom, ?tmp#22##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#22##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp#2##0:int_list.int_list, ~#io##5:wybe.phantom, ?tmp#25##0:wybe.phantom) #24 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#25##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+    int_list.insert<0>[410bae77d3](~tmp#2##0:int_list.int_list, 4:wybe.int, 78:wybe.int, ?tmp#3##0:int_list.int_list) #11 @int_list_test:nn:nn
+    int_list.pop<0>[410bae77d3](~tmp#3##0:int_list.int_list, 20:wybe.int, ?tmp#4##0:int_list.int_list) #12 @int_list_test:nn:nn
+    int_list.remove<0>[410bae77d3](~tmp#4##0:int_list.int_list, 2:wybe.int, ?tmp#5##0:int_list.int_list) #13 @int_list_test:nn:nn
+    foreign c print_string("-":wybe.string, ~#io##6:wybe.phantom, ?tmp#28##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#28##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp#5##0:int_list.int_list, ~#io##7:wybe.phantom, ?tmp#31##0:wybe.phantom) #25 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#31##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
+    int_list.sort<0>[410bae77d3](~tmp#5##0:int_list.int_list, ?l##5:int_list.int_list) #16 @int_list_test:nn:nn
+    foreign c print_string("-":wybe.string, ~#io##8:wybe.phantom, ?tmp#34##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#34##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
+    int_list.print<0>(~l##5:int_list.int_list, ~#io##9:wybe.phantom, ?tmp#37##0:wybe.phantom) #26 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#37##0:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
 
 LLVM code       : None
 
@@ -979,11 +979,11 @@ entry:
 (argc##0:wybe.int, [?argc##0:wybe.int], ?arguments##2:wybe.array(wybe.string), argv##0:wybe.array.raw_array(wybe.string), [?argv##0:wybe.array.raw_array(wybe.string)], ?command##2:wybe.string, ?exit_code##1:wybe.int, io##0:wybe.phantom, [?io##0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$9##0:wybe.array(?T))
-    foreign lpvm mutate(~tmp$9##0:wybe.array(?T), ?tmp$10##0:wybe.array(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
-    foreign lpvm mutate(~tmp$10##0:wybe.array(?T), ?tmp$1##0:wybe.array(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(?T))
-    wybe.array.[|]<0>(?command##2:?T, ?arguments##2:wybe.array(?T), ~tmp$1##0:wybe.array(?T), ?tmp$2##0:wybe.bool) #2 @command_line:nn:nn
-    case ~tmp$2##0:wybe.bool of
+    foreign lpvm alloc(16:wybe.int, ?tmp#9##0:wybe.array(?T))
+    foreign lpvm mutate(~tmp#9##0:wybe.array(?T), ?tmp#10##0:wybe.array(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
+    foreign lpvm mutate(~tmp#10##0:wybe.array(?T), ?tmp#1##0:wybe.array(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(?T))
+    wybe.array.[|]<0>(?command##2:?T, ?arguments##2:wybe.array(?T), ~tmp#1##0:wybe.array(?T), ?tmp#2##0:wybe.bool) #2 @command_line:nn:nn
+    case ~tmp#2##0:wybe.bool of
     0:
         foreign c {terminal,semipure} error_exit("command_line:17:10":wybe.string, "Erroneous program argument vector":wybe.string) @control:nn:nn
         foreign llvm move(0:wybe.int, ?exit_code##1:wybe.int)
@@ -1097,337 +1097,337 @@ entry:
 
 append > public (0 calls)
 0: int_list.append<0>[410bae77d3]
-append(lst##0:int_list.int_list, v##0:wybe.int, ?$##0:int_list.int_list):
+append(lst##0:int_list.int_list, v##0:wybe.int, ?###0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.extend<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign lpvm alloc(16:wybe.int, ?tmp$5##0:int_list.int_list)
-    foreign lpvm mutate(~tmp$5##0:int_list.int_list, ?tmp$6##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
-    foreign lpvm mutate(~tmp$6##0:int_list.int_list, ?tmp$7##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:int_list.int_list)
-    int_list.extend<0>(~lst##0:int_list.int_list, ~tmp$7##0:int_list.int_list, ?$##0:int_list.int_list) #2 @int_list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:int_list.int_list)
+    foreign lpvm mutate(~tmp#5##0:int_list.int_list, ?tmp#6##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
+    foreign lpvm mutate(~tmp#6##0:int_list.int_list, ?tmp#7##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:int_list.int_list)
+    int_list.extend<0>(~lst##0:int_list.int_list, ~tmp#7##0:int_list.int_list, ?###0:int_list.int_list) #2 @int_list:nn:nn
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm alloc(16:wybe.int, ?tmp$5##0:int_list.int_list)
-    foreign lpvm mutate(~tmp$5##0:int_list.int_list, ?tmp$6##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
-    foreign lpvm mutate(~tmp$6##0:int_list.int_list, ?tmp$7##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:int_list.int_list)
-    int_list.extend<0>[410bae77d3](~lst##0:int_list.int_list, ~tmp$7##0:int_list.int_list, ?$##0:int_list.int_list) #2 @int_list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:int_list.int_list)
+    foreign lpvm mutate(~tmp#5##0:int_list.int_list, ?tmp#6##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
+    foreign lpvm mutate(~tmp#6##0:int_list.int_list, ?tmp#7##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:int_list.int_list)
+    int_list.extend<0>[410bae77d3](~lst##0:int_list.int_list, ~tmp#7##0:int_list.int_list, ?###0:int_list.int_list) #2 @int_list:nn:nn
 
 
 count > public (3 calls)
 0: int_list.count<0>
-count(lst##0:int_list.int_list, x##0:wybe.int, ?$##0:wybe.int):
+count(lst##0:int_list.int_list, x##0:wybe.int, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.bool)
-    case ~tmp$7##0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.bool)
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.int, ?$##0:wybe.int) @int_list:nn:nn
+        foreign llvm move(0:wybe.int, ?###0:wybe.int) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
         foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
-        int_list.count<0>(~t##0:int_list.int_list, x##0:wybe.int, ?tmp$2##0:wybe.int) #1 @int_list:nn:nn
-        foreign llvm icmp_eq(~h##0:wybe.int, ~x##0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
-        case ~tmp$4##0:wybe.bool of
+        int_list.count<0>(~t##0:int_list.int_list, x##0:wybe.int, ?tmp#2##0:wybe.int) #1 @int_list:nn:nn
+        foreign llvm icmp_eq(~h##0:wybe.int, ~x##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
+        case ~tmp#4##0:wybe.bool of
         0:
-            foreign llvm move(~tmp$2##0:wybe.int, ?$##0:wybe.int) @int:nn:nn
+            foreign llvm move(~tmp#2##0:wybe.int, ?###0:wybe.int) @int:nn:nn
 
         1:
-            foreign llvm add(~tmp$2##0:wybe.int, 1:wybe.int, ?$##0:wybe.int) @int:nn:nn
+            foreign llvm add(~tmp#2##0:wybe.int, 1:wybe.int, ?###0:wybe.int) @int:nn:nn
 
 
 
 
 extend > public (3 calls)
 0: int_list.extend<0>[410bae77d3]
-extend(lst1##0:int_list.int_list, lst2##0:int_list.int_list, ?$##0:int_list.int_list):
- AliasPairs: [($##0,lst2##0)]
+extend(lst1##0:int_list.int_list, lst2##0:int_list.int_list, ?###0:int_list.int_list):
+ AliasPairs: [(###0,lst2##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(int_list.extend<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(lst1##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
-    case ~tmp$5##0:wybe.bool of
+    foreign llvm icmp_ne(lst1##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
+    case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~lst2##0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(~lst2##0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst1##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
         foreign lpvm access(~lst1##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
-        int_list.extend<0>(~t##0:int_list.int_list, ~lst2##0:int_list.int_list, ?tmp$2##0:int_list.int_list) #1 @int_list:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$8##0:int_list.int_list)
-        foreign lpvm mutate(~tmp$8##0:int_list.int_list, ?tmp$9##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-        foreign lpvm mutate(~tmp$9##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:int_list.int_list)
+        int_list.extend<0>(~t##0:int_list.int_list, ~lst2##0:int_list.int_list, ?tmp#2##0:int_list.int_list) #1 @int_list:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:int_list.int_list)
+        foreign lpvm mutate(~tmp#8##0:int_list.int_list, ?tmp#9##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+        foreign lpvm mutate(~tmp#9##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:int_list.int_list)
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_ne(lst1##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
-    case ~tmp$5##0:wybe.bool of
+    foreign llvm icmp_ne(lst1##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
+    case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~lst2##0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(~lst2##0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst1##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
-        int_list.extend<0>[410bae77d3](~t##0:int_list.int_list, ~lst2##0:int_list.int_list, ?tmp$2##0:int_list.int_list) #1 @int_list:nn:nn
-        foreign lpvm mutate(~lst1##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:int_list.int_list)
+        int_list.extend<0>[410bae77d3](~t##0:int_list.int_list, ~lst2##0:int_list.int_list, ?tmp#2##0:int_list.int_list) #1 @int_list:nn:nn
+        foreign lpvm mutate(~lst1##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:int_list.int_list)
 
 
 
-gen$1 > {inline} (2 calls)
-0: int_list.gen$1<0>
-gen$1([h##0:wybe.int], [lst##0:int_list.int_list], [t##0:int_list.int_list], tmp$2##0:wybe.int, tmp$3##0:wybe.int, [x##0:wybe.int], ?$##0:wybe.int):
+gen#1 > {inline} (2 calls)
+0: int_list.gen#1<0>
+gen#1([h##0:wybe.int], [lst##0:int_list.int_list], [t##0:int_list.int_list], tmp#2##0:wybe.int, tmp#3##0:wybe.int, [x##0:wybe.int], ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~tmp$2##0:wybe.int, ~tmp$3##0:wybe.int, ?$##0:wybe.int) @int:nn:nn
+    foreign llvm add(~tmp#2##0:wybe.int, ~tmp#3##0:wybe.int, ?###0:wybe.int) @int:nn:nn
 
 
-gen$2 > (2 calls)
-0: int_list.gen$2<0>
-gen$2(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, stop##0:wybe.int, tmp$0##0:int_list.int_list, ?result##1:int_list.int_list):
+gen#2 > (2 calls)
+0: int_list.gen#2<0>
+gen#2(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, stop##0:wybe.int, tmp#0##0:int_list.int_list, ?result##1:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
- MultiSpeczDepInfo: [(3,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.gen$2<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_slt(start##0:wybe.int, stop##0:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
-    case ~tmp$3##0:wybe.bool of
+ MultiSpeczDepInfo: [(3,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.gen#2<0>,fromList [NonAliasedParamCond 0 [0]]))]
+    foreign llvm icmp_slt(start##0:wybe.int, stop##0:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
+    case ~tmp#3##0:wybe.bool of
     0:
         int_list.reverse_helper<0>(~result##0:int_list.int_list, 0:int_list.int_list, ?result##1:int_list.int_list) #3 @int_list:nn:nn
 
     1:
-        foreign lpvm alloc(16:wybe.int, ?tmp$12##0:int_list.int_list)
-        foreign lpvm mutate(~tmp$12##0:int_list.int_list, ?tmp$13##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int)
-        foreign lpvm mutate(~tmp$13##0:int_list.int_list, ?tmp$14##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list)
-        foreign llvm add(~start##0:wybe.int, step##0:wybe.int, ?tmp$15##0:wybe.int) @int:nn:nn
-        int_list.gen$2<0>(~tmp$14##0:int_list.int_list, ~tmp$15##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ~tmp$0##0:int_list.int_list, ?result##1:int_list.int_list) #4 @int_list:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#12##0:int_list.int_list)
+        foreign lpvm mutate(~tmp#12##0:int_list.int_list, ?tmp#13##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int)
+        foreign lpvm mutate(~tmp#13##0:int_list.int_list, ?tmp#14##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list)
+        foreign llvm add(~start##0:wybe.int, step##0:wybe.int, ?tmp#15##0:wybe.int) @int:nn:nn
+        int_list.gen#2<0>(~tmp#14##0:int_list.int_list, ~tmp#15##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ~tmp#0##0:int_list.int_list, ?result##1:int_list.int_list) #4 @int_list:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_slt(start##0:wybe.int, stop##0:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
-    case ~tmp$3##0:wybe.bool of
+    foreign llvm icmp_slt(start##0:wybe.int, stop##0:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
+    case ~tmp#3##0:wybe.bool of
     0:
         int_list.reverse_helper<0>[410bae77d3](~result##0:int_list.int_list, 0:int_list.int_list, ?result##1:int_list.int_list) #3 @int_list:nn:nn
 
     1:
-        foreign lpvm alloc(16:wybe.int, ?tmp$12##0:int_list.int_list)
-        foreign lpvm mutate(~tmp$12##0:int_list.int_list, ?tmp$13##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int)
-        foreign lpvm mutate(~tmp$13##0:int_list.int_list, ?tmp$14##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list)
-        foreign llvm add(~start##0:wybe.int, step##0:wybe.int, ?tmp$15##0:wybe.int) @int:nn:nn
-        int_list.gen$2<0>[410bae77d3](~tmp$14##0:int_list.int_list, ~tmp$15##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ~tmp$0##0:int_list.int_list, ?result##1:int_list.int_list) #4 @int_list:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#12##0:int_list.int_list)
+        foreign lpvm mutate(~tmp#12##0:int_list.int_list, ?tmp#13##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int)
+        foreign lpvm mutate(~tmp#13##0:int_list.int_list, ?tmp#14##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list)
+        foreign llvm add(~start##0:wybe.int, step##0:wybe.int, ?tmp#15##0:wybe.int) @int:nn:nn
+        int_list.gen#2<0>[410bae77d3](~tmp#14##0:int_list.int_list, ~tmp#15##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ~tmp#0##0:int_list.int_list, ?result##1:int_list.int_list) #4 @int_list:nn:nn
 
 
 
-gen$3 > {inline} (1 calls)
-0: int_list.gen$3<0>
-gen$3(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, stop##0:wybe.int, tmp$0##0:int_list.int_list, ?result##2:int_list.int_list):
+gen#3 > {inline} (1 calls)
+0: int_list.gen#3<0>
+gen#3(result##0:int_list.int_list, start##0:wybe.int, step##0:wybe.int, stop##0:wybe.int, tmp#0##0:int_list.int_list, ?result##2:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$5##0:int_list.int_list)
-    foreign lpvm mutate(~tmp$5##0:int_list.int_list, ?tmp$6##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int)
-    foreign lpvm mutate(~tmp$6##0:int_list.int_list, ?tmp$7##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list)
-    foreign llvm add(~start##0:wybe.int, step##0:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
-    int_list.gen$2<0>(~tmp$7##0:int_list.int_list, ~tmp$2##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ~tmp$0##0:int_list.int_list, ?result##2:int_list.int_list) #2 @int_list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:int_list.int_list)
+    foreign lpvm mutate(~tmp#5##0:int_list.int_list, ?tmp#6##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, start##0:wybe.int)
+    foreign lpvm mutate(~tmp#6##0:int_list.int_list, ?tmp#7##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~result##0:int_list.int_list)
+    foreign llvm add(~start##0:wybe.int, step##0:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
+    int_list.gen#2<0>(~tmp#7##0:int_list.int_list, ~tmp#2##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, ~tmp#0##0:int_list.int_list, ?result##2:int_list.int_list) #2 @int_list:nn:nn
 
 
 greater > (3 calls)
 0: int_list.greater<0>[410bae77d3]
-greater(lst##0:int_list.int_list, v##0:wybe.int, ?$##0:int_list.int_list):
+greater(lst##0:int_list.int_list, v##0:wybe.int, ?###0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.greater<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.greater<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
-    case ~tmp$9##0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
+    case ~tmp#9##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
         foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
-        foreign llvm icmp_sge(h##0:wybe.int, v##0:wybe.int, ?tmp$6##0:wybe.bool) @int:nn:nn
-        case ~tmp$6##0:wybe.bool of
+        foreign llvm icmp_sge(h##0:wybe.int, v##0:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
+        case ~tmp#6##0:wybe.bool of
         0:
-            int_list.greater<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?$##0:int_list.int_list) #4 @int_list:nn:nn
+            int_list.greater<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?###0:int_list.int_list) #4 @int_list:nn:nn
 
         1:
-            int_list.greater<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp$3##0:int_list.int_list) #2 @int_list:nn:nn
-            foreign lpvm alloc(16:wybe.int, ?tmp$14##0:int_list.int_list)
-            foreign lpvm mutate(~tmp$14##0:int_list.int_list, ?tmp$15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-            foreign lpvm mutate(~tmp$15##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:int_list.int_list)
+            int_list.greater<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp#3##0:int_list.int_list) #2 @int_list:nn:nn
+            foreign lpvm alloc(16:wybe.int, ?tmp#14##0:int_list.int_list)
+            foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+            foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
 
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
-    case ~tmp$9##0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
+    case ~tmp#9##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
         foreign lpvm access(lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
-        foreign llvm icmp_sge(~h##0:wybe.int, v##0:wybe.int, ?tmp$6##0:wybe.bool) @int:nn:nn
-        case ~tmp$6##0:wybe.bool of
+        foreign llvm icmp_sge(~h##0:wybe.int, v##0:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
+        case ~tmp#6##0:wybe.bool of
         0:
-            int_list.greater<0>[410bae77d3](~t##0:int_list.int_list, ~v##0:wybe.int, ?$##0:int_list.int_list) #4 @int_list:nn:nn
+            int_list.greater<0>[410bae77d3](~t##0:int_list.int_list, ~v##0:wybe.int, ?###0:int_list.int_list) #4 @int_list:nn:nn
 
         1:
-            int_list.greater<0>[410bae77d3](~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp$3##0:int_list.int_list) #2 @int_list:nn:nn
-            foreign lpvm mutate(~lst##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:int_list.int_list)
+            int_list.greater<0>[410bae77d3](~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp#3##0:int_list.int_list) #2 @int_list:nn:nn
+            foreign lpvm mutate(~lst##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
 
 
 
 
 index > public {inline} (0 calls)
 0: int_list.index<0>
-index(lst##0:int_list.int_list, x##0:wybe.int, ?$##0:wybe.int):
+index(lst##0:int_list.int_list, x##0:wybe.int, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    int_list.index_helper<0>(~lst##0:int_list.int_list, 0:wybe.int, ~x##0:wybe.int, ?$##0:wybe.int) #0 @int_list:nn:nn
+    int_list.index_helper<0>(~lst##0:int_list.int_list, 0:wybe.int, ~x##0:wybe.int, ?###0:wybe.int) #0 @int_list:nn:nn
 
 
 index_helper > (2 calls)
 0: int_list.index_helper<0>
-index_helper(lst##0:int_list.int_list, idx##0:wybe.int, x##0:wybe.int, ?$##0:wybe.int):
+index_helper(lst##0:int_list.int_list, idx##0:wybe.int, x##0:wybe.int, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.bool)
-    case ~tmp$7##0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.bool)
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(-1:wybe.int, ?$##0:wybe.int) @int_list:nn:nn
+        foreign llvm move(-1:wybe.int, ?###0:wybe.int) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
         foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
-        foreign llvm icmp_eq(~h##0:wybe.int, x##0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
-        case ~tmp$4##0:wybe.bool of
+        foreign llvm icmp_eq(~h##0:wybe.int, x##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
+        case ~tmp#4##0:wybe.bool of
         0:
-            foreign llvm add(~idx##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
-            int_list.index_helper<0>(~t##0:int_list.int_list, ~tmp$3##0:wybe.int, ~x##0:wybe.int, ?$##0:wybe.int) #3 @int_list:nn:nn
+            foreign llvm add(~idx##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
+            int_list.index_helper<0>(~t##0:int_list.int_list, ~tmp#3##0:wybe.int, ~x##0:wybe.int, ?###0:wybe.int) #3 @int_list:nn:nn
 
         1:
-            foreign llvm move(~idx##0:wybe.int, ?$##0:wybe.int) @int_list:nn:nn
+            foreign llvm move(~idx##0:wybe.int, ?###0:wybe.int) @int_list:nn:nn
 
 
 
 
 insert > public (2 calls)
 0: int_list.insert<0>[410bae77d3]
-insert(lst##0:int_list.int_list, idx##0:wybe.int, v##0:wybe.int, ?$##0:int_list.int_list):
- AliasPairs: [($##0,lst##0)]
+insert(lst##0:int_list.int_list, idx##0:wybe.int, v##0:wybe.int, ?###0:int_list.int_list):
+ AliasPairs: [(###0,lst##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(4,(int_list.insert<0>,fromList [NonAliasedParamCond 0 [0]])),(7,(int_list.insert<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_eq(idx##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool) @int:nn:nn
-    case ~tmp$9##0:wybe.bool of
+    foreign llvm icmp_eq(idx##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool) @int:nn:nn
+    case ~tmp#9##0:wybe.bool of
     0:
-        foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$13##0:wybe.bool)
-        case ~tmp$13##0:wybe.bool of
+        foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#13##0:wybe.bool)
+        case ~tmp#13##0:wybe.bool of
         0:
-            foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp$7##0:wybe.int) @int:nn:nn
-            int_list.insert<0>(~lst##0:int_list.int_list, ~tmp$7##0:wybe.int, ~v##0:wybe.int, ?$##0:int_list.int_list) #7 @int_list:nn:nn
+            foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp#7##0:wybe.int) @int:nn:nn
+            int_list.insert<0>(~lst##0:int_list.int_list, ~tmp#7##0:wybe.int, ~v##0:wybe.int, ?###0:int_list.int_list) #7 @int_list:nn:nn
 
         1:
             foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
             foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
-            foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp$5##0:wybe.int) @int:nn:nn
-            int_list.insert<0>(~t##0:int_list.int_list, ~tmp$5##0:wybe.int, ~v##0:wybe.int, ?tmp$4##0:int_list.int_list) #4 @int_list:nn:nn
-            foreign lpvm alloc(16:wybe.int, ?tmp$18##0:int_list.int_list)
-            foreign lpvm mutate(~tmp$18##0:int_list.int_list, ?tmp$19##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-            foreign lpvm mutate(~tmp$19##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$4##0:int_list.int_list)
+            foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp#5##0:wybe.int) @int:nn:nn
+            int_list.insert<0>(~t##0:int_list.int_list, ~tmp#5##0:wybe.int, ~v##0:wybe.int, ?tmp#4##0:int_list.int_list) #4 @int_list:nn:nn
+            foreign lpvm alloc(16:wybe.int, ?tmp#18##0:int_list.int_list)
+            foreign lpvm mutate(~tmp#18##0:int_list.int_list, ?tmp#19##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+            foreign lpvm mutate(~tmp#19##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#4##0:int_list.int_list)
 
 
     1:
-        foreign lpvm alloc(16:wybe.int, ?tmp$14##0:int_list.int_list)
-        foreign lpvm mutate(~tmp$14##0:int_list.int_list, ?tmp$15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
-        foreign lpvm mutate(~tmp$15##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lst##0:int_list.int_list)
+        foreign lpvm alloc(16:wybe.int, ?tmp#14##0:int_list.int_list)
+        foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
+        foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lst##0:int_list.int_list)
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_eq(idx##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool) @int:nn:nn
-    case ~tmp$9##0:wybe.bool of
+    foreign llvm icmp_eq(idx##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool) @int:nn:nn
+    case ~tmp#9##0:wybe.bool of
     0:
-        foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$13##0:wybe.bool)
-        case ~tmp$13##0:wybe.bool of
+        foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#13##0:wybe.bool)
+        case ~tmp#13##0:wybe.bool of
         0:
-            foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp$7##0:wybe.int) @int:nn:nn
-            int_list.insert<0>[410bae77d3](~lst##0:int_list.int_list, ~tmp$7##0:wybe.int, ~v##0:wybe.int, ?$##0:int_list.int_list) #7 @int_list:nn:nn
+            foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp#7##0:wybe.int) @int:nn:nn
+            int_list.insert<0>[410bae77d3](~lst##0:int_list.int_list, ~tmp#7##0:wybe.int, ~v##0:wybe.int, ?###0:int_list.int_list) #7 @int_list:nn:nn
 
         1:
             foreign lpvm access(lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
-            foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp$5##0:wybe.int) @int:nn:nn
-            int_list.insert<0>[410bae77d3](~t##0:int_list.int_list, ~tmp$5##0:wybe.int, ~v##0:wybe.int, ?tmp$4##0:int_list.int_list) #4 @int_list:nn:nn
-            foreign lpvm mutate(~lst##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$4##0:int_list.int_list)
+            foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp#5##0:wybe.int) @int:nn:nn
+            int_list.insert<0>[410bae77d3](~t##0:int_list.int_list, ~tmp#5##0:wybe.int, ~v##0:wybe.int, ?tmp#4##0:int_list.int_list) #4 @int_list:nn:nn
+            foreign lpvm mutate(~lst##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#4##0:int_list.int_list)
 
 
     1:
-        foreign lpvm alloc(16:wybe.int, ?tmp$14##0:int_list.int_list)
-        foreign lpvm mutate(~tmp$14##0:int_list.int_list, ?tmp$15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
-        foreign lpvm mutate(~tmp$15##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lst##0:int_list.int_list)
+        foreign lpvm alloc(16:wybe.int, ?tmp#14##0:int_list.int_list)
+        foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
+        foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lst##0:int_list.int_list)
 
 
 
 lesser > (3 calls)
 0: int_list.lesser<0>
-lesser(lst##0:int_list.int_list, v##0:wybe.int, ?$##0:int_list.int_list):
+lesser(lst##0:int_list.int_list, v##0:wybe.int, ?###0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.lesser<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.lesser<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
-    case ~tmp$9##0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
+    case ~tmp#9##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
         foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
-        foreign llvm icmp_slt(h##0:wybe.int, v##0:wybe.int, ?tmp$6##0:wybe.bool) @int:nn:nn
-        case ~tmp$6##0:wybe.bool of
+        foreign llvm icmp_slt(h##0:wybe.int, v##0:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
+        case ~tmp#6##0:wybe.bool of
         0:
-            int_list.lesser<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?$##0:int_list.int_list) #4 @int_list:nn:nn
+            int_list.lesser<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?###0:int_list.int_list) #4 @int_list:nn:nn
 
         1:
-            int_list.lesser<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp$3##0:int_list.int_list) #2 @int_list:nn:nn
-            foreign lpvm alloc(16:wybe.int, ?tmp$14##0:int_list.int_list)
-            foreign lpvm mutate(~tmp$14##0:int_list.int_list, ?tmp$15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-            foreign lpvm mutate(~tmp$15##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:int_list.int_list)
+            int_list.lesser<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp#3##0:int_list.int_list) #2 @int_list:nn:nn
+            foreign lpvm alloc(16:wybe.int, ?tmp#14##0:int_list.int_list)
+            foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+            foreign lpvm mutate(~tmp#15##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
 
 
 
 
 pop > public (1 calls)
 0: int_list.pop<0>[410bae77d3]
-pop(lst##0:int_list.int_list, idx##0:wybe.int, ?$##0:int_list.int_list):
- AliasPairs: [($##0,lst##0)]
+pop(lst##0:int_list.int_list, idx##0:wybe.int, ?###0:int_list.int_list):
+ AliasPairs: [(###0,lst##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(3,(int_list.pop<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
-    case ~tmp$9##0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
+    case ~tmp#9##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
         foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
-        foreign llvm icmp_eq(idx##0:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.bool) @int:nn:nn
-        case ~tmp$6##0:wybe.bool of
+        foreign llvm icmp_eq(idx##0:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
+        case ~tmp#6##0:wybe.bool of
         0:
-            foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp$4##0:wybe.int) @int:nn:nn
-            int_list.pop<0>(~t##0:int_list.int_list, ~tmp$4##0:wybe.int, ?tmp$3##0:int_list.int_list) #3 @int_list:nn:nn
-            foreign lpvm alloc(16:wybe.int, ?tmp$16##0:int_list.int_list)
-            foreign lpvm mutate(~tmp$16##0:int_list.int_list, ?tmp$17##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-            foreign lpvm mutate(~tmp$17##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:int_list.int_list)
+            foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp#4##0:wybe.int) @int:nn:nn
+            int_list.pop<0>(~t##0:int_list.int_list, ~tmp#4##0:wybe.int, ?tmp#3##0:int_list.int_list) #3 @int_list:nn:nn
+            foreign lpvm alloc(16:wybe.int, ?tmp#16##0:int_list.int_list)
+            foreign lpvm mutate(~tmp#16##0:int_list.int_list, ?tmp#17##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+            foreign lpvm mutate(~tmp#17##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
 
         1:
-            foreign llvm move(~t##0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
+            foreign llvm move(~t##0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
 
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
-    case ~tmp$9##0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
+    case ~tmp#9##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
-        foreign llvm icmp_eq(idx##0:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.bool) @int:nn:nn
-        case ~tmp$6##0:wybe.bool of
+        foreign llvm icmp_eq(idx##0:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
+        case ~tmp#6##0:wybe.bool of
         0:
-            foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp$4##0:wybe.int) @int:nn:nn
-            int_list.pop<0>[410bae77d3](~t##0:int_list.int_list, ~tmp$4##0:wybe.int, ?tmp$3##0:int_list.int_list) #3 @int_list:nn:nn
-            foreign lpvm mutate(~lst##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:int_list.int_list)
+            foreign llvm sub(~idx##0:wybe.int, 1:wybe.int, ?tmp#4##0:wybe.int) @int:nn:nn
+            int_list.pop<0>[410bae77d3](~t##0:int_list.int_list, ~tmp#4##0:wybe.int, ?tmp#3##0:int_list.int_list) #3 @int_list:nn:nn
+            foreign lpvm mutate(~lst##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
 
         1:
-            foreign llvm move(~t##0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
+            foreign llvm move(~t##0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
 
 
 
@@ -1437,8 +1437,8 @@ print > public (2 calls)
 print(x##0:int_list.int_list, io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.bool)
-    case ~tmp$2##0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.bool)
+    case ~tmp#2##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##3:wybe.phantom)
 
@@ -1465,134 +1465,134 @@ range > public {inline} (0 calls)
 range(start##0:wybe.int, stop##0:wybe.int, step##0:wybe.int, ?result##1:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    int_list.gen$2<0>(0:int_list.int_list, ~start##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, 0:int_list.int_list, ?result##1:int_list.int_list) #1 @int_list:nn:nn
+    int_list.gen#2<0>(0:int_list.int_list, ~start##0:wybe.int, ~step##0:wybe.int, ~stop##0:wybe.int, 0:int_list.int_list, ?result##1:int_list.int_list) #1 @int_list:nn:nn
 
 
 remove > public (1 calls)
 0: int_list.remove<0>[410bae77d3]
-remove(lst##0:int_list.int_list, v##0:wybe.int, ?$##0:int_list.int_list):
- AliasPairs: [($##0,lst##0)]
+remove(lst##0:int_list.int_list, v##0:wybe.int, ?###0:int_list.int_list):
+ AliasPairs: [(###0,lst##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.remove<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.bool)
-    case ~tmp$8##0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool)
+    case ~tmp#8##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
         foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
-        foreign llvm icmp_eq(h##0:wybe.int, v##0:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
-        case ~tmp$5##0:wybe.bool of
+        foreign llvm icmp_eq(h##0:wybe.int, v##0:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
+        case ~tmp#5##0:wybe.bool of
         0:
-            int_list.remove<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp$3##0:int_list.int_list) #2 @int_list:nn:nn
-            foreign lpvm alloc(16:wybe.int, ?tmp$13##0:int_list.int_list)
-            foreign lpvm mutate(~tmp$13##0:int_list.int_list, ?tmp$14##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-            foreign lpvm mutate(~tmp$14##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:int_list.int_list)
+            int_list.remove<0>(~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp#3##0:int_list.int_list) #2 @int_list:nn:nn
+            foreign lpvm alloc(16:wybe.int, ?tmp#13##0:int_list.int_list)
+            foreign lpvm mutate(~tmp#13##0:int_list.int_list, ?tmp#14##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+            foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
 
         1:
-            foreign llvm move(~t##0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
+            foreign llvm move(~t##0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
 
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.bool)
-    case ~tmp$8##0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool)
+    case ~tmp#8##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
         foreign lpvm access(lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
-        foreign llvm icmp_eq(~h##0:wybe.int, v##0:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
-        case ~tmp$5##0:wybe.bool of
+        foreign llvm icmp_eq(~h##0:wybe.int, v##0:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
+        case ~tmp#5##0:wybe.bool of
         0:
-            int_list.remove<0>[410bae77d3](~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp$3##0:int_list.int_list) #2 @int_list:nn:nn
-            foreign lpvm mutate(~lst##0:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:int_list.int_list)
+            int_list.remove<0>[410bae77d3](~t##0:int_list.int_list, ~v##0:wybe.int, ?tmp#3##0:int_list.int_list) #2 @int_list:nn:nn
+            foreign lpvm mutate(~lst##0:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:int_list.int_list)
 
         1:
-            foreign llvm move(~t##0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
+            foreign llvm move(~t##0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
 
 
 
 
 reverse > public {inline} (1 calls)
 0: int_list.reverse<0>
-reverse(lst##0:int_list.int_list, ?$##0:int_list.int_list):
+reverse(lst##0:int_list.int_list, ?###0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    int_list.reverse_helper<0>(~lst##0:int_list.int_list, 0:int_list.int_list, ?$##0:int_list.int_list) #1 @int_list:nn:nn
+    int_list.reverse_helper<0>(~lst##0:int_list.int_list, 0:int_list.int_list, ?###0:int_list.int_list) #1 @int_list:nn:nn
 
 
 reverse_helper > (2 calls)
 0: int_list.reverse_helper<0>[410bae77d3]
-reverse_helper(lst##0:int_list.int_list, acc##0:int_list.int_list, ?$##0:int_list.int_list):
- AliasPairs: [($##0,acc##0)]
+reverse_helper(lst##0:int_list.int_list, acc##0:int_list.int_list, ?###0:int_list.int_list):
+ AliasPairs: [(###0,acc##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
-    case ~tmp$5##0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
+    case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~acc##0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(~acc##0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
         foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
-        foreign lpvm alloc(16:wybe.int, ?tmp$8##0:int_list.int_list)
-        foreign lpvm mutate(~tmp$8##0:int_list.int_list, ?tmp$9##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-        foreign lpvm mutate(~tmp$9##0:int_list.int_list, ?tmp$10##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~acc##0:int_list.int_list)
-        int_list.reverse_helper<0>(~t##0:int_list.int_list, ~tmp$10##0:int_list.int_list, ?$##0:int_list.int_list) #2 @int_list:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:int_list.int_list)
+        foreign lpvm mutate(~tmp#8##0:int_list.int_list, ?tmp#9##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+        foreign lpvm mutate(~tmp#9##0:int_list.int_list, ?tmp#10##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~acc##0:int_list.int_list)
+        int_list.reverse_helper<0>(~t##0:int_list.int_list, ~tmp#10##0:int_list.int_list, ?###0:int_list.int_list) #2 @int_list:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
-    case ~tmp$5##0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
+    case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~acc##0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(~acc##0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
-        foreign lpvm mutate(~lst##0:int_list.int_list, ?tmp$10##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~acc##0:int_list.int_list)
-        int_list.reverse_helper<0>[410bae77d3](~t##0:int_list.int_list, ~tmp$10##0:int_list.int_list, ?$##0:int_list.int_list) #2 @int_list:nn:nn
+        foreign lpvm mutate(~lst##0:int_list.int_list, ?tmp#10##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~acc##0:int_list.int_list)
+        int_list.reverse_helper<0>[410bae77d3](~t##0:int_list.int_list, ~tmp#10##0:int_list.int_list, ?###0:int_list.int_list) #2 @int_list:nn:nn
 
 
 
 sort > public (2 calls)
 0: int_list.sort<0>[410bae77d3]
-sort(lst##0:int_list.int_list, ?$##0:int_list.int_list):
+sort(lst##0:int_list.int_list, ?###0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(int_list.sort<0>,fromList [NonAliasedParamCond 0 []])),(3,(int_list.greater<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(int_list.sort<0>,fromList [NonAliasedParamCond 0 []])),(6,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.bool)
-    case ~tmp$10##0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
+    case ~tmp#10##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
         foreign lpvm access(~lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
-        int_list.lesser<0>(t##0:int_list.int_list, h##0:wybe.int, ?tmp$3##0:int_list.int_list) #1 @int_list:nn:nn
-        int_list.sort<0>[410bae77d3](~tmp$3##0:int_list.int_list, ?tmp$2##0:int_list.int_list) #2 @int_list:nn:nn
-        int_list.greater<0>(~t##0:int_list.int_list, h##0:wybe.int, ?tmp$6##0:int_list.int_list) #3 @int_list:nn:nn
-        int_list.sort<0>[410bae77d3](~tmp$6##0:int_list.int_list, ?tmp$5##0:int_list.int_list) #4 @int_list:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$13##0:int_list.int_list)
-        foreign lpvm mutate(~tmp$13##0:int_list.int_list, ?tmp$14##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-        foreign lpvm mutate(~tmp$14##0:int_list.int_list, ?tmp$15##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$5##0:int_list.int_list)
-        int_list.extend<0>[410bae77d3](~tmp$2##0:int_list.int_list, ~tmp$15##0:int_list.int_list, ?$##0:int_list.int_list) #6 @int_list:nn:nn
+        int_list.lesser<0>(t##0:int_list.int_list, h##0:wybe.int, ?tmp#3##0:int_list.int_list) #1 @int_list:nn:nn
+        int_list.sort<0>[410bae77d3](~tmp#3##0:int_list.int_list, ?tmp#2##0:int_list.int_list) #2 @int_list:nn:nn
+        int_list.greater<0>(~t##0:int_list.int_list, h##0:wybe.int, ?tmp#6##0:int_list.int_list) #3 @int_list:nn:nn
+        int_list.sort<0>[410bae77d3](~tmp#6##0:int_list.int_list, ?tmp#5##0:int_list.int_list) #4 @int_list:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#13##0:int_list.int_list)
+        foreign lpvm mutate(~tmp#13##0:int_list.int_list, ?tmp#14##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+        foreign lpvm mutate(~tmp#14##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##0:int_list.int_list)
+        int_list.extend<0>[410bae77d3](~tmp#2##0:int_list.int_list, ~tmp#15##0:int_list.int_list, ?###0:int_list.int_list) #6 @int_list:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.bool)
-    case ~tmp$10##0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
+    case ~tmp#10##0:wybe.bool of
     0:
-        foreign llvm move(0:int_list.int_list, ?$##0:int_list.int_list) @int_list:nn:nn
+        foreign llvm move(0:int_list.int_list, ?###0:int_list.int_list) @int_list:nn:nn
 
     1:
         foreign lpvm access(lst##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
         foreign lpvm access(lst##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
-        int_list.lesser<0>(t##0:int_list.int_list, h##0:wybe.int, ?tmp$3##0:int_list.int_list) #1 @int_list:nn:nn
-        int_list.sort<0>[410bae77d3](~tmp$3##0:int_list.int_list, ?tmp$2##0:int_list.int_list) #2 @int_list:nn:nn
-        int_list.greater<0>[410bae77d3](~t##0:int_list.int_list, ~h##0:wybe.int, ?tmp$6##0:int_list.int_list) #3 @int_list:nn:nn
-        int_list.sort<0>[410bae77d3](~tmp$6##0:int_list.int_list, ?tmp$5##0:int_list.int_list) #4 @int_list:nn:nn
-        foreign lpvm mutate(~lst##0:int_list.int_list, ?tmp$15##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$5##0:int_list.int_list)
-        int_list.extend<0>[410bae77d3](~tmp$2##0:int_list.int_list, ~tmp$15##0:int_list.int_list, ?$##0:int_list.int_list) #6 @int_list:nn:nn
+        int_list.lesser<0>(t##0:int_list.int_list, h##0:wybe.int, ?tmp#3##0:int_list.int_list) #1 @int_list:nn:nn
+        int_list.sort<0>[410bae77d3](~tmp#3##0:int_list.int_list, ?tmp#2##0:int_list.int_list) #2 @int_list:nn:nn
+        int_list.greater<0>[410bae77d3](~t##0:int_list.int_list, ~h##0:wybe.int, ?tmp#6##0:int_list.int_list) #3 @int_list:nn:nn
+        int_list.sort<0>[410bae77d3](~tmp#6##0:int_list.int_list, ?tmp#5##0:int_list.int_list) #4 @int_list:nn:nn
+        foreign lpvm mutate(~lst##0:int_list.int_list, ?tmp#15##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##0:int_list.int_list)
+        int_list.extend<0>[410bae77d3](~tmp#2##0:int_list.int_list, ~tmp#15##0:int_list.int_list, ?###0:int_list.int_list) #6 @int_list:nn:nn
 
 
   LLVM code       :
@@ -1627,8 +1627,8 @@ entry:
   %7 = inttoptr i64 %6 to i64* 
   %8 = getelementptr  i64, i64* %7, i64 0 
   store  i64 0, i64* %8 
-  %"1$$##0" = tail call fastcc  i64  @"int_list.extend<0>"(i64  %"lst##0", i64  %3)  
-  ret i64 %"1$$##0" 
+  %"1####0" = tail call fastcc  i64  @"int_list.extend<0>"(i64  %"lst##0", i64  %3)  
+  ret i64 %"1####0" 
 }
 
 
@@ -1644,15 +1644,15 @@ entry:
   %15 = inttoptr i64 %14 to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
   store  i64 0, i64* %16 
-  %"1$$##0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"lst##0", i64  %11)  
-  ret i64 %"1$$##0" 
+  %"1####0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"lst##0", i64  %11)  
+  ret i64 %"1####0" 
 }
 
 
 define external fastcc  i64 @"int_list.count<0>"(i64  %"lst##0", i64  %"x##0")    {
 entry:
-  %"1$tmp$7##0" = icmp ne i64 %"lst##0", 0 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %17 = inttoptr i64 %"lst##0" to i64* 
   %18 = getelementptr  i64, i64* %17, i64 0 
@@ -1661,23 +1661,23 @@ if.then:
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
   %23 = load  i64, i64* %22 
-  %"2$tmp$2##0" = tail call fastcc  i64  @"int_list.count<0>"(i64  %23, i64  %"x##0")  
-  %"2$tmp$4##0" = icmp eq i64 %19, %"x##0" 
-  br i1 %"2$tmp$4##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = tail call fastcc  i64  @"int_list.count<0>"(i64  %23, i64  %"x##0")  
+  %"2#tmp#4##0" = icmp eq i64 %19, %"x##0" 
+  br i1 %"2#tmp#4##0", label %if.then1, label %if.else1 
 if.else:
   ret i64 0 
 if.then1:
-  %"4$$##0" = add   i64 %"2$tmp$2##0", 1 
-  ret i64 %"4$$##0" 
+  %"4####0" = add   i64 %"2#tmp#2##0", 1 
+  ret i64 %"4####0" 
 if.else1:
-  ret i64 %"2$tmp$2##0" 
+  ret i64 %"2#tmp#2##0" 
 }
 
 
 define external fastcc  i64 @"int_list.extend<0>"(i64  %"lst1##0", i64  %"lst2##0")    {
 entry:
-  %"1$tmp$5##0" = icmp ne i64 %"lst1##0", 0 
-  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
+  %"1#tmp#5##0" = icmp ne i64 %"lst1##0", 0 
+  br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
   %24 = inttoptr i64 %"lst1##0" to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
@@ -1686,7 +1686,7 @@ if.then:
   %28 = inttoptr i64 %27 to i64* 
   %29 = getelementptr  i64, i64* %28, i64 0 
   %30 = load  i64, i64* %29 
-  %"2$tmp$2##0" = tail call fastcc  i64  @"int_list.extend<0>"(i64  %30, i64  %"lst2##0")  
+  %"2#tmp#2##0" = tail call fastcc  i64  @"int_list.extend<0>"(i64  %30, i64  %"lst2##0")  
   %31 = trunc i64 16 to i32  
   %32 = tail call ccc  i8*  @wybe_malloc(i32  %31)  
   %33 = ptrtoint i8* %32 to i64 
@@ -1696,7 +1696,7 @@ if.then:
   %36 = add   i64 %33, 8 
   %37 = inttoptr i64 %36 to i64* 
   %38 = getelementptr  i64, i64* %37, i64 0 
-  store  i64 %"2$tmp$2##0", i64* %38 
+  store  i64 %"2#tmp#2##0", i64* %38 
   ret i64 %33 
 if.else:
   ret i64 %"lst2##0" 
@@ -1705,35 +1705,35 @@ if.else:
 
 define external fastcc  i64 @"int_list.extend<0>[410bae77d3]"(i64  %"lst1##0", i64  %"lst2##0")    {
 entry:
-  %"1$tmp$5##0" = icmp ne i64 %"lst1##0", 0 
-  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
+  %"1#tmp#5##0" = icmp ne i64 %"lst1##0", 0 
+  br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
   %39 = add   i64 %"lst1##0", 8 
   %40 = inttoptr i64 %39 to i64* 
   %41 = getelementptr  i64, i64* %40, i64 0 
   %42 = load  i64, i64* %41 
-  %"2$tmp$2##0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %42, i64  %"lst2##0")  
+  %"2#tmp#2##0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %42, i64  %"lst2##0")  
   %43 = add   i64 %"lst1##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
-  store  i64 %"2$tmp$2##0", i64* %45 
+  store  i64 %"2#tmp#2##0", i64* %45 
   ret i64 %"lst1##0" 
 if.else:
   ret i64 %"lst2##0" 
 }
 
 
-define external fastcc  i64 @"int_list.gen$1<0>"(i64  %"tmp$2##0", i64  %"tmp$3##0")    {
+define external fastcc  i64 @"int_list.gen#1<0>"(i64  %"tmp#2##0", i64  %"tmp#3##0")    {
 entry:
-  %"1$$##0" = add   i64 %"tmp$2##0", %"tmp$3##0" 
-  ret i64 %"1$$##0" 
+  %"1####0" = add   i64 %"tmp#2##0", %"tmp#3##0" 
+  ret i64 %"1####0" 
 }
 
 
-define external fastcc  i64 @"int_list.gen$2<0>"(i64  %"result##0", i64  %"start##0", i64  %"step##0", i64  %"stop##0", i64  %"tmp$0##0")    {
+define external fastcc  i64 @"int_list.gen#2<0>"(i64  %"result##0", i64  %"start##0", i64  %"step##0", i64  %"stop##0", i64  %"tmp#0##0")    {
 entry:
-  %"1$tmp$3##0" = icmp slt i64 %"start##0", %"stop##0" 
-  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
+  %"1#tmp#3##0" = icmp slt i64 %"start##0", %"stop##0" 
+  br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
   %46 = trunc i64 16 to i32  
   %47 = tail call ccc  i8*  @wybe_malloc(i32  %46)  
@@ -1745,19 +1745,19 @@ if.then:
   %52 = inttoptr i64 %51 to i64* 
   %53 = getelementptr  i64, i64* %52, i64 0 
   store  i64 %"result##0", i64* %53 
-  %"2$tmp$15##0" = add   i64 %"start##0", %"step##0" 
-  %"2$result##1" = tail call fastcc  i64  @"int_list.gen$2<0>"(i64  %48, i64  %"2$tmp$15##0", i64  %"step##0", i64  %"stop##0", i64  %"tmp$0##0")  
-  ret i64 %"2$result##1" 
+  %"2#tmp#15##0" = add   i64 %"start##0", %"step##0" 
+  %"2#result##1" = tail call fastcc  i64  @"int_list.gen#2<0>"(i64  %48, i64  %"2#tmp#15##0", i64  %"step##0", i64  %"stop##0", i64  %"tmp#0##0")  
+  ret i64 %"2#result##1" 
 if.else:
-  %"3$result##1" = tail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %"result##0", i64  0)  
-  ret i64 %"3$result##1" 
+  %"3#result##1" = tail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %"result##0", i64  0)  
+  ret i64 %"3#result##1" 
 }
 
 
-define external fastcc  i64 @"int_list.gen$2<0>[410bae77d3]"(i64  %"result##0", i64  %"start##0", i64  %"step##0", i64  %"stop##0", i64  %"tmp$0##0")    {
+define external fastcc  i64 @"int_list.gen#2<0>[410bae77d3]"(i64  %"result##0", i64  %"start##0", i64  %"step##0", i64  %"stop##0", i64  %"tmp#0##0")    {
 entry:
-  %"1$tmp$3##0" = icmp slt i64 %"start##0", %"stop##0" 
-  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
+  %"1#tmp#3##0" = icmp slt i64 %"start##0", %"stop##0" 
+  br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
   %54 = trunc i64 16 to i32  
   %55 = tail call ccc  i8*  @wybe_malloc(i32  %54)  
@@ -1769,16 +1769,16 @@ if.then:
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   store  i64 %"result##0", i64* %61 
-  %"2$tmp$15##0" = add   i64 %"start##0", %"step##0" 
-  %"2$result##1" = tail call fastcc  i64  @"int_list.gen$2<0>[410bae77d3]"(i64  %56, i64  %"2$tmp$15##0", i64  %"step##0", i64  %"stop##0", i64  %"tmp$0##0")  
-  ret i64 %"2$result##1" 
+  %"2#tmp#15##0" = add   i64 %"start##0", %"step##0" 
+  %"2#result##1" = tail call fastcc  i64  @"int_list.gen#2<0>[410bae77d3]"(i64  %56, i64  %"2#tmp#15##0", i64  %"step##0", i64  %"stop##0", i64  %"tmp#0##0")  
+  ret i64 %"2#result##1" 
 if.else:
-  %"3$result##1" = tail call fastcc  i64  @"int_list.reverse_helper<0>[410bae77d3]"(i64  %"result##0", i64  0)  
-  ret i64 %"3$result##1" 
+  %"3#result##1" = tail call fastcc  i64  @"int_list.reverse_helper<0>[410bae77d3]"(i64  %"result##0", i64  0)  
+  ret i64 %"3#result##1" 
 }
 
 
-define external fastcc  i64 @"int_list.gen$3<0>"(i64  %"result##0", i64  %"start##0", i64  %"step##0", i64  %"stop##0", i64  %"tmp$0##0")    {
+define external fastcc  i64 @"int_list.gen#3<0>"(i64  %"result##0", i64  %"start##0", i64  %"step##0", i64  %"stop##0", i64  %"tmp#0##0")    {
 entry:
   %62 = trunc i64 16 to i32  
   %63 = tail call ccc  i8*  @wybe_malloc(i32  %62)  
@@ -1790,16 +1790,16 @@ entry:
   %68 = inttoptr i64 %67 to i64* 
   %69 = getelementptr  i64, i64* %68, i64 0 
   store  i64 %"result##0", i64* %69 
-  %"1$tmp$2##0" = add   i64 %"start##0", %"step##0" 
-  %"1$result##2" = tail call fastcc  i64  @"int_list.gen$2<0>"(i64  %64, i64  %"1$tmp$2##0", i64  %"step##0", i64  %"stop##0", i64  %"tmp$0##0")  
-  ret i64 %"1$result##2" 
+  %"1#tmp#2##0" = add   i64 %"start##0", %"step##0" 
+  %"1#result##2" = tail call fastcc  i64  @"int_list.gen#2<0>"(i64  %64, i64  %"1#tmp#2##0", i64  %"step##0", i64  %"stop##0", i64  %"tmp#0##0")  
+  ret i64 %"1#result##2" 
 }
 
 
 define external fastcc  i64 @"int_list.greater<0>"(i64  %"lst##0", i64  %"v##0")    {
 entry:
-  %"1$tmp$9##0" = icmp ne i64 %"lst##0", 0 
-  br i1 %"1$tmp$9##0", label %if.then, label %if.else 
+  %"1#tmp#9##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1#tmp#9##0", label %if.then, label %if.else 
 if.then:
   %70 = inttoptr i64 %"lst##0" to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
@@ -1808,12 +1808,12 @@ if.then:
   %74 = inttoptr i64 %73 to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
   %76 = load  i64, i64* %75 
-  %"2$tmp$6##0" = icmp sge i64 %72, %"v##0" 
-  br i1 %"2$tmp$6##0", label %if.then1, label %if.else1 
+  %"2#tmp#6##0" = icmp sge i64 %72, %"v##0" 
+  br i1 %"2#tmp#6##0", label %if.then1, label %if.else1 
 if.else:
   ret i64 0 
 if.then1:
-  %"4$tmp$3##0" = tail call fastcc  i64  @"int_list.greater<0>"(i64  %76, i64  %"v##0")  
+  %"4#tmp#3##0" = tail call fastcc  i64  @"int_list.greater<0>"(i64  %76, i64  %"v##0")  
   %77 = trunc i64 16 to i32  
   %78 = tail call ccc  i8*  @wybe_malloc(i32  %77)  
   %79 = ptrtoint i8* %78 to i64 
@@ -1823,18 +1823,18 @@ if.then1:
   %82 = add   i64 %79, 8 
   %83 = inttoptr i64 %82 to i64* 
   %84 = getelementptr  i64, i64* %83, i64 0 
-  store  i64 %"4$tmp$3##0", i64* %84 
+  store  i64 %"4#tmp#3##0", i64* %84 
   ret i64 %79 
 if.else1:
-  %"5$$##0" = tail call fastcc  i64  @"int_list.greater<0>"(i64  %76, i64  %"v##0")  
-  ret i64 %"5$$##0" 
+  %"5####0" = tail call fastcc  i64  @"int_list.greater<0>"(i64  %76, i64  %"v##0")  
+  ret i64 %"5####0" 
 }
 
 
 define external fastcc  i64 @"int_list.greater<0>[410bae77d3]"(i64  %"lst##0", i64  %"v##0")    {
 entry:
-  %"1$tmp$9##0" = icmp ne i64 %"lst##0", 0 
-  br i1 %"1$tmp$9##0", label %if.then, label %if.else 
+  %"1#tmp#9##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1#tmp#9##0", label %if.then, label %if.else 
 if.then:
   %85 = inttoptr i64 %"lst##0" to i64* 
   %86 = getelementptr  i64, i64* %85, i64 0 
@@ -1843,34 +1843,34 @@ if.then:
   %89 = inttoptr i64 %88 to i64* 
   %90 = getelementptr  i64, i64* %89, i64 0 
   %91 = load  i64, i64* %90 
-  %"2$tmp$6##0" = icmp sge i64 %87, %"v##0" 
-  br i1 %"2$tmp$6##0", label %if.then1, label %if.else1 
+  %"2#tmp#6##0" = icmp sge i64 %87, %"v##0" 
+  br i1 %"2#tmp#6##0", label %if.then1, label %if.else1 
 if.else:
   ret i64 0 
 if.then1:
-  %"4$tmp$3##0" = tail call fastcc  i64  @"int_list.greater<0>[410bae77d3]"(i64  %91, i64  %"v##0")  
+  %"4#tmp#3##0" = tail call fastcc  i64  @"int_list.greater<0>[410bae77d3]"(i64  %91, i64  %"v##0")  
   %92 = add   i64 %"lst##0", 8 
   %93 = inttoptr i64 %92 to i64* 
   %94 = getelementptr  i64, i64* %93, i64 0 
-  store  i64 %"4$tmp$3##0", i64* %94 
+  store  i64 %"4#tmp#3##0", i64* %94 
   ret i64 %"lst##0" 
 if.else1:
-  %"5$$##0" = tail call fastcc  i64  @"int_list.greater<0>[410bae77d3]"(i64  %91, i64  %"v##0")  
-  ret i64 %"5$$##0" 
+  %"5####0" = tail call fastcc  i64  @"int_list.greater<0>[410bae77d3]"(i64  %91, i64  %"v##0")  
+  ret i64 %"5####0" 
 }
 
 
 define external fastcc  i64 @"int_list.index<0>"(i64  %"lst##0", i64  %"x##0")    {
 entry:
-  %"1$$##0" = tail call fastcc  i64  @"int_list.index_helper<0>"(i64  %"lst##0", i64  0, i64  %"x##0")  
-  ret i64 %"1$$##0" 
+  %"1####0" = tail call fastcc  i64  @"int_list.index_helper<0>"(i64  %"lst##0", i64  0, i64  %"x##0")  
+  ret i64 %"1####0" 
 }
 
 
 define external fastcc  i64 @"int_list.index_helper<0>"(i64  %"lst##0", i64  %"idx##0", i64  %"x##0")    {
 entry:
-  %"1$tmp$7##0" = icmp ne i64 %"lst##0", 0 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %95 = inttoptr i64 %"lst##0" to i64* 
   %96 = getelementptr  i64, i64* %95, i64 0 
@@ -1879,23 +1879,23 @@ if.then:
   %99 = inttoptr i64 %98 to i64* 
   %100 = getelementptr  i64, i64* %99, i64 0 
   %101 = load  i64, i64* %100 
-  %"2$tmp$4##0" = icmp eq i64 %97, %"x##0" 
-  br i1 %"2$tmp$4##0", label %if.then1, label %if.else1 
+  %"2#tmp#4##0" = icmp eq i64 %97, %"x##0" 
+  br i1 %"2#tmp#4##0", label %if.then1, label %if.else1 
 if.else:
   ret i64 -1 
 if.then1:
   ret i64 %"idx##0" 
 if.else1:
-  %"5$tmp$3##0" = add   i64 %"idx##0", 1 
-  %"5$$##0" = tail call fastcc  i64  @"int_list.index_helper<0>"(i64  %101, i64  %"5$tmp$3##0", i64  %"x##0")  
-  ret i64 %"5$$##0" 
+  %"5#tmp#3##0" = add   i64 %"idx##0", 1 
+  %"5####0" = tail call fastcc  i64  @"int_list.index_helper<0>"(i64  %101, i64  %"5#tmp#3##0", i64  %"x##0")  
+  ret i64 %"5####0" 
 }
 
 
 define external fastcc  i64 @"int_list.insert<0>"(i64  %"lst##0", i64  %"idx##0", i64  %"v##0")    {
 entry:
-  %"1$tmp$9##0" = icmp eq i64 %"idx##0", 0 
-  br i1 %"1$tmp$9##0", label %if.then, label %if.else 
+  %"1#tmp#9##0" = icmp eq i64 %"idx##0", 0 
+  br i1 %"1#tmp#9##0", label %if.then, label %if.else 
 if.then:
   %102 = trunc i64 16 to i32  
   %103 = tail call ccc  i8*  @wybe_malloc(i32  %102)  
@@ -1909,8 +1909,8 @@ if.then:
   store  i64 %"lst##0", i64* %109 
   ret i64 %104 
 if.else:
-  %"3$tmp$13##0" = icmp ne i64 %"lst##0", 0 
-  br i1 %"3$tmp$13##0", label %if.then1, label %if.else1 
+  %"3#tmp#13##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"3#tmp#13##0", label %if.then1, label %if.else1 
 if.then1:
   %110 = inttoptr i64 %"lst##0" to i64* 
   %111 = getelementptr  i64, i64* %110, i64 0 
@@ -1919,8 +1919,8 @@ if.then1:
   %114 = inttoptr i64 %113 to i64* 
   %115 = getelementptr  i64, i64* %114, i64 0 
   %116 = load  i64, i64* %115 
-  %"4$tmp$5##0" = sub   i64 %"idx##0", 1 
-  %"4$tmp$4##0" = tail call fastcc  i64  @"int_list.insert<0>"(i64  %116, i64  %"4$tmp$5##0", i64  %"v##0")  
+  %"4#tmp#5##0" = sub   i64 %"idx##0", 1 
+  %"4#tmp#4##0" = tail call fastcc  i64  @"int_list.insert<0>"(i64  %116, i64  %"4#tmp#5##0", i64  %"v##0")  
   %117 = trunc i64 16 to i32  
   %118 = tail call ccc  i8*  @wybe_malloc(i32  %117)  
   %119 = ptrtoint i8* %118 to i64 
@@ -1930,19 +1930,19 @@ if.then1:
   %122 = add   i64 %119, 8 
   %123 = inttoptr i64 %122 to i64* 
   %124 = getelementptr  i64, i64* %123, i64 0 
-  store  i64 %"4$tmp$4##0", i64* %124 
+  store  i64 %"4#tmp#4##0", i64* %124 
   ret i64 %119 
 if.else1:
-  %"5$tmp$7##0" = sub   i64 %"idx##0", 1 
-  %"5$$##0" = tail call fastcc  i64  @"int_list.insert<0>"(i64  %"lst##0", i64  %"5$tmp$7##0", i64  %"v##0")  
-  ret i64 %"5$$##0" 
+  %"5#tmp#7##0" = sub   i64 %"idx##0", 1 
+  %"5####0" = tail call fastcc  i64  @"int_list.insert<0>"(i64  %"lst##0", i64  %"5#tmp#7##0", i64  %"v##0")  
+  ret i64 %"5####0" 
 }
 
 
 define external fastcc  i64 @"int_list.insert<0>[410bae77d3]"(i64  %"lst##0", i64  %"idx##0", i64  %"v##0")    {
 entry:
-  %"1$tmp$9##0" = icmp eq i64 %"idx##0", 0 
-  br i1 %"1$tmp$9##0", label %if.then, label %if.else 
+  %"1#tmp#9##0" = icmp eq i64 %"idx##0", 0 
+  br i1 %"1#tmp#9##0", label %if.then, label %if.else 
 if.then:
   %125 = trunc i64 16 to i32  
   %126 = tail call ccc  i8*  @wybe_malloc(i32  %125)  
@@ -1956,31 +1956,31 @@ if.then:
   store  i64 %"lst##0", i64* %132 
   ret i64 %127 
 if.else:
-  %"3$tmp$13##0" = icmp ne i64 %"lst##0", 0 
-  br i1 %"3$tmp$13##0", label %if.then1, label %if.else1 
+  %"3#tmp#13##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"3#tmp#13##0", label %if.then1, label %if.else1 
 if.then1:
   %133 = add   i64 %"lst##0", 8 
   %134 = inttoptr i64 %133 to i64* 
   %135 = getelementptr  i64, i64* %134, i64 0 
   %136 = load  i64, i64* %135 
-  %"4$tmp$5##0" = sub   i64 %"idx##0", 1 
-  %"4$tmp$4##0" = tail call fastcc  i64  @"int_list.insert<0>[410bae77d3]"(i64  %136, i64  %"4$tmp$5##0", i64  %"v##0")  
+  %"4#tmp#5##0" = sub   i64 %"idx##0", 1 
+  %"4#tmp#4##0" = tail call fastcc  i64  @"int_list.insert<0>[410bae77d3]"(i64  %136, i64  %"4#tmp#5##0", i64  %"v##0")  
   %137 = add   i64 %"lst##0", 8 
   %138 = inttoptr i64 %137 to i64* 
   %139 = getelementptr  i64, i64* %138, i64 0 
-  store  i64 %"4$tmp$4##0", i64* %139 
+  store  i64 %"4#tmp#4##0", i64* %139 
   ret i64 %"lst##0" 
 if.else1:
-  %"5$tmp$7##0" = sub   i64 %"idx##0", 1 
-  %"5$$##0" = tail call fastcc  i64  @"int_list.insert<0>[410bae77d3]"(i64  %"lst##0", i64  %"5$tmp$7##0", i64  %"v##0")  
-  ret i64 %"5$$##0" 
+  %"5#tmp#7##0" = sub   i64 %"idx##0", 1 
+  %"5####0" = tail call fastcc  i64  @"int_list.insert<0>[410bae77d3]"(i64  %"lst##0", i64  %"5#tmp#7##0", i64  %"v##0")  
+  ret i64 %"5####0" 
 }
 
 
 define external fastcc  i64 @"int_list.lesser<0>"(i64  %"lst##0", i64  %"v##0")    {
 entry:
-  %"1$tmp$9##0" = icmp ne i64 %"lst##0", 0 
-  br i1 %"1$tmp$9##0", label %if.then, label %if.else 
+  %"1#tmp#9##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1#tmp#9##0", label %if.then, label %if.else 
 if.then:
   %140 = inttoptr i64 %"lst##0" to i64* 
   %141 = getelementptr  i64, i64* %140, i64 0 
@@ -1989,12 +1989,12 @@ if.then:
   %144 = inttoptr i64 %143 to i64* 
   %145 = getelementptr  i64, i64* %144, i64 0 
   %146 = load  i64, i64* %145 
-  %"2$tmp$6##0" = icmp slt i64 %142, %"v##0" 
-  br i1 %"2$tmp$6##0", label %if.then1, label %if.else1 
+  %"2#tmp#6##0" = icmp slt i64 %142, %"v##0" 
+  br i1 %"2#tmp#6##0", label %if.then1, label %if.else1 
 if.else:
   ret i64 0 
 if.then1:
-  %"4$tmp$3##0" = tail call fastcc  i64  @"int_list.lesser<0>"(i64  %146, i64  %"v##0")  
+  %"4#tmp#3##0" = tail call fastcc  i64  @"int_list.lesser<0>"(i64  %146, i64  %"v##0")  
   %147 = trunc i64 16 to i32  
   %148 = tail call ccc  i8*  @wybe_malloc(i32  %147)  
   %149 = ptrtoint i8* %148 to i64 
@@ -2004,18 +2004,18 @@ if.then1:
   %152 = add   i64 %149, 8 
   %153 = inttoptr i64 %152 to i64* 
   %154 = getelementptr  i64, i64* %153, i64 0 
-  store  i64 %"4$tmp$3##0", i64* %154 
+  store  i64 %"4#tmp#3##0", i64* %154 
   ret i64 %149 
 if.else1:
-  %"5$$##0" = tail call fastcc  i64  @"int_list.lesser<0>"(i64  %146, i64  %"v##0")  
-  ret i64 %"5$$##0" 
+  %"5####0" = tail call fastcc  i64  @"int_list.lesser<0>"(i64  %146, i64  %"v##0")  
+  ret i64 %"5####0" 
 }
 
 
 define external fastcc  i64 @"int_list.pop<0>"(i64  %"lst##0", i64  %"idx##0")    {
 entry:
-  %"1$tmp$9##0" = icmp ne i64 %"lst##0", 0 
-  br i1 %"1$tmp$9##0", label %if.then, label %if.else 
+  %"1#tmp#9##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1#tmp#9##0", label %if.then, label %if.else 
 if.then:
   %155 = inttoptr i64 %"lst##0" to i64* 
   %156 = getelementptr  i64, i64* %155, i64 0 
@@ -2024,15 +2024,15 @@ if.then:
   %159 = inttoptr i64 %158 to i64* 
   %160 = getelementptr  i64, i64* %159, i64 0 
   %161 = load  i64, i64* %160 
-  %"2$tmp$6##0" = icmp eq i64 %"idx##0", 0 
-  br i1 %"2$tmp$6##0", label %if.then1, label %if.else1 
+  %"2#tmp#6##0" = icmp eq i64 %"idx##0", 0 
+  br i1 %"2#tmp#6##0", label %if.then1, label %if.else1 
 if.else:
   ret i64 0 
 if.then1:
   ret i64 %161 
 if.else1:
-  %"5$tmp$4##0" = sub   i64 %"idx##0", 1 
-  %"5$tmp$3##0" = tail call fastcc  i64  @"int_list.pop<0>"(i64  %161, i64  %"5$tmp$4##0")  
+  %"5#tmp#4##0" = sub   i64 %"idx##0", 1 
+  %"5#tmp#3##0" = tail call fastcc  i64  @"int_list.pop<0>"(i64  %161, i64  %"5#tmp#4##0")  
   %162 = trunc i64 16 to i32  
   %163 = tail call ccc  i8*  @wybe_malloc(i32  %162)  
   %164 = ptrtoint i8* %163 to i64 
@@ -2042,41 +2042,41 @@ if.else1:
   %167 = add   i64 %164, 8 
   %168 = inttoptr i64 %167 to i64* 
   %169 = getelementptr  i64, i64* %168, i64 0 
-  store  i64 %"5$tmp$3##0", i64* %169 
+  store  i64 %"5#tmp#3##0", i64* %169 
   ret i64 %164 
 }
 
 
 define external fastcc  i64 @"int_list.pop<0>[410bae77d3]"(i64  %"lst##0", i64  %"idx##0")    {
 entry:
-  %"1$tmp$9##0" = icmp ne i64 %"lst##0", 0 
-  br i1 %"1$tmp$9##0", label %if.then, label %if.else 
+  %"1#tmp#9##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1#tmp#9##0", label %if.then, label %if.else 
 if.then:
   %170 = add   i64 %"lst##0", 8 
   %171 = inttoptr i64 %170 to i64* 
   %172 = getelementptr  i64, i64* %171, i64 0 
   %173 = load  i64, i64* %172 
-  %"2$tmp$6##0" = icmp eq i64 %"idx##0", 0 
-  br i1 %"2$tmp$6##0", label %if.then1, label %if.else1 
+  %"2#tmp#6##0" = icmp eq i64 %"idx##0", 0 
+  br i1 %"2#tmp#6##0", label %if.then1, label %if.else1 
 if.else:
   ret i64 0 
 if.then1:
   ret i64 %173 
 if.else1:
-  %"5$tmp$4##0" = sub   i64 %"idx##0", 1 
-  %"5$tmp$3##0" = tail call fastcc  i64  @"int_list.pop<0>[410bae77d3]"(i64  %173, i64  %"5$tmp$4##0")  
+  %"5#tmp#4##0" = sub   i64 %"idx##0", 1 
+  %"5#tmp#3##0" = tail call fastcc  i64  @"int_list.pop<0>[410bae77d3]"(i64  %173, i64  %"5#tmp#4##0")  
   %174 = add   i64 %"lst##0", 8 
   %175 = inttoptr i64 %174 to i64* 
   %176 = getelementptr  i64, i64* %175, i64 0 
-  store  i64 %"5$tmp$3##0", i64* %176 
+  store  i64 %"5#tmp#3##0", i64* %176 
   ret i64 %"lst##0" 
 }
 
 
 define external fastcc  void @"int_list.print<0>"(i64  %"x##0")    {
 entry:
-  %"1$tmp$2##0" = icmp ne i64 %"x##0", 0 
-  br i1 %"1$tmp$2##0", label %if.then, label %if.else 
+  %"1#tmp#2##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1#tmp#2##0", label %if.then, label %if.else 
 if.then:
   %177 = inttoptr i64 %"x##0" to i64* 
   %178 = getelementptr  i64, i64* %177, i64 0 
@@ -2104,15 +2104,15 @@ entry:
 
 define external fastcc  i64 @"int_list.range<0>"(i64  %"start##0", i64  %"stop##0", i64  %"step##0")    {
 entry:
-  %"1$result##1" = tail call fastcc  i64  @"int_list.gen$2<0>"(i64  0, i64  %"start##0", i64  %"step##0", i64  %"stop##0", i64  0)  
-  ret i64 %"1$result##1" 
+  %"1#result##1" = tail call fastcc  i64  @"int_list.gen#2<0>"(i64  0, i64  %"start##0", i64  %"step##0", i64  %"stop##0", i64  0)  
+  ret i64 %"1#result##1" 
 }
 
 
 define external fastcc  i64 @"int_list.remove<0>"(i64  %"lst##0", i64  %"v##0")    {
 entry:
-  %"1$tmp$8##0" = icmp ne i64 %"lst##0", 0 
-  br i1 %"1$tmp$8##0", label %if.then, label %if.else 
+  %"1#tmp#8##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1#tmp#8##0", label %if.then, label %if.else 
 if.then:
   %184 = inttoptr i64 %"lst##0" to i64* 
   %185 = getelementptr  i64, i64* %184, i64 0 
@@ -2121,14 +2121,14 @@ if.then:
   %188 = inttoptr i64 %187 to i64* 
   %189 = getelementptr  i64, i64* %188, i64 0 
   %190 = load  i64, i64* %189 
-  %"2$tmp$5##0" = icmp eq i64 %186, %"v##0" 
-  br i1 %"2$tmp$5##0", label %if.then1, label %if.else1 
+  %"2#tmp#5##0" = icmp eq i64 %186, %"v##0" 
+  br i1 %"2#tmp#5##0", label %if.then1, label %if.else1 
 if.else:
   ret i64 0 
 if.then1:
   ret i64 %190 
 if.else1:
-  %"5$tmp$3##0" = tail call fastcc  i64  @"int_list.remove<0>"(i64  %190, i64  %"v##0")  
+  %"5#tmp#3##0" = tail call fastcc  i64  @"int_list.remove<0>"(i64  %190, i64  %"v##0")  
   %191 = trunc i64 16 to i32  
   %192 = tail call ccc  i8*  @wybe_malloc(i32  %191)  
   %193 = ptrtoint i8* %192 to i64 
@@ -2138,15 +2138,15 @@ if.else1:
   %196 = add   i64 %193, 8 
   %197 = inttoptr i64 %196 to i64* 
   %198 = getelementptr  i64, i64* %197, i64 0 
-  store  i64 %"5$tmp$3##0", i64* %198 
+  store  i64 %"5#tmp#3##0", i64* %198 
   ret i64 %193 
 }
 
 
 define external fastcc  i64 @"int_list.remove<0>[410bae77d3]"(i64  %"lst##0", i64  %"v##0")    {
 entry:
-  %"1$tmp$8##0" = icmp ne i64 %"lst##0", 0 
-  br i1 %"1$tmp$8##0", label %if.then, label %if.else 
+  %"1#tmp#8##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1#tmp#8##0", label %if.then, label %if.else 
 if.then:
   %199 = inttoptr i64 %"lst##0" to i64* 
   %200 = getelementptr  i64, i64* %199, i64 0 
@@ -2155,33 +2155,33 @@ if.then:
   %203 = inttoptr i64 %202 to i64* 
   %204 = getelementptr  i64, i64* %203, i64 0 
   %205 = load  i64, i64* %204 
-  %"2$tmp$5##0" = icmp eq i64 %201, %"v##0" 
-  br i1 %"2$tmp$5##0", label %if.then1, label %if.else1 
+  %"2#tmp#5##0" = icmp eq i64 %201, %"v##0" 
+  br i1 %"2#tmp#5##0", label %if.then1, label %if.else1 
 if.else:
   ret i64 0 
 if.then1:
   ret i64 %205 
 if.else1:
-  %"5$tmp$3##0" = tail call fastcc  i64  @"int_list.remove<0>[410bae77d3]"(i64  %205, i64  %"v##0")  
+  %"5#tmp#3##0" = tail call fastcc  i64  @"int_list.remove<0>[410bae77d3]"(i64  %205, i64  %"v##0")  
   %206 = add   i64 %"lst##0", 8 
   %207 = inttoptr i64 %206 to i64* 
   %208 = getelementptr  i64, i64* %207, i64 0 
-  store  i64 %"5$tmp$3##0", i64* %208 
+  store  i64 %"5#tmp#3##0", i64* %208 
   ret i64 %"lst##0" 
 }
 
 
 define external fastcc  i64 @"int_list.reverse<0>"(i64  %"lst##0")    {
 entry:
-  %"1$$##0" = tail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %"lst##0", i64  0)  
-  ret i64 %"1$$##0" 
+  %"1####0" = tail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %"lst##0", i64  0)  
+  ret i64 %"1####0" 
 }
 
 
 define external fastcc  i64 @"int_list.reverse_helper<0>"(i64  %"lst##0", i64  %"acc##0")    {
 entry:
-  %"1$tmp$5##0" = icmp ne i64 %"lst##0", 0 
-  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
+  %"1#tmp#5##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
   %209 = inttoptr i64 %"lst##0" to i64* 
   %210 = getelementptr  i64, i64* %209, i64 0 
@@ -2200,8 +2200,8 @@ if.then:
   %222 = inttoptr i64 %221 to i64* 
   %223 = getelementptr  i64, i64* %222, i64 0 
   store  i64 %"acc##0", i64* %223 
-  %"2$$##0" = tail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %215, i64  %218)  
-  ret i64 %"2$$##0" 
+  %"2####0" = tail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %215, i64  %218)  
+  ret i64 %"2####0" 
 if.else:
   ret i64 %"acc##0" 
 }
@@ -2209,8 +2209,8 @@ if.else:
 
 define external fastcc  i64 @"int_list.reverse_helper<0>[410bae77d3]"(i64  %"lst##0", i64  %"acc##0")    {
 entry:
-  %"1$tmp$5##0" = icmp ne i64 %"lst##0", 0 
-  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
+  %"1#tmp#5##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
   %224 = add   i64 %"lst##0", 8 
   %225 = inttoptr i64 %224 to i64* 
@@ -2220,8 +2220,8 @@ if.then:
   %229 = inttoptr i64 %228 to i64* 
   %230 = getelementptr  i64, i64* %229, i64 0 
   store  i64 %"acc##0", i64* %230 
-  %"2$$##0" = tail call fastcc  i64  @"int_list.reverse_helper<0>[410bae77d3]"(i64  %227, i64  %"lst##0")  
-  ret i64 %"2$$##0" 
+  %"2####0" = tail call fastcc  i64  @"int_list.reverse_helper<0>[410bae77d3]"(i64  %227, i64  %"lst##0")  
+  ret i64 %"2####0" 
 if.else:
   ret i64 %"acc##0" 
 }
@@ -2229,8 +2229,8 @@ if.else:
 
 define external fastcc  i64 @"int_list.sort<0>"(i64  %"lst##0")    {
 entry:
-  %"1$tmp$10##0" = icmp ne i64 %"lst##0", 0 
-  br i1 %"1$tmp$10##0", label %if.then, label %if.else 
+  %"1#tmp#10##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1#tmp#10##0", label %if.then, label %if.else 
 if.then:
   %231 = inttoptr i64 %"lst##0" to i64* 
   %232 = getelementptr  i64, i64* %231, i64 0 
@@ -2239,10 +2239,10 @@ if.then:
   %235 = inttoptr i64 %234 to i64* 
   %236 = getelementptr  i64, i64* %235, i64 0 
   %237 = load  i64, i64* %236 
-  %"2$tmp$3##0" = tail call fastcc  i64  @"int_list.lesser<0>"(i64  %237, i64  %233)  
-  %"2$tmp$2##0" = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %"2$tmp$3##0")  
-  %"2$tmp$6##0" = tail call fastcc  i64  @"int_list.greater<0>"(i64  %237, i64  %233)  
-  %"2$tmp$5##0" = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %"2$tmp$6##0")  
+  %"2#tmp#3##0" = tail call fastcc  i64  @"int_list.lesser<0>"(i64  %237, i64  %233)  
+  %"2#tmp#2##0" = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %"2#tmp#3##0")  
+  %"2#tmp#6##0" = tail call fastcc  i64  @"int_list.greater<0>"(i64  %237, i64  %233)  
+  %"2#tmp#5##0" = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %"2#tmp#6##0")  
   %238 = trunc i64 16 to i32  
   %239 = tail call ccc  i8*  @wybe_malloc(i32  %238)  
   %240 = ptrtoint i8* %239 to i64 
@@ -2252,9 +2252,9 @@ if.then:
   %243 = add   i64 %240, 8 
   %244 = inttoptr i64 %243 to i64* 
   %245 = getelementptr  i64, i64* %244, i64 0 
-  store  i64 %"2$tmp$5##0", i64* %245 
-  %"2$$##0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"2$tmp$2##0", i64  %240)  
-  ret i64 %"2$$##0" 
+  store  i64 %"2#tmp#5##0", i64* %245 
+  %"2####0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"2#tmp#2##0", i64  %240)  
+  ret i64 %"2####0" 
 if.else:
   ret i64 0 
 }
@@ -2262,8 +2262,8 @@ if.else:
 
 define external fastcc  i64 @"int_list.sort<0>[410bae77d3]"(i64  %"lst##0")    {
 entry:
-  %"1$tmp$10##0" = icmp ne i64 %"lst##0", 0 
-  br i1 %"1$tmp$10##0", label %if.then, label %if.else 
+  %"1#tmp#10##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1#tmp#10##0", label %if.then, label %if.else 
 if.then:
   %246 = inttoptr i64 %"lst##0" to i64* 
   %247 = getelementptr  i64, i64* %246, i64 0 
@@ -2272,16 +2272,16 @@ if.then:
   %250 = inttoptr i64 %249 to i64* 
   %251 = getelementptr  i64, i64* %250, i64 0 
   %252 = load  i64, i64* %251 
-  %"2$tmp$3##0" = tail call fastcc  i64  @"int_list.lesser<0>"(i64  %252, i64  %248)  
-  %"2$tmp$2##0" = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %"2$tmp$3##0")  
-  %"2$tmp$6##0" = tail call fastcc  i64  @"int_list.greater<0>[410bae77d3]"(i64  %252, i64  %248)  
-  %"2$tmp$5##0" = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %"2$tmp$6##0")  
+  %"2#tmp#3##0" = tail call fastcc  i64  @"int_list.lesser<0>"(i64  %252, i64  %248)  
+  %"2#tmp#2##0" = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %"2#tmp#3##0")  
+  %"2#tmp#6##0" = tail call fastcc  i64  @"int_list.greater<0>[410bae77d3]"(i64  %252, i64  %248)  
+  %"2#tmp#5##0" = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %"2#tmp#6##0")  
   %253 = add   i64 %"lst##0", 8 
   %254 = inttoptr i64 %253 to i64* 
   %255 = getelementptr  i64, i64* %254, i64 0 
-  store  i64 %"2$tmp$5##0", i64* %255 
-  %"2$$##0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"2$tmp$2##0", i64  %"lst##0")  
-  ret i64 %"2$$##0" 
+  store  i64 %"2#tmp#5##0", i64* %255 
+  %"2####0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"2#tmp#2##0", i64  %"lst##0")  
+  ret i64 %"2####0" 
 if.else:
   ret i64 0 
 }
@@ -2306,32 +2306,32 @@ if.else:
 
 = > public (2 calls)
 0: int_list.int_list.=<0>
-=($left##0:int_list.int_list, $right##0:int_list.int_list, ?$$##0:wybe.bool):
+=(#left##0:int_list.int_list, #right##0:int_list.int_list, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left##0:int_list.int_list, ~$right##0:int_list.int_list, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:int_list.int_list, ~#right##0:int_list.int_list, ?####0:wybe.bool)
 
     1:
-        foreign lpvm access($left##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$head##0:wybe.int)
-        foreign lpvm access(~$left##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$tail##0:int_list.int_list)
-        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
-        case ~tmp$9##0:wybe.bool of
+        foreign lpvm access(#left##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#head##0:wybe.int)
+        foreign lpvm access(~#left##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#tail##0:int_list.int_list)
+        foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
+        case ~tmp#9##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign lpvm access($right##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$head##0:wybe.int)
-            foreign lpvm access(~$right##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$tail##0:int_list.int_list)
-            foreign llvm icmp_eq(~$left$head##0:wybe.int, ~$right$head##0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
-            case ~tmp$4##0:wybe.bool of
+            foreign lpvm access(#right##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#head##0:wybe.int)
+            foreign lpvm access(~#right##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#tail##0:int_list.int_list)
+            foreign llvm icmp_eq(~#left#head##0:wybe.int, ~#right#head##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
+            case ~tmp#4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
             1:
-                int_list.int_list.=<0>(~$left$tail##0:int_list.int_list, ~$right$tail##0:int_list.int_list, ?$$##0:wybe.bool) #3
+                int_list.int_list.=<0>(~#left#tail##0:int_list.int_list, ~#right#tail##0:int_list.int_list, ?####0:wybe.bool) #3
 
 
 
@@ -2339,110 +2339,110 @@ if.else:
 
 cons > public {inline} (0 calls)
 0: int_list.int_list.cons<0>
-cons(head##0:wybe.int, tail##0:int_list.int_list, ?$##0:int_list.int_list):
+cons(head##0:wybe.int, tail##0:int_list.int_list, ?###0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:int_list.int_list)
-    foreign lpvm mutate(~$rec##0:int_list.int_list, ?$rec##1:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:int_list.int_list)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:int_list.int_list)
+    foreign lpvm mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:int_list.int_list)
 cons > public {inline} (12 calls)
 1: int_list.int_list.cons<1>
-cons(?head##0:wybe.int, ?tail##0:int_list.int_list, $##0:int_list.int_list, ?$$##0:wybe.bool):
+cons(?head##0:wybe.int, ?tail##0:int_list.int_list, ###0:int_list.int_list, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?head##0:wybe.int)
         foreign llvm move(undef:int_list.int_list, ?tail##0:int_list.int_list)
 
     1:
-        foreign lpvm access($##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
-        foreign lpvm access(~$##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:int_list.int_list)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(###0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
+        foreign lpvm access(~###0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:int_list.int_list)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 head > public {inline} (0 calls)
 0: int_list.int_list.head<0>
-head($rec##0:int_list.int_list, ?$##0:wybe.int, ?$$##0:wybe.bool):
+head(#rec##0:int_list.int_list, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 head > public {inline} (0 calls)
 1: int_list.int_list.head<1>
-head($rec##0:int_list.int_list, ?$rec##1:int_list.int_list, $field##0:wybe.int, ?$$##0:wybe.bool):
+head(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:int_list.int_list, ?$rec##1:int_list.int_list)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list)
 
     1:
-        foreign lpvm mutate(~$rec##0:int_list.int_list, ?$rec##1:int_list.int_list, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 nil > public {inline} (0 calls)
 0: int_list.int_list.nil<0>
-nil(?$##0:int_list.int_list):
+nil(?###0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:int_list.int_list, ?$##0:int_list.int_list)
+    foreign llvm move(0:int_list.int_list, ?###0:int_list.int_list)
 
 
 tail > public {inline} (0 calls)
 0: int_list.int_list.tail<0>
-tail($rec##0:int_list.int_list, ?$##0:int_list.int_list, ?$$##0:wybe.bool):
+tail(#rec##0:int_list.int_list, ?###0:int_list.int_list, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:int_list.int_list, ?$##0:int_list.int_list)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:int_list.int_list, ?###0:int_list.int_list)
 
     1:
-        foreign lpvm access(~$rec##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:int_list.int_list)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:int_list.int_list)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 tail > public {inline} (0 calls)
 1: int_list.int_list.tail<1>
-tail($rec##0:int_list.int_list, ?$rec##1:int_list.int_list, $field##0:int_list.int_list, ?$$##0:wybe.bool):
+tail(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:int_list.int_list, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:int_list.int_list, ?$rec##1:int_list.int_list)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec##0:int_list.int_list, ?$rec##1:int_list.int_list, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:int_list.int_list)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm {noalias} mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:int_list.int_list)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: int_list.int_list.~=<0>
-~=($left##0:int_list.int_list, $right##0:int_list.int_list, ?$$##0:wybe.bool):
+~=(#left##0:int_list.int_list, #right##0:int_list.int_list, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    int_list.int_list.=<0>(~$left##0:int_list.int_list, ~$right##0:int_list.int_list, ?tmp$0##0:wybe.bool) #0
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    int_list.int_list.=<0>(~#left##0:int_list.int_list, ~#right##0:int_list.int_list, ?tmp#0##0:wybe.bool) #0
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
   LLVM code       :
 
@@ -2458,38 +2458,38 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"int_list.int_list.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"int_list.int_list.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#left##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %"2$tmp$9##0" = icmp ne i64 %"$right##0", 0 
-  br i1 %"2$tmp$9##0", label %if.then1, label %if.else1 
+  %"2#tmp#9##0" = icmp ne i64 %"#right##0", 0 
+  br i1 %"2#tmp#9##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3#####0" 
 if.then1:
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"4$tmp$4##0" = icmp eq i64 %3, %10 
-  br i1 %"4$tmp$4##0", label %if.then2, label %if.else2 
+  %"4#tmp#4##0" = icmp eq i64 %3, %10 
+  br i1 %"4#tmp#4##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$$$##0" = tail call fastcc  i1  @"int_list.int_list.=<0>"(i64  %7, i64  %14)  
-  ret i1 %"6$$$##0" 
+  %"6#####0" = tail call fastcc  i1  @"int_list.int_list.=<0>"(i64  %7, i64  %14)  
+  ret i1 %"6#####0" 
 if.else2:
   ret i1 0 
 }
@@ -2511,15 +2511,15 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"int_list.int_list.cons<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64, i1} @"int_list.int_list.cons<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -2535,12 +2535,12 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"int_list.int_list.head<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"int_list.int_list.head<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %36 = inttoptr i64 %"$rec##0" to i64* 
+  %36 = inttoptr i64 %"#rec##0" to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
   %39 = insertvalue {i64, i1} undef, i64 %38, 0 
@@ -2553,26 +2553,26 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"int_list.int_list.head<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"int_list.int_list.head<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %43 = trunc i64 16 to i32  
   %44 = tail call ccc  i8*  @wybe_malloc(i32  %43)  
   %45 = ptrtoint i8* %44 to i64 
   %46 = inttoptr i64 %45 to i8* 
-  %47 = inttoptr i64 %"$rec##0" to i8* 
+  %47 = inttoptr i64 %"#rec##0" to i8* 
   %48 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %46, i8*  %47, i32  %48, i32  8, i1  0)  
   %49 = inttoptr i64 %45 to i64* 
   %50 = getelementptr  i64, i64* %49, i64 0 
-  store  i64 %"$field##0", i64* %50 
+  store  i64 %"#field##0", i64* %50 
   %51 = insertvalue {i64, i1} undef, i64 %45, 0 
   %52 = insertvalue {i64, i1} %51, i1 1, 1 
   ret {i64, i1} %52 
 if.else:
-  %53 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %53 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %54 = insertvalue {i64, i1} %53, i1 0, 1 
   ret {i64, i1} %54 
 }
@@ -2584,12 +2584,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"int_list.int_list.tail<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"int_list.int_list.tail<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %55 = add   i64 %"$rec##0", 8 
+  %55 = add   i64 %"#rec##0", 8 
   %56 = inttoptr i64 %55 to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
@@ -2603,37 +2603,37 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"int_list.int_list.tail<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"int_list.int_list.tail<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %63 = trunc i64 16 to i32  
   %64 = tail call ccc  i8*  @wybe_malloc(i32  %63)  
   %65 = ptrtoint i8* %64 to i64 
   %66 = inttoptr i64 %65 to i8* 
-  %67 = inttoptr i64 %"$rec##0" to i8* 
+  %67 = inttoptr i64 %"#rec##0" to i8* 
   %68 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %66, i8*  %67, i32  %68, i32  8, i1  0)  
   %69 = add   i64 %65, 8 
   %70 = inttoptr i64 %69 to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
-  store  i64 %"$field##0", i64* %71 
+  store  i64 %"#field##0", i64* %71 
   %72 = insertvalue {i64, i1} undef, i64 %65, 0 
   %73 = insertvalue {i64, i1} %72, i1 1, 1 
   ret {i64, i1} %73 
 if.else:
-  %74 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %74 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %75 = insertvalue {i64, i1} %74, i1 0, 1 
   ret {i64, i1} %75 
 }
 
 
-define external fastcc  i1 @"int_list.int_list.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"int_list.int_list.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = tail call fastcc  i1  @"int_list.int_list.=<0>"(i64  %"$left##0", i64  %"$right##0")  
-  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
-  ret i1 %"1$$$##0" 
+  %"1#tmp#0##0" = tail call fastcc  i1  @"int_list.int_list.=<0>"(i64  %"#left##0", i64  %"#right##0")  
+  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1#####0" 
 }
 --------------------------------------------------
  Module int_list_test
@@ -2652,58 +2652,58 @@ entry:
 (io##0:wybe.phantom, ?io##22:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
- MultiSpeczDepInfo: [(24,(int_list_test.test_int_list<0>,fromList [NonAliasedParamCond 0 [],NonAliasedParamCond 1 [],NonAliasedParamCond 2 []])),(34,(int_list.gen$2<0>,fromList [NonAliasedParamCond 0 []])),(35,(int_list.gen$2<0>,fromList [NonAliasedParamCond 0 []])),(36,(int_list.gen$2<0>,fromList [NonAliasedParamCond 0 []]))]
+ MultiSpeczDepInfo: [(24,(int_list_test.test_int_list<0>,fromList [NonAliasedParamCond 0 [],NonAliasedParamCond 1 [],NonAliasedParamCond 2 []])),(34,(int_list.gen#2<0>,fromList [NonAliasedParamCond 0 []])),(35,(int_list.gen#2<0>,fromList [NonAliasedParamCond 0 []])),(36,(int_list.gen#2<0>,fromList [NonAliasedParamCond 0 []]))]
     foreign c {impure} malloc_count(?mc1##0:wybe.int) @memory_management:nn:nn
-    int_list.gen$2<0>[410bae77d3](0:int_list.int_list, 1:wybe.int, 1:wybe.int, 10:wybe.int, 0:int_list.int_list, ?tmp$0##0:int_list.int_list) #34 @int_list:nn:nn
-    int_list.gen$2<0>[410bae77d3](0:int_list.int_list, 2:wybe.int, 2:wybe.int, 20:wybe.int, 0:int_list.int_list, ?tmp$1##0:int_list.int_list) #35 @int_list:nn:nn
-    int_list.gen$2<0>[410bae77d3](0:int_list.int_list, 3:wybe.int, 3:wybe.int, 30:wybe.int, 0:int_list.int_list, ?tmp$2##0:int_list.int_list) #36 @int_list:nn:nn
-    foreign c print_string("x y z:":wybe.string, ~#io##0:wybe.phantom, ?tmp$17##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$17##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$0##0:int_list.int_list, ~#io##1:wybe.phantom, ?tmp$20##0:wybe.phantom) #37 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$20##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$1##0:int_list.int_list, ~#io##2:wybe.phantom, ?tmp$23##0:wybe.phantom) #38 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$23##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$2##0:int_list.int_list, ~#io##3:wybe.phantom, ?tmp$26##0:wybe.phantom) #39 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$26##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    int_list.gen#2<0>[410bae77d3](0:int_list.int_list, 1:wybe.int, 1:wybe.int, 10:wybe.int, 0:int_list.int_list, ?tmp#0##0:int_list.int_list) #34 @int_list:nn:nn
+    int_list.gen#2<0>[410bae77d3](0:int_list.int_list, 2:wybe.int, 2:wybe.int, 20:wybe.int, 0:int_list.int_list, ?tmp#1##0:int_list.int_list) #35 @int_list:nn:nn
+    int_list.gen#2<0>[410bae77d3](0:int_list.int_list, 3:wybe.int, 3:wybe.int, 30:wybe.int, 0:int_list.int_list, ?tmp#2##0:int_list.int_list) #36 @int_list:nn:nn
+    foreign c print_string("x y z:":wybe.string, ~#io##0:wybe.phantom, ?tmp#17##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#17##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp#0##0:int_list.int_list, ~#io##1:wybe.phantom, ?tmp#20##0:wybe.phantom) #37 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#20##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp#1##0:int_list.int_list, ~#io##2:wybe.phantom, ?tmp#23##0:wybe.phantom) #38 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#23##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp#2##0:int_list.int_list, ~#io##3:wybe.phantom, ?tmp#26##0:wybe.phantom) #39 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#26##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     foreign c {impure} malloc_count(?mc2##0:wybe.int) @memory_management:nn:nn
-    foreign llvm sub(~mc2##0:wybe.int, ~mc1##0:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
-    foreign c print_string("--------------------":wybe.string, ~#io##4:wybe.phantom, ?tmp$31##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$31##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
-    foreign c print_string("tests with alias":wybe.string, ~#io##5:wybe.phantom, ?tmp$34##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$34##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+    foreign llvm sub(~mc2##0:wybe.int, ~mc1##0:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
+    foreign c print_string("--------------------":wybe.string, ~#io##4:wybe.phantom, ?tmp#31##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#31##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign c print_string("tests with alias":wybe.string, ~#io##5:wybe.phantom, ?tmp#34##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#34##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
     foreign c {impure} malloc_count(?mc1##1:wybe.int) @memory_management:nn:nn
-    int_list_test.test_int_list<0>(tmp$0##0:int_list.int_list, tmp$1##0:int_list.int_list, tmp$2##0:int_list.int_list, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) #13 @int_list_test:nn:nn
+    int_list_test.test_int_list<0>(tmp#0##0:int_list.int_list, tmp#1##0:int_list.int_list, tmp#2##0:int_list.int_list, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) #13 @int_list_test:nn:nn
     foreign c {impure} malloc_count(?mc2##1:wybe.int) @memory_management:nn:nn
-    foreign llvm sub(~mc2##1:wybe.int, ~mc1##1:wybe.int, ?tmp$4##0:wybe.int) @int:nn:nn
-    foreign c print_string("original x y z:":wybe.string, ~#io##7:wybe.phantom, ?tmp$39##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$39##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$0##0:int_list.int_list, ~#io##8:wybe.phantom, ?tmp$42##0:wybe.phantom) #40 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$42##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$1##0:int_list.int_list, ~#io##9:wybe.phantom, ?tmp$45##0:wybe.phantom) #41 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$45##0:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$2##0:int_list.int_list, ~#io##10:wybe.phantom, ?tmp$48##0:wybe.phantom) #42 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$48##0:wybe.phantom, ?#io##11:wybe.phantom) @io:nn:nn
-    foreign c print_string("--------------------":wybe.string, ~#io##11:wybe.phantom, ?tmp$51##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$51##0:wybe.phantom, ?#io##12:wybe.phantom) @io:nn:nn
-    foreign c print_string("--------------------":wybe.string, ~#io##12:wybe.phantom, ?tmp$54##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$54##0:wybe.phantom, ?#io##13:wybe.phantom) @io:nn:nn
-    foreign c print_string("tests without alias":wybe.string, ~#io##13:wybe.phantom, ?tmp$57##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$57##0:wybe.phantom, ?#io##14:wybe.phantom) @io:nn:nn
+    foreign llvm sub(~mc2##1:wybe.int, ~mc1##1:wybe.int, ?tmp#4##0:wybe.int) @int:nn:nn
+    foreign c print_string("original x y z:":wybe.string, ~#io##7:wybe.phantom, ?tmp#39##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#39##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp#0##0:int_list.int_list, ~#io##8:wybe.phantom, ?tmp#42##0:wybe.phantom) #40 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#42##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp#1##0:int_list.int_list, ~#io##9:wybe.phantom, ?tmp#45##0:wybe.phantom) #41 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#45##0:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp#2##0:int_list.int_list, ~#io##10:wybe.phantom, ?tmp#48##0:wybe.phantom) #42 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#48##0:wybe.phantom, ?#io##11:wybe.phantom) @io:nn:nn
+    foreign c print_string("--------------------":wybe.string, ~#io##11:wybe.phantom, ?tmp#51##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#51##0:wybe.phantom, ?#io##12:wybe.phantom) @io:nn:nn
+    foreign c print_string("--------------------":wybe.string, ~#io##12:wybe.phantom, ?tmp#54##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#54##0:wybe.phantom, ?#io##13:wybe.phantom) @io:nn:nn
+    foreign c print_string("tests without alias":wybe.string, ~#io##13:wybe.phantom, ?tmp#57##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#57##0:wybe.phantom, ?#io##14:wybe.phantom) @io:nn:nn
     foreign c {impure} malloc_count(?mc1##2:wybe.int) @memory_management:nn:nn
-    int_list_test.test_int_list<0>[9e35cb823b](~tmp$0##0:int_list.int_list, ~tmp$1##0:int_list.int_list, ~tmp$2##0:int_list.int_list, ~#io##14:wybe.phantom, ?#io##15:wybe.phantom) #24 @int_list_test:nn:nn
+    int_list_test.test_int_list<0>[9e35cb823b](~tmp#0##0:int_list.int_list, ~tmp#1##0:int_list.int_list, ~tmp#2##0:int_list.int_list, ~#io##14:wybe.phantom, ?#io##15:wybe.phantom) #24 @int_list_test:nn:nn
     foreign c {impure} malloc_count(?mc2##2:wybe.int) @memory_management:nn:nn
-    foreign llvm sub(~mc2##2:wybe.int, ~mc1##2:wybe.int, ?tmp$5##0:wybe.int) @int:nn:nn
-    foreign c print_string("--------------------":wybe.string, ~#io##15:wybe.phantom, ?tmp$62##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$62##0:wybe.phantom, ?#io##16:wybe.phantom) @io:nn:nn
+    foreign llvm sub(~mc2##2:wybe.int, ~mc1##2:wybe.int, ?tmp#5##0:wybe.int) @int:nn:nn
+    foreign c print_string("--------------------":wybe.string, ~#io##15:wybe.phantom, ?tmp#62##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#62##0:wybe.phantom, ?#io##16:wybe.phantom) @io:nn:nn
     foreign c print_string(" ** malloc count of building lists: ":wybe.string, ~#io##16:wybe.phantom, ?#io##17:wybe.phantom) @io:nn:nn
-    foreign c print_int(~tmp$3##0:wybe.int, ~#io##17:wybe.phantom, ?tmp$67##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$67##0:wybe.phantom, ?#io##18:wybe.phantom) @io:nn:nn
+    foreign c print_int(~tmp#3##0:wybe.int, ~#io##17:wybe.phantom, ?tmp#67##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#67##0:wybe.phantom, ?#io##18:wybe.phantom) @io:nn:nn
     foreign c print_string(" ** malloc count of test(aliased): ":wybe.string, ~#io##18:wybe.phantom, ?#io##19:wybe.phantom) @io:nn:nn
-    foreign c print_int(~tmp$4##0:wybe.int, ~#io##19:wybe.phantom, ?tmp$72##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$72##0:wybe.phantom, ?#io##20:wybe.phantom) @io:nn:nn
+    foreign c print_int(~tmp#4##0:wybe.int, ~#io##19:wybe.phantom, ?tmp#72##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#72##0:wybe.phantom, ?#io##20:wybe.phantom) @io:nn:nn
     foreign c print_string(" ** malloc count of test(non-aliased): ":wybe.string, ~#io##20:wybe.phantom, ?#io##21:wybe.phantom) @io:nn:nn
-    foreign c print_int(~tmp$5##0:wybe.int, ~#io##21:wybe.phantom, ?tmp$77##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$77##0:wybe.phantom, ?#io##22:wybe.phantom) @io:nn:nn
+    foreign c print_int(~tmp#5##0:wybe.int, ~#io##21:wybe.phantom, ?tmp#77##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#77##0:wybe.phantom, ?#io##22:wybe.phantom) @io:nn:nn
 
 
 test_int_list > (2 calls)
@@ -2714,63 +2714,63 @@ test_int_list(x##0:int_list.int_list, y##0:int_list.int_list, z##0:int_list.int_
  MultiSpeczDepInfo: [(2,(int_list.append<0>,fromList [NonAliasedParamCond 0 [1]])),(7,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []])),(8,(int_list.extend<0>,fromList [NonAliasedParamCond 0 []])),(11,(int_list.insert<0>,fromList [NonAliasedParamCond 0 []])),(12,(int_list.pop<0>,fromList [NonAliasedParamCond 0 []])),(13,(int_list.remove<0>,fromList [NonAliasedParamCond 0 []])),(16,(int_list.sort<0>,fromList [NonAliasedParamCond 0 []])),(19,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]])),(20,(int_list.reverse_helper<0>,fromList [NonAliasedParamCond 0 [2]]))]
     int_list.reverse_helper<0>(~x##0:int_list.int_list, 0:int_list.int_list, ?x##1:int_list.int_list) #19 @int_list:nn:nn
     int_list.reverse_helper<0>(~z##0:int_list.int_list, 0:int_list.int_list, ?z##1:int_list.int_list) #20 @int_list:nn:nn
-    int_list.append<0>(~y##0:int_list.int_list, 99:wybe.int, ?tmp$0##0:int_list.int_list) #2 @int_list_test:nn:nn
-    foreign c print_string("-":wybe.string, ~#io##0:wybe.phantom, ?tmp$10##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    int_list.print<0>(x##1:int_list.int_list, ~#io##1:wybe.phantom, ?tmp$13##0:wybe.phantom) #21 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$13##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$0##0:int_list.int_list, ~#io##2:wybe.phantom, ?tmp$16##0:wybe.phantom) #22 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$16##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    int_list.print<0>(z##1:int_list.int_list, ~#io##3:wybe.phantom, ?tmp$19##0:wybe.phantom) #23 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$19##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    int_list.extend<0>[410bae77d3](~x##1:int_list.int_list, ~tmp$0##0:int_list.int_list, ?tmp$1##0:int_list.int_list) #7 @int_list_test:nn:nn
-    int_list.extend<0>[410bae77d3](~tmp$1##0:int_list.int_list, ~z##1:int_list.int_list, ?tmp$2##0:int_list.int_list) #8 @int_list_test:nn:nn
-    foreign c print_string("-":wybe.string, ~#io##4:wybe.phantom, ?tmp$22##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$22##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$2##0:int_list.int_list, ~#io##5:wybe.phantom, ?tmp$25##0:wybe.phantom) #24 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$25##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
-    int_list.insert<0>[410bae77d3](~tmp$2##0:int_list.int_list, 4:wybe.int, 78:wybe.int, ?tmp$3##0:int_list.int_list) #11 @int_list_test:nn:nn
-    int_list.pop<0>[410bae77d3](~tmp$3##0:int_list.int_list, 20:wybe.int, ?tmp$4##0:int_list.int_list) #12 @int_list_test:nn:nn
-    int_list.remove<0>[410bae77d3](~tmp$4##0:int_list.int_list, 2:wybe.int, ?tmp$5##0:int_list.int_list) #13 @int_list_test:nn:nn
-    foreign c print_string("-":wybe.string, ~#io##6:wybe.phantom, ?tmp$28##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$28##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$5##0:int_list.int_list, ~#io##7:wybe.phantom, ?tmp$31##0:wybe.phantom) #25 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$31##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
-    int_list.sort<0>[410bae77d3](~tmp$5##0:int_list.int_list, ?l##5:int_list.int_list) #16 @int_list_test:nn:nn
-    foreign c print_string("-":wybe.string, ~#io##8:wybe.phantom, ?tmp$34##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$34##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
-    int_list.print<0>(~l##5:int_list.int_list, ~#io##9:wybe.phantom, ?tmp$37##0:wybe.phantom) #26 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$37##0:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
+    int_list.append<0>(~y##0:int_list.int_list, 99:wybe.int, ?tmp#0##0:int_list.int_list) #2 @int_list_test:nn:nn
+    foreign c print_string("-":wybe.string, ~#io##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    int_list.print<0>(x##1:int_list.int_list, ~#io##1:wybe.phantom, ?tmp#13##0:wybe.phantom) #21 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp#0##0:int_list.int_list, ~#io##2:wybe.phantom, ?tmp#16##0:wybe.phantom) #22 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    int_list.print<0>(z##1:int_list.int_list, ~#io##3:wybe.phantom, ?tmp#19##0:wybe.phantom) #23 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#19##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    int_list.extend<0>[410bae77d3](~x##1:int_list.int_list, ~tmp#0##0:int_list.int_list, ?tmp#1##0:int_list.int_list) #7 @int_list_test:nn:nn
+    int_list.extend<0>[410bae77d3](~tmp#1##0:int_list.int_list, ~z##1:int_list.int_list, ?tmp#2##0:int_list.int_list) #8 @int_list_test:nn:nn
+    foreign c print_string("-":wybe.string, ~#io##4:wybe.phantom, ?tmp#22##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#22##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp#2##0:int_list.int_list, ~#io##5:wybe.phantom, ?tmp#25##0:wybe.phantom) #24 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#25##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+    int_list.insert<0>[410bae77d3](~tmp#2##0:int_list.int_list, 4:wybe.int, 78:wybe.int, ?tmp#3##0:int_list.int_list) #11 @int_list_test:nn:nn
+    int_list.pop<0>[410bae77d3](~tmp#3##0:int_list.int_list, 20:wybe.int, ?tmp#4##0:int_list.int_list) #12 @int_list_test:nn:nn
+    int_list.remove<0>[410bae77d3](~tmp#4##0:int_list.int_list, 2:wybe.int, ?tmp#5##0:int_list.int_list) #13 @int_list_test:nn:nn
+    foreign c print_string("-":wybe.string, ~#io##6:wybe.phantom, ?tmp#28##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#28##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp#5##0:int_list.int_list, ~#io##7:wybe.phantom, ?tmp#31##0:wybe.phantom) #25 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#31##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
+    int_list.sort<0>[410bae77d3](~tmp#5##0:int_list.int_list, ?l##5:int_list.int_list) #16 @int_list_test:nn:nn
+    foreign c print_string("-":wybe.string, ~#io##8:wybe.phantom, ?tmp#34##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#34##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
+    int_list.print<0>(~l##5:int_list.int_list, ~#io##9:wybe.phantom, ?tmp#37##0:wybe.phantom) #26 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#37##0:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
  [9e35cb823b] [NonAliasedParam 0,NonAliasedParam 1,NonAliasedParam 2] :
     int_list.reverse_helper<0>[410bae77d3](~x##0:int_list.int_list, 0:int_list.int_list, ?x##1:int_list.int_list) #19 @int_list:nn:nn
     int_list.reverse_helper<0>[410bae77d3](~z##0:int_list.int_list, 0:int_list.int_list, ?z##1:int_list.int_list) #20 @int_list:nn:nn
-    int_list.append<0>[410bae77d3](~y##0:int_list.int_list, 99:wybe.int, ?tmp$0##0:int_list.int_list) #2 @int_list_test:nn:nn
-    foreign c print_string("-":wybe.string, ~#io##0:wybe.phantom, ?tmp$10##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    int_list.print<0>(x##1:int_list.int_list, ~#io##1:wybe.phantom, ?tmp$13##0:wybe.phantom) #21 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$13##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$0##0:int_list.int_list, ~#io##2:wybe.phantom, ?tmp$16##0:wybe.phantom) #22 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$16##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    int_list.print<0>(z##1:int_list.int_list, ~#io##3:wybe.phantom, ?tmp$19##0:wybe.phantom) #23 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$19##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    int_list.extend<0>[410bae77d3](~x##1:int_list.int_list, ~tmp$0##0:int_list.int_list, ?tmp$1##0:int_list.int_list) #7 @int_list_test:nn:nn
-    int_list.extend<0>[410bae77d3](~tmp$1##0:int_list.int_list, ~z##1:int_list.int_list, ?tmp$2##0:int_list.int_list) #8 @int_list_test:nn:nn
-    foreign c print_string("-":wybe.string, ~#io##4:wybe.phantom, ?tmp$22##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$22##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$2##0:int_list.int_list, ~#io##5:wybe.phantom, ?tmp$25##0:wybe.phantom) #24 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$25##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
-    int_list.insert<0>[410bae77d3](~tmp$2##0:int_list.int_list, 4:wybe.int, 78:wybe.int, ?tmp$3##0:int_list.int_list) #11 @int_list_test:nn:nn
-    int_list.pop<0>[410bae77d3](~tmp$3##0:int_list.int_list, 20:wybe.int, ?tmp$4##0:int_list.int_list) #12 @int_list_test:nn:nn
-    int_list.remove<0>[410bae77d3](~tmp$4##0:int_list.int_list, 2:wybe.int, ?tmp$5##0:int_list.int_list) #13 @int_list_test:nn:nn
-    foreign c print_string("-":wybe.string, ~#io##6:wybe.phantom, ?tmp$28##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$28##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
-    int_list.print<0>(tmp$5##0:int_list.int_list, ~#io##7:wybe.phantom, ?tmp$31##0:wybe.phantom) #25 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$31##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
-    int_list.sort<0>[410bae77d3](~tmp$5##0:int_list.int_list, ?l##5:int_list.int_list) #16 @int_list_test:nn:nn
-    foreign c print_string("-":wybe.string, ~#io##8:wybe.phantom, ?tmp$34##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$34##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
-    int_list.print<0>(~l##5:int_list.int_list, ~#io##9:wybe.phantom, ?tmp$37##0:wybe.phantom) #26 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$37##0:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
+    int_list.append<0>[410bae77d3](~y##0:int_list.int_list, 99:wybe.int, ?tmp#0##0:int_list.int_list) #2 @int_list_test:nn:nn
+    foreign c print_string("-":wybe.string, ~#io##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    int_list.print<0>(x##1:int_list.int_list, ~#io##1:wybe.phantom, ?tmp#13##0:wybe.phantom) #21 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp#0##0:int_list.int_list, ~#io##2:wybe.phantom, ?tmp#16##0:wybe.phantom) #22 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    int_list.print<0>(z##1:int_list.int_list, ~#io##3:wybe.phantom, ?tmp#19##0:wybe.phantom) #23 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#19##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    int_list.extend<0>[410bae77d3](~x##1:int_list.int_list, ~tmp#0##0:int_list.int_list, ?tmp#1##0:int_list.int_list) #7 @int_list_test:nn:nn
+    int_list.extend<0>[410bae77d3](~tmp#1##0:int_list.int_list, ~z##1:int_list.int_list, ?tmp#2##0:int_list.int_list) #8 @int_list_test:nn:nn
+    foreign c print_string("-":wybe.string, ~#io##4:wybe.phantom, ?tmp#22##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#22##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp#2##0:int_list.int_list, ~#io##5:wybe.phantom, ?tmp#25##0:wybe.phantom) #24 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#25##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+    int_list.insert<0>[410bae77d3](~tmp#2##0:int_list.int_list, 4:wybe.int, 78:wybe.int, ?tmp#3##0:int_list.int_list) #11 @int_list_test:nn:nn
+    int_list.pop<0>[410bae77d3](~tmp#3##0:int_list.int_list, 20:wybe.int, ?tmp#4##0:int_list.int_list) #12 @int_list_test:nn:nn
+    int_list.remove<0>[410bae77d3](~tmp#4##0:int_list.int_list, 2:wybe.int, ?tmp#5##0:int_list.int_list) #13 @int_list_test:nn:nn
+    foreign c print_string("-":wybe.string, ~#io##6:wybe.phantom, ?tmp#28##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#28##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
+    int_list.print<0>(tmp#5##0:int_list.int_list, ~#io##7:wybe.phantom, ?tmp#31##0:wybe.phantom) #25 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#31##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
+    int_list.sort<0>[410bae77d3](~tmp#5##0:int_list.int_list, ?l##5:int_list.int_list) #16 @int_list_test:nn:nn
+    foreign c print_string("-":wybe.string, ~#io##8:wybe.phantom, ?tmp#34##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#34##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
+    int_list.print<0>(~l##5:int_list.int_list, ~#io##9:wybe.phantom, ?tmp#37##0:wybe.phantom) #26 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#37##0:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -2795,7 +2795,7 @@ declare external ccc  i64 @malloc_count()
 declare external fastcc  void @"int_list.print<0>"(i64)    
 
 
-declare external fastcc  i64 @"int_list.gen$2<0>[410bae77d3]"(i64, i64, i64, i64, i64)    
+declare external fastcc  i64 @"int_list.gen#2<0>[410bae77d3]"(i64, i64, i64, i64, i64)    
 
 
 @int_list_test.21 =    constant [?? x i8] c" ** malloc count of test(non-aliased): \00"
@@ -2890,39 +2890,39 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"int_list_test.<0>"()    {
 entry:
-  %"1$mc1##0" = tail call ccc  i64  @malloc_count()  
-  %"1$tmp$0##0" = tail call fastcc  i64  @"int_list.gen$2<0>[410bae77d3]"(i64  0, i64  1, i64  1, i64  10, i64  0)  
-  %"1$tmp$1##0" = tail call fastcc  i64  @"int_list.gen$2<0>[410bae77d3]"(i64  0, i64  2, i64  2, i64  20, i64  0)  
-  %"1$tmp$2##0" = tail call fastcc  i64  @"int_list.gen$2<0>[410bae77d3]"(i64  0, i64  3, i64  3, i64  30, i64  0)  
+  %"1#mc1##0" = tail call ccc  i64  @malloc_count()  
+  %"1#tmp#0##0" = tail call fastcc  i64  @"int_list.gen#2<0>[410bae77d3]"(i64  0, i64  1, i64  1, i64  10, i64  0)  
+  %"1#tmp#1##0" = tail call fastcc  i64  @"int_list.gen#2<0>[410bae77d3]"(i64  0, i64  2, i64  2, i64  20, i64  0)  
+  %"1#tmp#2##0" = tail call fastcc  i64  @"int_list.gen#2<0>[410bae77d3]"(i64  0, i64  3, i64  3, i64  30, i64  0)  
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$0##0")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1#tmp#0##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$1##0")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1#tmp#1##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$2##0")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1#tmp#2##0")  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$mc2##0" = tail call ccc  i64  @malloc_count()  
-  %"1$tmp$3##0" = sub   i64 %"1$mc2##0", %"1$mc1##0" 
+  %"1#mc2##0" = tail call ccc  i64  @malloc_count()  
+  %"1#tmp#3##0" = sub   i64 %"1#mc2##0", %"1#mc1##0" 
   %4 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.3, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %4)  
   tail call ccc  void  @putchar(i8  10)  
   %6 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.5, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %6)  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$mc1##1" = tail call ccc  i64  @malloc_count()  
-  tail call fastcc  void  @"int_list_test.test_int_list<0>"(i64  %"1$tmp$0##0", i64  %"1$tmp$1##0", i64  %"1$tmp$2##0")  
-  %"1$mc2##1" = tail call ccc  i64  @malloc_count()  
-  %"1$tmp$4##0" = sub   i64 %"1$mc2##1", %"1$mc1##1" 
+  %"1#mc1##1" = tail call ccc  i64  @malloc_count()  
+  tail call fastcc  void  @"int_list_test.test_int_list<0>"(i64  %"1#tmp#0##0", i64  %"1#tmp#1##0", i64  %"1#tmp#2##0")  
+  %"1#mc2##1" = tail call ccc  i64  @malloc_count()  
+  %"1#tmp#4##0" = sub   i64 %"1#mc2##1", %"1#mc1##1" 
   %8 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.7, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %8)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$0##0")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1#tmp#0##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$1##0")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1#tmp#1##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$2##0")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1#tmp#2##0")  
   tail call ccc  void  @putchar(i8  10)  
   %10 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.9, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %10)  
@@ -2933,24 +2933,24 @@ entry:
   %14 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.13, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %14)  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$mc1##2" = tail call ccc  i64  @malloc_count()  
-  tail call fastcc  void  @"int_list_test.test_int_list<0>[9e35cb823b]"(i64  %"1$tmp$0##0", i64  %"1$tmp$1##0", i64  %"1$tmp$2##0")  
-  %"1$mc2##2" = tail call ccc  i64  @malloc_count()  
-  %"1$tmp$5##0" = sub   i64 %"1$mc2##2", %"1$mc1##2" 
+  %"1#mc1##2" = tail call ccc  i64  @malloc_count()  
+  tail call fastcc  void  @"int_list_test.test_int_list<0>[9e35cb823b]"(i64  %"1#tmp#0##0", i64  %"1#tmp#1##0", i64  %"1#tmp#2##0")  
+  %"1#mc2##2" = tail call ccc  i64  @malloc_count()  
+  %"1#tmp#5##0" = sub   i64 %"1#mc2##2", %"1#mc1##2" 
   %16 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.15, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %16)  
   tail call ccc  void  @putchar(i8  10)  
   %18 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.17, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %18)  
-  tail call ccc  void  @print_int(i64  %"1$tmp$3##0")  
+  tail call ccc  void  @print_int(i64  %"1#tmp#3##0")  
   tail call ccc  void  @putchar(i8  10)  
   %20 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.19, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %20)  
-  tail call ccc  void  @print_int(i64  %"1$tmp$4##0")  
+  tail call ccc  void  @print_int(i64  %"1#tmp#4##0")  
   tail call ccc  void  @putchar(i8  10)  
   %22 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.21, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %22)  
-  tail call ccc  void  @print_int(i64  %"1$tmp$5##0")  
+  tail call ccc  void  @print_int(i64  %"1#tmp#5##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -2958,38 +2958,38 @@ entry:
 
 define external fastcc  void @"int_list_test.test_int_list<0>"(i64  %"x##0", i64  %"y##0", i64  %"z##0")    {
 entry:
-  %"1$x##1" = tail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %"x##0", i64  0)  
-  %"1$z##1" = tail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %"z##0", i64  0)  
-  %"1$tmp$0##0" = tail call fastcc  i64  @"int_list.append<0>"(i64  %"y##0", i64  99)  
+  %"1#x##1" = tail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %"x##0", i64  0)  
+  %"1#z##1" = tail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %"z##0", i64  0)  
+  %"1#tmp#0##0" = tail call fastcc  i64  @"int_list.append<0>"(i64  %"y##0", i64  99)  
   %24 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.23, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %24)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$x##1")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1#x##1")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$0##0")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1#tmp#0##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$z##1")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1#z##1")  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$tmp$1##0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"1$x##1", i64  %"1$tmp$0##0")  
-  %"1$tmp$2##0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"1$tmp$1##0", i64  %"1$z##1")  
+  %"1#tmp#1##0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"1#x##1", i64  %"1#tmp#0##0")  
+  %"1#tmp#2##0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"1#tmp#1##0", i64  %"1#z##1")  
   %26 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.25, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %26)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$2##0")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1#tmp#2##0")  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$tmp$3##0" = tail call fastcc  i64  @"int_list.insert<0>[410bae77d3]"(i64  %"1$tmp$2##0", i64  4, i64  78)  
-  %"1$tmp$4##0" = tail call fastcc  i64  @"int_list.pop<0>[410bae77d3]"(i64  %"1$tmp$3##0", i64  20)  
-  %"1$tmp$5##0" = tail call fastcc  i64  @"int_list.remove<0>[410bae77d3]"(i64  %"1$tmp$4##0", i64  2)  
+  %"1#tmp#3##0" = tail call fastcc  i64  @"int_list.insert<0>[410bae77d3]"(i64  %"1#tmp#2##0", i64  4, i64  78)  
+  %"1#tmp#4##0" = tail call fastcc  i64  @"int_list.pop<0>[410bae77d3]"(i64  %"1#tmp#3##0", i64  20)  
+  %"1#tmp#5##0" = tail call fastcc  i64  @"int_list.remove<0>[410bae77d3]"(i64  %"1#tmp#4##0", i64  2)  
   %28 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.27, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %28)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$5##0")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1#tmp#5##0")  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$l##5" = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %"1$tmp$5##0")  
+  %"1#l##5" = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %"1#tmp#5##0")  
   %30 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.29, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %30)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$l##5")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1#l##5")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -2997,38 +2997,38 @@ entry:
 
 define external fastcc  void @"int_list_test.test_int_list<0>[9e35cb823b]"(i64  %"x##0", i64  %"y##0", i64  %"z##0")    {
 entry:
-  %"1$x##1" = tail call fastcc  i64  @"int_list.reverse_helper<0>[410bae77d3]"(i64  %"x##0", i64  0)  
-  %"1$z##1" = tail call fastcc  i64  @"int_list.reverse_helper<0>[410bae77d3]"(i64  %"z##0", i64  0)  
-  %"1$tmp$0##0" = tail call fastcc  i64  @"int_list.append<0>[410bae77d3]"(i64  %"y##0", i64  99)  
+  %"1#x##1" = tail call fastcc  i64  @"int_list.reverse_helper<0>[410bae77d3]"(i64  %"x##0", i64  0)  
+  %"1#z##1" = tail call fastcc  i64  @"int_list.reverse_helper<0>[410bae77d3]"(i64  %"z##0", i64  0)  
+  %"1#tmp#0##0" = tail call fastcc  i64  @"int_list.append<0>[410bae77d3]"(i64  %"y##0", i64  99)  
   %32 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.31, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %32)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$x##1")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1#x##1")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$0##0")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1#tmp#0##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$z##1")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1#z##1")  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$tmp$1##0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"1$x##1", i64  %"1$tmp$0##0")  
-  %"1$tmp$2##0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"1$tmp$1##0", i64  %"1$z##1")  
+  %"1#tmp#1##0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"1#x##1", i64  %"1#tmp#0##0")  
+  %"1#tmp#2##0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"1#tmp#1##0", i64  %"1#z##1")  
   %34 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.33, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %34)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$2##0")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1#tmp#2##0")  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$tmp$3##0" = tail call fastcc  i64  @"int_list.insert<0>[410bae77d3]"(i64  %"1$tmp$2##0", i64  4, i64  78)  
-  %"1$tmp$4##0" = tail call fastcc  i64  @"int_list.pop<0>[410bae77d3]"(i64  %"1$tmp$3##0", i64  20)  
-  %"1$tmp$5##0" = tail call fastcc  i64  @"int_list.remove<0>[410bae77d3]"(i64  %"1$tmp$4##0", i64  2)  
+  %"1#tmp#3##0" = tail call fastcc  i64  @"int_list.insert<0>[410bae77d3]"(i64  %"1#tmp#2##0", i64  4, i64  78)  
+  %"1#tmp#4##0" = tail call fastcc  i64  @"int_list.pop<0>[410bae77d3]"(i64  %"1#tmp#3##0", i64  20)  
+  %"1#tmp#5##0" = tail call fastcc  i64  @"int_list.remove<0>[410bae77d3]"(i64  %"1#tmp#4##0", i64  2)  
   %36 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.35, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %36)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$tmp$5##0")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1#tmp#5##0")  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$l##5" = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %"1$tmp$5##0")  
+  %"1#l##5" = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %"1#tmp#5##0")  
   %38 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @int_list_test.37, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %38)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"1$l##5")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"1#l##5")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/aaa.exp
+++ b/test-cases/final-dump/aaa.exp
@@ -13,11 +13,11 @@ AFTER EVERYTHING:
 
 *main* > public {inline} (0 calls)
 0: aaa.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("AAA: Init":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_string("AAA: Init":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -62,11 +62,11 @@ entry:
 
 *main* > public {inline} (0 calls)
 0: bbb.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("BBB: Init":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_string("BBB: Init":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -111,11 +111,11 @@ entry:
 
 *main* > public {inline} (0 calls)
 0: ccc.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("CCC: Init":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_string("CCC: Init":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -159,11 +159,11 @@ entry:
 
 *main* > public {inline} (0 calls)
 0: ddd.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("DDD: Init":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_string("DDD: Init":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/aaa.exp
+++ b/test-cases/final-dump/aaa.exp
@@ -16,8 +16,8 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("AAA: Init":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("AAA: Init":wybe.string, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -65,8 +65,8 @@ entry:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("BBB: Init":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("BBB: Init":wybe.string, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -114,8 +114,8 @@ entry:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("CCC: Init":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("CCC: Init":wybe.string, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -162,8 +162,8 @@ entry:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("DDD: Init":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("DDD: Init":wybe.string, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/afterbreak.exp
+++ b/test-cases/final-dump/afterbreak.exp
@@ -14,35 +14,35 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    afterbreak.gen$1<0>(~io##0:wybe.phantom, 1:wybe.int, ?io##1:wybe.phantom) #0 @afterbreak:nn:nn
+    afterbreak.gen#1<0>(~io##0:wybe.phantom, 1:wybe.int, ?io##1:wybe.phantom) #0 @afterbreak:nn:nn
 
 
-gen$1 > (2 calls)
-0: afterbreak.gen$1<0>
-gen$1(io##0:wybe.phantom, x##0:wybe.int, ?io##1:wybe.phantom):
+gen#1 > (2 calls)
+0: afterbreak.gen#1<0>
+gen#1(io##0:wybe.phantom, x##0:wybe.int, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_sgt(x##0:wybe.int, 10:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign llvm icmp_sgt(x##0:wybe.int, 10:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm add(~x##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
-        foreign c print_int(tmp$0##0:wybe.int, ~io##0:wybe.phantom, ?tmp$10##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$10##0:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
-        afterbreak.gen$1<0>(~tmp$11##0:wybe.phantom, ~tmp$0##0:wybe.int, ?io##1:wybe.phantom) #3 @afterbreak:nn:nn
+        foreign llvm add(~x##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
+        foreign c print_int(tmp#0##0:wybe.int, ~io##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
+        afterbreak.gen#1<0>(~tmp#11##0:wybe.phantom, ~tmp#0##0:wybe.int, ?io##1:wybe.phantom) #3 @afterbreak:nn:nn
 
     1:
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
 
 
-gen$2 > {inline} (1 calls)
-0: afterbreak.gen$2<0>
-gen$2(io##0:wybe.phantom, [tmp$0##0:wybe.int], [x##0:wybe.int], y##0:wybe.int, ?io##2:wybe.phantom):
+gen#2 > {inline} (1 calls)
+0: afterbreak.gen#2<0>
+gen#2(io##0:wybe.phantom, [tmp#0##0:wybe.int], [x##0:wybe.int], y##0:wybe.int, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(y##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$3##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$3##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    afterbreak.gen$1<0>(~io##1:wybe.phantom, ~y##0:wybe.int, ?io##2:wybe.phantom) #1 @afterbreak:nn:nn
+    foreign c print_int(y##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#3##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#3##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    afterbreak.gen#1<0>(~io##1:wybe.phantom, ~y##0:wybe.int, ?io##2:wybe.phantom) #1 @afterbreak:nn:nn
 
   LLVM code       :
 
@@ -66,30 +66,30 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"afterbreak.<0>"()    {
 entry:
-  tail call fastcc  void  @"afterbreak.gen$1<0>"(i64  1)  
+  tail call fastcc  void  @"afterbreak.gen#1<0>"(i64  1)  
   ret void 
 }
 
 
-define external fastcc  void @"afterbreak.gen$1<0>"(i64  %"x##0")    {
+define external fastcc  void @"afterbreak.gen#1<0>"(i64  %"x##0")    {
 entry:
-  %"1$tmp$1##0" = icmp sgt i64 %"x##0", 10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp sgt i64 %"x##0", 10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
   ret void 
 if.else:
-  %"3$tmp$0##0" = add   i64 %"x##0", 1 
-  tail call ccc  void  @print_int(i64  %"3$tmp$0##0")  
+  %"3#tmp#0##0" = add   i64 %"x##0", 1 
+  tail call ccc  void  @print_int(i64  %"3#tmp#0##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"afterbreak.gen$1<0>"(i64  %"3$tmp$0##0")  
+  tail call fastcc  void  @"afterbreak.gen#1<0>"(i64  %"3#tmp#0##0")  
   ret void 
 }
 
 
-define external fastcc  void @"afterbreak.gen$2<0>"(i64  %"y##0")    {
+define external fastcc  void @"afterbreak.gen#2<0>"(i64  %"y##0")    {
 entry:
   tail call ccc  void  @print_int(i64  %"y##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"afterbreak.gen$1<0>"(i64  %"y##0")  
+  tail call fastcc  void  @"afterbreak.gen#1<0>"(i64  %"y##0")  
   ret void 
 }

--- a/test-cases/final-dump/afterbreak.exp
+++ b/test-cases/final-dump/afterbreak.exp
@@ -11,38 +11,38 @@ AFTER EVERYTHING:
 
 *main* > public {inline} (0 calls)
 0: afterbreak.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    afterbreak.gen$1<0>(~io#0:wybe.phantom, 1:wybe.int, ?io#1:wybe.phantom) #0 @afterbreak:nn:nn
+    afterbreak.gen$1<0>(~io##0:wybe.phantom, 1:wybe.int, ?io##1:wybe.phantom) #0 @afterbreak:nn:nn
 
 
 gen$1 > (2 calls)
 0: afterbreak.gen$1<0>
-gen$1(io#0:wybe.phantom, x#0:wybe.int, ?io#1:wybe.phantom):
+gen$1(io##0:wybe.phantom, x##0:wybe.int, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_sgt(x#0:wybe.int, 10:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign llvm icmp_sgt(x##0:wybe.int, 10:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm add(~x#0:wybe.int, 1:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn
-        foreign c print_int(tmp$0#0:wybe.int, ~io#0:wybe.phantom, ?tmp$10#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$10#0:wybe.phantom, ?tmp$11#0:wybe.phantom) @io:nn:nn
-        afterbreak.gen$1<0>(~tmp$11#0:wybe.phantom, ~tmp$0#0:wybe.int, ?io#1:wybe.phantom) #3 @afterbreak:nn:nn
+        foreign llvm add(~x##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
+        foreign c print_int(tmp$0##0:wybe.int, ~io##0:wybe.phantom, ?tmp$10##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$10##0:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
+        afterbreak.gen$1<0>(~tmp$11##0:wybe.phantom, ~tmp$0##0:wybe.int, ?io##1:wybe.phantom) #3 @afterbreak:nn:nn
 
     1:
-        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
 
 
 gen$2 > {inline} (1 calls)
 0: afterbreak.gen$2<0>
-gen$2(io#0:wybe.phantom, [tmp$0#0:wybe.int], [x#0:wybe.int], y#0:wybe.int, ?io#2:wybe.phantom):
+gen$2(io##0:wybe.phantom, [tmp$0##0:wybe.int], [x##0:wybe.int], y##0:wybe.int, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(y#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$3#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$3#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    afterbreak.gen$1<0>(~io#1:wybe.phantom, ~y#0:wybe.int, ?io#2:wybe.phantom) #1 @afterbreak:nn:nn
+    foreign c print_int(y##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$3##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$3##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    afterbreak.gen$1<0>(~io##1:wybe.phantom, ~y##0:wybe.int, ?io##2:wybe.phantom) #1 @afterbreak:nn:nn
 
   LLVM code       :
 
@@ -71,25 +71,25 @@ entry:
 }
 
 
-define external fastcc  void @"afterbreak.gen$1<0>"(i64  %"x#0")    {
+define external fastcc  void @"afterbreak.gen$1<0>"(i64  %"x##0")    {
 entry:
-  %"1$tmp$1#0" = icmp sgt i64 %"x#0", 10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp sgt i64 %"x##0", 10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
   ret void 
 if.else:
-  %"3$tmp$0#0" = add   i64 %"x#0", 1 
-  tail call ccc  void  @print_int(i64  %"3$tmp$0#0")  
+  %"3$tmp$0##0" = add   i64 %"x##0", 1 
+  tail call ccc  void  @print_int(i64  %"3$tmp$0##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"afterbreak.gen$1<0>"(i64  %"3$tmp$0#0")  
+  tail call fastcc  void  @"afterbreak.gen$1<0>"(i64  %"3$tmp$0##0")  
   ret void 
 }
 
 
-define external fastcc  void @"afterbreak.gen$2<0>"(i64  %"y#0")    {
+define external fastcc  void @"afterbreak.gen$2<0>"(i64  %"y##0")    {
 entry:
-  tail call ccc  void  @print_int(i64  %"y#0")  
+  tail call ccc  void  @print_int(i64  %"y##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"afterbreak.gen$1<0>"(i64  %"y#0")  
+  tail call fastcc  void  @"afterbreak.gen$1<0>"(i64  %"y##0")  
   ret void 
 }

--- a/test-cases/final-dump/alias1.exp
+++ b/test-cases/final-dump/alias1.exp
@@ -16,113 +16,113 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: alias1.<0>
-(io#0:wybe.phantom, ?io#6:wybe.phantom):
+(io##0:wybe.phantom, ?io##6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("-------------- Calling foo: ":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    alias1.foo<0>(~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #1 @alias1:74:2
-    foreign c print_string("-------------- Calling bar: ":wybe.string, ~#io#2:wybe.phantom, ?tmp$5#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$5#0:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    alias1.bar<0>(~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #3 @alias1:76:2
-    foreign c print_string("-------------- Calling baz: ":wybe.string, ~#io#4:wybe.phantom, ?tmp$8#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$8#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-    alias1.baz<0>(~#io#5:wybe.phantom, ?#io#6:wybe.phantom) #5 @alias1:78:2
+    foreign c print_string("-------------- Calling foo: ":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    alias1.foo<0>(~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #1 @alias1:74:2
+    foreign c print_string("-------------- Calling bar: ":wybe.string, ~#io##2:wybe.phantom, ?tmp$5##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$5##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    alias1.bar<0>(~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #3 @alias1:76:2
+    foreign c print_string("-------------- Calling baz: ":wybe.string, ~#io##4:wybe.phantom, ?tmp$8##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$8##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    alias1.baz<0>(~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #5 @alias1:78:2
 
 
 bar > public (1 calls)
 0: alias1.bar<0>
-bar(io#0:wybe.phantom, ?io#11:wybe.phantom):
+bar(io##0:wybe.phantom, ?io##11:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$3#0:position.position)
-    foreign lpvm mutate(~tmp$3#0:position.position, ?tmp$4#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
-    foreign lpvm mutate(~tmp$4#0:position.position, ?tmp$0#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int)
-    alias1.replicate<0>(tmp$0#0:position.position, ?p2#0:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #1 @alias1:31:4
-    foreign c print_string("--- Inside bar: ":wybe.string, ~#io#1:wybe.phantom, ?tmp$7#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$7#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect p1(101,102):":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(tmp$0#0:position.position, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #4 @alias1:35:4
-    foreign c print_string("expect p2(101,102):":wybe.string, ~#io#4:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(p2#0:position.position, ~#io#5:wybe.phantom, ?#io#6:wybe.phantom) #6 @alias1:37:4
-    foreign lpvm {noalias} mutate(~%p2#0:position.position, ?%p2#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int)
-    foreign c print_string("--- Inside bar, after calling x(!p2, 555): ":wybe.string, ~#io#6:wybe.phantom, ?tmp$16#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$16#0:wybe.phantom, ?#io#7:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect p1(101,102):":wybe.string, ~#io#7:wybe.phantom, ?#io#8:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~tmp$0#0:position.position, ~#io#8:wybe.phantom, ?#io#9:wybe.phantom) #10 @alias1:43:4
-    foreign c print_string("expect p2(555,102):":wybe.string, ~#io#9:wybe.phantom, ?#io#10:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~p2#1:position.position, ~#io#10:wybe.phantom, ?#io#11:wybe.phantom) #12 @alias1:45:4
+    foreign lpvm alloc(16:wybe.int, ?tmp$3##0:position.position)
+    foreign lpvm mutate(~tmp$3##0:position.position, ?tmp$4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
+    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int)
+    alias1.replicate<0>(tmp$0##0:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias1:31:4
+    foreign c print_string("--- Inside bar: ":wybe.string, ~#io##1:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect p1(101,102):":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(tmp$0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias1:35:4
+    foreign c print_string("expect p2(101,102):":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(p2##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #6 @alias1:37:4
+    foreign lpvm {noalias} mutate(~%p2##0:position.position, ?%p2##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int)
+    foreign c print_string("--- Inside bar, after calling x(!p2, 555): ":wybe.string, ~#io##6:wybe.phantom, ?tmp$16##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$16##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect p1(101,102):":wybe.string, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~tmp$0##0:position.position, ~#io##8:wybe.phantom, ?#io##9:wybe.phantom) #10 @alias1:43:4
+    foreign c print_string("expect p2(555,102):":wybe.string, ~#io##9:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~p2##1:position.position, ~#io##10:wybe.phantom, ?#io##11:wybe.phantom) #12 @alias1:45:4
 
 
 baz > public (1 calls)
 0: alias1.baz<0>
-baz(io#0:wybe.phantom, ?io#15:wybe.phantom):
+baz(io##0:wybe.phantom, ?io##15:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$5#0:position.position)
-    foreign lpvm mutate(~tmp$5#0:position.position, ?tmp$6#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
-    foreign lpvm mutate(~tmp$6#0:position.position, ?tmp$0#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int)
-    alias1.replicate<0>(tmp$0#0:position.position, ?p2#0:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #1 @alias1:50:4
-    foreign c print_string("--- Inside baz: ":wybe.string, ~#io#1:wybe.phantom, ?tmp$9#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$9#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect p1(101,102):":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(tmp$0#0:position.position, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #4 @alias1:54:4
-    foreign c print_string("expect p2(101,102):":wybe.string, ~#io#4:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(p2#0:position.position, ~#io#5:wybe.phantom, ?#io#6:wybe.phantom) #6 @alias1:56:4
-    foreign lpvm access(p2#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$2#0:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$17#0:position.position)
-    foreign lpvm mutate(~tmp$17#0:position.position, ?tmp$18#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 33333333:wybe.int)
-    foreign lpvm mutate(~tmp$18#0:position.position, ?tmp$1#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:wybe.int)
-    foreign c print_string("expect p3(33333333,102):":wybe.string, ~#io#6:wybe.phantom, ?#io#7:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(tmp$1#0:position.position, ~#io#7:wybe.phantom, ?#io#8:wybe.phantom) #10 @alias1:60:4
-    foreign lpvm {noalias} mutate(~tmp$0#0:position.position, ?%p1#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int)
-    foreign c print_string("--- Inside baz, after calling x(!p1, 555): ":wybe.string, ~#io#8:wybe.phantom, ?tmp$25#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$25#0:wybe.phantom, ?#io#9:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect p1(555,102):":wybe.string, ~#io#9:wybe.phantom, ?#io#10:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~p1#1:position.position, ~#io#10:wybe.phantom, ?#io#11:wybe.phantom) #14 @alias1:66:4
-    foreign c print_string("expect p2(101,102):":wybe.string, ~#io#11:wybe.phantom, ?#io#12:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~p2#0:position.position, ~#io#12:wybe.phantom, ?#io#13:wybe.phantom) #16 @alias1:68:4
-    foreign c print_string("expect p3(33333333,102):":wybe.string, ~#io#13:wybe.phantom, ?#io#14:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~tmp$1#0:position.position, ~#io#14:wybe.phantom, ?#io#15:wybe.phantom) #18 @alias1:70:4
+    foreign lpvm alloc(16:wybe.int, ?tmp$5##0:position.position)
+    foreign lpvm mutate(~tmp$5##0:position.position, ?tmp$6##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
+    foreign lpvm mutate(~tmp$6##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int)
+    alias1.replicate<0>(tmp$0##0:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias1:50:4
+    foreign c print_string("--- Inside baz: ":wybe.string, ~#io##1:wybe.phantom, ?tmp$9##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$9##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect p1(101,102):":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(tmp$0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias1:54:4
+    foreign c print_string("expect p2(101,102):":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(p2##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #6 @alias1:56:4
+    foreign lpvm access(p2##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp$17##0:position.position)
+    foreign lpvm mutate(~tmp$17##0:position.position, ?tmp$18##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 33333333:wybe.int)
+    foreign lpvm mutate(~tmp$18##0:position.position, ?tmp$1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:wybe.int)
+    foreign c print_string("expect p3(33333333,102):":wybe.string, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(tmp$1##0:position.position, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) #10 @alias1:60:4
+    foreign lpvm {noalias} mutate(~tmp$0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int)
+    foreign c print_string("--- Inside baz, after calling x(!p1, 555): ":wybe.string, ~#io##8:wybe.phantom, ?tmp$25##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$25##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect p1(555,102):":wybe.string, ~#io##9:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~p1##1:position.position, ~#io##10:wybe.phantom, ?#io##11:wybe.phantom) #14 @alias1:66:4
+    foreign c print_string("expect p2(101,102):":wybe.string, ~#io##11:wybe.phantom, ?#io##12:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~p2##0:position.position, ~#io##12:wybe.phantom, ?#io##13:wybe.phantom) #16 @alias1:68:4
+    foreign c print_string("expect p3(33333333,102):":wybe.string, ~#io##13:wybe.phantom, ?#io##14:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~tmp$1##0:position.position, ~#io##14:wybe.phantom, ?#io##15:wybe.phantom) #18 @alias1:70:4
 
 
 foo > public (1 calls)
 0: alias1.foo<0>
-foo(io#0:wybe.phantom, ?io#11:wybe.phantom):
+foo(io##0:wybe.phantom, ?io##11:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$3#0:position.position)
-    foreign lpvm mutate(~tmp$3#0:position.position, ?tmp$4#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
-    foreign lpvm mutate(~tmp$4#0:position.position, ?tmp$0#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int)
-    alias1.replicate<0>(tmp$0#0:position.position, ?p2#0:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #1 @alias1:12:4
-    foreign c print_string("--- Inside foo: ":wybe.string, ~#io#1:wybe.phantom, ?tmp$7#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$7#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect p1(101,102):":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(tmp$0#0:position.position, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #4 @alias1:16:4
-    foreign c print_string("expect p2(101,102):":wybe.string, ~#io#4:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(p2#0:position.position, ~#io#5:wybe.phantom, ?#io#6:wybe.phantom) #6 @alias1:18:4
-    foreign lpvm {noalias} mutate(~tmp$0#0:position.position, ?%p1#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int)
-    foreign c print_string("--- Inside foo, after calling x(!p1, 555): ":wybe.string, ~#io#6:wybe.phantom, ?tmp$16#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$16#0:wybe.phantom, ?#io#7:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect p1(555,102):":wybe.string, ~#io#7:wybe.phantom, ?#io#8:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~p1#1:position.position, ~#io#8:wybe.phantom, ?#io#9:wybe.phantom) #10 @alias1:24:4
-    foreign c print_string("expect p2(101,102):":wybe.string, ~#io#9:wybe.phantom, ?#io#10:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~p2#0:position.position, ~#io#10:wybe.phantom, ?#io#11:wybe.phantom) #12 @alias1:26:4
+    foreign lpvm alloc(16:wybe.int, ?tmp$3##0:position.position)
+    foreign lpvm mutate(~tmp$3##0:position.position, ?tmp$4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
+    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int)
+    alias1.replicate<0>(tmp$0##0:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias1:12:4
+    foreign c print_string("--- Inside foo: ":wybe.string, ~#io##1:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect p1(101,102):":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(tmp$0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias1:16:4
+    foreign c print_string("expect p2(101,102):":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(p2##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #6 @alias1:18:4
+    foreign lpvm {noalias} mutate(~tmp$0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int)
+    foreign c print_string("--- Inside foo, after calling x(!p1, 555): ":wybe.string, ~#io##6:wybe.phantom, ?tmp$16##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$16##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect p1(555,102):":wybe.string, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~p1##1:position.position, ~#io##8:wybe.phantom, ?#io##9:wybe.phantom) #10 @alias1:24:4
+    foreign c print_string("expect p2(101,102):":wybe.string, ~#io##9:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~p2##0:position.position, ~#io##10:wybe.phantom, ?#io##11:wybe.phantom) #12 @alias1:26:4
 
 
 replicate > public (3 calls)
 0: alias1.replicate<0>
-replicate(p1#0:position.position, ?p2#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
- AliasPairs: [(p1#0,p2#0)]
+replicate(p1##0:position.position, ?p2##0:position.position, io##0:wybe.phantom, ?io##2:wybe.phantom):
+ AliasPairs: [(p1##0,p2##0)]
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$4#0:position.position)
-    foreign lpvm mutate(~tmp$4#0:position.position, ?tmp$5#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$5#0:position.position, ?tmp$0#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign c print_string("random print":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~tmp$0#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#1:wybe.phantom, ?tmp$11#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$11#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign llvm move(~p1#0:position.position, ?p2#0:position.position) @alias1:7:4
+    foreign lpvm alloc(16:wybe.int, ?tmp$4##0:position.position)
+    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp$5##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign c print_string("random print":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~tmp$0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$11##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias1:7:4
 
   LLVM code       :
 
@@ -252,7 +252,7 @@ entry:
   %13 = inttoptr i64 %12 to i64* 
   %14 = getelementptr  i64, i64* %13, i64 0 
   store  i64 102, i64* %14 
-  %"1$p2#0" = tail call fastcc  i64  @"alias1.replicate<0>"(i64  %9)  
+  %"1$p2##0" = tail call fastcc  i64  @"alias1.replicate<0>"(i64  %9)  
   %16 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias1.15, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %16)  
   tail call ccc  void  @putchar(i8  10)  
@@ -261,12 +261,12 @@ entry:
   tail call fastcc  void  @"position.printPosition<0>"(i64  %9)  
   %20 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias1.19, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %20)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2#0")  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2##0")  
   %21 = trunc i64 16 to i32  
   %22 = tail call ccc  i8*  @wybe_malloc(i32  %21)  
   %23 = ptrtoint i8* %22 to i64 
   %24 = inttoptr i64 %23 to i8* 
-  %25 = inttoptr i64 %"1$p2#0" to i8* 
+  %25 = inttoptr i64 %"1$p2##0" to i8* 
   %26 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %24, i8*  %25, i32  %26, i32  8, i1  0)  
   %27 = inttoptr i64 %23 to i64* 
@@ -297,7 +297,7 @@ entry:
   %41 = inttoptr i64 %40 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
   store  i64 102, i64* %42 
-  %"1$p2#0" = tail call fastcc  i64  @"alias1.replicate<0>"(i64  %37)  
+  %"1$p2##0" = tail call fastcc  i64  @"alias1.replicate<0>"(i64  %37)  
   %44 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias1.43, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %44)  
   tail call ccc  void  @putchar(i8  10)  
@@ -306,8 +306,8 @@ entry:
   tail call fastcc  void  @"position.printPosition<0>"(i64  %37)  
   %48 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias1.47, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %48)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2#0")  
-  %49 = add   i64 %"1$p2#0", 8 
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2##0")  
+  %49 = add   i64 %"1$p2##0", 8 
   %50 = inttoptr i64 %49 to i64* 
   %51 = getelementptr  i64, i64* %50, i64 0 
   %52 = load  i64, i64* %51 
@@ -342,7 +342,7 @@ entry:
   tail call fastcc  void  @"position.printPosition<0>"(i64  %65)  
   %76 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias1.75, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %76)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2#0")  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2##0")  
   %78 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias1.77, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %78)  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %55)  
@@ -362,7 +362,7 @@ entry:
   %85 = inttoptr i64 %84 to i64* 
   %86 = getelementptr  i64, i64* %85, i64 0 
   store  i64 102, i64* %86 
-  %"1$p2#0" = tail call fastcc  i64  @"alias1.replicate<0>"(i64  %81)  
+  %"1$p2##0" = tail call fastcc  i64  @"alias1.replicate<0>"(i64  %81)  
   %88 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias1.87, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %88)  
   tail call ccc  void  @putchar(i8  10)  
@@ -371,7 +371,7 @@ entry:
   tail call fastcc  void  @"position.printPosition<0>"(i64  %81)  
   %92 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias1.91, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %92)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2#0")  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2##0")  
   %93 = trunc i64 16 to i32  
   %94 = tail call ccc  i8*  @wybe_malloc(i32  %93)  
   %95 = ptrtoint i8* %94 to i64 
@@ -390,12 +390,12 @@ entry:
   tail call fastcc  void  @"position.printPosition<0>"(i64  %95)  
   %106 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias1.105, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %106)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2#0")  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2##0")  
   ret void 
 }
 
 
-define external fastcc  i64 @"alias1.replicate<0>"(i64  %"p1#0")    {
+define external fastcc  i64 @"alias1.replicate<0>"(i64  %"p1##0")    {
 entry:
   %107 = trunc i64 16 to i32  
   %108 = tail call ccc  i8*  @wybe_malloc(i32  %107)  
@@ -414,7 +414,7 @@ entry:
   %119 = load  i64, i64* %118 
   tail call ccc  void  @print_int(i64  %119)  
   tail call ccc  void  @putchar(i8  10)  
-  ret i64 %"p1#0" 
+  ret i64 %"p1##0" 
 }
 --------------------------------------------------
  Module position
@@ -438,17 +438,17 @@ entry:
 
 printPosition > public (0 calls)
 0: position.printPosition<0>
-printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string(",":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io#4:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -482,17 +482,17 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"position.printPosition<0>"(i64  %"pos#0")    {
+define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
-  %3 = inttoptr i64 %"pos#0" to i64* 
+  %3 = inttoptr i64 %"pos##0" to i64* 
   %4 = getelementptr  i64, i64* %3, i64 0 
   %5 = load  i64, i64* %4 
   tail call ccc  void  @print_int(i64  %5)  
   %7 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.6, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %7)  
-  %8 = add   i64 %"pos#0", 8 
+  %8 = add   i64 %"pos##0", 8 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
@@ -522,86 +522,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y#0:wybe.int)
-    foreign llvm icmp_eq(~$left$x#0:wybe.int, ~$right$x#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
+    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y#0:wybe.int, ~$right$y#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
-    foreign lpvm mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:position.position, ?$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
+    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
-    foreign lpvm access(~$#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y#0:wybe.int)
+    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec#0:position.position, ?$#0:wybe.int):
+x($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec#0:position.position, ?$#0:wybe.int):
+y($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -618,54 +618,54 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$#0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = icmp eq i64 %7, %14 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"x#0", i64* %19 
+  store  i64 %"x##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"y#0", i64* %22 
+  store  i64 %"y##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
 entry:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -675,34 +675,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec#0" to i64* 
+  %32 = inttoptr i64 %"$rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec#0" to i8* 
+  %39 = inttoptr i64 %"$rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field#0", i64* %42 
+  store  i64 %"$field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = add   i64 %"$rec#0", 8 
+  %43 = add   i64 %"$rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -710,46 +710,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec#0" to i8* 
+  %51 = inttoptr i64 %"$rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field#0", i64* %55 
+  store  i64 %"$field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %58, %65 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = icmp eq i64 %62, %69 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$0##0" = icmp eq i64 %62, %69 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }

--- a/test-cases/final-dump/alias1.exp
+++ b/test-cases/final-dump/alias1.exp
@@ -541,27 +541,27 @@ entry:
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x(#rec##0:position.position, ?###0:wybe.int):
+x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -572,10 +572,10 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y(#rec##0:position.position, ?###0:wybe.int):
+y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -660,12 +660,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 

--- a/test-cases/final-dump/alias1.exp
+++ b/test-cases/final-dump/alias1.exp
@@ -522,7 +522,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
@@ -532,10 +532,10 @@ entry:
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -586,7 +586,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -597,11 +597,11 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -637,8 +637,8 @@ entry:
   %"1#tmp#1##0" = icmp eq i64 %3, %10 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2#####0" = icmp eq i64 %7, %14 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %7, %14 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -747,9 +747,9 @@ entry:
   br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#0##0" = icmp eq i64 %62, %69 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }

--- a/test-cases/final-dump/alias1.exp
+++ b/test-cases/final-dump/alias1.exp
@@ -19,14 +19,14 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("-------------- Calling foo: ":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("-------------- Calling foo: ":wybe.string, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     alias1.foo<0>(~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #1 @alias1:74:2
-    foreign c print_string("-------------- Calling bar: ":wybe.string, ~#io##2:wybe.phantom, ?tmp$5##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$5##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign c print_string("-------------- Calling bar: ":wybe.string, ~#io##2:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
     alias1.bar<0>(~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #3 @alias1:76:2
-    foreign c print_string("-------------- Calling baz: ":wybe.string, ~#io##4:wybe.phantom, ?tmp$8##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$8##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign c print_string("-------------- Calling baz: ":wybe.string, ~#io##4:wybe.phantom, ?tmp#8##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#8##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
     alias1.baz<0>(~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #5 @alias1:78:2
 
 
@@ -35,21 +35,21 @@ bar > public (1 calls)
 bar(io##0:wybe.phantom, ?io##11:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$3##0:position.position)
-    foreign lpvm mutate(~tmp$3##0:position.position, ?tmp$4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
-    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int)
-    alias1.replicate<0>(tmp$0##0:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias1:31:4
-    foreign c print_string("--- Inside bar: ":wybe.string, ~#io##1:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position)
+    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int)
+    alias1.replicate<0>(tmp#0##0:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias1:31:4
+    foreign c print_string("--- Inside bar: ":wybe.string, ~#io##1:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string("expect p1(101,102):":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(tmp$0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias1:35:4
+    position.printPosition<0>(tmp#0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias1:35:4
     foreign c print_string("expect p2(101,102):":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
     position.printPosition<0>(p2##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #6 @alias1:37:4
     foreign lpvm {noalias} mutate(~%p2##0:position.position, ?%p2##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int)
-    foreign c print_string("--- Inside bar, after calling x(!p2, 555): ":wybe.string, ~#io##6:wybe.phantom, ?tmp$16##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$16##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
+    foreign c print_string("--- Inside bar, after calling x(!p2, 555): ":wybe.string, ~#io##6:wybe.phantom, ?tmp#16##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
     foreign c print_string("expect p1(101,102):":wybe.string, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~tmp$0##0:position.position, ~#io##8:wybe.phantom, ?#io##9:wybe.phantom) #10 @alias1:43:4
+    position.printPosition<0>(~tmp#0##0:position.position, ~#io##8:wybe.phantom, ?#io##9:wybe.phantom) #10 @alias1:43:4
     foreign c print_string("expect p2(555,102):":wybe.string, ~#io##9:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
     position.printPosition<0>(~p2##1:position.position, ~#io##10:wybe.phantom, ?#io##11:wybe.phantom) #12 @alias1:45:4
 
@@ -59,31 +59,31 @@ baz > public (1 calls)
 baz(io##0:wybe.phantom, ?io##15:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$5##0:position.position)
-    foreign lpvm mutate(~tmp$5##0:position.position, ?tmp$6##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
-    foreign lpvm mutate(~tmp$6##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int)
-    alias1.replicate<0>(tmp$0##0:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias1:50:4
-    foreign c print_string("--- Inside baz: ":wybe.string, ~#io##1:wybe.phantom, ?tmp$9##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$9##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:position.position)
+    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#6##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
+    foreign lpvm mutate(~tmp#6##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int)
+    alias1.replicate<0>(tmp#0##0:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias1:50:4
+    foreign c print_string("--- Inside baz: ":wybe.string, ~#io##1:wybe.phantom, ?tmp#9##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#9##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string("expect p1(101,102):":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(tmp$0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias1:54:4
+    position.printPosition<0>(tmp#0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias1:54:4
     foreign c print_string("expect p2(101,102):":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
     position.printPosition<0>(p2##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #6 @alias1:56:4
-    foreign lpvm access(p2##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$17##0:position.position)
-    foreign lpvm mutate(~tmp$17##0:position.position, ?tmp$18##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 33333333:wybe.int)
-    foreign lpvm mutate(~tmp$18##0:position.position, ?tmp$1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:wybe.int)
+    foreign lpvm access(p2##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#17##0:position.position)
+    foreign lpvm mutate(~tmp#17##0:position.position, ?tmp#18##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 33333333:wybe.int)
+    foreign lpvm mutate(~tmp#18##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
     foreign c print_string("expect p3(33333333,102):":wybe.string, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(tmp$1##0:position.position, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) #10 @alias1:60:4
-    foreign lpvm {noalias} mutate(~tmp$0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int)
-    foreign c print_string("--- Inside baz, after calling x(!p1, 555): ":wybe.string, ~#io##8:wybe.phantom, ?tmp$25##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$25##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(tmp#1##0:position.position, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) #10 @alias1:60:4
+    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int)
+    foreign c print_string("--- Inside baz, after calling x(!p1, 555): ":wybe.string, ~#io##8:wybe.phantom, ?tmp#25##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#25##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
     foreign c print_string("expect p1(555,102):":wybe.string, ~#io##9:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
     position.printPosition<0>(~p1##1:position.position, ~#io##10:wybe.phantom, ?#io##11:wybe.phantom) #14 @alias1:66:4
     foreign c print_string("expect p2(101,102):":wybe.string, ~#io##11:wybe.phantom, ?#io##12:wybe.phantom) @io:nn:nn
     position.printPosition<0>(~p2##0:position.position, ~#io##12:wybe.phantom, ?#io##13:wybe.phantom) #16 @alias1:68:4
     foreign c print_string("expect p3(33333333,102):":wybe.string, ~#io##13:wybe.phantom, ?#io##14:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~tmp$1##0:position.position, ~#io##14:wybe.phantom, ?#io##15:wybe.phantom) #18 @alias1:70:4
+    position.printPosition<0>(~tmp#1##0:position.position, ~#io##14:wybe.phantom, ?#io##15:wybe.phantom) #18 @alias1:70:4
 
 
 foo > public (1 calls)
@@ -91,19 +91,19 @@ foo > public (1 calls)
 foo(io##0:wybe.phantom, ?io##11:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$3##0:position.position)
-    foreign lpvm mutate(~tmp$3##0:position.position, ?tmp$4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
-    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int)
-    alias1.replicate<0>(tmp$0##0:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias1:12:4
-    foreign c print_string("--- Inside foo: ":wybe.string, ~#io##1:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position)
+    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int)
+    alias1.replicate<0>(tmp#0##0:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias1:12:4
+    foreign c print_string("--- Inside foo: ":wybe.string, ~#io##1:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string("expect p1(101,102):":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(tmp$0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias1:16:4
+    position.printPosition<0>(tmp#0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias1:16:4
     foreign c print_string("expect p2(101,102):":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
     position.printPosition<0>(p2##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #6 @alias1:18:4
-    foreign lpvm {noalias} mutate(~tmp$0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int)
-    foreign c print_string("--- Inside foo, after calling x(!p1, 555): ":wybe.string, ~#io##6:wybe.phantom, ?tmp$16##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$16##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
+    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int)
+    foreign c print_string("--- Inside foo, after calling x(!p1, 555): ":wybe.string, ~#io##6:wybe.phantom, ?tmp#16##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
     foreign c print_string("expect p1(555,102):":wybe.string, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
     position.printPosition<0>(~p1##1:position.position, ~#io##8:wybe.phantom, ?#io##9:wybe.phantom) #10 @alias1:24:4
     foreign c print_string("expect p2(101,102):":wybe.string, ~#io##9:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
@@ -115,13 +115,13 @@ replicate > public (3 calls)
 replicate(p1##0:position.position, ?p2##0:position.position, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: [(p1##0,p2##0)]
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$4##0:position.position)
-    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$5##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:position.position)
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
     foreign c print_string("random print":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~tmp$0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$11##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~tmp#0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias1:7:4
 
   LLVM code       :
@@ -252,7 +252,7 @@ entry:
   %13 = inttoptr i64 %12 to i64* 
   %14 = getelementptr  i64, i64* %13, i64 0 
   store  i64 102, i64* %14 
-  %"1$p2##0" = tail call fastcc  i64  @"alias1.replicate<0>"(i64  %9)  
+  %"1#p2##0" = tail call fastcc  i64  @"alias1.replicate<0>"(i64  %9)  
   %16 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias1.15, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %16)  
   tail call ccc  void  @putchar(i8  10)  
@@ -261,12 +261,12 @@ entry:
   tail call fastcc  void  @"position.printPosition<0>"(i64  %9)  
   %20 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias1.19, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %20)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2##0")  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
   %21 = trunc i64 16 to i32  
   %22 = tail call ccc  i8*  @wybe_malloc(i32  %21)  
   %23 = ptrtoint i8* %22 to i64 
   %24 = inttoptr i64 %23 to i8* 
-  %25 = inttoptr i64 %"1$p2##0" to i8* 
+  %25 = inttoptr i64 %"1#p2##0" to i8* 
   %26 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %24, i8*  %25, i32  %26, i32  8, i1  0)  
   %27 = inttoptr i64 %23 to i64* 
@@ -297,7 +297,7 @@ entry:
   %41 = inttoptr i64 %40 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
   store  i64 102, i64* %42 
-  %"1$p2##0" = tail call fastcc  i64  @"alias1.replicate<0>"(i64  %37)  
+  %"1#p2##0" = tail call fastcc  i64  @"alias1.replicate<0>"(i64  %37)  
   %44 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias1.43, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %44)  
   tail call ccc  void  @putchar(i8  10)  
@@ -306,8 +306,8 @@ entry:
   tail call fastcc  void  @"position.printPosition<0>"(i64  %37)  
   %48 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias1.47, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %48)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2##0")  
-  %49 = add   i64 %"1$p2##0", 8 
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
+  %49 = add   i64 %"1#p2##0", 8 
   %50 = inttoptr i64 %49 to i64* 
   %51 = getelementptr  i64, i64* %50, i64 0 
   %52 = load  i64, i64* %51 
@@ -342,7 +342,7 @@ entry:
   tail call fastcc  void  @"position.printPosition<0>"(i64  %65)  
   %76 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias1.75, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %76)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2##0")  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
   %78 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias1.77, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %78)  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %55)  
@@ -362,7 +362,7 @@ entry:
   %85 = inttoptr i64 %84 to i64* 
   %86 = getelementptr  i64, i64* %85, i64 0 
   store  i64 102, i64* %86 
-  %"1$p2##0" = tail call fastcc  i64  @"alias1.replicate<0>"(i64  %81)  
+  %"1#p2##0" = tail call fastcc  i64  @"alias1.replicate<0>"(i64  %81)  
   %88 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias1.87, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %88)  
   tail call ccc  void  @putchar(i8  10)  
@@ -371,7 +371,7 @@ entry:
   tail call fastcc  void  @"position.printPosition<0>"(i64  %81)  
   %92 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias1.91, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %92)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2##0")  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
   %93 = trunc i64 16 to i32  
   %94 = tail call ccc  i8*  @wybe_malloc(i32  %93)  
   %95 = ptrtoint i8* %94 to i64 
@@ -390,7 +390,7 @@ entry:
   tail call fastcc  void  @"position.printPosition<0>"(i64  %95)  
   %106 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias1.105, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %106)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2##0")  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
   ret void 
 }
 
@@ -442,13 +442,13 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -522,86 +522,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
-    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
-    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec##0:position.position, ?$##0:wybe.int):
+x(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec##0:position.position, ?$##0:wybe.int):
+y(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -618,27 +618,27 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$##0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$##0" 
+  %"2#####0" = icmp eq i64 %7, %14 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
@@ -660,12 +660,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
 entry:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -675,34 +675,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec##0" to i64* 
+  %32 = inttoptr i64 %"#rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec##0" to i8* 
+  %39 = inttoptr i64 %"#rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field##0", i64* %42 
+  store  i64 %"#field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = add   i64 %"$rec##0", 8 
+  %43 = add   i64 %"#rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -710,46 +710,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec##0" to i8* 
+  %51 = inttoptr i64 %"#rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field##0", i64* %55 
+  store  i64 %"#field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %58, %65 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = icmp eq i64 %62, %69 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#0##0" = icmp eq i64 %62, %69 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }

--- a/test-cases/final-dump/alias2.exp
+++ b/test-cases/final-dump/alias2.exp
@@ -17,30 +17,30 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("copy a position":wybe.string, ~#io##0:wybe.phantom, ?tmp$3##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$3##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm alloc(16:wybe.int, ?tmp$6##0:position.position)
-    foreign lpvm mutate(~tmp$6##0:position.position, ?tmp$7##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$7##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 20:wybe.int)
-    alias2.pcopy<0>(~tmp$0##0:position.position, ?r##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #2 @alias2:20:2
-    foreign c print_string("--- After calling pcopy: ":wybe.string, ~#io##2:wybe.phantom, ?tmp$10##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$10##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign c print_string("copy a position":wybe.string, ~#io##0:wybe.phantom, ?tmp#3##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#3##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#6##0:position.position)
+    foreign lpvm mutate(~tmp#6##0:position.position, ?tmp#7##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp#7##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 20:wybe.int)
+    alias2.pcopy<0>(~tmp#0##0:position.position, ?r##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #2 @alias2:20:2
+    foreign c print_string("--- After calling pcopy: ":wybe.string, ~#io##2:wybe.phantom, ?tmp#10##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
     foreign c print_string("expect r(0,20):":wybe.string, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     position.printPosition<0>(~r##0:position.position, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #5 @alias2:23:2
 
 
 fcopy > public (0 calls)
 0: alias2.fcopy<0>
-fcopy(p1##0:position.position, ?$##0:position.position):
+fcopy(p1##0:position.position, ?###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$5##0:position.position)
-    foreign lpvm mutate(~tmp$5##0:position.position, ?tmp$6##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$6##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign lpvm {noalias} mutate(~tmp$0##0:position.position, ?%p2##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$1##0:wybe.int)
-    foreign lpvm access(~p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.int)
-    foreign lpvm {noalias} mutate(~%p2##1:position.position, ?%$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:position.position)
+    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#6##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp#6##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%p2##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int)
+    foreign lpvm access(~p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int)
+    foreign lpvm {noalias} mutate(~%p2##1:position.position, ?%###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
 
 
 pcopy > public (1 calls)
@@ -48,15 +48,15 @@ pcopy > public (1 calls)
 pcopy(p1##0:position.position, ?p2##2:position.position, io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$5##0:position.position)
-    foreign lpvm mutate(~tmp$5##0:position.position, ?tmp$6##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$6##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign lpvm {noalias} mutate(~tmp$0##0:position.position, ?%p2##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$1##0:wybe.int)
-    foreign lpvm access(~p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.int)
-    foreign lpvm {noalias} mutate(~%p2##1:position.position, ?%p2##2:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:wybe.int)
-    foreign c print_string("--- Inside pcopy: ":wybe.string, ~#io##0:wybe.phantom, ?tmp$15##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$15##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:position.position)
+    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#6##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp#6##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%p2##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int)
+    foreign lpvm access(~p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int)
+    foreign lpvm {noalias} mutate(~%p2##1:position.position, ?%p2##2:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
+    foreign c print_string("--- Inside pcopy: ":wybe.string, ~#io##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#15##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     foreign c print_string("expect p2(0,20):":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     position.printPosition<0>(p2##2:position.position, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #7 @alias2:11:4
 
@@ -113,13 +113,13 @@ entry:
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   store  i64 20, i64* %10 
-  %"1$r##0" = tail call fastcc  i64  @"alias2.pcopy<0>"(i64  %5)  
+  %"1#r##0" = tail call fastcc  i64  @"alias2.pcopy<0>"(i64  %5)  
   %12 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias2.11, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %12)  
   tail call ccc  void  @putchar(i8  10)  
   %14 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias2.13, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %14)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$r##0")  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#r##0")  
   ret void 
 }
 
@@ -214,13 +214,13 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -294,86 +294,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
-    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
-    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec##0:position.position, ?$##0:wybe.int):
+x(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec##0:position.position, ?$##0:wybe.int):
+y(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -390,27 +390,27 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$##0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$##0" 
+  %"2#####0" = icmp eq i64 %7, %14 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
@@ -432,12 +432,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
 entry:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -447,34 +447,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec##0" to i64* 
+  %32 = inttoptr i64 %"#rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec##0" to i8* 
+  %39 = inttoptr i64 %"#rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field##0", i64* %42 
+  store  i64 %"#field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = add   i64 %"$rec##0", 8 
+  %43 = add   i64 %"#rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -482,46 +482,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec##0" to i8* 
+  %51 = inttoptr i64 %"#rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field##0", i64* %55 
+  store  i64 %"#field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %58, %65 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = icmp eq i64 %62, %69 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#0##0" = icmp eq i64 %62, %69 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }

--- a/test-cases/final-dump/alias2.exp
+++ b/test-cases/final-dump/alias2.exp
@@ -31,7 +31,7 @@ AFTER EVERYTHING:
 
 fcopy > public (0 calls)
 0: alias2.fcopy<0>
-fcopy(p1##0:position.position, ?###0:position.position):
+fcopy(p1##0:position.position, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp#5##0:position.position)
@@ -40,7 +40,7 @@ fcopy(p1##0:position.position, ?###0:position.position):
     foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
     foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%p2##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int)
     foreign lpvm access(~p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int)
-    foreign lpvm {noalias} mutate(~%p2##1:position.position, ?%###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
+    foreign lpvm {noalias} mutate(~%p2##1:position.position, ?%#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
 
 
 pcopy > public (1 calls)
@@ -313,27 +313,27 @@ entry:
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x(#rec##0:position.position, ?###0:wybe.int):
+x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -344,10 +344,10 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y(#rec##0:position.position, ?###0:wybe.int):
+y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -432,12 +432,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 

--- a/test-cases/final-dump/alias2.exp
+++ b/test-cases/final-dump/alias2.exp
@@ -14,51 +14,51 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: alias2.<0>
-(io#0:wybe.phantom, ?io#5:wybe.phantom):
+(io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("copy a position":wybe.string, ~#io#0:wybe.phantom, ?tmp$3#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$3#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm alloc(16:wybe.int, ?tmp$6#0:position.position)
-    foreign lpvm mutate(~tmp$6#0:position.position, ?tmp$7#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$7#0:position.position, ?tmp$0#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 20:wybe.int)
-    alias2.pcopy<0>(~tmp$0#0:position.position, ?r#0:position.position, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #2 @alias2:20:2
-    foreign c print_string("--- After calling pcopy: ":wybe.string, ~#io#2:wybe.phantom, ?tmp$10#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$10#0:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect r(0,20):":wybe.string, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~r#0:position.position, ~#io#4:wybe.phantom, ?#io#5:wybe.phantom) #5 @alias2:23:2
+    foreign c print_string("copy a position":wybe.string, ~#io##0:wybe.phantom, ?tmp$3##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$3##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$6##0:position.position)
+    foreign lpvm mutate(~tmp$6##0:position.position, ?tmp$7##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp$7##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 20:wybe.int)
+    alias2.pcopy<0>(~tmp$0##0:position.position, ?r##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #2 @alias2:20:2
+    foreign c print_string("--- After calling pcopy: ":wybe.string, ~#io##2:wybe.phantom, ?tmp$10##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$10##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect r(0,20):":wybe.string, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~r##0:position.position, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #5 @alias2:23:2
 
 
 fcopy > public (0 calls)
 0: alias2.fcopy<0>
-fcopy(p1#0:position.position, ?$#0:position.position):
+fcopy(p1##0:position.position, ?$##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$5#0:position.position)
-    foreign lpvm mutate(~tmp$5#0:position.position, ?tmp$6#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$6#0:position.position, ?tmp$0#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm access(p1#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign lpvm {noalias} mutate(~tmp$0#0:position.position, ?%p2#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$1#0:wybe.int)
-    foreign lpvm access(~p1#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$2#0:wybe.int)
-    foreign lpvm {noalias} mutate(~%p2#1:position.position, ?%$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp$5##0:position.position)
+    foreign lpvm mutate(~tmp$5##0:position.position, ?tmp$6##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp$6##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign lpvm {noalias} mutate(~tmp$0##0:position.position, ?%p2##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$1##0:wybe.int)
+    foreign lpvm access(~p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.int)
+    foreign lpvm {noalias} mutate(~%p2##1:position.position, ?%$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:wybe.int)
 
 
 pcopy > public (1 calls)
 0: alias2.pcopy<0>
-pcopy(p1#0:position.position, ?p2#2:position.position, io#0:wybe.phantom, ?io#3:wybe.phantom):
+pcopy(p1##0:position.position, ?p2##2:position.position, io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$5#0:position.position)
-    foreign lpvm mutate(~tmp$5#0:position.position, ?tmp$6#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$6#0:position.position, ?tmp$0#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm access(p1#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign lpvm {noalias} mutate(~tmp$0#0:position.position, ?%p2#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$1#0:wybe.int)
-    foreign lpvm access(~p1#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$2#0:wybe.int)
-    foreign lpvm {noalias} mutate(~%p2#1:position.position, ?%p2#2:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:wybe.int)
-    foreign c print_string("--- Inside pcopy: ":wybe.string, ~#io#0:wybe.phantom, ?tmp$15#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$15#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect p2(0,20):":wybe.string, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(p2#2:position.position, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) #7 @alias2:11:4
+    foreign lpvm alloc(16:wybe.int, ?tmp$5##0:position.position)
+    foreign lpvm mutate(~tmp$5##0:position.position, ?tmp$6##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp$6##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign lpvm {noalias} mutate(~tmp$0##0:position.position, ?%p2##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$1##0:wybe.int)
+    foreign lpvm access(~p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.int)
+    foreign lpvm {noalias} mutate(~%p2##1:position.position, ?%p2##2:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:wybe.int)
+    foreign c print_string("--- Inside pcopy: ":wybe.string, ~#io##0:wybe.phantom, ?tmp$15##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$15##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect p2(0,20):":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(p2##2:position.position, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #7 @alias2:11:4
 
   LLVM code       :
 
@@ -113,18 +113,18 @@ entry:
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   store  i64 20, i64* %10 
-  %"1$r#0" = tail call fastcc  i64  @"alias2.pcopy<0>"(i64  %5)  
+  %"1$r##0" = tail call fastcc  i64  @"alias2.pcopy<0>"(i64  %5)  
   %12 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias2.11, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %12)  
   tail call ccc  void  @putchar(i8  10)  
   %14 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias2.13, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %14)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$r#0")  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$r##0")  
   ret void 
 }
 
 
-define external fastcc  i64 @"alias2.fcopy<0>"(i64  %"p1#0")    {
+define external fastcc  i64 @"alias2.fcopy<0>"(i64  %"p1##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
@@ -136,13 +136,13 @@ entry:
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
   store  i64 0, i64* %22 
-  %23 = inttoptr i64 %"p1#0" to i64* 
+  %23 = inttoptr i64 %"p1##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
   %26 = inttoptr i64 %17 to i64* 
   %27 = getelementptr  i64, i64* %26, i64 0 
   store  i64 %25, i64* %27 
-  %28 = add   i64 %"p1#0", 8 
+  %28 = add   i64 %"p1##0", 8 
   %29 = inttoptr i64 %28 to i64* 
   %30 = getelementptr  i64, i64* %29, i64 0 
   %31 = load  i64, i64* %30 
@@ -154,7 +154,7 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias2.pcopy<0>"(i64  %"p1#0")    {
+define external fastcc  i64 @"alias2.pcopy<0>"(i64  %"p1##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
@@ -166,13 +166,13 @@ entry:
   %41 = inttoptr i64 %40 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
   store  i64 0, i64* %42 
-  %43 = inttoptr i64 %"p1#0" to i64* 
+  %43 = inttoptr i64 %"p1##0" to i64* 
   %44 = getelementptr  i64, i64* %43, i64 0 
   %45 = load  i64, i64* %44 
   %46 = inttoptr i64 %37 to i64* 
   %47 = getelementptr  i64, i64* %46, i64 0 
   store  i64 %45, i64* %47 
-  %48 = add   i64 %"p1#0", 8 
+  %48 = add   i64 %"p1##0", 8 
   %49 = inttoptr i64 %48 to i64* 
   %50 = getelementptr  i64, i64* %49, i64 0 
   %51 = load  i64, i64* %50 
@@ -210,17 +210,17 @@ entry:
 
 printPosition > public (0 calls)
 0: position.printPosition<0>
-printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string(",":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io#4:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -254,17 +254,17 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"position.printPosition<0>"(i64  %"pos#0")    {
+define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
-  %3 = inttoptr i64 %"pos#0" to i64* 
+  %3 = inttoptr i64 %"pos##0" to i64* 
   %4 = getelementptr  i64, i64* %3, i64 0 
   %5 = load  i64, i64* %4 
   tail call ccc  void  @print_int(i64  %5)  
   %7 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.6, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %7)  
-  %8 = add   i64 %"pos#0", 8 
+  %8 = add   i64 %"pos##0", 8 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
@@ -294,86 +294,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y#0:wybe.int)
-    foreign llvm icmp_eq(~$left$x#0:wybe.int, ~$right$x#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
+    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y#0:wybe.int, ~$right$y#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
-    foreign lpvm mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:position.position, ?$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
+    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
-    foreign lpvm access(~$#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y#0:wybe.int)
+    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec#0:position.position, ?$#0:wybe.int):
+x($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec#0:position.position, ?$#0:wybe.int):
+y($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -390,54 +390,54 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$#0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = icmp eq i64 %7, %14 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"x#0", i64* %19 
+  store  i64 %"x##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"y#0", i64* %22 
+  store  i64 %"y##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
 entry:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -447,34 +447,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec#0" to i64* 
+  %32 = inttoptr i64 %"$rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec#0" to i8* 
+  %39 = inttoptr i64 %"$rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field#0", i64* %42 
+  store  i64 %"$field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = add   i64 %"$rec#0", 8 
+  %43 = add   i64 %"$rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -482,46 +482,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec#0" to i8* 
+  %51 = inttoptr i64 %"$rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field#0", i64* %55 
+  store  i64 %"$field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %58, %65 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = icmp eq i64 %62, %69 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$0##0" = icmp eq i64 %62, %69 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }

--- a/test-cases/final-dump/alias2.exp
+++ b/test-cases/final-dump/alias2.exp
@@ -294,7 +294,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
@@ -304,10 +304,10 @@ entry:
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -358,7 +358,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -369,11 +369,11 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -409,8 +409,8 @@ entry:
   %"1#tmp#1##0" = icmp eq i64 %3, %10 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2#####0" = icmp eq i64 %7, %14 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %7, %14 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -519,9 +519,9 @@ entry:
   br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#0##0" = icmp eq i64 %62, %69 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }

--- a/test-cases/final-dump/alias3.exp
+++ b/test-cases/final-dump/alias3.exp
@@ -25,19 +25,19 @@ bar > public (1 calls)
 bar(io##0:wybe.phantom, ?io##11:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$3##0:position.position)
-    foreign lpvm mutate(~tmp$3##0:position.position, ?tmp$4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    alias3.replicate1<0>(tmp$0##0:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias3:21:4
-    foreign c print_string("--- After calling replicate1: ":wybe.string, ~#io##1:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position)
+    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    alias3.replicate1<0>(tmp#0##0:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias3:21:4
+    foreign c print_string("--- After calling replicate1: ":wybe.string, ~#io##1:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string("expect p1(1,1):":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(tmp$0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias3:25:4
+    position.printPosition<0>(tmp#0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias3:25:4
     foreign c print_string("expect p2(2,2):":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
     position.printPosition<0>(p2##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #6 @alias3:27:4
-    foreign lpvm {noalias} mutate(~tmp$0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int)
-    foreign c print_string("--- After calling x(!p1, 555): ":wybe.string, ~#io##6:wybe.phantom, ?tmp$16##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$16##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
+    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int)
+    foreign c print_string("--- After calling x(!p1, 555): ":wybe.string, ~#io##6:wybe.phantom, ?tmp#16##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
     foreign c print_string("expect p1(555,1):":wybe.string, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
     position.printPosition<0>(~p1##1:position.position, ~#io##8:wybe.phantom, ?#io##9:wybe.phantom) #10 @alias3:33:4
     foreign c print_string("expect p2(2,2):":wybe.string, ~#io##9:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
@@ -49,8 +49,8 @@ replicate1 > public (1 calls)
 replicate1(p1##0:position.position, ?p2##2:position.position, io##0:wybe.phantom, ?io##7:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("--- Inside replicate1: ":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("--- Inside replicate1: ":wybe.string, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     foreign c print_string("expect p1(1,1):":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     position.printPosition<0>(p1##0:position.position, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #2 @alias3:10:4
     foreign lpvm {noalias} mutate(p1##0:position.position, ?%p2##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
@@ -132,7 +132,7 @@ entry:
   %7 = inttoptr i64 %6 to i64* 
   %8 = getelementptr  i64, i64* %7, i64 0 
   store  i64 1, i64* %8 
-  %"1$p2##0" = tail call fastcc  i64  @"alias3.replicate1<0>"(i64  %3)  
+  %"1#p2##0" = tail call fastcc  i64  @"alias3.replicate1<0>"(i64  %3)  
   %10 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias3.9, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %10)  
   tail call ccc  void  @putchar(i8  10)  
@@ -141,7 +141,7 @@ entry:
   tail call fastcc  void  @"position.printPosition<0>"(i64  %3)  
   %14 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias3.13, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %14)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2##0")  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
   %15 = inttoptr i64 %3 to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
   store  i64 555, i64* %16 
@@ -153,7 +153,7 @@ entry:
   tail call fastcc  void  @"position.printPosition<0>"(i64  %3)  
   %22 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias3.21, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %22)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2##0")  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
   ret void 
 }
 
@@ -214,13 +214,13 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -294,86 +294,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
-    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
-    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec##0:position.position, ?$##0:wybe.int):
+x(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec##0:position.position, ?$##0:wybe.int):
+y(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -390,27 +390,27 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$##0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$##0" 
+  %"2#####0" = icmp eq i64 %7, %14 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
@@ -432,12 +432,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
 entry:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -447,34 +447,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec##0" to i64* 
+  %32 = inttoptr i64 %"#rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec##0" to i8* 
+  %39 = inttoptr i64 %"#rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field##0", i64* %42 
+  store  i64 %"#field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = add   i64 %"$rec##0", 8 
+  %43 = add   i64 %"#rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -482,46 +482,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec##0" to i8* 
+  %51 = inttoptr i64 %"#rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field##0", i64* %55 
+  store  i64 %"#field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %58, %65 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = icmp eq i64 %62, %69 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#0##0" = icmp eq i64 %62, %69 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }

--- a/test-cases/final-dump/alias3.exp
+++ b/test-cases/final-dump/alias3.exp
@@ -294,7 +294,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
@@ -304,10 +304,10 @@ entry:
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -358,7 +358,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -369,11 +369,11 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -409,8 +409,8 @@ entry:
   %"1#tmp#1##0" = icmp eq i64 %3, %10 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2#####0" = icmp eq i64 %7, %14 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %7, %14 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -519,9 +519,9 @@ entry:
   br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#0##0" = icmp eq i64 %62, %69 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }

--- a/test-cases/final-dump/alias3.exp
+++ b/test-cases/final-dump/alias3.exp
@@ -14,51 +14,51 @@ AFTER EVERYTHING:
 
 *main* > public {inline} (0 calls)
 0: alias3.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    alias3.bar<0>(~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @alias3:38:2
+    alias3.bar<0>(~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @alias3:38:2
 
 
 bar > public (1 calls)
 0: alias3.bar<0>
-bar(io#0:wybe.phantom, ?io#11:wybe.phantom):
+bar(io##0:wybe.phantom, ?io##11:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$3#0:position.position)
-    foreign lpvm mutate(~tmp$3#0:position.position, ?tmp$4#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp$4#0:position.position, ?tmp$0#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    alias3.replicate1<0>(tmp$0#0:position.position, ?p2#0:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #1 @alias3:21:4
-    foreign c print_string("--- After calling replicate1: ":wybe.string, ~#io#1:wybe.phantom, ?tmp$7#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$7#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect p1(1,1):":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(tmp$0#0:position.position, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #4 @alias3:25:4
-    foreign c print_string("expect p2(2,2):":wybe.string, ~#io#4:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(p2#0:position.position, ~#io#5:wybe.phantom, ?#io#6:wybe.phantom) #6 @alias3:27:4
-    foreign lpvm {noalias} mutate(~tmp$0#0:position.position, ?%p1#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int)
-    foreign c print_string("--- After calling x(!p1, 555): ":wybe.string, ~#io#6:wybe.phantom, ?tmp$16#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$16#0:wybe.phantom, ?#io#7:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect p1(555,1):":wybe.string, ~#io#7:wybe.phantom, ?#io#8:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~p1#1:position.position, ~#io#8:wybe.phantom, ?#io#9:wybe.phantom) #10 @alias3:33:4
-    foreign c print_string("expect p2(2,2):":wybe.string, ~#io#9:wybe.phantom, ?#io#10:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~p2#0:position.position, ~#io#10:wybe.phantom, ?#io#11:wybe.phantom) #12 @alias3:35:4
+    foreign lpvm alloc(16:wybe.int, ?tmp$3##0:position.position)
+    foreign lpvm mutate(~tmp$3##0:position.position, ?tmp$4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    alias3.replicate1<0>(tmp$0##0:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias3:21:4
+    foreign c print_string("--- After calling replicate1: ":wybe.string, ~#io##1:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect p1(1,1):":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(tmp$0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias3:25:4
+    foreign c print_string("expect p2(2,2):":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(p2##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #6 @alias3:27:4
+    foreign lpvm {noalias} mutate(~tmp$0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int)
+    foreign c print_string("--- After calling x(!p1, 555): ":wybe.string, ~#io##6:wybe.phantom, ?tmp$16##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$16##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect p1(555,1):":wybe.string, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~p1##1:position.position, ~#io##8:wybe.phantom, ?#io##9:wybe.phantom) #10 @alias3:33:4
+    foreign c print_string("expect p2(2,2):":wybe.string, ~#io##9:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~p2##0:position.position, ~#io##10:wybe.phantom, ?#io##11:wybe.phantom) #12 @alias3:35:4
 
 
 replicate1 > public (1 calls)
 0: alias3.replicate1<0>
-replicate1(p1#0:position.position, ?p2#2:position.position, io#0:wybe.phantom, ?io#7:wybe.phantom):
+replicate1(p1##0:position.position, ?p2##2:position.position, io##0:wybe.phantom, ?io##7:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("--- Inside replicate1: ":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect p1(1,1):":wybe.string, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(p1#0:position.position, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) #2 @alias3:10:4
-    foreign lpvm {noalias} mutate(p1#0:position.position, ?%p2#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm {noalias} mutate(~%p2#1:position.position, ?%p2#2:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign c print_string("expect p1(1,1):":wybe.string, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~p1#0:position.position, ~#io#4:wybe.phantom, ?#io#5:wybe.phantom) #6 @alias3:14:4
-    foreign c print_string("expect p2(2,2):":wybe.string, ~#io#5:wybe.phantom, ?#io#6:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(p2#2:position.position, ~#io#6:wybe.phantom, ?#io#7:wybe.phantom) #8 @alias3:16:4
+    foreign c print_string("--- Inside replicate1: ":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect p1(1,1):":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(p1##0:position.position, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #2 @alias3:10:4
+    foreign lpvm {noalias} mutate(p1##0:position.position, ?%p2##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+    foreign lpvm {noalias} mutate(~%p2##1:position.position, ?%p2##2:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+    foreign c print_string("expect p1(1,1):":wybe.string, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~p1##0:position.position, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #6 @alias3:14:4
+    foreign c print_string("expect p2(2,2):":wybe.string, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(p2##2:position.position, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) #8 @alias3:16:4
 
   LLVM code       :
 
@@ -132,7 +132,7 @@ entry:
   %7 = inttoptr i64 %6 to i64* 
   %8 = getelementptr  i64, i64* %7, i64 0 
   store  i64 1, i64* %8 
-  %"1$p2#0" = tail call fastcc  i64  @"alias3.replicate1<0>"(i64  %3)  
+  %"1$p2##0" = tail call fastcc  i64  @"alias3.replicate1<0>"(i64  %3)  
   %10 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias3.9, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %10)  
   tail call ccc  void  @putchar(i8  10)  
@@ -141,7 +141,7 @@ entry:
   tail call fastcc  void  @"position.printPosition<0>"(i64  %3)  
   %14 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias3.13, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %14)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2#0")  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2##0")  
   %15 = inttoptr i64 %3 to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
   store  i64 555, i64* %16 
@@ -153,24 +153,24 @@ entry:
   tail call fastcc  void  @"position.printPosition<0>"(i64  %3)  
   %22 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias3.21, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %22)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2#0")  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2##0")  
   ret void 
 }
 
 
-define external fastcc  i64 @"alias3.replicate1<0>"(i64  %"p1#0")    {
+define external fastcc  i64 @"alias3.replicate1<0>"(i64  %"p1##0")    {
 entry:
   %24 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias3.23, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %24)  
   tail call ccc  void  @putchar(i8  10)  
   %26 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias3.25, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %26)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"p1#0")  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"p1##0")  
   %27 = trunc i64 16 to i32  
   %28 = tail call ccc  i8*  @wybe_malloc(i32  %27)  
   %29 = ptrtoint i8* %28 to i64 
   %30 = inttoptr i64 %29 to i8* 
-  %31 = inttoptr i64 %"p1#0" to i8* 
+  %31 = inttoptr i64 %"p1##0" to i8* 
   %32 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %30, i8*  %31, i32  %32, i32  8, i1  0)  
   %33 = inttoptr i64 %29 to i64* 
@@ -182,7 +182,7 @@ entry:
   store  i64 2, i64* %37 
   %39 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias3.38, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %39)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"p1#0")  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"p1##0")  
   %41 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias3.40, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %41)  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %29)  
@@ -210,17 +210,17 @@ entry:
 
 printPosition > public (0 calls)
 0: position.printPosition<0>
-printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string(",":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io#4:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -254,17 +254,17 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"position.printPosition<0>"(i64  %"pos#0")    {
+define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
-  %3 = inttoptr i64 %"pos#0" to i64* 
+  %3 = inttoptr i64 %"pos##0" to i64* 
   %4 = getelementptr  i64, i64* %3, i64 0 
   %5 = load  i64, i64* %4 
   tail call ccc  void  @print_int(i64  %5)  
   %7 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.6, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %7)  
-  %8 = add   i64 %"pos#0", 8 
+  %8 = add   i64 %"pos##0", 8 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
@@ -294,86 +294,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y#0:wybe.int)
-    foreign llvm icmp_eq(~$left$x#0:wybe.int, ~$right$x#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
+    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y#0:wybe.int, ~$right$y#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
-    foreign lpvm mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:position.position, ?$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
+    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
-    foreign lpvm access(~$#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y#0:wybe.int)
+    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec#0:position.position, ?$#0:wybe.int):
+x($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec#0:position.position, ?$#0:wybe.int):
+y($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -390,54 +390,54 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$#0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = icmp eq i64 %7, %14 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"x#0", i64* %19 
+  store  i64 %"x##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"y#0", i64* %22 
+  store  i64 %"y##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
 entry:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -447,34 +447,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec#0" to i64* 
+  %32 = inttoptr i64 %"$rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec#0" to i8* 
+  %39 = inttoptr i64 %"$rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field#0", i64* %42 
+  store  i64 %"$field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = add   i64 %"$rec#0", 8 
+  %43 = add   i64 %"$rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -482,46 +482,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec#0" to i8* 
+  %51 = inttoptr i64 %"$rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field#0", i64* %55 
+  store  i64 %"$field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %58, %65 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = icmp eq i64 %62, %69 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$0##0" = icmp eq i64 %62, %69 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }

--- a/test-cases/final-dump/alias3.exp
+++ b/test-cases/final-dump/alias3.exp
@@ -313,27 +313,27 @@ entry:
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x(#rec##0:position.position, ?###0:wybe.int):
+x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -344,10 +344,10 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y(#rec##0:position.position, ?###0:wybe.int):
+y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -432,12 +432,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 

--- a/test-cases/final-dump/alias4.exp
+++ b/test-cases/final-dump/alias4.exp
@@ -14,52 +14,52 @@ AFTER EVERYTHING:
 
 *main* > public {inline} (0 calls)
 0: alias4.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    alias4.bar<0>(~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @alias4:32:2
+    alias4.bar<0>(~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @alias4:32:2
 
 
 bar > public (1 calls)
 0: alias4.bar<0>
-bar(io#0:wybe.phantom, ?io#11:wybe.phantom):
+bar(io##0:wybe.phantom, ?io##11:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$3#0:position.position)
-    foreign lpvm mutate(~tmp$3#0:position.position, ?tmp$4#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm mutate(~tmp$4#0:position.position, ?tmp$0#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    alias4.replicate1<0>(tmp$0#0:position.position, ?p2#0:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #1 @alias4:15:4
-    foreign c print_string("--- After calling replicate1: ":wybe.string, ~#io#1:wybe.phantom, ?tmp$7#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$7#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect p1(100,100):":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(tmp$0#0:position.position, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #4 @alias4:19:4
-    foreign c print_string("expect p2(100,200):":wybe.string, ~#io#4:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(p2#0:position.position, ~#io#5:wybe.phantom, ?#io#6:wybe.phantom) #6 @alias4:21:4
-    foreign lpvm {noalias} mutate(~tmp$0#0:position.position, ?%p1#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int)
-    foreign c print_string("--- After calling x(!p1, 555): ":wybe.string, ~#io#6:wybe.phantom, ?tmp$16#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$16#0:wybe.phantom, ?#io#7:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect p1(555,100):":wybe.string, ~#io#7:wybe.phantom, ?#io#8:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~p1#1:position.position, ~#io#8:wybe.phantom, ?#io#9:wybe.phantom) #10 @alias4:27:4
-    foreign c print_string("expect p2(100,200):":wybe.string, ~#io#9:wybe.phantom, ?#io#10:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~p2#0:position.position, ~#io#10:wybe.phantom, ?#io#11:wybe.phantom) #12 @alias4:29:4
+    foreign lpvm alloc(16:wybe.int, ?tmp$3##0:position.position)
+    foreign lpvm mutate(~tmp$3##0:position.position, ?tmp$4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
+    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
+    alias4.replicate1<0>(tmp$0##0:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias4:15:4
+    foreign c print_string("--- After calling replicate1: ":wybe.string, ~#io##1:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect p1(100,100):":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(tmp$0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias4:19:4
+    foreign c print_string("expect p2(100,200):":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(p2##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #6 @alias4:21:4
+    foreign lpvm {noalias} mutate(~tmp$0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int)
+    foreign c print_string("--- After calling x(!p1, 555): ":wybe.string, ~#io##6:wybe.phantom, ?tmp$16##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$16##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect p1(555,100):":wybe.string, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~p1##1:position.position, ~#io##8:wybe.phantom, ?#io##9:wybe.phantom) #10 @alias4:27:4
+    foreign c print_string("expect p2(100,200):":wybe.string, ~#io##9:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~p2##0:position.position, ~#io##10:wybe.phantom, ?#io##11:wybe.phantom) #12 @alias4:29:4
 
 
 replicate1 > public (1 calls)
 0: alias4.replicate1<0>
-replicate1(p1#0:position.position, ?p2#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
+replicate1(p1##0:position.position, ?p2##0:position.position, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$6#0:position.position)
-    foreign lpvm mutate(~tmp$6#0:position.position, ?tmp$7#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$7#0:position.position, ?tmp$0#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign c print_string("random replicate1":wybe.string, ~#io#0:wybe.phantom, ?tmp$10#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$10#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(tmp$0#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#1:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~p1#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm mutate(~tmp$0#0:position.position, ?tmp$19#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3#0:wybe.int)
-    foreign lpvm mutate(~tmp$19#0:position.position, ?p2#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp$6##0:position.position)
+    foreign lpvm mutate(~tmp$6##0:position.position, ?tmp$7##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp$7##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign c print_string("random replicate1":wybe.string, ~#io##0:wybe.phantom, ?tmp$10##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(tmp$0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm mutate(~tmp$0##0:position.position, ?tmp$19##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:wybe.int)
+    foreign lpvm mutate(~tmp$19##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
 
   LLVM code       :
 
@@ -127,7 +127,7 @@ entry:
   %7 = inttoptr i64 %6 to i64* 
   %8 = getelementptr  i64, i64* %7, i64 0 
   store  i64 100, i64* %8 
-  %"1$p2#0" = tail call fastcc  i64  @"alias4.replicate1<0>"(i64  %3)  
+  %"1$p2##0" = tail call fastcc  i64  @"alias4.replicate1<0>"(i64  %3)  
   %10 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias4.9, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %10)  
   tail call ccc  void  @putchar(i8  10)  
@@ -136,7 +136,7 @@ entry:
   tail call fastcc  void  @"position.printPosition<0>"(i64  %3)  
   %14 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias4.13, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %14)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2#0")  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2##0")  
   %15 = inttoptr i64 %3 to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
   store  i64 555, i64* %16 
@@ -148,12 +148,12 @@ entry:
   tail call fastcc  void  @"position.printPosition<0>"(i64  %3)  
   %22 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias4.21, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %22)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2#0")  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2##0")  
   ret void 
 }
 
 
-define external fastcc  i64 @"alias4.replicate1<0>"(i64  %"p1#0")    {
+define external fastcc  i64 @"alias4.replicate1<0>"(i64  %"p1##0")    {
 entry:
   %23 = trunc i64 16 to i32  
   %24 = tail call ccc  i8*  @wybe_malloc(i32  %23)  
@@ -173,7 +173,7 @@ entry:
   %35 = load  i64, i64* %34 
   tail call ccc  void  @print_int(i64  %35)  
   tail call ccc  void  @putchar(i8  10)  
-  %36 = inttoptr i64 %"p1#0" to i64* 
+  %36 = inttoptr i64 %"p1##0" to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
   %39 = inttoptr i64 %25 to i64* 
@@ -207,17 +207,17 @@ entry:
 
 printPosition > public (0 calls)
 0: position.printPosition<0>
-printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string(",":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io#4:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -251,17 +251,17 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"position.printPosition<0>"(i64  %"pos#0")    {
+define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
-  %3 = inttoptr i64 %"pos#0" to i64* 
+  %3 = inttoptr i64 %"pos##0" to i64* 
   %4 = getelementptr  i64, i64* %3, i64 0 
   %5 = load  i64, i64* %4 
   tail call ccc  void  @print_int(i64  %5)  
   %7 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.6, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %7)  
-  %8 = add   i64 %"pos#0", 8 
+  %8 = add   i64 %"pos##0", 8 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
@@ -291,86 +291,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y#0:wybe.int)
-    foreign llvm icmp_eq(~$left$x#0:wybe.int, ~$right$x#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
+    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y#0:wybe.int, ~$right$y#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
-    foreign lpvm mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:position.position, ?$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
+    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
-    foreign lpvm access(~$#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y#0:wybe.int)
+    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec#0:position.position, ?$#0:wybe.int):
+x($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec#0:position.position, ?$#0:wybe.int):
+y($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -387,54 +387,54 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$#0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = icmp eq i64 %7, %14 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"x#0", i64* %19 
+  store  i64 %"x##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"y#0", i64* %22 
+  store  i64 %"y##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
 entry:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -444,34 +444,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec#0" to i64* 
+  %32 = inttoptr i64 %"$rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec#0" to i8* 
+  %39 = inttoptr i64 %"$rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field#0", i64* %42 
+  store  i64 %"$field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = add   i64 %"$rec#0", 8 
+  %43 = add   i64 %"$rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -479,46 +479,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec#0" to i8* 
+  %51 = inttoptr i64 %"$rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field#0", i64* %55 
+  store  i64 %"$field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %58, %65 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = icmp eq i64 %62, %69 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$0##0" = icmp eq i64 %62, %69 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }

--- a/test-cases/final-dump/alias4.exp
+++ b/test-cases/final-dump/alias4.exp
@@ -291,7 +291,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
@@ -301,10 +301,10 @@ entry:
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -355,7 +355,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -366,11 +366,11 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -406,8 +406,8 @@ entry:
   %"1#tmp#1##0" = icmp eq i64 %3, %10 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2#####0" = icmp eq i64 %7, %14 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %7, %14 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -516,9 +516,9 @@ entry:
   br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#0##0" = icmp eq i64 %62, %69 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }

--- a/test-cases/final-dump/alias4.exp
+++ b/test-cases/final-dump/alias4.exp
@@ -25,19 +25,19 @@ bar > public (1 calls)
 bar(io##0:wybe.phantom, ?io##11:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$3##0:position.position)
-    foreign lpvm mutate(~tmp$3##0:position.position, ?tmp$4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    alias4.replicate1<0>(tmp$0##0:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias4:15:4
-    foreign c print_string("--- After calling replicate1: ":wybe.string, ~#io##1:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position)
+    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
+    alias4.replicate1<0>(tmp#0##0:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias4:15:4
+    foreign c print_string("--- After calling replicate1: ":wybe.string, ~#io##1:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string("expect p1(100,100):":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(tmp$0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias4:19:4
+    position.printPosition<0>(tmp#0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias4:19:4
     foreign c print_string("expect p2(100,200):":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
     position.printPosition<0>(p2##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #6 @alias4:21:4
-    foreign lpvm {noalias} mutate(~tmp$0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int)
-    foreign c print_string("--- After calling x(!p1, 555): ":wybe.string, ~#io##6:wybe.phantom, ?tmp$16##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$16##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
+    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int)
+    foreign c print_string("--- After calling x(!p1, 555): ":wybe.string, ~#io##6:wybe.phantom, ?tmp#16##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
     foreign c print_string("expect p1(555,100):":wybe.string, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
     position.printPosition<0>(~p1##1:position.position, ~#io##8:wybe.phantom, ?#io##9:wybe.phantom) #10 @alias4:27:4
     foreign c print_string("expect p2(100,200):":wybe.string, ~#io##9:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
@@ -49,17 +49,17 @@ replicate1 > public (1 calls)
 replicate1(p1##0:position.position, ?p2##0:position.position, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$6##0:position.position)
-    foreign lpvm mutate(~tmp$6##0:position.position, ?tmp$7##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$7##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign c print_string("random replicate1":wybe.string, ~#io##0:wybe.phantom, ?tmp$10##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(tmp$0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm mutate(~tmp$0##0:position.position, ?tmp$19##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:wybe.int)
-    foreign lpvm mutate(~tmp$19##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#6##0:position.position)
+    foreign lpvm mutate(~tmp#6##0:position.position, ?tmp#7##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp#7##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign c print_string("random replicate1":wybe.string, ~#io##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(tmp#0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm mutate(~tmp#0##0:position.position, ?tmp#19##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int)
+    foreign lpvm mutate(~tmp#19##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
 
   LLVM code       :
 
@@ -127,7 +127,7 @@ entry:
   %7 = inttoptr i64 %6 to i64* 
   %8 = getelementptr  i64, i64* %7, i64 0 
   store  i64 100, i64* %8 
-  %"1$p2##0" = tail call fastcc  i64  @"alias4.replicate1<0>"(i64  %3)  
+  %"1#p2##0" = tail call fastcc  i64  @"alias4.replicate1<0>"(i64  %3)  
   %10 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias4.9, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %10)  
   tail call ccc  void  @putchar(i8  10)  
@@ -136,7 +136,7 @@ entry:
   tail call fastcc  void  @"position.printPosition<0>"(i64  %3)  
   %14 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias4.13, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %14)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2##0")  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
   %15 = inttoptr i64 %3 to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
   store  i64 555, i64* %16 
@@ -148,7 +148,7 @@ entry:
   tail call fastcc  void  @"position.printPosition<0>"(i64  %3)  
   %22 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias4.21, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %22)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2##0")  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
   ret void 
 }
 
@@ -211,13 +211,13 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -291,86 +291,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
-    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
-    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec##0:position.position, ?$##0:wybe.int):
+x(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec##0:position.position, ?$##0:wybe.int):
+y(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -387,27 +387,27 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$##0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$##0" 
+  %"2#####0" = icmp eq i64 %7, %14 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
@@ -429,12 +429,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
 entry:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -444,34 +444,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec##0" to i64* 
+  %32 = inttoptr i64 %"#rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec##0" to i8* 
+  %39 = inttoptr i64 %"#rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field##0", i64* %42 
+  store  i64 %"#field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = add   i64 %"$rec##0", 8 
+  %43 = add   i64 %"#rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -479,46 +479,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec##0" to i8* 
+  %51 = inttoptr i64 %"#rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field##0", i64* %55 
+  store  i64 %"#field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %58, %65 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = icmp eq i64 %62, %69 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#0##0" = icmp eq i64 %62, %69 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }

--- a/test-cases/final-dump/alias4.exp
+++ b/test-cases/final-dump/alias4.exp
@@ -310,27 +310,27 @@ entry:
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x(#rec##0:position.position, ?###0:wybe.int):
+x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -341,10 +341,10 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y(#rec##0:position.position, ?###0:wybe.int):
+y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -429,12 +429,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 

--- a/test-cases/final-dump/alias5.exp
+++ b/test-cases/final-dump/alias5.exp
@@ -27,17 +27,17 @@ bar(io##0:wybe.phantom, ?io##10:wybe.phantom):
     alias5.replicate1<0>(100:wybe.int, ?p2##0:wybe.int, 800:wybe.int, ?p4##0:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @alias5:14:4
     alias5.replicate1<0>(100:wybe.int, ?p3##0:wybe.int, 800:wybe.int, ?p4##1:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #1 @alias5:15:4
     foreign c print_string("expect p1=111: ":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign c print_int(111:wybe.int, ~#io##3:wybe.phantom, ?tmp$4##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$4##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_int(111:wybe.int, ~#io##3:wybe.phantom, ?tmp#4##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#4##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     foreign c print_string("expect p2=100: ":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
-    foreign c print_int(~p2##0:wybe.int, ~#io##5:wybe.phantom, ?tmp$9##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$9##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+    foreign c print_int(~p2##0:wybe.int, ~#io##5:wybe.phantom, ?tmp#9##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#9##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
     foreign c print_string("expect p3=100: ":wybe.string, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
-    foreign c print_int(~p3##0:wybe.int, ~#io##7:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
+    foreign c print_int(~p3##0:wybe.int, ~#io##7:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
     foreign c print_string("expect p4=45000: ":wybe.string, ~#io##8:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
-    foreign c print_int(~p4##1:wybe.int, ~#io##9:wybe.phantom, ?tmp$19##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$19##0:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
+    foreign c print_int(~p4##1:wybe.int, ~#io##9:wybe.phantom, ?tmp#19##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#19##0:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
 
 
 replicate1 > public (2 calls)
@@ -46,11 +46,11 @@ replicate1(v1##0:wybe.int, ?v2##0:wybe.int, v3##0:wybe.int, ?v4##1:wybe.int, io#
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("random replicate1":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign c print_int(2:wybe.int, ~#io##1:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    foreign llvm add(~v3##0:wybe.int, 100:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
-    foreign llvm mul(~tmp$0##0:wybe.int, 200:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
-    foreign llvm sdiv(~tmp$2##0:wybe.int, 4:wybe.int, ?v4##1:wybe.int) @int:nn:nn
+    foreign c print_int(2:wybe.int, ~#io##1:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign llvm add(~v3##0:wybe.int, 100:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
+    foreign llvm mul(~tmp#0##0:wybe.int, 200:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
+    foreign llvm sdiv(~tmp#2##0:wybe.int, 4:wybe.int, ?v4##1:wybe.int) @int:nn:nn
     foreign llvm move(~v1##0:wybe.int, ?v2##0:wybe.int) @alias5:9:4
 
   LLVM code       :
@@ -132,10 +132,10 @@ entry:
   tail call ccc  void  @print_string(i64  %16)  
   tail call ccc  void  @print_int(i64  2)  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$tmp$0##0" = add   i64 %"v3##0", 100 
-  %"1$tmp$2##0" = mul   i64 %"1$tmp$0##0", 200 
-  %"1$v4##1" = sdiv exact i64 %"1$tmp$2##0", 4 
+  %"1#tmp#0##0" = add   i64 %"v3##0", 100 
+  %"1#tmp#2##0" = mul   i64 %"1#tmp#0##0", 200 
+  %"1#v4##1" = sdiv exact i64 %"1#tmp#2##0", 4 
   %17 = insertvalue {i64, i64} undef, i64 %"v1##0", 0 
-  %18 = insertvalue {i64, i64} %17, i64 %"1$v4##1", 1 
+  %18 = insertvalue {i64, i64} %17, i64 %"1#v4##1", 1 
   ret {i64, i64} %18 
 }

--- a/test-cases/final-dump/alias5.exp
+++ b/test-cases/final-dump/alias5.exp
@@ -13,45 +13,45 @@ AFTER EVERYTHING:
 
 *main* > public {inline} (0 calls)
 0: alias5.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    alias5.bar<0>(~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @alias5:28:2
+    alias5.bar<0>(~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @alias5:28:2
 
 
 bar > public (1 calls)
 0: alias5.bar<0>
-bar(io#0:wybe.phantom, ?io#10:wybe.phantom):
+bar(io##0:wybe.phantom, ?io##10:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    alias5.replicate1<0>(100:wybe.int, ?p2#0:wybe.int, 800:wybe.int, ?p4#0:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @alias5:14:4
-    alias5.replicate1<0>(100:wybe.int, ?p3#0:wybe.int, 800:wybe.int, ?p4#1:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #1 @alias5:15:4
-    foreign c print_string("expect p1=111: ":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign c print_int(111:wybe.int, ~#io#3:wybe.phantom, ?tmp$4#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$4#0:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect p2=100: ":wybe.string, ~#io#4:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-    foreign c print_int(~p2#0:wybe.int, ~#io#5:wybe.phantom, ?tmp$9#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$9#0:wybe.phantom, ?#io#6:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect p3=100: ":wybe.string, ~#io#6:wybe.phantom, ?#io#7:wybe.phantom) @io:nn:nn
-    foreign c print_int(~p3#0:wybe.int, ~#io#7:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#8:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect p4=45000: ":wybe.string, ~#io#8:wybe.phantom, ?#io#9:wybe.phantom) @io:nn:nn
-    foreign c print_int(~p4#1:wybe.int, ~#io#9:wybe.phantom, ?tmp$19#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$19#0:wybe.phantom, ?#io#10:wybe.phantom) @io:nn:nn
+    alias5.replicate1<0>(100:wybe.int, ?p2##0:wybe.int, 800:wybe.int, ?p4##0:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @alias5:14:4
+    alias5.replicate1<0>(100:wybe.int, ?p3##0:wybe.int, 800:wybe.int, ?p4##1:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #1 @alias5:15:4
+    foreign c print_string("expect p1=111: ":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign c print_int(111:wybe.int, ~#io##3:wybe.phantom, ?tmp$4##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$4##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect p2=100: ":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign c print_int(~p2##0:wybe.int, ~#io##5:wybe.phantom, ?tmp$9##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$9##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect p3=100: ":wybe.string, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
+    foreign c print_int(~p3##0:wybe.int, ~#io##7:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect p4=45000: ":wybe.string, ~#io##8:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
+    foreign c print_int(~p4##1:wybe.int, ~#io##9:wybe.phantom, ?tmp$19##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$19##0:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
 
 
 replicate1 > public (2 calls)
 0: alias5.replicate1<0>
-replicate1(v1#0:wybe.int, ?v2#0:wybe.int, v3#0:wybe.int, ?v4#1:wybe.int, io#0:wybe.phantom, ?io#2:wybe.phantom):
+replicate1(v1##0:wybe.int, ?v2##0:wybe.int, v3##0:wybe.int, ?v4##1:wybe.int, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("random replicate1":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_int(2:wybe.int, ~#io#1:wybe.phantom, ?tmp$7#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$7#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign llvm add(~v3#0:wybe.int, 100:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn
-    foreign llvm mul(~tmp$0#0:wybe.int, 200:wybe.int, ?tmp$2#0:wybe.int) @int:nn:nn
-    foreign llvm sdiv(~tmp$2#0:wybe.int, 4:wybe.int, ?v4#1:wybe.int) @int:nn:nn
-    foreign llvm move(~v1#0:wybe.int, ?v2#0:wybe.int) @alias5:9:4
+    foreign c print_string("random replicate1":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(2:wybe.int, ~#io##1:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign llvm add(~v3##0:wybe.int, 100:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
+    foreign llvm mul(~tmp$0##0:wybe.int, 200:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
+    foreign llvm sdiv(~tmp$2##0:wybe.int, 4:wybe.int, ?v4##1:wybe.int) @int:nn:nn
+    foreign llvm move(~v1##0:wybe.int, ?v2##0:wybe.int) @alias5:9:4
 
   LLVM code       :
 
@@ -126,16 +126,16 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"alias5.replicate1<0>"(i64  %"v1#0", i64  %"v3#0")    {
+define external fastcc  {i64, i64} @"alias5.replicate1<0>"(i64  %"v1##0", i64  %"v3##0")    {
 entry:
   %16 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias5.15, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %16)  
   tail call ccc  void  @print_int(i64  2)  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$tmp$0#0" = add   i64 %"v3#0", 100 
-  %"1$tmp$2#0" = mul   i64 %"1$tmp$0#0", 200 
-  %"1$v4#1" = sdiv exact i64 %"1$tmp$2#0", 4 
-  %17 = insertvalue {i64, i64} undef, i64 %"v1#0", 0 
-  %18 = insertvalue {i64, i64} %17, i64 %"1$v4#1", 1 
+  %"1$tmp$0##0" = add   i64 %"v3##0", 100 
+  %"1$tmp$2##0" = mul   i64 %"1$tmp$0##0", 200 
+  %"1$v4##1" = sdiv exact i64 %"1$tmp$2##0", 4 
+  %17 = insertvalue {i64, i64} undef, i64 %"v1##0", 0 
+  %18 = insertvalue {i64, i64} %17, i64 %"1$v4##1", 1 
   ret {i64, i64} %18 
 }

--- a/test-cases/final-dump/alias_cyclic.exp
+++ b/test-cases/final-dump/alias_cyclic.exp
@@ -374,27 +374,27 @@ entry:
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x(#rec##0:position.position, ?###0:wybe.int):
+x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -405,10 +405,10 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y(#rec##0:position.position, ?###0:wybe.int):
+y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -493,12 +493,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 

--- a/test-cases/final-dump/alias_cyclic.exp
+++ b/test-cases/final-dump/alias_cyclic.exp
@@ -15,90 +15,90 @@ AFTER EVERYTHING:
 
 *main* > public {inline} (0 calls)
 0: alias_cyclic.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    alias_cyclic.bar<0>(~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @alias_cyclic:nn:nn
+    alias_cyclic.bar<0>(~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @alias_cyclic:nn:nn
 
 
 bar > public (1 calls)
 0: alias_cyclic.bar<0>
-bar(io#0:wybe.phantom, ?io#5:wybe.phantom):
+bar(io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$3#0:position.position)
-    foreign lpvm mutate(~tmp$3#0:position.position, ?tmp$4#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm mutate(~tmp$4#0:position.position, ?tmp$0#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 900:wybe.int)
-    alias_cyclic.updateX<0>(tmp$0#0:position.position, ?p2#0:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #1 @alias_cyclic:nn:nn
-    foreign c print_string("p1(100,900):":wybe.string, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~tmp$0#0:position.position, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) #3 @alias_cyclic:nn:nn
-    foreign c print_string("p2(102,900):":wybe.string, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~p2#0:position.position, ~#io#4:wybe.phantom, ?#io#5:wybe.phantom) #5 @alias_cyclic:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$3##0:position.position)
+    foreign lpvm mutate(~tmp$3##0:position.position, ?tmp$4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
+    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 900:wybe.int)
+    alias_cyclic.updateX<0>(tmp$0##0:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias_cyclic:nn:nn
+    foreign c print_string("p1(100,900):":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~tmp$0##0:position.position, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @alias_cyclic:nn:nn
+    foreign c print_string("p2(102,900):":wybe.string, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~p2##0:position.position, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #5 @alias_cyclic:nn:nn
 
 
 updateX > public (2 calls)
 0: alias_cyclic.updateX<0>[410bae77d3]
-updateX(p1#0:position.position, ?p2#0:position.position, io#0:wybe.phantom, ?io#1:wybe.phantom):
- AliasPairs: [(p1#0,p2#0)]
+updateX(p1##0:position.position, ?p2##0:position.position, io##0:wybe.phantom, ?io##1:wybe.phantom):
+ AliasPairs: [(p1##0,p2##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(5,(alias_cyclic.updateY<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm access(p1#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0#0:wybe.int, 101:wybe.int, ?tmp$3#0:wybe.bool) @int:nn:nn
-    case ~tmp$3#0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 101:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
+    case ~tmp$3##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1#0:position.position, ?%p1#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:wybe.int)
-        alias_cyclic.updateY<0>[410bae77d3](~p1#1:position.position, ?p2#0:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #5 @alias_cyclic:nn:nn
+        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:wybe.int)
+        alias_cyclic.updateY<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_cyclic:nn:nn
 
     1:
-        foreign llvm move(~p1#0:position.position, ?p2#0:position.position) @alias_cyclic:nn:nn
-        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+        foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_cyclic:nn:nn
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(p1#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0#0:wybe.int, 101:wybe.int, ?tmp$3#0:wybe.bool) @int:nn:nn
-    case ~tmp$3#0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 101:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
+    case ~tmp$3##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1#0:position.position, ?%p1#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:wybe.int)
-        alias_cyclic.updateY<0>[410bae77d3](~p1#1:position.position, ?p2#0:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #5 @alias_cyclic:nn:nn
+        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:wybe.int)
+        alias_cyclic.updateY<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_cyclic:nn:nn
 
     1:
-        foreign llvm move(~p1#0:position.position, ?p2#0:position.position) @alias_cyclic:nn:nn
-        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+        foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_cyclic:nn:nn
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
 
 
 updateY > public (1 calls)
 0: alias_cyclic.updateY<0>[410bae77d3]
-updateY(p1#0:position.position, ?p2#0:position.position, io#0:wybe.phantom, ?io#1:wybe.phantom):
- AliasPairs: [(p1#0,p2#0)]
+updateY(p1##0:position.position, ?p2##0:position.position, io##0:wybe.phantom, ?io##1:wybe.phantom):
+ AliasPairs: [(p1##0,p2##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(5,(alias_cyclic.updateX<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm access(p1#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0#0:wybe.int, 901:wybe.int, ?tmp$3#0:wybe.bool) @int:nn:nn
-    case ~tmp$3#0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 901:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
+    case ~tmp$3##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1#0:position.position, ?%p1#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:wybe.int)
-        alias_cyclic.updateX<0>[410bae77d3](~p1#1:position.position, ?p2#0:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #5 @alias_cyclic:nn:nn
+        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:wybe.int)
+        alias_cyclic.updateX<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_cyclic:nn:nn
 
     1:
-        foreign llvm move(~p1#0:position.position, ?p2#0:position.position) @alias_cyclic:nn:nn
-        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+        foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_cyclic:nn:nn
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(p1#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0#0:wybe.int, 901:wybe.int, ?tmp$3#0:wybe.bool) @int:nn:nn
-    case ~tmp$3#0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 901:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
+    case ~tmp$3##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1#0:position.position, ?%p1#1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:wybe.int)
-        alias_cyclic.updateX<0>[410bae77d3](~p1#1:position.position, ?p2#0:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #5 @alias_cyclic:nn:nn
+        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:wybe.int)
+        alias_cyclic.updateX<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_cyclic:nn:nn
 
     1:
-        foreign llvm move(~p1#0:position.position, ?p2#0:position.position) @alias_cyclic:nn:nn
-        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+        foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_cyclic:nn:nn
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
 
   LLVM code       :
@@ -146,108 +146,108 @@ entry:
   %7 = inttoptr i64 %6 to i64* 
   %8 = getelementptr  i64, i64* %7, i64 0 
   store  i64 900, i64* %8 
-  %"1$p2#0" = tail call fastcc  i64  @"alias_cyclic.updateX<0>"(i64  %3)  
+  %"1$p2##0" = tail call fastcc  i64  @"alias_cyclic.updateX<0>"(i64  %3)  
   %10 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_cyclic.9, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %10)  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %3)  
   %12 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_cyclic.11, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %12)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2#0")  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2##0")  
   ret void 
 }
 
 
-define external fastcc  i64 @"alias_cyclic.updateX<0>"(i64  %"p1#0")    {
+define external fastcc  i64 @"alias_cyclic.updateX<0>"(i64  %"p1##0")    {
 entry:
-  %13 = inttoptr i64 %"p1#0" to i64* 
+  %13 = inttoptr i64 %"p1##0" to i64* 
   %14 = getelementptr  i64, i64* %13, i64 0 
   %15 = load  i64, i64* %14 
-  %"1$tmp$3#0" = icmp sgt i64 %15, 101 
-  br i1 %"1$tmp$3#0", label %if.then, label %if.else 
+  %"1$tmp$3##0" = icmp sgt i64 %15, 101 
+  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
 if.then:
-  ret i64 %"p1#0" 
+  ret i64 %"p1##0" 
 if.else:
-  %"3$tmp$2#0" = add   i64 %15, 1 
+  %"3$tmp$2##0" = add   i64 %15, 1 
   %16 = trunc i64 16 to i32  
   %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
   %18 = ptrtoint i8* %17 to i64 
   %19 = inttoptr i64 %18 to i8* 
-  %20 = inttoptr i64 %"p1#0" to i8* 
+  %20 = inttoptr i64 %"p1##0" to i8* 
   %21 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %19, i8*  %20, i32  %21, i32  8, i1  0)  
   %22 = inttoptr i64 %18 to i64* 
   %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 %"3$tmp$2#0", i64* %23 
-  %"3$p2#0" = tail call fastcc  i64  @"alias_cyclic.updateY<0>[410bae77d3]"(i64  %18)  
-  ret i64 %"3$p2#0" 
+  store  i64 %"3$tmp$2##0", i64* %23 
+  %"3$p2##0" = tail call fastcc  i64  @"alias_cyclic.updateY<0>[410bae77d3]"(i64  %18)  
+  ret i64 %"3$p2##0" 
 }
 
 
-define external fastcc  i64 @"alias_cyclic.updateX<0>[410bae77d3]"(i64  %"p1#0")    {
+define external fastcc  i64 @"alias_cyclic.updateX<0>[410bae77d3]"(i64  %"p1##0")    {
 entry:
-  %24 = inttoptr i64 %"p1#0" to i64* 
+  %24 = inttoptr i64 %"p1##0" to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
   %26 = load  i64, i64* %25 
-  %"1$tmp$3#0" = icmp sgt i64 %26, 101 
-  br i1 %"1$tmp$3#0", label %if.then, label %if.else 
+  %"1$tmp$3##0" = icmp sgt i64 %26, 101 
+  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
 if.then:
-  ret i64 %"p1#0" 
+  ret i64 %"p1##0" 
 if.else:
-  %"3$tmp$2#0" = add   i64 %26, 1 
-  %27 = inttoptr i64 %"p1#0" to i64* 
+  %"3$tmp$2##0" = add   i64 %26, 1 
+  %27 = inttoptr i64 %"p1##0" to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
-  store  i64 %"3$tmp$2#0", i64* %28 
-  %"3$p2#0" = tail call fastcc  i64  @"alias_cyclic.updateY<0>[410bae77d3]"(i64  %"p1#0")  
-  ret i64 %"3$p2#0" 
+  store  i64 %"3$tmp$2##0", i64* %28 
+  %"3$p2##0" = tail call fastcc  i64  @"alias_cyclic.updateY<0>[410bae77d3]"(i64  %"p1##0")  
+  ret i64 %"3$p2##0" 
 }
 
 
-define external fastcc  i64 @"alias_cyclic.updateY<0>"(i64  %"p1#0")    {
+define external fastcc  i64 @"alias_cyclic.updateY<0>"(i64  %"p1##0")    {
 entry:
-  %29 = add   i64 %"p1#0", 8 
+  %29 = add   i64 %"p1##0", 8 
   %30 = inttoptr i64 %29 to i64* 
   %31 = getelementptr  i64, i64* %30, i64 0 
   %32 = load  i64, i64* %31 
-  %"1$tmp$3#0" = icmp sgt i64 %32, 901 
-  br i1 %"1$tmp$3#0", label %if.then, label %if.else 
+  %"1$tmp$3##0" = icmp sgt i64 %32, 901 
+  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
 if.then:
-  ret i64 %"p1#0" 
+  ret i64 %"p1##0" 
 if.else:
-  %"3$tmp$2#0" = add   i64 %32, 1 
+  %"3$tmp$2##0" = add   i64 %32, 1 
   %33 = trunc i64 16 to i32  
   %34 = tail call ccc  i8*  @wybe_malloc(i32  %33)  
   %35 = ptrtoint i8* %34 to i64 
   %36 = inttoptr i64 %35 to i8* 
-  %37 = inttoptr i64 %"p1#0" to i8* 
+  %37 = inttoptr i64 %"p1##0" to i8* 
   %38 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %36, i8*  %37, i32  %38, i32  8, i1  0)  
   %39 = add   i64 %35, 8 
   %40 = inttoptr i64 %39 to i64* 
   %41 = getelementptr  i64, i64* %40, i64 0 
-  store  i64 %"3$tmp$2#0", i64* %41 
-  %"3$p2#0" = tail call fastcc  i64  @"alias_cyclic.updateX<0>[410bae77d3]"(i64  %35)  
-  ret i64 %"3$p2#0" 
+  store  i64 %"3$tmp$2##0", i64* %41 
+  %"3$p2##0" = tail call fastcc  i64  @"alias_cyclic.updateX<0>[410bae77d3]"(i64  %35)  
+  ret i64 %"3$p2##0" 
 }
 
 
-define external fastcc  i64 @"alias_cyclic.updateY<0>[410bae77d3]"(i64  %"p1#0")    {
+define external fastcc  i64 @"alias_cyclic.updateY<0>[410bae77d3]"(i64  %"p1##0")    {
 entry:
-  %42 = add   i64 %"p1#0", 8 
+  %42 = add   i64 %"p1##0", 8 
   %43 = inttoptr i64 %42 to i64* 
   %44 = getelementptr  i64, i64* %43, i64 0 
   %45 = load  i64, i64* %44 
-  %"1$tmp$3#0" = icmp sgt i64 %45, 901 
-  br i1 %"1$tmp$3#0", label %if.then, label %if.else 
+  %"1$tmp$3##0" = icmp sgt i64 %45, 901 
+  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
 if.then:
-  ret i64 %"p1#0" 
+  ret i64 %"p1##0" 
 if.else:
-  %"3$tmp$2#0" = add   i64 %45, 1 
-  %46 = add   i64 %"p1#0", 8 
+  %"3$tmp$2##0" = add   i64 %45, 1 
+  %46 = add   i64 %"p1##0", 8 
   %47 = inttoptr i64 %46 to i64* 
   %48 = getelementptr  i64, i64* %47, i64 0 
-  store  i64 %"3$tmp$2#0", i64* %48 
-  %"3$p2#0" = tail call fastcc  i64  @"alias_cyclic.updateX<0>[410bae77d3]"(i64  %"p1#0")  
-  ret i64 %"3$p2#0" 
+  store  i64 %"3$tmp$2##0", i64* %48 
+  %"3$p2##0" = tail call fastcc  i64  @"alias_cyclic.updateX<0>[410bae77d3]"(i64  %"p1##0")  
+  ret i64 %"3$p2##0" 
 }
 --------------------------------------------------
  Module position
@@ -271,17 +271,17 @@ if.else:
 
 printPosition > public (0 calls)
 0: position.printPosition<0>
-printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string(",":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io#4:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -315,17 +315,17 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"position.printPosition<0>"(i64  %"pos#0")    {
+define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
-  %3 = inttoptr i64 %"pos#0" to i64* 
+  %3 = inttoptr i64 %"pos##0" to i64* 
   %4 = getelementptr  i64, i64* %3, i64 0 
   %5 = load  i64, i64* %4 
   tail call ccc  void  @print_int(i64  %5)  
   %7 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.6, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %7)  
-  %8 = add   i64 %"pos#0", 8 
+  %8 = add   i64 %"pos##0", 8 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
@@ -355,86 +355,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y#0:wybe.int)
-    foreign llvm icmp_eq(~$left$x#0:wybe.int, ~$right$x#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
+    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y#0:wybe.int, ~$right$y#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
-    foreign lpvm mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:position.position, ?$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
+    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
-    foreign lpvm access(~$#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y#0:wybe.int)
+    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec#0:position.position, ?$#0:wybe.int):
+x($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec#0:position.position, ?$#0:wybe.int):
+y($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -451,54 +451,54 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$#0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = icmp eq i64 %7, %14 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"x#0", i64* %19 
+  store  i64 %"x##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"y#0", i64* %22 
+  store  i64 %"y##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
 entry:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -508,34 +508,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec#0" to i64* 
+  %32 = inttoptr i64 %"$rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec#0" to i8* 
+  %39 = inttoptr i64 %"$rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field#0", i64* %42 
+  store  i64 %"$field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = add   i64 %"$rec#0", 8 
+  %43 = add   i64 %"$rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -543,46 +543,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec#0" to i8* 
+  %51 = inttoptr i64 %"$rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field#0", i64* %55 
+  store  i64 %"$field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %58, %65 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = icmp eq i64 %62, %69 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$0##0" = icmp eq i64 %62, %69 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }

--- a/test-cases/final-dump/alias_cyclic.exp
+++ b/test-cases/final-dump/alias_cyclic.exp
@@ -355,7 +355,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
@@ -365,10 +365,10 @@ entry:
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -419,7 +419,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -430,11 +430,11 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -470,8 +470,8 @@ entry:
   %"1#tmp#1##0" = icmp eq i64 %3, %10 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2#####0" = icmp eq i64 %7, %14 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %7, %14 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -580,9 +580,9 @@ entry:
   br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#0##0" = icmp eq i64 %62, %69 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }

--- a/test-cases/final-dump/alias_cyclic.exp
+++ b/test-cases/final-dump/alias_cyclic.exp
@@ -26,12 +26,12 @@ bar > public (1 calls)
 bar(io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$3##0:position.position)
-    foreign lpvm mutate(~tmp$3##0:position.position, ?tmp$4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 900:wybe.int)
-    alias_cyclic.updateX<0>(tmp$0##0:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias_cyclic:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position)
+    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 900:wybe.int)
+    alias_cyclic.updateX<0>(tmp#0##0:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias_cyclic:nn:nn
     foreign c print_string("p1(100,900):":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~tmp$0##0:position.position, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @alias_cyclic:nn:nn
+    position.printPosition<0>(~tmp#0##0:position.position, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @alias_cyclic:nn:nn
     foreign c print_string("p2(102,900):":wybe.string, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     position.printPosition<0>(~p2##0:position.position, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #5 @alias_cyclic:nn:nn
 
@@ -42,12 +42,12 @@ updateX(p1##0:position.position, ?p2##0:position.position, io##0:wybe.phantom, ?
  AliasPairs: [(p1##0,p2##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(5,(alias_cyclic.updateY<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 101:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
-    case ~tmp$3##0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp#0##0:wybe.int, 101:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
+    case ~tmp#3##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:wybe.int)
+        foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
         alias_cyclic.updateY<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_cyclic:nn:nn
 
     1:
@@ -55,12 +55,12 @@ updateX(p1##0:position.position, ?p2##0:position.position, io##0:wybe.phantom, ?
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 101:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
-    case ~tmp$3##0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp#0##0:wybe.int, 101:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
+    case ~tmp#3##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:wybe.int)
+        foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
         alias_cyclic.updateY<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_cyclic:nn:nn
 
     1:
@@ -75,12 +75,12 @@ updateY(p1##0:position.position, ?p2##0:position.position, io##0:wybe.phantom, ?
  AliasPairs: [(p1##0,p2##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(5,(alias_cyclic.updateX<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 901:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
-    case ~tmp$3##0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp#0##0:wybe.int, 901:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
+    case ~tmp#3##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:wybe.int)
+        foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
         alias_cyclic.updateX<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_cyclic:nn:nn
 
     1:
@@ -88,12 +88,12 @@ updateY(p1##0:position.position, ?p2##0:position.position, io##0:wybe.phantom, ?
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 901:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
-    case ~tmp$3##0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp#0##0:wybe.int, 901:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
+    case ~tmp#3##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:wybe.int)
+        foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
         alias_cyclic.updateX<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_cyclic:nn:nn
 
     1:
@@ -146,13 +146,13 @@ entry:
   %7 = inttoptr i64 %6 to i64* 
   %8 = getelementptr  i64, i64* %7, i64 0 
   store  i64 900, i64* %8 
-  %"1$p2##0" = tail call fastcc  i64  @"alias_cyclic.updateX<0>"(i64  %3)  
+  %"1#p2##0" = tail call fastcc  i64  @"alias_cyclic.updateX<0>"(i64  %3)  
   %10 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_cyclic.9, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %10)  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %3)  
   %12 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_cyclic.11, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %12)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2##0")  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
   ret void 
 }
 
@@ -162,12 +162,12 @@ entry:
   %13 = inttoptr i64 %"p1##0" to i64* 
   %14 = getelementptr  i64, i64* %13, i64 0 
   %15 = load  i64, i64* %14 
-  %"1$tmp$3##0" = icmp sgt i64 %15, 101 
-  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
+  %"1#tmp#3##0" = icmp sgt i64 %15, 101 
+  br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
   ret i64 %"p1##0" 
 if.else:
-  %"3$tmp$2##0" = add   i64 %15, 1 
+  %"3#tmp#2##0" = add   i64 %15, 1 
   %16 = trunc i64 16 to i32  
   %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
   %18 = ptrtoint i8* %17 to i64 
@@ -177,9 +177,9 @@ if.else:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %19, i8*  %20, i32  %21, i32  8, i1  0)  
   %22 = inttoptr i64 %18 to i64* 
   %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 %"3$tmp$2##0", i64* %23 
-  %"3$p2##0" = tail call fastcc  i64  @"alias_cyclic.updateY<0>[410bae77d3]"(i64  %18)  
-  ret i64 %"3$p2##0" 
+  store  i64 %"3#tmp#2##0", i64* %23 
+  %"3#p2##0" = tail call fastcc  i64  @"alias_cyclic.updateY<0>[410bae77d3]"(i64  %18)  
+  ret i64 %"3#p2##0" 
 }
 
 
@@ -188,17 +188,17 @@ entry:
   %24 = inttoptr i64 %"p1##0" to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
   %26 = load  i64, i64* %25 
-  %"1$tmp$3##0" = icmp sgt i64 %26, 101 
-  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
+  %"1#tmp#3##0" = icmp sgt i64 %26, 101 
+  br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
   ret i64 %"p1##0" 
 if.else:
-  %"3$tmp$2##0" = add   i64 %26, 1 
+  %"3#tmp#2##0" = add   i64 %26, 1 
   %27 = inttoptr i64 %"p1##0" to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
-  store  i64 %"3$tmp$2##0", i64* %28 
-  %"3$p2##0" = tail call fastcc  i64  @"alias_cyclic.updateY<0>[410bae77d3]"(i64  %"p1##0")  
-  ret i64 %"3$p2##0" 
+  store  i64 %"3#tmp#2##0", i64* %28 
+  %"3#p2##0" = tail call fastcc  i64  @"alias_cyclic.updateY<0>[410bae77d3]"(i64  %"p1##0")  
+  ret i64 %"3#p2##0" 
 }
 
 
@@ -208,12 +208,12 @@ entry:
   %30 = inttoptr i64 %29 to i64* 
   %31 = getelementptr  i64, i64* %30, i64 0 
   %32 = load  i64, i64* %31 
-  %"1$tmp$3##0" = icmp sgt i64 %32, 901 
-  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
+  %"1#tmp#3##0" = icmp sgt i64 %32, 901 
+  br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
   ret i64 %"p1##0" 
 if.else:
-  %"3$tmp$2##0" = add   i64 %32, 1 
+  %"3#tmp#2##0" = add   i64 %32, 1 
   %33 = trunc i64 16 to i32  
   %34 = tail call ccc  i8*  @wybe_malloc(i32  %33)  
   %35 = ptrtoint i8* %34 to i64 
@@ -224,9 +224,9 @@ if.else:
   %39 = add   i64 %35, 8 
   %40 = inttoptr i64 %39 to i64* 
   %41 = getelementptr  i64, i64* %40, i64 0 
-  store  i64 %"3$tmp$2##0", i64* %41 
-  %"3$p2##0" = tail call fastcc  i64  @"alias_cyclic.updateX<0>[410bae77d3]"(i64  %35)  
-  ret i64 %"3$p2##0" 
+  store  i64 %"3#tmp#2##0", i64* %41 
+  %"3#p2##0" = tail call fastcc  i64  @"alias_cyclic.updateX<0>[410bae77d3]"(i64  %35)  
+  ret i64 %"3#p2##0" 
 }
 
 
@@ -236,18 +236,18 @@ entry:
   %43 = inttoptr i64 %42 to i64* 
   %44 = getelementptr  i64, i64* %43, i64 0 
   %45 = load  i64, i64* %44 
-  %"1$tmp$3##0" = icmp sgt i64 %45, 901 
-  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
+  %"1#tmp#3##0" = icmp sgt i64 %45, 901 
+  br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
   ret i64 %"p1##0" 
 if.else:
-  %"3$tmp$2##0" = add   i64 %45, 1 
+  %"3#tmp#2##0" = add   i64 %45, 1 
   %46 = add   i64 %"p1##0", 8 
   %47 = inttoptr i64 %46 to i64* 
   %48 = getelementptr  i64, i64* %47, i64 0 
-  store  i64 %"3$tmp$2##0", i64* %48 
-  %"3$p2##0" = tail call fastcc  i64  @"alias_cyclic.updateX<0>[410bae77d3]"(i64  %"p1##0")  
-  ret i64 %"3$p2##0" 
+  store  i64 %"3#tmp#2##0", i64* %48 
+  %"3#p2##0" = tail call fastcc  i64  @"alias_cyclic.updateX<0>[410bae77d3]"(i64  %"p1##0")  
+  ret i64 %"3#p2##0" 
 }
 --------------------------------------------------
  Module position
@@ -275,13 +275,13 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -355,86 +355,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
-    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
-    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec##0:position.position, ?$##0:wybe.int):
+x(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec##0:position.position, ?$##0:wybe.int):
+y(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -451,27 +451,27 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$##0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$##0" 
+  %"2#####0" = icmp eq i64 %7, %14 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
@@ -493,12 +493,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
 entry:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -508,34 +508,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec##0" to i64* 
+  %32 = inttoptr i64 %"#rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec##0" to i8* 
+  %39 = inttoptr i64 %"#rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field##0", i64* %42 
+  store  i64 %"#field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = add   i64 %"$rec##0", 8 
+  %43 = add   i64 %"#rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -543,46 +543,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec##0" to i8* 
+  %51 = inttoptr i64 %"#rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field##0", i64* %55 
+  store  i64 %"#field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %58, %65 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = icmp eq i64 %62, %69 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#0##0" = icmp eq i64 %62, %69 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }

--- a/test-cases/final-dump/alias_data.exp
+++ b/test-cases/final-dump/alias_data.exp
@@ -301,7 +301,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: student.course.=<0>
-=(#left##0:student.course, #right##0:student.course, ?####0:wybe.bool):
+=(#left##0:student.course, #right##0:student.course, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#code##0:wybe.int)
@@ -311,11 +311,11 @@ entry:
     foreign llvm icmp_eq(~#left#code##0:wybe.int, ~#right#code##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign c strcmp(~#left#name##0:wybe.string, ~#right#name##0:wybe.string, ?tmp#9##0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp#9##0:wybe.int, 0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~tmp#9##0:wybe.int, 0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -366,7 +366,7 @@ name(#rec##0:student.course, ?#rec##1:student.course, #field##0:wybe.string):
 
 ~= > public {inline} (0 calls)
 0: student.course.~=<0>
-~=(#left##0:student.course, #right##0:student.course, ?####0:wybe.bool):
+~=(#left##0:student.course, #right##0:student.course, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -377,12 +377,12 @@ name(#rec##0:student.course, ?#rec##1:student.course, #field##0:wybe.string):
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign c strcmp(~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ?tmp#8##0:wybe.int) @string:nn:nn
         foreign llvm icmp_eq(~tmp#8##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -422,8 +422,8 @@ entry:
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#9##0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
-  %"2#####0" = icmp eq i64 %"2#tmp#9##0", 0 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %"2#tmp#9##0", 0 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -533,11 +533,11 @@ entry:
 if.then:
   %"2#tmp#8##0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
   %"2#tmp#0##0" = icmp eq i64 %"2#tmp#8##0", 0 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }
 --------------------------------------------------
  Module student.student
@@ -559,7 +559,7 @@ if.else:
 
 = > public {inline} (1 calls)
 0: student.student.=<0>
-=(#left##0:student.student, #right##0:student.student, ?####0:wybe.bool):
+=(#left##0:student.student, #right##0:student.student, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#id##0:wybe.int)
@@ -569,7 +569,7 @@ if.else:
     foreign llvm icmp_eq(~#left#id##0:wybe.int, ~#right#id##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign lpvm access(#left#major##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
@@ -579,11 +579,11 @@ if.else:
         foreign llvm icmp_eq(~tmp#11##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#13##0:wybe.bool) @int:nn:nn
         case ~tmp#13##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign c strcmp(~tmp#10##0:wybe.string, ~tmp#12##0:wybe.string, ?tmp#14##0:wybe.int) @string:nn:nn
-            foreign llvm icmp_eq(~tmp#14##0:wybe.int, 0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+            foreign llvm icmp_eq(~tmp#14##0:wybe.int, 0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -635,7 +635,7 @@ student(?id##0:wybe.int, ?major##0:student.course, #result##0:student.student):
 
 ~= > public {inline} (0 calls)
 0: student.student.~=<0>
-~=(#left##0:student.student, #right##0:student.student, ?####0:wybe.bool):
+~=(#left##0:student.student, #right##0:student.student, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -646,7 +646,7 @@ student(?id##0:wybe.int, ?major##0:student.course, #result##0:student.student):
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign lpvm access(tmp#4##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
@@ -657,12 +657,12 @@ student(?id##0:wybe.int, ?major##0:student.course, #result##0:student.student):
         case ~tmp#12##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign c strcmp(~tmp#9##0:wybe.string, ~tmp#11##0:wybe.string, ?tmp#13##0:wybe.int) @string:nn:nn
             foreign llvm icmp_eq(~tmp#13##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -722,8 +722,8 @@ if.else:
   ret i1 0 
 if.then1:
   %"4#tmp#14##0" = tail call ccc  i64  @strcmp(i64  %21, i64  %28)  
-  %"4#####0" = icmp eq i64 %"4#tmp#14##0", 0 
-  ret i1 %"4#####0" 
+  %"4##success##0" = icmp eq i64 %"4#tmp#14##0", 0 
+  ret i1 %"4##success##0" 
 if.else1:
   ret i1 0 
 }
@@ -848,14 +848,14 @@ if.then:
   %"2#tmp#12##0" = icmp eq i64 %93, %86 
   br i1 %"2#tmp#12##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 if.then1:
   %"4#tmp#13##0" = tail call ccc  i64  @strcmp(i64  %90, i64  %97)  
   %"4#tmp#0##0" = icmp eq i64 %"4#tmp#13##0", 0 
-  %"4#####0" = xor i1 %"4#tmp#0##0", 1 
-  ret i1 %"4#####0" 
+  %"4##success##0" = xor i1 %"4#tmp#0##0", 1 
+  ret i1 %"4##success##0" 
 if.else1:
-  %"5#####0" = xor i1 0, 1 
-  ret i1 %"5#####0" 
+  %"5##success##0" = xor i1 0, 1 
+  ret i1 %"5##success##0" 
 }

--- a/test-cases/final-dump/alias_data.exp
+++ b/test-cases/final-dump/alias_data.exp
@@ -33,18 +33,18 @@ bar > public (1 calls)
 bar(io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$4##0:student.course)
-    foreign lpvm mutate(~tmp$4##0:student.course, ?tmp$5##0:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
-    foreign lpvm mutate(~tmp$5##0:student.course, ?tmp$0##0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, "intro to cs":wybe.string)
-    foreign lpvm alloc(16:wybe.int, ?tmp$8##0:student.student)
-    foreign lpvm mutate(~tmp$8##0:student.student, ?tmp$9##0:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 9401:wybe.int)
-    foreign lpvm mutate(~tmp$9##0:student.student, ?tmp$1##0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$0##0:student.course)
-    foreign c print_string("student1":wybe.string, ~#io##0:wybe.phantom, ?tmp$13##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$13##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    student.printStudent<0>(tmp$1##0:student.student, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #4 @alias_data:nn:nn
-    foreign c print_string("student2":wybe.string, ~#io##3:wybe.phantom, ?tmp$16##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$16##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    student.printStudent<0>(~tmp$1##0:student.student, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #6 @alias_data:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:student.course)
+    foreign lpvm mutate(~tmp#4##0:student.course, ?tmp#5##0:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
+    foreign lpvm mutate(~tmp#5##0:student.course, ?tmp#0##0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, "intro to cs":wybe.string)
+    foreign lpvm alloc(16:wybe.int, ?tmp#8##0:student.student)
+    foreign lpvm mutate(~tmp#8##0:student.student, ?tmp#9##0:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 9401:wybe.int)
+    foreign lpvm mutate(~tmp#9##0:student.student, ?tmp#1##0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#0##0:student.course)
+    foreign c print_string("student1":wybe.string, ~#io##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    student.printStudent<0>(tmp#1##0:student.student, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #4 @alias_data:nn:nn
+    foreign c print_string("student2":wybe.string, ~#io##3:wybe.phantom, ?tmp#16##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    student.printStudent<0>(~tmp#1##0:student.student, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #6 @alias_data:nn:nn
 
   LLVM code       :
 
@@ -160,13 +160,13 @@ entry:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$4##0:student.course)
-    foreign lpvm mutate(~tmp$4##0:student.course, ?tmp$5##0:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 90048:wybe.int)
-    foreign lpvm mutate(~tmp$5##0:student.course, ?tmp$6##0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, "Declarative Programming":wybe.string)
-    foreign lpvm alloc(16:wybe.int, ?tmp$9##0:student.student)
-    foreign lpvm mutate(~tmp$9##0:student.student, ?tmp$10##0:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 12345:wybe.int)
-    foreign lpvm mutate(~tmp$10##0:student.student, ?tmp$11##0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$6##0:student.course)
-    student.printStudent<0>(~tmp$11##0:student.student, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @student:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:student.course)
+    foreign lpvm mutate(~tmp#4##0:student.course, ?tmp#5##0:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 90048:wybe.int)
+    foreign lpvm mutate(~tmp#5##0:student.course, ?tmp#6##0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, "Declarative Programming":wybe.string)
+    foreign lpvm alloc(16:wybe.int, ?tmp#9##0:student.student)
+    foreign lpvm mutate(~tmp#9##0:student.student, ?tmp#10##0:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 12345:wybe.int)
+    foreign lpvm mutate(~tmp#10##0:student.student, ?tmp#11##0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#6##0:student.course)
+    student.printStudent<0>(~tmp#11##0:student.student, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @student:nn:nn
 
 
 printStudent > public (1 calls)
@@ -175,18 +175,18 @@ printStudent(stu##0:student.student, io##0:wybe.phantom, ?io##6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("student id: ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(stu##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$9##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$9##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~stu##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:student.course)
+    foreign lpvm access(stu##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#9##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#9##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~stu##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:student.course)
     foreign c print_string("course code: ":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(tmp$1##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.int)
-    foreign c print_int(~tmp$2##0:wybe.int, ~#io##3:wybe.phantom, ?tmp$16##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$16##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign lpvm access(tmp#1##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int)
+    foreign c print_int(~tmp#2##0:wybe.int, ~#io##3:wybe.phantom, ?tmp#16##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     foreign c print_string("course name: ":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~tmp$1##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.string)
-    foreign c print_string(~tmp$3##0:wybe.string, ~#io##5:wybe.phantom, ?tmp$22##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$22##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~tmp#1##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.string)
+    foreign c print_string(~tmp#3##0:wybe.string, ~#io##5:wybe.phantom, ?tmp#22##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#22##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -301,88 +301,88 @@ entry:
 
 = > public {inline} (1 calls)
 0: student.course.=<0>
-=($left##0:student.course, $right##0:student.course, ?$$##0:wybe.bool):
+=(#left##0:student.course, #right##0:student.course, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$code##0:wybe.int)
-    foreign lpvm access(~$left##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$name##0:wybe.string)
-    foreign lpvm access($right##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$code##0:wybe.int)
-    foreign lpvm access(~$right##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$name##0:wybe.string)
-    foreign llvm icmp_eq(~$left$code##0:wybe.int, ~$right$code##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#code##0:wybe.int)
+    foreign lpvm access(~#left##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#name##0:wybe.string)
+    foreign lpvm access(#right##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#code##0:wybe.int)
+    foreign lpvm access(~#right##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#name##0:wybe.string)
+    foreign llvm icmp_eq(~#left#code##0:wybe.int, ~#right#code##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign c strcmp(~$left$name##0:wybe.string, ~$right$name##0:wybe.string, ?tmp$9##0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp$9##0:wybe.int, 0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign c strcmp(~#left#name##0:wybe.string, ~#right#name##0:wybe.string, ?tmp#9##0:wybe.int) @string:nn:nn
+        foreign llvm icmp_eq(~tmp#9##0:wybe.int, 0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 code > public {inline} (0 calls)
 0: student.course.code<0>
-code($rec##0:student.course, ?$##0:wybe.int):
+code(#rec##0:student.course, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 code > public {inline} (0 calls)
 1: student.course.code<1>
-code($rec##0:student.course, ?$rec##1:student.course, $field##0:wybe.int):
+code(#rec##0:student.course, ?#rec##1:student.course, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec##0:student.course, ?$rec##1:student.course, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm mutate(~#rec##0:student.course, ?#rec##1:student.course, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 course > public {inline} (0 calls)
 0: student.course.course<0>
-course(code##0:wybe.int, name##0:wybe.string, ?$##0:student.course):
+course(code##0:wybe.int, name##0:wybe.string, ?###0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:student.course)
-    foreign lpvm mutate(~$rec##0:student.course, ?$rec##1:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~code##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:student.course, ?$##0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~name##0:wybe.string)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:student.course)
+    foreign lpvm mutate(~#rec##0:student.course, ?#rec##1:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~code##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:student.course, ?###0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~name##0:wybe.string)
 course > public {inline} (6 calls)
 1: student.course.course<1>
-course(?code##0:wybe.int, ?name##0:wybe.string, $##0:student.course):
+course(?code##0:wybe.int, ?name##0:wybe.string, ###0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?code##0:wybe.int)
-    foreign lpvm access(~$##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?name##0:wybe.string)
+    foreign lpvm access(###0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?code##0:wybe.int)
+    foreign lpvm access(~###0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?name##0:wybe.string)
 
 
 name > public {inline} (0 calls)
 0: student.course.name<0>
-name($rec##0:student.course, ?$##0:wybe.string):
+name(#rec##0:student.course, ?###0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.string)
+    foreign lpvm access(~#rec##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.string)
 name > public {inline} (0 calls)
 1: student.course.name<1>
-name($rec##0:student.course, ?$rec##1:student.course, $field##0:wybe.string):
+name(#rec##0:student.course, ?#rec##1:student.course, #field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:student.course, ?$rec##1:student.course, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.string)
+    foreign lpvm {noalias} mutate(~#rec##0:student.course, ?#rec##1:student.course, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string)
 
 
 ~= > public {inline} (0 calls)
 0: student.course.~=<0>
-~=($left##0:student.course, $right##0:student.course, ?$$##0:wybe.bool):
+~=(#left##0:student.course, #right##0:student.course, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.string)
-    foreign lpvm access($right##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.string)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.string)
+    foreign lpvm access(#right##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.string)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign c strcmp(~tmp$4##0:wybe.string, ~tmp$6##0:wybe.string, ?tmp$8##0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp$8##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign c strcmp(~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ?tmp#8##0:wybe.int) @string:nn:nn
+        foreign llvm icmp_eq(~tmp#8##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -402,54 +402,54 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"student.course.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"student.course.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$9##0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
-  %"2$$$##0" = icmp eq i64 %"2$tmp$9##0", 0 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#9##0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
+  %"2#####0" = icmp eq i64 %"2#tmp#9##0", 0 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"student.course.code<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"student.course.code<0>"(i64  %"#rec##0")    {
 entry:
-  %15 = inttoptr i64 %"$rec##0" to i64* 
+  %15 = inttoptr i64 %"#rec##0" to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
   %17 = load  i64, i64* %16 
   ret i64 %17 
 }
 
 
-define external fastcc  i64 @"student.course.code<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"student.course.code<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %18 = trunc i64 16 to i32  
   %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
   %20 = ptrtoint i8* %19 to i64 
   %21 = inttoptr i64 %20 to i8* 
-  %22 = inttoptr i64 %"$rec##0" to i8* 
+  %22 = inttoptr i64 %"#rec##0" to i8* 
   %23 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %21, i8*  %22, i32  %23, i32  8, i1  0)  
   %24 = inttoptr i64 %20 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
-  store  i64 %"$field##0", i64* %25 
+  store  i64 %"#field##0", i64* %25 
   ret i64 %20 
 }
 
@@ -470,12 +470,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"student.course.course<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"student.course.course<1>"(i64  %"###0")    {
 entry:
-  %34 = inttoptr i64 %"$##0" to i64* 
+  %34 = inttoptr i64 %"###0" to i64* 
   %35 = getelementptr  i64, i64* %34, i64 0 
   %36 = load  i64, i64* %35 
-  %37 = add   i64 %"$##0", 8 
+  %37 = add   i64 %"###0", 8 
   %38 = inttoptr i64 %37 to i64* 
   %39 = getelementptr  i64, i64* %38, i64 0 
   %40 = load  i64, i64* %39 
@@ -485,9 +485,9 @@ entry:
 }
 
 
-define external fastcc  i64 @"student.course.name<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"student.course.name<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = add   i64 %"$rec##0", 8 
+  %43 = add   i64 %"#rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -495,49 +495,49 @@ entry:
 }
 
 
-define external fastcc  i64 @"student.course.name<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"student.course.name<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec##0" to i8* 
+  %51 = inttoptr i64 %"#rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field##0", i64* %55 
+  store  i64 %"#field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"student.course.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"student.course.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %58, %65 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$8##0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
-  %"2$tmp$0##0" = icmp eq i64 %"2$tmp$8##0", 0 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#8##0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
+  %"2#tmp#0##0" = icmp eq i64 %"2#tmp#8##0", 0 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }
 --------------------------------------------------
  Module student.student
@@ -559,110 +559,110 @@ if.else:
 
 = > public {inline} (1 calls)
 0: student.student.=<0>
-=($left##0:student.student, $right##0:student.student, ?$$##0:wybe.bool):
+=(#left##0:student.student, #right##0:student.student, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$id##0:wybe.int)
-    foreign lpvm access(~$left##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$major##0:student.course)
-    foreign lpvm access($right##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$id##0:wybe.int)
-    foreign lpvm access(~$right##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$major##0:student.course)
-    foreign llvm icmp_eq(~$left$id##0:wybe.int, ~$right$id##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#id##0:wybe.int)
+    foreign lpvm access(~#left##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#major##0:student.course)
+    foreign lpvm access(#right##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#id##0:wybe.int)
+    foreign lpvm access(~#right##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#major##0:student.course)
+    foreign llvm icmp_eq(~#left#id##0:wybe.int, ~#right#id##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign lpvm access($left$major##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.int)
-        foreign lpvm access(~$left$major##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.string)
-        foreign lpvm access($right$major##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$11##0:wybe.int)
-        foreign lpvm access(~$right$major##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$12##0:wybe.string)
-        foreign llvm icmp_eq(~tmp$11##0:wybe.int, ~tmp$9##0:wybe.int, ?tmp$13##0:wybe.bool) @int:nn:nn
-        case ~tmp$13##0:wybe.bool of
+        foreign lpvm access(#left#major##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
+        foreign lpvm access(~#left#major##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.string)
+        foreign lpvm access(#right#major##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#11##0:wybe.int)
+        foreign lpvm access(~#right#major##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#12##0:wybe.string)
+        foreign llvm icmp_eq(~tmp#11##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#13##0:wybe.bool) @int:nn:nn
+        case ~tmp#13##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign c strcmp(~tmp$10##0:wybe.string, ~tmp$12##0:wybe.string, ?tmp$14##0:wybe.int) @string:nn:nn
-            foreign llvm icmp_eq(~tmp$14##0:wybe.int, 0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+            foreign c strcmp(~tmp#10##0:wybe.string, ~tmp#12##0:wybe.string, ?tmp#14##0:wybe.int) @string:nn:nn
+            foreign llvm icmp_eq(~tmp#14##0:wybe.int, 0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 
 id > public {inline} (0 calls)
 0: student.student.id<0>
-id($rec##0:student.student, ?$##0:wybe.int):
+id(#rec##0:student.student, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 id > public {inline} (0 calls)
 1: student.student.id<1>
-id($rec##0:student.student, ?$rec##1:student.student, $field##0:wybe.int):
+id(#rec##0:student.student, ?#rec##1:student.student, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec##0:student.student, ?$rec##1:student.student, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm mutate(~#rec##0:student.student, ?#rec##1:student.student, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 major > public {inline} (0 calls)
 0: student.student.major<0>
-major($rec##0:student.student, ?$##0:student.course):
+major(#rec##0:student.student, ?###0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:student.course)
+    foreign lpvm access(~#rec##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:student.course)
 major > public {inline} (0 calls)
 1: student.student.major<1>
-major($rec##0:student.student, ?$rec##1:student.student, $field##0:student.course):
+major(#rec##0:student.student, ?#rec##1:student.student, #field##0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:student.student, ?$rec##1:student.student, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:student.course)
+    foreign lpvm {noalias} mutate(~#rec##0:student.student, ?#rec##1:student.student, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:student.course)
 
 
 student > public {inline} (0 calls)
 0: student.student.student<0>
-student(id##0:wybe.int, major##0:student.course, ?$##0:student.student):
+student(id##0:wybe.int, major##0:student.course, ?###0:student.student):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:student.student)
-    foreign lpvm mutate(~$rec##0:student.student, ?$rec##1:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~id##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:student.student, ?$##0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~major##0:student.course)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:student.student)
+    foreign lpvm mutate(~#rec##0:student.student, ?#rec##1:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~id##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:student.student, ?###0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~major##0:student.course)
 student > public {inline} (6 calls)
 1: student.student.student<1>
-student(?id##0:wybe.int, ?major##0:student.course, $##0:student.student):
+student(?id##0:wybe.int, ?major##0:student.course, ###0:student.student):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?id##0:wybe.int)
-    foreign lpvm access(~$##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?major##0:student.course)
+    foreign lpvm access(###0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?id##0:wybe.int)
+    foreign lpvm access(~###0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?major##0:student.course)
 
 
 ~= > public {inline} (0 calls)
 0: student.student.~=<0>
-~=($left##0:student.student, $right##0:student.student, ?$$##0:wybe.bool):
+~=(#left##0:student.student, #right##0:student.student, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:student.course)
-    foreign lpvm access($right##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:student.course)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:student.course)
+    foreign lpvm access(#right##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:student.course)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign lpvm access(tmp$4##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
-        foreign lpvm access(~tmp$4##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.string)
-        foreign lpvm access(tmp$6##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.int)
-        foreign lpvm access(~tmp$6##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$11##0:wybe.string)
-        foreign llvm icmp_eq(~tmp$10##0:wybe.int, ~tmp$8##0:wybe.int, ?tmp$12##0:wybe.bool) @int:nn:nn
-        case ~tmp$12##0:wybe.bool of
+        foreign lpvm access(tmp#4##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
+        foreign lpvm access(~tmp#4##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.string)
+        foreign lpvm access(tmp#6##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int)
+        foreign lpvm access(~tmp#6##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#11##0:wybe.string)
+        foreign llvm icmp_eq(~tmp#10##0:wybe.int, ~tmp#8##0:wybe.int, ?tmp#12##0:wybe.bool) @int:nn:nn
+        case ~tmp#12##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign c strcmp(~tmp$9##0:wybe.string, ~tmp$11##0:wybe.string, ?tmp$13##0:wybe.int) @string:nn:nn
-            foreign llvm icmp_eq(~tmp$13##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+            foreign c strcmp(~tmp#9##0:wybe.string, ~tmp#11##0:wybe.string, ?tmp#13##0:wybe.int) @string:nn:nn
+            foreign llvm icmp_eq(~tmp#13##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
 
@@ -683,24 +683,24 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"student.student.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"student.student.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
   %15 = inttoptr i64 %7 to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
@@ -716,47 +716,47 @@ if.then:
   %26 = inttoptr i64 %25 to i64* 
   %27 = getelementptr  i64, i64* %26, i64 0 
   %28 = load  i64, i64* %27 
-  %"2$tmp$13##0" = icmp eq i64 %24, %17 
-  br i1 %"2$tmp$13##0", label %if.then1, label %if.else1 
+  %"2#tmp#13##0" = icmp eq i64 %24, %17 
+  br i1 %"2#tmp#13##0", label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %"4$tmp$14##0" = tail call ccc  i64  @strcmp(i64  %21, i64  %28)  
-  %"4$$$##0" = icmp eq i64 %"4$tmp$14##0", 0 
-  ret i1 %"4$$$##0" 
+  %"4#tmp#14##0" = tail call ccc  i64  @strcmp(i64  %21, i64  %28)  
+  %"4#####0" = icmp eq i64 %"4#tmp#14##0", 0 
+  ret i1 %"4#####0" 
 if.else1:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"student.student.id<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"student.student.id<0>"(i64  %"#rec##0")    {
 entry:
-  %29 = inttoptr i64 %"$rec##0" to i64* 
+  %29 = inttoptr i64 %"#rec##0" to i64* 
   %30 = getelementptr  i64, i64* %29, i64 0 
   %31 = load  i64, i64* %30 
   ret i64 %31 
 }
 
 
-define external fastcc  i64 @"student.student.id<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"student.student.id<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %32 = trunc i64 16 to i32  
   %33 = tail call ccc  i8*  @wybe_malloc(i32  %32)  
   %34 = ptrtoint i8* %33 to i64 
   %35 = inttoptr i64 %34 to i8* 
-  %36 = inttoptr i64 %"$rec##0" to i8* 
+  %36 = inttoptr i64 %"#rec##0" to i8* 
   %37 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %35, i8*  %36, i32  %37, i32  8, i1  0)  
   %38 = inttoptr i64 %34 to i64* 
   %39 = getelementptr  i64, i64* %38, i64 0 
-  store  i64 %"$field##0", i64* %39 
+  store  i64 %"#field##0", i64* %39 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"student.student.major<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"student.student.major<0>"(i64  %"#rec##0")    {
 entry:
-  %40 = add   i64 %"$rec##0", 8 
+  %40 = add   i64 %"#rec##0", 8 
   %41 = inttoptr i64 %40 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
   %43 = load  i64, i64* %42 
@@ -764,19 +764,19 @@ entry:
 }
 
 
-define external fastcc  i64 @"student.student.major<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"student.student.major<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %44 = trunc i64 16 to i32  
   %45 = tail call ccc  i8*  @wybe_malloc(i32  %44)  
   %46 = ptrtoint i8* %45 to i64 
   %47 = inttoptr i64 %46 to i8* 
-  %48 = inttoptr i64 %"$rec##0" to i8* 
+  %48 = inttoptr i64 %"#rec##0" to i8* 
   %49 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %47, i8*  %48, i32  %49, i32  8, i1  0)  
   %50 = add   i64 %46, 8 
   %51 = inttoptr i64 %50 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
-  store  i64 %"$field##0", i64* %52 
+  store  i64 %"#field##0", i64* %52 
   ret i64 %46 
 }
 
@@ -797,12 +797,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"student.student.student<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"student.student.student<1>"(i64  %"###0")    {
 entry:
-  %61 = inttoptr i64 %"$##0" to i64* 
+  %61 = inttoptr i64 %"###0" to i64* 
   %62 = getelementptr  i64, i64* %61, i64 0 
   %63 = load  i64, i64* %62 
-  %64 = add   i64 %"$##0", 8 
+  %64 = add   i64 %"###0", 8 
   %65 = inttoptr i64 %64 to i64* 
   %66 = getelementptr  i64, i64* %65, i64 0 
   %67 = load  i64, i64* %66 
@@ -812,24 +812,24 @@ entry:
 }
 
 
-define external fastcc  i1 @"student.student.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"student.student.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %70 = inttoptr i64 %"$left##0" to i64* 
+  %70 = inttoptr i64 %"#left##0" to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
   %72 = load  i64, i64* %71 
-  %73 = add   i64 %"$left##0", 8 
+  %73 = add   i64 %"#left##0", 8 
   %74 = inttoptr i64 %73 to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
   %76 = load  i64, i64* %75 
-  %77 = inttoptr i64 %"$right##0" to i64* 
+  %77 = inttoptr i64 %"#right##0" to i64* 
   %78 = getelementptr  i64, i64* %77, i64 0 
   %79 = load  i64, i64* %78 
-  %80 = add   i64 %"$right##0", 8 
+  %80 = add   i64 %"#right##0", 8 
   %81 = inttoptr i64 %80 to i64* 
   %82 = getelementptr  i64, i64* %81, i64 0 
   %83 = load  i64, i64* %82 
-  %"1$tmp$7##0" = icmp eq i64 %72, %79 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %72, %79 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %84 = inttoptr i64 %76 to i64* 
   %85 = getelementptr  i64, i64* %84, i64 0 
@@ -845,17 +845,17 @@ if.then:
   %95 = inttoptr i64 %94 to i64* 
   %96 = getelementptr  i64, i64* %95, i64 0 
   %97 = load  i64, i64* %96 
-  %"2$tmp$12##0" = icmp eq i64 %93, %86 
-  br i1 %"2$tmp$12##0", label %if.then1, label %if.else1 
+  %"2#tmp#12##0" = icmp eq i64 %93, %86 
+  br i1 %"2#tmp#12##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 if.then1:
-  %"4$tmp$13##0" = tail call ccc  i64  @strcmp(i64  %90, i64  %97)  
-  %"4$tmp$0##0" = icmp eq i64 %"4$tmp$13##0", 0 
-  %"4$$$##0" = xor i1 %"4$tmp$0##0", 1 
-  ret i1 %"4$$$##0" 
+  %"4#tmp#13##0" = tail call ccc  i64  @strcmp(i64  %90, i64  %97)  
+  %"4#tmp#0##0" = icmp eq i64 %"4#tmp#13##0", 0 
+  %"4#####0" = xor i1 %"4#tmp#0##0", 1 
+  ret i1 %"4#####0" 
 if.else1:
-  %"5$$$##0" = xor i1 0, 1 
-  ret i1 %"5$$$##0" 
+  %"5#####0" = xor i1 0, 1 
+  ret i1 %"5#####0" 
 }

--- a/test-cases/final-dump/alias_data.exp
+++ b/test-cases/final-dump/alias_data.exp
@@ -14,37 +14,37 @@ AFTER EVERYTHING:
 
 *main* > public {inline} (0 calls)
 0: alias_data.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    alias_data.bar<0>(~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @alias_data:nn:nn
+    alias_data.bar<0>(~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @alias_data:nn:nn
 
 
 backup > public {inline} (1 calls)
 0: alias_data.backup<0>
-backup(student1#0:student.student, ?student2#0:student.student, io#0:wybe.phantom, [?io#0:wybe.phantom]):
+backup(student1##0:student.student, ?student2##0:student.student, io##0:wybe.phantom, [?io##0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(~student1#0:student.student, ?student2#0:student.student) @alias_data:nn:nn
+    foreign llvm move(~student1##0:student.student, ?student2##0:student.student) @alias_data:nn:nn
 
 
 bar > public (1 calls)
 0: alias_data.bar<0>
-bar(io#0:wybe.phantom, ?io#5:wybe.phantom):
+bar(io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$4#0:student.course)
-    foreign lpvm mutate(~tmp$4#0:student.course, ?tmp$5#0:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
-    foreign lpvm mutate(~tmp$5#0:student.course, ?tmp$0#0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, "intro to cs":wybe.string)
-    foreign lpvm alloc(16:wybe.int, ?tmp$8#0:student.student)
-    foreign lpvm mutate(~tmp$8#0:student.student, ?tmp$9#0:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 9401:wybe.int)
-    foreign lpvm mutate(~tmp$9#0:student.student, ?tmp$1#0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$0#0:student.course)
-    foreign c print_string("student1":wybe.string, ~#io#0:wybe.phantom, ?tmp$13#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$13#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    student.printStudent<0>(tmp$1#0:student.student, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) #4 @alias_data:nn:nn
-    foreign c print_string("student2":wybe.string, ~#io#3:wybe.phantom, ?tmp$16#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$16#0:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    student.printStudent<0>(~tmp$1#0:student.student, ~#io#4:wybe.phantom, ?#io#5:wybe.phantom) #6 @alias_data:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$4##0:student.course)
+    foreign lpvm mutate(~tmp$4##0:student.course, ?tmp$5##0:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
+    foreign lpvm mutate(~tmp$5##0:student.course, ?tmp$0##0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, "intro to cs":wybe.string)
+    foreign lpvm alloc(16:wybe.int, ?tmp$8##0:student.student)
+    foreign lpvm mutate(~tmp$8##0:student.student, ?tmp$9##0:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 9401:wybe.int)
+    foreign lpvm mutate(~tmp$9##0:student.student, ?tmp$1##0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$0##0:student.course)
+    foreign c print_string("student1":wybe.string, ~#io##0:wybe.phantom, ?tmp$13##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$13##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    student.printStudent<0>(tmp$1##0:student.student, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #4 @alias_data:nn:nn
+    foreign c print_string("student2":wybe.string, ~#io##3:wybe.phantom, ?tmp$16##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$16##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    student.printStudent<0>(~tmp$1##0:student.student, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #6 @alias_data:nn:nn
 
   LLVM code       :
 
@@ -85,9 +85,9 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_data.backup<0>"(i64  %"student1#0")    {
+define external fastcc  i64 @"alias_data.backup<0>"(i64  %"student1##0")    {
 entry:
-  ret i64 %"student1#0" 
+  ret i64 %"student1##0" 
 }
 
 
@@ -157,36 +157,36 @@ entry:
 
 *main* > public (0 calls)
 0: student.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$4#0:student.course)
-    foreign lpvm mutate(~tmp$4#0:student.course, ?tmp$5#0:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 90048:wybe.int)
-    foreign lpvm mutate(~tmp$5#0:student.course, ?tmp$6#0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, "Declarative Programming":wybe.string)
-    foreign lpvm alloc(16:wybe.int, ?tmp$9#0:student.student)
-    foreign lpvm mutate(~tmp$9#0:student.student, ?tmp$10#0:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 12345:wybe.int)
-    foreign lpvm mutate(~tmp$10#0:student.student, ?tmp$11#0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$6#0:student.course)
-    student.printStudent<0>(~tmp$11#0:student.student, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #2 @student:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$4##0:student.course)
+    foreign lpvm mutate(~tmp$4##0:student.course, ?tmp$5##0:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 90048:wybe.int)
+    foreign lpvm mutate(~tmp$5##0:student.course, ?tmp$6##0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, "Declarative Programming":wybe.string)
+    foreign lpvm alloc(16:wybe.int, ?tmp$9##0:student.student)
+    foreign lpvm mutate(~tmp$9##0:student.student, ?tmp$10##0:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 12345:wybe.int)
+    foreign lpvm mutate(~tmp$10##0:student.student, ?tmp$11##0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$6##0:student.course)
+    student.printStudent<0>(~tmp$11##0:student.student, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @student:nn:nn
 
 
 printStudent > public (1 calls)
 0: student.printStudent<0>
-printStudent(stu#0:student.student, io#0:wybe.phantom, ?io#6:wybe.phantom):
+printStudent(stu##0:student.student, io##0:wybe.phantom, ?io##6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("student id: ":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(stu#0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#1:wybe.phantom, ?tmp$9#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$9#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~stu#0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:student.course)
-    foreign c print_string("course code: ":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(tmp$1#0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$2#0:wybe.int)
-    foreign c print_int(~tmp$2#0:wybe.int, ~#io#3:wybe.phantom, ?tmp$16#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$16#0:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_string("course name: ":wybe.string, ~#io#4:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~tmp$1#0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.string)
-    foreign c print_string(~tmp$3#0:wybe.string, ~#io#5:wybe.phantom, ?tmp$22#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$22#0:wybe.phantom, ?#io#6:wybe.phantom) @io:nn:nn
+    foreign c print_string("student id: ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(stu##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$9##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$9##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~stu##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:student.course)
+    foreign c print_string("course code: ":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign lpvm access(tmp$1##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.int)
+    foreign c print_int(~tmp$2##0:wybe.int, ~#io##3:wybe.phantom, ?tmp$16##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$16##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string("course name: ":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~tmp$1##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.string)
+    foreign c print_string(~tmp$3##0:wybe.string, ~#io##5:wybe.phantom, ?tmp$22##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$22##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -251,16 +251,16 @@ entry:
 }
 
 
-define external fastcc  void @"student.printStudent<0>"(i64  %"stu#0")    {
+define external fastcc  void @"student.printStudent<0>"(i64  %"stu##0")    {
 entry:
   %20 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @student.19, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %20)  
-  %21 = inttoptr i64 %"stu#0" to i64* 
+  %21 = inttoptr i64 %"stu##0" to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
   %23 = load  i64, i64* %22 
   tail call ccc  void  @print_int(i64  %23)  
   tail call ccc  void  @putchar(i8  10)  
-  %24 = add   i64 %"stu#0", 8 
+  %24 = add   i64 %"stu##0", 8 
   %25 = inttoptr i64 %24 to i64* 
   %26 = getelementptr  i64, i64* %25, i64 0 
   %27 = load  i64, i64* %26 
@@ -301,88 +301,88 @@ entry:
 
 = > public {inline} (1 calls)
 0: student.course.=<0>
-=($left#0:student.course, $right#0:student.course, ?$$#0:wybe.bool):
+=($left##0:student.course, $right##0:student.course, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$code#0:wybe.int)
-    foreign lpvm access(~$left#0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$name#0:wybe.string)
-    foreign lpvm access($right#0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$code#0:wybe.int)
-    foreign lpvm access(~$right#0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$name#0:wybe.string)
-    foreign llvm icmp_eq(~$left$code#0:wybe.int, ~$right$code#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$code##0:wybe.int)
+    foreign lpvm access(~$left##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$name##0:wybe.string)
+    foreign lpvm access($right##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$code##0:wybe.int)
+    foreign lpvm access(~$right##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$name##0:wybe.string)
+    foreign llvm icmp_eq(~$left$code##0:wybe.int, ~$right$code##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign c strcmp(~$left$name#0:wybe.string, ~$right$name#0:wybe.string, ?tmp$9#0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp$9#0:wybe.int, 0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign c strcmp(~$left$name##0:wybe.string, ~$right$name##0:wybe.string, ?tmp$9##0:wybe.int) @string:nn:nn
+        foreign llvm icmp_eq(~tmp$9##0:wybe.int, 0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 code > public {inline} (0 calls)
 0: student.course.code<0>
-code($rec#0:student.course, ?$#0:wybe.int):
+code($rec##0:student.course, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 code > public {inline} (0 calls)
 1: student.course.code<1>
-code($rec#0:student.course, ?$rec#1:student.course, $field#0:wybe.int):
+code($rec##0:student.course, ?$rec##1:student.course, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec#0:student.course, ?$rec#1:student.course, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm mutate(~$rec##0:student.course, ?$rec##1:student.course, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 course > public {inline} (0 calls)
 0: student.course.course<0>
-course(code#0:wybe.int, name#0:wybe.string, ?$#0:student.course):
+course(code##0:wybe.int, name##0:wybe.string, ?$##0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:student.course)
-    foreign lpvm mutate(~$rec#0:student.course, ?$rec#1:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~code#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:student.course, ?$#0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~name#0:wybe.string)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:student.course)
+    foreign lpvm mutate(~$rec##0:student.course, ?$rec##1:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~code##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:student.course, ?$##0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~name##0:wybe.string)
 course > public {inline} (6 calls)
 1: student.course.course<1>
-course(?code#0:wybe.int, ?name#0:wybe.string, $#0:student.course):
+course(?code##0:wybe.int, ?name##0:wybe.string, $##0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?code#0:wybe.int)
-    foreign lpvm access(~$#0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?name#0:wybe.string)
+    foreign lpvm access($##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?code##0:wybe.int)
+    foreign lpvm access(~$##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?name##0:wybe.string)
 
 
 name > public {inline} (0 calls)
 0: student.course.name<0>
-name($rec#0:student.course, ?$#0:wybe.string):
+name($rec##0:student.course, ?$##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.string)
+    foreign lpvm access(~$rec##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.string)
 name > public {inline} (0 calls)
 1: student.course.name<1>
-name($rec#0:student.course, ?$rec#1:student.course, $field#0:wybe.string):
+name($rec##0:student.course, ?$rec##1:student.course, $field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:student.course, ?$rec#1:student.course, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.string)
+    foreign lpvm {noalias} mutate(~$rec##0:student.course, ?$rec##1:student.course, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.string)
 
 
 ~= > public {inline} (0 calls)
 0: student.course.~=<0>
-~=($left#0:student.course, $right#0:student.course, ?$$#0:wybe.bool):
+~=($left##0:student.course, $right##0:student.course, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.string)
-    foreign lpvm access($right#0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.string)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.string)
+    foreign lpvm access($right##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.string)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign c strcmp(~tmp$4#0:wybe.string, ~tmp$6#0:wybe.string, ?tmp$8#0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp$8#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign c strcmp(~tmp$4##0:wybe.string, ~tmp$6##0:wybe.string, ?tmp$8##0:wybe.int) @string:nn:nn
+        foreign llvm icmp_eq(~tmp$8##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -402,80 +402,80 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"student.course.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"student.course.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$9#0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
-  %"2$$$#0" = icmp eq i64 %"2$tmp$9#0", 0 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$9##0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
+  %"2$$$##0" = icmp eq i64 %"2$tmp$9##0", 0 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"student.course.code<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"student.course.code<0>"(i64  %"$rec##0")    {
 entry:
-  %15 = inttoptr i64 %"$rec#0" to i64* 
+  %15 = inttoptr i64 %"$rec##0" to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
   %17 = load  i64, i64* %16 
   ret i64 %17 
 }
 
 
-define external fastcc  i64 @"student.course.code<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"student.course.code<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %18 = trunc i64 16 to i32  
   %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
   %20 = ptrtoint i8* %19 to i64 
   %21 = inttoptr i64 %20 to i8* 
-  %22 = inttoptr i64 %"$rec#0" to i8* 
+  %22 = inttoptr i64 %"$rec##0" to i8* 
   %23 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %21, i8*  %22, i32  %23, i32  8, i1  0)  
   %24 = inttoptr i64 %20 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
-  store  i64 %"$field#0", i64* %25 
+  store  i64 %"$field##0", i64* %25 
   ret i64 %20 
 }
 
 
-define external fastcc  i64 @"student.course.course<0>"(i64  %"code#0", i64  %"name#0")    {
+define external fastcc  i64 @"student.course.course<0>"(i64  %"code##0", i64  %"name##0")    {
 entry:
   %26 = trunc i64 16 to i32  
   %27 = tail call ccc  i8*  @wybe_malloc(i32  %26)  
   %28 = ptrtoint i8* %27 to i64 
   %29 = inttoptr i64 %28 to i64* 
   %30 = getelementptr  i64, i64* %29, i64 0 
-  store  i64 %"code#0", i64* %30 
+  store  i64 %"code##0", i64* %30 
   %31 = add   i64 %28, 8 
   %32 = inttoptr i64 %31 to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
-  store  i64 %"name#0", i64* %33 
+  store  i64 %"name##0", i64* %33 
   ret i64 %28 
 }
 
 
-define external fastcc  {i64, i64} @"student.course.course<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"student.course.course<1>"(i64  %"$##0")    {
 entry:
-  %34 = inttoptr i64 %"$#0" to i64* 
+  %34 = inttoptr i64 %"$##0" to i64* 
   %35 = getelementptr  i64, i64* %34, i64 0 
   %36 = load  i64, i64* %35 
-  %37 = add   i64 %"$#0", 8 
+  %37 = add   i64 %"$##0", 8 
   %38 = inttoptr i64 %37 to i64* 
   %39 = getelementptr  i64, i64* %38, i64 0 
   %40 = load  i64, i64* %39 
@@ -485,9 +485,9 @@ entry:
 }
 
 
-define external fastcc  i64 @"student.course.name<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"student.course.name<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = add   i64 %"$rec#0", 8 
+  %43 = add   i64 %"$rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -495,49 +495,49 @@ entry:
 }
 
 
-define external fastcc  i64 @"student.course.name<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"student.course.name<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec#0" to i8* 
+  %51 = inttoptr i64 %"$rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field#0", i64* %55 
+  store  i64 %"$field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"student.course.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"student.course.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %58, %65 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$8#0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
-  %"2$tmp$0#0" = icmp eq i64 %"2$tmp$8#0", 0 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$8##0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
+  %"2$tmp$0##0" = icmp eq i64 %"2$tmp$8##0", 0 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }
 --------------------------------------------------
  Module student.student
@@ -559,110 +559,110 @@ if.else:
 
 = > public {inline} (1 calls)
 0: student.student.=<0>
-=($left#0:student.student, $right#0:student.student, ?$$#0:wybe.bool):
+=($left##0:student.student, $right##0:student.student, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$id#0:wybe.int)
-    foreign lpvm access(~$left#0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$major#0:student.course)
-    foreign lpvm access($right#0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$id#0:wybe.int)
-    foreign lpvm access(~$right#0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$major#0:student.course)
-    foreign llvm icmp_eq(~$left$id#0:wybe.int, ~$right$id#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$id##0:wybe.int)
+    foreign lpvm access(~$left##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$major##0:student.course)
+    foreign lpvm access($right##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$id##0:wybe.int)
+    foreign lpvm access(~$right##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$major##0:student.course)
+    foreign llvm icmp_eq(~$left$id##0:wybe.int, ~$right$id##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign lpvm access($left$major#0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.int)
-        foreign lpvm access(~$left$major#0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.string)
-        foreign lpvm access($right$major#0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$11#0:wybe.int)
-        foreign lpvm access(~$right$major#0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$12#0:wybe.string)
-        foreign llvm icmp_eq(~tmp$11#0:wybe.int, ~tmp$9#0:wybe.int, ?tmp$13#0:wybe.bool) @int:nn:nn
-        case ~tmp$13#0:wybe.bool of
+        foreign lpvm access($left$major##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.int)
+        foreign lpvm access(~$left$major##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.string)
+        foreign lpvm access($right$major##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$11##0:wybe.int)
+        foreign lpvm access(~$right$major##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$12##0:wybe.string)
+        foreign llvm icmp_eq(~tmp$11##0:wybe.int, ~tmp$9##0:wybe.int, ?tmp$13##0:wybe.bool) @int:nn:nn
+        case ~tmp$13##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign c strcmp(~tmp$10#0:wybe.string, ~tmp$12#0:wybe.string, ?tmp$14#0:wybe.int) @string:nn:nn
-            foreign llvm icmp_eq(~tmp$14#0:wybe.int, 0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+            foreign c strcmp(~tmp$10##0:wybe.string, ~tmp$12##0:wybe.string, ?tmp$14##0:wybe.int) @string:nn:nn
+            foreign llvm icmp_eq(~tmp$14##0:wybe.int, 0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 
 id > public {inline} (0 calls)
 0: student.student.id<0>
-id($rec#0:student.student, ?$#0:wybe.int):
+id($rec##0:student.student, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 id > public {inline} (0 calls)
 1: student.student.id<1>
-id($rec#0:student.student, ?$rec#1:student.student, $field#0:wybe.int):
+id($rec##0:student.student, ?$rec##1:student.student, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec#0:student.student, ?$rec#1:student.student, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm mutate(~$rec##0:student.student, ?$rec##1:student.student, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 major > public {inline} (0 calls)
 0: student.student.major<0>
-major($rec#0:student.student, ?$#0:student.course):
+major($rec##0:student.student, ?$##0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:student.course)
+    foreign lpvm access(~$rec##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:student.course)
 major > public {inline} (0 calls)
 1: student.student.major<1>
-major($rec#0:student.student, ?$rec#1:student.student, $field#0:student.course):
+major($rec##0:student.student, ?$rec##1:student.student, $field##0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:student.student, ?$rec#1:student.student, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:student.course)
+    foreign lpvm {noalias} mutate(~$rec##0:student.student, ?$rec##1:student.student, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:student.course)
 
 
 student > public {inline} (0 calls)
 0: student.student.student<0>
-student(id#0:wybe.int, major#0:student.course, ?$#0:student.student):
+student(id##0:wybe.int, major##0:student.course, ?$##0:student.student):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:student.student)
-    foreign lpvm mutate(~$rec#0:student.student, ?$rec#1:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~id#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:student.student, ?$#0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~major#0:student.course)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:student.student)
+    foreign lpvm mutate(~$rec##0:student.student, ?$rec##1:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~id##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:student.student, ?$##0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~major##0:student.course)
 student > public {inline} (6 calls)
 1: student.student.student<1>
-student(?id#0:wybe.int, ?major#0:student.course, $#0:student.student):
+student(?id##0:wybe.int, ?major##0:student.course, $##0:student.student):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?id#0:wybe.int)
-    foreign lpvm access(~$#0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?major#0:student.course)
+    foreign lpvm access($##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?id##0:wybe.int)
+    foreign lpvm access(~$##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?major##0:student.course)
 
 
 ~= > public {inline} (0 calls)
 0: student.student.~=<0>
-~=($left#0:student.student, $right#0:student.student, ?$$#0:wybe.bool):
+~=($left##0:student.student, $right##0:student.student, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:student.course)
-    foreign lpvm access($right#0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:student.course)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:student.course)
+    foreign lpvm access($right##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:student.course)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign lpvm access(tmp$4#0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.int)
-        foreign lpvm access(~tmp$4#0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.string)
-        foreign lpvm access(tmp$6#0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.int)
-        foreign lpvm access(~tmp$6#0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$11#0:wybe.string)
-        foreign llvm icmp_eq(~tmp$10#0:wybe.int, ~tmp$8#0:wybe.int, ?tmp$12#0:wybe.bool) @int:nn:nn
-        case ~tmp$12#0:wybe.bool of
+        foreign lpvm access(tmp$4##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
+        foreign lpvm access(~tmp$4##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.string)
+        foreign lpvm access(tmp$6##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.int)
+        foreign lpvm access(~tmp$6##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$11##0:wybe.string)
+        foreign llvm icmp_eq(~tmp$10##0:wybe.int, ~tmp$8##0:wybe.int, ?tmp$12##0:wybe.bool) @int:nn:nn
+        case ~tmp$12##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-            foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign c strcmp(~tmp$9#0:wybe.string, ~tmp$11#0:wybe.string, ?tmp$13#0:wybe.int) @string:nn:nn
-            foreign llvm icmp_eq(~tmp$13#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-            foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+            foreign c strcmp(~tmp$9##0:wybe.string, ~tmp$11##0:wybe.string, ?tmp$13##0:wybe.int) @string:nn:nn
+            foreign llvm icmp_eq(~tmp$13##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
@@ -683,24 +683,24 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"student.student.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"student.student.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
   %15 = inttoptr i64 %7 to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
@@ -716,47 +716,47 @@ if.then:
   %26 = inttoptr i64 %25 to i64* 
   %27 = getelementptr  i64, i64* %26, i64 0 
   %28 = load  i64, i64* %27 
-  %"2$tmp$13#0" = icmp eq i64 %24, %17 
-  br i1 %"2$tmp$13#0", label %if.then1, label %if.else1 
+  %"2$tmp$13##0" = icmp eq i64 %24, %17 
+  br i1 %"2$tmp$13##0", label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %"4$tmp$14#0" = tail call ccc  i64  @strcmp(i64  %21, i64  %28)  
-  %"4$$$#0" = icmp eq i64 %"4$tmp$14#0", 0 
-  ret i1 %"4$$$#0" 
+  %"4$tmp$14##0" = tail call ccc  i64  @strcmp(i64  %21, i64  %28)  
+  %"4$$$##0" = icmp eq i64 %"4$tmp$14##0", 0 
+  ret i1 %"4$$$##0" 
 if.else1:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"student.student.id<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"student.student.id<0>"(i64  %"$rec##0")    {
 entry:
-  %29 = inttoptr i64 %"$rec#0" to i64* 
+  %29 = inttoptr i64 %"$rec##0" to i64* 
   %30 = getelementptr  i64, i64* %29, i64 0 
   %31 = load  i64, i64* %30 
   ret i64 %31 
 }
 
 
-define external fastcc  i64 @"student.student.id<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"student.student.id<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %32 = trunc i64 16 to i32  
   %33 = tail call ccc  i8*  @wybe_malloc(i32  %32)  
   %34 = ptrtoint i8* %33 to i64 
   %35 = inttoptr i64 %34 to i8* 
-  %36 = inttoptr i64 %"$rec#0" to i8* 
+  %36 = inttoptr i64 %"$rec##0" to i8* 
   %37 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %35, i8*  %36, i32  %37, i32  8, i1  0)  
   %38 = inttoptr i64 %34 to i64* 
   %39 = getelementptr  i64, i64* %38, i64 0 
-  store  i64 %"$field#0", i64* %39 
+  store  i64 %"$field##0", i64* %39 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"student.student.major<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"student.student.major<0>"(i64  %"$rec##0")    {
 entry:
-  %40 = add   i64 %"$rec#0", 8 
+  %40 = add   i64 %"$rec##0", 8 
   %41 = inttoptr i64 %40 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
   %43 = load  i64, i64* %42 
@@ -764,45 +764,45 @@ entry:
 }
 
 
-define external fastcc  i64 @"student.student.major<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"student.student.major<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %44 = trunc i64 16 to i32  
   %45 = tail call ccc  i8*  @wybe_malloc(i32  %44)  
   %46 = ptrtoint i8* %45 to i64 
   %47 = inttoptr i64 %46 to i8* 
-  %48 = inttoptr i64 %"$rec#0" to i8* 
+  %48 = inttoptr i64 %"$rec##0" to i8* 
   %49 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %47, i8*  %48, i32  %49, i32  8, i1  0)  
   %50 = add   i64 %46, 8 
   %51 = inttoptr i64 %50 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
-  store  i64 %"$field#0", i64* %52 
+  store  i64 %"$field##0", i64* %52 
   ret i64 %46 
 }
 
 
-define external fastcc  i64 @"student.student.student<0>"(i64  %"id#0", i64  %"major#0")    {
+define external fastcc  i64 @"student.student.student<0>"(i64  %"id##0", i64  %"major##0")    {
 entry:
   %53 = trunc i64 16 to i32  
   %54 = tail call ccc  i8*  @wybe_malloc(i32  %53)  
   %55 = ptrtoint i8* %54 to i64 
   %56 = inttoptr i64 %55 to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
-  store  i64 %"id#0", i64* %57 
+  store  i64 %"id##0", i64* %57 
   %58 = add   i64 %55, 8 
   %59 = inttoptr i64 %58 to i64* 
   %60 = getelementptr  i64, i64* %59, i64 0 
-  store  i64 %"major#0", i64* %60 
+  store  i64 %"major##0", i64* %60 
   ret i64 %55 
 }
 
 
-define external fastcc  {i64, i64} @"student.student.student<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"student.student.student<1>"(i64  %"$##0")    {
 entry:
-  %61 = inttoptr i64 %"$#0" to i64* 
+  %61 = inttoptr i64 %"$##0" to i64* 
   %62 = getelementptr  i64, i64* %61, i64 0 
   %63 = load  i64, i64* %62 
-  %64 = add   i64 %"$#0", 8 
+  %64 = add   i64 %"$##0", 8 
   %65 = inttoptr i64 %64 to i64* 
   %66 = getelementptr  i64, i64* %65, i64 0 
   %67 = load  i64, i64* %66 
@@ -812,24 +812,24 @@ entry:
 }
 
 
-define external fastcc  i1 @"student.student.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"student.student.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %70 = inttoptr i64 %"$left#0" to i64* 
+  %70 = inttoptr i64 %"$left##0" to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
   %72 = load  i64, i64* %71 
-  %73 = add   i64 %"$left#0", 8 
+  %73 = add   i64 %"$left##0", 8 
   %74 = inttoptr i64 %73 to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
   %76 = load  i64, i64* %75 
-  %77 = inttoptr i64 %"$right#0" to i64* 
+  %77 = inttoptr i64 %"$right##0" to i64* 
   %78 = getelementptr  i64, i64* %77, i64 0 
   %79 = load  i64, i64* %78 
-  %80 = add   i64 %"$right#0", 8 
+  %80 = add   i64 %"$right##0", 8 
   %81 = inttoptr i64 %80 to i64* 
   %82 = getelementptr  i64, i64* %81, i64 0 
   %83 = load  i64, i64* %82 
-  %"1$tmp$7#0" = icmp eq i64 %72, %79 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %72, %79 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
   %84 = inttoptr i64 %76 to i64* 
   %85 = getelementptr  i64, i64* %84, i64 0 
@@ -845,17 +845,17 @@ if.then:
   %95 = inttoptr i64 %94 to i64* 
   %96 = getelementptr  i64, i64* %95, i64 0 
   %97 = load  i64, i64* %96 
-  %"2$tmp$12#0" = icmp eq i64 %93, %86 
-  br i1 %"2$tmp$12#0", label %if.then1, label %if.else1 
+  %"2$tmp$12##0" = icmp eq i64 %93, %86 
+  br i1 %"2$tmp$12##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 if.then1:
-  %"4$tmp$13#0" = tail call ccc  i64  @strcmp(i64  %90, i64  %97)  
-  %"4$tmp$0#0" = icmp eq i64 %"4$tmp$13#0", 0 
-  %"4$$$#0" = xor i1 %"4$tmp$0#0", 1 
-  ret i1 %"4$$$#0" 
+  %"4$tmp$13##0" = tail call ccc  i64  @strcmp(i64  %90, i64  %97)  
+  %"4$tmp$0##0" = icmp eq i64 %"4$tmp$13##0", 0 
+  %"4$$$##0" = xor i1 %"4$tmp$0##0", 1 
+  ret i1 %"4$$$##0" 
 if.else1:
-  %"5$$$#0" = xor i1 0, 1 
-  ret i1 %"5$$$#0" 
+  %"5$$$##0" = xor i1 0, 1 
+  ret i1 %"5$$$##0" 
 }

--- a/test-cases/final-dump/alias_data.exp
+++ b/test-cases/final-dump/alias_data.exp
@@ -321,10 +321,10 @@ entry:
 
 code > public {inline} (0 calls)
 0: student.course.code<0>
-code(#rec##0:student.course, ?###0:wybe.int):
+code(#rec##0:student.course, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 code > public {inline} (0 calls)
 1: student.course.code<1>
 code(#rec##0:student.course, ?#rec##1:student.course, #field##0:wybe.int):
@@ -335,27 +335,27 @@ code(#rec##0:student.course, ?#rec##1:student.course, #field##0:wybe.int):
 
 course > public {inline} (0 calls)
 0: student.course.course<0>
-course(code##0:wybe.int, name##0:wybe.string, ?###0:student.course):
+course(code##0:wybe.int, name##0:wybe.string, ?#result##0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:student.course)
     foreign lpvm mutate(~#rec##0:student.course, ?#rec##1:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~code##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:student.course, ?###0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~name##0:wybe.string)
+    foreign lpvm mutate(~#rec##1:student.course, ?#result##0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~name##0:wybe.string)
 course > public {inline} (6 calls)
 1: student.course.course<1>
-course(?code##0:wybe.int, ?name##0:wybe.string, ###0:student.course):
+course(?code##0:wybe.int, ?name##0:wybe.string, #result##0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?code##0:wybe.int)
-    foreign lpvm access(~###0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?name##0:wybe.string)
+    foreign lpvm access(#result##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?code##0:wybe.int)
+    foreign lpvm access(~#result##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?name##0:wybe.string)
 
 
 name > public {inline} (0 calls)
 0: student.course.name<0>
-name(#rec##0:student.course, ?###0:wybe.string):
+name(#rec##0:student.course, ?#result##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.string)
+    foreign lpvm access(~#rec##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string)
 name > public {inline} (0 calls)
 1: student.course.name<1>
 name(#rec##0:student.course, ?#rec##1:student.course, #field##0:wybe.string):
@@ -470,12 +470,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"student.course.course<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"student.course.course<1>"(i64  %"#result##0")    {
 entry:
-  %34 = inttoptr i64 %"###0" to i64* 
+  %34 = inttoptr i64 %"#result##0" to i64* 
   %35 = getelementptr  i64, i64* %34, i64 0 
   %36 = load  i64, i64* %35 
-  %37 = add   i64 %"###0", 8 
+  %37 = add   i64 %"#result##0", 8 
   %38 = inttoptr i64 %37 to i64* 
   %39 = getelementptr  i64, i64* %38, i64 0 
   %40 = load  i64, i64* %39 
@@ -590,10 +590,10 @@ if.else:
 
 id > public {inline} (0 calls)
 0: student.student.id<0>
-id(#rec##0:student.student, ?###0:wybe.int):
+id(#rec##0:student.student, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 id > public {inline} (0 calls)
 1: student.student.id<1>
 id(#rec##0:student.student, ?#rec##1:student.student, #field##0:wybe.int):
@@ -604,10 +604,10 @@ id(#rec##0:student.student, ?#rec##1:student.student, #field##0:wybe.int):
 
 major > public {inline} (0 calls)
 0: student.student.major<0>
-major(#rec##0:student.student, ?###0:student.course):
+major(#rec##0:student.student, ?#result##0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:student.course)
+    foreign lpvm access(~#rec##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:student.course)
 major > public {inline} (0 calls)
 1: student.student.major<1>
 major(#rec##0:student.student, ?#rec##1:student.student, #field##0:student.course):
@@ -618,19 +618,19 @@ major(#rec##0:student.student, ?#rec##1:student.student, #field##0:student.cours
 
 student > public {inline} (0 calls)
 0: student.student.student<0>
-student(id##0:wybe.int, major##0:student.course, ?###0:student.student):
+student(id##0:wybe.int, major##0:student.course, ?#result##0:student.student):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:student.student)
     foreign lpvm mutate(~#rec##0:student.student, ?#rec##1:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~id##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:student.student, ?###0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~major##0:student.course)
+    foreign lpvm mutate(~#rec##1:student.student, ?#result##0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~major##0:student.course)
 student > public {inline} (6 calls)
 1: student.student.student<1>
-student(?id##0:wybe.int, ?major##0:student.course, ###0:student.student):
+student(?id##0:wybe.int, ?major##0:student.course, #result##0:student.student):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?id##0:wybe.int)
-    foreign lpvm access(~###0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?major##0:student.course)
+    foreign lpvm access(#result##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?id##0:wybe.int)
+    foreign lpvm access(~#result##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?major##0:student.course)
 
 
 ~= > public {inline} (0 calls)
@@ -797,12 +797,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"student.student.student<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"student.student.student<1>"(i64  %"#result##0")    {
 entry:
-  %61 = inttoptr i64 %"###0" to i64* 
+  %61 = inttoptr i64 %"#result##0" to i64* 
   %62 = getelementptr  i64, i64* %61, i64 0 
   %63 = load  i64, i64* %62 
-  %64 = add   i64 %"###0", 8 
+  %64 = add   i64 %"#result##0", 8 
   %65 = inttoptr i64 %64 to i64* 
   %66 = getelementptr  i64, i64* %65, i64 0 
   %67 = load  i64, i64* %66 

--- a/test-cases/final-dump/alias_des.exp
+++ b/test-cases/final-dump/alias_des.exp
@@ -14,43 +14,43 @@ AFTER EVERYTHING:
 
 *main* > public {inline} (0 calls)
 0: alias_des.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    alias_des.foo<0>(~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @alias_des:nn:nn
+    alias_des.foo<0>(~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @alias_des:nn:nn
 
 
 foo > public (1 calls)
 0: alias_des.foo<0>
-foo(io#0:wybe.phantom, ?io#3:wybe.phantom):
+foo(io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    alias_des.replicate<0>(?p2#0:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @alias_des:nn:nn
-    foreign lpvm {noalias} mutate(~%p2#0:position.position, ?%p2#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 20000:wybe.int)
-    foreign c print_string("--- after x(!p2, 20000) - expect p2(20000,103):":wybe.string, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~p2#1:position.position, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) #3 @alias_des:nn:nn
+    alias_des.replicate<0>(?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @alias_des:nn:nn
+    foreign lpvm {noalias} mutate(~%p2##0:position.position, ?%p2##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 20000:wybe.int)
+    foreign c print_string("--- after x(!p2, 20000) - expect p2(20000,103):":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~p2##1:position.position, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @alias_des:nn:nn
 
 
 replicate > public (1 calls)
 0: alias_des.replicate<0>
-replicate(?p2#1:position.position, io#0:wybe.phantom, ?io#4:wybe.phantom):
+replicate(?p2##1:position.position, io##0:wybe.phantom, ?io##4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$8#0:position.position)
-    foreign lpvm mutate(~tmp$8#0:position.position, ?tmp$9#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
-    foreign lpvm mutate(~tmp$9#0:position.position, ?tmp$0#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int)
-    foreign lpvm access(tmp$0#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$2#0:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$14#0:position.position)
-    foreign lpvm mutate(~tmp$14#0:position.position, ?tmp$15#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:wybe.int)
-    foreign lpvm mutate(~tmp$15#0:position.position, ?tmp$1#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int)
-    foreign lpvm {noalias} mutate(~tmp$0#0:position.position, ?%p1#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10000:wybe.int)
-    foreign lpvm access(p1#1:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign llvm add(~tmp$5#0:wybe.int, 1:wybe.int, ?tmp$4#0:wybe.int) @int:nn:nn
-    foreign lpvm {noalias} mutate(~tmp$1#0:position.position, ?%p2#1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$4#0:wybe.int)
-    foreign c print_string("expect p1(10000,102):":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~p1#1:position.position, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #9 @alias_des:nn:nn
-    foreign c print_string("expect p2(101,103):":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(p2#1:position.position, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #11 @alias_des:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$8##0:position.position)
+    foreign lpvm mutate(~tmp$8##0:position.position, ?tmp$9##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
+    foreign lpvm mutate(~tmp$9##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int)
+    foreign lpvm access(tmp$0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp$14##0:position.position)
+    foreign lpvm mutate(~tmp$14##0:position.position, ?tmp$15##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:wybe.int)
+    foreign lpvm mutate(~tmp$15##0:position.position, ?tmp$1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int)
+    foreign lpvm {noalias} mutate(~tmp$0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10000:wybe.int)
+    foreign lpvm access(p1##1:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign llvm add(~tmp$5##0:wybe.int, 1:wybe.int, ?tmp$4##0:wybe.int) @int:nn:nn
+    foreign lpvm {noalias} mutate(~tmp$1##0:position.position, ?%p2##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$4##0:wybe.int)
+    foreign c print_string("expect p1(10000,102):":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~p1##1:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #9 @alias_des:nn:nn
+    foreign c print_string("expect p2(101,103):":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(p2##1:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #11 @alias_des:nn:nn
 
   LLVM code       :
 
@@ -90,13 +90,13 @@ entry:
 
 define external fastcc  void @"alias_des.foo<0>"()    {
 entry:
-  %"1$p2#0" = tail call fastcc  i64  @"alias_des.replicate<0>"()  
-  %1 = inttoptr i64 %"1$p2#0" to i64* 
+  %"1$p2##0" = tail call fastcc  i64  @"alias_des.replicate<0>"()  
+  %1 = inttoptr i64 %"1$p2##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   store  i64 20000, i64* %2 
   %4 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_des.3, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %4)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2#0")  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2##0")  
   ret void 
 }
 
@@ -133,11 +133,11 @@ entry:
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
-  %"1$tmp$4#0" = add   i64 %29, 1 
+  %"1$tmp$4##0" = add   i64 %29, 1 
   %30 = add   i64 %18, 8 
   %31 = inttoptr i64 %30 to i64* 
   %32 = getelementptr  i64, i64* %31, i64 0 
-  store  i64 %"1$tmp$4#0", i64* %32 
+  store  i64 %"1$tmp$4##0", i64* %32 
   %34 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_des.33, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %34)  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %7)  
@@ -168,17 +168,17 @@ entry:
 
 printPosition > public (0 calls)
 0: position.printPosition<0>
-printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string(",":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io#4:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -212,17 +212,17 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"position.printPosition<0>"(i64  %"pos#0")    {
+define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
-  %3 = inttoptr i64 %"pos#0" to i64* 
+  %3 = inttoptr i64 %"pos##0" to i64* 
   %4 = getelementptr  i64, i64* %3, i64 0 
   %5 = load  i64, i64* %4 
   tail call ccc  void  @print_int(i64  %5)  
   %7 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.6, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %7)  
-  %8 = add   i64 %"pos#0", 8 
+  %8 = add   i64 %"pos##0", 8 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
@@ -252,86 +252,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y#0:wybe.int)
-    foreign llvm icmp_eq(~$left$x#0:wybe.int, ~$right$x#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
+    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y#0:wybe.int, ~$right$y#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
-    foreign lpvm mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:position.position, ?$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
+    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
-    foreign lpvm access(~$#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y#0:wybe.int)
+    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec#0:position.position, ?$#0:wybe.int):
+x($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec#0:position.position, ?$#0:wybe.int):
+y($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -348,54 +348,54 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$#0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = icmp eq i64 %7, %14 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"x#0", i64* %19 
+  store  i64 %"x##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"y#0", i64* %22 
+  store  i64 %"y##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
 entry:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -405,34 +405,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec#0" to i64* 
+  %32 = inttoptr i64 %"$rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec#0" to i8* 
+  %39 = inttoptr i64 %"$rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field#0", i64* %42 
+  store  i64 %"$field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = add   i64 %"$rec#0", 8 
+  %43 = add   i64 %"$rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -440,46 +440,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec#0" to i8* 
+  %51 = inttoptr i64 %"$rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field#0", i64* %55 
+  store  i64 %"$field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %58, %65 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = icmp eq i64 %62, %69 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$0##0" = icmp eq i64 %62, %69 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }

--- a/test-cases/final-dump/alias_des.exp
+++ b/test-cases/final-dump/alias_des.exp
@@ -252,7 +252,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
@@ -262,10 +262,10 @@ entry:
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -316,7 +316,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -327,11 +327,11 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -367,8 +367,8 @@ entry:
   %"1#tmp#1##0" = icmp eq i64 %3, %10 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2#####0" = icmp eq i64 %7, %14 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %7, %14 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -477,9 +477,9 @@ entry:
   br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#0##0" = icmp eq i64 %62, %69 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }

--- a/test-cases/final-dump/alias_des.exp
+++ b/test-cases/final-dump/alias_des.exp
@@ -271,27 +271,27 @@ entry:
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x(#rec##0:position.position, ?###0:wybe.int):
+x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -302,10 +302,10 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y(#rec##0:position.position, ?###0:wybe.int):
+y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -390,12 +390,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 

--- a/test-cases/final-dump/alias_des.exp
+++ b/test-cases/final-dump/alias_des.exp
@@ -36,17 +36,17 @@ replicate > public (1 calls)
 replicate(?p2##1:position.position, io##0:wybe.phantom, ?io##4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$8##0:position.position)
-    foreign lpvm mutate(~tmp$8##0:position.position, ?tmp$9##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
-    foreign lpvm mutate(~tmp$9##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int)
-    foreign lpvm access(tmp$0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$14##0:position.position)
-    foreign lpvm mutate(~tmp$14##0:position.position, ?tmp$15##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:wybe.int)
-    foreign lpvm mutate(~tmp$15##0:position.position, ?tmp$1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int)
-    foreign lpvm {noalias} mutate(~tmp$0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10000:wybe.int)
-    foreign lpvm access(p1##1:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign llvm add(~tmp$5##0:wybe.int, 1:wybe.int, ?tmp$4##0:wybe.int) @int:nn:nn
-    foreign lpvm {noalias} mutate(~tmp$1##0:position.position, ?%p2##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$4##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#8##0:position.position)
+    foreign lpvm mutate(~tmp#8##0:position.position, ?tmp#9##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
+    foreign lpvm mutate(~tmp#9##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int)
+    foreign lpvm access(tmp#0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:position.position)
+    foreign lpvm mutate(~tmp#14##0:position.position, ?tmp#15##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
+    foreign lpvm mutate(~tmp#15##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int)
+    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10000:wybe.int)
+    foreign lpvm access(p1##1:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign llvm add(~tmp#5##0:wybe.int, 1:wybe.int, ?tmp#4##0:wybe.int) @int:nn:nn
+    foreign lpvm {noalias} mutate(~tmp#1##0:position.position, ?%p2##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#4##0:wybe.int)
     foreign c print_string("expect p1(10000,102):":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     position.printPosition<0>(~p1##1:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #9 @alias_des:nn:nn
     foreign c print_string("expect p2(101,103):":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
@@ -90,13 +90,13 @@ entry:
 
 define external fastcc  void @"alias_des.foo<0>"()    {
 entry:
-  %"1$p2##0" = tail call fastcc  i64  @"alias_des.replicate<0>"()  
-  %1 = inttoptr i64 %"1$p2##0" to i64* 
+  %"1#p2##0" = tail call fastcc  i64  @"alias_des.replicate<0>"()  
+  %1 = inttoptr i64 %"1#p2##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   store  i64 20000, i64* %2 
   %4 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_des.3, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %4)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2##0")  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
   ret void 
 }
 
@@ -133,11 +133,11 @@ entry:
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
-  %"1$tmp$4##0" = add   i64 %29, 1 
+  %"1#tmp#4##0" = add   i64 %29, 1 
   %30 = add   i64 %18, 8 
   %31 = inttoptr i64 %30 to i64* 
   %32 = getelementptr  i64, i64* %31, i64 0 
-  store  i64 %"1$tmp$4##0", i64* %32 
+  store  i64 %"1#tmp#4##0", i64* %32 
   %34 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_des.33, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %34)  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %7)  
@@ -172,13 +172,13 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -252,86 +252,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
-    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
-    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec##0:position.position, ?$##0:wybe.int):
+x(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec##0:position.position, ?$##0:wybe.int):
+y(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -348,27 +348,27 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$##0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$##0" 
+  %"2#####0" = icmp eq i64 %7, %14 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
@@ -390,12 +390,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
 entry:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -405,34 +405,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec##0" to i64* 
+  %32 = inttoptr i64 %"#rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec##0" to i8* 
+  %39 = inttoptr i64 %"#rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field##0", i64* %42 
+  store  i64 %"#field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = add   i64 %"$rec##0", 8 
+  %43 = add   i64 %"#rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -440,46 +440,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec##0" to i8* 
+  %51 = inttoptr i64 %"#rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field##0", i64* %55 
+  store  i64 %"#field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %58, %65 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = icmp eq i64 %62, %69 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#0##0" = icmp eq i64 %62, %69 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }

--- a/test-cases/final-dump/alias_des2.exp
+++ b/test-cases/final-dump/alias_des2.exp
@@ -190,27 +190,27 @@ entry:
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x(#rec##0:position.position, ?###0:wybe.int):
+x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -221,10 +221,10 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y(#rec##0:position.position, ?###0:wybe.int):
+y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -309,12 +309,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 

--- a/test-cases/final-dump/alias_des2.exp
+++ b/test-cases/final-dump/alias_des2.exp
@@ -171,7 +171,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
@@ -181,10 +181,10 @@ entry:
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -235,7 +235,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -246,11 +246,11 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -286,8 +286,8 @@ entry:
   %"1#tmp#1##0" = icmp eq i64 %3, %10 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2#####0" = icmp eq i64 %7, %14 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %7, %14 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -396,9 +396,9 @@ entry:
   br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#0##0" = icmp eq i64 %62, %69 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }

--- a/test-cases/final-dump/alias_des2.exp
+++ b/test-cases/final-dump/alias_des2.exp
@@ -12,15 +12,15 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: alias_des2.<0>
-(io#0:wybe.phantom, ?io#2:wybe.phantom):
+(io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$3#0:position.position)
-    foreign lpvm mutate(~tmp$3#0:position.position, ?tmp$4#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm mutate(~tmp$4#0:position.position, ?tmp$0#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm {noalias} mutate(~tmp$0#0:position.position, ?%pos#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
-    foreign c print_string("expect pos(200,100):":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~pos#1:position.position, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #3 @alias_des2:6:2
+    foreign lpvm alloc(16:wybe.int, ?tmp$3##0:position.position)
+    foreign lpvm mutate(~tmp$3##0:position.position, ?tmp$4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
+    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
+    foreign lpvm {noalias} mutate(~tmp$0##0:position.position, ?%pos##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
+    foreign c print_string("expect pos(200,100):":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~pos##1:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #3 @alias_des2:6:2
 
   LLVM code       :
 
@@ -87,17 +87,17 @@ entry:
 
 printPosition > public (0 calls)
 0: position.printPosition<0>
-printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string(",":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io#4:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -131,17 +131,17 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"position.printPosition<0>"(i64  %"pos#0")    {
+define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
-  %3 = inttoptr i64 %"pos#0" to i64* 
+  %3 = inttoptr i64 %"pos##0" to i64* 
   %4 = getelementptr  i64, i64* %3, i64 0 
   %5 = load  i64, i64* %4 
   tail call ccc  void  @print_int(i64  %5)  
   %7 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.6, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %7)  
-  %8 = add   i64 %"pos#0", 8 
+  %8 = add   i64 %"pos##0", 8 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
@@ -171,86 +171,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y#0:wybe.int)
-    foreign llvm icmp_eq(~$left$x#0:wybe.int, ~$right$x#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
+    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y#0:wybe.int, ~$right$y#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
-    foreign lpvm mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:position.position, ?$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
+    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
-    foreign lpvm access(~$#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y#0:wybe.int)
+    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec#0:position.position, ?$#0:wybe.int):
+x($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec#0:position.position, ?$#0:wybe.int):
+y($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -267,54 +267,54 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$#0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = icmp eq i64 %7, %14 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"x#0", i64* %19 
+  store  i64 %"x##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"y#0", i64* %22 
+  store  i64 %"y##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
 entry:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -324,34 +324,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec#0" to i64* 
+  %32 = inttoptr i64 %"$rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec#0" to i8* 
+  %39 = inttoptr i64 %"$rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field#0", i64* %42 
+  store  i64 %"$field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = add   i64 %"$rec#0", 8 
+  %43 = add   i64 %"$rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -359,46 +359,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec#0" to i8* 
+  %51 = inttoptr i64 %"$rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field#0", i64* %55 
+  store  i64 %"$field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %58, %65 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = icmp eq i64 %62, %69 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$0##0" = icmp eq i64 %62, %69 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }

--- a/test-cases/final-dump/alias_des2.exp
+++ b/test-cases/final-dump/alias_des2.exp
@@ -15,10 +15,10 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$3##0:position.position)
-    foreign lpvm mutate(~tmp$3##0:position.position, ?tmp$4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm {noalias} mutate(~tmp$0##0:position.position, ?%pos##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position)
+    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
+    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%pos##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
     foreign c print_string("expect pos(200,100):":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     position.printPosition<0>(~pos##1:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #3 @alias_des2:6:2
 
@@ -91,13 +91,13 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -171,86 +171,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
-    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
-    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec##0:position.position, ?$##0:wybe.int):
+x(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec##0:position.position, ?$##0:wybe.int):
+y(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -267,27 +267,27 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$##0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$##0" 
+  %"2#####0" = icmp eq i64 %7, %14 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
@@ -309,12 +309,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
 entry:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -324,34 +324,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec##0" to i64* 
+  %32 = inttoptr i64 %"#rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec##0" to i8* 
+  %39 = inttoptr i64 %"#rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field##0", i64* %42 
+  store  i64 %"#field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = add   i64 %"$rec##0", 8 
+  %43 = add   i64 %"#rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -359,46 +359,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec##0" to i8* 
+  %51 = inttoptr i64 %"#rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field##0", i64* %55 
+  store  i64 %"#field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %58, %65 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = icmp eq i64 %62, %69 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#0##0" = icmp eq i64 %62, %69 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }

--- a/test-cases/final-dump/alias_fork1.exp
+++ b/test-cases/final-dump/alias_fork1.exp
@@ -389,13 +389,13 @@ if.else:
 
 = > public (7 calls)
 0: mytree.tree.=<0>
-=(#left##0:mytree.tree, #right##0:mytree.tree, ?####0:wybe.bool):
+=(#left##0:mytree.tree, #right##0:mytree.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~#left##0:mytree.tree, ~#right##0:mytree.tree, ?####0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:mytree.tree, ~#right##0:mytree.tree, ?#success##0:wybe.bool)
 
     1:
         foreign lpvm access(#left##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#left##0:mytree.tree)
@@ -404,7 +404,7 @@ if.else:
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
         case ~tmp#10##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign lpvm access(#right##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#left##0:mytree.tree)
@@ -413,16 +413,16 @@ if.else:
             mytree.tree.=<0>(~#left#left##0:mytree.tree, ~#right#left##0:mytree.tree, ?tmp#4##0:wybe.bool) #2
             case ~tmp#4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
                 foreign llvm icmp_eq(~#left#key##0:wybe.int, ~#right#key##0:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
                 case ~tmp#5##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                 1:
-                    mytree.tree.=<0>(~#left#right##0:mytree.tree, ~#right#right##0:mytree.tree, ?####0:wybe.bool) #4
+                    mytree.tree.=<0>(~#left#right##0:mytree.tree, ~#right#right##0:mytree.tree, ?#success##0:wybe.bool) #4
 
 
 
@@ -439,65 +439,65 @@ empty(?#result##0:mytree.tree):
 
 key > public {inline} (0 calls)
 0: mytree.tree.key<0>
-key(#rec##0:mytree.tree, ?#result##0:wybe.int, ?####0:wybe.bool):
+key(#rec##0:mytree.tree, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign lpvm access(~#rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 key > public {inline} (0 calls)
 1: mytree.tree.key<1>
-key(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:wybe.int, ?####0:wybe.bool):
+key(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
         foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 left > public {inline} (0 calls)
 0: mytree.tree.left<0>
-left(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?####0:wybe.bool):
+left(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:mytree.tree, ?#result##0:mytree.tree)
 
     1:
         foreign lpvm access(~#rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 left > public {inline} (0 calls)
 1: mytree.tree.left<1>
-left(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?####0:wybe.bool):
+left(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
         foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -512,13 +512,13 @@ node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?#result##0:myt
     foreign lpvm mutate(~#rec##2:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree)
 node > public {inline} (16 calls)
 1: mytree.tree.node<1>
-node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, #result##0:mytree.tree, ?####0:wybe.bool):
+node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, #result##0:mytree.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:mytree.tree, ?left##0:mytree.tree)
         foreign llvm move(undef:wybe.int, ?key##0:wybe.int)
         foreign llvm move(undef:mytree.tree, ?right##0:mytree.tree)
@@ -527,49 +527,49 @@ node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, #result##0:m
         foreign lpvm access(#result##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:mytree.tree)
         foreign lpvm access(#result##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
         foreign lpvm access(~#result##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 right > public {inline} (0 calls)
 0: mytree.tree.right<0>
-right(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?####0:wybe.bool):
+right(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:mytree.tree, ?#result##0:mytree.tree)
 
     1:
         foreign lpvm access(~#rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 right > public {inline} (0 calls)
 1: mytree.tree.right<1>
-right(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?####0:wybe.bool):
+right(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
         foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: mytree.tree.~=<0>
-~=(#left##0:mytree.tree, #right##0:mytree.tree, ?####0:wybe.bool):
+~=(#left##0:mytree.tree, #right##0:mytree.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     mytree.tree.=<0>(~#left##0:mytree.tree, ~#right##0:mytree.tree, ?tmp#0##0:wybe.bool) #0
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 
@@ -604,8 +604,8 @@ if.then:
   %"2#tmp#10##0" = icmp ne i64 %"#right##0", 0 
   br i1 %"2#tmp#10##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %"3#####0" 
+  %"3##success##0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3##success##0" 
 if.then1:
   %12 = inttoptr i64 %"#right##0" to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
@@ -628,8 +628,8 @@ if.then2:
 if.else2:
   ret i1 0 
 if.then3:
-  %"8#####0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %11, i64  %22)  
-  ret i1 %"8#####0" 
+  %"8##success##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %11, i64  %22)  
+  ret i1 %"8##success##0" 
 if.else3:
   ret i1 0 
 }
@@ -827,6 +827,6 @@ if.else:
 define external fastcc  i1 @"mytree.tree.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %"1#tmp#0##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %"#left##0", i64  %"#right##0")  
-  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
-  ret i1 %"1#####0" 
+  %"1##success##0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1##success##0" 
 }

--- a/test-cases/final-dump/alias_fork1.exp
+++ b/test-cases/final-dump/alias_fork1.exp
@@ -16,68 +16,68 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp$10##0:mytree.tree)
-    foreign lpvm mutate(~tmp$10##0:mytree.tree, ?tmp$11##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-    foreign lpvm mutate(~tmp$11##0:mytree.tree, ?tmp$12##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 222:wybe.int)
-    foreign lpvm mutate(~tmp$12##0:mytree.tree, ?tmp$0##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-    foreign lpvm alloc(24:wybe.int, ?tmp$16##0:mytree.tree)
-    foreign lpvm mutate(~tmp$16##0:mytree.tree, ?tmp$17##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-    foreign lpvm mutate(~tmp$17##0:mytree.tree, ?tmp$18##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 111:wybe.int)
-    foreign lpvm mutate(~tmp$18##0:mytree.tree, ?tmp$3##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-    alias_fork1.simpleMerge<0>(~tmp$0##0:mytree.tree, ~tmp$3##0:mytree.tree, ?tmp$6##0:mytree.tree) #6 @alias_fork1:18:6
-    mytree.printTree1<0>(~tmp$6##0:mytree.tree, "{":wybe.string, ?tmp$21##0:wybe.string, ~#io##0:wybe.phantom, ?tmp$22##0:wybe.phantom) #9 @mytree:nn:nn
-    foreign c print_string("}":wybe.string, ~tmp$22##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(24:wybe.int, ?tmp#10##0:mytree.tree)
+    foreign lpvm mutate(~tmp#10##0:mytree.tree, ?tmp#11##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+    foreign lpvm mutate(~tmp#11##0:mytree.tree, ?tmp#12##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 222:wybe.int)
+    foreign lpvm mutate(~tmp#12##0:mytree.tree, ?tmp#0##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+    foreign lpvm alloc(24:wybe.int, ?tmp#16##0:mytree.tree)
+    foreign lpvm mutate(~tmp#16##0:mytree.tree, ?tmp#17##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+    foreign lpvm mutate(~tmp#17##0:mytree.tree, ?tmp#18##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 111:wybe.int)
+    foreign lpvm mutate(~tmp#18##0:mytree.tree, ?tmp#3##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+    alias_fork1.simpleMerge<0>(~tmp#0##0:mytree.tree, ~tmp#3##0:mytree.tree, ?tmp#6##0:mytree.tree) #6 @alias_fork1:18:6
+    mytree.printTree1<0>(~tmp#6##0:mytree.tree, "{":wybe.string, ?tmp#21##0:wybe.string, ~#io##0:wybe.phantom, ?tmp#22##0:wybe.phantom) #9 @mytree:nn:nn
+    foreign c print_string("}":wybe.string, ~tmp#22##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
 
-gen$1 > {inline} (2 calls)
-0: alias_fork1.gen$1<0>
-gen$1([k1##0:wybe.int], [k2##0:wybe.int], [l1##0:mytree.tree], [l2##0:mytree.tree], [r1##0:mytree.tree], [r2##0:mytree.tree], [tl##0:mytree.tree], tmp$2##0:mytree.tree, [tr##0:mytree.tree], ?$##0:mytree.tree):
+gen#1 > {inline} (2 calls)
+0: alias_fork1.gen#1<0>
+gen#1([k1##0:wybe.int], [k2##0:wybe.int], [l1##0:mytree.tree], [l2##0:mytree.tree], [r1##0:mytree.tree], [r2##0:mytree.tree], [tl##0:mytree.tree], tmp#2##0:mytree.tree, [tr##0:mytree.tree], ?###0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(~tmp$2##0:mytree.tree, ?$##0:mytree.tree) @alias_fork1:5:5
+    foreign llvm move(~tmp#2##0:mytree.tree, ?###0:mytree.tree) @alias_fork1:5:5
 
 
 simpleMerge > public (1 calls)
 0: alias_fork1.simpleMerge<0>
-simpleMerge(tl##0:mytree.tree, tr##0:mytree.tree, ?$##0:mytree.tree):
- AliasPairs: [($##0,tl##0),($##0,tr##0),(tl##0,tr##0)]
+simpleMerge(tl##0:mytree.tree, tr##0:mytree.tree, ?###0:mytree.tree):
+ AliasPairs: [(###0,tl##0),(###0,tr##0),(tl##0,tr##0)]
  InterestingCallProperties: []
-    foreign llvm icmp_ne(tl##0:wybe.int, 0:wybe.int, ?tmp$15##0:wybe.bool)
-    case ~tmp$15##0:wybe.bool of
+    foreign llvm icmp_ne(tl##0:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.bool)
+    case ~tmp#15##0:wybe.bool of
     0:
-        foreign lpvm alloc(24:wybe.int, ?tmp$19##0:mytree.tree)
-        foreign lpvm mutate(~tmp$19##0:mytree.tree, ?tmp$20##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-        foreign lpvm mutate(~tmp$20##0:mytree.tree, ?tmp$21##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.int)
-        foreign lpvm mutate(~tmp$21##0:mytree.tree, ?$##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+        foreign lpvm alloc(24:wybe.int, ?tmp#19##0:mytree.tree)
+        foreign lpvm mutate(~tmp#19##0:mytree.tree, ?tmp#20##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+        foreign lpvm mutate(~tmp#20##0:mytree.tree, ?tmp#21##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.int)
+        foreign lpvm mutate(~tmp#21##0:mytree.tree, ?###0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
 
     1:
         foreign lpvm access(tl##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k1##0:wybe.int)
         foreign lpvm access(tl##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?r1##0:mytree.tree)
-        foreign llvm icmp_ne(tr##0:wybe.int, 0:wybe.int, ?tmp$17##0:wybe.bool)
-        case ~tmp$17##0:wybe.bool of
+        foreign llvm icmp_ne(tr##0:wybe.int, 0:wybe.int, ?tmp#17##0:wybe.bool)
+        case ~tmp#17##0:wybe.bool of
         0:
-            foreign lpvm alloc(24:wybe.int, ?tmp$21##0:mytree.tree)
-            foreign lpvm mutate(~tmp$21##0:mytree.tree, ?tmp$22##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-            foreign lpvm mutate(~tmp$22##0:mytree.tree, ?tmp$23##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.int)
-            foreign lpvm mutate(~tmp$23##0:mytree.tree, ?$##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+            foreign lpvm alloc(24:wybe.int, ?tmp#21##0:mytree.tree)
+            foreign lpvm mutate(~tmp#21##0:mytree.tree, ?tmp#22##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+            foreign lpvm mutate(~tmp#22##0:mytree.tree, ?tmp#23##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.int)
+            foreign lpvm mutate(~tmp#23##0:mytree.tree, ?###0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
 
         1:
             foreign lpvm access(tr##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k2##0:wybe.int)
             foreign lpvm access(tr##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?r2##0:mytree.tree)
-            foreign llvm icmp_slt(k1##0:wybe.int, k2##0:wybe.int, ?tmp$11##0:wybe.bool) @int:nn:nn
-            case ~tmp$11##0:wybe.bool of
+            foreign llvm icmp_slt(k1##0:wybe.int, k2##0:wybe.int, ?tmp#11##0:wybe.bool) @int:nn:nn
+            case ~tmp#11##0:wybe.bool of
             0:
-                foreign lpvm alloc(24:wybe.int, ?tmp$23##0:mytree.tree)
-                foreign lpvm mutate(~tmp$23##0:mytree.tree, ?tmp$24##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tr##0:mytree.tree)
-                foreign lpvm mutate(~tmp$24##0:mytree.tree, ?tmp$25##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~k1##0:wybe.int)
-                foreign lpvm mutate(~tmp$25##0:mytree.tree, ?$##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~r1##0:mytree.tree)
+                foreign lpvm alloc(24:wybe.int, ?tmp#23##0:mytree.tree)
+                foreign lpvm mutate(~tmp#23##0:mytree.tree, ?tmp#24##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tr##0:mytree.tree)
+                foreign lpvm mutate(~tmp#24##0:mytree.tree, ?tmp#25##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~k1##0:wybe.int)
+                foreign lpvm mutate(~tmp#25##0:mytree.tree, ?###0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~r1##0:mytree.tree)
 
             1:
-                foreign lpvm alloc(24:wybe.int, ?tmp$23##0:mytree.tree)
-                foreign lpvm mutate(~tmp$23##0:mytree.tree, ?tmp$24##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tl##0:mytree.tree)
-                foreign lpvm mutate(~tmp$24##0:mytree.tree, ?tmp$25##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~k2##0:wybe.int)
-                foreign lpvm mutate(~tmp$25##0:mytree.tree, ?$##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~r2##0:mytree.tree)
+                foreign lpvm alloc(24:wybe.int, ?tmp#23##0:mytree.tree)
+                foreign lpvm mutate(~tmp#23##0:mytree.tree, ?tmp#24##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tl##0:mytree.tree)
+                foreign lpvm mutate(~tmp#24##0:mytree.tree, ?tmp#25##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~k2##0:wybe.int)
+                foreign lpvm mutate(~tmp#25##0:mytree.tree, ?###0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~r2##0:mytree.tree)
 
 
 
@@ -141,9 +141,9 @@ entry:
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
   store  i64 0, i64* %22 
-  %"1$tmp$6##0" = tail call fastcc  i64  @"alias_fork1.simpleMerge<0>"(i64  %3, i64  %14)  
+  %"1#tmp#6##0" = tail call fastcc  i64  @"alias_fork1.simpleMerge<0>"(i64  %3, i64  %14)  
   %24 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_fork1.23, i32 0, i32 0) to i64 
-  %"1$tmp$21##0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"1$tmp$6##0", i64  %24)  
+  %"1#tmp#21##0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"1#tmp#6##0", i64  %24)  
   %26 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_fork1.25, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %26)  
   tail call ccc  void  @putchar(i8  10)  
@@ -151,16 +151,16 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_fork1.gen$1<0>"(i64  %"tmp$2##0")    {
+define external fastcc  i64 @"alias_fork1.gen#1<0>"(i64  %"tmp#2##0")    {
 entry:
-  ret i64 %"tmp$2##0" 
+  ret i64 %"tmp#2##0" 
 }
 
 
 define external fastcc  i64 @"alias_fork1.simpleMerge<0>"(i64  %"tl##0", i64  %"tr##0")    {
 entry:
-  %"1$tmp$15##0" = icmp ne i64 %"tl##0", 0 
-  br i1 %"1$tmp$15##0", label %if.then, label %if.else 
+  %"1#tmp#15##0" = icmp ne i64 %"tl##0", 0 
+  br i1 %"1#tmp#15##0", label %if.then, label %if.else 
 if.then:
   %27 = add   i64 %"tl##0", 8 
   %28 = inttoptr i64 %27 to i64* 
@@ -170,8 +170,8 @@ if.then:
   %32 = inttoptr i64 %31 to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
-  %"2$tmp$17##0" = icmp ne i64 %"tr##0", 0 
-  br i1 %"2$tmp$17##0", label %if.then1, label %if.else1 
+  %"2#tmp#17##0" = icmp ne i64 %"tr##0", 0 
+  br i1 %"2#tmp#17##0", label %if.then1, label %if.else1 
 if.else:
   %76 = trunc i64 24 to i32  
   %77 = tail call ccc  i8*  @wybe_malloc(i32  %76)  
@@ -197,8 +197,8 @@ if.then1:
   %40 = inttoptr i64 %39 to i64* 
   %41 = getelementptr  i64, i64* %40, i64 0 
   %42 = load  i64, i64* %41 
-  %"4$tmp$11##0" = icmp slt i64 %30, %38 
-  br i1 %"4$tmp$11##0", label %if.then2, label %if.else2 
+  %"4#tmp#11##0" = icmp slt i64 %30, %38 
+  br i1 %"4#tmp#11##0", label %if.then2, label %if.else2 
 if.else1:
   %65 = trunc i64 24 to i32  
   %66 = tail call ccc  i8*  @wybe_malloc(i32  %65)  
@@ -286,8 +286,8 @@ printTree1 > public (3 calls)
 printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string, io##0:wybe.phantom, ?io##4:wybe.phantom):
  AliasPairs: [(prefix##0,prefix##3)]
  InterestingCallProperties: []
-    foreign llvm icmp_ne(t##0:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.bool)
-    case ~tmp$2##0:wybe.bool of
+    foreign llvm icmp_ne(t##0:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.bool)
+    case ~tmp#2##0:wybe.bool of
     0:
         foreign llvm move(~prefix##0:wybe.string, ?prefix##3:wybe.string)
         foreign llvm move(~io##0:wybe.phantom, ?io##4:wybe.phantom)
@@ -334,7 +334,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 define external fastcc  void @"mytree.printTree<0>"(i64  %"t##0")    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @mytree.1, i32 0, i32 0) to i64 
-  %"1$prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t##0", i64  %2)  
+  %"1#prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t##0", i64  %2)  
   %4 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @mytree.3, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %4)  
   ret void 
@@ -343,8 +343,8 @@ entry:
 
 define external fastcc  i64 @"mytree.printTree1<0>"(i64  %"t##0", i64  %"prefix##0")    {
 entry:
-  %"1$tmp$2##0" = icmp ne i64 %"t##0", 0 
-  br i1 %"1$tmp$2##0", label %if.then, label %if.else 
+  %"1#tmp#2##0" = icmp ne i64 %"t##0", 0 
+  br i1 %"1#tmp#2##0", label %if.then, label %if.else 
 if.then:
   %5 = inttoptr i64 %"t##0" to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
@@ -357,12 +357,12 @@ if.then:
   %13 = inttoptr i64 %12 to i64* 
   %14 = getelementptr  i64, i64* %13, i64 0 
   %15 = load  i64, i64* %14 
-  %"2$prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %7, i64  %"prefix##0")  
-  tail call ccc  void  @print_string(i64  %"2$prefix##1")  
+  %"2#prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %7, i64  %"prefix##0")  
+  tail call ccc  void  @print_string(i64  %"2#prefix##1")  
   tail call ccc  void  @print_int(i64  %11)  
   %17 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @mytree.16, i32 0, i32 0) to i64 
-  %"2$prefix##3" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %15, i64  %17)  
-  ret i64 %"2$prefix##3" 
+  %"2#prefix##3" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %15, i64  %17)  
+  ret i64 %"2#prefix##3" 
 if.else:
   ret i64 %"prefix##0" 
 }
@@ -389,40 +389,40 @@ if.else:
 
 = > public (7 calls)
 0: mytree.tree.=<0>
-=($left##0:mytree.tree, $right##0:mytree.tree, ?$$##0:wybe.bool):
+=(#left##0:mytree.tree, #right##0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left##0:mytree.tree, ~$right##0:mytree.tree, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:mytree.tree, ~#right##0:mytree.tree, ?####0:wybe.bool)
 
     1:
-        foreign lpvm access($left##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$left##0:mytree.tree)
-        foreign lpvm access($left##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$key##0:wybe.int)
-        foreign lpvm access(~$left##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$right##0:mytree.tree)
-        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.bool)
-        case ~tmp$10##0:wybe.bool of
+        foreign lpvm access(#left##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#left##0:mytree.tree)
+        foreign lpvm access(#left##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#key##0:wybe.int)
+        foreign lpvm access(~#left##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#right##0:mytree.tree)
+        foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
+        case ~tmp#10##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign lpvm access($right##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$left##0:mytree.tree)
-            foreign lpvm access($right##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$key##0:wybe.int)
-            foreign lpvm access(~$right##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$right##0:mytree.tree)
-            mytree.tree.=<0>(~$left$left##0:mytree.tree, ~$right$left##0:mytree.tree, ?tmp$4##0:wybe.bool) #2
-            case ~tmp$4##0:wybe.bool of
+            foreign lpvm access(#right##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#left##0:mytree.tree)
+            foreign lpvm access(#right##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#key##0:wybe.int)
+            foreign lpvm access(~#right##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#right##0:mytree.tree)
+            mytree.tree.=<0>(~#left#left##0:mytree.tree, ~#right#left##0:mytree.tree, ?tmp#4##0:wybe.bool) #2
+            case ~tmp#4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
             1:
-                foreign llvm icmp_eq(~$left$key##0:wybe.int, ~$right$key##0:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
-                case ~tmp$5##0:wybe.bool of
+                foreign llvm icmp_eq(~#left#key##0:wybe.int, ~#right#key##0:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
+                case ~tmp#5##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                 1:
-                    mytree.tree.=<0>(~$left$right##0:mytree.tree, ~$right$right##0:mytree.tree, ?$$##0:wybe.bool) #4
+                    mytree.tree.=<0>(~#left#right##0:mytree.tree, ~#right#right##0:mytree.tree, ?####0:wybe.bool) #4
 
 
 
@@ -431,145 +431,145 @@ if.else:
 
 empty > public {inline} (0 calls)
 0: mytree.tree.empty<0>
-empty(?$##0:mytree.tree):
+empty(?###0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:mytree.tree, ?$##0:mytree.tree)
+    foreign llvm move(0:mytree.tree, ?###0:mytree.tree)
 
 
 key > public {inline} (0 calls)
 0: mytree.tree.key<0>
-key($rec##0:mytree.tree, ?$##0:wybe.int, ?$$##0:wybe.bool):
+key(#rec##0:mytree.tree, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 key > public {inline} (0 calls)
 1: mytree.tree.key<1>
-key($rec##0:mytree.tree, ?$rec##1:mytree.tree, $field##0:wybe.int, ?$$##0:wybe.bool):
+key(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:mytree.tree, ?$rec##1:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~$rec##0:mytree.tree, ?$rec##1:mytree.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 left > public {inline} (0 calls)
 0: mytree.tree.left<0>
-left($rec##0:mytree.tree, ?$##0:mytree.tree, ?$$##0:wybe.bool):
+left(#rec##0:mytree.tree, ?###0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:mytree.tree, ?$##0:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:mytree.tree, ?###0:mytree.tree)
 
     1:
-        foreign lpvm access(~$rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 left > public {inline} (0 calls)
 1: mytree.tree.left<1>
-left($rec##0:mytree.tree, ?$rec##1:mytree.tree, $field##0:mytree.tree, ?$$##0:wybe.bool):
+left(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:mytree.tree, ?$rec##1:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~$rec##0:mytree.tree, ?$rec##1:mytree.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 node > public {inline} (0 calls)
 0: mytree.tree.node<0>
-node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?$##0:mytree.tree):
+node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?###0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?$rec##0:mytree.tree)
-    foreign lpvm mutate(~$rec##0:mytree.tree, ?$rec##1:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:mytree.tree)
-    foreign lpvm mutate(~$rec##1:mytree.tree, ?$rec##2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int)
-    foreign lpvm mutate(~$rec##2:mytree.tree, ?$##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree)
+    foreign lpvm alloc(24:wybe.int, ?#rec##0:mytree.tree)
+    foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:mytree.tree)
+    foreign lpvm mutate(~#rec##1:mytree.tree, ?#rec##2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int)
+    foreign lpvm mutate(~#rec##2:mytree.tree, ?###0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree)
 node > public {inline} (16 calls)
 1: mytree.tree.node<1>
-node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, $##0:mytree.tree, ?$$##0:wybe.bool):
+node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, ###0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:mytree.tree, ?left##0:mytree.tree)
         foreign llvm move(undef:wybe.int, ?key##0:wybe.int)
         foreign llvm move(undef:mytree.tree, ?right##0:mytree.tree)
 
     1:
-        foreign lpvm access($##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:mytree.tree)
-        foreign lpvm access($##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
-        foreign lpvm access(~$##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(###0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:mytree.tree)
+        foreign lpvm access(###0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
+        foreign lpvm access(~###0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 right > public {inline} (0 calls)
 0: mytree.tree.right<0>
-right($rec##0:mytree.tree, ?$##0:mytree.tree, ?$$##0:wybe.bool):
+right(#rec##0:mytree.tree, ?###0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:mytree.tree, ?$##0:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:mytree.tree, ?###0:mytree.tree)
 
     1:
-        foreign lpvm access(~$rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 right > public {inline} (0 calls)
 1: mytree.tree.right<1>
-right($rec##0:mytree.tree, ?$rec##1:mytree.tree, $field##0:mytree.tree, ?$$##0:wybe.bool):
+right(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:mytree.tree, ?$rec##1:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~$rec##0:mytree.tree, ?$rec##1:mytree.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: mytree.tree.~=<0>
-~=($left##0:mytree.tree, $right##0:mytree.tree, ?$$##0:wybe.bool):
+~=(#left##0:mytree.tree, #right##0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    mytree.tree.=<0>(~$left##0:mytree.tree, ~$right##0:mytree.tree, ?tmp$0##0:wybe.bool) #0
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    mytree.tree.=<0>(~#left##0:mytree.tree, ~#right##0:mytree.tree, ?tmp#0##0:wybe.bool) #0
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
   LLVM code       :
 
@@ -585,51 +585,51 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"mytree.tree.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"mytree.tree.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#left##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = add   i64 %"$left##0", 16 
+  %8 = add   i64 %"#left##0", 16 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
-  %"2$tmp$10##0" = icmp ne i64 %"$right##0", 0 
-  br i1 %"2$tmp$10##0", label %if.then1, label %if.else1 
+  %"2#tmp#10##0" = icmp ne i64 %"#right##0", 0 
+  br i1 %"2#tmp#10##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3#####0" 
 if.then1:
-  %12 = inttoptr i64 %"$right##0" to i64* 
+  %12 = inttoptr i64 %"#right##0" to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %15 = add   i64 %"$right##0", 8 
+  %15 = add   i64 %"#right##0", 8 
   %16 = inttoptr i64 %15 to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
-  %19 = add   i64 %"$right##0", 16 
+  %19 = add   i64 %"#right##0", 16 
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %"4$tmp$4##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %3, i64  %14)  
-  br i1 %"4$tmp$4##0", label %if.then2, label %if.else2 
+  %"4#tmp#4##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %3, i64  %14)  
+  br i1 %"4#tmp#4##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$tmp$5##0" = icmp eq i64 %7, %18 
-  br i1 %"6$tmp$5##0", label %if.then3, label %if.else3 
+  %"6#tmp#5##0" = icmp eq i64 %7, %18 
+  br i1 %"6#tmp#5##0", label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %"8$$$##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %11, i64  %22)  
-  ret i1 %"8$$$##0" 
+  %"8#####0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %11, i64  %22)  
+  ret i1 %"8#####0" 
 if.else3:
   ret i1 0 
 }
@@ -641,12 +641,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.key<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.key<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %23 = add   i64 %"$rec##0", 8 
+  %23 = add   i64 %"#rec##0", 8 
   %24 = inttoptr i64 %23 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
   %26 = load  i64, i64* %25 
@@ -660,38 +660,38 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.key<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.key<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %31 = trunc i64 24 to i32  
   %32 = tail call ccc  i8*  @wybe_malloc(i32  %31)  
   %33 = ptrtoint i8* %32 to i64 
   %34 = inttoptr i64 %33 to i8* 
-  %35 = inttoptr i64 %"$rec##0" to i8* 
+  %35 = inttoptr i64 %"#rec##0" to i8* 
   %36 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %34, i8*  %35, i32  %36, i32  8, i1  0)  
   %37 = add   i64 %33, 8 
   %38 = inttoptr i64 %37 to i64* 
   %39 = getelementptr  i64, i64* %38, i64 0 
-  store  i64 %"$field##0", i64* %39 
+  store  i64 %"#field##0", i64* %39 
   %40 = insertvalue {i64, i1} undef, i64 %33, 0 
   %41 = insertvalue {i64, i1} %40, i1 1, 1 
   ret {i64, i1} %41 
 if.else:
-  %42 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %42 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %43 = insertvalue {i64, i1} %42, i1 0, 1 
   ret {i64, i1} %43 
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.left<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.left<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %44 = inttoptr i64 %"$rec##0" to i64* 
+  %44 = inttoptr i64 %"#rec##0" to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
   %47 = insertvalue {i64, i1} undef, i64 %46, 0 
@@ -704,26 +704,26 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.left<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.left<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %51 = trunc i64 24 to i32  
   %52 = tail call ccc  i8*  @wybe_malloc(i32  %51)  
   %53 = ptrtoint i8* %52 to i64 
   %54 = inttoptr i64 %53 to i8* 
-  %55 = inttoptr i64 %"$rec##0" to i8* 
+  %55 = inttoptr i64 %"#rec##0" to i8* 
   %56 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %54, i8*  %55, i32  %56, i32  8, i1  0)  
   %57 = inttoptr i64 %53 to i64* 
   %58 = getelementptr  i64, i64* %57, i64 0 
-  store  i64 %"$field##0", i64* %58 
+  store  i64 %"#field##0", i64* %58 
   %59 = insertvalue {i64, i1} undef, i64 %53, 0 
   %60 = insertvalue {i64, i1} %59, i1 1, 1 
   ret {i64, i1} %60 
 if.else:
-  %61 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %61 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %62 = insertvalue {i64, i1} %61, i1 0, 1 
   ret {i64, i1} %62 
 }
@@ -749,19 +749,19 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64, i1} @"mytree.tree.node<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64, i64, i1} @"mytree.tree.node<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %74 = inttoptr i64 %"$##0" to i64* 
+  %74 = inttoptr i64 %"###0" to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
   %76 = load  i64, i64* %75 
-  %77 = add   i64 %"$##0", 8 
+  %77 = add   i64 %"###0", 8 
   %78 = inttoptr i64 %77 to i64* 
   %79 = getelementptr  i64, i64* %78, i64 0 
   %80 = load  i64, i64* %79 
-  %81 = add   i64 %"$##0", 16 
+  %81 = add   i64 %"###0", 16 
   %82 = inttoptr i64 %81 to i64* 
   %83 = getelementptr  i64, i64* %82, i64 0 
   %84 = load  i64, i64* %83 
@@ -779,12 +779,12 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.right<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.right<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %93 = add   i64 %"$rec##0", 16 
+  %93 = add   i64 %"#rec##0", 16 
   %94 = inttoptr i64 %93 to i64* 
   %95 = getelementptr  i64, i64* %94, i64 0 
   %96 = load  i64, i64* %95 
@@ -798,35 +798,35 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.right<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.right<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %101 = trunc i64 24 to i32  
   %102 = tail call ccc  i8*  @wybe_malloc(i32  %101)  
   %103 = ptrtoint i8* %102 to i64 
   %104 = inttoptr i64 %103 to i8* 
-  %105 = inttoptr i64 %"$rec##0" to i8* 
+  %105 = inttoptr i64 %"#rec##0" to i8* 
   %106 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %104, i8*  %105, i32  %106, i32  8, i1  0)  
   %107 = add   i64 %103, 16 
   %108 = inttoptr i64 %107 to i64* 
   %109 = getelementptr  i64, i64* %108, i64 0 
-  store  i64 %"$field##0", i64* %109 
+  store  i64 %"#field##0", i64* %109 
   %110 = insertvalue {i64, i1} undef, i64 %103, 0 
   %111 = insertvalue {i64, i1} %110, i1 1, 1 
   ret {i64, i1} %111 
 if.else:
-  %112 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %112 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %113 = insertvalue {i64, i1} %112, i1 0, 1 
   ret {i64, i1} %113 
 }
 
 
-define external fastcc  i1 @"mytree.tree.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"mytree.tree.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %"$left##0", i64  %"$right##0")  
-  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
-  ret i1 %"1$$$##0" 
+  %"1#tmp#0##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %"#left##0", i64  %"#right##0")  
+  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1#####0" 
 }

--- a/test-cases/final-dump/alias_fork1.exp
+++ b/test-cases/final-dump/alias_fork1.exp
@@ -13,71 +13,71 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: alias_fork1.<0>
-(io#0:wybe.phantom, ?io#2:wybe.phantom):
+(io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp$10#0:mytree.tree)
-    foreign lpvm mutate(~tmp$10#0:mytree.tree, ?tmp$11#0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-    foreign lpvm mutate(~tmp$11#0:mytree.tree, ?tmp$12#0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 222:wybe.int)
-    foreign lpvm mutate(~tmp$12#0:mytree.tree, ?tmp$0#0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-    foreign lpvm alloc(24:wybe.int, ?tmp$16#0:mytree.tree)
-    foreign lpvm mutate(~tmp$16#0:mytree.tree, ?tmp$17#0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-    foreign lpvm mutate(~tmp$17#0:mytree.tree, ?tmp$18#0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 111:wybe.int)
-    foreign lpvm mutate(~tmp$18#0:mytree.tree, ?tmp$3#0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-    alias_fork1.simpleMerge<0>(~tmp$0#0:mytree.tree, ~tmp$3#0:mytree.tree, ?tmp$6#0:mytree.tree) #6 @alias_fork1:18:6
-    mytree.printTree1<0>(~tmp$6#0:mytree.tree, "{":wybe.string, ?tmp$21#0:wybe.string, ~#io#0:wybe.phantom, ?tmp$22#0:wybe.phantom) #9 @mytree:nn:nn
-    foreign c print_string("}":wybe.string, ~tmp$22#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(24:wybe.int, ?tmp$10##0:mytree.tree)
+    foreign lpvm mutate(~tmp$10##0:mytree.tree, ?tmp$11##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+    foreign lpvm mutate(~tmp$11##0:mytree.tree, ?tmp$12##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 222:wybe.int)
+    foreign lpvm mutate(~tmp$12##0:mytree.tree, ?tmp$0##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+    foreign lpvm alloc(24:wybe.int, ?tmp$16##0:mytree.tree)
+    foreign lpvm mutate(~tmp$16##0:mytree.tree, ?tmp$17##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+    foreign lpvm mutate(~tmp$17##0:mytree.tree, ?tmp$18##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 111:wybe.int)
+    foreign lpvm mutate(~tmp$18##0:mytree.tree, ?tmp$3##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+    alias_fork1.simpleMerge<0>(~tmp$0##0:mytree.tree, ~tmp$3##0:mytree.tree, ?tmp$6##0:mytree.tree) #6 @alias_fork1:18:6
+    mytree.printTree1<0>(~tmp$6##0:mytree.tree, "{":wybe.string, ?tmp$21##0:wybe.string, ~#io##0:wybe.phantom, ?tmp$22##0:wybe.phantom) #9 @mytree:nn:nn
+    foreign c print_string("}":wybe.string, ~tmp$22##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
 
 gen$1 > {inline} (2 calls)
 0: alias_fork1.gen$1<0>
-gen$1([k1#0:wybe.int], [k2#0:wybe.int], [l1#0:mytree.tree], [l2#0:mytree.tree], [r1#0:mytree.tree], [r2#0:mytree.tree], [tl#0:mytree.tree], tmp$2#0:mytree.tree, [tr#0:mytree.tree], ?$#0:mytree.tree):
+gen$1([k1##0:wybe.int], [k2##0:wybe.int], [l1##0:mytree.tree], [l2##0:mytree.tree], [r1##0:mytree.tree], [r2##0:mytree.tree], [tl##0:mytree.tree], tmp$2##0:mytree.tree, [tr##0:mytree.tree], ?$##0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(~tmp$2#0:mytree.tree, ?$#0:mytree.tree) @alias_fork1:5:5
+    foreign llvm move(~tmp$2##0:mytree.tree, ?$##0:mytree.tree) @alias_fork1:5:5
 
 
 simpleMerge > public (1 calls)
 0: alias_fork1.simpleMerge<0>
-simpleMerge(tl#0:mytree.tree, tr#0:mytree.tree, ?$#0:mytree.tree):
- AliasPairs: [($#0,tl#0),($#0,tr#0),(tl#0,tr#0)]
+simpleMerge(tl##0:mytree.tree, tr##0:mytree.tree, ?$##0:mytree.tree):
+ AliasPairs: [($##0,tl##0),($##0,tr##0),(tl##0,tr##0)]
  InterestingCallProperties: []
-    foreign llvm icmp_ne(tl#0:wybe.int, 0:wybe.int, ?tmp$15#0:wybe.bool)
-    case ~tmp$15#0:wybe.bool of
+    foreign llvm icmp_ne(tl##0:wybe.int, 0:wybe.int, ?tmp$15##0:wybe.bool)
+    case ~tmp$15##0:wybe.bool of
     0:
-        foreign lpvm alloc(24:wybe.int, ?tmp$19#0:mytree.tree)
-        foreign lpvm mutate(~tmp$19#0:mytree.tree, ?tmp$20#0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-        foreign lpvm mutate(~tmp$20#0:mytree.tree, ?tmp$21#0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.int)
-        foreign lpvm mutate(~tmp$21#0:mytree.tree, ?$#0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+        foreign lpvm alloc(24:wybe.int, ?tmp$19##0:mytree.tree)
+        foreign lpvm mutate(~tmp$19##0:mytree.tree, ?tmp$20##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+        foreign lpvm mutate(~tmp$20##0:mytree.tree, ?tmp$21##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.int)
+        foreign lpvm mutate(~tmp$21##0:mytree.tree, ?$##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
 
     1:
-        foreign lpvm access(tl#0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k1#0:wybe.int)
-        foreign lpvm access(tl#0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?r1#0:mytree.tree)
-        foreign llvm icmp_ne(tr#0:wybe.int, 0:wybe.int, ?tmp$17#0:wybe.bool)
-        case ~tmp$17#0:wybe.bool of
+        foreign lpvm access(tl##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k1##0:wybe.int)
+        foreign lpvm access(tl##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?r1##0:mytree.tree)
+        foreign llvm icmp_ne(tr##0:wybe.int, 0:wybe.int, ?tmp$17##0:wybe.bool)
+        case ~tmp$17##0:wybe.bool of
         0:
-            foreign lpvm alloc(24:wybe.int, ?tmp$21#0:mytree.tree)
-            foreign lpvm mutate(~tmp$21#0:mytree.tree, ?tmp$22#0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-            foreign lpvm mutate(~tmp$22#0:mytree.tree, ?tmp$23#0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.int)
-            foreign lpvm mutate(~tmp$23#0:mytree.tree, ?$#0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+            foreign lpvm alloc(24:wybe.int, ?tmp$21##0:mytree.tree)
+            foreign lpvm mutate(~tmp$21##0:mytree.tree, ?tmp$22##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+            foreign lpvm mutate(~tmp$22##0:mytree.tree, ?tmp$23##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.int)
+            foreign lpvm mutate(~tmp$23##0:mytree.tree, ?$##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
 
         1:
-            foreign lpvm access(tr#0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k2#0:wybe.int)
-            foreign lpvm access(tr#0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?r2#0:mytree.tree)
-            foreign llvm icmp_slt(k1#0:wybe.int, k2#0:wybe.int, ?tmp$11#0:wybe.bool) @int:nn:nn
-            case ~tmp$11#0:wybe.bool of
+            foreign lpvm access(tr##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k2##0:wybe.int)
+            foreign lpvm access(tr##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?r2##0:mytree.tree)
+            foreign llvm icmp_slt(k1##0:wybe.int, k2##0:wybe.int, ?tmp$11##0:wybe.bool) @int:nn:nn
+            case ~tmp$11##0:wybe.bool of
             0:
-                foreign lpvm alloc(24:wybe.int, ?tmp$23#0:mytree.tree)
-                foreign lpvm mutate(~tmp$23#0:mytree.tree, ?tmp$24#0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tr#0:mytree.tree)
-                foreign lpvm mutate(~tmp$24#0:mytree.tree, ?tmp$25#0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~k1#0:wybe.int)
-                foreign lpvm mutate(~tmp$25#0:mytree.tree, ?$#0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~r1#0:mytree.tree)
+                foreign lpvm alloc(24:wybe.int, ?tmp$23##0:mytree.tree)
+                foreign lpvm mutate(~tmp$23##0:mytree.tree, ?tmp$24##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tr##0:mytree.tree)
+                foreign lpvm mutate(~tmp$24##0:mytree.tree, ?tmp$25##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~k1##0:wybe.int)
+                foreign lpvm mutate(~tmp$25##0:mytree.tree, ?$##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~r1##0:mytree.tree)
 
             1:
-                foreign lpvm alloc(24:wybe.int, ?tmp$23#0:mytree.tree)
-                foreign lpvm mutate(~tmp$23#0:mytree.tree, ?tmp$24#0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tl#0:mytree.tree)
-                foreign lpvm mutate(~tmp$24#0:mytree.tree, ?tmp$25#0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~k2#0:wybe.int)
-                foreign lpvm mutate(~tmp$25#0:mytree.tree, ?$#0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~r2#0:mytree.tree)
+                foreign lpvm alloc(24:wybe.int, ?tmp$23##0:mytree.tree)
+                foreign lpvm mutate(~tmp$23##0:mytree.tree, ?tmp$24##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tl##0:mytree.tree)
+                foreign lpvm mutate(~tmp$24##0:mytree.tree, ?tmp$25##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~k2##0:wybe.int)
+                foreign lpvm mutate(~tmp$25##0:mytree.tree, ?$##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~r2##0:mytree.tree)
 
 
 
@@ -141,9 +141,9 @@ entry:
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
   store  i64 0, i64* %22 
-  %"1$tmp$6#0" = tail call fastcc  i64  @"alias_fork1.simpleMerge<0>"(i64  %3, i64  %14)  
+  %"1$tmp$6##0" = tail call fastcc  i64  @"alias_fork1.simpleMerge<0>"(i64  %3, i64  %14)  
   %24 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_fork1.23, i32 0, i32 0) to i64 
-  %"1$tmp$21#0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"1$tmp$6#0", i64  %24)  
+  %"1$tmp$21##0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"1$tmp$6##0", i64  %24)  
   %26 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_fork1.25, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %26)  
   tail call ccc  void  @putchar(i8  10)  
@@ -151,27 +151,27 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_fork1.gen$1<0>"(i64  %"tmp$2#0")    {
+define external fastcc  i64 @"alias_fork1.gen$1<0>"(i64  %"tmp$2##0")    {
 entry:
-  ret i64 %"tmp$2#0" 
+  ret i64 %"tmp$2##0" 
 }
 
 
-define external fastcc  i64 @"alias_fork1.simpleMerge<0>"(i64  %"tl#0", i64  %"tr#0")    {
+define external fastcc  i64 @"alias_fork1.simpleMerge<0>"(i64  %"tl##0", i64  %"tr##0")    {
 entry:
-  %"1$tmp$15#0" = icmp ne i64 %"tl#0", 0 
-  br i1 %"1$tmp$15#0", label %if.then, label %if.else 
+  %"1$tmp$15##0" = icmp ne i64 %"tl##0", 0 
+  br i1 %"1$tmp$15##0", label %if.then, label %if.else 
 if.then:
-  %27 = add   i64 %"tl#0", 8 
+  %27 = add   i64 %"tl##0", 8 
   %28 = inttoptr i64 %27 to i64* 
   %29 = getelementptr  i64, i64* %28, i64 0 
   %30 = load  i64, i64* %29 
-  %31 = add   i64 %"tl#0", 16 
+  %31 = add   i64 %"tl##0", 16 
   %32 = inttoptr i64 %31 to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
-  %"2$tmp$17#0" = icmp ne i64 %"tr#0", 0 
-  br i1 %"2$tmp$17#0", label %if.then1, label %if.else1 
+  %"2$tmp$17##0" = icmp ne i64 %"tr##0", 0 
+  br i1 %"2$tmp$17##0", label %if.then1, label %if.else1 
 if.else:
   %76 = trunc i64 24 to i32  
   %77 = tail call ccc  i8*  @wybe_malloc(i32  %76)  
@@ -189,16 +189,16 @@ if.else:
   store  i64 0, i64* %86 
   ret i64 %78 
 if.then1:
-  %35 = add   i64 %"tr#0", 8 
+  %35 = add   i64 %"tr##0", 8 
   %36 = inttoptr i64 %35 to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
-  %39 = add   i64 %"tr#0", 16 
+  %39 = add   i64 %"tr##0", 16 
   %40 = inttoptr i64 %39 to i64* 
   %41 = getelementptr  i64, i64* %40, i64 0 
   %42 = load  i64, i64* %41 
-  %"4$tmp$11#0" = icmp slt i64 %30, %38 
-  br i1 %"4$tmp$11#0", label %if.then2, label %if.else2 
+  %"4$tmp$11##0" = icmp slt i64 %30, %38 
+  br i1 %"4$tmp$11##0", label %if.then2, label %if.else2 
 if.else1:
   %65 = trunc i64 24 to i32  
   %66 = tail call ccc  i8*  @wybe_malloc(i32  %65)  
@@ -221,7 +221,7 @@ if.then2:
   %45 = ptrtoint i8* %44 to i64 
   %46 = inttoptr i64 %45 to i64* 
   %47 = getelementptr  i64, i64* %46, i64 0 
-  store  i64 %"tl#0", i64* %47 
+  store  i64 %"tl##0", i64* %47 
   %48 = add   i64 %45, 8 
   %49 = inttoptr i64 %48 to i64* 
   %50 = getelementptr  i64, i64* %49, i64 0 
@@ -237,7 +237,7 @@ if.else2:
   %56 = ptrtoint i8* %55 to i64 
   %57 = inttoptr i64 %56 to i64* 
   %58 = getelementptr  i64, i64* %57, i64 0 
-  store  i64 %"tr#0", i64* %58 
+  store  i64 %"tr##0", i64* %58 
   %59 = add   i64 %56, 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
@@ -274,32 +274,32 @@ if.else2:
 
 printTree > public {inline} (0 calls)
 0: mytree.printTree<0>
-printTree(t#0:mytree.tree, io#0:wybe.phantom, ?io#2:wybe.phantom):
+printTree(t##0:mytree.tree, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    mytree.printTree1<0>(~t#0:mytree.tree, "{":wybe.string, ?%prefix#1:wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @mytree:nn:nn
-    foreign c print_string("}":wybe.string, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
+    mytree.printTree1<0>(~t##0:mytree.tree, "{":wybe.string, ?%prefix##1:wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @mytree:nn:nn
+    foreign c print_string("}":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
 
 printTree1 > public (3 calls)
 0: mytree.printTree1<0>
-printTree1(t#0:mytree.tree, prefix#0:wybe.string, ?prefix#3:wybe.string, io#0:wybe.phantom, ?io#4:wybe.phantom):
- AliasPairs: [(prefix#0,prefix#3)]
+printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string, io##0:wybe.phantom, ?io##4:wybe.phantom):
+ AliasPairs: [(prefix##0,prefix##3)]
  InterestingCallProperties: []
-    foreign llvm icmp_ne(t#0:wybe.int, 0:wybe.int, ?tmp$2#0:wybe.bool)
-    case ~tmp$2#0:wybe.bool of
+    foreign llvm icmp_ne(t##0:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.bool)
+    case ~tmp$2##0:wybe.bool of
     0:
-        foreign llvm move(~prefix#0:wybe.string, ?prefix#3:wybe.string)
-        foreign llvm move(~io#0:wybe.phantom, ?io#4:wybe.phantom)
+        foreign llvm move(~prefix##0:wybe.string, ?prefix##3:wybe.string)
+        foreign llvm move(~io##0:wybe.phantom, ?io##4:wybe.phantom)
 
     1:
-        foreign lpvm access(t#0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?l#0:mytree.tree)
-        foreign lpvm access(t#0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k#0:wybe.int)
-        foreign lpvm access(~t#0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?r#0:mytree.tree)
-        mytree.printTree1<0>(~l#0:mytree.tree, ~%prefix#0:wybe.string, ?%prefix#1:wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #1 @mytree:nn:nn
-        foreign c print_string(~prefix#1:wybe.string, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-        foreign c print_int(~k#0:wybe.int, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-        mytree.printTree1<0>(~r#0:mytree.tree, ", ":wybe.string, ?%prefix#3:wybe.string, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #4 @mytree:nn:nn
+        foreign lpvm access(t##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?l##0:mytree.tree)
+        foreign lpvm access(t##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k##0:wybe.int)
+        foreign lpvm access(~t##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?r##0:mytree.tree)
+        mytree.printTree1<0>(~l##0:mytree.tree, ~%prefix##0:wybe.string, ?%prefix##1:wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @mytree:nn:nn
+        foreign c print_string(~prefix##1:wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+        foreign c print_int(~k##0:wybe.int, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+        mytree.printTree1<0>(~r##0:mytree.tree, ", ":wybe.string, ?%prefix##3:wybe.string, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @mytree:nn:nn
 
 
   LLVM code       :
@@ -331,40 +331,40 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"mytree.printTree<0>"(i64  %"t#0")    {
+define external fastcc  void @"mytree.printTree<0>"(i64  %"t##0")    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @mytree.1, i32 0, i32 0) to i64 
-  %"1$prefix#1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t#0", i64  %2)  
+  %"1$prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t##0", i64  %2)  
   %4 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @mytree.3, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %4)  
   ret void 
 }
 
 
-define external fastcc  i64 @"mytree.printTree1<0>"(i64  %"t#0", i64  %"prefix#0")    {
+define external fastcc  i64 @"mytree.printTree1<0>"(i64  %"t##0", i64  %"prefix##0")    {
 entry:
-  %"1$tmp$2#0" = icmp ne i64 %"t#0", 0 
-  br i1 %"1$tmp$2#0", label %if.then, label %if.else 
+  %"1$tmp$2##0" = icmp ne i64 %"t##0", 0 
+  br i1 %"1$tmp$2##0", label %if.then, label %if.else 
 if.then:
-  %5 = inttoptr i64 %"t#0" to i64* 
+  %5 = inttoptr i64 %"t##0" to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = add   i64 %"t#0", 8 
+  %8 = add   i64 %"t##0", 8 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
-  %12 = add   i64 %"t#0", 16 
+  %12 = add   i64 %"t##0", 16 
   %13 = inttoptr i64 %12 to i64* 
   %14 = getelementptr  i64, i64* %13, i64 0 
   %15 = load  i64, i64* %14 
-  %"2$prefix#1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %7, i64  %"prefix#0")  
-  tail call ccc  void  @print_string(i64  %"2$prefix#1")  
+  %"2$prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %7, i64  %"prefix##0")  
+  tail call ccc  void  @print_string(i64  %"2$prefix##1")  
   tail call ccc  void  @print_int(i64  %11)  
   %17 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @mytree.16, i32 0, i32 0) to i64 
-  %"2$prefix#3" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %15, i64  %17)  
-  ret i64 %"2$prefix#3" 
+  %"2$prefix##3" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %15, i64  %17)  
+  ret i64 %"2$prefix##3" 
 if.else:
-  ret i64 %"prefix#0" 
+  ret i64 %"prefix##0" 
 }
 --------------------------------------------------
  Module mytree.tree
@@ -389,40 +389,40 @@ if.else:
 
 = > public (7 calls)
 0: mytree.tree.=<0>
-=($left#0:mytree.tree, $right#0:mytree.tree, ?$$#0:wybe.bool):
+=($left##0:mytree.tree, $right##0:mytree.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left#0:mytree.tree, ~$right#0:mytree.tree, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~$left##0:mytree.tree, ~$right##0:mytree.tree, ?$$##0:wybe.bool)
 
     1:
-        foreign lpvm access($left#0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$left#0:mytree.tree)
-        foreign lpvm access($left#0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$key#0:wybe.int)
-        foreign lpvm access(~$left#0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$right#0:mytree.tree)
-        foreign llvm icmp_ne($right#0:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.bool)
-        case ~tmp$10#0:wybe.bool of
+        foreign lpvm access($left##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$left##0:mytree.tree)
+        foreign lpvm access($left##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$key##0:wybe.int)
+        foreign lpvm access(~$left##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$right##0:mytree.tree)
+        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.bool)
+        case ~tmp$10##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign lpvm access($right#0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$left#0:mytree.tree)
-            foreign lpvm access($right#0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$key#0:wybe.int)
-            foreign lpvm access(~$right#0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$right#0:mytree.tree)
-            mytree.tree.=<0>(~$left$left#0:mytree.tree, ~$right$left#0:mytree.tree, ?tmp$4#0:wybe.bool) #2
-            case ~tmp$4#0:wybe.bool of
+            foreign lpvm access($right##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$left##0:mytree.tree)
+            foreign lpvm access($right##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$key##0:wybe.int)
+            foreign lpvm access(~$right##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$right##0:mytree.tree)
+            mytree.tree.=<0>(~$left$left##0:mytree.tree, ~$right$left##0:mytree.tree, ?tmp$4##0:wybe.bool) #2
+            case ~tmp$4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                foreign llvm icmp_eq(~$left$key#0:wybe.int, ~$right$key#0:wybe.int, ?tmp$5#0:wybe.bool) @int:nn:nn
-                case ~tmp$5#0:wybe.bool of
+                foreign llvm icmp_eq(~$left$key##0:wybe.int, ~$right$key##0:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
+                case ~tmp$5##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                 1:
-                    mytree.tree.=<0>(~$left$right#0:mytree.tree, ~$right$right#0:mytree.tree, ?$$#0:wybe.bool) #4
+                    mytree.tree.=<0>(~$left$right##0:mytree.tree, ~$right$right##0:mytree.tree, ?$$##0:wybe.bool) #4
 
 
 
@@ -431,145 +431,145 @@ if.else:
 
 empty > public {inline} (0 calls)
 0: mytree.tree.empty<0>
-empty(?$#0:mytree.tree):
+empty(?$##0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:mytree.tree, ?$#0:mytree.tree)
+    foreign llvm move(0:mytree.tree, ?$##0:mytree.tree)
 
 
 key > public {inline} (0 calls)
 0: mytree.tree.key<0>
-key($rec#0:mytree.tree, ?$#0:wybe.int, ?$$#0:wybe.bool):
+key($rec##0:mytree.tree, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec#0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 key > public {inline} (0 calls)
 1: mytree.tree.key<1>
-key($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:wybe.int, ?$$#0:wybe.bool):
+key($rec##0:mytree.tree, ?$rec##1:mytree.tree, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:mytree.tree, ?$rec#1:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:mytree.tree, ?$rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~$rec#0:mytree.tree, ?$rec#1:mytree.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~$rec##0:mytree.tree, ?$rec##1:mytree.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 left > public {inline} (0 calls)
 0: mytree.tree.left<0>
-left($rec#0:mytree.tree, ?$#0:mytree.tree, ?$$#0:wybe.bool):
+left($rec##0:mytree.tree, ?$##0:mytree.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:mytree.tree, ?$#0:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:mytree.tree, ?$##0:mytree.tree)
 
     1:
-        foreign lpvm access(~$rec#0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 left > public {inline} (0 calls)
 1: mytree.tree.left<1>
-left($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:mytree.tree, ?$$#0:wybe.bool):
+left($rec##0:mytree.tree, ?$rec##1:mytree.tree, $field##0:mytree.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:mytree.tree, ?$rec#1:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:mytree.tree, ?$rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~$rec#0:mytree.tree, ?$rec#1:mytree.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field#0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~$rec##0:mytree.tree, ?$rec##1:mytree.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 node > public {inline} (0 calls)
 0: mytree.tree.node<0>
-node(left#0:mytree.tree, key#0:wybe.int, right#0:mytree.tree, ?$#0:mytree.tree):
+node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?$##0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?$rec#0:mytree.tree)
-    foreign lpvm mutate(~$rec#0:mytree.tree, ?$rec#1:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left#0:mytree.tree)
-    foreign lpvm mutate(~$rec#1:mytree.tree, ?$rec#2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key#0:wybe.int)
-    foreign lpvm mutate(~$rec#2:mytree.tree, ?$#0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right#0:mytree.tree)
+    foreign lpvm alloc(24:wybe.int, ?$rec##0:mytree.tree)
+    foreign lpvm mutate(~$rec##0:mytree.tree, ?$rec##1:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:mytree.tree)
+    foreign lpvm mutate(~$rec##1:mytree.tree, ?$rec##2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int)
+    foreign lpvm mutate(~$rec##2:mytree.tree, ?$##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree)
 node > public {inline} (16 calls)
 1: mytree.tree.node<1>
-node(?left#0:mytree.tree, ?key#0:wybe.int, ?right#0:mytree.tree, $#0:mytree.tree, ?$$#0:wybe.bool):
+node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, $##0:mytree.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:mytree.tree, ?left#0:mytree.tree)
-        foreign llvm move(undef:wybe.int, ?key#0:wybe.int)
-        foreign llvm move(undef:mytree.tree, ?right#0:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:mytree.tree, ?left##0:mytree.tree)
+        foreign llvm move(undef:wybe.int, ?key##0:wybe.int)
+        foreign llvm move(undef:mytree.tree, ?right##0:mytree.tree)
 
     1:
-        foreign lpvm access($#0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left#0:mytree.tree)
-        foreign lpvm access($#0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key#0:wybe.int)
-        foreign lpvm access(~$#0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right#0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access($##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:mytree.tree)
+        foreign lpvm access($##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
+        foreign lpvm access(~$##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 right > public {inline} (0 calls)
 0: mytree.tree.right<0>
-right($rec#0:mytree.tree, ?$#0:mytree.tree, ?$$#0:wybe.bool):
+right($rec##0:mytree.tree, ?$##0:mytree.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:mytree.tree, ?$#0:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:mytree.tree, ?$##0:mytree.tree)
 
     1:
-        foreign lpvm access(~$rec#0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 right > public {inline} (0 calls)
 1: mytree.tree.right<1>
-right($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:mytree.tree, ?$$#0:wybe.bool):
+right($rec##0:mytree.tree, ?$rec##1:mytree.tree, $field##0:mytree.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:mytree.tree, ?$rec#1:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:mytree.tree, ?$rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~$rec#0:mytree.tree, ?$rec#1:mytree.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field#0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~$rec##0:mytree.tree, ?$rec##1:mytree.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: mytree.tree.~=<0>
-~=($left#0:mytree.tree, $right#0:mytree.tree, ?$$#0:wybe.bool):
+~=($left##0:mytree.tree, $right##0:mytree.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    mytree.tree.=<0>(~$left#0:mytree.tree, ~$right#0:mytree.tree, ?tmp$0#0:wybe.bool) #0
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    mytree.tree.=<0>(~$left##0:mytree.tree, ~$right##0:mytree.tree, ?tmp$0##0:wybe.bool) #0
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
   LLVM code       :
 
@@ -585,51 +585,51 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"mytree.tree.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"mytree.tree.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$left#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = add   i64 %"$left#0", 16 
+  %8 = add   i64 %"$left##0", 16 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
-  %"2$tmp$10#0" = icmp ne i64 %"$right#0", 0 
-  br i1 %"2$tmp$10#0", label %if.then1, label %if.else1 
+  %"2$tmp$10##0" = icmp ne i64 %"$right##0", 0 
+  br i1 %"2$tmp$10##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = icmp eq i64 %"$left#0", %"$right#0" 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
+  ret i1 %"3$$$##0" 
 if.then1:
-  %12 = inttoptr i64 %"$right#0" to i64* 
+  %12 = inttoptr i64 %"$right##0" to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %15 = add   i64 %"$right#0", 8 
+  %15 = add   i64 %"$right##0", 8 
   %16 = inttoptr i64 %15 to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
-  %19 = add   i64 %"$right#0", 16 
+  %19 = add   i64 %"$right##0", 16 
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %"4$tmp$4#0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %3, i64  %14)  
-  br i1 %"4$tmp$4#0", label %if.then2, label %if.else2 
+  %"4$tmp$4##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %3, i64  %14)  
+  br i1 %"4$tmp$4##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$tmp$5#0" = icmp eq i64 %7, %18 
-  br i1 %"6$tmp$5#0", label %if.then3, label %if.else3 
+  %"6$tmp$5##0" = icmp eq i64 %7, %18 
+  br i1 %"6$tmp$5##0", label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %"8$$$#0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %11, i64  %22)  
-  ret i1 %"8$$$#0" 
+  %"8$$$##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %11, i64  %22)  
+  ret i1 %"8$$$##0" 
 if.else3:
   ret i1 0 
 }
@@ -641,12 +641,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.key<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"mytree.tree.key<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %23 = add   i64 %"$rec#0", 8 
+  %23 = add   i64 %"$rec##0", 8 
   %24 = inttoptr i64 %23 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
   %26 = load  i64, i64* %25 
@@ -660,38 +660,38 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.key<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"mytree.tree.key<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %31 = trunc i64 24 to i32  
   %32 = tail call ccc  i8*  @wybe_malloc(i32  %31)  
   %33 = ptrtoint i8* %32 to i64 
   %34 = inttoptr i64 %33 to i8* 
-  %35 = inttoptr i64 %"$rec#0" to i8* 
+  %35 = inttoptr i64 %"$rec##0" to i8* 
   %36 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %34, i8*  %35, i32  %36, i32  8, i1  0)  
   %37 = add   i64 %33, 8 
   %38 = inttoptr i64 %37 to i64* 
   %39 = getelementptr  i64, i64* %38, i64 0 
-  store  i64 %"$field#0", i64* %39 
+  store  i64 %"$field##0", i64* %39 
   %40 = insertvalue {i64, i1} undef, i64 %33, 0 
   %41 = insertvalue {i64, i1} %40, i1 1, 1 
   ret {i64, i1} %41 
 if.else:
-  %42 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %42 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %43 = insertvalue {i64, i1} %42, i1 0, 1 
   ret {i64, i1} %43 
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.left<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"mytree.tree.left<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %44 = inttoptr i64 %"$rec#0" to i64* 
+  %44 = inttoptr i64 %"$rec##0" to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
   %47 = insertvalue {i64, i1} undef, i64 %46, 0 
@@ -704,64 +704,64 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.left<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"mytree.tree.left<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %51 = trunc i64 24 to i32  
   %52 = tail call ccc  i8*  @wybe_malloc(i32  %51)  
   %53 = ptrtoint i8* %52 to i64 
   %54 = inttoptr i64 %53 to i8* 
-  %55 = inttoptr i64 %"$rec#0" to i8* 
+  %55 = inttoptr i64 %"$rec##0" to i8* 
   %56 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %54, i8*  %55, i32  %56, i32  8, i1  0)  
   %57 = inttoptr i64 %53 to i64* 
   %58 = getelementptr  i64, i64* %57, i64 0 
-  store  i64 %"$field#0", i64* %58 
+  store  i64 %"$field##0", i64* %58 
   %59 = insertvalue {i64, i1} undef, i64 %53, 0 
   %60 = insertvalue {i64, i1} %59, i1 1, 1 
   ret {i64, i1} %60 
 if.else:
-  %61 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %61 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %62 = insertvalue {i64, i1} %61, i1 0, 1 
   ret {i64, i1} %62 
 }
 
 
-define external fastcc  i64 @"mytree.tree.node<0>"(i64  %"left#0", i64  %"key#0", i64  %"right#0")    {
+define external fastcc  i64 @"mytree.tree.node<0>"(i64  %"left##0", i64  %"key##0", i64  %"right##0")    {
 entry:
   %63 = trunc i64 24 to i32  
   %64 = tail call ccc  i8*  @wybe_malloc(i32  %63)  
   %65 = ptrtoint i8* %64 to i64 
   %66 = inttoptr i64 %65 to i64* 
   %67 = getelementptr  i64, i64* %66, i64 0 
-  store  i64 %"left#0", i64* %67 
+  store  i64 %"left##0", i64* %67 
   %68 = add   i64 %65, 8 
   %69 = inttoptr i64 %68 to i64* 
   %70 = getelementptr  i64, i64* %69, i64 0 
-  store  i64 %"key#0", i64* %70 
+  store  i64 %"key##0", i64* %70 
   %71 = add   i64 %65, 16 
   %72 = inttoptr i64 %71 to i64* 
   %73 = getelementptr  i64, i64* %72, i64 0 
-  store  i64 %"right#0", i64* %73 
+  store  i64 %"right##0", i64* %73 
   ret i64 %65 
 }
 
 
-define external fastcc  {i64, i64, i64, i1} @"mytree.tree.node<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64, i64, i1} @"mytree.tree.node<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %74 = inttoptr i64 %"$#0" to i64* 
+  %74 = inttoptr i64 %"$##0" to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
   %76 = load  i64, i64* %75 
-  %77 = add   i64 %"$#0", 8 
+  %77 = add   i64 %"$##0", 8 
   %78 = inttoptr i64 %77 to i64* 
   %79 = getelementptr  i64, i64* %78, i64 0 
   %80 = load  i64, i64* %79 
-  %81 = add   i64 %"$#0", 16 
+  %81 = add   i64 %"$##0", 16 
   %82 = inttoptr i64 %81 to i64* 
   %83 = getelementptr  i64, i64* %82, i64 0 
   %84 = load  i64, i64* %83 
@@ -779,12 +779,12 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.right<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"mytree.tree.right<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %93 = add   i64 %"$rec#0", 16 
+  %93 = add   i64 %"$rec##0", 16 
   %94 = inttoptr i64 %93 to i64* 
   %95 = getelementptr  i64, i64* %94, i64 0 
   %96 = load  i64, i64* %95 
@@ -798,35 +798,35 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.right<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"mytree.tree.right<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %101 = trunc i64 24 to i32  
   %102 = tail call ccc  i8*  @wybe_malloc(i32  %101)  
   %103 = ptrtoint i8* %102 to i64 
   %104 = inttoptr i64 %103 to i8* 
-  %105 = inttoptr i64 %"$rec#0" to i8* 
+  %105 = inttoptr i64 %"$rec##0" to i8* 
   %106 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %104, i8*  %105, i32  %106, i32  8, i1  0)  
   %107 = add   i64 %103, 16 
   %108 = inttoptr i64 %107 to i64* 
   %109 = getelementptr  i64, i64* %108, i64 0 
-  store  i64 %"$field#0", i64* %109 
+  store  i64 %"$field##0", i64* %109 
   %110 = insertvalue {i64, i1} undef, i64 %103, 0 
   %111 = insertvalue {i64, i1} %110, i1 1, 1 
   ret {i64, i1} %111 
 if.else:
-  %112 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %112 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %113 = insertvalue {i64, i1} %112, i1 0, 1 
   ret {i64, i1} %113 
 }
 
 
-define external fastcc  i1 @"mytree.tree.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"mytree.tree.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %"$left#0", i64  %"$right#0")  
-  %"1$$$#0" = xor i1 %"1$tmp$0#0", 1 
-  ret i1 %"1$$$#0" 
+  %"1$tmp$0##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %"$left##0", i64  %"$right##0")  
+  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
+  ret i1 %"1$$$##0" 
 }

--- a/test-cases/final-dump/alias_fork1.exp
+++ b/test-cases/final-dump/alias_fork1.exp
@@ -32,16 +32,16 @@ AFTER EVERYTHING:
 
 gen#1 > {inline} (2 calls)
 0: alias_fork1.gen#1<0>
-gen#1([k1##0:wybe.int], [k2##0:wybe.int], [l1##0:mytree.tree], [l2##0:mytree.tree], [r1##0:mytree.tree], [r2##0:mytree.tree], [tl##0:mytree.tree], tmp#2##0:mytree.tree, [tr##0:mytree.tree], ?###0:mytree.tree):
+gen#1([k1##0:wybe.int], [k2##0:wybe.int], [l1##0:mytree.tree], [l2##0:mytree.tree], [r1##0:mytree.tree], [r2##0:mytree.tree], [tl##0:mytree.tree], tmp#2##0:mytree.tree, [tr##0:mytree.tree], ?#result##0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(~tmp#2##0:mytree.tree, ?###0:mytree.tree) @alias_fork1:5:5
+    foreign llvm move(~tmp#2##0:mytree.tree, ?#result##0:mytree.tree) @alias_fork1:5:5
 
 
 simpleMerge > public (1 calls)
 0: alias_fork1.simpleMerge<0>
-simpleMerge(tl##0:mytree.tree, tr##0:mytree.tree, ?###0:mytree.tree):
- AliasPairs: [(###0,tl##0),(###0,tr##0),(tl##0,tr##0)]
+simpleMerge(tl##0:mytree.tree, tr##0:mytree.tree, ?#result##0:mytree.tree):
+ AliasPairs: [(#result##0,tl##0),(#result##0,tr##0),(tl##0,tr##0)]
  InterestingCallProperties: []
     foreign llvm icmp_ne(tl##0:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.bool)
     case ~tmp#15##0:wybe.bool of
@@ -49,7 +49,7 @@ simpleMerge(tl##0:mytree.tree, tr##0:mytree.tree, ?###0:mytree.tree):
         foreign lpvm alloc(24:wybe.int, ?tmp#19##0:mytree.tree)
         foreign lpvm mutate(~tmp#19##0:mytree.tree, ?tmp#20##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
         foreign lpvm mutate(~tmp#20##0:mytree.tree, ?tmp#21##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.int)
-        foreign lpvm mutate(~tmp#21##0:mytree.tree, ?###0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+        foreign lpvm mutate(~tmp#21##0:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
 
     1:
         foreign lpvm access(tl##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k1##0:wybe.int)
@@ -60,7 +60,7 @@ simpleMerge(tl##0:mytree.tree, tr##0:mytree.tree, ?###0:mytree.tree):
             foreign lpvm alloc(24:wybe.int, ?tmp#21##0:mytree.tree)
             foreign lpvm mutate(~tmp#21##0:mytree.tree, ?tmp#22##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
             foreign lpvm mutate(~tmp#22##0:mytree.tree, ?tmp#23##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.int)
-            foreign lpvm mutate(~tmp#23##0:mytree.tree, ?###0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+            foreign lpvm mutate(~tmp#23##0:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
 
         1:
             foreign lpvm access(tr##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k2##0:wybe.int)
@@ -71,13 +71,13 @@ simpleMerge(tl##0:mytree.tree, tr##0:mytree.tree, ?###0:mytree.tree):
                 foreign lpvm alloc(24:wybe.int, ?tmp#23##0:mytree.tree)
                 foreign lpvm mutate(~tmp#23##0:mytree.tree, ?tmp#24##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tr##0:mytree.tree)
                 foreign lpvm mutate(~tmp#24##0:mytree.tree, ?tmp#25##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~k1##0:wybe.int)
-                foreign lpvm mutate(~tmp#25##0:mytree.tree, ?###0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~r1##0:mytree.tree)
+                foreign lpvm mutate(~tmp#25##0:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~r1##0:mytree.tree)
 
             1:
                 foreign lpvm alloc(24:wybe.int, ?tmp#23##0:mytree.tree)
                 foreign lpvm mutate(~tmp#23##0:mytree.tree, ?tmp#24##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tl##0:mytree.tree)
                 foreign lpvm mutate(~tmp#24##0:mytree.tree, ?tmp#25##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~k2##0:wybe.int)
-                foreign lpvm mutate(~tmp#25##0:mytree.tree, ?###0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~r2##0:mytree.tree)
+                foreign lpvm mutate(~tmp#25##0:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~r2##0:mytree.tree)
 
 
 
@@ -431,25 +431,25 @@ if.else:
 
 empty > public {inline} (0 calls)
 0: mytree.tree.empty<0>
-empty(?###0:mytree.tree):
+empty(?#result##0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:mytree.tree, ?###0:mytree.tree)
+    foreign llvm move(0:mytree.tree, ?#result##0:mytree.tree)
 
 
 key > public {inline} (0 calls)
 0: mytree.tree.key<0>
-key(#rec##0:mytree.tree, ?###0:wybe.int, ?####0:wybe.bool):
+key(#rec##0:mytree.tree, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign lpvm access(~#rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 key > public {inline} (0 calls)
@@ -471,17 +471,17 @@ key(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:wybe.int, ?####0:wybe.b
 
 left > public {inline} (0 calls)
 0: mytree.tree.left<0>
-left(#rec##0:mytree.tree, ?###0:mytree.tree, ?####0:wybe.bool):
+left(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:mytree.tree, ?###0:mytree.tree)
+        foreign llvm move(undef:mytree.tree, ?#result##0:mytree.tree)
 
     1:
-        foreign lpvm access(~#rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:mytree.tree)
+        foreign lpvm access(~#rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 left > public {inline} (0 calls)
@@ -503,19 +503,19 @@ left(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?####0:wy
 
 node > public {inline} (0 calls)
 0: mytree.tree.node<0>
-node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?###0:mytree.tree):
+node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?#result##0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(24:wybe.int, ?#rec##0:mytree.tree)
     foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:mytree.tree)
     foreign lpvm mutate(~#rec##1:mytree.tree, ?#rec##2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int)
-    foreign lpvm mutate(~#rec##2:mytree.tree, ?###0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree)
+    foreign lpvm mutate(~#rec##2:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree)
 node > public {inline} (16 calls)
 1: mytree.tree.node<1>
-node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, ###0:mytree.tree, ?####0:wybe.bool):
+node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, #result##0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
@@ -524,26 +524,26 @@ node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, ###0:mytree.
         foreign llvm move(undef:mytree.tree, ?right##0:mytree.tree)
 
     1:
-        foreign lpvm access(###0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:mytree.tree)
-        foreign lpvm access(###0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
-        foreign lpvm access(~###0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:mytree.tree)
+        foreign lpvm access(#result##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:mytree.tree)
+        foreign lpvm access(#result##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
+        foreign lpvm access(~#result##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:mytree.tree)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 right > public {inline} (0 calls)
 0: mytree.tree.right<0>
-right(#rec##0:mytree.tree, ?###0:mytree.tree, ?####0:wybe.bool):
+right(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:mytree.tree, ?###0:mytree.tree)
+        foreign llvm move(undef:mytree.tree, ?#result##0:mytree.tree)
 
     1:
-        foreign lpvm access(~#rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:mytree.tree)
+        foreign lpvm access(~#rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 right > public {inline} (0 calls)
@@ -749,19 +749,19 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64, i1} @"mytree.tree.node<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64, i64, i1} @"mytree.tree.node<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  %"1#tmp#0##0" = icmp ne i64 %"#result##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %74 = inttoptr i64 %"###0" to i64* 
+  %74 = inttoptr i64 %"#result##0" to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
   %76 = load  i64, i64* %75 
-  %77 = add   i64 %"###0", 8 
+  %77 = add   i64 %"#result##0", 8 
   %78 = inttoptr i64 %77 to i64* 
   %79 = getelementptr  i64, i64* %78, i64 0 
   %80 = load  i64, i64* %79 
-  %81 = add   i64 %"###0", 16 
+  %81 = add   i64 %"#result##0", 16 
   %82 = inttoptr i64 %81 to i64* 
   %83 = getelementptr  i64, i64* %82, i64 0 
   %84 = load  i64, i64* %83 

--- a/test-cases/final-dump/alias_fork2.exp
+++ b/test-cases/final-dump/alias_fork2.exp
@@ -13,63 +13,63 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: alias_fork2.<0>
-(io#0:wybe.phantom, ?io#4:wybe.phantom):
+(io##0:wybe.phantom, ?io##4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp$9#0:mytree.tree)
-    foreign lpvm mutate(~tmp$9#0:mytree.tree, ?tmp$10#0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-    foreign lpvm mutate(~tmp$10#0:mytree.tree, ?tmp$11#0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp$11#0:mytree.tree, ?tmp$0#0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-    alias_fork2.simpleMerge<0>(tmp$0#0:mytree.tree, ?tmp$3#0:mytree.tree) #3 @alias_fork2:11:6
-    foreign c print_string("expect t -  1 200:":wybe.string, ~#io#0:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    mytree.printTree1<0>(tmp$3#0:mytree.tree, "{":wybe.string, ?tmp$17#0:wybe.string, ~#io#1:wybe.phantom, ?tmp$18#0:wybe.phantom) #11 @mytree:nn:nn
-    foreign c print_string("}":wybe.string, ~tmp$18#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string("":wybe.string, ~#io#2:wybe.phantom, ?tmp$21#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$21#0:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign llvm icmp_ne(tmp$0#0:wybe.int, 0:wybe.int, ?tmp$23#0:wybe.bool)
-    case ~tmp$23#0:wybe.bool of
+    foreign lpvm alloc(24:wybe.int, ?tmp$9##0:mytree.tree)
+    foreign lpvm mutate(~tmp$9##0:mytree.tree, ?tmp$10##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+    foreign lpvm mutate(~tmp$10##0:mytree.tree, ?tmp$11##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp$11##0:mytree.tree, ?tmp$0##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+    alias_fork2.simpleMerge<0>(tmp$0##0:mytree.tree, ?tmp$3##0:mytree.tree) #3 @alias_fork2:11:6
+    foreign c print_string("expect t -  1 200:":wybe.string, ~#io##0:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    mytree.printTree1<0>(tmp$3##0:mytree.tree, "{":wybe.string, ?tmp$17##0:wybe.string, ~#io##1:wybe.phantom, ?tmp$18##0:wybe.phantom) #11 @mytree:nn:nn
+    foreign c print_string("}":wybe.string, ~tmp$18##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string("":wybe.string, ~#io##2:wybe.phantom, ?tmp$21##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$21##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign llvm icmp_ne(tmp$0##0:wybe.int, 0:wybe.int, ?tmp$23##0:wybe.bool)
+    case ~tmp$23##0:wybe.bool of
     0:
-        alias_fork2.gen$1<0>(~io#3:wybe.phantom, ~tmp$3#0:mytree.tree, ~tmp$0#0:mytree.tree, _:mytree.tree, _:mytree.tree, _:mytree.tree, _:mytree.tree, ?io#4:wybe.phantom) #10
+        alias_fork2.gen$1<0>(~io##3:wybe.phantom, ~tmp$3##0:mytree.tree, ~tmp$0##0:mytree.tree, _:mytree.tree, _:mytree.tree, _:mytree.tree, _:mytree.tree, ?io##4:wybe.phantom) #10
 
     1:
-        foreign lpvm access(~tmp$0#0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?l#0:mytree.tree)
-        foreign lpvm alloc(24:wybe.int, ?tmp$27#0:mytree.tree)
-        foreign lpvm mutate(~tmp$27#0:mytree.tree, ?tmp$28#0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~l#0:mytree.tree)
-        foreign lpvm mutate(~tmp$28#0:mytree.tree, ?tmp$29#0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1000:wybe.int)
-        foreign lpvm mutate(~tmp$29#0:mytree.tree, ?tmp$4#0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-        alias_fork2.gen$1<0>(~io#3:wybe.phantom, ~tmp$3#0:mytree.tree, ~tmp$4#0:mytree.tree, _:mytree.tree, _:mytree.tree, _:mytree.tree, _:mytree.tree, ?io#4:wybe.phantom) #9
+        foreign lpvm access(~tmp$0##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?l##0:mytree.tree)
+        foreign lpvm alloc(24:wybe.int, ?tmp$27##0:mytree.tree)
+        foreign lpvm mutate(~tmp$27##0:mytree.tree, ?tmp$28##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~l##0:mytree.tree)
+        foreign lpvm mutate(~tmp$28##0:mytree.tree, ?tmp$29##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1000:wybe.int)
+        foreign lpvm mutate(~tmp$29##0:mytree.tree, ?tmp$4##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+        alias_fork2.gen$1<0>(~io##3:wybe.phantom, ~tmp$3##0:mytree.tree, ~tmp$4##0:mytree.tree, _:mytree.tree, _:mytree.tree, _:mytree.tree, _:mytree.tree, ?io##4:wybe.phantom) #9
 
 
 
 gen$1 > (2 calls)
 0: alias_fork2.gen$1<0>
-gen$1(io#0:wybe.phantom, t#0:mytree.tree, t1#0:mytree.tree, [tmp$0#0:mytree.tree], [tmp$1#0:mytree.tree], [tmp$2#0:mytree.tree], [tmp$3#0:mytree.tree], ?io#6:wybe.phantom):
+gen$1(io##0:wybe.phantom, t##0:mytree.tree, t1##0:mytree.tree, [tmp$0##0:mytree.tree], [tmp$1##0:mytree.tree], [tmp$2##0:mytree.tree], [tmp$3##0:mytree.tree], ?io##6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("expect t1 - 1000:":wybe.string, ~#io#0:wybe.phantom, ?tmp$7#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$7#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    mytree.printTree1<0>(~t1#0:mytree.tree, "{":wybe.string, ?tmp$10#0:wybe.string, ~#io#1:wybe.phantom, ?tmp$11#0:wybe.phantom) #6 @mytree:nn:nn
-    foreign c print_string("}":wybe.string, ~tmp$11#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string("":wybe.string, ~#io#2:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect t1 - 1 200:":wybe.string, ~#io#3:wybe.phantom, ?tmp$17#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$17#0:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    mytree.printTree1<0>(~t#0:mytree.tree, "{":wybe.string, ?tmp$20#0:wybe.string, ~#io#4:wybe.phantom, ?tmp$21#0:wybe.phantom) #7 @mytree:nn:nn
-    foreign c print_string("}":wybe.string, ~tmp$21#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-    foreign c print_string("":wybe.string, ~#io#5:wybe.phantom, ?tmp$24#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$24#0:wybe.phantom, ?#io#6:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect t1 - 1000:":wybe.string, ~#io##0:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    mytree.printTree1<0>(~t1##0:mytree.tree, "{":wybe.string, ?tmp$10##0:wybe.string, ~#io##1:wybe.phantom, ?tmp$11##0:wybe.phantom) #6 @mytree:nn:nn
+    foreign c print_string("}":wybe.string, ~tmp$11##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string("":wybe.string, ~#io##2:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect t1 - 1 200:":wybe.string, ~#io##3:wybe.phantom, ?tmp$17##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$17##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    mytree.printTree1<0>(~t##0:mytree.tree, "{":wybe.string, ?tmp$20##0:wybe.string, ~#io##4:wybe.phantom, ?tmp$21##0:wybe.phantom) #7 @mytree:nn:nn
+    foreign c print_string("}":wybe.string, ~tmp$21##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign c print_string("":wybe.string, ~#io##5:wybe.phantom, ?tmp$24##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$24##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
 
 
 simpleMerge > public (3 calls)
 0: alias_fork2.simpleMerge<0>
-simpleMerge(tl#0:mytree.tree, ?$#0:mytree.tree):
- AliasPairs: [($#0,tl#0)]
+simpleMerge(tl##0:mytree.tree, ?$##0:mytree.tree):
+ AliasPairs: [($##0,tl##0)]
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp$5#0:mytree.tree)
-    foreign lpvm mutate(~tmp$5#0:mytree.tree, ?tmp$6#0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tl#0:mytree.tree)
-    foreign lpvm mutate(~tmp$6#0:mytree.tree, ?tmp$7#0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 200:wybe.int)
-    foreign lpvm mutate(~tmp$7#0:mytree.tree, ?$#0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+    foreign lpvm alloc(24:wybe.int, ?tmp$5##0:mytree.tree)
+    foreign lpvm mutate(~tmp$5##0:mytree.tree, ?tmp$6##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tl##0:mytree.tree)
+    foreign lpvm mutate(~tmp$6##0:mytree.tree, ?tmp$7##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 200:wybe.int)
+    foreign lpvm mutate(~tmp$7##0:mytree.tree, ?$##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
 
   LLVM code       :
 
@@ -146,19 +146,19 @@ entry:
   %10 = inttoptr i64 %9 to i64* 
   %11 = getelementptr  i64, i64* %10, i64 0 
   store  i64 0, i64* %11 
-  %"1$tmp$3#0" = tail call fastcc  i64  @"alias_fork2.simpleMerge<0>"(i64  %3)  
+  %"1$tmp$3##0" = tail call fastcc  i64  @"alias_fork2.simpleMerge<0>"(i64  %3)  
   %13 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_fork2.12, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %13)  
   tail call ccc  void  @putchar(i8  10)  
   %15 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_fork2.14, i32 0, i32 0) to i64 
-  %"1$tmp$17#0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"1$tmp$3#0", i64  %15)  
+  %"1$tmp$17##0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"1$tmp$3##0", i64  %15)  
   %17 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_fork2.16, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %17)  
   %19 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_fork2.18, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %19)  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$tmp$23#0" = icmp ne i64 %3, 0 
-  br i1 %"1$tmp$23#0", label %if.then, label %if.else 
+  %"1$tmp$23##0" = icmp ne i64 %3, 0 
+  br i1 %"1$tmp$23##0", label %if.then, label %if.else 
 if.then:
   %20 = inttoptr i64 %3 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
@@ -177,21 +177,21 @@ if.then:
   %32 = inttoptr i64 %31 to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   store  i64 0, i64* %33 
-  tail call fastcc  void  @"alias_fork2.gen$1<0>"(i64  %"1$tmp$3#0", i64  %25)  
+  tail call fastcc  void  @"alias_fork2.gen$1<0>"(i64  %"1$tmp$3##0", i64  %25)  
   ret void 
 if.else:
-  tail call fastcc  void  @"alias_fork2.gen$1<0>"(i64  %"1$tmp$3#0", i64  %3)  
+  tail call fastcc  void  @"alias_fork2.gen$1<0>"(i64  %"1$tmp$3##0", i64  %3)  
   ret void 
 }
 
 
-define external fastcc  void @"alias_fork2.gen$1<0>"(i64  %"t#0", i64  %"t1#0")    {
+define external fastcc  void @"alias_fork2.gen$1<0>"(i64  %"t##0", i64  %"t1##0")    {
 entry:
   %35 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_fork2.34, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %35)  
   tail call ccc  void  @putchar(i8  10)  
   %37 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_fork2.36, i32 0, i32 0) to i64 
-  %"1$tmp$10#0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t1#0", i64  %37)  
+  %"1$tmp$10##0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t1##0", i64  %37)  
   %39 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_fork2.38, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %39)  
   %41 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_fork2.40, i32 0, i32 0) to i64 
@@ -201,7 +201,7 @@ entry:
   tail call ccc  void  @print_string(i64  %43)  
   tail call ccc  void  @putchar(i8  10)  
   %45 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_fork2.44, i32 0, i32 0) to i64 
-  %"1$tmp$20#0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t#0", i64  %45)  
+  %"1$tmp$20##0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t##0", i64  %45)  
   %47 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_fork2.46, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %47)  
   %49 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_fork2.48, i32 0, i32 0) to i64 
@@ -211,14 +211,14 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_fork2.simpleMerge<0>"(i64  %"tl#0")    {
+define external fastcc  i64 @"alias_fork2.simpleMerge<0>"(i64  %"tl##0")    {
 entry:
   %50 = trunc i64 24 to i32  
   %51 = tail call ccc  i8*  @wybe_malloc(i32  %50)  
   %52 = ptrtoint i8* %51 to i64 
   %53 = inttoptr i64 %52 to i64* 
   %54 = getelementptr  i64, i64* %53, i64 0 
-  store  i64 %"tl#0", i64* %54 
+  store  i64 %"tl##0", i64* %54 
   %55 = add   i64 %52, 8 
   %56 = inttoptr i64 %55 to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
@@ -255,32 +255,32 @@ entry:
 
 printTree > public {inline} (0 calls)
 0: mytree.printTree<0>
-printTree(t#0:mytree.tree, io#0:wybe.phantom, ?io#2:wybe.phantom):
+printTree(t##0:mytree.tree, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    mytree.printTree1<0>(~t#0:mytree.tree, "{":wybe.string, ?%prefix#1:wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @mytree:nn:nn
-    foreign c print_string("}":wybe.string, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
+    mytree.printTree1<0>(~t##0:mytree.tree, "{":wybe.string, ?%prefix##1:wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @mytree:nn:nn
+    foreign c print_string("}":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
 
 printTree1 > public (3 calls)
 0: mytree.printTree1<0>
-printTree1(t#0:mytree.tree, prefix#0:wybe.string, ?prefix#3:wybe.string, io#0:wybe.phantom, ?io#4:wybe.phantom):
- AliasPairs: [(prefix#0,prefix#3)]
+printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string, io##0:wybe.phantom, ?io##4:wybe.phantom):
+ AliasPairs: [(prefix##0,prefix##3)]
  InterestingCallProperties: []
-    foreign llvm icmp_ne(t#0:wybe.int, 0:wybe.int, ?tmp$2#0:wybe.bool)
-    case ~tmp$2#0:wybe.bool of
+    foreign llvm icmp_ne(t##0:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.bool)
+    case ~tmp$2##0:wybe.bool of
     0:
-        foreign llvm move(~prefix#0:wybe.string, ?prefix#3:wybe.string)
-        foreign llvm move(~io#0:wybe.phantom, ?io#4:wybe.phantom)
+        foreign llvm move(~prefix##0:wybe.string, ?prefix##3:wybe.string)
+        foreign llvm move(~io##0:wybe.phantom, ?io##4:wybe.phantom)
 
     1:
-        foreign lpvm access(t#0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?l#0:mytree.tree)
-        foreign lpvm access(t#0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k#0:wybe.int)
-        foreign lpvm access(~t#0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?r#0:mytree.tree)
-        mytree.printTree1<0>(~l#0:mytree.tree, ~%prefix#0:wybe.string, ?%prefix#1:wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #1 @mytree:nn:nn
-        foreign c print_string(~prefix#1:wybe.string, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-        foreign c print_int(~k#0:wybe.int, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-        mytree.printTree1<0>(~r#0:mytree.tree, ", ":wybe.string, ?%prefix#3:wybe.string, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #4 @mytree:nn:nn
+        foreign lpvm access(t##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?l##0:mytree.tree)
+        foreign lpvm access(t##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k##0:wybe.int)
+        foreign lpvm access(~t##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?r##0:mytree.tree)
+        mytree.printTree1<0>(~l##0:mytree.tree, ~%prefix##0:wybe.string, ?%prefix##1:wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @mytree:nn:nn
+        foreign c print_string(~prefix##1:wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+        foreign c print_int(~k##0:wybe.int, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+        mytree.printTree1<0>(~r##0:mytree.tree, ", ":wybe.string, ?%prefix##3:wybe.string, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @mytree:nn:nn
 
 
   LLVM code       :
@@ -312,40 +312,40 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"mytree.printTree<0>"(i64  %"t#0")    {
+define external fastcc  void @"mytree.printTree<0>"(i64  %"t##0")    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @mytree.1, i32 0, i32 0) to i64 
-  %"1$prefix#1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t#0", i64  %2)  
+  %"1$prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t##0", i64  %2)  
   %4 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @mytree.3, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %4)  
   ret void 
 }
 
 
-define external fastcc  i64 @"mytree.printTree1<0>"(i64  %"t#0", i64  %"prefix#0")    {
+define external fastcc  i64 @"mytree.printTree1<0>"(i64  %"t##0", i64  %"prefix##0")    {
 entry:
-  %"1$tmp$2#0" = icmp ne i64 %"t#0", 0 
-  br i1 %"1$tmp$2#0", label %if.then, label %if.else 
+  %"1$tmp$2##0" = icmp ne i64 %"t##0", 0 
+  br i1 %"1$tmp$2##0", label %if.then, label %if.else 
 if.then:
-  %5 = inttoptr i64 %"t#0" to i64* 
+  %5 = inttoptr i64 %"t##0" to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = add   i64 %"t#0", 8 
+  %8 = add   i64 %"t##0", 8 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
-  %12 = add   i64 %"t#0", 16 
+  %12 = add   i64 %"t##0", 16 
   %13 = inttoptr i64 %12 to i64* 
   %14 = getelementptr  i64, i64* %13, i64 0 
   %15 = load  i64, i64* %14 
-  %"2$prefix#1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %7, i64  %"prefix#0")  
-  tail call ccc  void  @print_string(i64  %"2$prefix#1")  
+  %"2$prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %7, i64  %"prefix##0")  
+  tail call ccc  void  @print_string(i64  %"2$prefix##1")  
   tail call ccc  void  @print_int(i64  %11)  
   %17 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @mytree.16, i32 0, i32 0) to i64 
-  %"2$prefix#3" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %15, i64  %17)  
-  ret i64 %"2$prefix#3" 
+  %"2$prefix##3" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %15, i64  %17)  
+  ret i64 %"2$prefix##3" 
 if.else:
-  ret i64 %"prefix#0" 
+  ret i64 %"prefix##0" 
 }
 --------------------------------------------------
  Module mytree.tree
@@ -370,40 +370,40 @@ if.else:
 
 = > public (7 calls)
 0: mytree.tree.=<0>
-=($left#0:mytree.tree, $right#0:mytree.tree, ?$$#0:wybe.bool):
+=($left##0:mytree.tree, $right##0:mytree.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left#0:mytree.tree, ~$right#0:mytree.tree, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~$left##0:mytree.tree, ~$right##0:mytree.tree, ?$$##0:wybe.bool)
 
     1:
-        foreign lpvm access($left#0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$left#0:mytree.tree)
-        foreign lpvm access($left#0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$key#0:wybe.int)
-        foreign lpvm access(~$left#0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$right#0:mytree.tree)
-        foreign llvm icmp_ne($right#0:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.bool)
-        case ~tmp$10#0:wybe.bool of
+        foreign lpvm access($left##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$left##0:mytree.tree)
+        foreign lpvm access($left##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$key##0:wybe.int)
+        foreign lpvm access(~$left##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$right##0:mytree.tree)
+        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.bool)
+        case ~tmp$10##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign lpvm access($right#0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$left#0:mytree.tree)
-            foreign lpvm access($right#0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$key#0:wybe.int)
-            foreign lpvm access(~$right#0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$right#0:mytree.tree)
-            mytree.tree.=<0>(~$left$left#0:mytree.tree, ~$right$left#0:mytree.tree, ?tmp$4#0:wybe.bool) #2
-            case ~tmp$4#0:wybe.bool of
+            foreign lpvm access($right##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$left##0:mytree.tree)
+            foreign lpvm access($right##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$key##0:wybe.int)
+            foreign lpvm access(~$right##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$right##0:mytree.tree)
+            mytree.tree.=<0>(~$left$left##0:mytree.tree, ~$right$left##0:mytree.tree, ?tmp$4##0:wybe.bool) #2
+            case ~tmp$4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                foreign llvm icmp_eq(~$left$key#0:wybe.int, ~$right$key#0:wybe.int, ?tmp$5#0:wybe.bool) @int:nn:nn
-                case ~tmp$5#0:wybe.bool of
+                foreign llvm icmp_eq(~$left$key##0:wybe.int, ~$right$key##0:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
+                case ~tmp$5##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                 1:
-                    mytree.tree.=<0>(~$left$right#0:mytree.tree, ~$right$right#0:mytree.tree, ?$$#0:wybe.bool) #4
+                    mytree.tree.=<0>(~$left$right##0:mytree.tree, ~$right$right##0:mytree.tree, ?$$##0:wybe.bool) #4
 
 
 
@@ -412,145 +412,145 @@ if.else:
 
 empty > public {inline} (0 calls)
 0: mytree.tree.empty<0>
-empty(?$#0:mytree.tree):
+empty(?$##0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:mytree.tree, ?$#0:mytree.tree)
+    foreign llvm move(0:mytree.tree, ?$##0:mytree.tree)
 
 
 key > public {inline} (0 calls)
 0: mytree.tree.key<0>
-key($rec#0:mytree.tree, ?$#0:wybe.int, ?$$#0:wybe.bool):
+key($rec##0:mytree.tree, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec#0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 key > public {inline} (0 calls)
 1: mytree.tree.key<1>
-key($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:wybe.int, ?$$#0:wybe.bool):
+key($rec##0:mytree.tree, ?$rec##1:mytree.tree, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:mytree.tree, ?$rec#1:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:mytree.tree, ?$rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~$rec#0:mytree.tree, ?$rec#1:mytree.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~$rec##0:mytree.tree, ?$rec##1:mytree.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 left > public {inline} (0 calls)
 0: mytree.tree.left<0>
-left($rec#0:mytree.tree, ?$#0:mytree.tree, ?$$#0:wybe.bool):
+left($rec##0:mytree.tree, ?$##0:mytree.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:mytree.tree, ?$#0:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:mytree.tree, ?$##0:mytree.tree)
 
     1:
-        foreign lpvm access(~$rec#0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 left > public {inline} (0 calls)
 1: mytree.tree.left<1>
-left($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:mytree.tree, ?$$#0:wybe.bool):
+left($rec##0:mytree.tree, ?$rec##1:mytree.tree, $field##0:mytree.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:mytree.tree, ?$rec#1:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:mytree.tree, ?$rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~$rec#0:mytree.tree, ?$rec#1:mytree.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field#0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~$rec##0:mytree.tree, ?$rec##1:mytree.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 node > public {inline} (0 calls)
 0: mytree.tree.node<0>
-node(left#0:mytree.tree, key#0:wybe.int, right#0:mytree.tree, ?$#0:mytree.tree):
+node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?$##0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?$rec#0:mytree.tree)
-    foreign lpvm mutate(~$rec#0:mytree.tree, ?$rec#1:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left#0:mytree.tree)
-    foreign lpvm mutate(~$rec#1:mytree.tree, ?$rec#2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key#0:wybe.int)
-    foreign lpvm mutate(~$rec#2:mytree.tree, ?$#0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right#0:mytree.tree)
+    foreign lpvm alloc(24:wybe.int, ?$rec##0:mytree.tree)
+    foreign lpvm mutate(~$rec##0:mytree.tree, ?$rec##1:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:mytree.tree)
+    foreign lpvm mutate(~$rec##1:mytree.tree, ?$rec##2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int)
+    foreign lpvm mutate(~$rec##2:mytree.tree, ?$##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree)
 node > public {inline} (16 calls)
 1: mytree.tree.node<1>
-node(?left#0:mytree.tree, ?key#0:wybe.int, ?right#0:mytree.tree, $#0:mytree.tree, ?$$#0:wybe.bool):
+node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, $##0:mytree.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:mytree.tree, ?left#0:mytree.tree)
-        foreign llvm move(undef:wybe.int, ?key#0:wybe.int)
-        foreign llvm move(undef:mytree.tree, ?right#0:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:mytree.tree, ?left##0:mytree.tree)
+        foreign llvm move(undef:wybe.int, ?key##0:wybe.int)
+        foreign llvm move(undef:mytree.tree, ?right##0:mytree.tree)
 
     1:
-        foreign lpvm access($#0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left#0:mytree.tree)
-        foreign lpvm access($#0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key#0:wybe.int)
-        foreign lpvm access(~$#0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right#0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access($##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:mytree.tree)
+        foreign lpvm access($##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
+        foreign lpvm access(~$##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 right > public {inline} (0 calls)
 0: mytree.tree.right<0>
-right($rec#0:mytree.tree, ?$#0:mytree.tree, ?$$#0:wybe.bool):
+right($rec##0:mytree.tree, ?$##0:mytree.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:mytree.tree, ?$#0:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:mytree.tree, ?$##0:mytree.tree)
 
     1:
-        foreign lpvm access(~$rec#0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 right > public {inline} (0 calls)
 1: mytree.tree.right<1>
-right($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:mytree.tree, ?$$#0:wybe.bool):
+right($rec##0:mytree.tree, ?$rec##1:mytree.tree, $field##0:mytree.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:mytree.tree, ?$rec#1:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:mytree.tree, ?$rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~$rec#0:mytree.tree, ?$rec#1:mytree.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field#0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~$rec##0:mytree.tree, ?$rec##1:mytree.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: mytree.tree.~=<0>
-~=($left#0:mytree.tree, $right#0:mytree.tree, ?$$#0:wybe.bool):
+~=($left##0:mytree.tree, $right##0:mytree.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    mytree.tree.=<0>(~$left#0:mytree.tree, ~$right#0:mytree.tree, ?tmp$0#0:wybe.bool) #0
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    mytree.tree.=<0>(~$left##0:mytree.tree, ~$right##0:mytree.tree, ?tmp$0##0:wybe.bool) #0
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
   LLVM code       :
 
@@ -566,51 +566,51 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"mytree.tree.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"mytree.tree.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$left#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = add   i64 %"$left#0", 16 
+  %8 = add   i64 %"$left##0", 16 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
-  %"2$tmp$10#0" = icmp ne i64 %"$right#0", 0 
-  br i1 %"2$tmp$10#0", label %if.then1, label %if.else1 
+  %"2$tmp$10##0" = icmp ne i64 %"$right##0", 0 
+  br i1 %"2$tmp$10##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = icmp eq i64 %"$left#0", %"$right#0" 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
+  ret i1 %"3$$$##0" 
 if.then1:
-  %12 = inttoptr i64 %"$right#0" to i64* 
+  %12 = inttoptr i64 %"$right##0" to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %15 = add   i64 %"$right#0", 8 
+  %15 = add   i64 %"$right##0", 8 
   %16 = inttoptr i64 %15 to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
-  %19 = add   i64 %"$right#0", 16 
+  %19 = add   i64 %"$right##0", 16 
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %"4$tmp$4#0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %3, i64  %14)  
-  br i1 %"4$tmp$4#0", label %if.then2, label %if.else2 
+  %"4$tmp$4##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %3, i64  %14)  
+  br i1 %"4$tmp$4##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$tmp$5#0" = icmp eq i64 %7, %18 
-  br i1 %"6$tmp$5#0", label %if.then3, label %if.else3 
+  %"6$tmp$5##0" = icmp eq i64 %7, %18 
+  br i1 %"6$tmp$5##0", label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %"8$$$#0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %11, i64  %22)  
-  ret i1 %"8$$$#0" 
+  %"8$$$##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %11, i64  %22)  
+  ret i1 %"8$$$##0" 
 if.else3:
   ret i1 0 
 }
@@ -622,12 +622,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.key<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"mytree.tree.key<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %23 = add   i64 %"$rec#0", 8 
+  %23 = add   i64 %"$rec##0", 8 
   %24 = inttoptr i64 %23 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
   %26 = load  i64, i64* %25 
@@ -641,38 +641,38 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.key<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"mytree.tree.key<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %31 = trunc i64 24 to i32  
   %32 = tail call ccc  i8*  @wybe_malloc(i32  %31)  
   %33 = ptrtoint i8* %32 to i64 
   %34 = inttoptr i64 %33 to i8* 
-  %35 = inttoptr i64 %"$rec#0" to i8* 
+  %35 = inttoptr i64 %"$rec##0" to i8* 
   %36 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %34, i8*  %35, i32  %36, i32  8, i1  0)  
   %37 = add   i64 %33, 8 
   %38 = inttoptr i64 %37 to i64* 
   %39 = getelementptr  i64, i64* %38, i64 0 
-  store  i64 %"$field#0", i64* %39 
+  store  i64 %"$field##0", i64* %39 
   %40 = insertvalue {i64, i1} undef, i64 %33, 0 
   %41 = insertvalue {i64, i1} %40, i1 1, 1 
   ret {i64, i1} %41 
 if.else:
-  %42 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %42 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %43 = insertvalue {i64, i1} %42, i1 0, 1 
   ret {i64, i1} %43 
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.left<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"mytree.tree.left<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %44 = inttoptr i64 %"$rec#0" to i64* 
+  %44 = inttoptr i64 %"$rec##0" to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
   %47 = insertvalue {i64, i1} undef, i64 %46, 0 
@@ -685,64 +685,64 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.left<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"mytree.tree.left<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %51 = trunc i64 24 to i32  
   %52 = tail call ccc  i8*  @wybe_malloc(i32  %51)  
   %53 = ptrtoint i8* %52 to i64 
   %54 = inttoptr i64 %53 to i8* 
-  %55 = inttoptr i64 %"$rec#0" to i8* 
+  %55 = inttoptr i64 %"$rec##0" to i8* 
   %56 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %54, i8*  %55, i32  %56, i32  8, i1  0)  
   %57 = inttoptr i64 %53 to i64* 
   %58 = getelementptr  i64, i64* %57, i64 0 
-  store  i64 %"$field#0", i64* %58 
+  store  i64 %"$field##0", i64* %58 
   %59 = insertvalue {i64, i1} undef, i64 %53, 0 
   %60 = insertvalue {i64, i1} %59, i1 1, 1 
   ret {i64, i1} %60 
 if.else:
-  %61 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %61 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %62 = insertvalue {i64, i1} %61, i1 0, 1 
   ret {i64, i1} %62 
 }
 
 
-define external fastcc  i64 @"mytree.tree.node<0>"(i64  %"left#0", i64  %"key#0", i64  %"right#0")    {
+define external fastcc  i64 @"mytree.tree.node<0>"(i64  %"left##0", i64  %"key##0", i64  %"right##0")    {
 entry:
   %63 = trunc i64 24 to i32  
   %64 = tail call ccc  i8*  @wybe_malloc(i32  %63)  
   %65 = ptrtoint i8* %64 to i64 
   %66 = inttoptr i64 %65 to i64* 
   %67 = getelementptr  i64, i64* %66, i64 0 
-  store  i64 %"left#0", i64* %67 
+  store  i64 %"left##0", i64* %67 
   %68 = add   i64 %65, 8 
   %69 = inttoptr i64 %68 to i64* 
   %70 = getelementptr  i64, i64* %69, i64 0 
-  store  i64 %"key#0", i64* %70 
+  store  i64 %"key##0", i64* %70 
   %71 = add   i64 %65, 16 
   %72 = inttoptr i64 %71 to i64* 
   %73 = getelementptr  i64, i64* %72, i64 0 
-  store  i64 %"right#0", i64* %73 
+  store  i64 %"right##0", i64* %73 
   ret i64 %65 
 }
 
 
-define external fastcc  {i64, i64, i64, i1} @"mytree.tree.node<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64, i64, i1} @"mytree.tree.node<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %74 = inttoptr i64 %"$#0" to i64* 
+  %74 = inttoptr i64 %"$##0" to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
   %76 = load  i64, i64* %75 
-  %77 = add   i64 %"$#0", 8 
+  %77 = add   i64 %"$##0", 8 
   %78 = inttoptr i64 %77 to i64* 
   %79 = getelementptr  i64, i64* %78, i64 0 
   %80 = load  i64, i64* %79 
-  %81 = add   i64 %"$#0", 16 
+  %81 = add   i64 %"$##0", 16 
   %82 = inttoptr i64 %81 to i64* 
   %83 = getelementptr  i64, i64* %82, i64 0 
   %84 = load  i64, i64* %83 
@@ -760,12 +760,12 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.right<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"mytree.tree.right<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %93 = add   i64 %"$rec#0", 16 
+  %93 = add   i64 %"$rec##0", 16 
   %94 = inttoptr i64 %93 to i64* 
   %95 = getelementptr  i64, i64* %94, i64 0 
   %96 = load  i64, i64* %95 
@@ -779,35 +779,35 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.right<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"mytree.tree.right<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %101 = trunc i64 24 to i32  
   %102 = tail call ccc  i8*  @wybe_malloc(i32  %101)  
   %103 = ptrtoint i8* %102 to i64 
   %104 = inttoptr i64 %103 to i8* 
-  %105 = inttoptr i64 %"$rec#0" to i8* 
+  %105 = inttoptr i64 %"$rec##0" to i8* 
   %106 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %104, i8*  %105, i32  %106, i32  8, i1  0)  
   %107 = add   i64 %103, 16 
   %108 = inttoptr i64 %107 to i64* 
   %109 = getelementptr  i64, i64* %108, i64 0 
-  store  i64 %"$field#0", i64* %109 
+  store  i64 %"$field##0", i64* %109 
   %110 = insertvalue {i64, i1} undef, i64 %103, 0 
   %111 = insertvalue {i64, i1} %110, i1 1, 1 
   ret {i64, i1} %111 
 if.else:
-  %112 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %112 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %113 = insertvalue {i64, i1} %112, i1 0, 1 
   ret {i64, i1} %113 
 }
 
 
-define external fastcc  i1 @"mytree.tree.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"mytree.tree.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %"$left#0", i64  %"$right#0")  
-  %"1$$$#0" = xor i1 %"1$tmp$0#0", 1 
-  ret i1 %"1$$$#0" 
+  %"1$tmp$0##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %"$left##0", i64  %"$right##0")  
+  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
+  ret i1 %"1$$$##0" 
 }

--- a/test-cases/final-dump/alias_fork2.exp
+++ b/test-cases/final-dump/alias_fork2.exp
@@ -63,13 +63,13 @@ gen#1(io##0:wybe.phantom, t##0:mytree.tree, t1##0:mytree.tree, [tmp#0##0:mytree.
 
 simpleMerge > public (3 calls)
 0: alias_fork2.simpleMerge<0>
-simpleMerge(tl##0:mytree.tree, ?###0:mytree.tree):
- AliasPairs: [(###0,tl##0)]
+simpleMerge(tl##0:mytree.tree, ?#result##0:mytree.tree):
+ AliasPairs: [(#result##0,tl##0)]
  InterestingCallProperties: []
     foreign lpvm alloc(24:wybe.int, ?tmp#5##0:mytree.tree)
     foreign lpvm mutate(~tmp#5##0:mytree.tree, ?tmp#6##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tl##0:mytree.tree)
     foreign lpvm mutate(~tmp#6##0:mytree.tree, ?tmp#7##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 200:wybe.int)
-    foreign lpvm mutate(~tmp#7##0:mytree.tree, ?###0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+    foreign lpvm mutate(~tmp#7##0:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
 
   LLVM code       :
 
@@ -412,25 +412,25 @@ if.else:
 
 empty > public {inline} (0 calls)
 0: mytree.tree.empty<0>
-empty(?###0:mytree.tree):
+empty(?#result##0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:mytree.tree, ?###0:mytree.tree)
+    foreign llvm move(0:mytree.tree, ?#result##0:mytree.tree)
 
 
 key > public {inline} (0 calls)
 0: mytree.tree.key<0>
-key(#rec##0:mytree.tree, ?###0:wybe.int, ?####0:wybe.bool):
+key(#rec##0:mytree.tree, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign lpvm access(~#rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 key > public {inline} (0 calls)
@@ -452,17 +452,17 @@ key(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:wybe.int, ?####0:wybe.b
 
 left > public {inline} (0 calls)
 0: mytree.tree.left<0>
-left(#rec##0:mytree.tree, ?###0:mytree.tree, ?####0:wybe.bool):
+left(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:mytree.tree, ?###0:mytree.tree)
+        foreign llvm move(undef:mytree.tree, ?#result##0:mytree.tree)
 
     1:
-        foreign lpvm access(~#rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:mytree.tree)
+        foreign lpvm access(~#rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 left > public {inline} (0 calls)
@@ -484,19 +484,19 @@ left(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?####0:wy
 
 node > public {inline} (0 calls)
 0: mytree.tree.node<0>
-node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?###0:mytree.tree):
+node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?#result##0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(24:wybe.int, ?#rec##0:mytree.tree)
     foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:mytree.tree)
     foreign lpvm mutate(~#rec##1:mytree.tree, ?#rec##2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int)
-    foreign lpvm mutate(~#rec##2:mytree.tree, ?###0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree)
+    foreign lpvm mutate(~#rec##2:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree)
 node > public {inline} (16 calls)
 1: mytree.tree.node<1>
-node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, ###0:mytree.tree, ?####0:wybe.bool):
+node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, #result##0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
@@ -505,26 +505,26 @@ node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, ###0:mytree.
         foreign llvm move(undef:mytree.tree, ?right##0:mytree.tree)
 
     1:
-        foreign lpvm access(###0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:mytree.tree)
-        foreign lpvm access(###0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
-        foreign lpvm access(~###0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:mytree.tree)
+        foreign lpvm access(#result##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:mytree.tree)
+        foreign lpvm access(#result##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
+        foreign lpvm access(~#result##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:mytree.tree)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 right > public {inline} (0 calls)
 0: mytree.tree.right<0>
-right(#rec##0:mytree.tree, ?###0:mytree.tree, ?####0:wybe.bool):
+right(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:mytree.tree, ?###0:mytree.tree)
+        foreign llvm move(undef:mytree.tree, ?#result##0:mytree.tree)
 
     1:
-        foreign lpvm access(~#rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:mytree.tree)
+        foreign lpvm access(~#rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 right > public {inline} (0 calls)
@@ -730,19 +730,19 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64, i1} @"mytree.tree.node<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64, i64, i1} @"mytree.tree.node<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  %"1#tmp#0##0" = icmp ne i64 %"#result##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %74 = inttoptr i64 %"###0" to i64* 
+  %74 = inttoptr i64 %"#result##0" to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
   %76 = load  i64, i64* %75 
-  %77 = add   i64 %"###0", 8 
+  %77 = add   i64 %"#result##0", 8 
   %78 = inttoptr i64 %77 to i64* 
   %79 = getelementptr  i64, i64* %78, i64 0 
   %80 = load  i64, i64* %79 
-  %81 = add   i64 %"###0", 16 
+  %81 = add   i64 %"#result##0", 16 
   %82 = inttoptr i64 %81 to i64* 
   %83 = getelementptr  i64, i64* %82, i64 0 
   %84 = load  i64, i64* %83 

--- a/test-cases/final-dump/alias_fork2.exp
+++ b/test-cases/final-dump/alias_fork2.exp
@@ -370,13 +370,13 @@ if.else:
 
 = > public (7 calls)
 0: mytree.tree.=<0>
-=(#left##0:mytree.tree, #right##0:mytree.tree, ?####0:wybe.bool):
+=(#left##0:mytree.tree, #right##0:mytree.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~#left##0:mytree.tree, ~#right##0:mytree.tree, ?####0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:mytree.tree, ~#right##0:mytree.tree, ?#success##0:wybe.bool)
 
     1:
         foreign lpvm access(#left##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#left##0:mytree.tree)
@@ -385,7 +385,7 @@ if.else:
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
         case ~tmp#10##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign lpvm access(#right##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#left##0:mytree.tree)
@@ -394,16 +394,16 @@ if.else:
             mytree.tree.=<0>(~#left#left##0:mytree.tree, ~#right#left##0:mytree.tree, ?tmp#4##0:wybe.bool) #2
             case ~tmp#4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
                 foreign llvm icmp_eq(~#left#key##0:wybe.int, ~#right#key##0:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
                 case ~tmp#5##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                 1:
-                    mytree.tree.=<0>(~#left#right##0:mytree.tree, ~#right#right##0:mytree.tree, ?####0:wybe.bool) #4
+                    mytree.tree.=<0>(~#left#right##0:mytree.tree, ~#right#right##0:mytree.tree, ?#success##0:wybe.bool) #4
 
 
 
@@ -420,65 +420,65 @@ empty(?#result##0:mytree.tree):
 
 key > public {inline} (0 calls)
 0: mytree.tree.key<0>
-key(#rec##0:mytree.tree, ?#result##0:wybe.int, ?####0:wybe.bool):
+key(#rec##0:mytree.tree, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign lpvm access(~#rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 key > public {inline} (0 calls)
 1: mytree.tree.key<1>
-key(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:wybe.int, ?####0:wybe.bool):
+key(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
         foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 left > public {inline} (0 calls)
 0: mytree.tree.left<0>
-left(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?####0:wybe.bool):
+left(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:mytree.tree, ?#result##0:mytree.tree)
 
     1:
         foreign lpvm access(~#rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 left > public {inline} (0 calls)
 1: mytree.tree.left<1>
-left(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?####0:wybe.bool):
+left(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
         foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -493,13 +493,13 @@ node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?#result##0:myt
     foreign lpvm mutate(~#rec##2:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree)
 node > public {inline} (16 calls)
 1: mytree.tree.node<1>
-node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, #result##0:mytree.tree, ?####0:wybe.bool):
+node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, #result##0:mytree.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:mytree.tree, ?left##0:mytree.tree)
         foreign llvm move(undef:wybe.int, ?key##0:wybe.int)
         foreign llvm move(undef:mytree.tree, ?right##0:mytree.tree)
@@ -508,49 +508,49 @@ node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, #result##0:m
         foreign lpvm access(#result##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:mytree.tree)
         foreign lpvm access(#result##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
         foreign lpvm access(~#result##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 right > public {inline} (0 calls)
 0: mytree.tree.right<0>
-right(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?####0:wybe.bool):
+right(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:mytree.tree, ?#result##0:mytree.tree)
 
     1:
         foreign lpvm access(~#rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 right > public {inline} (0 calls)
 1: mytree.tree.right<1>
-right(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?####0:wybe.bool):
+right(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
         foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: mytree.tree.~=<0>
-~=(#left##0:mytree.tree, #right##0:mytree.tree, ?####0:wybe.bool):
+~=(#left##0:mytree.tree, #right##0:mytree.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     mytree.tree.=<0>(~#left##0:mytree.tree, ~#right##0:mytree.tree, ?tmp#0##0:wybe.bool) #0
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 
@@ -585,8 +585,8 @@ if.then:
   %"2#tmp#10##0" = icmp ne i64 %"#right##0", 0 
   br i1 %"2#tmp#10##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %"3#####0" 
+  %"3##success##0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3##success##0" 
 if.then1:
   %12 = inttoptr i64 %"#right##0" to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
@@ -609,8 +609,8 @@ if.then2:
 if.else2:
   ret i1 0 
 if.then3:
-  %"8#####0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %11, i64  %22)  
-  ret i1 %"8#####0" 
+  %"8##success##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %11, i64  %22)  
+  ret i1 %"8##success##0" 
 if.else3:
   ret i1 0 
 }
@@ -808,6 +808,6 @@ if.else:
 define external fastcc  i1 @"mytree.tree.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %"1#tmp#0##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %"#left##0", i64  %"#right##0")  
-  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
-  ret i1 %"1#####0" 
+  %"1##success##0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1##success##0" 
 }

--- a/test-cases/final-dump/alias_fork2.exp
+++ b/test-cases/final-dump/alias_fork2.exp
@@ -16,60 +16,60 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp$9##0:mytree.tree)
-    foreign lpvm mutate(~tmp$9##0:mytree.tree, ?tmp$10##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-    foreign lpvm mutate(~tmp$10##0:mytree.tree, ?tmp$11##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp$11##0:mytree.tree, ?tmp$0##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-    alias_fork2.simpleMerge<0>(tmp$0##0:mytree.tree, ?tmp$3##0:mytree.tree) #3 @alias_fork2:11:6
-    foreign c print_string("expect t -  1 200:":wybe.string, ~#io##0:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    mytree.printTree1<0>(tmp$3##0:mytree.tree, "{":wybe.string, ?tmp$17##0:wybe.string, ~#io##1:wybe.phantom, ?tmp$18##0:wybe.phantom) #11 @mytree:nn:nn
-    foreign c print_string("}":wybe.string, ~tmp$18##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    foreign c print_string("":wybe.string, ~#io##2:wybe.phantom, ?tmp$21##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$21##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign llvm icmp_ne(tmp$0##0:wybe.int, 0:wybe.int, ?tmp$23##0:wybe.bool)
-    case ~tmp$23##0:wybe.bool of
+    foreign lpvm alloc(24:wybe.int, ?tmp#9##0:mytree.tree)
+    foreign lpvm mutate(~tmp#9##0:mytree.tree, ?tmp#10##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+    foreign lpvm mutate(~tmp#10##0:mytree.tree, ?tmp#11##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp#11##0:mytree.tree, ?tmp#0##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+    alias_fork2.simpleMerge<0>(tmp#0##0:mytree.tree, ?tmp#3##0:mytree.tree) #3 @alias_fork2:11:6
+    foreign c print_string("expect t -  1 200:":wybe.string, ~#io##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    mytree.printTree1<0>(tmp#3##0:mytree.tree, "{":wybe.string, ?tmp#17##0:wybe.string, ~#io##1:wybe.phantom, ?tmp#18##0:wybe.phantom) #11 @mytree:nn:nn
+    foreign c print_string("}":wybe.string, ~tmp#18##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string("":wybe.string, ~#io##2:wybe.phantom, ?tmp#21##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign llvm icmp_ne(tmp#0##0:wybe.int, 0:wybe.int, ?tmp#23##0:wybe.bool)
+    case ~tmp#23##0:wybe.bool of
     0:
-        alias_fork2.gen$1<0>(~io##3:wybe.phantom, ~tmp$3##0:mytree.tree, ~tmp$0##0:mytree.tree, _:mytree.tree, _:mytree.tree, _:mytree.tree, _:mytree.tree, ?io##4:wybe.phantom) #10
+        alias_fork2.gen#1<0>(~io##3:wybe.phantom, ~tmp#3##0:mytree.tree, ~tmp#0##0:mytree.tree, _:mytree.tree, _:mytree.tree, _:mytree.tree, _:mytree.tree, ?io##4:wybe.phantom) #10
 
     1:
-        foreign lpvm access(~tmp$0##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?l##0:mytree.tree)
-        foreign lpvm alloc(24:wybe.int, ?tmp$27##0:mytree.tree)
-        foreign lpvm mutate(~tmp$27##0:mytree.tree, ?tmp$28##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~l##0:mytree.tree)
-        foreign lpvm mutate(~tmp$28##0:mytree.tree, ?tmp$29##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1000:wybe.int)
-        foreign lpvm mutate(~tmp$29##0:mytree.tree, ?tmp$4##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-        alias_fork2.gen$1<0>(~io##3:wybe.phantom, ~tmp$3##0:mytree.tree, ~tmp$4##0:mytree.tree, _:mytree.tree, _:mytree.tree, _:mytree.tree, _:mytree.tree, ?io##4:wybe.phantom) #9
+        foreign lpvm access(~tmp#0##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?l##0:mytree.tree)
+        foreign lpvm alloc(24:wybe.int, ?tmp#27##0:mytree.tree)
+        foreign lpvm mutate(~tmp#27##0:mytree.tree, ?tmp#28##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~l##0:mytree.tree)
+        foreign lpvm mutate(~tmp#28##0:mytree.tree, ?tmp#29##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1000:wybe.int)
+        foreign lpvm mutate(~tmp#29##0:mytree.tree, ?tmp#4##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+        alias_fork2.gen#1<0>(~io##3:wybe.phantom, ~tmp#3##0:mytree.tree, ~tmp#4##0:mytree.tree, _:mytree.tree, _:mytree.tree, _:mytree.tree, _:mytree.tree, ?io##4:wybe.phantom) #9
 
 
 
-gen$1 > (2 calls)
-0: alias_fork2.gen$1<0>
-gen$1(io##0:wybe.phantom, t##0:mytree.tree, t1##0:mytree.tree, [tmp$0##0:mytree.tree], [tmp$1##0:mytree.tree], [tmp$2##0:mytree.tree], [tmp$3##0:mytree.tree], ?io##6:wybe.phantom):
+gen#1 > (2 calls)
+0: alias_fork2.gen#1<0>
+gen#1(io##0:wybe.phantom, t##0:mytree.tree, t1##0:mytree.tree, [tmp#0##0:mytree.tree], [tmp#1##0:mytree.tree], [tmp#2##0:mytree.tree], [tmp#3##0:mytree.tree], ?io##6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("expect t1 - 1000:":wybe.string, ~#io##0:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    mytree.printTree1<0>(~t1##0:mytree.tree, "{":wybe.string, ?tmp$10##0:wybe.string, ~#io##1:wybe.phantom, ?tmp$11##0:wybe.phantom) #6 @mytree:nn:nn
-    foreign c print_string("}":wybe.string, ~tmp$11##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    foreign c print_string("":wybe.string, ~#io##2:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect t1 - 1 200:":wybe.string, ~#io##3:wybe.phantom, ?tmp$17##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$17##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    mytree.printTree1<0>(~t##0:mytree.tree, "{":wybe.string, ?tmp$20##0:wybe.string, ~#io##4:wybe.phantom, ?tmp$21##0:wybe.phantom) #7 @mytree:nn:nn
-    foreign c print_string("}":wybe.string, ~tmp$21##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
-    foreign c print_string("":wybe.string, ~#io##5:wybe.phantom, ?tmp$24##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$24##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect t1 - 1000:":wybe.string, ~#io##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    mytree.printTree1<0>(~t1##0:mytree.tree, "{":wybe.string, ?tmp#10##0:wybe.string, ~#io##1:wybe.phantom, ?tmp#11##0:wybe.phantom) #6 @mytree:nn:nn
+    foreign c print_string("}":wybe.string, ~tmp#11##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string("":wybe.string, ~#io##2:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect t1 - 1 200:":wybe.string, ~#io##3:wybe.phantom, ?tmp#17##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#17##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    mytree.printTree1<0>(~t##0:mytree.tree, "{":wybe.string, ?tmp#20##0:wybe.string, ~#io##4:wybe.phantom, ?tmp#21##0:wybe.phantom) #7 @mytree:nn:nn
+    foreign c print_string("}":wybe.string, ~tmp#21##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign c print_string("":wybe.string, ~#io##5:wybe.phantom, ?tmp#24##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#24##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
 
 
 simpleMerge > public (3 calls)
 0: alias_fork2.simpleMerge<0>
-simpleMerge(tl##0:mytree.tree, ?$##0:mytree.tree):
- AliasPairs: [($##0,tl##0)]
+simpleMerge(tl##0:mytree.tree, ?###0:mytree.tree):
+ AliasPairs: [(###0,tl##0)]
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp$5##0:mytree.tree)
-    foreign lpvm mutate(~tmp$5##0:mytree.tree, ?tmp$6##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tl##0:mytree.tree)
-    foreign lpvm mutate(~tmp$6##0:mytree.tree, ?tmp$7##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 200:wybe.int)
-    foreign lpvm mutate(~tmp$7##0:mytree.tree, ?$##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+    foreign lpvm alloc(24:wybe.int, ?tmp#5##0:mytree.tree)
+    foreign lpvm mutate(~tmp#5##0:mytree.tree, ?tmp#6##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tl##0:mytree.tree)
+    foreign lpvm mutate(~tmp#6##0:mytree.tree, ?tmp#7##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 200:wybe.int)
+    foreign lpvm mutate(~tmp#7##0:mytree.tree, ?###0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
 
   LLVM code       :
 
@@ -146,19 +146,19 @@ entry:
   %10 = inttoptr i64 %9 to i64* 
   %11 = getelementptr  i64, i64* %10, i64 0 
   store  i64 0, i64* %11 
-  %"1$tmp$3##0" = tail call fastcc  i64  @"alias_fork2.simpleMerge<0>"(i64  %3)  
+  %"1#tmp#3##0" = tail call fastcc  i64  @"alias_fork2.simpleMerge<0>"(i64  %3)  
   %13 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_fork2.12, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %13)  
   tail call ccc  void  @putchar(i8  10)  
   %15 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_fork2.14, i32 0, i32 0) to i64 
-  %"1$tmp$17##0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"1$tmp$3##0", i64  %15)  
+  %"1#tmp#17##0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"1#tmp#3##0", i64  %15)  
   %17 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_fork2.16, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %17)  
   %19 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_fork2.18, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %19)  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$tmp$23##0" = icmp ne i64 %3, 0 
-  br i1 %"1$tmp$23##0", label %if.then, label %if.else 
+  %"1#tmp#23##0" = icmp ne i64 %3, 0 
+  br i1 %"1#tmp#23##0", label %if.then, label %if.else 
 if.then:
   %20 = inttoptr i64 %3 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
@@ -177,21 +177,21 @@ if.then:
   %32 = inttoptr i64 %31 to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   store  i64 0, i64* %33 
-  tail call fastcc  void  @"alias_fork2.gen$1<0>"(i64  %"1$tmp$3##0", i64  %25)  
+  tail call fastcc  void  @"alias_fork2.gen#1<0>"(i64  %"1#tmp#3##0", i64  %25)  
   ret void 
 if.else:
-  tail call fastcc  void  @"alias_fork2.gen$1<0>"(i64  %"1$tmp$3##0", i64  %3)  
+  tail call fastcc  void  @"alias_fork2.gen#1<0>"(i64  %"1#tmp#3##0", i64  %3)  
   ret void 
 }
 
 
-define external fastcc  void @"alias_fork2.gen$1<0>"(i64  %"t##0", i64  %"t1##0")    {
+define external fastcc  void @"alias_fork2.gen#1<0>"(i64  %"t##0", i64  %"t1##0")    {
 entry:
   %35 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_fork2.34, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %35)  
   tail call ccc  void  @putchar(i8  10)  
   %37 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_fork2.36, i32 0, i32 0) to i64 
-  %"1$tmp$10##0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t1##0", i64  %37)  
+  %"1#tmp#10##0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t1##0", i64  %37)  
   %39 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_fork2.38, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %39)  
   %41 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_fork2.40, i32 0, i32 0) to i64 
@@ -201,7 +201,7 @@ entry:
   tail call ccc  void  @print_string(i64  %43)  
   tail call ccc  void  @putchar(i8  10)  
   %45 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_fork2.44, i32 0, i32 0) to i64 
-  %"1$tmp$20##0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t##0", i64  %45)  
+  %"1#tmp#20##0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t##0", i64  %45)  
   %47 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_fork2.46, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %47)  
   %49 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_fork2.48, i32 0, i32 0) to i64 
@@ -267,8 +267,8 @@ printTree1 > public (3 calls)
 printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string, io##0:wybe.phantom, ?io##4:wybe.phantom):
  AliasPairs: [(prefix##0,prefix##3)]
  InterestingCallProperties: []
-    foreign llvm icmp_ne(t##0:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.bool)
-    case ~tmp$2##0:wybe.bool of
+    foreign llvm icmp_ne(t##0:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.bool)
+    case ~tmp#2##0:wybe.bool of
     0:
         foreign llvm move(~prefix##0:wybe.string, ?prefix##3:wybe.string)
         foreign llvm move(~io##0:wybe.phantom, ?io##4:wybe.phantom)
@@ -315,7 +315,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 define external fastcc  void @"mytree.printTree<0>"(i64  %"t##0")    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @mytree.1, i32 0, i32 0) to i64 
-  %"1$prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t##0", i64  %2)  
+  %"1#prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t##0", i64  %2)  
   %4 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @mytree.3, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %4)  
   ret void 
@@ -324,8 +324,8 @@ entry:
 
 define external fastcc  i64 @"mytree.printTree1<0>"(i64  %"t##0", i64  %"prefix##0")    {
 entry:
-  %"1$tmp$2##0" = icmp ne i64 %"t##0", 0 
-  br i1 %"1$tmp$2##0", label %if.then, label %if.else 
+  %"1#tmp#2##0" = icmp ne i64 %"t##0", 0 
+  br i1 %"1#tmp#2##0", label %if.then, label %if.else 
 if.then:
   %5 = inttoptr i64 %"t##0" to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
@@ -338,12 +338,12 @@ if.then:
   %13 = inttoptr i64 %12 to i64* 
   %14 = getelementptr  i64, i64* %13, i64 0 
   %15 = load  i64, i64* %14 
-  %"2$prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %7, i64  %"prefix##0")  
-  tail call ccc  void  @print_string(i64  %"2$prefix##1")  
+  %"2#prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %7, i64  %"prefix##0")  
+  tail call ccc  void  @print_string(i64  %"2#prefix##1")  
   tail call ccc  void  @print_int(i64  %11)  
   %17 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @mytree.16, i32 0, i32 0) to i64 
-  %"2$prefix##3" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %15, i64  %17)  
-  ret i64 %"2$prefix##3" 
+  %"2#prefix##3" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %15, i64  %17)  
+  ret i64 %"2#prefix##3" 
 if.else:
   ret i64 %"prefix##0" 
 }
@@ -370,40 +370,40 @@ if.else:
 
 = > public (7 calls)
 0: mytree.tree.=<0>
-=($left##0:mytree.tree, $right##0:mytree.tree, ?$$##0:wybe.bool):
+=(#left##0:mytree.tree, #right##0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left##0:mytree.tree, ~$right##0:mytree.tree, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:mytree.tree, ~#right##0:mytree.tree, ?####0:wybe.bool)
 
     1:
-        foreign lpvm access($left##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$left##0:mytree.tree)
-        foreign lpvm access($left##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$key##0:wybe.int)
-        foreign lpvm access(~$left##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$right##0:mytree.tree)
-        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.bool)
-        case ~tmp$10##0:wybe.bool of
+        foreign lpvm access(#left##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#left##0:mytree.tree)
+        foreign lpvm access(#left##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#key##0:wybe.int)
+        foreign lpvm access(~#left##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#right##0:mytree.tree)
+        foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
+        case ~tmp#10##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign lpvm access($right##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$left##0:mytree.tree)
-            foreign lpvm access($right##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$key##0:wybe.int)
-            foreign lpvm access(~$right##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$right##0:mytree.tree)
-            mytree.tree.=<0>(~$left$left##0:mytree.tree, ~$right$left##0:mytree.tree, ?tmp$4##0:wybe.bool) #2
-            case ~tmp$4##0:wybe.bool of
+            foreign lpvm access(#right##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#left##0:mytree.tree)
+            foreign lpvm access(#right##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#key##0:wybe.int)
+            foreign lpvm access(~#right##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#right##0:mytree.tree)
+            mytree.tree.=<0>(~#left#left##0:mytree.tree, ~#right#left##0:mytree.tree, ?tmp#4##0:wybe.bool) #2
+            case ~tmp#4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
             1:
-                foreign llvm icmp_eq(~$left$key##0:wybe.int, ~$right$key##0:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
-                case ~tmp$5##0:wybe.bool of
+                foreign llvm icmp_eq(~#left#key##0:wybe.int, ~#right#key##0:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
+                case ~tmp#5##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                 1:
-                    mytree.tree.=<0>(~$left$right##0:mytree.tree, ~$right$right##0:mytree.tree, ?$$##0:wybe.bool) #4
+                    mytree.tree.=<0>(~#left#right##0:mytree.tree, ~#right#right##0:mytree.tree, ?####0:wybe.bool) #4
 
 
 
@@ -412,145 +412,145 @@ if.else:
 
 empty > public {inline} (0 calls)
 0: mytree.tree.empty<0>
-empty(?$##0:mytree.tree):
+empty(?###0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:mytree.tree, ?$##0:mytree.tree)
+    foreign llvm move(0:mytree.tree, ?###0:mytree.tree)
 
 
 key > public {inline} (0 calls)
 0: mytree.tree.key<0>
-key($rec##0:mytree.tree, ?$##0:wybe.int, ?$$##0:wybe.bool):
+key(#rec##0:mytree.tree, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 key > public {inline} (0 calls)
 1: mytree.tree.key<1>
-key($rec##0:mytree.tree, ?$rec##1:mytree.tree, $field##0:wybe.int, ?$$##0:wybe.bool):
+key(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:mytree.tree, ?$rec##1:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~$rec##0:mytree.tree, ?$rec##1:mytree.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 left > public {inline} (0 calls)
 0: mytree.tree.left<0>
-left($rec##0:mytree.tree, ?$##0:mytree.tree, ?$$##0:wybe.bool):
+left(#rec##0:mytree.tree, ?###0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:mytree.tree, ?$##0:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:mytree.tree, ?###0:mytree.tree)
 
     1:
-        foreign lpvm access(~$rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 left > public {inline} (0 calls)
 1: mytree.tree.left<1>
-left($rec##0:mytree.tree, ?$rec##1:mytree.tree, $field##0:mytree.tree, ?$$##0:wybe.bool):
+left(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:mytree.tree, ?$rec##1:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~$rec##0:mytree.tree, ?$rec##1:mytree.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 node > public {inline} (0 calls)
 0: mytree.tree.node<0>
-node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?$##0:mytree.tree):
+node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?###0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?$rec##0:mytree.tree)
-    foreign lpvm mutate(~$rec##0:mytree.tree, ?$rec##1:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:mytree.tree)
-    foreign lpvm mutate(~$rec##1:mytree.tree, ?$rec##2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int)
-    foreign lpvm mutate(~$rec##2:mytree.tree, ?$##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree)
+    foreign lpvm alloc(24:wybe.int, ?#rec##0:mytree.tree)
+    foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:mytree.tree)
+    foreign lpvm mutate(~#rec##1:mytree.tree, ?#rec##2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int)
+    foreign lpvm mutate(~#rec##2:mytree.tree, ?###0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree)
 node > public {inline} (16 calls)
 1: mytree.tree.node<1>
-node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, $##0:mytree.tree, ?$$##0:wybe.bool):
+node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, ###0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:mytree.tree, ?left##0:mytree.tree)
         foreign llvm move(undef:wybe.int, ?key##0:wybe.int)
         foreign llvm move(undef:mytree.tree, ?right##0:mytree.tree)
 
     1:
-        foreign lpvm access($##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:mytree.tree)
-        foreign lpvm access($##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
-        foreign lpvm access(~$##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(###0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:mytree.tree)
+        foreign lpvm access(###0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
+        foreign lpvm access(~###0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 right > public {inline} (0 calls)
 0: mytree.tree.right<0>
-right($rec##0:mytree.tree, ?$##0:mytree.tree, ?$$##0:wybe.bool):
+right(#rec##0:mytree.tree, ?###0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:mytree.tree, ?$##0:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:mytree.tree, ?###0:mytree.tree)
 
     1:
-        foreign lpvm access(~$rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 right > public {inline} (0 calls)
 1: mytree.tree.right<1>
-right($rec##0:mytree.tree, ?$rec##1:mytree.tree, $field##0:mytree.tree, ?$$##0:wybe.bool):
+right(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:mytree.tree, ?$rec##1:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~$rec##0:mytree.tree, ?$rec##1:mytree.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: mytree.tree.~=<0>
-~=($left##0:mytree.tree, $right##0:mytree.tree, ?$$##0:wybe.bool):
+~=(#left##0:mytree.tree, #right##0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    mytree.tree.=<0>(~$left##0:mytree.tree, ~$right##0:mytree.tree, ?tmp$0##0:wybe.bool) #0
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    mytree.tree.=<0>(~#left##0:mytree.tree, ~#right##0:mytree.tree, ?tmp#0##0:wybe.bool) #0
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
   LLVM code       :
 
@@ -566,51 +566,51 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"mytree.tree.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"mytree.tree.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#left##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = add   i64 %"$left##0", 16 
+  %8 = add   i64 %"#left##0", 16 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
-  %"2$tmp$10##0" = icmp ne i64 %"$right##0", 0 
-  br i1 %"2$tmp$10##0", label %if.then1, label %if.else1 
+  %"2#tmp#10##0" = icmp ne i64 %"#right##0", 0 
+  br i1 %"2#tmp#10##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3#####0" 
 if.then1:
-  %12 = inttoptr i64 %"$right##0" to i64* 
+  %12 = inttoptr i64 %"#right##0" to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %15 = add   i64 %"$right##0", 8 
+  %15 = add   i64 %"#right##0", 8 
   %16 = inttoptr i64 %15 to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
-  %19 = add   i64 %"$right##0", 16 
+  %19 = add   i64 %"#right##0", 16 
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %"4$tmp$4##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %3, i64  %14)  
-  br i1 %"4$tmp$4##0", label %if.then2, label %if.else2 
+  %"4#tmp#4##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %3, i64  %14)  
+  br i1 %"4#tmp#4##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$tmp$5##0" = icmp eq i64 %7, %18 
-  br i1 %"6$tmp$5##0", label %if.then3, label %if.else3 
+  %"6#tmp#5##0" = icmp eq i64 %7, %18 
+  br i1 %"6#tmp#5##0", label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %"8$$$##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %11, i64  %22)  
-  ret i1 %"8$$$##0" 
+  %"8#####0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %11, i64  %22)  
+  ret i1 %"8#####0" 
 if.else3:
   ret i1 0 
 }
@@ -622,12 +622,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.key<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.key<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %23 = add   i64 %"$rec##0", 8 
+  %23 = add   i64 %"#rec##0", 8 
   %24 = inttoptr i64 %23 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
   %26 = load  i64, i64* %25 
@@ -641,38 +641,38 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.key<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.key<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %31 = trunc i64 24 to i32  
   %32 = tail call ccc  i8*  @wybe_malloc(i32  %31)  
   %33 = ptrtoint i8* %32 to i64 
   %34 = inttoptr i64 %33 to i8* 
-  %35 = inttoptr i64 %"$rec##0" to i8* 
+  %35 = inttoptr i64 %"#rec##0" to i8* 
   %36 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %34, i8*  %35, i32  %36, i32  8, i1  0)  
   %37 = add   i64 %33, 8 
   %38 = inttoptr i64 %37 to i64* 
   %39 = getelementptr  i64, i64* %38, i64 0 
-  store  i64 %"$field##0", i64* %39 
+  store  i64 %"#field##0", i64* %39 
   %40 = insertvalue {i64, i1} undef, i64 %33, 0 
   %41 = insertvalue {i64, i1} %40, i1 1, 1 
   ret {i64, i1} %41 
 if.else:
-  %42 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %42 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %43 = insertvalue {i64, i1} %42, i1 0, 1 
   ret {i64, i1} %43 
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.left<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.left<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %44 = inttoptr i64 %"$rec##0" to i64* 
+  %44 = inttoptr i64 %"#rec##0" to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
   %47 = insertvalue {i64, i1} undef, i64 %46, 0 
@@ -685,26 +685,26 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.left<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.left<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %51 = trunc i64 24 to i32  
   %52 = tail call ccc  i8*  @wybe_malloc(i32  %51)  
   %53 = ptrtoint i8* %52 to i64 
   %54 = inttoptr i64 %53 to i8* 
-  %55 = inttoptr i64 %"$rec##0" to i8* 
+  %55 = inttoptr i64 %"#rec##0" to i8* 
   %56 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %54, i8*  %55, i32  %56, i32  8, i1  0)  
   %57 = inttoptr i64 %53 to i64* 
   %58 = getelementptr  i64, i64* %57, i64 0 
-  store  i64 %"$field##0", i64* %58 
+  store  i64 %"#field##0", i64* %58 
   %59 = insertvalue {i64, i1} undef, i64 %53, 0 
   %60 = insertvalue {i64, i1} %59, i1 1, 1 
   ret {i64, i1} %60 
 if.else:
-  %61 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %61 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %62 = insertvalue {i64, i1} %61, i1 0, 1 
   ret {i64, i1} %62 
 }
@@ -730,19 +730,19 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64, i1} @"mytree.tree.node<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64, i64, i1} @"mytree.tree.node<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %74 = inttoptr i64 %"$##0" to i64* 
+  %74 = inttoptr i64 %"###0" to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
   %76 = load  i64, i64* %75 
-  %77 = add   i64 %"$##0", 8 
+  %77 = add   i64 %"###0", 8 
   %78 = inttoptr i64 %77 to i64* 
   %79 = getelementptr  i64, i64* %78, i64 0 
   %80 = load  i64, i64* %79 
-  %81 = add   i64 %"$##0", 16 
+  %81 = add   i64 %"###0", 16 
   %82 = inttoptr i64 %81 to i64* 
   %83 = getelementptr  i64, i64* %82, i64 0 
   %84 = load  i64, i64* %83 
@@ -760,12 +760,12 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.right<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.right<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %93 = add   i64 %"$rec##0", 16 
+  %93 = add   i64 %"#rec##0", 16 
   %94 = inttoptr i64 %93 to i64* 
   %95 = getelementptr  i64, i64* %94, i64 0 
   %96 = load  i64, i64* %95 
@@ -779,35 +779,35 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.right<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.right<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %101 = trunc i64 24 to i32  
   %102 = tail call ccc  i8*  @wybe_malloc(i32  %101)  
   %103 = ptrtoint i8* %102 to i64 
   %104 = inttoptr i64 %103 to i8* 
-  %105 = inttoptr i64 %"$rec##0" to i8* 
+  %105 = inttoptr i64 %"#rec##0" to i8* 
   %106 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %104, i8*  %105, i32  %106, i32  8, i1  0)  
   %107 = add   i64 %103, 16 
   %108 = inttoptr i64 %107 to i64* 
   %109 = getelementptr  i64, i64* %108, i64 0 
-  store  i64 %"$field##0", i64* %109 
+  store  i64 %"#field##0", i64* %109 
   %110 = insertvalue {i64, i1} undef, i64 %103, 0 
   %111 = insertvalue {i64, i1} %110, i1 1, 1 
   ret {i64, i1} %111 
 if.else:
-  %112 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %112 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %113 = insertvalue {i64, i1} %112, i1 0, 1 
   ret {i64, i1} %113 
 }
 
 
-define external fastcc  i1 @"mytree.tree.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"mytree.tree.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %"$left##0", i64  %"$right##0")  
-  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
-  ret i1 %"1$$$##0" 
+  %"1#tmp#0##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %"#left##0", i64  %"#right##0")  
+  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1#####0" 
 }

--- a/test-cases/final-dump/alias_fork3.exp
+++ b/test-cases/final-dump/alias_fork3.exp
@@ -16,38 +16,38 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp$9##0:mytree.tree)
-    foreign lpvm mutate(~tmp$9##0:mytree.tree, ?tmp$10##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-    foreign lpvm mutate(~tmp$10##0:mytree.tree, ?tmp$11##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm mutate(~tmp$11##0:mytree.tree, ?tmp$1##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-    foreign lpvm alloc(24:wybe.int, ?tmp$15##0:mytree.tree)
-    foreign lpvm mutate(~tmp$15##0:mytree.tree, ?tmp$16##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp$1##0:mytree.tree)
-    foreign lpvm mutate(~tmp$16##0:mytree.tree, ?tmp$17##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 200:wybe.int)
-    foreign lpvm mutate(~tmp$17##0:mytree.tree, ?tmp$0##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-    alias_fork3.simpleSlice<0>(~tmp$0##0:mytree.tree, ?tmp$5##0:mytree.tree) #5 @alias_fork3:15:6
-    foreign c print_string("expect t - 100:":wybe.string, ~#io##0:wybe.phantom, ?tmp$20##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$20##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    mytree.printTree1<0>(~tmp$5##0:mytree.tree, "{":wybe.string, ?tmp$23##0:wybe.string, ~#io##1:wybe.phantom, ?tmp$24##0:wybe.phantom) #9 @mytree:nn:nn
-    foreign c print_string("}":wybe.string, ~tmp$24##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    foreign c print_string("":wybe.string, ~#io##2:wybe.phantom, ?tmp$27##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$27##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(24:wybe.int, ?tmp#9##0:mytree.tree)
+    foreign lpvm mutate(~tmp#9##0:mytree.tree, ?tmp#10##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+    foreign lpvm mutate(~tmp#10##0:mytree.tree, ?tmp#11##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 100:wybe.int)
+    foreign lpvm mutate(~tmp#11##0:mytree.tree, ?tmp#1##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+    foreign lpvm alloc(24:wybe.int, ?tmp#15##0:mytree.tree)
+    foreign lpvm mutate(~tmp#15##0:mytree.tree, ?tmp#16##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp#1##0:mytree.tree)
+    foreign lpvm mutate(~tmp#16##0:mytree.tree, ?tmp#17##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 200:wybe.int)
+    foreign lpvm mutate(~tmp#17##0:mytree.tree, ?tmp#0##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+    alias_fork3.simpleSlice<0>(~tmp#0##0:mytree.tree, ?tmp#5##0:mytree.tree) #5 @alias_fork3:15:6
+    foreign c print_string("expect t - 100:":wybe.string, ~#io##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#20##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    mytree.printTree1<0>(~tmp#5##0:mytree.tree, "{":wybe.string, ?tmp#23##0:wybe.string, ~#io##1:wybe.phantom, ?tmp#24##0:wybe.phantom) #9 @mytree:nn:nn
+    foreign c print_string("}":wybe.string, ~tmp#24##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string("":wybe.string, ~#io##2:wybe.phantom, ?tmp#27##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#27##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
 
 
 simpleSlice > public (1 calls)
 0: alias_fork3.simpleSlice<0>
-simpleSlice(tr##0:mytree.tree, ?$##0:mytree.tree):
- AliasPairs: [($##0,tr##0)]
+simpleSlice(tr##0:mytree.tree, ?###0:mytree.tree):
+ AliasPairs: [(###0,tr##0)]
  InterestingCallProperties: []
-    foreign llvm icmp_ne(tr##0:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.bool)
-    case ~tmp$6##0:wybe.bool of
+    foreign llvm icmp_ne(tr##0:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.bool)
+    case ~tmp#6##0:wybe.bool of
     0:
-        foreign lpvm alloc(24:wybe.int, ?tmp$10##0:mytree.tree)
-        foreign lpvm mutate(~tmp$10##0:mytree.tree, ?tmp$11##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-        foreign lpvm mutate(~tmp$11##0:mytree.tree, ?tmp$12##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, -1:wybe.int)
-        foreign lpvm mutate(~tmp$12##0:mytree.tree, ?$##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+        foreign lpvm alloc(24:wybe.int, ?tmp#10##0:mytree.tree)
+        foreign lpvm mutate(~tmp#10##0:mytree.tree, ?tmp#11##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+        foreign lpvm mutate(~tmp#11##0:mytree.tree, ?tmp#12##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, -1:wybe.int)
+        foreign lpvm mutate(~tmp#12##0:mytree.tree, ?###0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
 
     1:
-        foreign lpvm access(~tr##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:mytree.tree)
+        foreign lpvm access(~tr##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:mytree.tree)
 
 
   LLVM code       :
@@ -115,12 +115,12 @@ entry:
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
   store  i64 0, i64* %22 
-  %"1$tmp$5##0" = tail call fastcc  i64  @"alias_fork3.simpleSlice<0>"(i64  %14)  
+  %"1#tmp#5##0" = tail call fastcc  i64  @"alias_fork3.simpleSlice<0>"(i64  %14)  
   %24 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_fork3.23, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %24)  
   tail call ccc  void  @putchar(i8  10)  
   %26 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_fork3.25, i32 0, i32 0) to i64 
-  %"1$tmp$23##0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"1$tmp$5##0", i64  %26)  
+  %"1#tmp#23##0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"1#tmp#5##0", i64  %26)  
   %28 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_fork3.27, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %28)  
   %30 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_fork3.29, i32 0, i32 0) to i64 
@@ -132,8 +132,8 @@ entry:
 
 define external fastcc  i64 @"alias_fork3.simpleSlice<0>"(i64  %"tr##0")    {
 entry:
-  %"1$tmp$6##0" = icmp ne i64 %"tr##0", 0 
-  br i1 %"1$tmp$6##0", label %if.then, label %if.else 
+  %"1#tmp#6##0" = icmp ne i64 %"tr##0", 0 
+  br i1 %"1#tmp#6##0", label %if.then, label %if.else 
 if.then:
   %31 = inttoptr i64 %"tr##0" to i64* 
   %32 = getelementptr  i64, i64* %31, i64 0 
@@ -194,8 +194,8 @@ printTree1 > public (3 calls)
 printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string, io##0:wybe.phantom, ?io##4:wybe.phantom):
  AliasPairs: [(prefix##0,prefix##3)]
  InterestingCallProperties: []
-    foreign llvm icmp_ne(t##0:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.bool)
-    case ~tmp$2##0:wybe.bool of
+    foreign llvm icmp_ne(t##0:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.bool)
+    case ~tmp#2##0:wybe.bool of
     0:
         foreign llvm move(~prefix##0:wybe.string, ?prefix##3:wybe.string)
         foreign llvm move(~io##0:wybe.phantom, ?io##4:wybe.phantom)
@@ -242,7 +242,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 define external fastcc  void @"mytree.printTree<0>"(i64  %"t##0")    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @mytree.1, i32 0, i32 0) to i64 
-  %"1$prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t##0", i64  %2)  
+  %"1#prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t##0", i64  %2)  
   %4 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @mytree.3, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %4)  
   ret void 
@@ -251,8 +251,8 @@ entry:
 
 define external fastcc  i64 @"mytree.printTree1<0>"(i64  %"t##0", i64  %"prefix##0")    {
 entry:
-  %"1$tmp$2##0" = icmp ne i64 %"t##0", 0 
-  br i1 %"1$tmp$2##0", label %if.then, label %if.else 
+  %"1#tmp#2##0" = icmp ne i64 %"t##0", 0 
+  br i1 %"1#tmp#2##0", label %if.then, label %if.else 
 if.then:
   %5 = inttoptr i64 %"t##0" to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
@@ -265,12 +265,12 @@ if.then:
   %13 = inttoptr i64 %12 to i64* 
   %14 = getelementptr  i64, i64* %13, i64 0 
   %15 = load  i64, i64* %14 
-  %"2$prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %7, i64  %"prefix##0")  
-  tail call ccc  void  @print_string(i64  %"2$prefix##1")  
+  %"2#prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %7, i64  %"prefix##0")  
+  tail call ccc  void  @print_string(i64  %"2#prefix##1")  
   tail call ccc  void  @print_int(i64  %11)  
   %17 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @mytree.16, i32 0, i32 0) to i64 
-  %"2$prefix##3" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %15, i64  %17)  
-  ret i64 %"2$prefix##3" 
+  %"2#prefix##3" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %15, i64  %17)  
+  ret i64 %"2#prefix##3" 
 if.else:
   ret i64 %"prefix##0" 
 }
@@ -297,40 +297,40 @@ if.else:
 
 = > public (7 calls)
 0: mytree.tree.=<0>
-=($left##0:mytree.tree, $right##0:mytree.tree, ?$$##0:wybe.bool):
+=(#left##0:mytree.tree, #right##0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left##0:mytree.tree, ~$right##0:mytree.tree, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:mytree.tree, ~#right##0:mytree.tree, ?####0:wybe.bool)
 
     1:
-        foreign lpvm access($left##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$left##0:mytree.tree)
-        foreign lpvm access($left##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$key##0:wybe.int)
-        foreign lpvm access(~$left##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$right##0:mytree.tree)
-        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.bool)
-        case ~tmp$10##0:wybe.bool of
+        foreign lpvm access(#left##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#left##0:mytree.tree)
+        foreign lpvm access(#left##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#key##0:wybe.int)
+        foreign lpvm access(~#left##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#right##0:mytree.tree)
+        foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
+        case ~tmp#10##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign lpvm access($right##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$left##0:mytree.tree)
-            foreign lpvm access($right##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$key##0:wybe.int)
-            foreign lpvm access(~$right##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$right##0:mytree.tree)
-            mytree.tree.=<0>(~$left$left##0:mytree.tree, ~$right$left##0:mytree.tree, ?tmp$4##0:wybe.bool) #2
-            case ~tmp$4##0:wybe.bool of
+            foreign lpvm access(#right##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#left##0:mytree.tree)
+            foreign lpvm access(#right##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#key##0:wybe.int)
+            foreign lpvm access(~#right##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#right##0:mytree.tree)
+            mytree.tree.=<0>(~#left#left##0:mytree.tree, ~#right#left##0:mytree.tree, ?tmp#4##0:wybe.bool) #2
+            case ~tmp#4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
             1:
-                foreign llvm icmp_eq(~$left$key##0:wybe.int, ~$right$key##0:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
-                case ~tmp$5##0:wybe.bool of
+                foreign llvm icmp_eq(~#left#key##0:wybe.int, ~#right#key##0:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
+                case ~tmp#5##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                 1:
-                    mytree.tree.=<0>(~$left$right##0:mytree.tree, ~$right$right##0:mytree.tree, ?$$##0:wybe.bool) #4
+                    mytree.tree.=<0>(~#left#right##0:mytree.tree, ~#right#right##0:mytree.tree, ?####0:wybe.bool) #4
 
 
 
@@ -339,145 +339,145 @@ if.else:
 
 empty > public {inline} (0 calls)
 0: mytree.tree.empty<0>
-empty(?$##0:mytree.tree):
+empty(?###0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:mytree.tree, ?$##0:mytree.tree)
+    foreign llvm move(0:mytree.tree, ?###0:mytree.tree)
 
 
 key > public {inline} (0 calls)
 0: mytree.tree.key<0>
-key($rec##0:mytree.tree, ?$##0:wybe.int, ?$$##0:wybe.bool):
+key(#rec##0:mytree.tree, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 key > public {inline} (0 calls)
 1: mytree.tree.key<1>
-key($rec##0:mytree.tree, ?$rec##1:mytree.tree, $field##0:wybe.int, ?$$##0:wybe.bool):
+key(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:mytree.tree, ?$rec##1:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~$rec##0:mytree.tree, ?$rec##1:mytree.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 left > public {inline} (0 calls)
 0: mytree.tree.left<0>
-left($rec##0:mytree.tree, ?$##0:mytree.tree, ?$$##0:wybe.bool):
+left(#rec##0:mytree.tree, ?###0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:mytree.tree, ?$##0:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:mytree.tree, ?###0:mytree.tree)
 
     1:
-        foreign lpvm access(~$rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 left > public {inline} (0 calls)
 1: mytree.tree.left<1>
-left($rec##0:mytree.tree, ?$rec##1:mytree.tree, $field##0:mytree.tree, ?$$##0:wybe.bool):
+left(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:mytree.tree, ?$rec##1:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~$rec##0:mytree.tree, ?$rec##1:mytree.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 node > public {inline} (0 calls)
 0: mytree.tree.node<0>
-node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?$##0:mytree.tree):
+node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?###0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?$rec##0:mytree.tree)
-    foreign lpvm mutate(~$rec##0:mytree.tree, ?$rec##1:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:mytree.tree)
-    foreign lpvm mutate(~$rec##1:mytree.tree, ?$rec##2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int)
-    foreign lpvm mutate(~$rec##2:mytree.tree, ?$##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree)
+    foreign lpvm alloc(24:wybe.int, ?#rec##0:mytree.tree)
+    foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:mytree.tree)
+    foreign lpvm mutate(~#rec##1:mytree.tree, ?#rec##2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int)
+    foreign lpvm mutate(~#rec##2:mytree.tree, ?###0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree)
 node > public {inline} (16 calls)
 1: mytree.tree.node<1>
-node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, $##0:mytree.tree, ?$$##0:wybe.bool):
+node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, ###0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:mytree.tree, ?left##0:mytree.tree)
         foreign llvm move(undef:wybe.int, ?key##0:wybe.int)
         foreign llvm move(undef:mytree.tree, ?right##0:mytree.tree)
 
     1:
-        foreign lpvm access($##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:mytree.tree)
-        foreign lpvm access($##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
-        foreign lpvm access(~$##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(###0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:mytree.tree)
+        foreign lpvm access(###0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
+        foreign lpvm access(~###0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 right > public {inline} (0 calls)
 0: mytree.tree.right<0>
-right($rec##0:mytree.tree, ?$##0:mytree.tree, ?$$##0:wybe.bool):
+right(#rec##0:mytree.tree, ?###0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:mytree.tree, ?$##0:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:mytree.tree, ?###0:mytree.tree)
 
     1:
-        foreign lpvm access(~$rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 right > public {inline} (0 calls)
 1: mytree.tree.right<1>
-right($rec##0:mytree.tree, ?$rec##1:mytree.tree, $field##0:mytree.tree, ?$$##0:wybe.bool):
+right(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:mytree.tree, ?$rec##1:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~$rec##0:mytree.tree, ?$rec##1:mytree.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: mytree.tree.~=<0>
-~=($left##0:mytree.tree, $right##0:mytree.tree, ?$$##0:wybe.bool):
+~=(#left##0:mytree.tree, #right##0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    mytree.tree.=<0>(~$left##0:mytree.tree, ~$right##0:mytree.tree, ?tmp$0##0:wybe.bool) #0
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    mytree.tree.=<0>(~#left##0:mytree.tree, ~#right##0:mytree.tree, ?tmp#0##0:wybe.bool) #0
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
   LLVM code       :
 
@@ -493,51 +493,51 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"mytree.tree.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"mytree.tree.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#left##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = add   i64 %"$left##0", 16 
+  %8 = add   i64 %"#left##0", 16 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
-  %"2$tmp$10##0" = icmp ne i64 %"$right##0", 0 
-  br i1 %"2$tmp$10##0", label %if.then1, label %if.else1 
+  %"2#tmp#10##0" = icmp ne i64 %"#right##0", 0 
+  br i1 %"2#tmp#10##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3#####0" 
 if.then1:
-  %12 = inttoptr i64 %"$right##0" to i64* 
+  %12 = inttoptr i64 %"#right##0" to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %15 = add   i64 %"$right##0", 8 
+  %15 = add   i64 %"#right##0", 8 
   %16 = inttoptr i64 %15 to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
-  %19 = add   i64 %"$right##0", 16 
+  %19 = add   i64 %"#right##0", 16 
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %"4$tmp$4##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %3, i64  %14)  
-  br i1 %"4$tmp$4##0", label %if.then2, label %if.else2 
+  %"4#tmp#4##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %3, i64  %14)  
+  br i1 %"4#tmp#4##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$tmp$5##0" = icmp eq i64 %7, %18 
-  br i1 %"6$tmp$5##0", label %if.then3, label %if.else3 
+  %"6#tmp#5##0" = icmp eq i64 %7, %18 
+  br i1 %"6#tmp#5##0", label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %"8$$$##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %11, i64  %22)  
-  ret i1 %"8$$$##0" 
+  %"8#####0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %11, i64  %22)  
+  ret i1 %"8#####0" 
 if.else3:
   ret i1 0 
 }
@@ -549,12 +549,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.key<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.key<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %23 = add   i64 %"$rec##0", 8 
+  %23 = add   i64 %"#rec##0", 8 
   %24 = inttoptr i64 %23 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
   %26 = load  i64, i64* %25 
@@ -568,38 +568,38 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.key<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.key<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %31 = trunc i64 24 to i32  
   %32 = tail call ccc  i8*  @wybe_malloc(i32  %31)  
   %33 = ptrtoint i8* %32 to i64 
   %34 = inttoptr i64 %33 to i8* 
-  %35 = inttoptr i64 %"$rec##0" to i8* 
+  %35 = inttoptr i64 %"#rec##0" to i8* 
   %36 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %34, i8*  %35, i32  %36, i32  8, i1  0)  
   %37 = add   i64 %33, 8 
   %38 = inttoptr i64 %37 to i64* 
   %39 = getelementptr  i64, i64* %38, i64 0 
-  store  i64 %"$field##0", i64* %39 
+  store  i64 %"#field##0", i64* %39 
   %40 = insertvalue {i64, i1} undef, i64 %33, 0 
   %41 = insertvalue {i64, i1} %40, i1 1, 1 
   ret {i64, i1} %41 
 if.else:
-  %42 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %42 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %43 = insertvalue {i64, i1} %42, i1 0, 1 
   ret {i64, i1} %43 
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.left<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.left<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %44 = inttoptr i64 %"$rec##0" to i64* 
+  %44 = inttoptr i64 %"#rec##0" to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
   %47 = insertvalue {i64, i1} undef, i64 %46, 0 
@@ -612,26 +612,26 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.left<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.left<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %51 = trunc i64 24 to i32  
   %52 = tail call ccc  i8*  @wybe_malloc(i32  %51)  
   %53 = ptrtoint i8* %52 to i64 
   %54 = inttoptr i64 %53 to i8* 
-  %55 = inttoptr i64 %"$rec##0" to i8* 
+  %55 = inttoptr i64 %"#rec##0" to i8* 
   %56 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %54, i8*  %55, i32  %56, i32  8, i1  0)  
   %57 = inttoptr i64 %53 to i64* 
   %58 = getelementptr  i64, i64* %57, i64 0 
-  store  i64 %"$field##0", i64* %58 
+  store  i64 %"#field##0", i64* %58 
   %59 = insertvalue {i64, i1} undef, i64 %53, 0 
   %60 = insertvalue {i64, i1} %59, i1 1, 1 
   ret {i64, i1} %60 
 if.else:
-  %61 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %61 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %62 = insertvalue {i64, i1} %61, i1 0, 1 
   ret {i64, i1} %62 
 }
@@ -657,19 +657,19 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64, i1} @"mytree.tree.node<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64, i64, i1} @"mytree.tree.node<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %74 = inttoptr i64 %"$##0" to i64* 
+  %74 = inttoptr i64 %"###0" to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
   %76 = load  i64, i64* %75 
-  %77 = add   i64 %"$##0", 8 
+  %77 = add   i64 %"###0", 8 
   %78 = inttoptr i64 %77 to i64* 
   %79 = getelementptr  i64, i64* %78, i64 0 
   %80 = load  i64, i64* %79 
-  %81 = add   i64 %"$##0", 16 
+  %81 = add   i64 %"###0", 16 
   %82 = inttoptr i64 %81 to i64* 
   %83 = getelementptr  i64, i64* %82, i64 0 
   %84 = load  i64, i64* %83 
@@ -687,12 +687,12 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.right<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.right<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %93 = add   i64 %"$rec##0", 16 
+  %93 = add   i64 %"#rec##0", 16 
   %94 = inttoptr i64 %93 to i64* 
   %95 = getelementptr  i64, i64* %94, i64 0 
   %96 = load  i64, i64* %95 
@@ -706,35 +706,35 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.right<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.right<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %101 = trunc i64 24 to i32  
   %102 = tail call ccc  i8*  @wybe_malloc(i32  %101)  
   %103 = ptrtoint i8* %102 to i64 
   %104 = inttoptr i64 %103 to i8* 
-  %105 = inttoptr i64 %"$rec##0" to i8* 
+  %105 = inttoptr i64 %"#rec##0" to i8* 
   %106 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %104, i8*  %105, i32  %106, i32  8, i1  0)  
   %107 = add   i64 %103, 16 
   %108 = inttoptr i64 %107 to i64* 
   %109 = getelementptr  i64, i64* %108, i64 0 
-  store  i64 %"$field##0", i64* %109 
+  store  i64 %"#field##0", i64* %109 
   %110 = insertvalue {i64, i1} undef, i64 %103, 0 
   %111 = insertvalue {i64, i1} %110, i1 1, 1 
   ret {i64, i1} %111 
 if.else:
-  %112 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %112 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %113 = insertvalue {i64, i1} %112, i1 0, 1 
   ret {i64, i1} %113 
 }
 
 
-define external fastcc  i1 @"mytree.tree.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"mytree.tree.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %"$left##0", i64  %"$right##0")  
-  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
-  ret i1 %"1$$$##0" 
+  %"1#tmp#0##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %"#left##0", i64  %"#right##0")  
+  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1#####0" 
 }

--- a/test-cases/final-dump/alias_fork3.exp
+++ b/test-cases/final-dump/alias_fork3.exp
@@ -13,41 +13,41 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: alias_fork3.<0>
-(io#0:wybe.phantom, ?io#3:wybe.phantom):
+(io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp$9#0:mytree.tree)
-    foreign lpvm mutate(~tmp$9#0:mytree.tree, ?tmp$10#0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-    foreign lpvm mutate(~tmp$10#0:mytree.tree, ?tmp$11#0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm mutate(~tmp$11#0:mytree.tree, ?tmp$1#0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-    foreign lpvm alloc(24:wybe.int, ?tmp$15#0:mytree.tree)
-    foreign lpvm mutate(~tmp$15#0:mytree.tree, ?tmp$16#0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp$1#0:mytree.tree)
-    foreign lpvm mutate(~tmp$16#0:mytree.tree, ?tmp$17#0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 200:wybe.int)
-    foreign lpvm mutate(~tmp$17#0:mytree.tree, ?tmp$0#0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-    alias_fork3.simpleSlice<0>(~tmp$0#0:mytree.tree, ?tmp$5#0:mytree.tree) #5 @alias_fork3:15:6
-    foreign c print_string("expect t - 100:":wybe.string, ~#io#0:wybe.phantom, ?tmp$20#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$20#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    mytree.printTree1<0>(~tmp$5#0:mytree.tree, "{":wybe.string, ?tmp$23#0:wybe.string, ~#io#1:wybe.phantom, ?tmp$24#0:wybe.phantom) #9 @mytree:nn:nn
-    foreign c print_string("}":wybe.string, ~tmp$24#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string("":wybe.string, ~#io#2:wybe.phantom, ?tmp$27#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$27#0:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(24:wybe.int, ?tmp$9##0:mytree.tree)
+    foreign lpvm mutate(~tmp$9##0:mytree.tree, ?tmp$10##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+    foreign lpvm mutate(~tmp$10##0:mytree.tree, ?tmp$11##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 100:wybe.int)
+    foreign lpvm mutate(~tmp$11##0:mytree.tree, ?tmp$1##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+    foreign lpvm alloc(24:wybe.int, ?tmp$15##0:mytree.tree)
+    foreign lpvm mutate(~tmp$15##0:mytree.tree, ?tmp$16##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp$1##0:mytree.tree)
+    foreign lpvm mutate(~tmp$16##0:mytree.tree, ?tmp$17##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 200:wybe.int)
+    foreign lpvm mutate(~tmp$17##0:mytree.tree, ?tmp$0##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+    alias_fork3.simpleSlice<0>(~tmp$0##0:mytree.tree, ?tmp$5##0:mytree.tree) #5 @alias_fork3:15:6
+    foreign c print_string("expect t - 100:":wybe.string, ~#io##0:wybe.phantom, ?tmp$20##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$20##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    mytree.printTree1<0>(~tmp$5##0:mytree.tree, "{":wybe.string, ?tmp$23##0:wybe.string, ~#io##1:wybe.phantom, ?tmp$24##0:wybe.phantom) #9 @mytree:nn:nn
+    foreign c print_string("}":wybe.string, ~tmp$24##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string("":wybe.string, ~#io##2:wybe.phantom, ?tmp$27##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$27##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
 
 
 simpleSlice > public (1 calls)
 0: alias_fork3.simpleSlice<0>
-simpleSlice(tr#0:mytree.tree, ?$#0:mytree.tree):
- AliasPairs: [($#0,tr#0)]
+simpleSlice(tr##0:mytree.tree, ?$##0:mytree.tree):
+ AliasPairs: [($##0,tr##0)]
  InterestingCallProperties: []
-    foreign llvm icmp_ne(tr#0:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.bool)
-    case ~tmp$6#0:wybe.bool of
+    foreign llvm icmp_ne(tr##0:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.bool)
+    case ~tmp$6##0:wybe.bool of
     0:
-        foreign lpvm alloc(24:wybe.int, ?tmp$10#0:mytree.tree)
-        foreign lpvm mutate(~tmp$10#0:mytree.tree, ?tmp$11#0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
-        foreign lpvm mutate(~tmp$11#0:mytree.tree, ?tmp$12#0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, -1:wybe.int)
-        foreign lpvm mutate(~tmp$12#0:mytree.tree, ?$#0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+        foreign lpvm alloc(24:wybe.int, ?tmp$10##0:mytree.tree)
+        foreign lpvm mutate(~tmp$10##0:mytree.tree, ?tmp$11##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+        foreign lpvm mutate(~tmp$11##0:mytree.tree, ?tmp$12##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, -1:wybe.int)
+        foreign lpvm mutate(~tmp$12##0:mytree.tree, ?$##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
 
     1:
-        foreign lpvm access(~tr#0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:mytree.tree)
+        foreign lpvm access(~tr##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:mytree.tree)
 
 
   LLVM code       :
@@ -115,12 +115,12 @@ entry:
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
   store  i64 0, i64* %22 
-  %"1$tmp$5#0" = tail call fastcc  i64  @"alias_fork3.simpleSlice<0>"(i64  %14)  
+  %"1$tmp$5##0" = tail call fastcc  i64  @"alias_fork3.simpleSlice<0>"(i64  %14)  
   %24 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_fork3.23, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %24)  
   tail call ccc  void  @putchar(i8  10)  
   %26 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_fork3.25, i32 0, i32 0) to i64 
-  %"1$tmp$23#0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"1$tmp$5#0", i64  %26)  
+  %"1$tmp$23##0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"1$tmp$5##0", i64  %26)  
   %28 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_fork3.27, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %28)  
   %30 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_fork3.29, i32 0, i32 0) to i64 
@@ -130,12 +130,12 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_fork3.simpleSlice<0>"(i64  %"tr#0")    {
+define external fastcc  i64 @"alias_fork3.simpleSlice<0>"(i64  %"tr##0")    {
 entry:
-  %"1$tmp$6#0" = icmp ne i64 %"tr#0", 0 
-  br i1 %"1$tmp$6#0", label %if.then, label %if.else 
+  %"1$tmp$6##0" = icmp ne i64 %"tr##0", 0 
+  br i1 %"1$tmp$6##0", label %if.then, label %if.else 
 if.then:
-  %31 = inttoptr i64 %"tr#0" to i64* 
+  %31 = inttoptr i64 %"tr##0" to i64* 
   %32 = getelementptr  i64, i64* %31, i64 0 
   %33 = load  i64, i64* %32 
   ret i64 %33 
@@ -182,32 +182,32 @@ if.else:
 
 printTree > public {inline} (0 calls)
 0: mytree.printTree<0>
-printTree(t#0:mytree.tree, io#0:wybe.phantom, ?io#2:wybe.phantom):
+printTree(t##0:mytree.tree, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    mytree.printTree1<0>(~t#0:mytree.tree, "{":wybe.string, ?%prefix#1:wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @mytree:nn:nn
-    foreign c print_string("}":wybe.string, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
+    mytree.printTree1<0>(~t##0:mytree.tree, "{":wybe.string, ?%prefix##1:wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @mytree:nn:nn
+    foreign c print_string("}":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
 
 printTree1 > public (3 calls)
 0: mytree.printTree1<0>
-printTree1(t#0:mytree.tree, prefix#0:wybe.string, ?prefix#3:wybe.string, io#0:wybe.phantom, ?io#4:wybe.phantom):
- AliasPairs: [(prefix#0,prefix#3)]
+printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string, io##0:wybe.phantom, ?io##4:wybe.phantom):
+ AliasPairs: [(prefix##0,prefix##3)]
  InterestingCallProperties: []
-    foreign llvm icmp_ne(t#0:wybe.int, 0:wybe.int, ?tmp$2#0:wybe.bool)
-    case ~tmp$2#0:wybe.bool of
+    foreign llvm icmp_ne(t##0:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.bool)
+    case ~tmp$2##0:wybe.bool of
     0:
-        foreign llvm move(~prefix#0:wybe.string, ?prefix#3:wybe.string)
-        foreign llvm move(~io#0:wybe.phantom, ?io#4:wybe.phantom)
+        foreign llvm move(~prefix##0:wybe.string, ?prefix##3:wybe.string)
+        foreign llvm move(~io##0:wybe.phantom, ?io##4:wybe.phantom)
 
     1:
-        foreign lpvm access(t#0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?l#0:mytree.tree)
-        foreign lpvm access(t#0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k#0:wybe.int)
-        foreign lpvm access(~t#0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?r#0:mytree.tree)
-        mytree.printTree1<0>(~l#0:mytree.tree, ~%prefix#0:wybe.string, ?%prefix#1:wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #1 @mytree:nn:nn
-        foreign c print_string(~prefix#1:wybe.string, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-        foreign c print_int(~k#0:wybe.int, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-        mytree.printTree1<0>(~r#0:mytree.tree, ", ":wybe.string, ?%prefix#3:wybe.string, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #4 @mytree:nn:nn
+        foreign lpvm access(t##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?l##0:mytree.tree)
+        foreign lpvm access(t##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k##0:wybe.int)
+        foreign lpvm access(~t##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?r##0:mytree.tree)
+        mytree.printTree1<0>(~l##0:mytree.tree, ~%prefix##0:wybe.string, ?%prefix##1:wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @mytree:nn:nn
+        foreign c print_string(~prefix##1:wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+        foreign c print_int(~k##0:wybe.int, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+        mytree.printTree1<0>(~r##0:mytree.tree, ", ":wybe.string, ?%prefix##3:wybe.string, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @mytree:nn:nn
 
 
   LLVM code       :
@@ -239,40 +239,40 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"mytree.printTree<0>"(i64  %"t#0")    {
+define external fastcc  void @"mytree.printTree<0>"(i64  %"t##0")    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @mytree.1, i32 0, i32 0) to i64 
-  %"1$prefix#1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t#0", i64  %2)  
+  %"1$prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t##0", i64  %2)  
   %4 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @mytree.3, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %4)  
   ret void 
 }
 
 
-define external fastcc  i64 @"mytree.printTree1<0>"(i64  %"t#0", i64  %"prefix#0")    {
+define external fastcc  i64 @"mytree.printTree1<0>"(i64  %"t##0", i64  %"prefix##0")    {
 entry:
-  %"1$tmp$2#0" = icmp ne i64 %"t#0", 0 
-  br i1 %"1$tmp$2#0", label %if.then, label %if.else 
+  %"1$tmp$2##0" = icmp ne i64 %"t##0", 0 
+  br i1 %"1$tmp$2##0", label %if.then, label %if.else 
 if.then:
-  %5 = inttoptr i64 %"t#0" to i64* 
+  %5 = inttoptr i64 %"t##0" to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = add   i64 %"t#0", 8 
+  %8 = add   i64 %"t##0", 8 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
-  %12 = add   i64 %"t#0", 16 
+  %12 = add   i64 %"t##0", 16 
   %13 = inttoptr i64 %12 to i64* 
   %14 = getelementptr  i64, i64* %13, i64 0 
   %15 = load  i64, i64* %14 
-  %"2$prefix#1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %7, i64  %"prefix#0")  
-  tail call ccc  void  @print_string(i64  %"2$prefix#1")  
+  %"2$prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %7, i64  %"prefix##0")  
+  tail call ccc  void  @print_string(i64  %"2$prefix##1")  
   tail call ccc  void  @print_int(i64  %11)  
   %17 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @mytree.16, i32 0, i32 0) to i64 
-  %"2$prefix#3" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %15, i64  %17)  
-  ret i64 %"2$prefix#3" 
+  %"2$prefix##3" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %15, i64  %17)  
+  ret i64 %"2$prefix##3" 
 if.else:
-  ret i64 %"prefix#0" 
+  ret i64 %"prefix##0" 
 }
 --------------------------------------------------
  Module mytree.tree
@@ -297,40 +297,40 @@ if.else:
 
 = > public (7 calls)
 0: mytree.tree.=<0>
-=($left#0:mytree.tree, $right#0:mytree.tree, ?$$#0:wybe.bool):
+=($left##0:mytree.tree, $right##0:mytree.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left#0:mytree.tree, ~$right#0:mytree.tree, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~$left##0:mytree.tree, ~$right##0:mytree.tree, ?$$##0:wybe.bool)
 
     1:
-        foreign lpvm access($left#0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$left#0:mytree.tree)
-        foreign lpvm access($left#0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$key#0:wybe.int)
-        foreign lpvm access(~$left#0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$right#0:mytree.tree)
-        foreign llvm icmp_ne($right#0:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.bool)
-        case ~tmp$10#0:wybe.bool of
+        foreign lpvm access($left##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$left##0:mytree.tree)
+        foreign lpvm access($left##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$key##0:wybe.int)
+        foreign lpvm access(~$left##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$right##0:mytree.tree)
+        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.bool)
+        case ~tmp$10##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign lpvm access($right#0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$left#0:mytree.tree)
-            foreign lpvm access($right#0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$key#0:wybe.int)
-            foreign lpvm access(~$right#0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$right#0:mytree.tree)
-            mytree.tree.=<0>(~$left$left#0:mytree.tree, ~$right$left#0:mytree.tree, ?tmp$4#0:wybe.bool) #2
-            case ~tmp$4#0:wybe.bool of
+            foreign lpvm access($right##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$left##0:mytree.tree)
+            foreign lpvm access($right##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$key##0:wybe.int)
+            foreign lpvm access(~$right##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$right##0:mytree.tree)
+            mytree.tree.=<0>(~$left$left##0:mytree.tree, ~$right$left##0:mytree.tree, ?tmp$4##0:wybe.bool) #2
+            case ~tmp$4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                foreign llvm icmp_eq(~$left$key#0:wybe.int, ~$right$key#0:wybe.int, ?tmp$5#0:wybe.bool) @int:nn:nn
-                case ~tmp$5#0:wybe.bool of
+                foreign llvm icmp_eq(~$left$key##0:wybe.int, ~$right$key##0:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
+                case ~tmp$5##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                 1:
-                    mytree.tree.=<0>(~$left$right#0:mytree.tree, ~$right$right#0:mytree.tree, ?$$#0:wybe.bool) #4
+                    mytree.tree.=<0>(~$left$right##0:mytree.tree, ~$right$right##0:mytree.tree, ?$$##0:wybe.bool) #4
 
 
 
@@ -339,145 +339,145 @@ if.else:
 
 empty > public {inline} (0 calls)
 0: mytree.tree.empty<0>
-empty(?$#0:mytree.tree):
+empty(?$##0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:mytree.tree, ?$#0:mytree.tree)
+    foreign llvm move(0:mytree.tree, ?$##0:mytree.tree)
 
 
 key > public {inline} (0 calls)
 0: mytree.tree.key<0>
-key($rec#0:mytree.tree, ?$#0:wybe.int, ?$$#0:wybe.bool):
+key($rec##0:mytree.tree, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec#0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 key > public {inline} (0 calls)
 1: mytree.tree.key<1>
-key($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:wybe.int, ?$$#0:wybe.bool):
+key($rec##0:mytree.tree, ?$rec##1:mytree.tree, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:mytree.tree, ?$rec#1:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:mytree.tree, ?$rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~$rec#0:mytree.tree, ?$rec#1:mytree.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~$rec##0:mytree.tree, ?$rec##1:mytree.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 left > public {inline} (0 calls)
 0: mytree.tree.left<0>
-left($rec#0:mytree.tree, ?$#0:mytree.tree, ?$$#0:wybe.bool):
+left($rec##0:mytree.tree, ?$##0:mytree.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:mytree.tree, ?$#0:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:mytree.tree, ?$##0:mytree.tree)
 
     1:
-        foreign lpvm access(~$rec#0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 left > public {inline} (0 calls)
 1: mytree.tree.left<1>
-left($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:mytree.tree, ?$$#0:wybe.bool):
+left($rec##0:mytree.tree, ?$rec##1:mytree.tree, $field##0:mytree.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:mytree.tree, ?$rec#1:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:mytree.tree, ?$rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~$rec#0:mytree.tree, ?$rec#1:mytree.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field#0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~$rec##0:mytree.tree, ?$rec##1:mytree.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 node > public {inline} (0 calls)
 0: mytree.tree.node<0>
-node(left#0:mytree.tree, key#0:wybe.int, right#0:mytree.tree, ?$#0:mytree.tree):
+node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?$##0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?$rec#0:mytree.tree)
-    foreign lpvm mutate(~$rec#0:mytree.tree, ?$rec#1:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left#0:mytree.tree)
-    foreign lpvm mutate(~$rec#1:mytree.tree, ?$rec#2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key#0:wybe.int)
-    foreign lpvm mutate(~$rec#2:mytree.tree, ?$#0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right#0:mytree.tree)
+    foreign lpvm alloc(24:wybe.int, ?$rec##0:mytree.tree)
+    foreign lpvm mutate(~$rec##0:mytree.tree, ?$rec##1:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:mytree.tree)
+    foreign lpvm mutate(~$rec##1:mytree.tree, ?$rec##2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int)
+    foreign lpvm mutate(~$rec##2:mytree.tree, ?$##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree)
 node > public {inline} (16 calls)
 1: mytree.tree.node<1>
-node(?left#0:mytree.tree, ?key#0:wybe.int, ?right#0:mytree.tree, $#0:mytree.tree, ?$$#0:wybe.bool):
+node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, $##0:mytree.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:mytree.tree, ?left#0:mytree.tree)
-        foreign llvm move(undef:wybe.int, ?key#0:wybe.int)
-        foreign llvm move(undef:mytree.tree, ?right#0:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:mytree.tree, ?left##0:mytree.tree)
+        foreign llvm move(undef:wybe.int, ?key##0:wybe.int)
+        foreign llvm move(undef:mytree.tree, ?right##0:mytree.tree)
 
     1:
-        foreign lpvm access($#0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left#0:mytree.tree)
-        foreign lpvm access($#0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key#0:wybe.int)
-        foreign lpvm access(~$#0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right#0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access($##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:mytree.tree)
+        foreign lpvm access($##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
+        foreign lpvm access(~$##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 right > public {inline} (0 calls)
 0: mytree.tree.right<0>
-right($rec#0:mytree.tree, ?$#0:mytree.tree, ?$$#0:wybe.bool):
+right($rec##0:mytree.tree, ?$##0:mytree.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:mytree.tree, ?$#0:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:mytree.tree, ?$##0:mytree.tree)
 
     1:
-        foreign lpvm access(~$rec#0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 right > public {inline} (0 calls)
 1: mytree.tree.right<1>
-right($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:mytree.tree, ?$$#0:wybe.bool):
+right($rec##0:mytree.tree, ?$rec##1:mytree.tree, $field##0:mytree.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:mytree.tree, ?$rec#1:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:mytree.tree, ?$rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~$rec#0:mytree.tree, ?$rec#1:mytree.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field#0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~$rec##0:mytree.tree, ?$rec##1:mytree.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: mytree.tree.~=<0>
-~=($left#0:mytree.tree, $right#0:mytree.tree, ?$$#0:wybe.bool):
+~=($left##0:mytree.tree, $right##0:mytree.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    mytree.tree.=<0>(~$left#0:mytree.tree, ~$right#0:mytree.tree, ?tmp$0#0:wybe.bool) #0
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    mytree.tree.=<0>(~$left##0:mytree.tree, ~$right##0:mytree.tree, ?tmp$0##0:wybe.bool) #0
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
   LLVM code       :
 
@@ -493,51 +493,51 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"mytree.tree.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"mytree.tree.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$left#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = add   i64 %"$left#0", 16 
+  %8 = add   i64 %"$left##0", 16 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
-  %"2$tmp$10#0" = icmp ne i64 %"$right#0", 0 
-  br i1 %"2$tmp$10#0", label %if.then1, label %if.else1 
+  %"2$tmp$10##0" = icmp ne i64 %"$right##0", 0 
+  br i1 %"2$tmp$10##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = icmp eq i64 %"$left#0", %"$right#0" 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
+  ret i1 %"3$$$##0" 
 if.then1:
-  %12 = inttoptr i64 %"$right#0" to i64* 
+  %12 = inttoptr i64 %"$right##0" to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %15 = add   i64 %"$right#0", 8 
+  %15 = add   i64 %"$right##0", 8 
   %16 = inttoptr i64 %15 to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
-  %19 = add   i64 %"$right#0", 16 
+  %19 = add   i64 %"$right##0", 16 
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %"4$tmp$4#0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %3, i64  %14)  
-  br i1 %"4$tmp$4#0", label %if.then2, label %if.else2 
+  %"4$tmp$4##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %3, i64  %14)  
+  br i1 %"4$tmp$4##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$tmp$5#0" = icmp eq i64 %7, %18 
-  br i1 %"6$tmp$5#0", label %if.then3, label %if.else3 
+  %"6$tmp$5##0" = icmp eq i64 %7, %18 
+  br i1 %"6$tmp$5##0", label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %"8$$$#0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %11, i64  %22)  
-  ret i1 %"8$$$#0" 
+  %"8$$$##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %11, i64  %22)  
+  ret i1 %"8$$$##0" 
 if.else3:
   ret i1 0 
 }
@@ -549,12 +549,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.key<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"mytree.tree.key<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %23 = add   i64 %"$rec#0", 8 
+  %23 = add   i64 %"$rec##0", 8 
   %24 = inttoptr i64 %23 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
   %26 = load  i64, i64* %25 
@@ -568,38 +568,38 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.key<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"mytree.tree.key<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %31 = trunc i64 24 to i32  
   %32 = tail call ccc  i8*  @wybe_malloc(i32  %31)  
   %33 = ptrtoint i8* %32 to i64 
   %34 = inttoptr i64 %33 to i8* 
-  %35 = inttoptr i64 %"$rec#0" to i8* 
+  %35 = inttoptr i64 %"$rec##0" to i8* 
   %36 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %34, i8*  %35, i32  %36, i32  8, i1  0)  
   %37 = add   i64 %33, 8 
   %38 = inttoptr i64 %37 to i64* 
   %39 = getelementptr  i64, i64* %38, i64 0 
-  store  i64 %"$field#0", i64* %39 
+  store  i64 %"$field##0", i64* %39 
   %40 = insertvalue {i64, i1} undef, i64 %33, 0 
   %41 = insertvalue {i64, i1} %40, i1 1, 1 
   ret {i64, i1} %41 
 if.else:
-  %42 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %42 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %43 = insertvalue {i64, i1} %42, i1 0, 1 
   ret {i64, i1} %43 
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.left<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"mytree.tree.left<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %44 = inttoptr i64 %"$rec#0" to i64* 
+  %44 = inttoptr i64 %"$rec##0" to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
   %47 = insertvalue {i64, i1} undef, i64 %46, 0 
@@ -612,64 +612,64 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.left<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"mytree.tree.left<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %51 = trunc i64 24 to i32  
   %52 = tail call ccc  i8*  @wybe_malloc(i32  %51)  
   %53 = ptrtoint i8* %52 to i64 
   %54 = inttoptr i64 %53 to i8* 
-  %55 = inttoptr i64 %"$rec#0" to i8* 
+  %55 = inttoptr i64 %"$rec##0" to i8* 
   %56 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %54, i8*  %55, i32  %56, i32  8, i1  0)  
   %57 = inttoptr i64 %53 to i64* 
   %58 = getelementptr  i64, i64* %57, i64 0 
-  store  i64 %"$field#0", i64* %58 
+  store  i64 %"$field##0", i64* %58 
   %59 = insertvalue {i64, i1} undef, i64 %53, 0 
   %60 = insertvalue {i64, i1} %59, i1 1, 1 
   ret {i64, i1} %60 
 if.else:
-  %61 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %61 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %62 = insertvalue {i64, i1} %61, i1 0, 1 
   ret {i64, i1} %62 
 }
 
 
-define external fastcc  i64 @"mytree.tree.node<0>"(i64  %"left#0", i64  %"key#0", i64  %"right#0")    {
+define external fastcc  i64 @"mytree.tree.node<0>"(i64  %"left##0", i64  %"key##0", i64  %"right##0")    {
 entry:
   %63 = trunc i64 24 to i32  
   %64 = tail call ccc  i8*  @wybe_malloc(i32  %63)  
   %65 = ptrtoint i8* %64 to i64 
   %66 = inttoptr i64 %65 to i64* 
   %67 = getelementptr  i64, i64* %66, i64 0 
-  store  i64 %"left#0", i64* %67 
+  store  i64 %"left##0", i64* %67 
   %68 = add   i64 %65, 8 
   %69 = inttoptr i64 %68 to i64* 
   %70 = getelementptr  i64, i64* %69, i64 0 
-  store  i64 %"key#0", i64* %70 
+  store  i64 %"key##0", i64* %70 
   %71 = add   i64 %65, 16 
   %72 = inttoptr i64 %71 to i64* 
   %73 = getelementptr  i64, i64* %72, i64 0 
-  store  i64 %"right#0", i64* %73 
+  store  i64 %"right##0", i64* %73 
   ret i64 %65 
 }
 
 
-define external fastcc  {i64, i64, i64, i1} @"mytree.tree.node<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64, i64, i1} @"mytree.tree.node<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %74 = inttoptr i64 %"$#0" to i64* 
+  %74 = inttoptr i64 %"$##0" to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
   %76 = load  i64, i64* %75 
-  %77 = add   i64 %"$#0", 8 
+  %77 = add   i64 %"$##0", 8 
   %78 = inttoptr i64 %77 to i64* 
   %79 = getelementptr  i64, i64* %78, i64 0 
   %80 = load  i64, i64* %79 
-  %81 = add   i64 %"$#0", 16 
+  %81 = add   i64 %"$##0", 16 
   %82 = inttoptr i64 %81 to i64* 
   %83 = getelementptr  i64, i64* %82, i64 0 
   %84 = load  i64, i64* %83 
@@ -687,12 +687,12 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.right<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"mytree.tree.right<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %93 = add   i64 %"$rec#0", 16 
+  %93 = add   i64 %"$rec##0", 16 
   %94 = inttoptr i64 %93 to i64* 
   %95 = getelementptr  i64, i64* %94, i64 0 
   %96 = load  i64, i64* %95 
@@ -706,35 +706,35 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.right<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"mytree.tree.right<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %101 = trunc i64 24 to i32  
   %102 = tail call ccc  i8*  @wybe_malloc(i32  %101)  
   %103 = ptrtoint i8* %102 to i64 
   %104 = inttoptr i64 %103 to i8* 
-  %105 = inttoptr i64 %"$rec#0" to i8* 
+  %105 = inttoptr i64 %"$rec##0" to i8* 
   %106 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %104, i8*  %105, i32  %106, i32  8, i1  0)  
   %107 = add   i64 %103, 16 
   %108 = inttoptr i64 %107 to i64* 
   %109 = getelementptr  i64, i64* %108, i64 0 
-  store  i64 %"$field#0", i64* %109 
+  store  i64 %"$field##0", i64* %109 
   %110 = insertvalue {i64, i1} undef, i64 %103, 0 
   %111 = insertvalue {i64, i1} %110, i1 1, 1 
   ret {i64, i1} %111 
 if.else:
-  %112 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %112 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %113 = insertvalue {i64, i1} %112, i1 0, 1 
   ret {i64, i1} %113 
 }
 
 
-define external fastcc  i1 @"mytree.tree.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"mytree.tree.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %"$left#0", i64  %"$right#0")  
-  %"1$$$#0" = xor i1 %"1$tmp$0#0", 1 
-  ret i1 %"1$$$#0" 
+  %"1$tmp$0##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %"$left##0", i64  %"$right##0")  
+  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
+  ret i1 %"1$$$##0" 
 }

--- a/test-cases/final-dump/alias_fork3.exp
+++ b/test-cases/final-dump/alias_fork3.exp
@@ -35,8 +35,8 @@ AFTER EVERYTHING:
 
 simpleSlice > public (1 calls)
 0: alias_fork3.simpleSlice<0>
-simpleSlice(tr##0:mytree.tree, ?###0:mytree.tree):
- AliasPairs: [(###0,tr##0)]
+simpleSlice(tr##0:mytree.tree, ?#result##0:mytree.tree):
+ AliasPairs: [(#result##0,tr##0)]
  InterestingCallProperties: []
     foreign llvm icmp_ne(tr##0:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.bool)
     case ~tmp#6##0:wybe.bool of
@@ -44,10 +44,10 @@ simpleSlice(tr##0:mytree.tree, ?###0:mytree.tree):
         foreign lpvm alloc(24:wybe.int, ?tmp#10##0:mytree.tree)
         foreign lpvm mutate(~tmp#10##0:mytree.tree, ?tmp#11##0:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
         foreign lpvm mutate(~tmp#11##0:mytree.tree, ?tmp#12##0:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, -1:wybe.int)
-        foreign lpvm mutate(~tmp#12##0:mytree.tree, ?###0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
+        foreign lpvm mutate(~tmp#12##0:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:mytree.tree)
 
     1:
-        foreign lpvm access(~tr##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:mytree.tree)
+        foreign lpvm access(~tr##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree)
 
 
   LLVM code       :
@@ -339,25 +339,25 @@ if.else:
 
 empty > public {inline} (0 calls)
 0: mytree.tree.empty<0>
-empty(?###0:mytree.tree):
+empty(?#result##0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:mytree.tree, ?###0:mytree.tree)
+    foreign llvm move(0:mytree.tree, ?#result##0:mytree.tree)
 
 
 key > public {inline} (0 calls)
 0: mytree.tree.key<0>
-key(#rec##0:mytree.tree, ?###0:wybe.int, ?####0:wybe.bool):
+key(#rec##0:mytree.tree, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign lpvm access(~#rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 key > public {inline} (0 calls)
@@ -379,17 +379,17 @@ key(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:wybe.int, ?####0:wybe.b
 
 left > public {inline} (0 calls)
 0: mytree.tree.left<0>
-left(#rec##0:mytree.tree, ?###0:mytree.tree, ?####0:wybe.bool):
+left(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:mytree.tree, ?###0:mytree.tree)
+        foreign llvm move(undef:mytree.tree, ?#result##0:mytree.tree)
 
     1:
-        foreign lpvm access(~#rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:mytree.tree)
+        foreign lpvm access(~#rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 left > public {inline} (0 calls)
@@ -411,19 +411,19 @@ left(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?####0:wy
 
 node > public {inline} (0 calls)
 0: mytree.tree.node<0>
-node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?###0:mytree.tree):
+node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?#result##0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(24:wybe.int, ?#rec##0:mytree.tree)
     foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:mytree.tree)
     foreign lpvm mutate(~#rec##1:mytree.tree, ?#rec##2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int)
-    foreign lpvm mutate(~#rec##2:mytree.tree, ?###0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree)
+    foreign lpvm mutate(~#rec##2:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree)
 node > public {inline} (16 calls)
 1: mytree.tree.node<1>
-node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, ###0:mytree.tree, ?####0:wybe.bool):
+node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, #result##0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
@@ -432,26 +432,26 @@ node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, ###0:mytree.
         foreign llvm move(undef:mytree.tree, ?right##0:mytree.tree)
 
     1:
-        foreign lpvm access(###0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:mytree.tree)
-        foreign lpvm access(###0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
-        foreign lpvm access(~###0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:mytree.tree)
+        foreign lpvm access(#result##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:mytree.tree)
+        foreign lpvm access(#result##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
+        foreign lpvm access(~#result##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:mytree.tree)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 right > public {inline} (0 calls)
 0: mytree.tree.right<0>
-right(#rec##0:mytree.tree, ?###0:mytree.tree, ?####0:wybe.bool):
+right(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:mytree.tree, ?###0:mytree.tree)
+        foreign llvm move(undef:mytree.tree, ?#result##0:mytree.tree)
 
     1:
-        foreign lpvm access(~#rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:mytree.tree)
+        foreign lpvm access(~#rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 right > public {inline} (0 calls)
@@ -657,19 +657,19 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64, i1} @"mytree.tree.node<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64, i64, i1} @"mytree.tree.node<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  %"1#tmp#0##0" = icmp ne i64 %"#result##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %74 = inttoptr i64 %"###0" to i64* 
+  %74 = inttoptr i64 %"#result##0" to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
   %76 = load  i64, i64* %75 
-  %77 = add   i64 %"###0", 8 
+  %77 = add   i64 %"#result##0", 8 
   %78 = inttoptr i64 %77 to i64* 
   %79 = getelementptr  i64, i64* %78, i64 0 
   %80 = load  i64, i64* %79 
-  %81 = add   i64 %"###0", 16 
+  %81 = add   i64 %"#result##0", 16 
   %82 = inttoptr i64 %81 to i64* 
   %83 = getelementptr  i64, i64* %82, i64 0 
   %84 = load  i64, i64* %83 

--- a/test-cases/final-dump/alias_fork3.exp
+++ b/test-cases/final-dump/alias_fork3.exp
@@ -297,13 +297,13 @@ if.else:
 
 = > public (7 calls)
 0: mytree.tree.=<0>
-=(#left##0:mytree.tree, #right##0:mytree.tree, ?####0:wybe.bool):
+=(#left##0:mytree.tree, #right##0:mytree.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~#left##0:mytree.tree, ~#right##0:mytree.tree, ?####0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:mytree.tree, ~#right##0:mytree.tree, ?#success##0:wybe.bool)
 
     1:
         foreign lpvm access(#left##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#left##0:mytree.tree)
@@ -312,7 +312,7 @@ if.else:
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
         case ~tmp#10##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign lpvm access(#right##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#left##0:mytree.tree)
@@ -321,16 +321,16 @@ if.else:
             mytree.tree.=<0>(~#left#left##0:mytree.tree, ~#right#left##0:mytree.tree, ?tmp#4##0:wybe.bool) #2
             case ~tmp#4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
                 foreign llvm icmp_eq(~#left#key##0:wybe.int, ~#right#key##0:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
                 case ~tmp#5##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                 1:
-                    mytree.tree.=<0>(~#left#right##0:mytree.tree, ~#right#right##0:mytree.tree, ?####0:wybe.bool) #4
+                    mytree.tree.=<0>(~#left#right##0:mytree.tree, ~#right#right##0:mytree.tree, ?#success##0:wybe.bool) #4
 
 
 
@@ -347,65 +347,65 @@ empty(?#result##0:mytree.tree):
 
 key > public {inline} (0 calls)
 0: mytree.tree.key<0>
-key(#rec##0:mytree.tree, ?#result##0:wybe.int, ?####0:wybe.bool):
+key(#rec##0:mytree.tree, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign lpvm access(~#rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 key > public {inline} (0 calls)
 1: mytree.tree.key<1>
-key(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:wybe.int, ?####0:wybe.bool):
+key(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
         foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 left > public {inline} (0 calls)
 0: mytree.tree.left<0>
-left(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?####0:wybe.bool):
+left(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:mytree.tree, ?#result##0:mytree.tree)
 
     1:
         foreign lpvm access(~#rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 left > public {inline} (0 calls)
 1: mytree.tree.left<1>
-left(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?####0:wybe.bool):
+left(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
         foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -420,13 +420,13 @@ node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?#result##0:myt
     foreign lpvm mutate(~#rec##2:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree)
 node > public {inline} (16 calls)
 1: mytree.tree.node<1>
-node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, #result##0:mytree.tree, ?####0:wybe.bool):
+node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, #result##0:mytree.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:mytree.tree, ?left##0:mytree.tree)
         foreign llvm move(undef:wybe.int, ?key##0:wybe.int)
         foreign llvm move(undef:mytree.tree, ?right##0:mytree.tree)
@@ -435,49 +435,49 @@ node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, #result##0:m
         foreign lpvm access(#result##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:mytree.tree)
         foreign lpvm access(#result##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
         foreign lpvm access(~#result##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 right > public {inline} (0 calls)
 0: mytree.tree.right<0>
-right(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?####0:wybe.bool):
+right(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:mytree.tree, ?#result##0:mytree.tree)
 
     1:
         foreign lpvm access(~#rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 right > public {inline} (0 calls)
 1: mytree.tree.right<1>
-right(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?####0:wybe.bool):
+right(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
         foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: mytree.tree.~=<0>
-~=(#left##0:mytree.tree, #right##0:mytree.tree, ?####0:wybe.bool):
+~=(#left##0:mytree.tree, #right##0:mytree.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     mytree.tree.=<0>(~#left##0:mytree.tree, ~#right##0:mytree.tree, ?tmp#0##0:wybe.bool) #0
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 
@@ -512,8 +512,8 @@ if.then:
   %"2#tmp#10##0" = icmp ne i64 %"#right##0", 0 
   br i1 %"2#tmp#10##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %"3#####0" 
+  %"3##success##0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3##success##0" 
 if.then1:
   %12 = inttoptr i64 %"#right##0" to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
@@ -536,8 +536,8 @@ if.then2:
 if.else2:
   ret i1 0 
 if.then3:
-  %"8#####0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %11, i64  %22)  
-  ret i1 %"8#####0" 
+  %"8##success##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %11, i64  %22)  
+  ret i1 %"8##success##0" 
 if.else3:
   ret i1 0 
 }
@@ -735,6 +735,6 @@ if.else:
 define external fastcc  i1 @"mytree.tree.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %"1#tmp#0##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %"#left##0", i64  %"#right##0")  
-  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
-  ret i1 %"1#####0" 
+  %"1##success##0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1##success##0" 
 }

--- a/test-cases/final-dump/alias_m.exp
+++ b/test-cases/final-dump/alias_m.exp
@@ -13,19 +13,19 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: alias_m.<0>
-(io#0:wybe.phantom, ?io#7:wybe.phantom):
+(io##0:wybe.phantom, ?io##7:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$3#0:position.position)
-    foreign lpvm mutate(~tmp$3#0:position.position, ?tmp$4#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp$4#0:position.position, ?tmp$0#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    alias_mfoo.foo<0>(tmp$0#0:position.position, ?p2#0:position.position, ?p3#0:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #1 @alias_m:nn:nn
-    foreign c print_string("expect p1(2,2)":wybe.string, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~tmp$0#0:position.position, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) #3 @alias_m:nn:nn
-    foreign c print_string("expect p2(2,2)":wybe.string, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~p2#0:position.position, ~#io#4:wybe.phantom, ?#io#5:wybe.phantom) #5 @alias_m:nn:nn
-    foreign c print_string("expect p3(3,3)":wybe.string, ~#io#5:wybe.phantom, ?#io#6:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~p3#0:position.position, ~#io#6:wybe.phantom, ?#io#7:wybe.phantom) #7 @alias_m:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$3##0:position.position)
+    foreign lpvm mutate(~tmp$3##0:position.position, ?tmp$4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    alias_mfoo.foo<0>(tmp$0##0:position.position, ?p2##0:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias_m:nn:nn
+    foreign c print_string("expect p1(2,2)":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~tmp$0##0:position.position, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @alias_m:nn:nn
+    foreign c print_string("expect p2(2,2)":wybe.string, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~p2##0:position.position, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #5 @alias_m:nn:nn
+    foreign c print_string("expect p3(3,3)":wybe.string, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~p3##0:position.position, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) #7 @alias_m:nn:nn
 
   LLVM code       :
 
@@ -99,34 +99,34 @@ entry:
 
 bar > public (0 calls)
 0: alias_mbar.bar<0>[410bae77d3]
-bar(p1#0:position.position, ?p3#1:position.position, io#0:wybe.phantom, ?io#1:wybe.phantom):
- AliasPairs: [(p1#0,p3#1)]
+bar(p1##0:position.position, ?p3##1:position.position, io##0:wybe.phantom, ?io##1:wybe.phantom):
+ AliasPairs: [(p1##0,p3##1)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(5,(alias_mfoo.foo<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm access(p1#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.bool) @int:nn:nn
-    case ~tmp$3#0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
+    case ~tmp$3##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1#0:position.position, ?%p1#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:wybe.int)
-        alias_mfoo.foo<0>[410bae77d3](~p1#1:position.position, ?p2#0:position.position, ?p3#1:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #5 @alias_mbar:nn:nn
+        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:wybe.int)
+        alias_mfoo.foo<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ?p3##1:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_mbar:nn:nn
 
     1:
-        foreign llvm move(~p1#0:position.position, ?p3#1:position.position)
-        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+        foreign llvm move(~p1##0:position.position, ?p3##1:position.position)
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(p1#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.bool) @int:nn:nn
-    case ~tmp$3#0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
+    case ~tmp$3##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1#0:position.position, ?%p1#1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:wybe.int)
-        alias_mfoo.foo<0>[410bae77d3](~p1#1:position.position, ?p2#0:position.position, ?p3#1:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #5 @alias_mbar:nn:nn
+        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:wybe.int)
+        alias_mfoo.foo<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ?p3##1:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_mbar:nn:nn
 
     1:
-        foreign llvm move(~p1#0:position.position, ?p3#1:position.position)
-        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+        foreign llvm move(~p1##0:position.position, ?p3##1:position.position)
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
 
   LLVM code       :
@@ -146,29 +146,29 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i64 @"alias_mbar.bar<0>"(i64  %"p1#0")    {
+define external fastcc  i64 @"alias_mbar.bar<0>"(i64  %"p1##0")    {
 entry:
-  %1 = add   i64 %"p1#0", 8 
+  %1 = add   i64 %"p1##0", 8 
   %2 = inttoptr i64 %1 to i64* 
   %3 = getelementptr  i64, i64* %2, i64 0 
   %4 = load  i64, i64* %3 
-  %"1$tmp$3#0" = icmp sgt i64 %4, 1 
-  br i1 %"1$tmp$3#0", label %if.then, label %if.else 
+  %"1$tmp$3##0" = icmp sgt i64 %4, 1 
+  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
 if.then:
-  ret i64 %"p1#0" 
+  ret i64 %"p1##0" 
 if.else:
-  %"3$tmp$2#0" = add   i64 %4, 1 
+  %"3$tmp$2##0" = add   i64 %4, 1 
   %5 = trunc i64 16 to i32  
   %6 = tail call ccc  i8*  @wybe_malloc(i32  %5)  
   %7 = ptrtoint i8* %6 to i64 
   %8 = inttoptr i64 %7 to i8* 
-  %9 = inttoptr i64 %"p1#0" to i8* 
+  %9 = inttoptr i64 %"p1##0" to i8* 
   %10 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %8, i8*  %9, i32  %10, i32  8, i1  0)  
   %11 = add   i64 %7, 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 %"3$tmp$2#0", i64* %13 
+  store  i64 %"3$tmp$2##0", i64* %13 
   %14 = tail call fastcc  {i64, i64}  @"alias_mfoo.foo<0>[410bae77d3]"(i64  %7)  
   %15 = extractvalue {i64, i64} %14, 0 
   %16 = extractvalue {i64, i64} %14, 1 
@@ -176,23 +176,23 @@ if.else:
 }
 
 
-define external fastcc  i64 @"alias_mbar.bar<0>[410bae77d3]"(i64  %"p1#0")    {
+define external fastcc  i64 @"alias_mbar.bar<0>[410bae77d3]"(i64  %"p1##0")    {
 entry:
-  %17 = add   i64 %"p1#0", 8 
+  %17 = add   i64 %"p1##0", 8 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
   %20 = load  i64, i64* %19 
-  %"1$tmp$3#0" = icmp sgt i64 %20, 1 
-  br i1 %"1$tmp$3#0", label %if.then, label %if.else 
+  %"1$tmp$3##0" = icmp sgt i64 %20, 1 
+  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
 if.then:
-  ret i64 %"p1#0" 
+  ret i64 %"p1##0" 
 if.else:
-  %"3$tmp$2#0" = add   i64 %20, 1 
-  %21 = add   i64 %"p1#0", 8 
+  %"3$tmp$2##0" = add   i64 %20, 1 
+  %21 = add   i64 %"p1##0", 8 
   %22 = inttoptr i64 %21 to i64* 
   %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 %"3$tmp$2#0", i64* %23 
-  %24 = tail call fastcc  {i64, i64}  @"alias_mfoo.foo<0>[410bae77d3]"(i64  %"p1#0")  
+  store  i64 %"3$tmp$2##0", i64* %23 
+  %24 = tail call fastcc  {i64, i64}  @"alias_mfoo.foo<0>[410bae77d3]"(i64  %"p1##0")  
   %25 = extractvalue {i64, i64} %24, 0 
   %26 = extractvalue {i64, i64} %24, 1 
   ret i64 %26 
@@ -211,50 +211,50 @@ if.else:
 
 foo > public (0 calls)
 0: alias_mfoo.foo<0>[410bae77d3]
-foo(p1#0:position.position, ?p2#0:position.position, ?p3#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
- AliasPairs: [(p1#0,p2#0)]
+foo(p1##0:position.position, ?p2##0:position.position, ?p3##0:position.position, io##0:wybe.phantom, ?io##2:wybe.phantom):
+ AliasPairs: [(p1##0,p2##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(8,(alias_mbar.bar<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm access(p1#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0#0:wybe.int, 1:wybe.int, ?tmp$5#0:wybe.bool) @int:nn:nn
-    case ~tmp$5#0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 1:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
+    case ~tmp$5##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1#0:position.position, ?%p1#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3#0:wybe.int)
-        alias_mbar.bar<0>[410bae77d3](~p1#1:position.position, ?p3#0:position.position, ~#io#0:wybe.phantom, ?#io#2:wybe.phantom) #8 @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$16#0:position.position)
-        foreign lpvm mutate(~tmp$16#0:position.position, ?tmp$17#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-        foreign lpvm mutate(~tmp$17#0:position.position, ?p2#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:wybe.int)
+        alias_mbar.bar<0>[410bae77d3](~p1##1:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##2:wybe.phantom) #8 @alias_mfoo:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp$16##0:position.position)
+        foreign lpvm mutate(~tmp$16##0:position.position, ?tmp$17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm mutate(~tmp$17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
 
     1:
-        foreign llvm move(~p1#0:position.position, ?p2#0:position.position) @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$11#0:position.position)
-        foreign lpvm mutate(~tmp$11#0:position.position, ?tmp$12#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign lpvm mutate(~tmp$12#0:position.position, ?tmp$1#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign llvm move(tmp$1#0:position.position, ?p3#0:position.position) @alias_mfoo:nn:nn
-        foreign c print_string("p3:":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        position.printPosition<0>(~tmp$1#0:position.position, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #4 @alias_mfoo:nn:nn
+        foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_mfoo:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp$11##0:position.position)
+        foreign lpvm mutate(~tmp$11##0:position.position, ?tmp$12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign lpvm mutate(~tmp$12##0:position.position, ?tmp$1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign llvm move(tmp$1##0:position.position, ?p3##0:position.position) @alias_mfoo:nn:nn
+        foreign c print_string("p3:":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        position.printPosition<0>(~tmp$1##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @alias_mfoo:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(p1#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0#0:wybe.int, 1:wybe.int, ?tmp$5#0:wybe.bool) @int:nn:nn
-    case ~tmp$5#0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 1:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
+    case ~tmp$5##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1#0:position.position, ?%p1#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3#0:wybe.int)
-        alias_mbar.bar<0>[410bae77d3](~p1#1:position.position, ?p3#0:position.position, ~#io#0:wybe.phantom, ?#io#2:wybe.phantom) #8 @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$16#0:position.position)
-        foreign lpvm mutate(~tmp$16#0:position.position, ?tmp$17#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-        foreign lpvm mutate(~tmp$17#0:position.position, ?p2#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:wybe.int)
+        alias_mbar.bar<0>[410bae77d3](~p1##1:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##2:wybe.phantom) #8 @alias_mfoo:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp$16##0:position.position)
+        foreign lpvm mutate(~tmp$16##0:position.position, ?tmp$17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm mutate(~tmp$17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
 
     1:
-        foreign llvm move(~p1#0:position.position, ?p2#0:position.position) @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$11#0:position.position)
-        foreign lpvm mutate(~tmp$11#0:position.position, ?tmp$12#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign lpvm mutate(~tmp$12#0:position.position, ?tmp$1#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign llvm move(tmp$1#0:position.position, ?p3#0:position.position) @alias_mfoo:nn:nn
-        foreign c print_string("p3:":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        position.printPosition<0>(~tmp$1#0:position.position, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #4 @alias_mfoo:nn:nn
+        foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_mfoo:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp$11##0:position.position)
+        foreign lpvm mutate(~tmp$11##0:position.position, ?tmp$12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign lpvm mutate(~tmp$12##0:position.position, ?tmp$1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign llvm move(tmp$1##0:position.position, ?p3##0:position.position) @alias_mfoo:nn:nn
+        foreign c print_string("p3:":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        position.printPosition<0>(~tmp$1##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @alias_mfoo:nn:nn
 
 
   LLVM code       :
@@ -286,13 +286,13 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  {i64, i64} @"alias_mfoo.foo<0>"(i64  %"p1#0")    {
+define external fastcc  {i64, i64} @"alias_mfoo.foo<0>"(i64  %"p1##0")    {
 entry:
-  %1 = inttoptr i64 %"p1#0" to i64* 
+  %1 = inttoptr i64 %"p1##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %"1$tmp$5#0" = icmp sgt i64 %3, 1 
-  br i1 %"1$tmp$5#0", label %if.then, label %if.else 
+  %"1$tmp$5##0" = icmp sgt i64 %3, 1 
+  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
 if.then:
   %4 = trunc i64 16 to i32  
   %5 = tail call ccc  i8*  @wybe_malloc(i32  %4)  
@@ -307,22 +307,22 @@ if.then:
   %13 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_mfoo.12, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %13)  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %6)  
-  %14 = insertvalue {i64, i64} undef, i64 %"p1#0", 0 
+  %14 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
   %15 = insertvalue {i64, i64} %14, i64 %6, 1 
   ret {i64, i64} %15 
 if.else:
-  %"3$tmp$3#0" = add   i64 %3, 1 
+  %"3$tmp$3##0" = add   i64 %3, 1 
   %16 = trunc i64 16 to i32  
   %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
   %18 = ptrtoint i8* %17 to i64 
   %19 = inttoptr i64 %18 to i8* 
-  %20 = inttoptr i64 %"p1#0" to i8* 
+  %20 = inttoptr i64 %"p1##0" to i8* 
   %21 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %19, i8*  %20, i32  %21, i32  8, i1  0)  
   %22 = inttoptr i64 %18 to i64* 
   %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 %"3$tmp$3#0", i64* %23 
-  %"3$p3#0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %18)  
+  store  i64 %"3$tmp$3##0", i64* %23 
+  %"3$p3##0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %18)  
   %24 = trunc i64 16 to i32  
   %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
   %26 = ptrtoint i8* %25 to i64 
@@ -334,18 +334,18 @@ if.else:
   %31 = getelementptr  i64, i64* %30, i64 0 
   store  i64 2, i64* %31 
   %32 = insertvalue {i64, i64} undef, i64 %26, 0 
-  %33 = insertvalue {i64, i64} %32, i64 %"3$p3#0", 1 
+  %33 = insertvalue {i64, i64} %32, i64 %"3$p3##0", 1 
   ret {i64, i64} %33 
 }
 
 
-define external fastcc  {i64, i64} @"alias_mfoo.foo<0>[410bae77d3]"(i64  %"p1#0")    {
+define external fastcc  {i64, i64} @"alias_mfoo.foo<0>[410bae77d3]"(i64  %"p1##0")    {
 entry:
-  %34 = inttoptr i64 %"p1#0" to i64* 
+  %34 = inttoptr i64 %"p1##0" to i64* 
   %35 = getelementptr  i64, i64* %34, i64 0 
   %36 = load  i64, i64* %35 
-  %"1$tmp$5#0" = icmp sgt i64 %36, 1 
-  br i1 %"1$tmp$5#0", label %if.then, label %if.else 
+  %"1$tmp$5##0" = icmp sgt i64 %36, 1 
+  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
 if.then:
   %37 = trunc i64 16 to i32  
   %38 = tail call ccc  i8*  @wybe_malloc(i32  %37)  
@@ -360,15 +360,15 @@ if.then:
   %46 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_mfoo.45, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %46)  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %39)  
-  %47 = insertvalue {i64, i64} undef, i64 %"p1#0", 0 
+  %47 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
   %48 = insertvalue {i64, i64} %47, i64 %39, 1 
   ret {i64, i64} %48 
 if.else:
-  %"3$tmp$3#0" = add   i64 %36, 1 
-  %49 = inttoptr i64 %"p1#0" to i64* 
+  %"3$tmp$3##0" = add   i64 %36, 1 
+  %49 = inttoptr i64 %"p1##0" to i64* 
   %50 = getelementptr  i64, i64* %49, i64 0 
-  store  i64 %"3$tmp$3#0", i64* %50 
-  %"3$p3#0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %"p1#0")  
+  store  i64 %"3$tmp$3##0", i64* %50 
+  %"3$p3##0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %"p1##0")  
   %51 = trunc i64 16 to i32  
   %52 = tail call ccc  i8*  @wybe_malloc(i32  %51)  
   %53 = ptrtoint i8* %52 to i64 
@@ -380,7 +380,7 @@ if.else:
   %58 = getelementptr  i64, i64* %57, i64 0 
   store  i64 2, i64* %58 
   %59 = insertvalue {i64, i64} undef, i64 %53, 0 
-  %60 = insertvalue {i64, i64} %59, i64 %"3$p3#0", 1 
+  %60 = insertvalue {i64, i64} %59, i64 %"3$p3##0", 1 
   ret {i64, i64} %60 
 }
 --------------------------------------------------
@@ -405,17 +405,17 @@ if.else:
 
 printPosition > public (0 calls)
 0: position.printPosition<0>
-printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string(",":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io#4:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -449,17 +449,17 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"position.printPosition<0>"(i64  %"pos#0")    {
+define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
-  %3 = inttoptr i64 %"pos#0" to i64* 
+  %3 = inttoptr i64 %"pos##0" to i64* 
   %4 = getelementptr  i64, i64* %3, i64 0 
   %5 = load  i64, i64* %4 
   tail call ccc  void  @print_int(i64  %5)  
   %7 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.6, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %7)  
-  %8 = add   i64 %"pos#0", 8 
+  %8 = add   i64 %"pos##0", 8 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
@@ -489,86 +489,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y#0:wybe.int)
-    foreign llvm icmp_eq(~$left$x#0:wybe.int, ~$right$x#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
+    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y#0:wybe.int, ~$right$y#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
-    foreign lpvm mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:position.position, ?$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
+    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
-    foreign lpvm access(~$#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y#0:wybe.int)
+    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec#0:position.position, ?$#0:wybe.int):
+x($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec#0:position.position, ?$#0:wybe.int):
+y($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -585,54 +585,54 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$#0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = icmp eq i64 %7, %14 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"x#0", i64* %19 
+  store  i64 %"x##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"y#0", i64* %22 
+  store  i64 %"y##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
 entry:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -642,34 +642,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec#0" to i64* 
+  %32 = inttoptr i64 %"$rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec#0" to i8* 
+  %39 = inttoptr i64 %"$rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field#0", i64* %42 
+  store  i64 %"$field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = add   i64 %"$rec#0", 8 
+  %43 = add   i64 %"$rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -677,46 +677,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec#0" to i8* 
+  %51 = inttoptr i64 %"$rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field#0", i64* %55 
+  store  i64 %"$field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %58, %65 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = icmp eq i64 %62, %69 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$0##0" = icmp eq i64 %62, %69 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }

--- a/test-cases/final-dump/alias_m.exp
+++ b/test-cases/final-dump/alias_m.exp
@@ -508,27 +508,27 @@ entry:
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x(#rec##0:position.position, ?###0:wybe.int):
+x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -539,10 +539,10 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y(#rec##0:position.position, ?###0:wybe.int):
+y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -627,12 +627,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 

--- a/test-cases/final-dump/alias_m.exp
+++ b/test-cases/final-dump/alias_m.exp
@@ -16,12 +16,12 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##7:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$3##0:position.position)
-    foreign lpvm mutate(~tmp$3##0:position.position, ?tmp$4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    alias_mfoo.foo<0>(tmp$0##0:position.position, ?p2##0:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias_m:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position)
+    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    alias_mfoo.foo<0>(tmp#0##0:position.position, ?p2##0:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias_m:nn:nn
     foreign c print_string("expect p1(2,2)":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~tmp$0##0:position.position, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @alias_m:nn:nn
+    position.printPosition<0>(~tmp#0##0:position.position, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @alias_m:nn:nn
     foreign c print_string("expect p2(2,2)":wybe.string, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     position.printPosition<0>(~p2##0:position.position, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #5 @alias_m:nn:nn
     foreign c print_string("expect p3(3,3)":wybe.string, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
@@ -103,12 +103,12 @@ bar(p1##0:position.position, ?p3##1:position.position, io##0:wybe.phantom, ?io##
  AliasPairs: [(p1##0,p3##1)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(5,(alias_mfoo.foo<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
-    case ~tmp$3##0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp#0##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
+    case ~tmp#3##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:wybe.int)
+        foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
         alias_mfoo.foo<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ?p3##1:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_mbar:nn:nn
 
     1:
@@ -116,12 +116,12 @@ bar(p1##0:position.position, ?p3##1:position.position, io##0:wybe.phantom, ?io##
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
-    case ~tmp$3##0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp#0##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
+    case ~tmp#3##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:wybe.int)
+        foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
         alias_mfoo.foo<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ?p3##1:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_mbar:nn:nn
 
     1:
@@ -152,12 +152,12 @@ entry:
   %2 = inttoptr i64 %1 to i64* 
   %3 = getelementptr  i64, i64* %2, i64 0 
   %4 = load  i64, i64* %3 
-  %"1$tmp$3##0" = icmp sgt i64 %4, 1 
-  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
+  %"1#tmp#3##0" = icmp sgt i64 %4, 1 
+  br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
   ret i64 %"p1##0" 
 if.else:
-  %"3$tmp$2##0" = add   i64 %4, 1 
+  %"3#tmp#2##0" = add   i64 %4, 1 
   %5 = trunc i64 16 to i32  
   %6 = tail call ccc  i8*  @wybe_malloc(i32  %5)  
   %7 = ptrtoint i8* %6 to i64 
@@ -168,7 +168,7 @@ if.else:
   %11 = add   i64 %7, 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 %"3$tmp$2##0", i64* %13 
+  store  i64 %"3#tmp#2##0", i64* %13 
   %14 = tail call fastcc  {i64, i64}  @"alias_mfoo.foo<0>[410bae77d3]"(i64  %7)  
   %15 = extractvalue {i64, i64} %14, 0 
   %16 = extractvalue {i64, i64} %14, 1 
@@ -182,16 +182,16 @@ entry:
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
   %20 = load  i64, i64* %19 
-  %"1$tmp$3##0" = icmp sgt i64 %20, 1 
-  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
+  %"1#tmp#3##0" = icmp sgt i64 %20, 1 
+  br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
   ret i64 %"p1##0" 
 if.else:
-  %"3$tmp$2##0" = add   i64 %20, 1 
+  %"3#tmp#2##0" = add   i64 %20, 1 
   %21 = add   i64 %"p1##0", 8 
   %22 = inttoptr i64 %21 to i64* 
   %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 %"3$tmp$2##0", i64* %23 
+  store  i64 %"3#tmp#2##0", i64* %23 
   %24 = tail call fastcc  {i64, i64}  @"alias_mfoo.foo<0>[410bae77d3]"(i64  %"p1##0")  
   %25 = extractvalue {i64, i64} %24, 0 
   %26 = extractvalue {i64, i64} %24, 1 
@@ -215,46 +215,46 @@ foo(p1##0:position.position, ?p2##0:position.position, ?p3##0:position.position,
  AliasPairs: [(p1##0,p2##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(8,(alias_mbar.bar<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 1:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
-    case ~tmp$5##0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp#0##0:wybe.int, 1:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
+    case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:wybe.int)
+        foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int)
         alias_mbar.bar<0>[410bae77d3](~p1##1:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##2:wybe.phantom) #8 @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$16##0:position.position)
-        foreign lpvm mutate(~tmp$16##0:position.position, ?tmp$17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-        foreign lpvm mutate(~tmp$17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm alloc(16:wybe.int, ?tmp#16##0:position.position)
+        foreign lpvm mutate(~tmp#16##0:position.position, ?tmp#17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm mutate(~tmp#17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
 
     1:
         foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$11##0:position.position)
-        foreign lpvm mutate(~tmp$11##0:position.position, ?tmp$12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign lpvm mutate(~tmp$12##0:position.position, ?tmp$1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign llvm move(tmp$1##0:position.position, ?p3##0:position.position) @alias_mfoo:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:position.position)
+        foreign lpvm mutate(~tmp#11##0:position.position, ?tmp#12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign lpvm mutate(~tmp#12##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign llvm move(tmp#1##0:position.position, ?p3##0:position.position) @alias_mfoo:nn:nn
         foreign c print_string("p3:":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        position.printPosition<0>(~tmp$1##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @alias_mfoo:nn:nn
+        position.printPosition<0>(~tmp#1##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @alias_mfoo:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 1:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
-    case ~tmp$5##0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp#0##0:wybe.int, 1:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
+    case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:wybe.int)
+        foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int)
         alias_mbar.bar<0>[410bae77d3](~p1##1:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##2:wybe.phantom) #8 @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$16##0:position.position)
-        foreign lpvm mutate(~tmp$16##0:position.position, ?tmp$17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-        foreign lpvm mutate(~tmp$17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm alloc(16:wybe.int, ?tmp#16##0:position.position)
+        foreign lpvm mutate(~tmp#16##0:position.position, ?tmp#17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm mutate(~tmp#17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
 
     1:
         foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$11##0:position.position)
-        foreign lpvm mutate(~tmp$11##0:position.position, ?tmp$12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign lpvm mutate(~tmp$12##0:position.position, ?tmp$1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign llvm move(tmp$1##0:position.position, ?p3##0:position.position) @alias_mfoo:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:position.position)
+        foreign lpvm mutate(~tmp#11##0:position.position, ?tmp#12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign lpvm mutate(~tmp#12##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign llvm move(tmp#1##0:position.position, ?p3##0:position.position) @alias_mfoo:nn:nn
         foreign c print_string("p3:":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        position.printPosition<0>(~tmp$1##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @alias_mfoo:nn:nn
+        position.printPosition<0>(~tmp#1##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @alias_mfoo:nn:nn
 
 
   LLVM code       :
@@ -291,8 +291,8 @@ entry:
   %1 = inttoptr i64 %"p1##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %"1$tmp$5##0" = icmp sgt i64 %3, 1 
-  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
+  %"1#tmp#5##0" = icmp sgt i64 %3, 1 
+  br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
   %4 = trunc i64 16 to i32  
   %5 = tail call ccc  i8*  @wybe_malloc(i32  %4)  
@@ -311,7 +311,7 @@ if.then:
   %15 = insertvalue {i64, i64} %14, i64 %6, 1 
   ret {i64, i64} %15 
 if.else:
-  %"3$tmp$3##0" = add   i64 %3, 1 
+  %"3#tmp#3##0" = add   i64 %3, 1 
   %16 = trunc i64 16 to i32  
   %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
   %18 = ptrtoint i8* %17 to i64 
@@ -321,8 +321,8 @@ if.else:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %19, i8*  %20, i32  %21, i32  8, i1  0)  
   %22 = inttoptr i64 %18 to i64* 
   %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 %"3$tmp$3##0", i64* %23 
-  %"3$p3##0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %18)  
+  store  i64 %"3#tmp#3##0", i64* %23 
+  %"3#p3##0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %18)  
   %24 = trunc i64 16 to i32  
   %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
   %26 = ptrtoint i8* %25 to i64 
@@ -334,7 +334,7 @@ if.else:
   %31 = getelementptr  i64, i64* %30, i64 0 
   store  i64 2, i64* %31 
   %32 = insertvalue {i64, i64} undef, i64 %26, 0 
-  %33 = insertvalue {i64, i64} %32, i64 %"3$p3##0", 1 
+  %33 = insertvalue {i64, i64} %32, i64 %"3#p3##0", 1 
   ret {i64, i64} %33 
 }
 
@@ -344,8 +344,8 @@ entry:
   %34 = inttoptr i64 %"p1##0" to i64* 
   %35 = getelementptr  i64, i64* %34, i64 0 
   %36 = load  i64, i64* %35 
-  %"1$tmp$5##0" = icmp sgt i64 %36, 1 
-  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
+  %"1#tmp#5##0" = icmp sgt i64 %36, 1 
+  br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
   %37 = trunc i64 16 to i32  
   %38 = tail call ccc  i8*  @wybe_malloc(i32  %37)  
@@ -364,11 +364,11 @@ if.then:
   %48 = insertvalue {i64, i64} %47, i64 %39, 1 
   ret {i64, i64} %48 
 if.else:
-  %"3$tmp$3##0" = add   i64 %36, 1 
+  %"3#tmp#3##0" = add   i64 %36, 1 
   %49 = inttoptr i64 %"p1##0" to i64* 
   %50 = getelementptr  i64, i64* %49, i64 0 
-  store  i64 %"3$tmp$3##0", i64* %50 
-  %"3$p3##0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %"p1##0")  
+  store  i64 %"3#tmp#3##0", i64* %50 
+  %"3#p3##0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %"p1##0")  
   %51 = trunc i64 16 to i32  
   %52 = tail call ccc  i8*  @wybe_malloc(i32  %51)  
   %53 = ptrtoint i8* %52 to i64 
@@ -380,7 +380,7 @@ if.else:
   %58 = getelementptr  i64, i64* %57, i64 0 
   store  i64 2, i64* %58 
   %59 = insertvalue {i64, i64} undef, i64 %53, 0 
-  %60 = insertvalue {i64, i64} %59, i64 %"3$p3##0", 1 
+  %60 = insertvalue {i64, i64} %59, i64 %"3#p3##0", 1 
   ret {i64, i64} %60 
 }
 --------------------------------------------------
@@ -409,13 +409,13 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -489,86 +489,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
-    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
-    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec##0:position.position, ?$##0:wybe.int):
+x(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec##0:position.position, ?$##0:wybe.int):
+y(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -585,27 +585,27 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$##0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$##0" 
+  %"2#####0" = icmp eq i64 %7, %14 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
@@ -627,12 +627,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
 entry:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -642,34 +642,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec##0" to i64* 
+  %32 = inttoptr i64 %"#rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec##0" to i8* 
+  %39 = inttoptr i64 %"#rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field##0", i64* %42 
+  store  i64 %"#field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = add   i64 %"$rec##0", 8 
+  %43 = add   i64 %"#rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -677,46 +677,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec##0" to i8* 
+  %51 = inttoptr i64 %"#rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field##0", i64* %55 
+  store  i64 %"#field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %58, %65 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = icmp eq i64 %62, %69 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#0##0" = icmp eq i64 %62, %69 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }

--- a/test-cases/final-dump/alias_m.exp
+++ b/test-cases/final-dump/alias_m.exp
@@ -489,7 +489,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
@@ -499,10 +499,10 @@ entry:
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -553,7 +553,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -564,11 +564,11 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -604,8 +604,8 @@ entry:
   %"1#tmp#1##0" = icmp eq i64 %3, %10 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2#####0" = icmp eq i64 %7, %14 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %7, %14 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -714,9 +714,9 @@ entry:
   br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#0##0" = icmp eq i64 %62, %69 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }

--- a/test-cases/final-dump/alias_mbar.exp
+++ b/test-cases/final-dump/alias_mbar.exp
@@ -17,12 +17,12 @@ bar(p1##0:position.position, ?p3##1:position.position, io##0:wybe.phantom, ?io##
  AliasPairs: [(p1##0,p3##1)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(5,(alias_mfoo.foo<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
-    case ~tmp$3##0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp#0##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
+    case ~tmp#3##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:wybe.int)
+        foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
         alias_mfoo.foo<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ?p3##1:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_mbar:nn:nn
 
     1:
@@ -30,12 +30,12 @@ bar(p1##0:position.position, ?p3##1:position.position, io##0:wybe.phantom, ?io##
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
-    case ~tmp$3##0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp#0##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
+    case ~tmp#3##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:wybe.int)
+        foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
         alias_mfoo.foo<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ?p3##1:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_mbar:nn:nn
 
     1:
@@ -66,12 +66,12 @@ entry:
   %2 = inttoptr i64 %1 to i64* 
   %3 = getelementptr  i64, i64* %2, i64 0 
   %4 = load  i64, i64* %3 
-  %"1$tmp$3##0" = icmp sgt i64 %4, 1 
-  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
+  %"1#tmp#3##0" = icmp sgt i64 %4, 1 
+  br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
   ret i64 %"p1##0" 
 if.else:
-  %"3$tmp$2##0" = add   i64 %4, 1 
+  %"3#tmp#2##0" = add   i64 %4, 1 
   %5 = trunc i64 16 to i32  
   %6 = tail call ccc  i8*  @wybe_malloc(i32  %5)  
   %7 = ptrtoint i8* %6 to i64 
@@ -82,7 +82,7 @@ if.else:
   %11 = add   i64 %7, 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 %"3$tmp$2##0", i64* %13 
+  store  i64 %"3#tmp#2##0", i64* %13 
   %14 = tail call fastcc  {i64, i64}  @"alias_mfoo.foo<0>[410bae77d3]"(i64  %7)  
   %15 = extractvalue {i64, i64} %14, 0 
   %16 = extractvalue {i64, i64} %14, 1 
@@ -96,16 +96,16 @@ entry:
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
   %20 = load  i64, i64* %19 
-  %"1$tmp$3##0" = icmp sgt i64 %20, 1 
-  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
+  %"1#tmp#3##0" = icmp sgt i64 %20, 1 
+  br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
   ret i64 %"p1##0" 
 if.else:
-  %"3$tmp$2##0" = add   i64 %20, 1 
+  %"3#tmp#2##0" = add   i64 %20, 1 
   %21 = add   i64 %"p1##0", 8 
   %22 = inttoptr i64 %21 to i64* 
   %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 %"3$tmp$2##0", i64* %23 
+  store  i64 %"3#tmp#2##0", i64* %23 
   %24 = tail call fastcc  {i64, i64}  @"alias_mfoo.foo<0>[410bae77d3]"(i64  %"p1##0")  
   %25 = extractvalue {i64, i64} %24, 0 
   %26 = extractvalue {i64, i64} %24, 1 
@@ -129,46 +129,46 @@ foo(p1##0:position.position, ?p2##0:position.position, ?p3##0:position.position,
  AliasPairs: [(p1##0,p2##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(8,(alias_mbar.bar<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 1:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
-    case ~tmp$5##0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp#0##0:wybe.int, 1:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
+    case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:wybe.int)
+        foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int)
         alias_mbar.bar<0>[410bae77d3](~p1##1:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##2:wybe.phantom) #8 @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$16##0:position.position)
-        foreign lpvm mutate(~tmp$16##0:position.position, ?tmp$17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-        foreign lpvm mutate(~tmp$17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm alloc(16:wybe.int, ?tmp#16##0:position.position)
+        foreign lpvm mutate(~tmp#16##0:position.position, ?tmp#17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm mutate(~tmp#17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
 
     1:
         foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$11##0:position.position)
-        foreign lpvm mutate(~tmp$11##0:position.position, ?tmp$12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign lpvm mutate(~tmp$12##0:position.position, ?tmp$1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign llvm move(tmp$1##0:position.position, ?p3##0:position.position) @alias_mfoo:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:position.position)
+        foreign lpvm mutate(~tmp#11##0:position.position, ?tmp#12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign lpvm mutate(~tmp#12##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign llvm move(tmp#1##0:position.position, ?p3##0:position.position) @alias_mfoo:nn:nn
         foreign c print_string("p3:":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        position.printPosition<0>(~tmp$1##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @alias_mfoo:nn:nn
+        position.printPosition<0>(~tmp#1##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @alias_mfoo:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 1:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
-    case ~tmp$5##0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp#0##0:wybe.int, 1:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
+    case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:wybe.int)
+        foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int)
         alias_mbar.bar<0>[410bae77d3](~p1##1:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##2:wybe.phantom) #8 @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$16##0:position.position)
-        foreign lpvm mutate(~tmp$16##0:position.position, ?tmp$17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-        foreign lpvm mutate(~tmp$17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm alloc(16:wybe.int, ?tmp#16##0:position.position)
+        foreign lpvm mutate(~tmp#16##0:position.position, ?tmp#17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm mutate(~tmp#17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
 
     1:
         foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$11##0:position.position)
-        foreign lpvm mutate(~tmp$11##0:position.position, ?tmp$12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign lpvm mutate(~tmp$12##0:position.position, ?tmp$1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign llvm move(tmp$1##0:position.position, ?p3##0:position.position) @alias_mfoo:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:position.position)
+        foreign lpvm mutate(~tmp#11##0:position.position, ?tmp#12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign lpvm mutate(~tmp#12##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign llvm move(tmp#1##0:position.position, ?p3##0:position.position) @alias_mfoo:nn:nn
         foreign c print_string("p3:":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        position.printPosition<0>(~tmp$1##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @alias_mfoo:nn:nn
+        position.printPosition<0>(~tmp#1##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @alias_mfoo:nn:nn
 
 
   LLVM code       :
@@ -205,8 +205,8 @@ entry:
   %1 = inttoptr i64 %"p1##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %"1$tmp$5##0" = icmp sgt i64 %3, 1 
-  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
+  %"1#tmp#5##0" = icmp sgt i64 %3, 1 
+  br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
   %4 = trunc i64 16 to i32  
   %5 = tail call ccc  i8*  @wybe_malloc(i32  %4)  
@@ -225,7 +225,7 @@ if.then:
   %15 = insertvalue {i64, i64} %14, i64 %6, 1 
   ret {i64, i64} %15 
 if.else:
-  %"3$tmp$3##0" = add   i64 %3, 1 
+  %"3#tmp#3##0" = add   i64 %3, 1 
   %16 = trunc i64 16 to i32  
   %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
   %18 = ptrtoint i8* %17 to i64 
@@ -235,8 +235,8 @@ if.else:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %19, i8*  %20, i32  %21, i32  8, i1  0)  
   %22 = inttoptr i64 %18 to i64* 
   %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 %"3$tmp$3##0", i64* %23 
-  %"3$p3##0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %18)  
+  store  i64 %"3#tmp#3##0", i64* %23 
+  %"3#p3##0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %18)  
   %24 = trunc i64 16 to i32  
   %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
   %26 = ptrtoint i8* %25 to i64 
@@ -248,7 +248,7 @@ if.else:
   %31 = getelementptr  i64, i64* %30, i64 0 
   store  i64 2, i64* %31 
   %32 = insertvalue {i64, i64} undef, i64 %26, 0 
-  %33 = insertvalue {i64, i64} %32, i64 %"3$p3##0", 1 
+  %33 = insertvalue {i64, i64} %32, i64 %"3#p3##0", 1 
   ret {i64, i64} %33 
 }
 
@@ -258,8 +258,8 @@ entry:
   %34 = inttoptr i64 %"p1##0" to i64* 
   %35 = getelementptr  i64, i64* %34, i64 0 
   %36 = load  i64, i64* %35 
-  %"1$tmp$5##0" = icmp sgt i64 %36, 1 
-  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
+  %"1#tmp#5##0" = icmp sgt i64 %36, 1 
+  br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
   %37 = trunc i64 16 to i32  
   %38 = tail call ccc  i8*  @wybe_malloc(i32  %37)  
@@ -278,11 +278,11 @@ if.then:
   %48 = insertvalue {i64, i64} %47, i64 %39, 1 
   ret {i64, i64} %48 
 if.else:
-  %"3$tmp$3##0" = add   i64 %36, 1 
+  %"3#tmp#3##0" = add   i64 %36, 1 
   %49 = inttoptr i64 %"p1##0" to i64* 
   %50 = getelementptr  i64, i64* %49, i64 0 
-  store  i64 %"3$tmp$3##0", i64* %50 
-  %"3$p3##0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %"p1##0")  
+  store  i64 %"3#tmp#3##0", i64* %50 
+  %"3#p3##0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %"p1##0")  
   %51 = trunc i64 16 to i32  
   %52 = tail call ccc  i8*  @wybe_malloc(i32  %51)  
   %53 = ptrtoint i8* %52 to i64 
@@ -294,7 +294,7 @@ if.else:
   %58 = getelementptr  i64, i64* %57, i64 0 
   store  i64 2, i64* %58 
   %59 = insertvalue {i64, i64} undef, i64 %53, 0 
-  %60 = insertvalue {i64, i64} %59, i64 %"3$p3##0", 1 
+  %60 = insertvalue {i64, i64} %59, i64 %"3#p3##0", 1 
   ret {i64, i64} %60 
 }
 --------------------------------------------------
@@ -323,13 +323,13 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -403,86 +403,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
-    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
-    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec##0:position.position, ?$##0:wybe.int):
+x(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec##0:position.position, ?$##0:wybe.int):
+y(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -499,27 +499,27 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$##0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$##0" 
+  %"2#####0" = icmp eq i64 %7, %14 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
@@ -541,12 +541,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
 entry:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -556,34 +556,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec##0" to i64* 
+  %32 = inttoptr i64 %"#rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec##0" to i8* 
+  %39 = inttoptr i64 %"#rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field##0", i64* %42 
+  store  i64 %"#field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = add   i64 %"$rec##0", 8 
+  %43 = add   i64 %"#rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -591,46 +591,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec##0" to i8* 
+  %51 = inttoptr i64 %"#rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field##0", i64* %55 
+  store  i64 %"#field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %58, %65 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = icmp eq i64 %62, %69 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#0##0" = icmp eq i64 %62, %69 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }

--- a/test-cases/final-dump/alias_mbar.exp
+++ b/test-cases/final-dump/alias_mbar.exp
@@ -422,27 +422,27 @@ entry:
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x(#rec##0:position.position, ?###0:wybe.int):
+x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -453,10 +453,10 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y(#rec##0:position.position, ?###0:wybe.int):
+y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -541,12 +541,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 

--- a/test-cases/final-dump/alias_mbar.exp
+++ b/test-cases/final-dump/alias_mbar.exp
@@ -13,34 +13,34 @@ AFTER EVERYTHING:
 
 bar > public (0 calls)
 0: alias_mbar.bar<0>[410bae77d3]
-bar(p1#0:position.position, ?p3#1:position.position, io#0:wybe.phantom, ?io#1:wybe.phantom):
- AliasPairs: [(p1#0,p3#1)]
+bar(p1##0:position.position, ?p3##1:position.position, io##0:wybe.phantom, ?io##1:wybe.phantom):
+ AliasPairs: [(p1##0,p3##1)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(5,(alias_mfoo.foo<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm access(p1#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.bool) @int:nn:nn
-    case ~tmp$3#0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
+    case ~tmp$3##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1#0:position.position, ?%p1#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:wybe.int)
-        alias_mfoo.foo<0>[410bae77d3](~p1#1:position.position, ?p2#0:position.position, ?p3#1:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #5 @alias_mbar:nn:nn
+        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:wybe.int)
+        alias_mfoo.foo<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ?p3##1:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_mbar:nn:nn
 
     1:
-        foreign llvm move(~p1#0:position.position, ?p3#1:position.position)
-        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+        foreign llvm move(~p1##0:position.position, ?p3##1:position.position)
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(p1#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.bool) @int:nn:nn
-    case ~tmp$3#0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
+    case ~tmp$3##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1#0:position.position, ?%p1#1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:wybe.int)
-        alias_mfoo.foo<0>[410bae77d3](~p1#1:position.position, ?p2#0:position.position, ?p3#1:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #5 @alias_mbar:nn:nn
+        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:wybe.int)
+        alias_mfoo.foo<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ?p3##1:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_mbar:nn:nn
 
     1:
-        foreign llvm move(~p1#0:position.position, ?p3#1:position.position)
-        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+        foreign llvm move(~p1##0:position.position, ?p3##1:position.position)
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
 
   LLVM code       :
@@ -60,29 +60,29 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i64 @"alias_mbar.bar<0>"(i64  %"p1#0")    {
+define external fastcc  i64 @"alias_mbar.bar<0>"(i64  %"p1##0")    {
 entry:
-  %1 = add   i64 %"p1#0", 8 
+  %1 = add   i64 %"p1##0", 8 
   %2 = inttoptr i64 %1 to i64* 
   %3 = getelementptr  i64, i64* %2, i64 0 
   %4 = load  i64, i64* %3 
-  %"1$tmp$3#0" = icmp sgt i64 %4, 1 
-  br i1 %"1$tmp$3#0", label %if.then, label %if.else 
+  %"1$tmp$3##0" = icmp sgt i64 %4, 1 
+  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
 if.then:
-  ret i64 %"p1#0" 
+  ret i64 %"p1##0" 
 if.else:
-  %"3$tmp$2#0" = add   i64 %4, 1 
+  %"3$tmp$2##0" = add   i64 %4, 1 
   %5 = trunc i64 16 to i32  
   %6 = tail call ccc  i8*  @wybe_malloc(i32  %5)  
   %7 = ptrtoint i8* %6 to i64 
   %8 = inttoptr i64 %7 to i8* 
-  %9 = inttoptr i64 %"p1#0" to i8* 
+  %9 = inttoptr i64 %"p1##0" to i8* 
   %10 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %8, i8*  %9, i32  %10, i32  8, i1  0)  
   %11 = add   i64 %7, 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 %"3$tmp$2#0", i64* %13 
+  store  i64 %"3$tmp$2##0", i64* %13 
   %14 = tail call fastcc  {i64, i64}  @"alias_mfoo.foo<0>[410bae77d3]"(i64  %7)  
   %15 = extractvalue {i64, i64} %14, 0 
   %16 = extractvalue {i64, i64} %14, 1 
@@ -90,23 +90,23 @@ if.else:
 }
 
 
-define external fastcc  i64 @"alias_mbar.bar<0>[410bae77d3]"(i64  %"p1#0")    {
+define external fastcc  i64 @"alias_mbar.bar<0>[410bae77d3]"(i64  %"p1##0")    {
 entry:
-  %17 = add   i64 %"p1#0", 8 
+  %17 = add   i64 %"p1##0", 8 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
   %20 = load  i64, i64* %19 
-  %"1$tmp$3#0" = icmp sgt i64 %20, 1 
-  br i1 %"1$tmp$3#0", label %if.then, label %if.else 
+  %"1$tmp$3##0" = icmp sgt i64 %20, 1 
+  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
 if.then:
-  ret i64 %"p1#0" 
+  ret i64 %"p1##0" 
 if.else:
-  %"3$tmp$2#0" = add   i64 %20, 1 
-  %21 = add   i64 %"p1#0", 8 
+  %"3$tmp$2##0" = add   i64 %20, 1 
+  %21 = add   i64 %"p1##0", 8 
   %22 = inttoptr i64 %21 to i64* 
   %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 %"3$tmp$2#0", i64* %23 
-  %24 = tail call fastcc  {i64, i64}  @"alias_mfoo.foo<0>[410bae77d3]"(i64  %"p1#0")  
+  store  i64 %"3$tmp$2##0", i64* %23 
+  %24 = tail call fastcc  {i64, i64}  @"alias_mfoo.foo<0>[410bae77d3]"(i64  %"p1##0")  
   %25 = extractvalue {i64, i64} %24, 0 
   %26 = extractvalue {i64, i64} %24, 1 
   ret i64 %26 
@@ -125,50 +125,50 @@ if.else:
 
 foo > public (0 calls)
 0: alias_mfoo.foo<0>[410bae77d3]
-foo(p1#0:position.position, ?p2#0:position.position, ?p3#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
- AliasPairs: [(p1#0,p2#0)]
+foo(p1##0:position.position, ?p2##0:position.position, ?p3##0:position.position, io##0:wybe.phantom, ?io##2:wybe.phantom):
+ AliasPairs: [(p1##0,p2##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(8,(alias_mbar.bar<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm access(p1#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0#0:wybe.int, 1:wybe.int, ?tmp$5#0:wybe.bool) @int:nn:nn
-    case ~tmp$5#0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 1:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
+    case ~tmp$5##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1#0:position.position, ?%p1#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3#0:wybe.int)
-        alias_mbar.bar<0>[410bae77d3](~p1#1:position.position, ?p3#0:position.position, ~#io#0:wybe.phantom, ?#io#2:wybe.phantom) #8 @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$16#0:position.position)
-        foreign lpvm mutate(~tmp$16#0:position.position, ?tmp$17#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-        foreign lpvm mutate(~tmp$17#0:position.position, ?p2#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:wybe.int)
+        alias_mbar.bar<0>[410bae77d3](~p1##1:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##2:wybe.phantom) #8 @alias_mfoo:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp$16##0:position.position)
+        foreign lpvm mutate(~tmp$16##0:position.position, ?tmp$17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm mutate(~tmp$17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
 
     1:
-        foreign llvm move(~p1#0:position.position, ?p2#0:position.position) @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$11#0:position.position)
-        foreign lpvm mutate(~tmp$11#0:position.position, ?tmp$12#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign lpvm mutate(~tmp$12#0:position.position, ?tmp$1#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign llvm move(tmp$1#0:position.position, ?p3#0:position.position) @alias_mfoo:nn:nn
-        foreign c print_string("p3:":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        position.printPosition<0>(~tmp$1#0:position.position, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #4 @alias_mfoo:nn:nn
+        foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_mfoo:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp$11##0:position.position)
+        foreign lpvm mutate(~tmp$11##0:position.position, ?tmp$12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign lpvm mutate(~tmp$12##0:position.position, ?tmp$1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign llvm move(tmp$1##0:position.position, ?p3##0:position.position) @alias_mfoo:nn:nn
+        foreign c print_string("p3:":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        position.printPosition<0>(~tmp$1##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @alias_mfoo:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(p1#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0#0:wybe.int, 1:wybe.int, ?tmp$5#0:wybe.bool) @int:nn:nn
-    case ~tmp$5#0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 1:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
+    case ~tmp$5##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1#0:position.position, ?%p1#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3#0:wybe.int)
-        alias_mbar.bar<0>[410bae77d3](~p1#1:position.position, ?p3#0:position.position, ~#io#0:wybe.phantom, ?#io#2:wybe.phantom) #8 @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$16#0:position.position)
-        foreign lpvm mutate(~tmp$16#0:position.position, ?tmp$17#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-        foreign lpvm mutate(~tmp$17#0:position.position, ?p2#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:wybe.int)
+        alias_mbar.bar<0>[410bae77d3](~p1##1:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##2:wybe.phantom) #8 @alias_mfoo:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp$16##0:position.position)
+        foreign lpvm mutate(~tmp$16##0:position.position, ?tmp$17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm mutate(~tmp$17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
 
     1:
-        foreign llvm move(~p1#0:position.position, ?p2#0:position.position) @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$11#0:position.position)
-        foreign lpvm mutate(~tmp$11#0:position.position, ?tmp$12#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign lpvm mutate(~tmp$12#0:position.position, ?tmp$1#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign llvm move(tmp$1#0:position.position, ?p3#0:position.position) @alias_mfoo:nn:nn
-        foreign c print_string("p3:":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        position.printPosition<0>(~tmp$1#0:position.position, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #4 @alias_mfoo:nn:nn
+        foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_mfoo:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp$11##0:position.position)
+        foreign lpvm mutate(~tmp$11##0:position.position, ?tmp$12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign lpvm mutate(~tmp$12##0:position.position, ?tmp$1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign llvm move(tmp$1##0:position.position, ?p3##0:position.position) @alias_mfoo:nn:nn
+        foreign c print_string("p3:":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        position.printPosition<0>(~tmp$1##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @alias_mfoo:nn:nn
 
 
   LLVM code       :
@@ -200,13 +200,13 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  {i64, i64} @"alias_mfoo.foo<0>"(i64  %"p1#0")    {
+define external fastcc  {i64, i64} @"alias_mfoo.foo<0>"(i64  %"p1##0")    {
 entry:
-  %1 = inttoptr i64 %"p1#0" to i64* 
+  %1 = inttoptr i64 %"p1##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %"1$tmp$5#0" = icmp sgt i64 %3, 1 
-  br i1 %"1$tmp$5#0", label %if.then, label %if.else 
+  %"1$tmp$5##0" = icmp sgt i64 %3, 1 
+  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
 if.then:
   %4 = trunc i64 16 to i32  
   %5 = tail call ccc  i8*  @wybe_malloc(i32  %4)  
@@ -221,22 +221,22 @@ if.then:
   %13 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_mfoo.12, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %13)  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %6)  
-  %14 = insertvalue {i64, i64} undef, i64 %"p1#0", 0 
+  %14 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
   %15 = insertvalue {i64, i64} %14, i64 %6, 1 
   ret {i64, i64} %15 
 if.else:
-  %"3$tmp$3#0" = add   i64 %3, 1 
+  %"3$tmp$3##0" = add   i64 %3, 1 
   %16 = trunc i64 16 to i32  
   %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
   %18 = ptrtoint i8* %17 to i64 
   %19 = inttoptr i64 %18 to i8* 
-  %20 = inttoptr i64 %"p1#0" to i8* 
+  %20 = inttoptr i64 %"p1##0" to i8* 
   %21 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %19, i8*  %20, i32  %21, i32  8, i1  0)  
   %22 = inttoptr i64 %18 to i64* 
   %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 %"3$tmp$3#0", i64* %23 
-  %"3$p3#0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %18)  
+  store  i64 %"3$tmp$3##0", i64* %23 
+  %"3$p3##0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %18)  
   %24 = trunc i64 16 to i32  
   %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
   %26 = ptrtoint i8* %25 to i64 
@@ -248,18 +248,18 @@ if.else:
   %31 = getelementptr  i64, i64* %30, i64 0 
   store  i64 2, i64* %31 
   %32 = insertvalue {i64, i64} undef, i64 %26, 0 
-  %33 = insertvalue {i64, i64} %32, i64 %"3$p3#0", 1 
+  %33 = insertvalue {i64, i64} %32, i64 %"3$p3##0", 1 
   ret {i64, i64} %33 
 }
 
 
-define external fastcc  {i64, i64} @"alias_mfoo.foo<0>[410bae77d3]"(i64  %"p1#0")    {
+define external fastcc  {i64, i64} @"alias_mfoo.foo<0>[410bae77d3]"(i64  %"p1##0")    {
 entry:
-  %34 = inttoptr i64 %"p1#0" to i64* 
+  %34 = inttoptr i64 %"p1##0" to i64* 
   %35 = getelementptr  i64, i64* %34, i64 0 
   %36 = load  i64, i64* %35 
-  %"1$tmp$5#0" = icmp sgt i64 %36, 1 
-  br i1 %"1$tmp$5#0", label %if.then, label %if.else 
+  %"1$tmp$5##0" = icmp sgt i64 %36, 1 
+  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
 if.then:
   %37 = trunc i64 16 to i32  
   %38 = tail call ccc  i8*  @wybe_malloc(i32  %37)  
@@ -274,15 +274,15 @@ if.then:
   %46 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_mfoo.45, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %46)  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %39)  
-  %47 = insertvalue {i64, i64} undef, i64 %"p1#0", 0 
+  %47 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
   %48 = insertvalue {i64, i64} %47, i64 %39, 1 
   ret {i64, i64} %48 
 if.else:
-  %"3$tmp$3#0" = add   i64 %36, 1 
-  %49 = inttoptr i64 %"p1#0" to i64* 
+  %"3$tmp$3##0" = add   i64 %36, 1 
+  %49 = inttoptr i64 %"p1##0" to i64* 
   %50 = getelementptr  i64, i64* %49, i64 0 
-  store  i64 %"3$tmp$3#0", i64* %50 
-  %"3$p3#0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %"p1#0")  
+  store  i64 %"3$tmp$3##0", i64* %50 
+  %"3$p3##0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %"p1##0")  
   %51 = trunc i64 16 to i32  
   %52 = tail call ccc  i8*  @wybe_malloc(i32  %51)  
   %53 = ptrtoint i8* %52 to i64 
@@ -294,7 +294,7 @@ if.else:
   %58 = getelementptr  i64, i64* %57, i64 0 
   store  i64 2, i64* %58 
   %59 = insertvalue {i64, i64} undef, i64 %53, 0 
-  %60 = insertvalue {i64, i64} %59, i64 %"3$p3#0", 1 
+  %60 = insertvalue {i64, i64} %59, i64 %"3$p3##0", 1 
   ret {i64, i64} %60 
 }
 --------------------------------------------------
@@ -319,17 +319,17 @@ if.else:
 
 printPosition > public (0 calls)
 0: position.printPosition<0>
-printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string(",":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io#4:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -363,17 +363,17 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"position.printPosition<0>"(i64  %"pos#0")    {
+define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
-  %3 = inttoptr i64 %"pos#0" to i64* 
+  %3 = inttoptr i64 %"pos##0" to i64* 
   %4 = getelementptr  i64, i64* %3, i64 0 
   %5 = load  i64, i64* %4 
   tail call ccc  void  @print_int(i64  %5)  
   %7 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.6, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %7)  
-  %8 = add   i64 %"pos#0", 8 
+  %8 = add   i64 %"pos##0", 8 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
@@ -403,86 +403,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y#0:wybe.int)
-    foreign llvm icmp_eq(~$left$x#0:wybe.int, ~$right$x#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
+    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y#0:wybe.int, ~$right$y#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
-    foreign lpvm mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:position.position, ?$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
+    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
-    foreign lpvm access(~$#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y#0:wybe.int)
+    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec#0:position.position, ?$#0:wybe.int):
+x($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec#0:position.position, ?$#0:wybe.int):
+y($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -499,54 +499,54 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$#0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = icmp eq i64 %7, %14 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"x#0", i64* %19 
+  store  i64 %"x##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"y#0", i64* %22 
+  store  i64 %"y##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
 entry:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -556,34 +556,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec#0" to i64* 
+  %32 = inttoptr i64 %"$rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec#0" to i8* 
+  %39 = inttoptr i64 %"$rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field#0", i64* %42 
+  store  i64 %"$field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = add   i64 %"$rec#0", 8 
+  %43 = add   i64 %"$rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -591,46 +591,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec#0" to i8* 
+  %51 = inttoptr i64 %"$rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field#0", i64* %55 
+  store  i64 %"$field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %58, %65 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = icmp eq i64 %62, %69 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$0##0" = icmp eq i64 %62, %69 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }

--- a/test-cases/final-dump/alias_mbar.exp
+++ b/test-cases/final-dump/alias_mbar.exp
@@ -403,7 +403,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
@@ -413,10 +413,10 @@ entry:
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -467,7 +467,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -478,11 +478,11 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -518,8 +518,8 @@ entry:
   %"1#tmp#1##0" = icmp eq i64 %3, %10 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2#####0" = icmp eq i64 %7, %14 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %7, %14 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -628,9 +628,9 @@ entry:
   br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#0##0" = icmp eq i64 %62, %69 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }

--- a/test-cases/final-dump/alias_mfoo.exp
+++ b/test-cases/final-dump/alias_mfoo.exp
@@ -17,12 +17,12 @@ bar(p1##0:position.position, ?p3##1:position.position, io##0:wybe.phantom, ?io##
  AliasPairs: [(p1##0,p3##1)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(5,(alias_mfoo.foo<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
-    case ~tmp$3##0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp#0##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
+    case ~tmp#3##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:wybe.int)
+        foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
         alias_mfoo.foo<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ?p3##1:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_mbar:nn:nn
 
     1:
@@ -30,12 +30,12 @@ bar(p1##0:position.position, ?p3##1:position.position, io##0:wybe.phantom, ?io##
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
-    case ~tmp$3##0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp#0##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
+    case ~tmp#3##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:wybe.int)
+        foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
         alias_mfoo.foo<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ?p3##1:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_mbar:nn:nn
 
     1:
@@ -66,12 +66,12 @@ entry:
   %2 = inttoptr i64 %1 to i64* 
   %3 = getelementptr  i64, i64* %2, i64 0 
   %4 = load  i64, i64* %3 
-  %"1$tmp$3##0" = icmp sgt i64 %4, 1 
-  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
+  %"1#tmp#3##0" = icmp sgt i64 %4, 1 
+  br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
   ret i64 %"p1##0" 
 if.else:
-  %"3$tmp$2##0" = add   i64 %4, 1 
+  %"3#tmp#2##0" = add   i64 %4, 1 
   %5 = trunc i64 16 to i32  
   %6 = tail call ccc  i8*  @wybe_malloc(i32  %5)  
   %7 = ptrtoint i8* %6 to i64 
@@ -82,7 +82,7 @@ if.else:
   %11 = add   i64 %7, 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 %"3$tmp$2##0", i64* %13 
+  store  i64 %"3#tmp#2##0", i64* %13 
   %14 = tail call fastcc  {i64, i64}  @"alias_mfoo.foo<0>[410bae77d3]"(i64  %7)  
   %15 = extractvalue {i64, i64} %14, 0 
   %16 = extractvalue {i64, i64} %14, 1 
@@ -96,16 +96,16 @@ entry:
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
   %20 = load  i64, i64* %19 
-  %"1$tmp$3##0" = icmp sgt i64 %20, 1 
-  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
+  %"1#tmp#3##0" = icmp sgt i64 %20, 1 
+  br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
   ret i64 %"p1##0" 
 if.else:
-  %"3$tmp$2##0" = add   i64 %20, 1 
+  %"3#tmp#2##0" = add   i64 %20, 1 
   %21 = add   i64 %"p1##0", 8 
   %22 = inttoptr i64 %21 to i64* 
   %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 %"3$tmp$2##0", i64* %23 
+  store  i64 %"3#tmp#2##0", i64* %23 
   %24 = tail call fastcc  {i64, i64}  @"alias_mfoo.foo<0>[410bae77d3]"(i64  %"p1##0")  
   %25 = extractvalue {i64, i64} %24, 0 
   %26 = extractvalue {i64, i64} %24, 1 
@@ -129,46 +129,46 @@ foo(p1##0:position.position, ?p2##0:position.position, ?p3##0:position.position,
  AliasPairs: [(p1##0,p2##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(8,(alias_mbar.bar<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 1:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
-    case ~tmp$5##0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp#0##0:wybe.int, 1:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
+    case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:wybe.int)
+        foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int)
         alias_mbar.bar<0>[410bae77d3](~p1##1:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##2:wybe.phantom) #8 @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$16##0:position.position)
-        foreign lpvm mutate(~tmp$16##0:position.position, ?tmp$17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-        foreign lpvm mutate(~tmp$17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm alloc(16:wybe.int, ?tmp#16##0:position.position)
+        foreign lpvm mutate(~tmp#16##0:position.position, ?tmp#17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm mutate(~tmp#17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
 
     1:
         foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$11##0:position.position)
-        foreign lpvm mutate(~tmp$11##0:position.position, ?tmp$12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign lpvm mutate(~tmp$12##0:position.position, ?tmp$1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign llvm move(tmp$1##0:position.position, ?p3##0:position.position) @alias_mfoo:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:position.position)
+        foreign lpvm mutate(~tmp#11##0:position.position, ?tmp#12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign lpvm mutate(~tmp#12##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign llvm move(tmp#1##0:position.position, ?p3##0:position.position) @alias_mfoo:nn:nn
         foreign c print_string("p3:":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        position.printPosition<0>(~tmp$1##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @alias_mfoo:nn:nn
+        position.printPosition<0>(~tmp#1##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @alias_mfoo:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 1:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
-    case ~tmp$5##0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp#0##0:wybe.int, 1:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
+    case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:wybe.int)
+        foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int)
         alias_mbar.bar<0>[410bae77d3](~p1##1:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##2:wybe.phantom) #8 @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$16##0:position.position)
-        foreign lpvm mutate(~tmp$16##0:position.position, ?tmp$17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-        foreign lpvm mutate(~tmp$17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm alloc(16:wybe.int, ?tmp#16##0:position.position)
+        foreign lpvm mutate(~tmp#16##0:position.position, ?tmp#17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm mutate(~tmp#17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
 
     1:
         foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$11##0:position.position)
-        foreign lpvm mutate(~tmp$11##0:position.position, ?tmp$12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign lpvm mutate(~tmp$12##0:position.position, ?tmp$1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign llvm move(tmp$1##0:position.position, ?p3##0:position.position) @alias_mfoo:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:position.position)
+        foreign lpvm mutate(~tmp#11##0:position.position, ?tmp#12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign lpvm mutate(~tmp#12##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign llvm move(tmp#1##0:position.position, ?p3##0:position.position) @alias_mfoo:nn:nn
         foreign c print_string("p3:":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        position.printPosition<0>(~tmp$1##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @alias_mfoo:nn:nn
+        position.printPosition<0>(~tmp#1##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @alias_mfoo:nn:nn
 
 
   LLVM code       :
@@ -205,8 +205,8 @@ entry:
   %1 = inttoptr i64 %"p1##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %"1$tmp$5##0" = icmp sgt i64 %3, 1 
-  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
+  %"1#tmp#5##0" = icmp sgt i64 %3, 1 
+  br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
   %4 = trunc i64 16 to i32  
   %5 = tail call ccc  i8*  @wybe_malloc(i32  %4)  
@@ -225,7 +225,7 @@ if.then:
   %15 = insertvalue {i64, i64} %14, i64 %6, 1 
   ret {i64, i64} %15 
 if.else:
-  %"3$tmp$3##0" = add   i64 %3, 1 
+  %"3#tmp#3##0" = add   i64 %3, 1 
   %16 = trunc i64 16 to i32  
   %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
   %18 = ptrtoint i8* %17 to i64 
@@ -235,8 +235,8 @@ if.else:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %19, i8*  %20, i32  %21, i32  8, i1  0)  
   %22 = inttoptr i64 %18 to i64* 
   %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 %"3$tmp$3##0", i64* %23 
-  %"3$p3##0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %18)  
+  store  i64 %"3#tmp#3##0", i64* %23 
+  %"3#p3##0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %18)  
   %24 = trunc i64 16 to i32  
   %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
   %26 = ptrtoint i8* %25 to i64 
@@ -248,7 +248,7 @@ if.else:
   %31 = getelementptr  i64, i64* %30, i64 0 
   store  i64 2, i64* %31 
   %32 = insertvalue {i64, i64} undef, i64 %26, 0 
-  %33 = insertvalue {i64, i64} %32, i64 %"3$p3##0", 1 
+  %33 = insertvalue {i64, i64} %32, i64 %"3#p3##0", 1 
   ret {i64, i64} %33 
 }
 
@@ -258,8 +258,8 @@ entry:
   %34 = inttoptr i64 %"p1##0" to i64* 
   %35 = getelementptr  i64, i64* %34, i64 0 
   %36 = load  i64, i64* %35 
-  %"1$tmp$5##0" = icmp sgt i64 %36, 1 
-  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
+  %"1#tmp#5##0" = icmp sgt i64 %36, 1 
+  br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
   %37 = trunc i64 16 to i32  
   %38 = tail call ccc  i8*  @wybe_malloc(i32  %37)  
@@ -278,11 +278,11 @@ if.then:
   %48 = insertvalue {i64, i64} %47, i64 %39, 1 
   ret {i64, i64} %48 
 if.else:
-  %"3$tmp$3##0" = add   i64 %36, 1 
+  %"3#tmp#3##0" = add   i64 %36, 1 
   %49 = inttoptr i64 %"p1##0" to i64* 
   %50 = getelementptr  i64, i64* %49, i64 0 
-  store  i64 %"3$tmp$3##0", i64* %50 
-  %"3$p3##0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %"p1##0")  
+  store  i64 %"3#tmp#3##0", i64* %50 
+  %"3#p3##0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %"p1##0")  
   %51 = trunc i64 16 to i32  
   %52 = tail call ccc  i8*  @wybe_malloc(i32  %51)  
   %53 = ptrtoint i8* %52 to i64 
@@ -294,7 +294,7 @@ if.else:
   %58 = getelementptr  i64, i64* %57, i64 0 
   store  i64 2, i64* %58 
   %59 = insertvalue {i64, i64} undef, i64 %53, 0 
-  %60 = insertvalue {i64, i64} %59, i64 %"3$p3##0", 1 
+  %60 = insertvalue {i64, i64} %59, i64 %"3#p3##0", 1 
   ret {i64, i64} %60 
 }
 --------------------------------------------------
@@ -323,13 +323,13 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -403,86 +403,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
-    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
-    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec##0:position.position, ?$##0:wybe.int):
+x(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec##0:position.position, ?$##0:wybe.int):
+y(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -499,27 +499,27 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$##0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$##0" 
+  %"2#####0" = icmp eq i64 %7, %14 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
@@ -541,12 +541,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
 entry:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -556,34 +556,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec##0" to i64* 
+  %32 = inttoptr i64 %"#rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec##0" to i8* 
+  %39 = inttoptr i64 %"#rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field##0", i64* %42 
+  store  i64 %"#field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = add   i64 %"$rec##0", 8 
+  %43 = add   i64 %"#rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -591,46 +591,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec##0" to i8* 
+  %51 = inttoptr i64 %"#rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field##0", i64* %55 
+  store  i64 %"#field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %58, %65 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = icmp eq i64 %62, %69 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#0##0" = icmp eq i64 %62, %69 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }

--- a/test-cases/final-dump/alias_mfoo.exp
+++ b/test-cases/final-dump/alias_mfoo.exp
@@ -422,27 +422,27 @@ entry:
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x(#rec##0:position.position, ?###0:wybe.int):
+x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -453,10 +453,10 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y(#rec##0:position.position, ?###0:wybe.int):
+y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -541,12 +541,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 

--- a/test-cases/final-dump/alias_mfoo.exp
+++ b/test-cases/final-dump/alias_mfoo.exp
@@ -13,34 +13,34 @@ AFTER EVERYTHING:
 
 bar > public (0 calls)
 0: alias_mbar.bar<0>[410bae77d3]
-bar(p1#0:position.position, ?p3#1:position.position, io#0:wybe.phantom, ?io#1:wybe.phantom):
- AliasPairs: [(p1#0,p3#1)]
+bar(p1##0:position.position, ?p3##1:position.position, io##0:wybe.phantom, ?io##1:wybe.phantom):
+ AliasPairs: [(p1##0,p3##1)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(5,(alias_mfoo.foo<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm access(p1#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.bool) @int:nn:nn
-    case ~tmp$3#0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
+    case ~tmp$3##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1#0:position.position, ?%p1#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:wybe.int)
-        alias_mfoo.foo<0>[410bae77d3](~p1#1:position.position, ?p2#0:position.position, ?p3#1:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #5 @alias_mbar:nn:nn
+        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:wybe.int)
+        alias_mfoo.foo<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ?p3##1:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_mbar:nn:nn
 
     1:
-        foreign llvm move(~p1#0:position.position, ?p3#1:position.position)
-        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+        foreign llvm move(~p1##0:position.position, ?p3##1:position.position)
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(p1#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.bool) @int:nn:nn
-    case ~tmp$3#0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
+    case ~tmp$3##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1#0:position.position, ?%p1#1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:wybe.int)
-        alias_mfoo.foo<0>[410bae77d3](~p1#1:position.position, ?p2#0:position.position, ?p3#1:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #5 @alias_mbar:nn:nn
+        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:wybe.int)
+        alias_mfoo.foo<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ?p3##1:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_mbar:nn:nn
 
     1:
-        foreign llvm move(~p1#0:position.position, ?p3#1:position.position)
-        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+        foreign llvm move(~p1##0:position.position, ?p3##1:position.position)
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
 
   LLVM code       :
@@ -60,29 +60,29 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i64 @"alias_mbar.bar<0>"(i64  %"p1#0")    {
+define external fastcc  i64 @"alias_mbar.bar<0>"(i64  %"p1##0")    {
 entry:
-  %1 = add   i64 %"p1#0", 8 
+  %1 = add   i64 %"p1##0", 8 
   %2 = inttoptr i64 %1 to i64* 
   %3 = getelementptr  i64, i64* %2, i64 0 
   %4 = load  i64, i64* %3 
-  %"1$tmp$3#0" = icmp sgt i64 %4, 1 
-  br i1 %"1$tmp$3#0", label %if.then, label %if.else 
+  %"1$tmp$3##0" = icmp sgt i64 %4, 1 
+  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
 if.then:
-  ret i64 %"p1#0" 
+  ret i64 %"p1##0" 
 if.else:
-  %"3$tmp$2#0" = add   i64 %4, 1 
+  %"3$tmp$2##0" = add   i64 %4, 1 
   %5 = trunc i64 16 to i32  
   %6 = tail call ccc  i8*  @wybe_malloc(i32  %5)  
   %7 = ptrtoint i8* %6 to i64 
   %8 = inttoptr i64 %7 to i8* 
-  %9 = inttoptr i64 %"p1#0" to i8* 
+  %9 = inttoptr i64 %"p1##0" to i8* 
   %10 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %8, i8*  %9, i32  %10, i32  8, i1  0)  
   %11 = add   i64 %7, 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 %"3$tmp$2#0", i64* %13 
+  store  i64 %"3$tmp$2##0", i64* %13 
   %14 = tail call fastcc  {i64, i64}  @"alias_mfoo.foo<0>[410bae77d3]"(i64  %7)  
   %15 = extractvalue {i64, i64} %14, 0 
   %16 = extractvalue {i64, i64} %14, 1 
@@ -90,23 +90,23 @@ if.else:
 }
 
 
-define external fastcc  i64 @"alias_mbar.bar<0>[410bae77d3]"(i64  %"p1#0")    {
+define external fastcc  i64 @"alias_mbar.bar<0>[410bae77d3]"(i64  %"p1##0")    {
 entry:
-  %17 = add   i64 %"p1#0", 8 
+  %17 = add   i64 %"p1##0", 8 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
   %20 = load  i64, i64* %19 
-  %"1$tmp$3#0" = icmp sgt i64 %20, 1 
-  br i1 %"1$tmp$3#0", label %if.then, label %if.else 
+  %"1$tmp$3##0" = icmp sgt i64 %20, 1 
+  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
 if.then:
-  ret i64 %"p1#0" 
+  ret i64 %"p1##0" 
 if.else:
-  %"3$tmp$2#0" = add   i64 %20, 1 
-  %21 = add   i64 %"p1#0", 8 
+  %"3$tmp$2##0" = add   i64 %20, 1 
+  %21 = add   i64 %"p1##0", 8 
   %22 = inttoptr i64 %21 to i64* 
   %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 %"3$tmp$2#0", i64* %23 
-  %24 = tail call fastcc  {i64, i64}  @"alias_mfoo.foo<0>[410bae77d3]"(i64  %"p1#0")  
+  store  i64 %"3$tmp$2##0", i64* %23 
+  %24 = tail call fastcc  {i64, i64}  @"alias_mfoo.foo<0>[410bae77d3]"(i64  %"p1##0")  
   %25 = extractvalue {i64, i64} %24, 0 
   %26 = extractvalue {i64, i64} %24, 1 
   ret i64 %26 
@@ -125,50 +125,50 @@ if.else:
 
 foo > public (0 calls)
 0: alias_mfoo.foo<0>[410bae77d3]
-foo(p1#0:position.position, ?p2#0:position.position, ?p3#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
- AliasPairs: [(p1#0,p2#0)]
+foo(p1##0:position.position, ?p2##0:position.position, ?p3##0:position.position, io##0:wybe.phantom, ?io##2:wybe.phantom):
+ AliasPairs: [(p1##0,p2##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(8,(alias_mbar.bar<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm access(p1#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0#0:wybe.int, 1:wybe.int, ?tmp$5#0:wybe.bool) @int:nn:nn
-    case ~tmp$5#0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 1:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
+    case ~tmp$5##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1#0:position.position, ?%p1#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3#0:wybe.int)
-        alias_mbar.bar<0>[410bae77d3](~p1#1:position.position, ?p3#0:position.position, ~#io#0:wybe.phantom, ?#io#2:wybe.phantom) #8 @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$16#0:position.position)
-        foreign lpvm mutate(~tmp$16#0:position.position, ?tmp$17#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-        foreign lpvm mutate(~tmp$17#0:position.position, ?p2#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:wybe.int)
+        alias_mbar.bar<0>[410bae77d3](~p1##1:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##2:wybe.phantom) #8 @alias_mfoo:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp$16##0:position.position)
+        foreign lpvm mutate(~tmp$16##0:position.position, ?tmp$17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm mutate(~tmp$17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
 
     1:
-        foreign llvm move(~p1#0:position.position, ?p2#0:position.position) @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$11#0:position.position)
-        foreign lpvm mutate(~tmp$11#0:position.position, ?tmp$12#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign lpvm mutate(~tmp$12#0:position.position, ?tmp$1#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign llvm move(tmp$1#0:position.position, ?p3#0:position.position) @alias_mfoo:nn:nn
-        foreign c print_string("p3:":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        position.printPosition<0>(~tmp$1#0:position.position, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #4 @alias_mfoo:nn:nn
+        foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_mfoo:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp$11##0:position.position)
+        foreign lpvm mutate(~tmp$11##0:position.position, ?tmp$12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign lpvm mutate(~tmp$12##0:position.position, ?tmp$1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign llvm move(tmp$1##0:position.position, ?p3##0:position.position) @alias_mfoo:nn:nn
+        foreign c print_string("p3:":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        position.printPosition<0>(~tmp$1##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @alias_mfoo:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(p1#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0#0:wybe.int, 1:wybe.int, ?tmp$5#0:wybe.bool) @int:nn:nn
-    case ~tmp$5#0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 1:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
+    case ~tmp$5##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1#0:position.position, ?%p1#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3#0:wybe.int)
-        alias_mbar.bar<0>[410bae77d3](~p1#1:position.position, ?p3#0:position.position, ~#io#0:wybe.phantom, ?#io#2:wybe.phantom) #8 @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$16#0:position.position)
-        foreign lpvm mutate(~tmp$16#0:position.position, ?tmp$17#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-        foreign lpvm mutate(~tmp$17#0:position.position, ?p2#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:wybe.int)
+        alias_mbar.bar<0>[410bae77d3](~p1##1:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##2:wybe.phantom) #8 @alias_mfoo:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp$16##0:position.position)
+        foreign lpvm mutate(~tmp$16##0:position.position, ?tmp$17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm mutate(~tmp$17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
 
     1:
-        foreign llvm move(~p1#0:position.position, ?p2#0:position.position) @alias_mfoo:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$11#0:position.position)
-        foreign lpvm mutate(~tmp$11#0:position.position, ?tmp$12#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign lpvm mutate(~tmp$12#0:position.position, ?tmp$1#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign llvm move(tmp$1#0:position.position, ?p3#0:position.position) @alias_mfoo:nn:nn
-        foreign c print_string("p3:":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        position.printPosition<0>(~tmp$1#0:position.position, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #4 @alias_mfoo:nn:nn
+        foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_mfoo:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp$11##0:position.position)
+        foreign lpvm mutate(~tmp$11##0:position.position, ?tmp$12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign lpvm mutate(~tmp$12##0:position.position, ?tmp$1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign llvm move(tmp$1##0:position.position, ?p3##0:position.position) @alias_mfoo:nn:nn
+        foreign c print_string("p3:":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        position.printPosition<0>(~tmp$1##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @alias_mfoo:nn:nn
 
 
   LLVM code       :
@@ -200,13 +200,13 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  {i64, i64} @"alias_mfoo.foo<0>"(i64  %"p1#0")    {
+define external fastcc  {i64, i64} @"alias_mfoo.foo<0>"(i64  %"p1##0")    {
 entry:
-  %1 = inttoptr i64 %"p1#0" to i64* 
+  %1 = inttoptr i64 %"p1##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %"1$tmp$5#0" = icmp sgt i64 %3, 1 
-  br i1 %"1$tmp$5#0", label %if.then, label %if.else 
+  %"1$tmp$5##0" = icmp sgt i64 %3, 1 
+  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
 if.then:
   %4 = trunc i64 16 to i32  
   %5 = tail call ccc  i8*  @wybe_malloc(i32  %4)  
@@ -221,22 +221,22 @@ if.then:
   %13 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_mfoo.12, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %13)  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %6)  
-  %14 = insertvalue {i64, i64} undef, i64 %"p1#0", 0 
+  %14 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
   %15 = insertvalue {i64, i64} %14, i64 %6, 1 
   ret {i64, i64} %15 
 if.else:
-  %"3$tmp$3#0" = add   i64 %3, 1 
+  %"3$tmp$3##0" = add   i64 %3, 1 
   %16 = trunc i64 16 to i32  
   %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
   %18 = ptrtoint i8* %17 to i64 
   %19 = inttoptr i64 %18 to i8* 
-  %20 = inttoptr i64 %"p1#0" to i8* 
+  %20 = inttoptr i64 %"p1##0" to i8* 
   %21 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %19, i8*  %20, i32  %21, i32  8, i1  0)  
   %22 = inttoptr i64 %18 to i64* 
   %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 %"3$tmp$3#0", i64* %23 
-  %"3$p3#0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %18)  
+  store  i64 %"3$tmp$3##0", i64* %23 
+  %"3$p3##0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %18)  
   %24 = trunc i64 16 to i32  
   %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
   %26 = ptrtoint i8* %25 to i64 
@@ -248,18 +248,18 @@ if.else:
   %31 = getelementptr  i64, i64* %30, i64 0 
   store  i64 2, i64* %31 
   %32 = insertvalue {i64, i64} undef, i64 %26, 0 
-  %33 = insertvalue {i64, i64} %32, i64 %"3$p3#0", 1 
+  %33 = insertvalue {i64, i64} %32, i64 %"3$p3##0", 1 
   ret {i64, i64} %33 
 }
 
 
-define external fastcc  {i64, i64} @"alias_mfoo.foo<0>[410bae77d3]"(i64  %"p1#0")    {
+define external fastcc  {i64, i64} @"alias_mfoo.foo<0>[410bae77d3]"(i64  %"p1##0")    {
 entry:
-  %34 = inttoptr i64 %"p1#0" to i64* 
+  %34 = inttoptr i64 %"p1##0" to i64* 
   %35 = getelementptr  i64, i64* %34, i64 0 
   %36 = load  i64, i64* %35 
-  %"1$tmp$5#0" = icmp sgt i64 %36, 1 
-  br i1 %"1$tmp$5#0", label %if.then, label %if.else 
+  %"1$tmp$5##0" = icmp sgt i64 %36, 1 
+  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
 if.then:
   %37 = trunc i64 16 to i32  
   %38 = tail call ccc  i8*  @wybe_malloc(i32  %37)  
@@ -274,15 +274,15 @@ if.then:
   %46 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_mfoo.45, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %46)  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %39)  
-  %47 = insertvalue {i64, i64} undef, i64 %"p1#0", 0 
+  %47 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
   %48 = insertvalue {i64, i64} %47, i64 %39, 1 
   ret {i64, i64} %48 
 if.else:
-  %"3$tmp$3#0" = add   i64 %36, 1 
-  %49 = inttoptr i64 %"p1#0" to i64* 
+  %"3$tmp$3##0" = add   i64 %36, 1 
+  %49 = inttoptr i64 %"p1##0" to i64* 
   %50 = getelementptr  i64, i64* %49, i64 0 
-  store  i64 %"3$tmp$3#0", i64* %50 
-  %"3$p3#0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %"p1#0")  
+  store  i64 %"3$tmp$3##0", i64* %50 
+  %"3$p3##0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %"p1##0")  
   %51 = trunc i64 16 to i32  
   %52 = tail call ccc  i8*  @wybe_malloc(i32  %51)  
   %53 = ptrtoint i8* %52 to i64 
@@ -294,7 +294,7 @@ if.else:
   %58 = getelementptr  i64, i64* %57, i64 0 
   store  i64 2, i64* %58 
   %59 = insertvalue {i64, i64} undef, i64 %53, 0 
-  %60 = insertvalue {i64, i64} %59, i64 %"3$p3#0", 1 
+  %60 = insertvalue {i64, i64} %59, i64 %"3$p3##0", 1 
   ret {i64, i64} %60 
 }
 --------------------------------------------------
@@ -319,17 +319,17 @@ if.else:
 
 printPosition > public (0 calls)
 0: position.printPosition<0>
-printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string(",":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io#4:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -363,17 +363,17 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"position.printPosition<0>"(i64  %"pos#0")    {
+define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
-  %3 = inttoptr i64 %"pos#0" to i64* 
+  %3 = inttoptr i64 %"pos##0" to i64* 
   %4 = getelementptr  i64, i64* %3, i64 0 
   %5 = load  i64, i64* %4 
   tail call ccc  void  @print_int(i64  %5)  
   %7 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.6, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %7)  
-  %8 = add   i64 %"pos#0", 8 
+  %8 = add   i64 %"pos##0", 8 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
@@ -403,86 +403,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y#0:wybe.int)
-    foreign llvm icmp_eq(~$left$x#0:wybe.int, ~$right$x#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
+    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y#0:wybe.int, ~$right$y#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
-    foreign lpvm mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:position.position, ?$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
+    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
-    foreign lpvm access(~$#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y#0:wybe.int)
+    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec#0:position.position, ?$#0:wybe.int):
+x($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec#0:position.position, ?$#0:wybe.int):
+y($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -499,54 +499,54 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$#0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = icmp eq i64 %7, %14 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"x#0", i64* %19 
+  store  i64 %"x##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"y#0", i64* %22 
+  store  i64 %"y##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
 entry:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -556,34 +556,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec#0" to i64* 
+  %32 = inttoptr i64 %"$rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec#0" to i8* 
+  %39 = inttoptr i64 %"$rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field#0", i64* %42 
+  store  i64 %"$field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = add   i64 %"$rec#0", 8 
+  %43 = add   i64 %"$rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -591,46 +591,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec#0" to i8* 
+  %51 = inttoptr i64 %"$rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field#0", i64* %55 
+  store  i64 %"$field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %58, %65 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = icmp eq i64 %62, %69 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$0##0" = icmp eq i64 %62, %69 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }

--- a/test-cases/final-dump/alias_mfoo.exp
+++ b/test-cases/final-dump/alias_mfoo.exp
@@ -403,7 +403,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
@@ -413,10 +413,10 @@ entry:
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -467,7 +467,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -478,11 +478,11 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -518,8 +518,8 @@ entry:
   %"1#tmp#1##0" = icmp eq i64 %3, %10 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2#####0" = icmp eq i64 %7, %14 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %7, %14 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -628,9 +628,9 @@ entry:
   br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#0##0" = icmp eq i64 %62, %69 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }

--- a/test-cases/final-dump/alias_mod_param.exp
+++ b/test-cases/final-dump/alias_mod_param.exp
@@ -13,25 +13,25 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: alias_mod_param.<0>
-(io#0:wybe.phantom, ?io#3:wybe.phantom):
+(io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$3#0:position.position)
-    foreign lpvm mutate(~tmp$3#0:position.position, ?tmp$4#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    foreign lpvm mutate(~tmp$4#0:position.position, ?tmp$0#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    alias_mod_param.foo<0>(tmp$0#0:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #1 @alias_mod_param:nn:nn
-    foreign c print_string("expect p1(10,10):":wybe.string, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~tmp$0#0:position.position, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) #3 @alias_mod_param:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$3##0:position.position)
+    foreign lpvm mutate(~tmp$3##0:position.position, ?tmp$4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    alias_mod_param.foo<0>(tmp$0##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias_mod_param:nn:nn
+    foreign c print_string("expect p1(10,10):":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~tmp$0##0:position.position, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @alias_mod_param:nn:nn
 
 
 foo > public (1 calls)
 0: alias_mod_param.foo<0>
-foo(pa#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
+foo(pa##0:position.position, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
-    foreign lpvm {noalias} mutate(~%pa#0:position.position, ?%pa#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 1111:wybe.int)
-    foreign c print_string("expect pa(1111,10):":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~pa#1:position.position, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #2 @alias_mod_param:nn:nn
+    foreign lpvm {noalias} mutate(~%pa##0:position.position, ?%pa##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 1111:wybe.int)
+    foreign c print_string("expect pa(1111,10):":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~pa##1:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #2 @alias_mod_param:nn:nn
 
   LLVM code       :
 
@@ -79,13 +79,13 @@ entry:
 }
 
 
-define external fastcc  void @"alias_mod_param.foo<0>"(i64  %"pa#0")    {
+define external fastcc  void @"alias_mod_param.foo<0>"(i64  %"pa##0")    {
 entry:
   %11 = trunc i64 16 to i32  
   %12 = tail call ccc  i8*  @wybe_malloc(i32  %11)  
   %13 = ptrtoint i8* %12 to i64 
   %14 = inttoptr i64 %13 to i8* 
-  %15 = inttoptr i64 %"pa#0" to i8* 
+  %15 = inttoptr i64 %"pa##0" to i8* 
   %16 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %14, i8*  %15, i32  %16, i32  8, i1  0)  
   %17 = inttoptr i64 %13 to i64* 
@@ -118,17 +118,17 @@ entry:
 
 printPosition > public (0 calls)
 0: position.printPosition<0>
-printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string(",":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io#4:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -162,17 +162,17 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"position.printPosition<0>"(i64  %"pos#0")    {
+define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
-  %3 = inttoptr i64 %"pos#0" to i64* 
+  %3 = inttoptr i64 %"pos##0" to i64* 
   %4 = getelementptr  i64, i64* %3, i64 0 
   %5 = load  i64, i64* %4 
   tail call ccc  void  @print_int(i64  %5)  
   %7 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.6, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %7)  
-  %8 = add   i64 %"pos#0", 8 
+  %8 = add   i64 %"pos##0", 8 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
@@ -202,86 +202,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y#0:wybe.int)
-    foreign llvm icmp_eq(~$left$x#0:wybe.int, ~$right$x#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
+    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y#0:wybe.int, ~$right$y#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
-    foreign lpvm mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:position.position, ?$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
+    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
-    foreign lpvm access(~$#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y#0:wybe.int)
+    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec#0:position.position, ?$#0:wybe.int):
+x($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec#0:position.position, ?$#0:wybe.int):
+y($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -298,54 +298,54 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$#0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = icmp eq i64 %7, %14 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"x#0", i64* %19 
+  store  i64 %"x##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"y#0", i64* %22 
+  store  i64 %"y##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
 entry:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -355,34 +355,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec#0" to i64* 
+  %32 = inttoptr i64 %"$rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec#0" to i8* 
+  %39 = inttoptr i64 %"$rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field#0", i64* %42 
+  store  i64 %"$field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = add   i64 %"$rec#0", 8 
+  %43 = add   i64 %"$rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -390,46 +390,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec#0" to i8* 
+  %51 = inttoptr i64 %"$rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field#0", i64* %55 
+  store  i64 %"$field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %58, %65 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = icmp eq i64 %62, %69 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$0##0" = icmp eq i64 %62, %69 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }

--- a/test-cases/final-dump/alias_mod_param.exp
+++ b/test-cases/final-dump/alias_mod_param.exp
@@ -16,12 +16,12 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$3##0:position.position)
-    foreign lpvm mutate(~tmp$3##0:position.position, ?tmp$4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    alias_mod_param.foo<0>(tmp$0##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias_mod_param:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position)
+    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    alias_mod_param.foo<0>(tmp#0##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias_mod_param:nn:nn
     foreign c print_string("expect p1(10,10):":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~tmp$0##0:position.position, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @alias_mod_param:nn:nn
+    position.printPosition<0>(~tmp#0##0:position.position, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @alias_mod_param:nn:nn
 
 
 foo > public (1 calls)
@@ -122,13 +122,13 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -202,86 +202,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
-    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
-    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec##0:position.position, ?$##0:wybe.int):
+x(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec##0:position.position, ?$##0:wybe.int):
+y(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -298,27 +298,27 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$##0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$##0" 
+  %"2#####0" = icmp eq i64 %7, %14 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
@@ -340,12 +340,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
 entry:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -355,34 +355,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec##0" to i64* 
+  %32 = inttoptr i64 %"#rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec##0" to i8* 
+  %39 = inttoptr i64 %"#rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field##0", i64* %42 
+  store  i64 %"#field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = add   i64 %"$rec##0", 8 
+  %43 = add   i64 %"#rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -390,46 +390,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec##0" to i8* 
+  %51 = inttoptr i64 %"#rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field##0", i64* %55 
+  store  i64 %"#field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %58, %65 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = icmp eq i64 %62, %69 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#0##0" = icmp eq i64 %62, %69 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }

--- a/test-cases/final-dump/alias_mod_param.exp
+++ b/test-cases/final-dump/alias_mod_param.exp
@@ -221,27 +221,27 @@ entry:
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x(#rec##0:position.position, ?###0:wybe.int):
+x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -252,10 +252,10 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y(#rec##0:position.position, ?###0:wybe.int):
+y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -340,12 +340,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 

--- a/test-cases/final-dump/alias_mod_param.exp
+++ b/test-cases/final-dump/alias_mod_param.exp
@@ -202,7 +202,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
@@ -212,10 +212,10 @@ entry:
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -266,7 +266,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -277,11 +277,11 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -317,8 +317,8 @@ entry:
   %"1#tmp#1##0" = icmp eq i64 %3, %10 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2#####0" = icmp eq i64 %7, %14 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %7, %14 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -427,9 +427,9 @@ entry:
   br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#0##0" = icmp eq i64 %62, %69 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }

--- a/test-cases/final-dump/alias_multifunc.exp
+++ b/test-cases/final-dump/alias_multifunc.exp
@@ -26,21 +26,21 @@ bar > public (1 calls)
 bar(io##0:wybe.phantom, ?io##15:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$3##0:position.position)
-    foreign lpvm mutate(~tmp$3##0:position.position, ?tmp$4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
-    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int)
-    alias_multifunc.replicate1<0>(tmp$0##0:position.position, ?p2##0:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias_multifunc:nn:nn
-    foreign c print_string("--- After calling replicate1: ":wybe.string, ~#io##1:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position)
+    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int)
+    alias_multifunc.replicate1<0>(tmp#0##0:position.position, ?p2##0:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias_multifunc:nn:nn
+    foreign c print_string("--- After calling replicate1: ":wybe.string, ~#io##1:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string("expect p1(101,102):":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(tmp$0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias_multifunc:nn:nn
+    position.printPosition<0>(tmp#0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias_multifunc:nn:nn
     foreign c print_string("expect p2(101,102):":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
     position.printPosition<0>(p2##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #6 @alias_multifunc:nn:nn
     foreign c print_string("expect p3(101,102):":wybe.string, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
     position.printPosition<0>(p3##0:position.position, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) #8 @alias_multifunc:nn:nn
-    foreign lpvm {noalias} mutate(~tmp$0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int)
-    foreign c print_string("--- After calling x(!p1, 555): ":wybe.string, ~#io##8:wybe.phantom, ?tmp$18##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$18##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
+    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int)
+    foreign c print_string("--- After calling x(!p1, 555): ":wybe.string, ~#io##8:wybe.phantom, ?tmp#18##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#18##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
     foreign c print_string("expect p1(555,102):":wybe.string, ~#io##9:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
     position.printPosition<0>(~p1##1:position.position, ~#io##10:wybe.phantom, ?#io##11:wybe.phantom) #12 @alias_multifunc:nn:nn
     foreign c print_string("expect p2(101,102):":wybe.string, ~#io##11:wybe.phantom, ?#io##12:wybe.phantom) @io:nn:nn
@@ -54,13 +54,13 @@ replicate1 > public (1 calls)
 replicate1(p1##0:position.position, ?p2##0:position.position, ?p3##0:position.position, io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: [(p1##0,p2##0),(p1##0,p3##0),(p2##0,p3##0)]
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$4##0:position.position)
-    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$5##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:position.position)
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
     foreign c print_string("random replicate1 ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~tmp$0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$11##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~tmp#0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign llvm move(p1##0:position.position, ?p2##0:position.position) @alias_multifunc:nn:nn
     alias_multifunc.replicate2<0>(~p1##0:position.position, ?p3##0:position.position, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #4 @alias_multifunc:nn:nn
 
@@ -70,13 +70,13 @@ replicate2 > public (1 calls)
 replicate2(p1##0:position.position, ?p2##0:position.position, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: [(p1##0,p2##0)]
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$4##0:position.position)
-    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$5##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:position.position)
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
     foreign c print_string("random replicate2 ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~tmp$0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$11##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~tmp#0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_multifunc:nn:nn
 
   LLVM code       :
@@ -214,9 +214,9 @@ entry:
   %48 = load  i64, i64* %47 
   tail call ccc  void  @print_int(i64  %48)  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$p3##0" = tail call fastcc  i64  @"alias_multifunc.replicate2<0>"(i64  %"p1##0")  
+  %"1#p3##0" = tail call fastcc  i64  @"alias_multifunc.replicate2<0>"(i64  %"p1##0")  
   %49 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
-  %50 = insertvalue {i64, i64} %49, i64 %"1$p3##0", 1 
+  %50 = insertvalue {i64, i64} %49, i64 %"1#p3##0", 1 
   ret {i64, i64} %50 
 }
 
@@ -268,13 +268,13 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -348,86 +348,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
-    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
-    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec##0:position.position, ?$##0:wybe.int):
+x(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec##0:position.position, ?$##0:wybe.int):
+y(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -444,27 +444,27 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$##0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$##0" 
+  %"2#####0" = icmp eq i64 %7, %14 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
@@ -486,12 +486,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
 entry:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -501,34 +501,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec##0" to i64* 
+  %32 = inttoptr i64 %"#rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec##0" to i8* 
+  %39 = inttoptr i64 %"#rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field##0", i64* %42 
+  store  i64 %"#field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = add   i64 %"$rec##0", 8 
+  %43 = add   i64 %"#rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -536,46 +536,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec##0" to i8* 
+  %51 = inttoptr i64 %"#rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field##0", i64* %55 
+  store  i64 %"#field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %58, %65 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = icmp eq i64 %62, %69 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#0##0" = icmp eq i64 %62, %69 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }

--- a/test-cases/final-dump/alias_multifunc.exp
+++ b/test-cases/final-dump/alias_multifunc.exp
@@ -15,69 +15,69 @@ AFTER EVERYTHING:
 
 *main* > public {inline} (0 calls)
 0: alias_multifunc.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    alias_multifunc.bar<0>(~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @alias_multifunc:nn:nn
+    alias_multifunc.bar<0>(~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @alias_multifunc:nn:nn
 
 
 bar > public (1 calls)
 0: alias_multifunc.bar<0>
-bar(io#0:wybe.phantom, ?io#15:wybe.phantom):
+bar(io##0:wybe.phantom, ?io##15:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$3#0:position.position)
-    foreign lpvm mutate(~tmp$3#0:position.position, ?tmp$4#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
-    foreign lpvm mutate(~tmp$4#0:position.position, ?tmp$0#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int)
-    alias_multifunc.replicate1<0>(tmp$0#0:position.position, ?p2#0:position.position, ?p3#0:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #1 @alias_multifunc:nn:nn
-    foreign c print_string("--- After calling replicate1: ":wybe.string, ~#io#1:wybe.phantom, ?tmp$7#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$7#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect p1(101,102):":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(tmp$0#0:position.position, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #4 @alias_multifunc:nn:nn
-    foreign c print_string("expect p2(101,102):":wybe.string, ~#io#4:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(p2#0:position.position, ~#io#5:wybe.phantom, ?#io#6:wybe.phantom) #6 @alias_multifunc:nn:nn
-    foreign c print_string("expect p3(101,102):":wybe.string, ~#io#6:wybe.phantom, ?#io#7:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(p3#0:position.position, ~#io#7:wybe.phantom, ?#io#8:wybe.phantom) #8 @alias_multifunc:nn:nn
-    foreign lpvm {noalias} mutate(~tmp$0#0:position.position, ?%p1#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int)
-    foreign c print_string("--- After calling x(!p1, 555): ":wybe.string, ~#io#8:wybe.phantom, ?tmp$18#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$18#0:wybe.phantom, ?#io#9:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect p1(555,102):":wybe.string, ~#io#9:wybe.phantom, ?#io#10:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~p1#1:position.position, ~#io#10:wybe.phantom, ?#io#11:wybe.phantom) #12 @alias_multifunc:nn:nn
-    foreign c print_string("expect p2(101,102):":wybe.string, ~#io#11:wybe.phantom, ?#io#12:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~p2#0:position.position, ~#io#12:wybe.phantom, ?#io#13:wybe.phantom) #14 @alias_multifunc:nn:nn
-    foreign c print_string("expect p3(101,102):":wybe.string, ~#io#13:wybe.phantom, ?#io#14:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~p3#0:position.position, ~#io#14:wybe.phantom, ?#io#15:wybe.phantom) #16 @alias_multifunc:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$3##0:position.position)
+    foreign lpvm mutate(~tmp$3##0:position.position, ?tmp$4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
+    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 102:wybe.int)
+    alias_multifunc.replicate1<0>(tmp$0##0:position.position, ?p2##0:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias_multifunc:nn:nn
+    foreign c print_string("--- After calling replicate1: ":wybe.string, ~#io##1:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect p1(101,102):":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(tmp$0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias_multifunc:nn:nn
+    foreign c print_string("expect p2(101,102):":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(p2##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #6 @alias_multifunc:nn:nn
+    foreign c print_string("expect p3(101,102):":wybe.string, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(p3##0:position.position, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) #8 @alias_multifunc:nn:nn
+    foreign lpvm {noalias} mutate(~tmp$0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 555:wybe.int)
+    foreign c print_string("--- After calling x(!p1, 555): ":wybe.string, ~#io##8:wybe.phantom, ?tmp$18##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$18##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect p1(555,102):":wybe.string, ~#io##9:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~p1##1:position.position, ~#io##10:wybe.phantom, ?#io##11:wybe.phantom) #12 @alias_multifunc:nn:nn
+    foreign c print_string("expect p2(101,102):":wybe.string, ~#io##11:wybe.phantom, ?#io##12:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~p2##0:position.position, ~#io##12:wybe.phantom, ?#io##13:wybe.phantom) #14 @alias_multifunc:nn:nn
+    foreign c print_string("expect p3(101,102):":wybe.string, ~#io##13:wybe.phantom, ?#io##14:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~p3##0:position.position, ~#io##14:wybe.phantom, ?#io##15:wybe.phantom) #16 @alias_multifunc:nn:nn
 
 
 replicate1 > public (1 calls)
 0: alias_multifunc.replicate1<0>
-replicate1(p1#0:position.position, ?p2#0:position.position, ?p3#0:position.position, io#0:wybe.phantom, ?io#3:wybe.phantom):
- AliasPairs: [(p1#0,p2#0),(p1#0,p3#0),(p2#0,p3#0)]
+replicate1(p1##0:position.position, ?p2##0:position.position, ?p3##0:position.position, io##0:wybe.phantom, ?io##3:wybe.phantom):
+ AliasPairs: [(p1##0,p2##0),(p1##0,p3##0),(p2##0,p3##0)]
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$4#0:position.position)
-    foreign lpvm mutate(~tmp$4#0:position.position, ?tmp$5#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$5#0:position.position, ?tmp$0#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign c print_string("random replicate1 ":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~tmp$0#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#1:wybe.phantom, ?tmp$11#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$11#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign llvm move(p1#0:position.position, ?p2#0:position.position) @alias_multifunc:nn:nn
-    alias_multifunc.replicate2<0>(~p1#0:position.position, ?p3#0:position.position, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) #4 @alias_multifunc:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$4##0:position.position)
+    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp$5##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign c print_string("random replicate1 ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~tmp$0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$11##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign llvm move(p1##0:position.position, ?p2##0:position.position) @alias_multifunc:nn:nn
+    alias_multifunc.replicate2<0>(~p1##0:position.position, ?p3##0:position.position, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #4 @alias_multifunc:nn:nn
 
 
 replicate2 > public (1 calls)
 0: alias_multifunc.replicate2<0>
-replicate2(p1#0:position.position, ?p2#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
- AliasPairs: [(p1#0,p2#0)]
+replicate2(p1##0:position.position, ?p2##0:position.position, io##0:wybe.phantom, ?io##2:wybe.phantom):
+ AliasPairs: [(p1##0,p2##0)]
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$4#0:position.position)
-    foreign lpvm mutate(~tmp$4#0:position.position, ?tmp$5#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$5#0:position.position, ?tmp$0#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign c print_string("random replicate2 ":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~tmp$0#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#1:wybe.phantom, ?tmp$11#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$11#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign llvm move(~p1#0:position.position, ?p2#0:position.position) @alias_multifunc:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$4##0:position.position)
+    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp$5##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign c print_string("random replicate2 ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~tmp$0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$11##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_multifunc:nn:nn
 
   LLVM code       :
 
@@ -195,7 +195,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"alias_multifunc.replicate1<0>"(i64  %"p1#0")    {
+define external fastcc  {i64, i64} @"alias_multifunc.replicate1<0>"(i64  %"p1##0")    {
 entry:
   %36 = trunc i64 16 to i32  
   %37 = tail call ccc  i8*  @wybe_malloc(i32  %36)  
@@ -214,14 +214,14 @@ entry:
   %48 = load  i64, i64* %47 
   tail call ccc  void  @print_int(i64  %48)  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$p3#0" = tail call fastcc  i64  @"alias_multifunc.replicate2<0>"(i64  %"p1#0")  
-  %49 = insertvalue {i64, i64} undef, i64 %"p1#0", 0 
-  %50 = insertvalue {i64, i64} %49, i64 %"1$p3#0", 1 
+  %"1$p3##0" = tail call fastcc  i64  @"alias_multifunc.replicate2<0>"(i64  %"p1##0")  
+  %49 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
+  %50 = insertvalue {i64, i64} %49, i64 %"1$p3##0", 1 
   ret {i64, i64} %50 
 }
 
 
-define external fastcc  i64 @"alias_multifunc.replicate2<0>"(i64  %"p1#0")    {
+define external fastcc  i64 @"alias_multifunc.replicate2<0>"(i64  %"p1##0")    {
 entry:
   %51 = trunc i64 16 to i32  
   %52 = tail call ccc  i8*  @wybe_malloc(i32  %51)  
@@ -240,7 +240,7 @@ entry:
   %63 = load  i64, i64* %62 
   tail call ccc  void  @print_int(i64  %63)  
   tail call ccc  void  @putchar(i8  10)  
-  ret i64 %"p1#0" 
+  ret i64 %"p1##0" 
 }
 --------------------------------------------------
  Module position
@@ -264,17 +264,17 @@ entry:
 
 printPosition > public (0 calls)
 0: position.printPosition<0>
-printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string(",":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io#4:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -308,17 +308,17 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"position.printPosition<0>"(i64  %"pos#0")    {
+define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
-  %3 = inttoptr i64 %"pos#0" to i64* 
+  %3 = inttoptr i64 %"pos##0" to i64* 
   %4 = getelementptr  i64, i64* %3, i64 0 
   %5 = load  i64, i64* %4 
   tail call ccc  void  @print_int(i64  %5)  
   %7 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.6, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %7)  
-  %8 = add   i64 %"pos#0", 8 
+  %8 = add   i64 %"pos##0", 8 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
@@ -348,86 +348,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y#0:wybe.int)
-    foreign llvm icmp_eq(~$left$x#0:wybe.int, ~$right$x#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
+    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y#0:wybe.int, ~$right$y#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
-    foreign lpvm mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:position.position, ?$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
+    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
-    foreign lpvm access(~$#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y#0:wybe.int)
+    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec#0:position.position, ?$#0:wybe.int):
+x($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec#0:position.position, ?$#0:wybe.int):
+y($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -444,54 +444,54 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$#0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = icmp eq i64 %7, %14 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"x#0", i64* %19 
+  store  i64 %"x##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"y#0", i64* %22 
+  store  i64 %"y##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
 entry:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -501,34 +501,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec#0" to i64* 
+  %32 = inttoptr i64 %"$rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec#0" to i8* 
+  %39 = inttoptr i64 %"$rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field#0", i64* %42 
+  store  i64 %"$field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = add   i64 %"$rec#0", 8 
+  %43 = add   i64 %"$rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -536,46 +536,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec#0" to i8* 
+  %51 = inttoptr i64 %"$rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field#0", i64* %55 
+  store  i64 %"$field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %58, %65 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = icmp eq i64 %62, %69 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$0##0" = icmp eq i64 %62, %69 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }

--- a/test-cases/final-dump/alias_multifunc.exp
+++ b/test-cases/final-dump/alias_multifunc.exp
@@ -367,27 +367,27 @@ entry:
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x(#rec##0:position.position, ?###0:wybe.int):
+x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -398,10 +398,10 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y(#rec##0:position.position, ?###0:wybe.int):
+y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -486,12 +486,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 

--- a/test-cases/final-dump/alias_multifunc.exp
+++ b/test-cases/final-dump/alias_multifunc.exp
@@ -348,7 +348,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
@@ -358,10 +358,10 @@ entry:
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -412,7 +412,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -423,11 +423,11 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -463,8 +463,8 @@ entry:
   %"1#tmp#1##0" = icmp eq i64 %3, %10 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2#####0" = icmp eq i64 %7, %14 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %7, %14 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -573,9 +573,9 @@ entry:
   br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#0##0" = icmp eq i64 %62, %69 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }

--- a/test-cases/final-dump/alias_multifunc1.exp
+++ b/test-cases/final-dump/alias_multifunc1.exp
@@ -329,7 +329,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
@@ -339,10 +339,10 @@ entry:
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -393,7 +393,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -404,11 +404,11 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -444,8 +444,8 @@ entry:
   %"1#tmp#1##0" = icmp eq i64 %3, %10 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2#####0" = icmp eq i64 %7, %14 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %7, %14 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -554,9 +554,9 @@ entry:
   br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#0##0" = icmp eq i64 %62, %69 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }

--- a/test-cases/final-dump/alias_multifunc1.exp
+++ b/test-cases/final-dump/alias_multifunc1.exp
@@ -348,27 +348,27 @@ entry:
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x(#rec##0:position.position, ?###0:wybe.int):
+x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -379,10 +379,10 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y(#rec##0:position.position, ?###0:wybe.int):
+y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -467,12 +467,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 

--- a/test-cases/final-dump/alias_multifunc1.exp
+++ b/test-cases/final-dump/alias_multifunc1.exp
@@ -17,26 +17,26 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##16:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$3##0:position.position)
-    foreign lpvm mutate(~tmp$3##0:position.position, ?tmp$4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    alias_multifunc1.replicate1<0>(tmp$0##0:position.position, ?p2##0:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias_multifunc1:19:2
-    foreign c print_string("--- After calling replicate1: ":wybe.string, ~#io##1:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position)
+    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    alias_multifunc1.replicate1<0>(tmp#0##0:position.position, ?p2##0:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias_multifunc1:19:2
+    foreign c print_string("--- After calling replicate1: ":wybe.string, ~#io##1:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string("expect p1(10,10):":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(tmp$0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias_multifunc1:23:2
+    position.printPosition<0>(tmp#0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias_multifunc1:23:2
     foreign c print_string("expect p2(22,10):":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
     position.printPosition<0>(p2##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #6 @alias_multifunc1:25:2
     foreign c print_string("expect p3(10,10):":wybe.string, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
     position.printPosition<0>(p3##0:position.position, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) #8 @alias_multifunc1:27:2
     foreign lpvm {noalias} mutate(~%p2##0:position.position, ?%p2##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2222222:wybe.int)
-    foreign c print_string("--- After calling x(!p2, 2222222): ":wybe.string, ~#io##8:wybe.phantom, ?tmp$18##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$18##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
+    foreign c print_string("--- After calling x(!p2, 2222222): ":wybe.string, ~#io##8:wybe.phantom, ?tmp#18##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#18##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
     foreign c print_string("expect p2(2222222,10):":wybe.string, ~#io##9:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
     position.printPosition<0>(~p2##1:position.position, ~#io##10:wybe.phantom, ?#io##11:wybe.phantom) #12 @alias_multifunc1:33:2
-    foreign lpvm {noalias} mutate(~tmp$0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 11:wybe.int)
-    foreign c print_string("--- After calling x(!p1, 11): ":wybe.string, ~#io##11:wybe.phantom, ?tmp$25##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$25##0:wybe.phantom, ?#io##12:wybe.phantom) @io:nn:nn
+    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 11:wybe.int)
+    foreign c print_string("--- After calling x(!p1, 11): ":wybe.string, ~#io##11:wybe.phantom, ?tmp#25##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#25##0:wybe.phantom, ?#io##12:wybe.phantom) @io:nn:nn
     foreign c print_string("expect p1(11,10):":wybe.string, ~#io##12:wybe.phantom, ?#io##13:wybe.phantom) @io:nn:nn
     position.printPosition<0>(~p1##1:position.position, ~#io##13:wybe.phantom, ?#io##14:wybe.phantom) #16 @alias_multifunc1:45:2
     foreign c print_string("expect p3(10,10):":wybe.string, ~#io##14:wybe.phantom, ?#io##15:wybe.phantom) @io:nn:nn
@@ -58,13 +58,13 @@ replicate2 > public (2 calls)
 replicate2(p1##0:position.position, ?p2##0:position.position, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: [(p1##0,p2##0)]
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$4##0:position.position)
-    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$5##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:position.position)
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
     foreign c print_string("some noise...":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~tmp$0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$11##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~tmp#0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_multifunc1:8:6
 
   LLVM code       :
@@ -184,20 +184,20 @@ entry:
 
 define external fastcc  {i64, i64} @"alias_multifunc1.replicate1<0>"(i64  %"p1##0")    {
 entry:
-  %"1$p2##0" = tail call fastcc  i64  @"alias_multifunc1.replicate2<0>"(i64  %"p1##0")  
-  %"1$p3##0" = tail call fastcc  i64  @"alias_multifunc1.replicate2<0>"(i64  %"1$p2##0")  
+  %"1#p2##0" = tail call fastcc  i64  @"alias_multifunc1.replicate2<0>"(i64  %"p1##0")  
+  %"1#p3##0" = tail call fastcc  i64  @"alias_multifunc1.replicate2<0>"(i64  %"1#p2##0")  
   %40 = trunc i64 16 to i32  
   %41 = tail call ccc  i8*  @wybe_malloc(i32  %40)  
   %42 = ptrtoint i8* %41 to i64 
   %43 = inttoptr i64 %42 to i8* 
-  %44 = inttoptr i64 %"1$p2##0" to i8* 
+  %44 = inttoptr i64 %"1#p2##0" to i8* 
   %45 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %43, i8*  %44, i32  %45, i32  8, i1  0)  
   %46 = inttoptr i64 %42 to i64* 
   %47 = getelementptr  i64, i64* %46, i64 0 
   store  i64 22, i64* %47 
   %48 = insertvalue {i64, i64} undef, i64 %42, 0 
-  %49 = insertvalue {i64, i64} %48, i64 %"1$p3##0", 1 
+  %49 = insertvalue {i64, i64} %48, i64 %"1#p3##0", 1 
   ret {i64, i64} %49 
 }
 
@@ -249,13 +249,13 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -329,86 +329,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
-    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
-    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec##0:position.position, ?$##0:wybe.int):
+x(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec##0:position.position, ?$##0:wybe.int):
+y(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -425,27 +425,27 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$##0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$##0" 
+  %"2#####0" = icmp eq i64 %7, %14 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
@@ -467,12 +467,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
 entry:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -482,34 +482,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec##0" to i64* 
+  %32 = inttoptr i64 %"#rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec##0" to i8* 
+  %39 = inttoptr i64 %"#rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field##0", i64* %42 
+  store  i64 %"#field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = add   i64 %"$rec##0", 8 
+  %43 = add   i64 %"#rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -517,46 +517,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec##0" to i8* 
+  %51 = inttoptr i64 %"#rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field##0", i64* %55 
+  store  i64 %"#field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %58, %65 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = icmp eq i64 %62, %69 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#0##0" = icmp eq i64 %62, %69 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }

--- a/test-cases/final-dump/alias_multifunc1.exp
+++ b/test-cases/final-dump/alias_multifunc1.exp
@@ -14,58 +14,58 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: alias_multifunc1.<0>
-(io#0:wybe.phantom, ?io#16:wybe.phantom):
+(io##0:wybe.phantom, ?io##16:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$3#0:position.position)
-    foreign lpvm mutate(~tmp$3#0:position.position, ?tmp$4#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    foreign lpvm mutate(~tmp$4#0:position.position, ?tmp$0#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    alias_multifunc1.replicate1<0>(tmp$0#0:position.position, ?p2#0:position.position, ?p3#0:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #1 @alias_multifunc1:19:2
-    foreign c print_string("--- After calling replicate1: ":wybe.string, ~#io#1:wybe.phantom, ?tmp$7#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$7#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect p1(10,10):":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(tmp$0#0:position.position, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #4 @alias_multifunc1:23:2
-    foreign c print_string("expect p2(22,10):":wybe.string, ~#io#4:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(p2#0:position.position, ~#io#5:wybe.phantom, ?#io#6:wybe.phantom) #6 @alias_multifunc1:25:2
-    foreign c print_string("expect p3(10,10):":wybe.string, ~#io#6:wybe.phantom, ?#io#7:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(p3#0:position.position, ~#io#7:wybe.phantom, ?#io#8:wybe.phantom) #8 @alias_multifunc1:27:2
-    foreign lpvm {noalias} mutate(~%p2#0:position.position, ?%p2#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2222222:wybe.int)
-    foreign c print_string("--- After calling x(!p2, 2222222): ":wybe.string, ~#io#8:wybe.phantom, ?tmp$18#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$18#0:wybe.phantom, ?#io#9:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect p2(2222222,10):":wybe.string, ~#io#9:wybe.phantom, ?#io#10:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~p2#1:position.position, ~#io#10:wybe.phantom, ?#io#11:wybe.phantom) #12 @alias_multifunc1:33:2
-    foreign lpvm {noalias} mutate(~tmp$0#0:position.position, ?%p1#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 11:wybe.int)
-    foreign c print_string("--- After calling x(!p1, 11): ":wybe.string, ~#io#11:wybe.phantom, ?tmp$25#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$25#0:wybe.phantom, ?#io#12:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect p1(11,10):":wybe.string, ~#io#12:wybe.phantom, ?#io#13:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~p1#1:position.position, ~#io#13:wybe.phantom, ?#io#14:wybe.phantom) #16 @alias_multifunc1:45:2
-    foreign c print_string("expect p3(10,10):":wybe.string, ~#io#14:wybe.phantom, ?#io#15:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~p3#0:position.position, ~#io#15:wybe.phantom, ?#io#16:wybe.phantom) #18 @alias_multifunc1:47:2
+    foreign lpvm alloc(16:wybe.int, ?tmp$3##0:position.position)
+    foreign lpvm mutate(~tmp$3##0:position.position, ?tmp$4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    alias_multifunc1.replicate1<0>(tmp$0##0:position.position, ?p2##0:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias_multifunc1:19:2
+    foreign c print_string("--- After calling replicate1: ":wybe.string, ~#io##1:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect p1(10,10):":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(tmp$0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias_multifunc1:23:2
+    foreign c print_string("expect p2(22,10):":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(p2##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #6 @alias_multifunc1:25:2
+    foreign c print_string("expect p3(10,10):":wybe.string, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(p3##0:position.position, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) #8 @alias_multifunc1:27:2
+    foreign lpvm {noalias} mutate(~%p2##0:position.position, ?%p2##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2222222:wybe.int)
+    foreign c print_string("--- After calling x(!p2, 2222222): ":wybe.string, ~#io##8:wybe.phantom, ?tmp$18##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$18##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect p2(2222222,10):":wybe.string, ~#io##9:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~p2##1:position.position, ~#io##10:wybe.phantom, ?#io##11:wybe.phantom) #12 @alias_multifunc1:33:2
+    foreign lpvm {noalias} mutate(~tmp$0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 11:wybe.int)
+    foreign c print_string("--- After calling x(!p1, 11): ":wybe.string, ~#io##11:wybe.phantom, ?tmp$25##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$25##0:wybe.phantom, ?#io##12:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect p1(11,10):":wybe.string, ~#io##12:wybe.phantom, ?#io##13:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~p1##1:position.position, ~#io##13:wybe.phantom, ?#io##14:wybe.phantom) #16 @alias_multifunc1:45:2
+    foreign c print_string("expect p3(10,10):":wybe.string, ~#io##14:wybe.phantom, ?#io##15:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~p3##0:position.position, ~#io##15:wybe.phantom, ?#io##16:wybe.phantom) #18 @alias_multifunc1:47:2
 
 
 replicate1 > public (1 calls)
 0: alias_multifunc1.replicate1<0>
-replicate1(p1#0:position.position, ?p2#1:position.position, ?p3#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
- AliasPairs: [(p1#0,p3#0)]
+replicate1(p1##0:position.position, ?p2##1:position.position, ?p3##0:position.position, io##0:wybe.phantom, ?io##2:wybe.phantom):
+ AliasPairs: [(p1##0,p3##0)]
  InterestingCallProperties: []
-    alias_multifunc1.replicate2<0>(~p1#0:position.position, ?p2#0:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @alias_multifunc1:13:6
-    alias_multifunc1.replicate2<0>(p2#0:position.position, ?p3#0:position.position, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #1 @alias_multifunc1:14:6
-    foreign lpvm {noalias} mutate(~%p2#0:position.position, ?%p2#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 22:wybe.int)
+    alias_multifunc1.replicate2<0>(~p1##0:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @alias_multifunc1:13:6
+    alias_multifunc1.replicate2<0>(p2##0:position.position, ?p3##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #1 @alias_multifunc1:14:6
+    foreign lpvm {noalias} mutate(~%p2##0:position.position, ?%p2##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 22:wybe.int)
 
 
 replicate2 > public (2 calls)
 0: alias_multifunc1.replicate2<0>
-replicate2(p1#0:position.position, ?p2#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
- AliasPairs: [(p1#0,p2#0)]
+replicate2(p1##0:position.position, ?p2##0:position.position, io##0:wybe.phantom, ?io##2:wybe.phantom):
+ AliasPairs: [(p1##0,p2##0)]
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$4#0:position.position)
-    foreign lpvm mutate(~tmp$4#0:position.position, ?tmp$5#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$5#0:position.position, ?tmp$0#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign c print_string("some noise...":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~tmp$0#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#1:wybe.phantom, ?tmp$11#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$11#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign llvm move(~p1#0:position.position, ?p2#0:position.position) @alias_multifunc1:8:6
+    foreign lpvm alloc(16:wybe.int, ?tmp$4##0:position.position)
+    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp$5##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign c print_string("some noise...":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~tmp$0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$11##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_multifunc1:8:6
 
   LLVM code       :
 
@@ -182,27 +182,27 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"alias_multifunc1.replicate1<0>"(i64  %"p1#0")    {
+define external fastcc  {i64, i64} @"alias_multifunc1.replicate1<0>"(i64  %"p1##0")    {
 entry:
-  %"1$p2#0" = tail call fastcc  i64  @"alias_multifunc1.replicate2<0>"(i64  %"p1#0")  
-  %"1$p3#0" = tail call fastcc  i64  @"alias_multifunc1.replicate2<0>"(i64  %"1$p2#0")  
+  %"1$p2##0" = tail call fastcc  i64  @"alias_multifunc1.replicate2<0>"(i64  %"p1##0")  
+  %"1$p3##0" = tail call fastcc  i64  @"alias_multifunc1.replicate2<0>"(i64  %"1$p2##0")  
   %40 = trunc i64 16 to i32  
   %41 = tail call ccc  i8*  @wybe_malloc(i32  %40)  
   %42 = ptrtoint i8* %41 to i64 
   %43 = inttoptr i64 %42 to i8* 
-  %44 = inttoptr i64 %"1$p2#0" to i8* 
+  %44 = inttoptr i64 %"1$p2##0" to i8* 
   %45 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %43, i8*  %44, i32  %45, i32  8, i1  0)  
   %46 = inttoptr i64 %42 to i64* 
   %47 = getelementptr  i64, i64* %46, i64 0 
   store  i64 22, i64* %47 
   %48 = insertvalue {i64, i64} undef, i64 %42, 0 
-  %49 = insertvalue {i64, i64} %48, i64 %"1$p3#0", 1 
+  %49 = insertvalue {i64, i64} %48, i64 %"1$p3##0", 1 
   ret {i64, i64} %49 
 }
 
 
-define external fastcc  i64 @"alias_multifunc1.replicate2<0>"(i64  %"p1#0")    {
+define external fastcc  i64 @"alias_multifunc1.replicate2<0>"(i64  %"p1##0")    {
 entry:
   %50 = trunc i64 16 to i32  
   %51 = tail call ccc  i8*  @wybe_malloc(i32  %50)  
@@ -221,7 +221,7 @@ entry:
   %62 = load  i64, i64* %61 
   tail call ccc  void  @print_int(i64  %62)  
   tail call ccc  void  @putchar(i8  10)  
-  ret i64 %"p1#0" 
+  ret i64 %"p1##0" 
 }
 --------------------------------------------------
  Module position
@@ -245,17 +245,17 @@ entry:
 
 printPosition > public (0 calls)
 0: position.printPosition<0>
-printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string(",":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io#4:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -289,17 +289,17 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"position.printPosition<0>"(i64  %"pos#0")    {
+define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
-  %3 = inttoptr i64 %"pos#0" to i64* 
+  %3 = inttoptr i64 %"pos##0" to i64* 
   %4 = getelementptr  i64, i64* %3, i64 0 
   %5 = load  i64, i64* %4 
   tail call ccc  void  @print_int(i64  %5)  
   %7 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.6, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %7)  
-  %8 = add   i64 %"pos#0", 8 
+  %8 = add   i64 %"pos##0", 8 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
@@ -329,86 +329,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y#0:wybe.int)
-    foreign llvm icmp_eq(~$left$x#0:wybe.int, ~$right$x#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
+    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y#0:wybe.int, ~$right$y#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
-    foreign lpvm mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:position.position, ?$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
+    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
-    foreign lpvm access(~$#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y#0:wybe.int)
+    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec#0:position.position, ?$#0:wybe.int):
+x($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec#0:position.position, ?$#0:wybe.int):
+y($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -425,54 +425,54 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$#0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = icmp eq i64 %7, %14 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"x#0", i64* %19 
+  store  i64 %"x##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"y#0", i64* %22 
+  store  i64 %"y##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
 entry:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -482,34 +482,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec#0" to i64* 
+  %32 = inttoptr i64 %"$rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec#0" to i8* 
+  %39 = inttoptr i64 %"$rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field#0", i64* %42 
+  store  i64 %"$field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = add   i64 %"$rec#0", 8 
+  %43 = add   i64 %"$rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -517,46 +517,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec#0" to i8* 
+  %51 = inttoptr i64 %"$rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field#0", i64* %55 
+  store  i64 %"$field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %58, %65 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = icmp eq i64 %62, %69 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$0##0" = icmp eq i64 %62, %69 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }

--- a/test-cases/final-dump/alias_multifunc2.exp
+++ b/test-cases/final-dump/alias_multifunc2.exp
@@ -14,55 +14,55 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: alias_multifunc2.<0>
-(io#0:wybe.phantom, ?io#15:wybe.phantom):
+(io##0:wybe.phantom, ?io##15:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$3#0:position.position)
-    foreign lpvm mutate(~tmp$3#0:position.position, ?tmp$4#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    foreign lpvm mutate(~tmp$4#0:position.position, ?tmp$0#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    alias_multifunc2.replicate1<0>(tmp$0#0:position.position, ?p2#0:position.position, ?p3#0:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #1 @alias_multifunc2:20:2
-    foreign c print_string("--- After calling replicate1: ":wybe.string, ~#io#1:wybe.phantom, ?tmp$7#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$7#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect p1(10,10):":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(tmp$0#0:position.position, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #4 @alias_multifunc2:24:2
-    foreign c print_string("expect p2(22,10):":wybe.string, ~#io#4:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(p2#0:position.position, ~#io#5:wybe.phantom, ?#io#6:wybe.phantom) #6 @alias_multifunc2:26:2
-    foreign c print_string("expect p3(10,10):":wybe.string, ~#io#6:wybe.phantom, ?#io#7:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(p3#0:position.position, ~#io#7:wybe.phantom, ?#io#8:wybe.phantom) #8 @alias_multifunc2:28:2
-    foreign lpvm {noalias} mutate(~tmp$0#0:position.position, ?%p1#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 11:wybe.int)
-    foreign c print_string("--- After calling x(!p1, 11): ":wybe.string, ~#io#8:wybe.phantom, ?tmp$18#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$18#0:wybe.phantom, ?#io#9:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect p1(11,10):":wybe.string, ~#io#9:wybe.phantom, ?#io#10:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~p1#1:position.position, ~#io#10:wybe.phantom, ?#io#11:wybe.phantom) #12 @alias_multifunc2:34:2
-    foreign c print_string("expect p2(22,10):":wybe.string, ~#io#11:wybe.phantom, ?#io#12:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~p2#0:position.position, ~#io#12:wybe.phantom, ?#io#13:wybe.phantom) #14 @alias_multifunc2:36:2
-    foreign c print_string("expect p3(10,10):":wybe.string, ~#io#13:wybe.phantom, ?#io#14:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~p3#0:position.position, ~#io#14:wybe.phantom, ?#io#15:wybe.phantom) #16 @alias_multifunc2:38:2
+    foreign lpvm alloc(16:wybe.int, ?tmp$3##0:position.position)
+    foreign lpvm mutate(~tmp$3##0:position.position, ?tmp$4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    alias_multifunc2.replicate1<0>(tmp$0##0:position.position, ?p2##0:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias_multifunc2:20:2
+    foreign c print_string("--- After calling replicate1: ":wybe.string, ~#io##1:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect p1(10,10):":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(tmp$0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias_multifunc2:24:2
+    foreign c print_string("expect p2(22,10):":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(p2##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #6 @alias_multifunc2:26:2
+    foreign c print_string("expect p3(10,10):":wybe.string, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(p3##0:position.position, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) #8 @alias_multifunc2:28:2
+    foreign lpvm {noalias} mutate(~tmp$0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 11:wybe.int)
+    foreign c print_string("--- After calling x(!p1, 11): ":wybe.string, ~#io##8:wybe.phantom, ?tmp$18##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$18##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect p1(11,10):":wybe.string, ~#io##9:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~p1##1:position.position, ~#io##10:wybe.phantom, ?#io##11:wybe.phantom) #12 @alias_multifunc2:34:2
+    foreign c print_string("expect p2(22,10):":wybe.string, ~#io##11:wybe.phantom, ?#io##12:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~p2##0:position.position, ~#io##12:wybe.phantom, ?#io##13:wybe.phantom) #14 @alias_multifunc2:36:2
+    foreign c print_string("expect p3(10,10):":wybe.string, ~#io##13:wybe.phantom, ?#io##14:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~p3##0:position.position, ~#io##14:wybe.phantom, ?#io##15:wybe.phantom) #16 @alias_multifunc2:38:2
 
 
 replicate1 > public (1 calls)
 0: alias_multifunc2.replicate1<0>
-replicate1(p1#0:position.position, ?p2#1:position.position, ?p3#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
- AliasPairs: [(p1#0,p3#0)]
+replicate1(p1##0:position.position, ?p2##1:position.position, ?p3##0:position.position, io##0:wybe.phantom, ?io##2:wybe.phantom):
+ AliasPairs: [(p1##0,p3##0)]
  InterestingCallProperties: []
-    alias_multifunc2.replicate2<0>(~p1#0:position.position, ?p2#0:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @alias_multifunc2:14:6
-    alias_multifunc2.replicate2<0>(p2#0:position.position, ?p3#0:position.position, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #1 @alias_multifunc2:15:6
-    foreign lpvm {noalias} mutate(~%p2#0:position.position, ?%p2#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 22:wybe.int)
+    alias_multifunc2.replicate2<0>(~p1##0:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @alias_multifunc2:14:6
+    alias_multifunc2.replicate2<0>(p2##0:position.position, ?p3##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #1 @alias_multifunc2:15:6
+    foreign lpvm {noalias} mutate(~%p2##0:position.position, ?%p2##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 22:wybe.int)
 
 
 replicate2 > public (2 calls)
 0: alias_multifunc2.replicate2<0>
-replicate2(p1#0:position.position, ?p2#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
- AliasPairs: [(p1#0,p2#0)]
+replicate2(p1##0:position.position, ?p2##0:position.position, io##0:wybe.phantom, ?io##2:wybe.phantom):
+ AliasPairs: [(p1##0,p2##0)]
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$4#0:position.position)
-    foreign lpvm mutate(~tmp$4#0:position.position, ?tmp$5#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$5#0:position.position, ?tmp$0#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign c print_string("random replicate2 ":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~tmp$0#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#1:wybe.phantom, ?tmp$11#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$11#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign llvm move(~p1#0:position.position, ?p2#0:position.position) @alias_multifunc2:9:6
+    foreign lpvm alloc(16:wybe.int, ?tmp$4##0:position.position)
+    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp$5##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign c print_string("random replicate2 ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~tmp$0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$11##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_multifunc2:9:6
 
   LLVM code       :
 
@@ -170,27 +170,27 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"alias_multifunc2.replicate1<0>"(i64  %"p1#0")    {
+define external fastcc  {i64, i64} @"alias_multifunc2.replicate1<0>"(i64  %"p1##0")    {
 entry:
-  %"1$p2#0" = tail call fastcc  i64  @"alias_multifunc2.replicate2<0>"(i64  %"p1#0")  
-  %"1$p3#0" = tail call fastcc  i64  @"alias_multifunc2.replicate2<0>"(i64  %"1$p2#0")  
+  %"1$p2##0" = tail call fastcc  i64  @"alias_multifunc2.replicate2<0>"(i64  %"p1##0")  
+  %"1$p3##0" = tail call fastcc  i64  @"alias_multifunc2.replicate2<0>"(i64  %"1$p2##0")  
   %36 = trunc i64 16 to i32  
   %37 = tail call ccc  i8*  @wybe_malloc(i32  %36)  
   %38 = ptrtoint i8* %37 to i64 
   %39 = inttoptr i64 %38 to i8* 
-  %40 = inttoptr i64 %"1$p2#0" to i8* 
+  %40 = inttoptr i64 %"1$p2##0" to i8* 
   %41 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %39, i8*  %40, i32  %41, i32  8, i1  0)  
   %42 = inttoptr i64 %38 to i64* 
   %43 = getelementptr  i64, i64* %42, i64 0 
   store  i64 22, i64* %43 
   %44 = insertvalue {i64, i64} undef, i64 %38, 0 
-  %45 = insertvalue {i64, i64} %44, i64 %"1$p3#0", 1 
+  %45 = insertvalue {i64, i64} %44, i64 %"1$p3##0", 1 
   ret {i64, i64} %45 
 }
 
 
-define external fastcc  i64 @"alias_multifunc2.replicate2<0>"(i64  %"p1#0")    {
+define external fastcc  i64 @"alias_multifunc2.replicate2<0>"(i64  %"p1##0")    {
 entry:
   %46 = trunc i64 16 to i32  
   %47 = tail call ccc  i8*  @wybe_malloc(i32  %46)  
@@ -209,7 +209,7 @@ entry:
   %58 = load  i64, i64* %57 
   tail call ccc  void  @print_int(i64  %58)  
   tail call ccc  void  @putchar(i8  10)  
-  ret i64 %"p1#0" 
+  ret i64 %"p1##0" 
 }
 --------------------------------------------------
  Module position
@@ -233,17 +233,17 @@ entry:
 
 printPosition > public (0 calls)
 0: position.printPosition<0>
-printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string(",":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io#4:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -277,17 +277,17 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"position.printPosition<0>"(i64  %"pos#0")    {
+define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
-  %3 = inttoptr i64 %"pos#0" to i64* 
+  %3 = inttoptr i64 %"pos##0" to i64* 
   %4 = getelementptr  i64, i64* %3, i64 0 
   %5 = load  i64, i64* %4 
   tail call ccc  void  @print_int(i64  %5)  
   %7 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.6, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %7)  
-  %8 = add   i64 %"pos#0", 8 
+  %8 = add   i64 %"pos##0", 8 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
@@ -317,86 +317,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y#0:wybe.int)
-    foreign llvm icmp_eq(~$left$x#0:wybe.int, ~$right$x#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
+    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y#0:wybe.int, ~$right$y#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
-    foreign lpvm mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:position.position, ?$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
+    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
-    foreign lpvm access(~$#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y#0:wybe.int)
+    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec#0:position.position, ?$#0:wybe.int):
+x($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec#0:position.position, ?$#0:wybe.int):
+y($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -413,54 +413,54 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$#0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = icmp eq i64 %7, %14 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"x#0", i64* %19 
+  store  i64 %"x##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"y#0", i64* %22 
+  store  i64 %"y##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
 entry:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -470,34 +470,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec#0" to i64* 
+  %32 = inttoptr i64 %"$rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec#0" to i8* 
+  %39 = inttoptr i64 %"$rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field#0", i64* %42 
+  store  i64 %"$field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = add   i64 %"$rec#0", 8 
+  %43 = add   i64 %"$rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -505,46 +505,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec#0" to i8* 
+  %51 = inttoptr i64 %"$rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field#0", i64* %55 
+  store  i64 %"$field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %58, %65 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = icmp eq i64 %62, %69 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$0##0" = icmp eq i64 %62, %69 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }

--- a/test-cases/final-dump/alias_multifunc2.exp
+++ b/test-cases/final-dump/alias_multifunc2.exp
@@ -317,7 +317,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
@@ -327,10 +327,10 @@ entry:
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -381,7 +381,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -392,11 +392,11 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -432,8 +432,8 @@ entry:
   %"1#tmp#1##0" = icmp eq i64 %3, %10 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2#####0" = icmp eq i64 %7, %14 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %7, %14 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -542,9 +542,9 @@ entry:
   br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#0##0" = icmp eq i64 %62, %69 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }

--- a/test-cases/final-dump/alias_multifunc2.exp
+++ b/test-cases/final-dump/alias_multifunc2.exp
@@ -17,21 +17,21 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##15:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$3##0:position.position)
-    foreign lpvm mutate(~tmp$3##0:position.position, ?tmp$4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    alias_multifunc2.replicate1<0>(tmp$0##0:position.position, ?p2##0:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias_multifunc2:20:2
-    foreign c print_string("--- After calling replicate1: ":wybe.string, ~#io##1:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position)
+    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    alias_multifunc2.replicate1<0>(tmp#0##0:position.position, ?p2##0:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias_multifunc2:20:2
+    foreign c print_string("--- After calling replicate1: ":wybe.string, ~#io##1:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string("expect p1(10,10):":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(tmp$0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias_multifunc2:24:2
+    position.printPosition<0>(tmp#0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias_multifunc2:24:2
     foreign c print_string("expect p2(22,10):":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
     position.printPosition<0>(p2##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #6 @alias_multifunc2:26:2
     foreign c print_string("expect p3(10,10):":wybe.string, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
     position.printPosition<0>(p3##0:position.position, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) #8 @alias_multifunc2:28:2
-    foreign lpvm {noalias} mutate(~tmp$0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 11:wybe.int)
-    foreign c print_string("--- After calling x(!p1, 11): ":wybe.string, ~#io##8:wybe.phantom, ?tmp$18##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$18##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
+    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 11:wybe.int)
+    foreign c print_string("--- After calling x(!p1, 11): ":wybe.string, ~#io##8:wybe.phantom, ?tmp#18##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#18##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
     foreign c print_string("expect p1(11,10):":wybe.string, ~#io##9:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
     position.printPosition<0>(~p1##1:position.position, ~#io##10:wybe.phantom, ?#io##11:wybe.phantom) #12 @alias_multifunc2:34:2
     foreign c print_string("expect p2(22,10):":wybe.string, ~#io##11:wybe.phantom, ?#io##12:wybe.phantom) @io:nn:nn
@@ -55,13 +55,13 @@ replicate2 > public (2 calls)
 replicate2(p1##0:position.position, ?p2##0:position.position, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: [(p1##0,p2##0)]
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$4##0:position.position)
-    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$5##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:position.position)
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
     foreign c print_string("random replicate2 ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~tmp$0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$11##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~tmp#0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_multifunc2:9:6
 
   LLVM code       :
@@ -172,20 +172,20 @@ entry:
 
 define external fastcc  {i64, i64} @"alias_multifunc2.replicate1<0>"(i64  %"p1##0")    {
 entry:
-  %"1$p2##0" = tail call fastcc  i64  @"alias_multifunc2.replicate2<0>"(i64  %"p1##0")  
-  %"1$p3##0" = tail call fastcc  i64  @"alias_multifunc2.replicate2<0>"(i64  %"1$p2##0")  
+  %"1#p2##0" = tail call fastcc  i64  @"alias_multifunc2.replicate2<0>"(i64  %"p1##0")  
+  %"1#p3##0" = tail call fastcc  i64  @"alias_multifunc2.replicate2<0>"(i64  %"1#p2##0")  
   %36 = trunc i64 16 to i32  
   %37 = tail call ccc  i8*  @wybe_malloc(i32  %36)  
   %38 = ptrtoint i8* %37 to i64 
   %39 = inttoptr i64 %38 to i8* 
-  %40 = inttoptr i64 %"1$p2##0" to i8* 
+  %40 = inttoptr i64 %"1#p2##0" to i8* 
   %41 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %39, i8*  %40, i32  %41, i32  8, i1  0)  
   %42 = inttoptr i64 %38 to i64* 
   %43 = getelementptr  i64, i64* %42, i64 0 
   store  i64 22, i64* %43 
   %44 = insertvalue {i64, i64} undef, i64 %38, 0 
-  %45 = insertvalue {i64, i64} %44, i64 %"1$p3##0", 1 
+  %45 = insertvalue {i64, i64} %44, i64 %"1#p3##0", 1 
   ret {i64, i64} %45 
 }
 
@@ -237,13 +237,13 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -317,86 +317,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
-    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
-    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec##0:position.position, ?$##0:wybe.int):
+x(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec##0:position.position, ?$##0:wybe.int):
+y(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -413,27 +413,27 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$##0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$##0" 
+  %"2#####0" = icmp eq i64 %7, %14 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
@@ -455,12 +455,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
 entry:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -470,34 +470,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec##0" to i64* 
+  %32 = inttoptr i64 %"#rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec##0" to i8* 
+  %39 = inttoptr i64 %"#rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field##0", i64* %42 
+  store  i64 %"#field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = add   i64 %"$rec##0", 8 
+  %43 = add   i64 %"#rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -505,46 +505,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec##0" to i8* 
+  %51 = inttoptr i64 %"#rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field##0", i64* %55 
+  store  i64 %"#field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %58, %65 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = icmp eq i64 %62, %69 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#0##0" = icmp eq i64 %62, %69 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }

--- a/test-cases/final-dump/alias_multifunc2.exp
+++ b/test-cases/final-dump/alias_multifunc2.exp
@@ -336,27 +336,27 @@ entry:
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x(#rec##0:position.position, ?###0:wybe.int):
+x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -367,10 +367,10 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y(#rec##0:position.position, ?###0:wybe.int):
+y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -455,12 +455,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 

--- a/test-cases/final-dump/alias_multifunc3.exp
+++ b/test-cases/final-dump/alias_multifunc3.exp
@@ -273,7 +273,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
@@ -283,10 +283,10 @@ entry:
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -337,7 +337,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -348,11 +348,11 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -388,8 +388,8 @@ entry:
   %"1#tmp#1##0" = icmp eq i64 %3, %10 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2#####0" = icmp eq i64 %7, %14 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %7, %14 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -498,9 +498,9 @@ entry:
   br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#0##0" = icmp eq i64 %62, %69 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }

--- a/test-cases/final-dump/alias_multifunc3.exp
+++ b/test-cases/final-dump/alias_multifunc3.exp
@@ -13,41 +13,41 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: alias_multifunc3.<0>
-(io#0:wybe.phantom, ?io#11:wybe.phantom):
+(io##0:wybe.phantom, ?io##11:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$3#0:position.position)
-    foreign lpvm mutate(~tmp$3#0:position.position, ?tmp$4#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    foreign lpvm mutate(~tmp$4#0:position.position, ?tmp$0#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    alias_multifunc3.replicate1<0>(tmp$0#0:position.position, ?p2#0:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #1 @alias_multifunc3:17:2
-    foreign c print_string("--- After calling replicate1:":wybe.string, ~#io#1:wybe.phantom, ?tmp$7#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$7#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect p1(10,10):":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(tmp$0#0:position.position, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #4 @alias_multifunc3:21:2
-    foreign c print_string("expect p2(10,10):":wybe.string, ~#io#4:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(p2#0:position.position, ~#io#5:wybe.phantom, ?#io#6:wybe.phantom) #6 @alias_multifunc3:23:2
-    foreign lpvm {noalias} mutate(~tmp$0#0:position.position, ?%p1#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 999:wybe.int)
-    foreign c print_string("--- After called x(!p1, 999):":wybe.string, ~#io#6:wybe.phantom, ?tmp$16#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$16#0:wybe.phantom, ?#io#7:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect p1(999,10):":wybe.string, ~#io#7:wybe.phantom, ?#io#8:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~p1#1:position.position, ~#io#8:wybe.phantom, ?#io#9:wybe.phantom) #10 @alias_multifunc3:28:2
-    foreign c print_string("expect p2(10,10):":wybe.string, ~#io#9:wybe.phantom, ?#io#10:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~p2#0:position.position, ~#io#10:wybe.phantom, ?#io#11:wybe.phantom) #12 @alias_multifunc3:30:2
+    foreign lpvm alloc(16:wybe.int, ?tmp$3##0:position.position)
+    foreign lpvm mutate(~tmp$3##0:position.position, ?tmp$4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    alias_multifunc3.replicate1<0>(tmp$0##0:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias_multifunc3:17:2
+    foreign c print_string("--- After calling replicate1:":wybe.string, ~#io##1:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect p1(10,10):":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(tmp$0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias_multifunc3:21:2
+    foreign c print_string("expect p2(10,10):":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(p2##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #6 @alias_multifunc3:23:2
+    foreign lpvm {noalias} mutate(~tmp$0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 999:wybe.int)
+    foreign c print_string("--- After called x(!p1, 999):":wybe.string, ~#io##6:wybe.phantom, ?tmp$16##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$16##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect p1(999,10):":wybe.string, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~p1##1:position.position, ~#io##8:wybe.phantom, ?#io##9:wybe.phantom) #10 @alias_multifunc3:28:2
+    foreign c print_string("expect p2(10,10):":wybe.string, ~#io##9:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~p2##0:position.position, ~#io##10:wybe.phantom, ?#io##11:wybe.phantom) #12 @alias_multifunc3:30:2
 
 
 replicate1 > public (1 calls)
 0: alias_multifunc3.replicate1<0>
-replicate1(pa#0:position.position, ?pb#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
- AliasPairs: [(pa#0,pb#0)]
+replicate1(pa##0:position.position, ?pb##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom):
+ AliasPairs: [(pa##0,pb##0)]
  InterestingCallProperties: []
-    foreign llvm move(pa#0:position.position, ?pb#0:position.position) @alias_multifunc3:6:6
-    foreign lpvm {noalias} mutate(%pa#0:position.position, ?%pa#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 1111:wybe.int)
-    foreign c print_string("--- Inside replicate1:":wybe.string, ~#io#0:wybe.phantom, ?tmp$4#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$4#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect pa(1111,10):":wybe.string, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~pa#1:position.position, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) #3 @alias_multifunc3:11:6
-    foreign c print_string("expect pb(10,10):":wybe.string, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~pa#0:position.position, ~#io#4:wybe.phantom, ?#io#5:wybe.phantom) #5 @alias_multifunc3:13:6
+    foreign llvm move(pa##0:position.position, ?pb##0:position.position) @alias_multifunc3:6:6
+    foreign lpvm {noalias} mutate(%pa##0:position.position, ?%pa##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 1111:wybe.int)
+    foreign c print_string("--- Inside replicate1:":wybe.string, ~#io##0:wybe.phantom, ?tmp$4##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$4##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect pa(1111,10):":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~pa##1:position.position, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @alias_multifunc3:11:6
+    foreign c print_string("expect pb(10,10):":wybe.string, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~pa##0:position.position, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #5 @alias_multifunc3:13:6
 
   LLVM code       :
 
@@ -111,7 +111,7 @@ entry:
   %7 = inttoptr i64 %6 to i64* 
   %8 = getelementptr  i64, i64* %7, i64 0 
   store  i64 10, i64* %8 
-  %"1$p2#0" = tail call fastcc  i64  @"alias_multifunc3.replicate1<0>"(i64  %3)  
+  %"1$p2##0" = tail call fastcc  i64  @"alias_multifunc3.replicate1<0>"(i64  %3)  
   %10 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_multifunc3.9, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %10)  
   tail call ccc  void  @putchar(i8  10)  
@@ -120,7 +120,7 @@ entry:
   tail call fastcc  void  @"position.printPosition<0>"(i64  %3)  
   %14 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_multifunc3.13, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %14)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2#0")  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2##0")  
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
@@ -139,18 +139,18 @@ entry:
   tail call fastcc  void  @"position.printPosition<0>"(i64  %17)  
   %28 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_multifunc3.27, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %28)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2#0")  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2##0")  
   ret void 
 }
 
 
-define external fastcc  i64 @"alias_multifunc3.replicate1<0>"(i64  %"pa#0")    {
+define external fastcc  i64 @"alias_multifunc3.replicate1<0>"(i64  %"pa##0")    {
 entry:
   %29 = trunc i64 16 to i32  
   %30 = tail call ccc  i8*  @wybe_malloc(i32  %29)  
   %31 = ptrtoint i8* %30 to i64 
   %32 = inttoptr i64 %31 to i8* 
-  %33 = inttoptr i64 %"pa#0" to i8* 
+  %33 = inttoptr i64 %"pa##0" to i8* 
   %34 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %32, i8*  %33, i32  %34, i32  8, i1  0)  
   %35 = inttoptr i64 %31 to i64* 
@@ -164,8 +164,8 @@ entry:
   tail call fastcc  void  @"position.printPosition<0>"(i64  %31)  
   %42 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_multifunc3.41, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %42)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"pa#0")  
-  ret i64 %"pa#0" 
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"pa##0")  
+  ret i64 %"pa##0" 
 }
 --------------------------------------------------
  Module position
@@ -189,17 +189,17 @@ entry:
 
 printPosition > public (0 calls)
 0: position.printPosition<0>
-printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string(",":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io#4:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -233,17 +233,17 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"position.printPosition<0>"(i64  %"pos#0")    {
+define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
-  %3 = inttoptr i64 %"pos#0" to i64* 
+  %3 = inttoptr i64 %"pos##0" to i64* 
   %4 = getelementptr  i64, i64* %3, i64 0 
   %5 = load  i64, i64* %4 
   tail call ccc  void  @print_int(i64  %5)  
   %7 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.6, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %7)  
-  %8 = add   i64 %"pos#0", 8 
+  %8 = add   i64 %"pos##0", 8 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
@@ -273,86 +273,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y#0:wybe.int)
-    foreign llvm icmp_eq(~$left$x#0:wybe.int, ~$right$x#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
+    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y#0:wybe.int, ~$right$y#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
-    foreign lpvm mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:position.position, ?$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
+    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
-    foreign lpvm access(~$#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y#0:wybe.int)
+    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec#0:position.position, ?$#0:wybe.int):
+x($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec#0:position.position, ?$#0:wybe.int):
+y($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -369,54 +369,54 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$#0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = icmp eq i64 %7, %14 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"x#0", i64* %19 
+  store  i64 %"x##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"y#0", i64* %22 
+  store  i64 %"y##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
 entry:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -426,34 +426,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec#0" to i64* 
+  %32 = inttoptr i64 %"$rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec#0" to i8* 
+  %39 = inttoptr i64 %"$rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field#0", i64* %42 
+  store  i64 %"$field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = add   i64 %"$rec#0", 8 
+  %43 = add   i64 %"$rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -461,46 +461,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec#0" to i8* 
+  %51 = inttoptr i64 %"$rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field#0", i64* %55 
+  store  i64 %"$field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %58, %65 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = icmp eq i64 %62, %69 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$0##0" = icmp eq i64 %62, %69 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }

--- a/test-cases/final-dump/alias_multifunc3.exp
+++ b/test-cases/final-dump/alias_multifunc3.exp
@@ -292,27 +292,27 @@ entry:
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x(#rec##0:position.position, ?###0:wybe.int):
+x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -323,10 +323,10 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y(#rec##0:position.position, ?###0:wybe.int):
+y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -411,12 +411,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 

--- a/test-cases/final-dump/alias_multifunc3.exp
+++ b/test-cases/final-dump/alias_multifunc3.exp
@@ -16,19 +16,19 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##11:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$3##0:position.position)
-    foreign lpvm mutate(~tmp$3##0:position.position, ?tmp$4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    alias_multifunc3.replicate1<0>(tmp$0##0:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias_multifunc3:17:2
-    foreign c print_string("--- After calling replicate1:":wybe.string, ~#io##1:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position)
+    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    alias_multifunc3.replicate1<0>(tmp#0##0:position.position, ?p2##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias_multifunc3:17:2
+    foreign c print_string("--- After calling replicate1:":wybe.string, ~#io##1:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string("expect p1(10,10):":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(tmp$0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias_multifunc3:21:2
+    position.printPosition<0>(tmp#0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias_multifunc3:21:2
     foreign c print_string("expect p2(10,10):":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
     position.printPosition<0>(p2##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #6 @alias_multifunc3:23:2
-    foreign lpvm {noalias} mutate(~tmp$0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 999:wybe.int)
-    foreign c print_string("--- After called x(!p1, 999):":wybe.string, ~#io##6:wybe.phantom, ?tmp$16##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$16##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
+    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 999:wybe.int)
+    foreign c print_string("--- After called x(!p1, 999):":wybe.string, ~#io##6:wybe.phantom, ?tmp#16##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
     foreign c print_string("expect p1(999,10):":wybe.string, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
     position.printPosition<0>(~p1##1:position.position, ~#io##8:wybe.phantom, ?#io##9:wybe.phantom) #10 @alias_multifunc3:28:2
     foreign c print_string("expect p2(10,10):":wybe.string, ~#io##9:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
@@ -42,8 +42,8 @@ replicate1(pa##0:position.position, ?pb##0:position.position, io##0:wybe.phantom
  InterestingCallProperties: []
     foreign llvm move(pa##0:position.position, ?pb##0:position.position) @alias_multifunc3:6:6
     foreign lpvm {noalias} mutate(%pa##0:position.position, ?%pa##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 1111:wybe.int)
-    foreign c print_string("--- Inside replicate1:":wybe.string, ~#io##0:wybe.phantom, ?tmp$4##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$4##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("--- Inside replicate1:":wybe.string, ~#io##0:wybe.phantom, ?tmp#4##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#4##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     foreign c print_string("expect pa(1111,10):":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     position.printPosition<0>(~pa##1:position.position, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @alias_multifunc3:11:6
     foreign c print_string("expect pb(10,10):":wybe.string, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
@@ -111,7 +111,7 @@ entry:
   %7 = inttoptr i64 %6 to i64* 
   %8 = getelementptr  i64, i64* %7, i64 0 
   store  i64 10, i64* %8 
-  %"1$p2##0" = tail call fastcc  i64  @"alias_multifunc3.replicate1<0>"(i64  %3)  
+  %"1#p2##0" = tail call fastcc  i64  @"alias_multifunc3.replicate1<0>"(i64  %3)  
   %10 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_multifunc3.9, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %10)  
   tail call ccc  void  @putchar(i8  10)  
@@ -120,7 +120,7 @@ entry:
   tail call fastcc  void  @"position.printPosition<0>"(i64  %3)  
   %14 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_multifunc3.13, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %14)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2##0")  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
@@ -139,7 +139,7 @@ entry:
   tail call fastcc  void  @"position.printPosition<0>"(i64  %17)  
   %28 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_multifunc3.27, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %28)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p2##0")  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
   ret void 
 }
 
@@ -193,13 +193,13 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -273,86 +273,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
-    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
-    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec##0:position.position, ?$##0:wybe.int):
+x(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec##0:position.position, ?$##0:wybe.int):
+y(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -369,27 +369,27 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$##0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$##0" 
+  %"2#####0" = icmp eq i64 %7, %14 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
@@ -411,12 +411,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
 entry:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -426,34 +426,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec##0" to i64* 
+  %32 = inttoptr i64 %"#rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec##0" to i8* 
+  %39 = inttoptr i64 %"#rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field##0", i64* %42 
+  store  i64 %"#field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = add   i64 %"$rec##0", 8 
+  %43 = add   i64 %"#rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -461,46 +461,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec##0" to i8* 
+  %51 = inttoptr i64 %"#rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field##0", i64* %55 
+  store  i64 %"#field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %58, %65 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = icmp eq i64 %62, %69 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#0##0" = icmp eq i64 %62, %69 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }

--- a/test-cases/final-dump/alias_multifunc4.exp
+++ b/test-cases/final-dump/alias_multifunc4.exp
@@ -393,7 +393,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
@@ -403,10 +403,10 @@ entry:
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -457,7 +457,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -468,11 +468,11 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -508,8 +508,8 @@ entry:
   %"1#tmp#1##0" = icmp eq i64 %3, %10 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2#####0" = icmp eq i64 %7, %14 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %7, %14 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -618,9 +618,9 @@ entry:
   br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#0##0" = icmp eq i64 %62, %69 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }

--- a/test-cases/final-dump/alias_multifunc4.exp
+++ b/test-cases/final-dump/alias_multifunc4.exp
@@ -18,26 +18,26 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##18:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$3##0:position.position)
-    foreign lpvm mutate(~tmp$3##0:position.position, ?tmp$4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    alias_multifunc4.replicate1<0>(tmp$0##0:position.position, ?p2##0:position.position, ?p3##0:position.position, #io##0:wybe.phantom, ?_:wybe.phantom) #1 @alias_multifunc4:36:2
-    foreign c print_string("--- After calling replicate1:":wybe.string, ~#io##0:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position)
+    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    alias_multifunc4.replicate1<0>(tmp#0##0:position.position, ?p2##0:position.position, ?p3##0:position.position, #io##0:wybe.phantom, ?_:wybe.phantom) #1 @alias_multifunc4:36:2
+    foreign c print_string("--- After calling replicate1:":wybe.string, ~#io##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string("expect p1(10,10):":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~tmp$0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias_multifunc4:40:2
+    position.printPosition<0>(~tmp#0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias_multifunc4:40:2
     foreign c print_string("expect p2(99,10):":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
     position.printPosition<0>(~p2##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #6 @alias_multifunc4:42:2
     foreign c print_string("expect p3(10,10):":wybe.string, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
     position.printPosition<0>(~p3##0:position.position, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) #8 @alias_multifunc4:44:2
     alias_multifunc4.replicate21<0>(?p4##0:position.position, ~#io##8:wybe.phantom, ?#io##9:wybe.phantom) #9 @alias_multifunc4:47:2
-    foreign c print_string("--- After calling replicate21:":wybe.string, ~#io##9:wybe.phantom, ?tmp$16##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$16##0:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
+    foreign c print_string("--- After calling replicate21:":wybe.string, ~#io##9:wybe.phantom, ?tmp#16##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
     foreign c print_string("expect p4(99999,99999):":wybe.string, ~#io##10:wybe.phantom, ?#io##11:wybe.phantom) @io:nn:nn
     position.printPosition<0>(~p4##0:position.position, ~#io##11:wybe.phantom, ?#io##12:wybe.phantom) #12 @alias_multifunc4:50:2
     alias_multifunc4.replicate22<0>(?p6##0:position.position, ?p7##0:position.position, ~#io##12:wybe.phantom, ?#io##13:wybe.phantom) #13 @alias_multifunc4:53:2
-    foreign c print_string("--- After calling replicate22:":wybe.string, ~#io##13:wybe.phantom, ?tmp$21##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$21##0:wybe.phantom, ?#io##14:wybe.phantom) @io:nn:nn
+    foreign c print_string("--- After calling replicate22:":wybe.string, ~#io##13:wybe.phantom, ?tmp#21##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?#io##14:wybe.phantom) @io:nn:nn
     foreign c print_string("expect p6(99999,99999):":wybe.string, ~#io##14:wybe.phantom, ?#io##15:wybe.phantom) @io:nn:nn
     position.printPosition<0>(~p6##0:position.position, ~#io##15:wybe.phantom, ?#io##16:wybe.phantom) #16 @alias_multifunc4:56:2
     foreign c print_string("expect p7(1111111111,99999):":wybe.string, ~#io##16:wybe.phantom, ?#io##17:wybe.phantom) @io:nn:nn
@@ -50,11 +50,11 @@ replicate1(pa##0:position.position, ?pb##1:position.position, ?pc##0:position.po
  AliasPairs: [(pa##0,pc##0)]
  InterestingCallProperties: []
     foreign llvm move(pa##0:position.position, ?pc##0:position.position) @alias_multifunc4:8:6
-    foreign lpvm alloc(16:wybe.int, ?tmp$4##0:position.position)
-    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99:wybe.int)
-    foreign lpvm mutate(~tmp$5##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99:wybe.int)
-    foreign lpvm access(~tmp$0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign lpvm {noalias} mutate(~pa##0:position.position, ?%pb##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$1##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:position.position)
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99:wybe.int)
+    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99:wybe.int)
+    foreign lpvm access(~tmp#0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign lpvm {noalias} mutate(~pa##0:position.position, ?%pb##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int)
 
 
 replicate21 > public (1 calls)
@@ -62,11 +62,11 @@ replicate21 > public (1 calls)
 replicate21(?pb##0:position.position, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$3##0:position.position)
-    foreign lpvm mutate(~tmp$3##0:position.position, ?tmp$4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99999:wybe.int)
-    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99999:wybe.int)
-    foreign llvm move(tmp$0##0:position.position, ?pb##0:position.position) @alias_multifunc4:16:6
-    foreign lpvm {noalias} mutate(~tmp$0##0:position.position, ?%pc##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 1111111111:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position)
+    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99999:wybe.int)
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99999:wybe.int)
+    foreign llvm move(tmp#0##0:position.position, ?pb##0:position.position) @alias_multifunc4:16:6
+    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%pc##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 1111111111:wybe.int)
     foreign c print_string("--- Inside replicate21, expect pc(1111111111,99999): ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     position.printPosition<0>(~pc##1:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #3 @alias_multifunc4:20:6
 
@@ -76,13 +76,13 @@ replicate22 > public (1 calls)
 replicate22(?pb##0:position.position, ?pc##1:position.position, io##0:wybe.phantom, ?io##4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$3##0:position.position)
-    foreign lpvm mutate(~tmp$3##0:position.position, ?tmp$4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99999:wybe.int)
-    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99999:wybe.int)
-    foreign llvm move(tmp$0##0:position.position, ?pb##0:position.position) @alias_multifunc4:25:6
+    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position)
+    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99999:wybe.int)
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99999:wybe.int)
+    foreign llvm move(tmp#0##0:position.position, ?pb##0:position.position) @alias_multifunc4:25:6
     foreign c print_string("--- Inside replicate22, expect pc(99999,99999):":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(tmp$0##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #2 @alias_multifunc4:28:6
-    foreign lpvm {noalias} mutate(~tmp$0##0:position.position, ?%pc##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 1111111111:wybe.int)
+    position.printPosition<0>(tmp#0##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #2 @alias_multifunc4:28:6
+    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%pc##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 1111111111:wybe.int)
     foreign c print_string("--- Inside replicate22, after calling x(!pc,1111111111), expect pc(1111111111,99999): ":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
     position.printPosition<0>(pc##1:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #5 @alias_multifunc4:32:6
 
@@ -172,13 +172,13 @@ entry:
   %19 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_multifunc4.18, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %19)  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %11)  
-  %"1$p4##0" = tail call fastcc  i64  @"alias_multifunc4.replicate21<0>"()  
+  %"1#p4##0" = tail call fastcc  i64  @"alias_multifunc4.replicate21<0>"()  
   %21 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_multifunc4.20, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %21)  
   tail call ccc  void  @putchar(i8  10)  
   %23 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_multifunc4.22, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %23)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p4##0")  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p4##0")  
   %24 = tail call fastcc  {i64, i64}  @"alias_multifunc4.replicate22<0>"()  
   %25 = extractvalue {i64, i64} %24, 0 
   %26 = extractvalue {i64, i64} %24, 1 
@@ -313,13 +313,13 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -393,86 +393,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
-    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
-    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec##0:position.position, ?$##0:wybe.int):
+x(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec##0:position.position, ?$##0:wybe.int):
+y(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -489,27 +489,27 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$##0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$##0" 
+  %"2#####0" = icmp eq i64 %7, %14 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
@@ -531,12 +531,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
 entry:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -546,34 +546,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec##0" to i64* 
+  %32 = inttoptr i64 %"#rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec##0" to i8* 
+  %39 = inttoptr i64 %"#rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field##0", i64* %42 
+  store  i64 %"#field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = add   i64 %"$rec##0", 8 
+  %43 = add   i64 %"#rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -581,46 +581,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec##0" to i8* 
+  %51 = inttoptr i64 %"#rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field##0", i64* %55 
+  store  i64 %"#field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %58, %65 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = icmp eq i64 %62, %69 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#0##0" = icmp eq i64 %62, %69 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }

--- a/test-cases/final-dump/alias_multifunc4.exp
+++ b/test-cases/final-dump/alias_multifunc4.exp
@@ -412,27 +412,27 @@ entry:
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x(#rec##0:position.position, ?###0:wybe.int):
+x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -443,10 +443,10 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y(#rec##0:position.position, ?###0:wybe.int):
+y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -531,12 +531,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 

--- a/test-cases/final-dump/alias_multifunc4.exp
+++ b/test-cases/final-dump/alias_multifunc4.exp
@@ -15,76 +15,76 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: alias_multifunc4.<0>
-(io#0:wybe.phantom, ?io#18:wybe.phantom):
+(io##0:wybe.phantom, ?io##18:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$3#0:position.position)
-    foreign lpvm mutate(~tmp$3#0:position.position, ?tmp$4#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    foreign lpvm mutate(~tmp$4#0:position.position, ?tmp$0#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    alias_multifunc4.replicate1<0>(tmp$0#0:position.position, ?p2#0:position.position, ?p3#0:position.position, #io#0:wybe.phantom, ?_:wybe.phantom) #1 @alias_multifunc4:36:2
-    foreign c print_string("--- After calling replicate1:":wybe.string, ~#io#0:wybe.phantom, ?tmp$7#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$7#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect p1(10,10):":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~tmp$0#0:position.position, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #4 @alias_multifunc4:40:2
-    foreign c print_string("expect p2(99,10):":wybe.string, ~#io#4:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~p2#0:position.position, ~#io#5:wybe.phantom, ?#io#6:wybe.phantom) #6 @alias_multifunc4:42:2
-    foreign c print_string("expect p3(10,10):":wybe.string, ~#io#6:wybe.phantom, ?#io#7:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~p3#0:position.position, ~#io#7:wybe.phantom, ?#io#8:wybe.phantom) #8 @alias_multifunc4:44:2
-    alias_multifunc4.replicate21<0>(?p4#0:position.position, ~#io#8:wybe.phantom, ?#io#9:wybe.phantom) #9 @alias_multifunc4:47:2
-    foreign c print_string("--- After calling replicate21:":wybe.string, ~#io#9:wybe.phantom, ?tmp$16#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$16#0:wybe.phantom, ?#io#10:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect p4(99999,99999):":wybe.string, ~#io#10:wybe.phantom, ?#io#11:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~p4#0:position.position, ~#io#11:wybe.phantom, ?#io#12:wybe.phantom) #12 @alias_multifunc4:50:2
-    alias_multifunc4.replicate22<0>(?p6#0:position.position, ?p7#0:position.position, ~#io#12:wybe.phantom, ?#io#13:wybe.phantom) #13 @alias_multifunc4:53:2
-    foreign c print_string("--- After calling replicate22:":wybe.string, ~#io#13:wybe.phantom, ?tmp$21#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$21#0:wybe.phantom, ?#io#14:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect p6(99999,99999):":wybe.string, ~#io#14:wybe.phantom, ?#io#15:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~p6#0:position.position, ~#io#15:wybe.phantom, ?#io#16:wybe.phantom) #16 @alias_multifunc4:56:2
-    foreign c print_string("expect p7(1111111111,99999):":wybe.string, ~#io#16:wybe.phantom, ?#io#17:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~p7#0:position.position, ~#io#17:wybe.phantom, ?#io#18:wybe.phantom) #18 @alias_multifunc4:58:2
+    foreign lpvm alloc(16:wybe.int, ?tmp$3##0:position.position)
+    foreign lpvm mutate(~tmp$3##0:position.position, ?tmp$4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    alias_multifunc4.replicate1<0>(tmp$0##0:position.position, ?p2##0:position.position, ?p3##0:position.position, #io##0:wybe.phantom, ?_:wybe.phantom) #1 @alias_multifunc4:36:2
+    foreign c print_string("--- After calling replicate1:":wybe.string, ~#io##0:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect p1(10,10):":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~tmp$0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias_multifunc4:40:2
+    foreign c print_string("expect p2(99,10):":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~p2##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #6 @alias_multifunc4:42:2
+    foreign c print_string("expect p3(10,10):":wybe.string, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~p3##0:position.position, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) #8 @alias_multifunc4:44:2
+    alias_multifunc4.replicate21<0>(?p4##0:position.position, ~#io##8:wybe.phantom, ?#io##9:wybe.phantom) #9 @alias_multifunc4:47:2
+    foreign c print_string("--- After calling replicate21:":wybe.string, ~#io##9:wybe.phantom, ?tmp$16##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$16##0:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect p4(99999,99999):":wybe.string, ~#io##10:wybe.phantom, ?#io##11:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~p4##0:position.position, ~#io##11:wybe.phantom, ?#io##12:wybe.phantom) #12 @alias_multifunc4:50:2
+    alias_multifunc4.replicate22<0>(?p6##0:position.position, ?p7##0:position.position, ~#io##12:wybe.phantom, ?#io##13:wybe.phantom) #13 @alias_multifunc4:53:2
+    foreign c print_string("--- After calling replicate22:":wybe.string, ~#io##13:wybe.phantom, ?tmp$21##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$21##0:wybe.phantom, ?#io##14:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect p6(99999,99999):":wybe.string, ~#io##14:wybe.phantom, ?#io##15:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~p6##0:position.position, ~#io##15:wybe.phantom, ?#io##16:wybe.phantom) #16 @alias_multifunc4:56:2
+    foreign c print_string("expect p7(1111111111,99999):":wybe.string, ~#io##16:wybe.phantom, ?#io##17:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~p7##0:position.position, ~#io##17:wybe.phantom, ?#io##18:wybe.phantom) #18 @alias_multifunc4:58:2
 
 
 replicate1 > public (1 calls)
 0: alias_multifunc4.replicate1<0>
-replicate1(pa#0:position.position, ?pb#1:position.position, ?pc#0:position.position, io#0:wybe.phantom, [?io#0:wybe.phantom]):
- AliasPairs: [(pa#0,pc#0)]
+replicate1(pa##0:position.position, ?pb##1:position.position, ?pc##0:position.position, io##0:wybe.phantom, [?io##0:wybe.phantom]):
+ AliasPairs: [(pa##0,pc##0)]
  InterestingCallProperties: []
-    foreign llvm move(pa#0:position.position, ?pc#0:position.position) @alias_multifunc4:8:6
-    foreign lpvm alloc(16:wybe.int, ?tmp$4#0:position.position)
-    foreign lpvm mutate(~tmp$4#0:position.position, ?tmp$5#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99:wybe.int)
-    foreign lpvm mutate(~tmp$5#0:position.position, ?tmp$0#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99:wybe.int)
-    foreign lpvm access(~tmp$0#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign lpvm {noalias} mutate(~pa#0:position.position, ?%pb#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$1#0:wybe.int)
+    foreign llvm move(pa##0:position.position, ?pc##0:position.position) @alias_multifunc4:8:6
+    foreign lpvm alloc(16:wybe.int, ?tmp$4##0:position.position)
+    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99:wybe.int)
+    foreign lpvm mutate(~tmp$5##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99:wybe.int)
+    foreign lpvm access(~tmp$0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign lpvm {noalias} mutate(~pa##0:position.position, ?%pb##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$1##0:wybe.int)
 
 
 replicate21 > public (1 calls)
 0: alias_multifunc4.replicate21<0>
-replicate21(?pb#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
+replicate21(?pb##0:position.position, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$3#0:position.position)
-    foreign lpvm mutate(~tmp$3#0:position.position, ?tmp$4#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99999:wybe.int)
-    foreign lpvm mutate(~tmp$4#0:position.position, ?tmp$0#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99999:wybe.int)
-    foreign llvm move(tmp$0#0:position.position, ?pb#0:position.position) @alias_multifunc4:16:6
-    foreign lpvm {noalias} mutate(~tmp$0#0:position.position, ?%pc#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 1111111111:wybe.int)
-    foreign c print_string("--- Inside replicate21, expect pc(1111111111,99999): ":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~pc#1:position.position, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #3 @alias_multifunc4:20:6
+    foreign lpvm alloc(16:wybe.int, ?tmp$3##0:position.position)
+    foreign lpvm mutate(~tmp$3##0:position.position, ?tmp$4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99999:wybe.int)
+    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99999:wybe.int)
+    foreign llvm move(tmp$0##0:position.position, ?pb##0:position.position) @alias_multifunc4:16:6
+    foreign lpvm {noalias} mutate(~tmp$0##0:position.position, ?%pc##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 1111111111:wybe.int)
+    foreign c print_string("--- Inside replicate21, expect pc(1111111111,99999): ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~pc##1:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #3 @alias_multifunc4:20:6
 
 
 replicate22 > public (1 calls)
 0: alias_multifunc4.replicate22<0>
-replicate22(?pb#0:position.position, ?pc#1:position.position, io#0:wybe.phantom, ?io#4:wybe.phantom):
+replicate22(?pb##0:position.position, ?pc##1:position.position, io##0:wybe.phantom, ?io##4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$3#0:position.position)
-    foreign lpvm mutate(~tmp$3#0:position.position, ?tmp$4#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99999:wybe.int)
-    foreign lpvm mutate(~tmp$4#0:position.position, ?tmp$0#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99999:wybe.int)
-    foreign llvm move(tmp$0#0:position.position, ?pb#0:position.position) @alias_multifunc4:25:6
-    foreign c print_string("--- Inside replicate22, expect pc(99999,99999):":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(tmp$0#0:position.position, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #2 @alias_multifunc4:28:6
-    foreign lpvm {noalias} mutate(~tmp$0#0:position.position, ?%pc#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 1111111111:wybe.int)
-    foreign c print_string("--- Inside replicate22, after calling x(!pc,1111111111), expect pc(1111111111,99999): ":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(pc#1:position.position, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #5 @alias_multifunc4:32:6
+    foreign lpvm alloc(16:wybe.int, ?tmp$3##0:position.position)
+    foreign lpvm mutate(~tmp$3##0:position.position, ?tmp$4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99999:wybe.int)
+    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 99999:wybe.int)
+    foreign llvm move(tmp$0##0:position.position, ?pb##0:position.position) @alias_multifunc4:25:6
+    foreign c print_string("--- Inside replicate22, expect pc(99999,99999):":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(tmp$0##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #2 @alias_multifunc4:28:6
+    foreign lpvm {noalias} mutate(~tmp$0##0:position.position, ?%pc##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 1111111111:wybe.int)
+    foreign c print_string("--- Inside replicate22, after calling x(!pc,1111111111), expect pc(1111111111,99999): ":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(pc##1:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #5 @alias_multifunc4:32:6
 
   LLVM code       :
 
@@ -172,13 +172,13 @@ entry:
   %19 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_multifunc4.18, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %19)  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %11)  
-  %"1$p4#0" = tail call fastcc  i64  @"alias_multifunc4.replicate21<0>"()  
+  %"1$p4##0" = tail call fastcc  i64  @"alias_multifunc4.replicate21<0>"()  
   %21 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_multifunc4.20, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %21)  
   tail call ccc  void  @putchar(i8  10)  
   %23 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_multifunc4.22, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %23)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p4#0")  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$p4##0")  
   %24 = tail call fastcc  {i64, i64}  @"alias_multifunc4.replicate22<0>"()  
   %25 = extractvalue {i64, i64} %24, 0 
   %26 = extractvalue {i64, i64} %24, 1 
@@ -195,7 +195,7 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"alias_multifunc4.replicate1<0>"(i64  %"pa#0")    {
+define external fastcc  {i64, i64} @"alias_multifunc4.replicate1<0>"(i64  %"pa##0")    {
 entry:
   %33 = trunc i64 16 to i32  
   %34 = tail call ccc  i8*  @wybe_malloc(i32  %33)  
@@ -214,14 +214,14 @@ entry:
   %45 = tail call ccc  i8*  @wybe_malloc(i32  %44)  
   %46 = ptrtoint i8* %45 to i64 
   %47 = inttoptr i64 %46 to i8* 
-  %48 = inttoptr i64 %"pa#0" to i8* 
+  %48 = inttoptr i64 %"pa##0" to i8* 
   %49 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %47, i8*  %48, i32  %49, i32  8, i1  0)  
   %50 = inttoptr i64 %46 to i64* 
   %51 = getelementptr  i64, i64* %50, i64 0 
   store  i64 %43, i64* %51 
   %52 = insertvalue {i64, i64} undef, i64 %46, 0 
-  %53 = insertvalue {i64, i64} %52, i64 %"pa#0", 1 
+  %53 = insertvalue {i64, i64} %52, i64 %"pa##0", 1 
   ret {i64, i64} %53 
 }
 
@@ -309,17 +309,17 @@ entry:
 
 printPosition > public (0 calls)
 0: position.printPosition<0>
-printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string(",":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io#4:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -353,17 +353,17 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"position.printPosition<0>"(i64  %"pos#0")    {
+define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
-  %3 = inttoptr i64 %"pos#0" to i64* 
+  %3 = inttoptr i64 %"pos##0" to i64* 
   %4 = getelementptr  i64, i64* %3, i64 0 
   %5 = load  i64, i64* %4 
   tail call ccc  void  @print_int(i64  %5)  
   %7 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.6, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %7)  
-  %8 = add   i64 %"pos#0", 8 
+  %8 = add   i64 %"pos##0", 8 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
@@ -393,86 +393,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y#0:wybe.int)
-    foreign llvm icmp_eq(~$left$x#0:wybe.int, ~$right$x#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
+    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y#0:wybe.int, ~$right$y#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
-    foreign lpvm mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:position.position, ?$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
+    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
-    foreign lpvm access(~$#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y#0:wybe.int)
+    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec#0:position.position, ?$#0:wybe.int):
+x($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec#0:position.position, ?$#0:wybe.int):
+y($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -489,54 +489,54 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$#0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = icmp eq i64 %7, %14 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"x#0", i64* %19 
+  store  i64 %"x##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"y#0", i64* %22 
+  store  i64 %"y##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
 entry:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -546,34 +546,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec#0" to i64* 
+  %32 = inttoptr i64 %"$rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec#0" to i8* 
+  %39 = inttoptr i64 %"$rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field#0", i64* %42 
+  store  i64 %"$field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = add   i64 %"$rec#0", 8 
+  %43 = add   i64 %"$rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -581,46 +581,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec#0" to i8* 
+  %51 = inttoptr i64 %"$rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field#0", i64* %55 
+  store  i64 %"$field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %58, %65 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = icmp eq i64 %62, %69 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$0##0" = icmp eq i64 %62, %69 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }

--- a/test-cases/final-dump/alias_recursion1.exp
+++ b/test-cases/final-dump/alias_recursion1.exp
@@ -327,27 +327,27 @@ entry:
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x(#rec##0:position.position, ?###0:wybe.int):
+x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -358,10 +358,10 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y(#rec##0:position.position, ?###0:wybe.int):
+y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -446,12 +446,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 

--- a/test-cases/final-dump/alias_recursion1.exp
+++ b/test-cases/final-dump/alias_recursion1.exp
@@ -13,54 +13,54 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: alias_recursion1.<0>
-(io#0:wybe.phantom, ?io#18:wybe.phantom):
+(io##0:wybe.phantom, ?io##18:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$4#0:position.position)
-    foreign lpvm mutate(~tmp$4#0:position.position, ?tmp$5#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm mutate(~tmp$5#0:position.position, ?tmp$0#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$8#0:position.position)
-    foreign lpvm mutate(~tmp$8#0:position.position, ?tmp$9#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, -200:wybe.int)
-    foreign lpvm mutate(~tmp$9#0:position.position, ?tmp$1#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, -201:wybe.int)
-    foreign c print_string("--- before proc call: ":wybe.string, ~#io#0:wybe.phantom, ?tmp$12#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$12#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect pa(100,101):":wybe.string, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(tmp$0#0:position.position, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) #4 @alias_recursion1:20:2
-    foreign c print_string("expect pb(-200,-201):":wybe.string, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(tmp$1#0:position.position, ~#io#4:wybe.phantom, ?#io#5:wybe.phantom) #6 @alias_recursion1:22:2
-    alias_recursion1.if_test<0>(tmp$0#0:position.position, tmp$1#0:position.position, ?r#0:position.position) #7 @alias_recursion1:24:1
-    foreign c print_string("--- after calling if_test, pa and pb should be the same: ":wybe.string, ~#io#5:wybe.phantom, ?tmp$19#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$19#0:wybe.phantom, ?#io#6:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect pa(100,101):":wybe.string, ~#io#6:wybe.phantom, ?#io#7:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(tmp$0#0:position.position, ~#io#7:wybe.phantom, ?#io#8:wybe.phantom) #10 @alias_recursion1:28:2
-    foreign c print_string("expect pb(-200,-201):":wybe.string, ~#io#8:wybe.phantom, ?#io#9:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~tmp$1#0:position.position, ~#io#9:wybe.phantom, ?#io#10:wybe.phantom) #12 @alias_recursion1:30:2
-    foreign c print_string("--- expected result to be same as pb: ":wybe.string, ~#io#10:wybe.phantom, ?tmp$26#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$26#0:wybe.phantom, ?#io#11:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect r(-200,-201):":wybe.string, ~#io#11:wybe.phantom, ?#io#12:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(r#0:position.position, ~#io#12:wybe.phantom, ?#io#13:wybe.phantom) #15 @alias_recursion1:34:2
-    foreign c print_string("--- modify pa^x: ":wybe.string, ~#io#13:wybe.phantom, ?tmp$31#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$31#0:wybe.phantom, ?#io#14:wybe.phantom) @io:nn:nn
-    foreign lpvm {noalias} mutate(~tmp$0#0:position.position, ?%pa#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, -1000:wybe.int)
-    foreign c print_string("expect pa(-1000,101):":wybe.string, ~#io#14:wybe.phantom, ?#io#15:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~pa#1:position.position, ~#io#15:wybe.phantom, ?#io#16:wybe.phantom) #19 @alias_recursion1:39:2
-    foreign c print_string("expect r still (-200,-201):":wybe.string, ~#io#16:wybe.phantom, ?#io#17:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~r#0:position.position, ~#io#17:wybe.phantom, ?#io#18:wybe.phantom) #21 @alias_recursion1:42:2
+    foreign lpvm alloc(16:wybe.int, ?tmp$4##0:position.position)
+    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
+    foreign lpvm mutate(~tmp$5##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp$8##0:position.position)
+    foreign lpvm mutate(~tmp$8##0:position.position, ?tmp$9##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, -200:wybe.int)
+    foreign lpvm mutate(~tmp$9##0:position.position, ?tmp$1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, -201:wybe.int)
+    foreign c print_string("--- before proc call: ":wybe.string, ~#io##0:wybe.phantom, ?tmp$12##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$12##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect pa(100,101):":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(tmp$0##0:position.position, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #4 @alias_recursion1:20:2
+    foreign c print_string("expect pb(-200,-201):":wybe.string, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(tmp$1##0:position.position, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #6 @alias_recursion1:22:2
+    alias_recursion1.if_test<0>(tmp$0##0:position.position, tmp$1##0:position.position, ?r##0:position.position) #7 @alias_recursion1:24:1
+    foreign c print_string("--- after calling if_test, pa and pb should be the same: ":wybe.string, ~#io##5:wybe.phantom, ?tmp$19##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$19##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect pa(100,101):":wybe.string, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(tmp$0##0:position.position, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) #10 @alias_recursion1:28:2
+    foreign c print_string("expect pb(-200,-201):":wybe.string, ~#io##8:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~tmp$1##0:position.position, ~#io##9:wybe.phantom, ?#io##10:wybe.phantom) #12 @alias_recursion1:30:2
+    foreign c print_string("--- expected result to be same as pb: ":wybe.string, ~#io##10:wybe.phantom, ?tmp$26##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$26##0:wybe.phantom, ?#io##11:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect r(-200,-201):":wybe.string, ~#io##11:wybe.phantom, ?#io##12:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(r##0:position.position, ~#io##12:wybe.phantom, ?#io##13:wybe.phantom) #15 @alias_recursion1:34:2
+    foreign c print_string("--- modify pa^x: ":wybe.string, ~#io##13:wybe.phantom, ?tmp$31##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$31##0:wybe.phantom, ?#io##14:wybe.phantom) @io:nn:nn
+    foreign lpvm {noalias} mutate(~tmp$0##0:position.position, ?%pa##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, -1000:wybe.int)
+    foreign c print_string("expect pa(-1000,101):":wybe.string, ~#io##14:wybe.phantom, ?#io##15:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~pa##1:position.position, ~#io##15:wybe.phantom, ?#io##16:wybe.phantom) #19 @alias_recursion1:39:2
+    foreign c print_string("expect r still (-200,-201):":wybe.string, ~#io##16:wybe.phantom, ?#io##17:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~r##0:position.position, ~#io##17:wybe.phantom, ?#io##18:wybe.phantom) #21 @alias_recursion1:42:2
 
 
 if_test > public (2 calls)
 0: alias_recursion1.if_test<0>
-if_test(a#0:position.position, b#0:position.position, ?r#0:position.position):
- AliasPairs: [(a#0,b#0),(a#0,r#0),(b#0,r#0)]
+if_test(a##0:position.position, b##0:position.position, ?r##0:position.position):
+ AliasPairs: [(a##0,b##0),(a##0,r##0),(b##0,r##0)]
  InterestingCallProperties: []
-    foreign lpvm access(a#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign llvm icmp_sgt(~tmp$0#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access(a##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign llvm icmp_sgt(~tmp$0##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(~a#0:position.position, ?r#0:position.position) @alias_recursion1:12:14
+        foreign llvm move(~a##0:position.position, ?r##0:position.position) @alias_recursion1:12:14
 
     1:
-        alias_recursion1.if_test<0>(~b#0:position.position, ~a#0:position.position, ?r#0:position.position) #2 @alias_recursion1:10:13
+        alias_recursion1.if_test<0>(~b##0:position.position, ~a##0:position.position, ?r##0:position.position) #2 @alias_recursion1:10:13
 
 
   LLVM code       :
@@ -150,7 +150,7 @@ entry:
   %22 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_recursion1.21, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %22)  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %11)  
-  %"1$r#0" = tail call fastcc  i64  @"alias_recursion1.if_test<0>"(i64  %3, i64  %11)  
+  %"1$r##0" = tail call fastcc  i64  @"alias_recursion1.if_test<0>"(i64  %3, i64  %11)  
   %24 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_recursion1.23, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %24)  
   tail call ccc  void  @putchar(i8  10)  
@@ -165,7 +165,7 @@ entry:
   tail call ccc  void  @putchar(i8  10)  
   %32 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_recursion1.31, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %32)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$r#0")  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$r##0")  
   %34 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_recursion1.33, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %34)  
   tail call ccc  void  @putchar(i8  10)  
@@ -184,23 +184,23 @@ entry:
   tail call fastcc  void  @"position.printPosition<0>"(i64  %37)  
   %46 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_recursion1.45, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %46)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$r#0")  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$r##0")  
   ret void 
 }
 
 
-define external fastcc  i64 @"alias_recursion1.if_test<0>"(i64  %"a#0", i64  %"b#0")    {
+define external fastcc  i64 @"alias_recursion1.if_test<0>"(i64  %"a##0", i64  %"b##0")    {
 entry:
-  %47 = inttoptr i64 %"a#0" to i64* 
+  %47 = inttoptr i64 %"a##0" to i64* 
   %48 = getelementptr  i64, i64* %47, i64 0 
   %49 = load  i64, i64* %48 
-  %"1$tmp$1#0" = icmp sgt i64 %49, 0 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp sgt i64 %49, 0 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$r#0" = tail call fastcc  i64  @"alias_recursion1.if_test<0>"(i64  %"b#0", i64  %"a#0")  
-  ret i64 %"2$r#0" 
+  %"2$r##0" = tail call fastcc  i64  @"alias_recursion1.if_test<0>"(i64  %"b##0", i64  %"a##0")  
+  ret i64 %"2$r##0" 
 if.else:
-  ret i64 %"a#0" 
+  ret i64 %"a##0" 
 }
 --------------------------------------------------
  Module position
@@ -224,17 +224,17 @@ if.else:
 
 printPosition > public (0 calls)
 0: position.printPosition<0>
-printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string(",":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io#4:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -268,17 +268,17 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"position.printPosition<0>"(i64  %"pos#0")    {
+define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
-  %3 = inttoptr i64 %"pos#0" to i64* 
+  %3 = inttoptr i64 %"pos##0" to i64* 
   %4 = getelementptr  i64, i64* %3, i64 0 
   %5 = load  i64, i64* %4 
   tail call ccc  void  @print_int(i64  %5)  
   %7 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.6, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %7)  
-  %8 = add   i64 %"pos#0", 8 
+  %8 = add   i64 %"pos##0", 8 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
@@ -308,86 +308,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y#0:wybe.int)
-    foreign llvm icmp_eq(~$left$x#0:wybe.int, ~$right$x#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
+    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y#0:wybe.int, ~$right$y#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
-    foreign lpvm mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:position.position, ?$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
+    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
-    foreign lpvm access(~$#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y#0:wybe.int)
+    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec#0:position.position, ?$#0:wybe.int):
+x($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec#0:position.position, ?$#0:wybe.int):
+y($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -404,54 +404,54 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$#0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = icmp eq i64 %7, %14 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"x#0", i64* %19 
+  store  i64 %"x##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"y#0", i64* %22 
+  store  i64 %"y##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
 entry:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -461,34 +461,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec#0" to i64* 
+  %32 = inttoptr i64 %"$rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec#0" to i8* 
+  %39 = inttoptr i64 %"$rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field#0", i64* %42 
+  store  i64 %"$field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = add   i64 %"$rec#0", 8 
+  %43 = add   i64 %"$rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -496,46 +496,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec#0" to i8* 
+  %51 = inttoptr i64 %"$rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field#0", i64* %55 
+  store  i64 %"$field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %58, %65 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = icmp eq i64 %62, %69 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$0##0" = icmp eq i64 %62, %69 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }

--- a/test-cases/final-dump/alias_recursion1.exp
+++ b/test-cases/final-dump/alias_recursion1.exp
@@ -16,32 +16,32 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##18:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$4##0:position.position)
-    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm mutate(~tmp$5##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$8##0:position.position)
-    foreign lpvm mutate(~tmp$8##0:position.position, ?tmp$9##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, -200:wybe.int)
-    foreign lpvm mutate(~tmp$9##0:position.position, ?tmp$1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, -201:wybe.int)
-    foreign c print_string("--- before proc call: ":wybe.string, ~#io##0:wybe.phantom, ?tmp$12##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$12##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:position.position)
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
+    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 101:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#8##0:position.position)
+    foreign lpvm mutate(~tmp#8##0:position.position, ?tmp#9##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, -200:wybe.int)
+    foreign lpvm mutate(~tmp#9##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, -201:wybe.int)
+    foreign c print_string("--- before proc call: ":wybe.string, ~#io##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#12##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     foreign c print_string("expect pa(100,101):":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(tmp$0##0:position.position, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #4 @alias_recursion1:20:2
+    position.printPosition<0>(tmp#0##0:position.position, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #4 @alias_recursion1:20:2
     foreign c print_string("expect pb(-200,-201):":wybe.string, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(tmp$1##0:position.position, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #6 @alias_recursion1:22:2
-    alias_recursion1.if_test<0>(tmp$0##0:position.position, tmp$1##0:position.position, ?r##0:position.position) #7 @alias_recursion1:24:1
-    foreign c print_string("--- after calling if_test, pa and pb should be the same: ":wybe.string, ~#io##5:wybe.phantom, ?tmp$19##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$19##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(tmp#1##0:position.position, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #6 @alias_recursion1:22:2
+    alias_recursion1.if_test<0>(tmp#0##0:position.position, tmp#1##0:position.position, ?r##0:position.position) #7 @alias_recursion1:24:1
+    foreign c print_string("--- after calling if_test, pa and pb should be the same: ":wybe.string, ~#io##5:wybe.phantom, ?tmp#19##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#19##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
     foreign c print_string("expect pa(100,101):":wybe.string, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(tmp$0##0:position.position, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) #10 @alias_recursion1:28:2
+    position.printPosition<0>(tmp#0##0:position.position, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) #10 @alias_recursion1:28:2
     foreign c print_string("expect pb(-200,-201):":wybe.string, ~#io##8:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~tmp$1##0:position.position, ~#io##9:wybe.phantom, ?#io##10:wybe.phantom) #12 @alias_recursion1:30:2
-    foreign c print_string("--- expected result to be same as pb: ":wybe.string, ~#io##10:wybe.phantom, ?tmp$26##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$26##0:wybe.phantom, ?#io##11:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~tmp#1##0:position.position, ~#io##9:wybe.phantom, ?#io##10:wybe.phantom) #12 @alias_recursion1:30:2
+    foreign c print_string("--- expected result to be same as pb: ":wybe.string, ~#io##10:wybe.phantom, ?tmp#26##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#26##0:wybe.phantom, ?#io##11:wybe.phantom) @io:nn:nn
     foreign c print_string("expect r(-200,-201):":wybe.string, ~#io##11:wybe.phantom, ?#io##12:wybe.phantom) @io:nn:nn
     position.printPosition<0>(r##0:position.position, ~#io##12:wybe.phantom, ?#io##13:wybe.phantom) #15 @alias_recursion1:34:2
-    foreign c print_string("--- modify pa^x: ":wybe.string, ~#io##13:wybe.phantom, ?tmp$31##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$31##0:wybe.phantom, ?#io##14:wybe.phantom) @io:nn:nn
-    foreign lpvm {noalias} mutate(~tmp$0##0:position.position, ?%pa##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, -1000:wybe.int)
+    foreign c print_string("--- modify pa^x: ":wybe.string, ~#io##13:wybe.phantom, ?tmp#31##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#31##0:wybe.phantom, ?#io##14:wybe.phantom) @io:nn:nn
+    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%pa##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, -1000:wybe.int)
     foreign c print_string("expect pa(-1000,101):":wybe.string, ~#io##14:wybe.phantom, ?#io##15:wybe.phantom) @io:nn:nn
     position.printPosition<0>(~pa##1:position.position, ~#io##15:wybe.phantom, ?#io##16:wybe.phantom) #19 @alias_recursion1:39:2
     foreign c print_string("expect r still (-200,-201):":wybe.string, ~#io##16:wybe.phantom, ?#io##17:wybe.phantom) @io:nn:nn
@@ -53,9 +53,9 @@ if_test > public (2 calls)
 if_test(a##0:position.position, b##0:position.position, ?r##0:position.position):
  AliasPairs: [(a##0,b##0),(a##0,r##0),(b##0,r##0)]
  InterestingCallProperties: []
-    foreign lpvm access(a##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign llvm icmp_sgt(~tmp$0##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(a##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign llvm icmp_sgt(~tmp#0##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
         foreign llvm move(~a##0:position.position, ?r##0:position.position) @alias_recursion1:12:14
 
@@ -150,7 +150,7 @@ entry:
   %22 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_recursion1.21, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %22)  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %11)  
-  %"1$r##0" = tail call fastcc  i64  @"alias_recursion1.if_test<0>"(i64  %3, i64  %11)  
+  %"1#r##0" = tail call fastcc  i64  @"alias_recursion1.if_test<0>"(i64  %3, i64  %11)  
   %24 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_recursion1.23, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %24)  
   tail call ccc  void  @putchar(i8  10)  
@@ -165,7 +165,7 @@ entry:
   tail call ccc  void  @putchar(i8  10)  
   %32 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_recursion1.31, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %32)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$r##0")  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#r##0")  
   %34 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_recursion1.33, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %34)  
   tail call ccc  void  @putchar(i8  10)  
@@ -184,7 +184,7 @@ entry:
   tail call fastcc  void  @"position.printPosition<0>"(i64  %37)  
   %46 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_recursion1.45, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %46)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1$r##0")  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#r##0")  
   ret void 
 }
 
@@ -194,11 +194,11 @@ entry:
   %47 = inttoptr i64 %"a##0" to i64* 
   %48 = getelementptr  i64, i64* %47, i64 0 
   %49 = load  i64, i64* %48 
-  %"1$tmp$1##0" = icmp sgt i64 %49, 0 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp sgt i64 %49, 0 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$r##0" = tail call fastcc  i64  @"alias_recursion1.if_test<0>"(i64  %"b##0", i64  %"a##0")  
-  ret i64 %"2$r##0" 
+  %"2#r##0" = tail call fastcc  i64  @"alias_recursion1.if_test<0>"(i64  %"b##0", i64  %"a##0")  
+  ret i64 %"2#r##0" 
 if.else:
   ret i64 %"a##0" 
 }
@@ -228,13 +228,13 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -308,86 +308,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
-    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
-    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec##0:position.position, ?$##0:wybe.int):
+x(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec##0:position.position, ?$##0:wybe.int):
+y(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -404,27 +404,27 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$##0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$##0" 
+  %"2#####0" = icmp eq i64 %7, %14 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
@@ -446,12 +446,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
 entry:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -461,34 +461,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec##0" to i64* 
+  %32 = inttoptr i64 %"#rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec##0" to i8* 
+  %39 = inttoptr i64 %"#rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field##0", i64* %42 
+  store  i64 %"#field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = add   i64 %"$rec##0", 8 
+  %43 = add   i64 %"#rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -496,46 +496,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec##0" to i8* 
+  %51 = inttoptr i64 %"#rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field##0", i64* %55 
+  store  i64 %"#field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %58, %65 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = icmp eq i64 %62, %69 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#0##0" = icmp eq i64 %62, %69 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }

--- a/test-cases/final-dump/alias_recursion1.exp
+++ b/test-cases/final-dump/alias_recursion1.exp
@@ -308,7 +308,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
@@ -318,10 +318,10 @@ entry:
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -372,7 +372,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -383,11 +383,11 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -423,8 +423,8 @@ entry:
   %"1#tmp#1##0" = icmp eq i64 %3, %10 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2#####0" = icmp eq i64 %7, %14 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %7, %14 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -533,9 +533,9 @@ entry:
   br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#0##0" = icmp eq i64 %62, %69 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }

--- a/test-cases/final-dump/alias_scc_proc.exp
+++ b/test-cases/final-dump/alias_scc_proc.exp
@@ -459,27 +459,27 @@ entry:
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x(#rec##0:position.position, ?###0:wybe.int):
+x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -490,10 +490,10 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y(#rec##0:position.position, ?###0:wybe.int):
+y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -578,12 +578,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 

--- a/test-cases/final-dump/alias_scc_proc.exp
+++ b/test-cases/final-dump/alias_scc_proc.exp
@@ -440,7 +440,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
@@ -450,10 +450,10 @@ entry:
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -504,7 +504,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -515,11 +515,11 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -555,8 +555,8 @@ entry:
   %"1#tmp#1##0" = icmp eq i64 %3, %10 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2#####0" = icmp eq i64 %7, %14 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %7, %14 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -665,9 +665,9 @@ entry:
   br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#0##0" = icmp eq i64 %62, %69 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }

--- a/test-cases/final-dump/alias_scc_proc.exp
+++ b/test-cases/final-dump/alias_scc_proc.exp
@@ -17,14 +17,14 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##8:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$3##0:position.position)
-    foreign lpvm mutate(~tmp$3##0:position.position, ?tmp$4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    alias_scc_proc.foo<0>(tmp$0##0:position.position, ?p2##0:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias_scc_proc:nn:nn
-    foreign c print_string("--- After calling foo: ":wybe.string, ~#io##1:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#3##0:position.position)
+    foreign lpvm mutate(~tmp#3##0:position.position, ?tmp#4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    alias_scc_proc.foo<0>(tmp#0##0:position.position, ?p2##0:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias_scc_proc:nn:nn
+    foreign c print_string("--- After calling foo: ":wybe.string, ~#io##1:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string("expect p1(2,2):":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~tmp$0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias_scc_proc:nn:nn
+    position.printPosition<0>(~tmp#0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias_scc_proc:nn:nn
     foreign c print_string("expect p2(2,2):":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
     position.printPosition<0>(~p2##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #6 @alias_scc_proc:nn:nn
     foreign c print_string("expect p3(3,3):":wybe.string, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
@@ -37,12 +37,12 @@ bar(p1##0:position.position, ?p3##1:position.position, io##0:wybe.phantom, ?io##
  AliasPairs: [(p1##0,p3##1)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(5,(alias_scc_proc.foo<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
-    case ~tmp$3##0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp#0##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
+    case ~tmp#3##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:wybe.int)
+        foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
         alias_scc_proc.foo<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ?p3##1:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_scc_proc:nn:nn
 
     1:
@@ -50,12 +50,12 @@ bar(p1##0:position.position, ?p3##1:position.position, io##0:wybe.phantom, ?io##
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
-    case ~tmp$3##0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp#0##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
+    case ~tmp#3##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:wybe.int)
+        foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
         alias_scc_proc.foo<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ?p3##1:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_scc_proc:nn:nn
 
     1:
@@ -70,46 +70,46 @@ foo(p1##0:position.position, ?p2##0:position.position, ?p3##0:position.position,
  AliasPairs: [(p1##0,p2##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(8,(alias_scc_proc.bar<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 1:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
-    case ~tmp$5##0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp#0##0:wybe.int, 1:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
+    case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:wybe.int)
+        foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int)
         alias_scc_proc.bar<0>[410bae77d3](~p1##1:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##2:wybe.phantom) #8 @alias_scc_proc:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$16##0:position.position)
-        foreign lpvm mutate(~tmp$16##0:position.position, ?tmp$17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-        foreign lpvm mutate(~tmp$17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm alloc(16:wybe.int, ?tmp#16##0:position.position)
+        foreign lpvm mutate(~tmp#16##0:position.position, ?tmp#17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm mutate(~tmp#17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
 
     1:
         foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_scc_proc:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$11##0:position.position)
-        foreign lpvm mutate(~tmp$11##0:position.position, ?tmp$12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign lpvm mutate(~tmp$12##0:position.position, ?tmp$1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign llvm move(tmp$1##0:position.position, ?p3##0:position.position) @alias_scc_proc:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:position.position)
+        foreign lpvm mutate(~tmp#11##0:position.position, ?tmp#12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign lpvm mutate(~tmp#12##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign llvm move(tmp#1##0:position.position, ?p3##0:position.position) @alias_scc_proc:nn:nn
         foreign c print_string("--- Inside foo: expect p3(3,3):":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        position.printPosition<0>(~tmp$1##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @alias_scc_proc:nn:nn
+        position.printPosition<0>(~tmp#1##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @alias_scc_proc:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 1:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
-    case ~tmp$5##0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp#0##0:wybe.int, 1:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
+    case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:wybe.int)
+        foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int)
         alias_scc_proc.bar<0>[410bae77d3](~p1##1:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##2:wybe.phantom) #8 @alias_scc_proc:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$16##0:position.position)
-        foreign lpvm mutate(~tmp$16##0:position.position, ?tmp$17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-        foreign lpvm mutate(~tmp$17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm alloc(16:wybe.int, ?tmp#16##0:position.position)
+        foreign lpvm mutate(~tmp#16##0:position.position, ?tmp#17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm mutate(~tmp#17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
 
     1:
         foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_scc_proc:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$11##0:position.position)
-        foreign lpvm mutate(~tmp$11##0:position.position, ?tmp$12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign lpvm mutate(~tmp$12##0:position.position, ?tmp$1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign llvm move(tmp$1##0:position.position, ?p3##0:position.position) @alias_scc_proc:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:position.position)
+        foreign lpvm mutate(~tmp#11##0:position.position, ?tmp#12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign lpvm mutate(~tmp#12##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign llvm move(tmp#1##0:position.position, ?p3##0:position.position) @alias_scc_proc:nn:nn
         foreign c print_string("--- Inside foo: expect p3(3,3):":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        position.printPosition<0>(~tmp$1##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @alias_scc_proc:nn:nn
+        position.printPosition<0>(~tmp#1##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @alias_scc_proc:nn:nn
 
 
   LLVM code       :
@@ -190,12 +190,12 @@ entry:
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
   %23 = load  i64, i64* %22 
-  %"1$tmp$3##0" = icmp sgt i64 %23, 1 
-  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
+  %"1#tmp#3##0" = icmp sgt i64 %23, 1 
+  br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
   ret i64 %"p1##0" 
 if.else:
-  %"3$tmp$2##0" = add   i64 %23, 1 
+  %"3#tmp#2##0" = add   i64 %23, 1 
   %24 = trunc i64 16 to i32  
   %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
   %26 = ptrtoint i8* %25 to i64 
@@ -206,7 +206,7 @@ if.else:
   %30 = add   i64 %26, 8 
   %31 = inttoptr i64 %30 to i64* 
   %32 = getelementptr  i64, i64* %31, i64 0 
-  store  i64 %"3$tmp$2##0", i64* %32 
+  store  i64 %"3#tmp#2##0", i64* %32 
   %33 = tail call fastcc  {i64, i64}  @"alias_scc_proc.foo<0>[410bae77d3]"(i64  %26)  
   %34 = extractvalue {i64, i64} %33, 0 
   %35 = extractvalue {i64, i64} %33, 1 
@@ -220,16 +220,16 @@ entry:
   %37 = inttoptr i64 %36 to i64* 
   %38 = getelementptr  i64, i64* %37, i64 0 
   %39 = load  i64, i64* %38 
-  %"1$tmp$3##0" = icmp sgt i64 %39, 1 
-  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
+  %"1#tmp#3##0" = icmp sgt i64 %39, 1 
+  br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
   ret i64 %"p1##0" 
 if.else:
-  %"3$tmp$2##0" = add   i64 %39, 1 
+  %"3#tmp#2##0" = add   i64 %39, 1 
   %40 = add   i64 %"p1##0", 8 
   %41 = inttoptr i64 %40 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"3$tmp$2##0", i64* %42 
+  store  i64 %"3#tmp#2##0", i64* %42 
   %43 = tail call fastcc  {i64, i64}  @"alias_scc_proc.foo<0>[410bae77d3]"(i64  %"p1##0")  
   %44 = extractvalue {i64, i64} %43, 0 
   %45 = extractvalue {i64, i64} %43, 1 
@@ -242,8 +242,8 @@ entry:
   %46 = inttoptr i64 %"p1##0" to i64* 
   %47 = getelementptr  i64, i64* %46, i64 0 
   %48 = load  i64, i64* %47 
-  %"1$tmp$5##0" = icmp sgt i64 %48, 1 
-  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
+  %"1#tmp#5##0" = icmp sgt i64 %48, 1 
+  br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
   %49 = trunc i64 16 to i32  
   %50 = tail call ccc  i8*  @wybe_malloc(i32  %49)  
@@ -262,7 +262,7 @@ if.then:
   %60 = insertvalue {i64, i64} %59, i64 %51, 1 
   ret {i64, i64} %60 
 if.else:
-  %"3$tmp$3##0" = add   i64 %48, 1 
+  %"3#tmp#3##0" = add   i64 %48, 1 
   %61 = trunc i64 16 to i32  
   %62 = tail call ccc  i8*  @wybe_malloc(i32  %61)  
   %63 = ptrtoint i8* %62 to i64 
@@ -272,8 +272,8 @@ if.else:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %64, i8*  %65, i32  %66, i32  8, i1  0)  
   %67 = inttoptr i64 %63 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
-  store  i64 %"3$tmp$3##0", i64* %68 
-  %"3$p3##0" = tail call fastcc  i64  @"alias_scc_proc.bar<0>[410bae77d3]"(i64  %63)  
+  store  i64 %"3#tmp#3##0", i64* %68 
+  %"3#p3##0" = tail call fastcc  i64  @"alias_scc_proc.bar<0>[410bae77d3]"(i64  %63)  
   %69 = trunc i64 16 to i32  
   %70 = tail call ccc  i8*  @wybe_malloc(i32  %69)  
   %71 = ptrtoint i8* %70 to i64 
@@ -285,7 +285,7 @@ if.else:
   %76 = getelementptr  i64, i64* %75, i64 0 
   store  i64 2, i64* %76 
   %77 = insertvalue {i64, i64} undef, i64 %71, 0 
-  %78 = insertvalue {i64, i64} %77, i64 %"3$p3##0", 1 
+  %78 = insertvalue {i64, i64} %77, i64 %"3#p3##0", 1 
   ret {i64, i64} %78 
 }
 
@@ -295,8 +295,8 @@ entry:
   %79 = inttoptr i64 %"p1##0" to i64* 
   %80 = getelementptr  i64, i64* %79, i64 0 
   %81 = load  i64, i64* %80 
-  %"1$tmp$5##0" = icmp sgt i64 %81, 1 
-  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
+  %"1#tmp#5##0" = icmp sgt i64 %81, 1 
+  br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
   %82 = trunc i64 16 to i32  
   %83 = tail call ccc  i8*  @wybe_malloc(i32  %82)  
@@ -315,11 +315,11 @@ if.then:
   %93 = insertvalue {i64, i64} %92, i64 %84, 1 
   ret {i64, i64} %93 
 if.else:
-  %"3$tmp$3##0" = add   i64 %81, 1 
+  %"3#tmp#3##0" = add   i64 %81, 1 
   %94 = inttoptr i64 %"p1##0" to i64* 
   %95 = getelementptr  i64, i64* %94, i64 0 
-  store  i64 %"3$tmp$3##0", i64* %95 
-  %"3$p3##0" = tail call fastcc  i64  @"alias_scc_proc.bar<0>[410bae77d3]"(i64  %"p1##0")  
+  store  i64 %"3#tmp#3##0", i64* %95 
+  %"3#p3##0" = tail call fastcc  i64  @"alias_scc_proc.bar<0>[410bae77d3]"(i64  %"p1##0")  
   %96 = trunc i64 16 to i32  
   %97 = tail call ccc  i8*  @wybe_malloc(i32  %96)  
   %98 = ptrtoint i8* %97 to i64 
@@ -331,7 +331,7 @@ if.else:
   %103 = getelementptr  i64, i64* %102, i64 0 
   store  i64 2, i64* %103 
   %104 = insertvalue {i64, i64} undef, i64 %98, 0 
-  %105 = insertvalue {i64, i64} %104, i64 %"3$p3##0", 1 
+  %105 = insertvalue {i64, i64} %104, i64 %"3#p3##0", 1 
   ret {i64, i64} %105 
 }
 --------------------------------------------------
@@ -360,13 +360,13 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -440,86 +440,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
-    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
-    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec##0:position.position, ?$##0:wybe.int):
+x(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec##0:position.position, ?$##0:wybe.int):
+y(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -536,27 +536,27 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$##0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$##0" 
+  %"2#####0" = icmp eq i64 %7, %14 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
@@ -578,12 +578,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
 entry:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -593,34 +593,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec##0" to i64* 
+  %32 = inttoptr i64 %"#rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec##0" to i8* 
+  %39 = inttoptr i64 %"#rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field##0", i64* %42 
+  store  i64 %"#field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = add   i64 %"$rec##0", 8 
+  %43 = add   i64 %"#rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -628,46 +628,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec##0" to i8* 
+  %51 = inttoptr i64 %"#rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field##0", i64* %55 
+  store  i64 %"#field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %58, %65 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = icmp eq i64 %62, %69 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#0##0" = icmp eq i64 %62, %69 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }

--- a/test-cases/final-dump/alias_scc_proc.exp
+++ b/test-cases/final-dump/alias_scc_proc.exp
@@ -14,102 +14,102 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: alias_scc_proc.<0>
-(io#0:wybe.phantom, ?io#8:wybe.phantom):
+(io##0:wybe.phantom, ?io##8:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$3#0:position.position)
-    foreign lpvm mutate(~tmp$3#0:position.position, ?tmp$4#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp$4#0:position.position, ?tmp$0#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    alias_scc_proc.foo<0>(tmp$0#0:position.position, ?p2#0:position.position, ?p3#0:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #1 @alias_scc_proc:nn:nn
-    foreign c print_string("--- After calling foo: ":wybe.string, ~#io#1:wybe.phantom, ?tmp$7#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$7#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect p1(2,2):":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~tmp$0#0:position.position, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #4 @alias_scc_proc:nn:nn
-    foreign c print_string("expect p2(2,2):":wybe.string, ~#io#4:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~p2#0:position.position, ~#io#5:wybe.phantom, ?#io#6:wybe.phantom) #6 @alias_scc_proc:nn:nn
-    foreign c print_string("expect p3(3,3):":wybe.string, ~#io#6:wybe.phantom, ?#io#7:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~p3#0:position.position, ~#io#7:wybe.phantom, ?#io#8:wybe.phantom) #8 @alias_scc_proc:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$3##0:position.position)
+    foreign lpvm mutate(~tmp$3##0:position.position, ?tmp$4##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    alias_scc_proc.foo<0>(tmp$0##0:position.position, ?p2##0:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @alias_scc_proc:nn:nn
+    foreign c print_string("--- After calling foo: ":wybe.string, ~#io##1:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect p1(2,2):":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~tmp$0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @alias_scc_proc:nn:nn
+    foreign c print_string("expect p2(2,2):":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~p2##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #6 @alias_scc_proc:nn:nn
+    foreign c print_string("expect p3(3,3):":wybe.string, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~p3##0:position.position, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) #8 @alias_scc_proc:nn:nn
 
 
 bar > public (1 calls)
 0: alias_scc_proc.bar<0>[410bae77d3]
-bar(p1#0:position.position, ?p3#1:position.position, io#0:wybe.phantom, ?io#1:wybe.phantom):
- AliasPairs: [(p1#0,p3#1)]
+bar(p1##0:position.position, ?p3##1:position.position, io##0:wybe.phantom, ?io##1:wybe.phantom):
+ AliasPairs: [(p1##0,p3##1)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(5,(alias_scc_proc.foo<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm access(p1#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.bool) @int:nn:nn
-    case ~tmp$3#0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
+    case ~tmp$3##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1#0:position.position, ?%p1#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:wybe.int)
-        alias_scc_proc.foo<0>[410bae77d3](~p1#1:position.position, ?p2#0:position.position, ?p3#1:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #5 @alias_scc_proc:nn:nn
+        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:wybe.int)
+        alias_scc_proc.foo<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ?p3##1:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_scc_proc:nn:nn
 
     1:
-        foreign llvm move(~p1#0:position.position, ?p3#1:position.position)
-        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+        foreign llvm move(~p1##0:position.position, ?p3##1:position.position)
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(p1#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.bool) @int:nn:nn
-    case ~tmp$3#0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
+    case ~tmp$3##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1#0:position.position, ?%p1#1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:wybe.int)
-        alias_scc_proc.foo<0>[410bae77d3](~p1#1:position.position, ?p2#0:position.position, ?p3#1:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #5 @alias_scc_proc:nn:nn
+        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:wybe.int)
+        alias_scc_proc.foo<0>[410bae77d3](~p1##1:position.position, ?p2##0:position.position, ?p3##1:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #5 @alias_scc_proc:nn:nn
 
     1:
-        foreign llvm move(~p1#0:position.position, ?p3#1:position.position)
-        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+        foreign llvm move(~p1##0:position.position, ?p3##1:position.position)
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
 
 
 foo > public (2 calls)
 0: alias_scc_proc.foo<0>[410bae77d3]
-foo(p1#0:position.position, ?p2#0:position.position, ?p3#0:position.position, io#0:wybe.phantom, ?io#2:wybe.phantom):
- AliasPairs: [(p1#0,p2#0)]
+foo(p1##0:position.position, ?p2##0:position.position, ?p3##0:position.position, io##0:wybe.phantom, ?io##2:wybe.phantom):
+ AliasPairs: [(p1##0,p2##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(8,(alias_scc_proc.bar<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm access(p1#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0#0:wybe.int, 1:wybe.int, ?tmp$5#0:wybe.bool) @int:nn:nn
-    case ~tmp$5#0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 1:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
+    case ~tmp$5##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1#0:position.position, ?%p1#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3#0:wybe.int)
-        alias_scc_proc.bar<0>[410bae77d3](~p1#1:position.position, ?p3#0:position.position, ~#io#0:wybe.phantom, ?#io#2:wybe.phantom) #8 @alias_scc_proc:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$16#0:position.position)
-        foreign lpvm mutate(~tmp$16#0:position.position, ?tmp$17#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-        foreign lpvm mutate(~tmp$17#0:position.position, ?p2#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:wybe.int)
+        alias_scc_proc.bar<0>[410bae77d3](~p1##1:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##2:wybe.phantom) #8 @alias_scc_proc:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp$16##0:position.position)
+        foreign lpvm mutate(~tmp$16##0:position.position, ?tmp$17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm mutate(~tmp$17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
 
     1:
-        foreign llvm move(~p1#0:position.position, ?p2#0:position.position) @alias_scc_proc:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$11#0:position.position)
-        foreign lpvm mutate(~tmp$11#0:position.position, ?tmp$12#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign lpvm mutate(~tmp$12#0:position.position, ?tmp$1#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign llvm move(tmp$1#0:position.position, ?p3#0:position.position) @alias_scc_proc:nn:nn
-        foreign c print_string("--- Inside foo: expect p3(3,3):":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        position.printPosition<0>(~tmp$1#0:position.position, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #4 @alias_scc_proc:nn:nn
+        foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_scc_proc:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp$11##0:position.position)
+        foreign lpvm mutate(~tmp$11##0:position.position, ?tmp$12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign lpvm mutate(~tmp$12##0:position.position, ?tmp$1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign llvm move(tmp$1##0:position.position, ?p3##0:position.position) @alias_scc_proc:nn:nn
+        foreign c print_string("--- Inside foo: expect p3(3,3):":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        position.printPosition<0>(~tmp$1##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @alias_scc_proc:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(p1#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign llvm icmp_sgt(tmp$0#0:wybe.int, 1:wybe.int, ?tmp$5#0:wybe.bool) @int:nn:nn
-    case ~tmp$5#0:wybe.bool of
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign llvm icmp_sgt(tmp$0##0:wybe.int, 1:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
+    case ~tmp$5##0:wybe.bool of
     0:
-        foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%p1#0:position.position, ?%p1#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3#0:wybe.int)
-        alias_scc_proc.bar<0>[410bae77d3](~p1#1:position.position, ?p3#0:position.position, ~#io#0:wybe.phantom, ?#io#2:wybe.phantom) #8 @alias_scc_proc:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$16#0:position.position)
-        foreign lpvm mutate(~tmp$16#0:position.position, ?tmp$17#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-        foreign lpvm mutate(~tmp$17#0:position.position, ?p2#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%p1##0:position.position, ?%p1##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$3##0:wybe.int)
+        alias_scc_proc.bar<0>[410bae77d3](~p1##1:position.position, ?p3##0:position.position, ~#io##0:wybe.phantom, ?#io##2:wybe.phantom) #8 @alias_scc_proc:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp$16##0:position.position)
+        foreign lpvm mutate(~tmp$16##0:position.position, ?tmp$17##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+        foreign lpvm mutate(~tmp$17##0:position.position, ?p2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
 
     1:
-        foreign llvm move(~p1#0:position.position, ?p2#0:position.position) @alias_scc_proc:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$11#0:position.position)
-        foreign lpvm mutate(~tmp$11#0:position.position, ?tmp$12#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign lpvm mutate(~tmp$12#0:position.position, ?tmp$1#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-        foreign llvm move(tmp$1#0:position.position, ?p3#0:position.position) @alias_scc_proc:nn:nn
-        foreign c print_string("--- Inside foo: expect p3(3,3):":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        position.printPosition<0>(~tmp$1#0:position.position, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #4 @alias_scc_proc:nn:nn
+        foreign llvm move(~p1##0:position.position, ?p2##0:position.position) @alias_scc_proc:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp$11##0:position.position)
+        foreign lpvm mutate(~tmp$11##0:position.position, ?tmp$12##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign lpvm mutate(~tmp$12##0:position.position, ?tmp$1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+        foreign llvm move(tmp$1##0:position.position, ?p3##0:position.position) @alias_scc_proc:nn:nn
+        foreign c print_string("--- Inside foo: expect p3(3,3):":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        position.printPosition<0>(~tmp$1##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @alias_scc_proc:nn:nn
 
 
   LLVM code       :
@@ -184,29 +184,29 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_scc_proc.bar<0>"(i64  %"p1#0")    {
+define external fastcc  i64 @"alias_scc_proc.bar<0>"(i64  %"p1##0")    {
 entry:
-  %20 = add   i64 %"p1#0", 8 
+  %20 = add   i64 %"p1##0", 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
   %23 = load  i64, i64* %22 
-  %"1$tmp$3#0" = icmp sgt i64 %23, 1 
-  br i1 %"1$tmp$3#0", label %if.then, label %if.else 
+  %"1$tmp$3##0" = icmp sgt i64 %23, 1 
+  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
 if.then:
-  ret i64 %"p1#0" 
+  ret i64 %"p1##0" 
 if.else:
-  %"3$tmp$2#0" = add   i64 %23, 1 
+  %"3$tmp$2##0" = add   i64 %23, 1 
   %24 = trunc i64 16 to i32  
   %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
   %26 = ptrtoint i8* %25 to i64 
   %27 = inttoptr i64 %26 to i8* 
-  %28 = inttoptr i64 %"p1#0" to i8* 
+  %28 = inttoptr i64 %"p1##0" to i8* 
   %29 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %27, i8*  %28, i32  %29, i32  8, i1  0)  
   %30 = add   i64 %26, 8 
   %31 = inttoptr i64 %30 to i64* 
   %32 = getelementptr  i64, i64* %31, i64 0 
-  store  i64 %"3$tmp$2#0", i64* %32 
+  store  i64 %"3$tmp$2##0", i64* %32 
   %33 = tail call fastcc  {i64, i64}  @"alias_scc_proc.foo<0>[410bae77d3]"(i64  %26)  
   %34 = extractvalue {i64, i64} %33, 0 
   %35 = extractvalue {i64, i64} %33, 1 
@@ -214,36 +214,36 @@ if.else:
 }
 
 
-define external fastcc  i64 @"alias_scc_proc.bar<0>[410bae77d3]"(i64  %"p1#0")    {
+define external fastcc  i64 @"alias_scc_proc.bar<0>[410bae77d3]"(i64  %"p1##0")    {
 entry:
-  %36 = add   i64 %"p1#0", 8 
+  %36 = add   i64 %"p1##0", 8 
   %37 = inttoptr i64 %36 to i64* 
   %38 = getelementptr  i64, i64* %37, i64 0 
   %39 = load  i64, i64* %38 
-  %"1$tmp$3#0" = icmp sgt i64 %39, 1 
-  br i1 %"1$tmp$3#0", label %if.then, label %if.else 
+  %"1$tmp$3##0" = icmp sgt i64 %39, 1 
+  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
 if.then:
-  ret i64 %"p1#0" 
+  ret i64 %"p1##0" 
 if.else:
-  %"3$tmp$2#0" = add   i64 %39, 1 
-  %40 = add   i64 %"p1#0", 8 
+  %"3$tmp$2##0" = add   i64 %39, 1 
+  %40 = add   i64 %"p1##0", 8 
   %41 = inttoptr i64 %40 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"3$tmp$2#0", i64* %42 
-  %43 = tail call fastcc  {i64, i64}  @"alias_scc_proc.foo<0>[410bae77d3]"(i64  %"p1#0")  
+  store  i64 %"3$tmp$2##0", i64* %42 
+  %43 = tail call fastcc  {i64, i64}  @"alias_scc_proc.foo<0>[410bae77d3]"(i64  %"p1##0")  
   %44 = extractvalue {i64, i64} %43, 0 
   %45 = extractvalue {i64, i64} %43, 1 
   ret i64 %45 
 }
 
 
-define external fastcc  {i64, i64} @"alias_scc_proc.foo<0>"(i64  %"p1#0")    {
+define external fastcc  {i64, i64} @"alias_scc_proc.foo<0>"(i64  %"p1##0")    {
 entry:
-  %46 = inttoptr i64 %"p1#0" to i64* 
+  %46 = inttoptr i64 %"p1##0" to i64* 
   %47 = getelementptr  i64, i64* %46, i64 0 
   %48 = load  i64, i64* %47 
-  %"1$tmp$5#0" = icmp sgt i64 %48, 1 
-  br i1 %"1$tmp$5#0", label %if.then, label %if.else 
+  %"1$tmp$5##0" = icmp sgt i64 %48, 1 
+  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
 if.then:
   %49 = trunc i64 16 to i32  
   %50 = tail call ccc  i8*  @wybe_malloc(i32  %49)  
@@ -258,22 +258,22 @@ if.then:
   %58 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_scc_proc.57, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %58)  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %51)  
-  %59 = insertvalue {i64, i64} undef, i64 %"p1#0", 0 
+  %59 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
   %60 = insertvalue {i64, i64} %59, i64 %51, 1 
   ret {i64, i64} %60 
 if.else:
-  %"3$tmp$3#0" = add   i64 %48, 1 
+  %"3$tmp$3##0" = add   i64 %48, 1 
   %61 = trunc i64 16 to i32  
   %62 = tail call ccc  i8*  @wybe_malloc(i32  %61)  
   %63 = ptrtoint i8* %62 to i64 
   %64 = inttoptr i64 %63 to i8* 
-  %65 = inttoptr i64 %"p1#0" to i8* 
+  %65 = inttoptr i64 %"p1##0" to i8* 
   %66 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %64, i8*  %65, i32  %66, i32  8, i1  0)  
   %67 = inttoptr i64 %63 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
-  store  i64 %"3$tmp$3#0", i64* %68 
-  %"3$p3#0" = tail call fastcc  i64  @"alias_scc_proc.bar<0>[410bae77d3]"(i64  %63)  
+  store  i64 %"3$tmp$3##0", i64* %68 
+  %"3$p3##0" = tail call fastcc  i64  @"alias_scc_proc.bar<0>[410bae77d3]"(i64  %63)  
   %69 = trunc i64 16 to i32  
   %70 = tail call ccc  i8*  @wybe_malloc(i32  %69)  
   %71 = ptrtoint i8* %70 to i64 
@@ -285,18 +285,18 @@ if.else:
   %76 = getelementptr  i64, i64* %75, i64 0 
   store  i64 2, i64* %76 
   %77 = insertvalue {i64, i64} undef, i64 %71, 0 
-  %78 = insertvalue {i64, i64} %77, i64 %"3$p3#0", 1 
+  %78 = insertvalue {i64, i64} %77, i64 %"3$p3##0", 1 
   ret {i64, i64} %78 
 }
 
 
-define external fastcc  {i64, i64} @"alias_scc_proc.foo<0>[410bae77d3]"(i64  %"p1#0")    {
+define external fastcc  {i64, i64} @"alias_scc_proc.foo<0>[410bae77d3]"(i64  %"p1##0")    {
 entry:
-  %79 = inttoptr i64 %"p1#0" to i64* 
+  %79 = inttoptr i64 %"p1##0" to i64* 
   %80 = getelementptr  i64, i64* %79, i64 0 
   %81 = load  i64, i64* %80 
-  %"1$tmp$5#0" = icmp sgt i64 %81, 1 
-  br i1 %"1$tmp$5#0", label %if.then, label %if.else 
+  %"1$tmp$5##0" = icmp sgt i64 %81, 1 
+  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
 if.then:
   %82 = trunc i64 16 to i32  
   %83 = tail call ccc  i8*  @wybe_malloc(i32  %82)  
@@ -311,15 +311,15 @@ if.then:
   %91 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @alias_scc_proc.90, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %91)  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %84)  
-  %92 = insertvalue {i64, i64} undef, i64 %"p1#0", 0 
+  %92 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
   %93 = insertvalue {i64, i64} %92, i64 %84, 1 
   ret {i64, i64} %93 
 if.else:
-  %"3$tmp$3#0" = add   i64 %81, 1 
-  %94 = inttoptr i64 %"p1#0" to i64* 
+  %"3$tmp$3##0" = add   i64 %81, 1 
+  %94 = inttoptr i64 %"p1##0" to i64* 
   %95 = getelementptr  i64, i64* %94, i64 0 
-  store  i64 %"3$tmp$3#0", i64* %95 
-  %"3$p3#0" = tail call fastcc  i64  @"alias_scc_proc.bar<0>[410bae77d3]"(i64  %"p1#0")  
+  store  i64 %"3$tmp$3##0", i64* %95 
+  %"3$p3##0" = tail call fastcc  i64  @"alias_scc_proc.bar<0>[410bae77d3]"(i64  %"p1##0")  
   %96 = trunc i64 16 to i32  
   %97 = tail call ccc  i8*  @wybe_malloc(i32  %96)  
   %98 = ptrtoint i8* %97 to i64 
@@ -331,7 +331,7 @@ if.else:
   %103 = getelementptr  i64, i64* %102, i64 0 
   store  i64 2, i64* %103 
   %104 = insertvalue {i64, i64} undef, i64 %98, 0 
-  %105 = insertvalue {i64, i64} %104, i64 %"3$p3#0", 1 
+  %105 = insertvalue {i64, i64} %104, i64 %"3$p3##0", 1 
   ret {i64, i64} %105 
 }
 --------------------------------------------------
@@ -356,17 +356,17 @@ if.else:
 
 printPosition > public (0 calls)
 0: position.printPosition<0>
-printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string(",":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io#4:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -400,17 +400,17 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"position.printPosition<0>"(i64  %"pos#0")    {
+define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
-  %3 = inttoptr i64 %"pos#0" to i64* 
+  %3 = inttoptr i64 %"pos##0" to i64* 
   %4 = getelementptr  i64, i64* %3, i64 0 
   %5 = load  i64, i64* %4 
   tail call ccc  void  @print_int(i64  %5)  
   %7 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.6, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %7)  
-  %8 = add   i64 %"pos#0", 8 
+  %8 = add   i64 %"pos##0", 8 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
@@ -440,86 +440,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y#0:wybe.int)
-    foreign llvm icmp_eq(~$left$x#0:wybe.int, ~$right$x#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
+    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y#0:wybe.int, ~$right$y#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
-    foreign lpvm mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:position.position, ?$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
+    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
-    foreign lpvm access(~$#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y#0:wybe.int)
+    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec#0:position.position, ?$#0:wybe.int):
+x($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec#0:position.position, ?$#0:wybe.int):
+y($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -536,54 +536,54 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$#0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = icmp eq i64 %7, %14 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"x#0", i64* %19 
+  store  i64 %"x##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"y#0", i64* %22 
+  store  i64 %"y##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
 entry:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -593,34 +593,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec#0" to i64* 
+  %32 = inttoptr i64 %"$rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec#0" to i8* 
+  %39 = inttoptr i64 %"$rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field#0", i64* %42 
+  store  i64 %"$field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = add   i64 %"$rec#0", 8 
+  %43 = add   i64 %"$rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -628,46 +628,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec#0" to i8* 
+  %51 = inttoptr i64 %"$rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field#0", i64* %55 
+  store  i64 %"$field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %58, %65 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = icmp eq i64 %62, %69 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$0##0" = icmp eq i64 %62, %69 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }

--- a/test-cases/final-dump/alias_type1.exp
+++ b/test-cases/final-dump/alias_type1.exp
@@ -34,19 +34,19 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$6##0:alias_type1.position)
-    foreign lpvm mutate(~tmp$6##0:alias_type1.position, ?tmp$7##0:alias_type1.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm mutate(~tmp$7##0:alias_type1.position, ?tmp$8##0:alias_type1.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$11##0:alias_type1.posrec)
-    foreign lpvm mutate(~tmp$11##0:alias_type1.posrec, ?tmp$12##0:alias_type1.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp$12##0:alias_type1.posrec, ?tmp$13##0:alias_type1.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$8##0:alias_type1.position)
-    foreign lpvm {noalias} mutate(~tmp$8##0:alias_type1.position, ?%pos##1:alias_type1.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
-    foreign lpvm access(~pos##1:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.int)
-    foreign c print_int(~tmp$2##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$19##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$19##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~tmp$13##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign c print_int(~tmp$3##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$23##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$23##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#6##0:alias_type1.position)
+    foreign lpvm mutate(~tmp#6##0:alias_type1.position, ?tmp#7##0:alias_type1.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
+    foreign lpvm mutate(~tmp#7##0:alias_type1.position, ?tmp#8##0:alias_type1.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:alias_type1.posrec)
+    foreign lpvm mutate(~tmp#11##0:alias_type1.posrec, ?tmp#12##0:alias_type1.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp#12##0:alias_type1.posrec, ?tmp#13##0:alias_type1.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#8##0:alias_type1.position)
+    foreign lpvm {noalias} mutate(~tmp#8##0:alias_type1.position, ?%pos##1:alias_type1.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
+    foreign lpvm access(~pos##1:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int)
+    foreign c print_int(~tmp#2##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#19##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#19##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~tmp#13##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign c print_int(~tmp#3##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#23##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#23##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -132,86 +132,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: alias_type1.position.=<0>
-=($left##0:alias_type1.position, $right##0:alias_type1.position, ?$$##0:wybe.bool):
+=(#left##0:alias_type1.position, #right##0:alias_type1.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
-    foreign lpvm access(~$left##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
-    foreign lpvm access($right##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
-    foreign lpvm access(~$right##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
-    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
+    foreign lpvm access(~#left##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
+    foreign lpvm access(#right##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
+    foreign lpvm access(~#right##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: alias_type1.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?$##0:alias_type1.position):
+position(x##0:wybe.int, y##0:wybe.int, ?###0:alias_type1.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:alias_type1.position)
-    foreign lpvm mutate(~$rec##0:alias_type1.position, ?$rec##1:alias_type1.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:alias_type1.position, ?$##0:alias_type1.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type1.position)
+    foreign lpvm mutate(~#rec##0:alias_type1.position, ?#rec##1:alias_type1.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:alias_type1.position, ?###0:alias_type1.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: alias_type1.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, $##0:alias_type1.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, ###0:alias_type1.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~$##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(###0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~###0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: alias_type1.position.x<0>
-x($rec##0:alias_type1.position, ?$##0:wybe.int):
+x(#rec##0:alias_type1.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 x > public {inline} (0 calls)
 1: alias_type1.position.x<1>
-x($rec##0:alias_type1.position, ?$rec##1:alias_type1.position, $field##0:wybe.int):
+x(#rec##0:alias_type1.position, ?#rec##1:alias_type1.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:alias_type1.position, ?$rec##1:alias_type1.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:alias_type1.position, ?#rec##1:alias_type1.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: alias_type1.position.y<0>
-y($rec##0:alias_type1.position, ?$##0:wybe.int):
+y(#rec##0:alias_type1.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 y > public {inline} (0 calls)
 1: alias_type1.position.y<1>
-y($rec##0:alias_type1.position, ?$rec##1:alias_type1.position, $field##0:wybe.int):
+y(#rec##0:alias_type1.position, ?#rec##1:alias_type1.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:alias_type1.position, ?$rec##1:alias_type1.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:alias_type1.position, ?#rec##1:alias_type1.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: alias_type1.position.~=<0>
-~=($left##0:alias_type1.position, $right##0:alias_type1.position, ?$$##0:wybe.bool):
+~=(#left##0:alias_type1.position, #right##0:alias_type1.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -228,27 +228,27 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"alias_type1.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"alias_type1.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$##0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$##0" 
+  %"2#####0" = icmp eq i64 %7, %14 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
@@ -270,12 +270,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"alias_type1.position.position<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"alias_type1.position.position<1>"(i64  %"###0")    {
 entry:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -285,34 +285,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type1.position.x<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"alias_type1.position.x<0>"(i64  %"#rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec##0" to i64* 
+  %32 = inttoptr i64 %"#rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"alias_type1.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"alias_type1.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec##0" to i8* 
+  %39 = inttoptr i64 %"#rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field##0", i64* %42 
+  store  i64 %"#field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"alias_type1.position.y<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"alias_type1.position.y<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = add   i64 %"$rec##0", 8 
+  %43 = add   i64 %"#rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -320,48 +320,48 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type1.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"alias_type1.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec##0" to i8* 
+  %51 = inttoptr i64 %"#rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field##0", i64* %55 
+  store  i64 %"#field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"alias_type1.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"alias_type1.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %58, %65 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = icmp eq i64 %62, %69 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#0##0" = icmp eq i64 %62, %69 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }
 --------------------------------------------------
  Module alias_type1.posrec
@@ -383,108 +383,108 @@ if.else:
 
 = > public {inline} (1 calls)
 0: alias_type1.posrec.=<0>
-=($left##0:alias_type1.posrec, $right##0:alias_type1.posrec, ?$$##0:wybe.bool):
+=(#left##0:alias_type1.posrec, #right##0:alias_type1.posrec, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$a##0:wybe.int)
-    foreign lpvm access(~$left##0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$p##0:alias_type1.position)
-    foreign lpvm access($right##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$a##0:wybe.int)
-    foreign lpvm access(~$right##0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$p##0:alias_type1.position)
-    foreign llvm icmp_eq(~$left$a##0:wybe.int, ~$right$a##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#a##0:wybe.int)
+    foreign lpvm access(~#left##0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#p##0:alias_type1.position)
+    foreign lpvm access(#right##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#a##0:wybe.int)
+    foreign lpvm access(~#right##0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#p##0:alias_type1.position)
+    foreign llvm icmp_eq(~#left#a##0:wybe.int, ~#right#a##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign lpvm access($left$p##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.int)
-        foreign lpvm access(~$left$p##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.int)
-        foreign lpvm access($right$p##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$11##0:wybe.int)
-        foreign lpvm access(~$right$p##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$12##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$11##0:wybe.int, ~tmp$9##0:wybe.int, ?tmp$13##0:wybe.bool) @int:nn:nn
-        case ~tmp$13##0:wybe.bool of
+        foreign lpvm access(#left#p##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
+        foreign lpvm access(~#left#p##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int)
+        foreign lpvm access(#right#p##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#11##0:wybe.int)
+        foreign lpvm access(~#right#p##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#12##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#11##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#13##0:wybe.bool) @int:nn:nn
+        case ~tmp#13##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~tmp$10##0:wybe.int, ~tmp$12##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+            foreign llvm icmp_eq(~tmp#10##0:wybe.int, ~tmp#12##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 
 a > public {inline} (0 calls)
 0: alias_type1.posrec.a<0>
-a($rec##0:alias_type1.posrec, ?$##0:wybe.int):
+a(#rec##0:alias_type1.posrec, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 a > public {inline} (0 calls)
 1: alias_type1.posrec.a<1>
-a($rec##0:alias_type1.posrec, ?$rec##1:alias_type1.posrec, $field##0:wybe.int):
+a(#rec##0:alias_type1.posrec, ?#rec##1:alias_type1.posrec, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec##0:alias_type1.posrec, ?$rec##1:alias_type1.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm mutate(~#rec##0:alias_type1.posrec, ?#rec##1:alias_type1.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 p > public {inline} (0 calls)
 0: alias_type1.posrec.p<0>
-p($rec##0:alias_type1.posrec, ?$##0:alias_type1.position):
+p(#rec##0:alias_type1.posrec, ?###0:alias_type1.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:alias_type1.position)
+    foreign lpvm access(~#rec##0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:alias_type1.position)
 p > public {inline} (0 calls)
 1: alias_type1.posrec.p<1>
-p($rec##0:alias_type1.posrec, ?$rec##1:alias_type1.posrec, $field##0:alias_type1.position):
+p(#rec##0:alias_type1.posrec, ?#rec##1:alias_type1.posrec, #field##0:alias_type1.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:alias_type1.posrec, ?$rec##1:alias_type1.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:alias_type1.position)
+    foreign lpvm {noalias} mutate(~#rec##0:alias_type1.posrec, ?#rec##1:alias_type1.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:alias_type1.position)
 
 
 posrec > public {inline} (0 calls)
 0: alias_type1.posrec.posrec<0>
-posrec(a##0:wybe.int, p##0:alias_type1.position, ?$##0:alias_type1.posrec):
+posrec(a##0:wybe.int, p##0:alias_type1.position, ?###0:alias_type1.posrec):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:alias_type1.posrec)
-    foreign lpvm mutate(~$rec##0:alias_type1.posrec, ?$rec##1:alias_type1.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:alias_type1.posrec, ?$##0:alias_type1.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p##0:alias_type1.position)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type1.posrec)
+    foreign lpvm mutate(~#rec##0:alias_type1.posrec, ?#rec##1:alias_type1.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:alias_type1.posrec, ?###0:alias_type1.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p##0:alias_type1.position)
 posrec > public {inline} (6 calls)
 1: alias_type1.posrec.posrec<1>
-posrec(?a##0:wybe.int, ?p##0:alias_type1.position, $##0:alias_type1.posrec):
+posrec(?a##0:wybe.int, ?p##0:alias_type1.position, ###0:alias_type1.posrec):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?a##0:wybe.int)
-    foreign lpvm access(~$##0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?p##0:alias_type1.position)
+    foreign lpvm access(###0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?a##0:wybe.int)
+    foreign lpvm access(~###0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?p##0:alias_type1.position)
 
 
 ~= > public {inline} (0 calls)
 0: alias_type1.posrec.~=<0>
-~=($left##0:alias_type1.posrec, $right##0:alias_type1.posrec, ?$$##0:wybe.bool):
+~=(#left##0:alias_type1.posrec, #right##0:alias_type1.posrec, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:alias_type1.position)
-    foreign lpvm access($right##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:alias_type1.position)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:alias_type1.position)
+    foreign lpvm access(#right##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:alias_type1.position)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign lpvm access(tmp$4##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
-        foreign lpvm access(~tmp$4##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.int)
-        foreign lpvm access(tmp$6##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.int)
-        foreign lpvm access(~tmp$6##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$11##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$10##0:wybe.int, ~tmp$8##0:wybe.int, ?tmp$12##0:wybe.bool) @int:nn:nn
-        case ~tmp$12##0:wybe.bool of
+        foreign lpvm access(tmp#4##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
+        foreign lpvm access(~tmp#4##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
+        foreign lpvm access(tmp#6##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int)
+        foreign lpvm access(~tmp#6##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#11##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#10##0:wybe.int, ~tmp#8##0:wybe.int, ?tmp#12##0:wybe.bool) @int:nn:nn
+        case ~tmp#12##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~tmp$11##0:wybe.int, ~tmp$9##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm icmp_eq(~tmp#11##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
 
@@ -502,24 +502,24 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"alias_type1.posrec.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"alias_type1.posrec.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
   %15 = inttoptr i64 %7 to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
@@ -535,46 +535,46 @@ if.then:
   %26 = inttoptr i64 %25 to i64* 
   %27 = getelementptr  i64, i64* %26, i64 0 
   %28 = load  i64, i64* %27 
-  %"2$tmp$13##0" = icmp eq i64 %24, %17 
-  br i1 %"2$tmp$13##0", label %if.then1, label %if.else1 
+  %"2#tmp#13##0" = icmp eq i64 %24, %17 
+  br i1 %"2#tmp#13##0", label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %"4$$$##0" = icmp eq i64 %21, %28 
-  ret i1 %"4$$$##0" 
+  %"4#####0" = icmp eq i64 %21, %28 
+  ret i1 %"4#####0" 
 if.else1:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"alias_type1.posrec.a<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"alias_type1.posrec.a<0>"(i64  %"#rec##0")    {
 entry:
-  %29 = inttoptr i64 %"$rec##0" to i64* 
+  %29 = inttoptr i64 %"#rec##0" to i64* 
   %30 = getelementptr  i64, i64* %29, i64 0 
   %31 = load  i64, i64* %30 
   ret i64 %31 
 }
 
 
-define external fastcc  i64 @"alias_type1.posrec.a<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"alias_type1.posrec.a<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %32 = trunc i64 16 to i32  
   %33 = tail call ccc  i8*  @wybe_malloc(i32  %32)  
   %34 = ptrtoint i8* %33 to i64 
   %35 = inttoptr i64 %34 to i8* 
-  %36 = inttoptr i64 %"$rec##0" to i8* 
+  %36 = inttoptr i64 %"#rec##0" to i8* 
   %37 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %35, i8*  %36, i32  %37, i32  8, i1  0)  
   %38 = inttoptr i64 %34 to i64* 
   %39 = getelementptr  i64, i64* %38, i64 0 
-  store  i64 %"$field##0", i64* %39 
+  store  i64 %"#field##0", i64* %39 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"alias_type1.posrec.p<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"alias_type1.posrec.p<0>"(i64  %"#rec##0")    {
 entry:
-  %40 = add   i64 %"$rec##0", 8 
+  %40 = add   i64 %"#rec##0", 8 
   %41 = inttoptr i64 %40 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
   %43 = load  i64, i64* %42 
@@ -582,19 +582,19 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type1.posrec.p<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"alias_type1.posrec.p<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %44 = trunc i64 16 to i32  
   %45 = tail call ccc  i8*  @wybe_malloc(i32  %44)  
   %46 = ptrtoint i8* %45 to i64 
   %47 = inttoptr i64 %46 to i8* 
-  %48 = inttoptr i64 %"$rec##0" to i8* 
+  %48 = inttoptr i64 %"#rec##0" to i8* 
   %49 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %47, i8*  %48, i32  %49, i32  8, i1  0)  
   %50 = add   i64 %46, 8 
   %51 = inttoptr i64 %50 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
-  store  i64 %"$field##0", i64* %52 
+  store  i64 %"#field##0", i64* %52 
   ret i64 %46 
 }
 
@@ -615,12 +615,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"alias_type1.posrec.posrec<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"alias_type1.posrec.posrec<1>"(i64  %"###0")    {
 entry:
-  %61 = inttoptr i64 %"$##0" to i64* 
+  %61 = inttoptr i64 %"###0" to i64* 
   %62 = getelementptr  i64, i64* %61, i64 0 
   %63 = load  i64, i64* %62 
-  %64 = add   i64 %"$##0", 8 
+  %64 = add   i64 %"###0", 8 
   %65 = inttoptr i64 %64 to i64* 
   %66 = getelementptr  i64, i64* %65, i64 0 
   %67 = load  i64, i64* %66 
@@ -630,24 +630,24 @@ entry:
 }
 
 
-define external fastcc  i1 @"alias_type1.posrec.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"alias_type1.posrec.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %70 = inttoptr i64 %"$left##0" to i64* 
+  %70 = inttoptr i64 %"#left##0" to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
   %72 = load  i64, i64* %71 
-  %73 = add   i64 %"$left##0", 8 
+  %73 = add   i64 %"#left##0", 8 
   %74 = inttoptr i64 %73 to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
   %76 = load  i64, i64* %75 
-  %77 = inttoptr i64 %"$right##0" to i64* 
+  %77 = inttoptr i64 %"#right##0" to i64* 
   %78 = getelementptr  i64, i64* %77, i64 0 
   %79 = load  i64, i64* %78 
-  %80 = add   i64 %"$right##0", 8 
+  %80 = add   i64 %"#right##0", 8 
   %81 = inttoptr i64 %80 to i64* 
   %82 = getelementptr  i64, i64* %81, i64 0 
   %83 = load  i64, i64* %82 
-  %"1$tmp$7##0" = icmp eq i64 %72, %79 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %72, %79 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %84 = inttoptr i64 %76 to i64* 
   %85 = getelementptr  i64, i64* %84, i64 0 
@@ -663,16 +663,16 @@ if.then:
   %95 = inttoptr i64 %94 to i64* 
   %96 = getelementptr  i64, i64* %95, i64 0 
   %97 = load  i64, i64* %96 
-  %"2$tmp$12##0" = icmp eq i64 %93, %86 
-  br i1 %"2$tmp$12##0", label %if.then1, label %if.else1 
+  %"2#tmp#12##0" = icmp eq i64 %93, %86 
+  br i1 %"2#tmp#12##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 if.then1:
-  %"4$tmp$0##0" = icmp eq i64 %97, %90 
-  %"4$$$##0" = xor i1 %"4$tmp$0##0", 1 
-  ret i1 %"4$$$##0" 
+  %"4#tmp#0##0" = icmp eq i64 %97, %90 
+  %"4#####0" = xor i1 %"4#tmp#0##0", 1 
+  ret i1 %"4#####0" 
 if.else1:
-  %"5$$$##0" = xor i1 0, 1 
-  ret i1 %"5$$$##0" 
+  %"5#####0" = xor i1 0, 1 
+  ret i1 %"5#####0" 
 }

--- a/test-cases/final-dump/alias_type1.exp
+++ b/test-cases/final-dump/alias_type1.exp
@@ -31,22 +31,22 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: alias_type1.<0>
-(io#0:wybe.phantom, ?io#2:wybe.phantom):
+(io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$6#0:alias_type1.position)
-    foreign lpvm mutate(~tmp$6#0:alias_type1.position, ?tmp$7#0:alias_type1.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm mutate(~tmp$7#0:alias_type1.position, ?tmp$8#0:alias_type1.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$11#0:alias_type1.posrec)
-    foreign lpvm mutate(~tmp$11#0:alias_type1.posrec, ?tmp$12#0:alias_type1.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp$12#0:alias_type1.posrec, ?tmp$13#0:alias_type1.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$8#0:alias_type1.position)
-    foreign lpvm {noalias} mutate(~tmp$8#0:alias_type1.position, ?%pos#1:alias_type1.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
-    foreign lpvm access(~pos#1:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$2#0:wybe.int)
-    foreign c print_int(~tmp$2#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$19#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$19#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~tmp$13#0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign c print_int(~tmp$3#0:wybe.int, ~#io#1:wybe.phantom, ?tmp$23#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$23#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$6##0:alias_type1.position)
+    foreign lpvm mutate(~tmp$6##0:alias_type1.position, ?tmp$7##0:alias_type1.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
+    foreign lpvm mutate(~tmp$7##0:alias_type1.position, ?tmp$8##0:alias_type1.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp$11##0:alias_type1.posrec)
+    foreign lpvm mutate(~tmp$11##0:alias_type1.posrec, ?tmp$12##0:alias_type1.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp$12##0:alias_type1.posrec, ?tmp$13##0:alias_type1.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$8##0:alias_type1.position)
+    foreign lpvm {noalias} mutate(~tmp$8##0:alias_type1.position, ?%pos##1:alias_type1.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
+    foreign lpvm access(~pos##1:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.int)
+    foreign c print_int(~tmp$2##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$19##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$19##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~tmp$13##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign c print_int(~tmp$3##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$23##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$23##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -132,86 +132,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: alias_type1.position.=<0>
-=($left#0:alias_type1.position, $right#0:alias_type1.position, ?$$#0:wybe.bool):
+=($left##0:alias_type1.position, $right##0:alias_type1.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
-    foreign lpvm access(~$left#0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y#0:wybe.int)
-    foreign lpvm access($right#0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x#0:wybe.int)
-    foreign lpvm access(~$right#0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y#0:wybe.int)
-    foreign llvm icmp_eq(~$left$x#0:wybe.int, ~$right$x#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
+    foreign lpvm access(~$left##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
+    foreign lpvm access($right##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
+    foreign lpvm access(~$right##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
+    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y#0:wybe.int, ~$right$y#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: alias_type1.position.position<0>
-position(x#0:wybe.int, y#0:wybe.int, ?$#0:alias_type1.position):
+position(x##0:wybe.int, y##0:wybe.int, ?$##0:alias_type1.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:alias_type1.position)
-    foreign lpvm mutate(~$rec#0:alias_type1.position, ?$rec#1:alias_type1.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:alias_type1.position, ?$#0:alias_type1.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:alias_type1.position)
+    foreign lpvm mutate(~$rec##0:alias_type1.position, ?$rec##1:alias_type1.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:alias_type1.position, ?$##0:alias_type1.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: alias_type1.position.position<1>
-position(?x#0:wybe.int, ?y#0:wybe.int, $#0:alias_type1.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, $##0:alias_type1.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
-    foreign lpvm access(~$#0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y#0:wybe.int)
+    foreign lpvm access($##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~$##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: alias_type1.position.x<0>
-x($rec#0:alias_type1.position, ?$#0:wybe.int):
+x($rec##0:alias_type1.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 x > public {inline} (0 calls)
 1: alias_type1.position.x<1>
-x($rec#0:alias_type1.position, ?$rec#1:alias_type1.position, $field#0:wybe.int):
+x($rec##0:alias_type1.position, ?$rec##1:alias_type1.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:alias_type1.position, ?$rec#1:alias_type1.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:alias_type1.position, ?$rec##1:alias_type1.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: alias_type1.position.y<0>
-y($rec#0:alias_type1.position, ?$#0:wybe.int):
+y($rec##0:alias_type1.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 y > public {inline} (0 calls)
 1: alias_type1.position.y<1>
-y($rec#0:alias_type1.position, ?$rec#1:alias_type1.position, $field#0:wybe.int):
+y($rec##0:alias_type1.position, ?$rec##1:alias_type1.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:alias_type1.position, ?$rec#1:alias_type1.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:alias_type1.position, ?$rec##1:alias_type1.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: alias_type1.position.~=<0>
-~=($left#0:alias_type1.position, $right#0:alias_type1.position, ?$$#0:wybe.bool):
+~=($left##0:alias_type1.position, $right##0:alias_type1.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -228,54 +228,54 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"alias_type1.position.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"alias_type1.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$#0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = icmp eq i64 %7, %14 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"alias_type1.position.position<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"alias_type1.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"x#0", i64* %19 
+  store  i64 %"x##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"y#0", i64* %22 
+  store  i64 %"y##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64} @"alias_type1.position.position<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"alias_type1.position.position<1>"(i64  %"$##0")    {
 entry:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -285,34 +285,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type1.position.x<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"alias_type1.position.x<0>"(i64  %"$rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec#0" to i64* 
+  %32 = inttoptr i64 %"$rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"alias_type1.position.x<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"alias_type1.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec#0" to i8* 
+  %39 = inttoptr i64 %"$rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field#0", i64* %42 
+  store  i64 %"$field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"alias_type1.position.y<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"alias_type1.position.y<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = add   i64 %"$rec#0", 8 
+  %43 = add   i64 %"$rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -320,48 +320,48 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type1.position.y<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"alias_type1.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec#0" to i8* 
+  %51 = inttoptr i64 %"$rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field#0", i64* %55 
+  store  i64 %"$field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"alias_type1.position.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"alias_type1.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %58, %65 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = icmp eq i64 %62, %69 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$0##0" = icmp eq i64 %62, %69 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }
 --------------------------------------------------
  Module alias_type1.posrec
@@ -383,108 +383,108 @@ if.else:
 
 = > public {inline} (1 calls)
 0: alias_type1.posrec.=<0>
-=($left#0:alias_type1.posrec, $right#0:alias_type1.posrec, ?$$#0:wybe.bool):
+=($left##0:alias_type1.posrec, $right##0:alias_type1.posrec, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$a#0:wybe.int)
-    foreign lpvm access(~$left#0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$p#0:alias_type1.position)
-    foreign lpvm access($right#0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$a#0:wybe.int)
-    foreign lpvm access(~$right#0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$p#0:alias_type1.position)
-    foreign llvm icmp_eq(~$left$a#0:wybe.int, ~$right$a#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$a##0:wybe.int)
+    foreign lpvm access(~$left##0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$p##0:alias_type1.position)
+    foreign lpvm access($right##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$a##0:wybe.int)
+    foreign lpvm access(~$right##0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$p##0:alias_type1.position)
+    foreign llvm icmp_eq(~$left$a##0:wybe.int, ~$right$a##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign lpvm access($left$p#0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.int)
-        foreign lpvm access(~$left$p#0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.int)
-        foreign lpvm access($right$p#0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$11#0:wybe.int)
-        foreign lpvm access(~$right$p#0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$12#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$11#0:wybe.int, ~tmp$9#0:wybe.int, ?tmp$13#0:wybe.bool) @int:nn:nn
-        case ~tmp$13#0:wybe.bool of
+        foreign lpvm access($left$p##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.int)
+        foreign lpvm access(~$left$p##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.int)
+        foreign lpvm access($right$p##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$11##0:wybe.int)
+        foreign lpvm access(~$right$p##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$12##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$11##0:wybe.int, ~tmp$9##0:wybe.int, ?tmp$13##0:wybe.bool) @int:nn:nn
+        case ~tmp$13##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~tmp$10#0:wybe.int, ~tmp$12#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+            foreign llvm icmp_eq(~tmp$10##0:wybe.int, ~tmp$12##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 
 a > public {inline} (0 calls)
 0: alias_type1.posrec.a<0>
-a($rec#0:alias_type1.posrec, ?$#0:wybe.int):
+a($rec##0:alias_type1.posrec, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 a > public {inline} (0 calls)
 1: alias_type1.posrec.a<1>
-a($rec#0:alias_type1.posrec, ?$rec#1:alias_type1.posrec, $field#0:wybe.int):
+a($rec##0:alias_type1.posrec, ?$rec##1:alias_type1.posrec, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec#0:alias_type1.posrec, ?$rec#1:alias_type1.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm mutate(~$rec##0:alias_type1.posrec, ?$rec##1:alias_type1.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 p > public {inline} (0 calls)
 0: alias_type1.posrec.p<0>
-p($rec#0:alias_type1.posrec, ?$#0:alias_type1.position):
+p($rec##0:alias_type1.posrec, ?$##0:alias_type1.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:alias_type1.position)
+    foreign lpvm access(~$rec##0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:alias_type1.position)
 p > public {inline} (0 calls)
 1: alias_type1.posrec.p<1>
-p($rec#0:alias_type1.posrec, ?$rec#1:alias_type1.posrec, $field#0:alias_type1.position):
+p($rec##0:alias_type1.posrec, ?$rec##1:alias_type1.posrec, $field##0:alias_type1.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:alias_type1.posrec, ?$rec#1:alias_type1.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:alias_type1.position)
+    foreign lpvm {noalias} mutate(~$rec##0:alias_type1.posrec, ?$rec##1:alias_type1.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:alias_type1.position)
 
 
 posrec > public {inline} (0 calls)
 0: alias_type1.posrec.posrec<0>
-posrec(a#0:wybe.int, p#0:alias_type1.position, ?$#0:alias_type1.posrec):
+posrec(a##0:wybe.int, p##0:alias_type1.position, ?$##0:alias_type1.posrec):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:alias_type1.posrec)
-    foreign lpvm mutate(~$rec#0:alias_type1.posrec, ?$rec#1:alias_type1.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:alias_type1.posrec, ?$#0:alias_type1.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p#0:alias_type1.position)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:alias_type1.posrec)
+    foreign lpvm mutate(~$rec##0:alias_type1.posrec, ?$rec##1:alias_type1.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:alias_type1.posrec, ?$##0:alias_type1.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p##0:alias_type1.position)
 posrec > public {inline} (6 calls)
 1: alias_type1.posrec.posrec<1>
-posrec(?a#0:wybe.int, ?p#0:alias_type1.position, $#0:alias_type1.posrec):
+posrec(?a##0:wybe.int, ?p##0:alias_type1.position, $##0:alias_type1.posrec):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?a#0:wybe.int)
-    foreign lpvm access(~$#0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?p#0:alias_type1.position)
+    foreign lpvm access($##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?a##0:wybe.int)
+    foreign lpvm access(~$##0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?p##0:alias_type1.position)
 
 
 ~= > public {inline} (0 calls)
 0: alias_type1.posrec.~=<0>
-~=($left#0:alias_type1.posrec, $right#0:alias_type1.posrec, ?$$#0:wybe.bool):
+~=($left##0:alias_type1.posrec, $right##0:alias_type1.posrec, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:alias_type1.position)
-    foreign lpvm access($right#0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:alias_type1.position)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:alias_type1.position)
+    foreign lpvm access($right##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:alias_type1.position)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign lpvm access(tmp$4#0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.int)
-        foreign lpvm access(~tmp$4#0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.int)
-        foreign lpvm access(tmp$6#0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.int)
-        foreign lpvm access(~tmp$6#0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$11#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$10#0:wybe.int, ~tmp$8#0:wybe.int, ?tmp$12#0:wybe.bool) @int:nn:nn
-        case ~tmp$12#0:wybe.bool of
+        foreign lpvm access(tmp$4##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
+        foreign lpvm access(~tmp$4##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.int)
+        foreign lpvm access(tmp$6##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.int)
+        foreign lpvm access(~tmp$6##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$11##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$10##0:wybe.int, ~tmp$8##0:wybe.int, ?tmp$12##0:wybe.bool) @int:nn:nn
+        case ~tmp$12##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-            foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~tmp$11#0:wybe.int, ~tmp$9#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-            foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm icmp_eq(~tmp$11##0:wybe.int, ~tmp$9##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
@@ -502,24 +502,24 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"alias_type1.posrec.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"alias_type1.posrec.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
   %15 = inttoptr i64 %7 to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
@@ -535,46 +535,46 @@ if.then:
   %26 = inttoptr i64 %25 to i64* 
   %27 = getelementptr  i64, i64* %26, i64 0 
   %28 = load  i64, i64* %27 
-  %"2$tmp$13#0" = icmp eq i64 %24, %17 
-  br i1 %"2$tmp$13#0", label %if.then1, label %if.else1 
+  %"2$tmp$13##0" = icmp eq i64 %24, %17 
+  br i1 %"2$tmp$13##0", label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %"4$$$#0" = icmp eq i64 %21, %28 
-  ret i1 %"4$$$#0" 
+  %"4$$$##0" = icmp eq i64 %21, %28 
+  ret i1 %"4$$$##0" 
 if.else1:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"alias_type1.posrec.a<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"alias_type1.posrec.a<0>"(i64  %"$rec##0")    {
 entry:
-  %29 = inttoptr i64 %"$rec#0" to i64* 
+  %29 = inttoptr i64 %"$rec##0" to i64* 
   %30 = getelementptr  i64, i64* %29, i64 0 
   %31 = load  i64, i64* %30 
   ret i64 %31 
 }
 
 
-define external fastcc  i64 @"alias_type1.posrec.a<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"alias_type1.posrec.a<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %32 = trunc i64 16 to i32  
   %33 = tail call ccc  i8*  @wybe_malloc(i32  %32)  
   %34 = ptrtoint i8* %33 to i64 
   %35 = inttoptr i64 %34 to i8* 
-  %36 = inttoptr i64 %"$rec#0" to i8* 
+  %36 = inttoptr i64 %"$rec##0" to i8* 
   %37 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %35, i8*  %36, i32  %37, i32  8, i1  0)  
   %38 = inttoptr i64 %34 to i64* 
   %39 = getelementptr  i64, i64* %38, i64 0 
-  store  i64 %"$field#0", i64* %39 
+  store  i64 %"$field##0", i64* %39 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"alias_type1.posrec.p<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"alias_type1.posrec.p<0>"(i64  %"$rec##0")    {
 entry:
-  %40 = add   i64 %"$rec#0", 8 
+  %40 = add   i64 %"$rec##0", 8 
   %41 = inttoptr i64 %40 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
   %43 = load  i64, i64* %42 
@@ -582,45 +582,45 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type1.posrec.p<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"alias_type1.posrec.p<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %44 = trunc i64 16 to i32  
   %45 = tail call ccc  i8*  @wybe_malloc(i32  %44)  
   %46 = ptrtoint i8* %45 to i64 
   %47 = inttoptr i64 %46 to i8* 
-  %48 = inttoptr i64 %"$rec#0" to i8* 
+  %48 = inttoptr i64 %"$rec##0" to i8* 
   %49 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %47, i8*  %48, i32  %49, i32  8, i1  0)  
   %50 = add   i64 %46, 8 
   %51 = inttoptr i64 %50 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
-  store  i64 %"$field#0", i64* %52 
+  store  i64 %"$field##0", i64* %52 
   ret i64 %46 
 }
 
 
-define external fastcc  i64 @"alias_type1.posrec.posrec<0>"(i64  %"a#0", i64  %"p#0")    {
+define external fastcc  i64 @"alias_type1.posrec.posrec<0>"(i64  %"a##0", i64  %"p##0")    {
 entry:
   %53 = trunc i64 16 to i32  
   %54 = tail call ccc  i8*  @wybe_malloc(i32  %53)  
   %55 = ptrtoint i8* %54 to i64 
   %56 = inttoptr i64 %55 to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
-  store  i64 %"a#0", i64* %57 
+  store  i64 %"a##0", i64* %57 
   %58 = add   i64 %55, 8 
   %59 = inttoptr i64 %58 to i64* 
   %60 = getelementptr  i64, i64* %59, i64 0 
-  store  i64 %"p#0", i64* %60 
+  store  i64 %"p##0", i64* %60 
   ret i64 %55 
 }
 
 
-define external fastcc  {i64, i64} @"alias_type1.posrec.posrec<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"alias_type1.posrec.posrec<1>"(i64  %"$##0")    {
 entry:
-  %61 = inttoptr i64 %"$#0" to i64* 
+  %61 = inttoptr i64 %"$##0" to i64* 
   %62 = getelementptr  i64, i64* %61, i64 0 
   %63 = load  i64, i64* %62 
-  %64 = add   i64 %"$#0", 8 
+  %64 = add   i64 %"$##0", 8 
   %65 = inttoptr i64 %64 to i64* 
   %66 = getelementptr  i64, i64* %65, i64 0 
   %67 = load  i64, i64* %66 
@@ -630,24 +630,24 @@ entry:
 }
 
 
-define external fastcc  i1 @"alias_type1.posrec.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"alias_type1.posrec.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %70 = inttoptr i64 %"$left#0" to i64* 
+  %70 = inttoptr i64 %"$left##0" to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
   %72 = load  i64, i64* %71 
-  %73 = add   i64 %"$left#0", 8 
+  %73 = add   i64 %"$left##0", 8 
   %74 = inttoptr i64 %73 to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
   %76 = load  i64, i64* %75 
-  %77 = inttoptr i64 %"$right#0" to i64* 
+  %77 = inttoptr i64 %"$right##0" to i64* 
   %78 = getelementptr  i64, i64* %77, i64 0 
   %79 = load  i64, i64* %78 
-  %80 = add   i64 %"$right#0", 8 
+  %80 = add   i64 %"$right##0", 8 
   %81 = inttoptr i64 %80 to i64* 
   %82 = getelementptr  i64, i64* %81, i64 0 
   %83 = load  i64, i64* %82 
-  %"1$tmp$7#0" = icmp eq i64 %72, %79 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %72, %79 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
   %84 = inttoptr i64 %76 to i64* 
   %85 = getelementptr  i64, i64* %84, i64 0 
@@ -663,16 +663,16 @@ if.then:
   %95 = inttoptr i64 %94 to i64* 
   %96 = getelementptr  i64, i64* %95, i64 0 
   %97 = load  i64, i64* %96 
-  %"2$tmp$12#0" = icmp eq i64 %93, %86 
-  br i1 %"2$tmp$12#0", label %if.then1, label %if.else1 
+  %"2$tmp$12##0" = icmp eq i64 %93, %86 
+  br i1 %"2$tmp$12##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 if.then1:
-  %"4$tmp$0#0" = icmp eq i64 %97, %90 
-  %"4$$$#0" = xor i1 %"4$tmp$0#0", 1 
-  ret i1 %"4$$$#0" 
+  %"4$tmp$0##0" = icmp eq i64 %97, %90 
+  %"4$$$##0" = xor i1 %"4$tmp$0##0", 1 
+  ret i1 %"4$$$##0" 
 if.else1:
-  %"5$$$#0" = xor i1 0, 1 
-  ret i1 %"5$$$#0" 
+  %"5$$$##0" = xor i1 0, 1 
+  ret i1 %"5$$$##0" 
 }

--- a/test-cases/final-dump/alias_type1.exp
+++ b/test-cases/final-dump/alias_type1.exp
@@ -151,27 +151,27 @@ entry:
 
 position > public {inline} (0 calls)
 0: alias_type1.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?###0:alias_type1.position):
+position(x##0:wybe.int, y##0:wybe.int, ?#result##0:alias_type1.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type1.position)
     foreign lpvm mutate(~#rec##0:alias_type1.position, ?#rec##1:alias_type1.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:alias_type1.position, ?###0:alias_type1.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:alias_type1.position, ?#result##0:alias_type1.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: alias_type1.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, ###0:alias_type1.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:alias_type1.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~###0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~#result##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: alias_type1.position.x<0>
-x(#rec##0:alias_type1.position, ?###0:wybe.int):
+x(#rec##0:alias_type1.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 x > public {inline} (0 calls)
 1: alias_type1.position.x<1>
 x(#rec##0:alias_type1.position, ?#rec##1:alias_type1.position, #field##0:wybe.int):
@@ -182,10 +182,10 @@ x(#rec##0:alias_type1.position, ?#rec##1:alias_type1.position, #field##0:wybe.in
 
 y > public {inline} (0 calls)
 0: alias_type1.position.y<0>
-y(#rec##0:alias_type1.position, ?###0:wybe.int):
+y(#rec##0:alias_type1.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type1.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 y > public {inline} (0 calls)
 1: alias_type1.position.y<1>
 y(#rec##0:alias_type1.position, ?#rec##1:alias_type1.position, #field##0:wybe.int):
@@ -270,12 +270,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"alias_type1.position.position<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"alias_type1.position.position<1>"(i64  %"#result##0")    {
 entry:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -413,10 +413,10 @@ if.else:
 
 a > public {inline} (0 calls)
 0: alias_type1.posrec.a<0>
-a(#rec##0:alias_type1.posrec, ?###0:wybe.int):
+a(#rec##0:alias_type1.posrec, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 a > public {inline} (0 calls)
 1: alias_type1.posrec.a<1>
 a(#rec##0:alias_type1.posrec, ?#rec##1:alias_type1.posrec, #field##0:wybe.int):
@@ -427,10 +427,10 @@ a(#rec##0:alias_type1.posrec, ?#rec##1:alias_type1.posrec, #field##0:wybe.int):
 
 p > public {inline} (0 calls)
 0: alias_type1.posrec.p<0>
-p(#rec##0:alias_type1.posrec, ?###0:alias_type1.position):
+p(#rec##0:alias_type1.posrec, ?#result##0:alias_type1.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:alias_type1.position)
+    foreign lpvm access(~#rec##0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:alias_type1.position)
 p > public {inline} (0 calls)
 1: alias_type1.posrec.p<1>
 p(#rec##0:alias_type1.posrec, ?#rec##1:alias_type1.posrec, #field##0:alias_type1.position):
@@ -441,19 +441,19 @@ p(#rec##0:alias_type1.posrec, ?#rec##1:alias_type1.posrec, #field##0:alias_type1
 
 posrec > public {inline} (0 calls)
 0: alias_type1.posrec.posrec<0>
-posrec(a##0:wybe.int, p##0:alias_type1.position, ?###0:alias_type1.posrec):
+posrec(a##0:wybe.int, p##0:alias_type1.position, ?#result##0:alias_type1.posrec):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type1.posrec)
     foreign lpvm mutate(~#rec##0:alias_type1.posrec, ?#rec##1:alias_type1.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:alias_type1.posrec, ?###0:alias_type1.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p##0:alias_type1.position)
+    foreign lpvm mutate(~#rec##1:alias_type1.posrec, ?#result##0:alias_type1.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p##0:alias_type1.position)
 posrec > public {inline} (6 calls)
 1: alias_type1.posrec.posrec<1>
-posrec(?a##0:wybe.int, ?p##0:alias_type1.position, ###0:alias_type1.posrec):
+posrec(?a##0:wybe.int, ?p##0:alias_type1.position, #result##0:alias_type1.posrec):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?a##0:wybe.int)
-    foreign lpvm access(~###0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?p##0:alias_type1.position)
+    foreign lpvm access(#result##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?a##0:wybe.int)
+    foreign lpvm access(~#result##0:alias_type1.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?p##0:alias_type1.position)
 
 
 ~= > public {inline} (0 calls)
@@ -615,12 +615,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"alias_type1.posrec.posrec<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"alias_type1.posrec.posrec<1>"(i64  %"#result##0")    {
 entry:
-  %61 = inttoptr i64 %"###0" to i64* 
+  %61 = inttoptr i64 %"#result##0" to i64* 
   %62 = getelementptr  i64, i64* %61, i64 0 
   %63 = load  i64, i64* %62 
-  %64 = add   i64 %"###0", 8 
+  %64 = add   i64 %"#result##0", 8 
   %65 = inttoptr i64 %64 to i64* 
   %66 = getelementptr  i64, i64* %65, i64 0 
   %67 = load  i64, i64* %66 

--- a/test-cases/final-dump/alias_type1.exp
+++ b/test-cases/final-dump/alias_type1.exp
@@ -132,7 +132,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: alias_type1.position.=<0>
-=(#left##0:alias_type1.position, #right##0:alias_type1.position, ?####0:wybe.bool):
+=(#left##0:alias_type1.position, #right##0:alias_type1.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
@@ -142,10 +142,10 @@ entry:
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -196,7 +196,7 @@ y(#rec##0:alias_type1.position, ?#rec##1:alias_type1.position, #field##0:wybe.in
 
 ~= > public {inline} (0 calls)
 0: alias_type1.position.~=<0>
-~=(#left##0:alias_type1.position, #right##0:alias_type1.position, ?####0:wybe.bool):
+~=(#left##0:alias_type1.position, #right##0:alias_type1.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -207,11 +207,11 @@ y(#rec##0:alias_type1.position, ?#rec##1:alias_type1.position, #field##0:wybe.in
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -247,8 +247,8 @@ entry:
   %"1#tmp#1##0" = icmp eq i64 %3, %10 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2#####0" = icmp eq i64 %7, %14 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %7, %14 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -357,11 +357,11 @@ entry:
   br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#0##0" = icmp eq i64 %62, %69 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }
 --------------------------------------------------
  Module alias_type1.posrec
@@ -383,7 +383,7 @@ if.else:
 
 = > public {inline} (1 calls)
 0: alias_type1.posrec.=<0>
-=(#left##0:alias_type1.posrec, #right##0:alias_type1.posrec, ?####0:wybe.bool):
+=(#left##0:alias_type1.posrec, #right##0:alias_type1.posrec, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#a##0:wybe.int)
@@ -393,7 +393,7 @@ if.else:
     foreign llvm icmp_eq(~#left#a##0:wybe.int, ~#right#a##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign lpvm access(#left#p##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
@@ -403,10 +403,10 @@ if.else:
         foreign llvm icmp_eq(~tmp#11##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#13##0:wybe.bool) @int:nn:nn
         case ~tmp#13##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~tmp#10##0:wybe.int, ~tmp#12##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+            foreign llvm icmp_eq(~tmp#10##0:wybe.int, ~tmp#12##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -458,7 +458,7 @@ posrec(?a##0:wybe.int, ?p##0:alias_type1.position, #result##0:alias_type1.posrec
 
 ~= > public {inline} (0 calls)
 0: alias_type1.posrec.~=<0>
-~=(#left##0:alias_type1.posrec, #right##0:alias_type1.posrec, ?####0:wybe.bool):
+~=(#left##0:alias_type1.posrec, #right##0:alias_type1.posrec, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:alias_type1.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -469,7 +469,7 @@ posrec(?a##0:wybe.int, ?p##0:alias_type1.position, #result##0:alias_type1.posrec
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign lpvm access(tmp#4##0:alias_type1.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
@@ -480,11 +480,11 @@ posrec(?a##0:wybe.int, ?p##0:alias_type1.position, #result##0:alias_type1.posrec
         case ~tmp#12##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign llvm icmp_eq(~tmp#11##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -540,8 +540,8 @@ if.then:
 if.else:
   ret i1 0 
 if.then1:
-  %"4#####0" = icmp eq i64 %21, %28 
-  ret i1 %"4#####0" 
+  %"4##success##0" = icmp eq i64 %21, %28 
+  ret i1 %"4##success##0" 
 if.else1:
   ret i1 0 
 }
@@ -666,13 +666,13 @@ if.then:
   %"2#tmp#12##0" = icmp eq i64 %93, %86 
   br i1 %"2#tmp#12##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 if.then1:
   %"4#tmp#0##0" = icmp eq i64 %97, %90 
-  %"4#####0" = xor i1 %"4#tmp#0##0", 1 
-  ret i1 %"4#####0" 
+  %"4##success##0" = xor i1 %"4#tmp#0##0", 1 
+  ret i1 %"4##success##0" 
 if.else1:
-  %"5#####0" = xor i1 0, 1 
-  ret i1 %"5#####0" 
+  %"5##success##0" = xor i1 0, 1 
+  ret i1 %"5##success##0" 
 }

--- a/test-cases/final-dump/alias_type2.exp
+++ b/test-cases/final-dump/alias_type2.exp
@@ -34,21 +34,21 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$7##0:alias_type2.position)
-    foreign lpvm mutate(~tmp$7##0:alias_type2.position, ?tmp$8##0:alias_type2.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm mutate(~tmp$8##0:alias_type2.position, ?tmp$9##0:alias_type2.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$12##0:alias_type2.posrec)
-    foreign lpvm mutate(~tmp$12##0:alias_type2.posrec, ?tmp$13##0:alias_type2.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$9##0:alias_type2.position)
-    foreign lpvm mutate(~tmp$13##0:alias_type2.posrec, ?tmp$14##0:alias_type2.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp$14##0:alias_type2.posrec, ?%rec##1:alias_type2.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm {noalias} mutate(~tmp$9##0:alias_type2.position, ?%pos##1:alias_type2.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
-    foreign lpvm access(~pos##1:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.int)
-    foreign c print_int(~tmp$2##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$22##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$22##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~rec##1:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:alias_type2.position)
-    foreign lpvm access(~tmp$3##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign c print_int(~tmp$4##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$27##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$27##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#7##0:alias_type2.position)
+    foreign lpvm mutate(~tmp#7##0:alias_type2.position, ?tmp#8##0:alias_type2.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
+    foreign lpvm mutate(~tmp#8##0:alias_type2.position, ?tmp#9##0:alias_type2.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#12##0:alias_type2.posrec)
+    foreign lpvm mutate(~tmp#12##0:alias_type2.posrec, ?tmp#13##0:alias_type2.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#9##0:alias_type2.position)
+    foreign lpvm mutate(~tmp#13##0:alias_type2.posrec, ?tmp#14##0:alias_type2.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp#14##0:alias_type2.posrec, ?%rec##1:alias_type2.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+    foreign lpvm {noalias} mutate(~tmp#9##0:alias_type2.position, ?%pos##1:alias_type2.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
+    foreign lpvm access(~pos##1:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int)
+    foreign c print_int(~tmp#2##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#22##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~rec##1:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:alias_type2.position)
+    foreign lpvm access(~tmp#3##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign c print_int(~tmp#4##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#27##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#27##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -148,86 +148,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: alias_type2.position.=<0>
-=($left##0:alias_type2.position, $right##0:alias_type2.position, ?$$##0:wybe.bool):
+=(#left##0:alias_type2.position, #right##0:alias_type2.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
-    foreign lpvm access(~$left##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
-    foreign lpvm access($right##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
-    foreign lpvm access(~$right##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
-    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
+    foreign lpvm access(~#left##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
+    foreign lpvm access(#right##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
+    foreign lpvm access(~#right##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: alias_type2.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?$##0:alias_type2.position):
+position(x##0:wybe.int, y##0:wybe.int, ?###0:alias_type2.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:alias_type2.position)
-    foreign lpvm mutate(~$rec##0:alias_type2.position, ?$rec##1:alias_type2.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:alias_type2.position, ?$##0:alias_type2.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type2.position)
+    foreign lpvm mutate(~#rec##0:alias_type2.position, ?#rec##1:alias_type2.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:alias_type2.position, ?###0:alias_type2.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: alias_type2.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, $##0:alias_type2.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, ###0:alias_type2.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~$##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(###0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~###0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: alias_type2.position.x<0>
-x($rec##0:alias_type2.position, ?$##0:wybe.int):
+x(#rec##0:alias_type2.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 x > public {inline} (0 calls)
 1: alias_type2.position.x<1>
-x($rec##0:alias_type2.position, ?$rec##1:alias_type2.position, $field##0:wybe.int):
+x(#rec##0:alias_type2.position, ?#rec##1:alias_type2.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:alias_type2.position, ?$rec##1:alias_type2.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:alias_type2.position, ?#rec##1:alias_type2.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: alias_type2.position.y<0>
-y($rec##0:alias_type2.position, ?$##0:wybe.int):
+y(#rec##0:alias_type2.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 y > public {inline} (0 calls)
 1: alias_type2.position.y<1>
-y($rec##0:alias_type2.position, ?$rec##1:alias_type2.position, $field##0:wybe.int):
+y(#rec##0:alias_type2.position, ?#rec##1:alias_type2.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:alias_type2.position, ?$rec##1:alias_type2.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:alias_type2.position, ?#rec##1:alias_type2.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: alias_type2.position.~=<0>
-~=($left##0:alias_type2.position, $right##0:alias_type2.position, ?$$##0:wybe.bool):
+~=(#left##0:alias_type2.position, #right##0:alias_type2.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -244,27 +244,27 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"alias_type2.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"alias_type2.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$##0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$##0" 
+  %"2#####0" = icmp eq i64 %7, %14 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
@@ -286,12 +286,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"alias_type2.position.position<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"alias_type2.position.position<1>"(i64  %"###0")    {
 entry:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -301,34 +301,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type2.position.x<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"alias_type2.position.x<0>"(i64  %"#rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec##0" to i64* 
+  %32 = inttoptr i64 %"#rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"alias_type2.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"alias_type2.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec##0" to i8* 
+  %39 = inttoptr i64 %"#rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field##0", i64* %42 
+  store  i64 %"#field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"alias_type2.position.y<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"alias_type2.position.y<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = add   i64 %"$rec##0", 8 
+  %43 = add   i64 %"#rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -336,48 +336,48 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type2.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"alias_type2.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec##0" to i8* 
+  %51 = inttoptr i64 %"#rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field##0", i64* %55 
+  store  i64 %"#field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"alias_type2.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"alias_type2.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %58, %65 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = icmp eq i64 %62, %69 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#0##0" = icmp eq i64 %62, %69 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }
 --------------------------------------------------
  Module alias_type2.posrec
@@ -399,108 +399,108 @@ if.else:
 
 = > public {inline} (1 calls)
 0: alias_type2.posrec.=<0>
-=($left##0:alias_type2.posrec, $right##0:alias_type2.posrec, ?$$##0:wybe.bool):
+=(#left##0:alias_type2.posrec, #right##0:alias_type2.posrec, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$p##0:alias_type2.position)
-    foreign lpvm access(~$left##0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$a##0:wybe.int)
-    foreign lpvm access($right##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$p##0:alias_type2.position)
-    foreign lpvm access(~$right##0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$a##0:wybe.int)
-    foreign lpvm access($left$p##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.int)
-    foreign lpvm access(~$left$p##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
-    foreign lpvm access($right$p##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.int)
-    foreign lpvm access(~$right$p##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$7##0:wybe.int, ~tmp$9##0:wybe.int, ?tmp$11##0:wybe.bool) @int:nn:nn
-    case ~tmp$11##0:wybe.bool of
+    foreign lpvm access(#left##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#p##0:alias_type2.position)
+    foreign lpvm access(~#left##0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#a##0:wybe.int)
+    foreign lpvm access(#right##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#p##0:alias_type2.position)
+    foreign lpvm access(~#right##0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#a##0:wybe.int)
+    foreign lpvm access(#left#p##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int)
+    foreign lpvm access(~#left#p##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
+    foreign lpvm access(#right#p##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
+    foreign lpvm access(~#right#p##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#7##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#11##0:wybe.bool) @int:nn:nn
+    case ~tmp#11##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$10##0:wybe.int, ~tmp$8##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm icmp_eq(~tmp#10##0:wybe.int, ~tmp#8##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~$left$a##0:wybe.int, ~$right$a##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+            foreign llvm icmp_eq(~#left#a##0:wybe.int, ~#right#a##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 
 a > public {inline} (0 calls)
 0: alias_type2.posrec.a<0>
-a($rec##0:alias_type2.posrec, ?$##0:wybe.int):
+a(#rec##0:alias_type2.posrec, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 a > public {inline} (0 calls)
 1: alias_type2.posrec.a<1>
-a($rec##0:alias_type2.posrec, ?$rec##1:alias_type2.posrec, $field##0:wybe.int):
+a(#rec##0:alias_type2.posrec, ?#rec##1:alias_type2.posrec, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec##0:alias_type2.posrec, ?$rec##1:alias_type2.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm mutate(~#rec##0:alias_type2.posrec, ?#rec##1:alias_type2.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 p > public {inline} (0 calls)
 0: alias_type2.posrec.p<0>
-p($rec##0:alias_type2.posrec, ?$##0:alias_type2.position):
+p(#rec##0:alias_type2.posrec, ?###0:alias_type2.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:alias_type2.position)
+    foreign lpvm access(~#rec##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:alias_type2.position)
 p > public {inline} (0 calls)
 1: alias_type2.posrec.p<1>
-p($rec##0:alias_type2.posrec, ?$rec##1:alias_type2.posrec, $field##0:alias_type2.position):
+p(#rec##0:alias_type2.posrec, ?#rec##1:alias_type2.posrec, #field##0:alias_type2.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:alias_type2.posrec, ?$rec##1:alias_type2.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:alias_type2.position)
+    foreign lpvm {noalias} mutate(~#rec##0:alias_type2.posrec, ?#rec##1:alias_type2.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:alias_type2.position)
 
 
 posrec > public {inline} (0 calls)
 0: alias_type2.posrec.posrec<0>
-posrec(p##0:alias_type2.position, a##0:wybe.int, ?$##0:alias_type2.posrec):
+posrec(p##0:alias_type2.position, a##0:wybe.int, ?###0:alias_type2.posrec):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:alias_type2.posrec)
-    foreign lpvm mutate(~$rec##0:alias_type2.posrec, ?$rec##1:alias_type2.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p##0:alias_type2.position)
-    foreign lpvm mutate(~$rec##1:alias_type2.posrec, ?$##0:alias_type2.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type2.posrec)
+    foreign lpvm mutate(~#rec##0:alias_type2.posrec, ?#rec##1:alias_type2.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p##0:alias_type2.position)
+    foreign lpvm mutate(~#rec##1:alias_type2.posrec, ?###0:alias_type2.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a##0:wybe.int)
 posrec > public {inline} (6 calls)
 1: alias_type2.posrec.posrec<1>
-posrec(?p##0:alias_type2.position, ?a##0:wybe.int, $##0:alias_type2.posrec):
+posrec(?p##0:alias_type2.position, ?a##0:wybe.int, ###0:alias_type2.posrec):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?p##0:alias_type2.position)
-    foreign lpvm access(~$##0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?a##0:wybe.int)
+    foreign lpvm access(###0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?p##0:alias_type2.position)
+    foreign lpvm access(~###0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?a##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: alias_type2.posrec.~=<0>
-~=($left##0:alias_type2.posrec, $right##0:alias_type2.posrec, ?$$##0:wybe.bool):
+~=(#left##0:alias_type2.posrec, #right##0:alias_type2.posrec, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:alias_type2.position)
-    foreign lpvm access(~$left##0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:alias_type2.position)
-    foreign lpvm access(~$right##0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign lpvm access(tmp$3##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.int)
-    foreign lpvm access(~tmp$3##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
-    foreign lpvm access(tmp$5##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.int)
-    foreign lpvm access(~tmp$5##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$7##0:wybe.int, ~tmp$9##0:wybe.int, ?tmp$11##0:wybe.bool) @int:nn:nn
-    case ~tmp$11##0:wybe.bool of
+    foreign lpvm access(#left##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:alias_type2.position)
+    foreign lpvm access(~#left##0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:alias_type2.position)
+    foreign lpvm access(~#right##0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(tmp#3##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int)
+    foreign lpvm access(~tmp#3##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
+    foreign lpvm access(tmp#5##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
+    foreign lpvm access(~tmp#5##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#7##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#11##0:wybe.bool) @int:nn:nn
+    case ~tmp#11##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$10##0:wybe.int, ~tmp$8##0:wybe.int, ?tmp$12##0:wybe.bool) @int:nn:nn
-        case ~tmp$12##0:wybe.bool of
+        foreign llvm icmp_eq(~tmp#10##0:wybe.int, ~tmp#8##0:wybe.int, ?tmp#12##0:wybe.bool) @int:nn:nn
+        case ~tmp#12##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
 
@@ -518,19 +518,19 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"alias_type2.posrec.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"alias_type2.posrec.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
@@ -548,24 +548,24 @@ entry:
   %26 = inttoptr i64 %25 to i64* 
   %27 = getelementptr  i64, i64* %26, i64 0 
   %28 = load  i64, i64* %27 
-  %"1$tmp$11##0" = icmp eq i64 %17, %24 
-  br i1 %"1$tmp$11##0", label %if.then, label %if.else 
+  %"1#tmp#11##0" = icmp eq i64 %17, %24 
+  br i1 %"1#tmp#11##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$1##0" = icmp eq i64 %28, %21 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#1##0" = icmp eq i64 %28, %21 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %"4$$$##0" = icmp eq i64 %7, %14 
-  ret i1 %"4$$$##0" 
+  %"4#####0" = icmp eq i64 %7, %14 
+  ret i1 %"4#####0" 
 if.else1:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"alias_type2.posrec.a<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"alias_type2.posrec.a<0>"(i64  %"#rec##0")    {
 entry:
-  %29 = add   i64 %"$rec##0", 8 
+  %29 = add   i64 %"#rec##0", 8 
   %30 = inttoptr i64 %29 to i64* 
   %31 = getelementptr  i64, i64* %30, i64 0 
   %32 = load  i64, i64* %31 
@@ -573,44 +573,44 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type2.posrec.a<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"alias_type2.posrec.a<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %33 = trunc i64 16 to i32  
   %34 = tail call ccc  i8*  @wybe_malloc(i32  %33)  
   %35 = ptrtoint i8* %34 to i64 
   %36 = inttoptr i64 %35 to i8* 
-  %37 = inttoptr i64 %"$rec##0" to i8* 
+  %37 = inttoptr i64 %"#rec##0" to i8* 
   %38 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %36, i8*  %37, i32  %38, i32  8, i1  0)  
   %39 = add   i64 %35, 8 
   %40 = inttoptr i64 %39 to i64* 
   %41 = getelementptr  i64, i64* %40, i64 0 
-  store  i64 %"$field##0", i64* %41 
+  store  i64 %"#field##0", i64* %41 
   ret i64 %35 
 }
 
 
-define external fastcc  i64 @"alias_type2.posrec.p<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"alias_type2.posrec.p<0>"(i64  %"#rec##0")    {
 entry:
-  %42 = inttoptr i64 %"$rec##0" to i64* 
+  %42 = inttoptr i64 %"#rec##0" to i64* 
   %43 = getelementptr  i64, i64* %42, i64 0 
   %44 = load  i64, i64* %43 
   ret i64 %44 
 }
 
 
-define external fastcc  i64 @"alias_type2.posrec.p<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"alias_type2.posrec.p<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %45 = trunc i64 16 to i32  
   %46 = tail call ccc  i8*  @wybe_malloc(i32  %45)  
   %47 = ptrtoint i8* %46 to i64 
   %48 = inttoptr i64 %47 to i8* 
-  %49 = inttoptr i64 %"$rec##0" to i8* 
+  %49 = inttoptr i64 %"#rec##0" to i8* 
   %50 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %48, i8*  %49, i32  %50, i32  8, i1  0)  
   %51 = inttoptr i64 %47 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
-  store  i64 %"$field##0", i64* %52 
+  store  i64 %"#field##0", i64* %52 
   ret i64 %47 
 }
 
@@ -631,12 +631,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"alias_type2.posrec.posrec<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"alias_type2.posrec.posrec<1>"(i64  %"###0")    {
 entry:
-  %61 = inttoptr i64 %"$##0" to i64* 
+  %61 = inttoptr i64 %"###0" to i64* 
   %62 = getelementptr  i64, i64* %61, i64 0 
   %63 = load  i64, i64* %62 
-  %64 = add   i64 %"$##0", 8 
+  %64 = add   i64 %"###0", 8 
   %65 = inttoptr i64 %64 to i64* 
   %66 = getelementptr  i64, i64* %65, i64 0 
   %67 = load  i64, i64* %66 
@@ -646,19 +646,19 @@ entry:
 }
 
 
-define external fastcc  i1 @"alias_type2.posrec.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"alias_type2.posrec.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %70 = inttoptr i64 %"$left##0" to i64* 
+  %70 = inttoptr i64 %"#left##0" to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
   %72 = load  i64, i64* %71 
-  %73 = add   i64 %"$left##0", 8 
+  %73 = add   i64 %"#left##0", 8 
   %74 = inttoptr i64 %73 to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
   %76 = load  i64, i64* %75 
-  %77 = inttoptr i64 %"$right##0" to i64* 
+  %77 = inttoptr i64 %"#right##0" to i64* 
   %78 = getelementptr  i64, i64* %77, i64 0 
   %79 = load  i64, i64* %78 
-  %80 = add   i64 %"$right##0", 8 
+  %80 = add   i64 %"#right##0", 8 
   %81 = inttoptr i64 %80 to i64* 
   %82 = getelementptr  i64, i64* %81, i64 0 
   %83 = load  i64, i64* %82 
@@ -676,19 +676,19 @@ entry:
   %95 = inttoptr i64 %94 to i64* 
   %96 = getelementptr  i64, i64* %95, i64 0 
   %97 = load  i64, i64* %96 
-  %"1$tmp$11##0" = icmp eq i64 %86, %93 
-  br i1 %"1$tmp$11##0", label %if.then, label %if.else 
+  %"1#tmp#11##0" = icmp eq i64 %86, %93 
+  br i1 %"1#tmp#11##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$12##0" = icmp eq i64 %97, %90 
-  br i1 %"2$tmp$12##0", label %if.then1, label %if.else1 
+  %"2#tmp#12##0" = icmp eq i64 %97, %90 
+  br i1 %"2#tmp#12##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 if.then1:
-  %"4$tmp$0##0" = icmp eq i64 %76, %83 
-  %"4$$$##0" = xor i1 %"4$tmp$0##0", 1 
-  ret i1 %"4$$$##0" 
+  %"4#tmp#0##0" = icmp eq i64 %76, %83 
+  %"4#####0" = xor i1 %"4#tmp#0##0", 1 
+  ret i1 %"4#####0" 
 if.else1:
-  %"5$$$##0" = xor i1 0, 1 
-  ret i1 %"5$$$##0" 
+  %"5#####0" = xor i1 0, 1 
+  ret i1 %"5#####0" 
 }

--- a/test-cases/final-dump/alias_type2.exp
+++ b/test-cases/final-dump/alias_type2.exp
@@ -148,7 +148,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: alias_type2.position.=<0>
-=(#left##0:alias_type2.position, #right##0:alias_type2.position, ?####0:wybe.bool):
+=(#left##0:alias_type2.position, #right##0:alias_type2.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
@@ -158,10 +158,10 @@ entry:
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -212,7 +212,7 @@ y(#rec##0:alias_type2.position, ?#rec##1:alias_type2.position, #field##0:wybe.in
 
 ~= > public {inline} (0 calls)
 0: alias_type2.position.~=<0>
-~=(#left##0:alias_type2.position, #right##0:alias_type2.position, ?####0:wybe.bool):
+~=(#left##0:alias_type2.position, #right##0:alias_type2.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -223,11 +223,11 @@ y(#rec##0:alias_type2.position, ?#rec##1:alias_type2.position, #field##0:wybe.in
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -263,8 +263,8 @@ entry:
   %"1#tmp#1##0" = icmp eq i64 %3, %10 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2#####0" = icmp eq i64 %7, %14 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %7, %14 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -373,11 +373,11 @@ entry:
   br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#0##0" = icmp eq i64 %62, %69 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }
 --------------------------------------------------
  Module alias_type2.posrec
@@ -399,7 +399,7 @@ if.else:
 
 = > public {inline} (1 calls)
 0: alias_type2.posrec.=<0>
-=(#left##0:alias_type2.posrec, #right##0:alias_type2.posrec, ?####0:wybe.bool):
+=(#left##0:alias_type2.posrec, #right##0:alias_type2.posrec, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#p##0:alias_type2.position)
@@ -413,16 +413,16 @@ if.else:
     foreign llvm icmp_eq(~tmp#7##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#11##0:wybe.bool) @int:nn:nn
     case ~tmp#11##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#10##0:wybe.int, ~tmp#8##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~#left#a##0:wybe.int, ~#right#a##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+            foreign llvm icmp_eq(~#left#a##0:wybe.int, ~#right#a##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -474,7 +474,7 @@ posrec(?p##0:alias_type2.position, ?a##0:wybe.int, #result##0:alias_type2.posrec
 
 ~= > public {inline} (0 calls)
 0: alias_type2.posrec.~=<0>
-~=(#left##0:alias_type2.posrec, #right##0:alias_type2.posrec, ?####0:wybe.bool):
+~=(#left##0:alias_type2.posrec, #right##0:alias_type2.posrec, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:alias_type2.position)
@@ -489,18 +489,18 @@ posrec(?p##0:alias_type2.position, ?a##0:wybe.int, #result##0:alias_type2.posrec
     case ~tmp#11##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#10##0:wybe.int, ~tmp#8##0:wybe.int, ?tmp#12##0:wybe.bool) @int:nn:nn
         case ~tmp#12##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -556,8 +556,8 @@ if.then:
 if.else:
   ret i1 0 
 if.then1:
-  %"4#####0" = icmp eq i64 %7, %14 
-  ret i1 %"4#####0" 
+  %"4##success##0" = icmp eq i64 %7, %14 
+  ret i1 %"4##success##0" 
 if.else1:
   ret i1 0 
 }
@@ -682,13 +682,13 @@ if.then:
   %"2#tmp#12##0" = icmp eq i64 %97, %90 
   br i1 %"2#tmp#12##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 if.then1:
   %"4#tmp#0##0" = icmp eq i64 %76, %83 
-  %"4#####0" = xor i1 %"4#tmp#0##0", 1 
-  ret i1 %"4#####0" 
+  %"4##success##0" = xor i1 %"4#tmp#0##0", 1 
+  ret i1 %"4##success##0" 
 if.else1:
-  %"5#####0" = xor i1 0, 1 
-  ret i1 %"5#####0" 
+  %"5##success##0" = xor i1 0, 1 
+  ret i1 %"5##success##0" 
 }

--- a/test-cases/final-dump/alias_type2.exp
+++ b/test-cases/final-dump/alias_type2.exp
@@ -167,27 +167,27 @@ entry:
 
 position > public {inline} (0 calls)
 0: alias_type2.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?###0:alias_type2.position):
+position(x##0:wybe.int, y##0:wybe.int, ?#result##0:alias_type2.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type2.position)
     foreign lpvm mutate(~#rec##0:alias_type2.position, ?#rec##1:alias_type2.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:alias_type2.position, ?###0:alias_type2.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:alias_type2.position, ?#result##0:alias_type2.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: alias_type2.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, ###0:alias_type2.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:alias_type2.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~###0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~#result##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: alias_type2.position.x<0>
-x(#rec##0:alias_type2.position, ?###0:wybe.int):
+x(#rec##0:alias_type2.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 x > public {inline} (0 calls)
 1: alias_type2.position.x<1>
 x(#rec##0:alias_type2.position, ?#rec##1:alias_type2.position, #field##0:wybe.int):
@@ -198,10 +198,10 @@ x(#rec##0:alias_type2.position, ?#rec##1:alias_type2.position, #field##0:wybe.in
 
 y > public {inline} (0 calls)
 0: alias_type2.position.y<0>
-y(#rec##0:alias_type2.position, ?###0:wybe.int):
+y(#rec##0:alias_type2.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 y > public {inline} (0 calls)
 1: alias_type2.position.y<1>
 y(#rec##0:alias_type2.position, ?#rec##1:alias_type2.position, #field##0:wybe.int):
@@ -286,12 +286,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"alias_type2.position.position<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"alias_type2.position.position<1>"(i64  %"#result##0")    {
 entry:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -429,10 +429,10 @@ if.else:
 
 a > public {inline} (0 calls)
 0: alias_type2.posrec.a<0>
-a(#rec##0:alias_type2.posrec, ?###0:wybe.int):
+a(#rec##0:alias_type2.posrec, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 a > public {inline} (0 calls)
 1: alias_type2.posrec.a<1>
 a(#rec##0:alias_type2.posrec, ?#rec##1:alias_type2.posrec, #field##0:wybe.int):
@@ -443,10 +443,10 @@ a(#rec##0:alias_type2.posrec, ?#rec##1:alias_type2.posrec, #field##0:wybe.int):
 
 p > public {inline} (0 calls)
 0: alias_type2.posrec.p<0>
-p(#rec##0:alias_type2.posrec, ?###0:alias_type2.position):
+p(#rec##0:alias_type2.posrec, ?#result##0:alias_type2.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:alias_type2.position)
+    foreign lpvm access(~#rec##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:alias_type2.position)
 p > public {inline} (0 calls)
 1: alias_type2.posrec.p<1>
 p(#rec##0:alias_type2.posrec, ?#rec##1:alias_type2.posrec, #field##0:alias_type2.position):
@@ -457,19 +457,19 @@ p(#rec##0:alias_type2.posrec, ?#rec##1:alias_type2.posrec, #field##0:alias_type2
 
 posrec > public {inline} (0 calls)
 0: alias_type2.posrec.posrec<0>
-posrec(p##0:alias_type2.position, a##0:wybe.int, ?###0:alias_type2.posrec):
+posrec(p##0:alias_type2.position, a##0:wybe.int, ?#result##0:alias_type2.posrec):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type2.posrec)
     foreign lpvm mutate(~#rec##0:alias_type2.posrec, ?#rec##1:alias_type2.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p##0:alias_type2.position)
-    foreign lpvm mutate(~#rec##1:alias_type2.posrec, ?###0:alias_type2.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:alias_type2.posrec, ?#result##0:alias_type2.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a##0:wybe.int)
 posrec > public {inline} (6 calls)
 1: alias_type2.posrec.posrec<1>
-posrec(?p##0:alias_type2.position, ?a##0:wybe.int, ###0:alias_type2.posrec):
+posrec(?p##0:alias_type2.position, ?a##0:wybe.int, #result##0:alias_type2.posrec):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?p##0:alias_type2.position)
-    foreign lpvm access(~###0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?a##0:wybe.int)
+    foreign lpvm access(#result##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?p##0:alias_type2.position)
+    foreign lpvm access(~#result##0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?a##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
@@ -631,12 +631,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"alias_type2.posrec.posrec<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"alias_type2.posrec.posrec<1>"(i64  %"#result##0")    {
 entry:
-  %61 = inttoptr i64 %"###0" to i64* 
+  %61 = inttoptr i64 %"#result##0" to i64* 
   %62 = getelementptr  i64, i64* %61, i64 0 
   %63 = load  i64, i64* %62 
-  %64 = add   i64 %"###0", 8 
+  %64 = add   i64 %"#result##0", 8 
   %65 = inttoptr i64 %64 to i64* 
   %66 = getelementptr  i64, i64* %65, i64 0 
   %67 = load  i64, i64* %66 

--- a/test-cases/final-dump/alias_type2.exp
+++ b/test-cases/final-dump/alias_type2.exp
@@ -31,24 +31,24 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: alias_type2.<0>
-(io#0:wybe.phantom, ?io#2:wybe.phantom):
+(io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$7#0:alias_type2.position)
-    foreign lpvm mutate(~tmp$7#0:alias_type2.position, ?tmp$8#0:alias_type2.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm mutate(~tmp$8#0:alias_type2.position, ?tmp$9#0:alias_type2.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$12#0:alias_type2.posrec)
-    foreign lpvm mutate(~tmp$12#0:alias_type2.posrec, ?tmp$13#0:alias_type2.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$9#0:alias_type2.position)
-    foreign lpvm mutate(~tmp$13#0:alias_type2.posrec, ?tmp$14#0:alias_type2.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp$14#0:alias_type2.posrec, ?%rec#1:alias_type2.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm {noalias} mutate(~tmp$9#0:alias_type2.position, ?%pos#1:alias_type2.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
-    foreign lpvm access(~pos#1:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$2#0:wybe.int)
-    foreign c print_int(~tmp$2#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$22#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$22#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~rec#1:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:alias_type2.position)
-    foreign lpvm access(~tmp$3#0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign c print_int(~tmp$4#0:wybe.int, ~#io#1:wybe.phantom, ?tmp$27#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$27#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$7##0:alias_type2.position)
+    foreign lpvm mutate(~tmp$7##0:alias_type2.position, ?tmp$8##0:alias_type2.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
+    foreign lpvm mutate(~tmp$8##0:alias_type2.position, ?tmp$9##0:alias_type2.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp$12##0:alias_type2.posrec)
+    foreign lpvm mutate(~tmp$12##0:alias_type2.posrec, ?tmp$13##0:alias_type2.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$9##0:alias_type2.position)
+    foreign lpvm mutate(~tmp$13##0:alias_type2.posrec, ?tmp$14##0:alias_type2.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp$14##0:alias_type2.posrec, ?%rec##1:alias_type2.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+    foreign lpvm {noalias} mutate(~tmp$9##0:alias_type2.position, ?%pos##1:alias_type2.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
+    foreign lpvm access(~pos##1:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.int)
+    foreign c print_int(~tmp$2##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$22##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$22##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~rec##1:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:alias_type2.position)
+    foreign lpvm access(~tmp$3##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign c print_int(~tmp$4##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$27##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$27##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -148,86 +148,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: alias_type2.position.=<0>
-=($left#0:alias_type2.position, $right#0:alias_type2.position, ?$$#0:wybe.bool):
+=($left##0:alias_type2.position, $right##0:alias_type2.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
-    foreign lpvm access(~$left#0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y#0:wybe.int)
-    foreign lpvm access($right#0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x#0:wybe.int)
-    foreign lpvm access(~$right#0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y#0:wybe.int)
-    foreign llvm icmp_eq(~$left$x#0:wybe.int, ~$right$x#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
+    foreign lpvm access(~$left##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
+    foreign lpvm access($right##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
+    foreign lpvm access(~$right##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
+    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y#0:wybe.int, ~$right$y#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: alias_type2.position.position<0>
-position(x#0:wybe.int, y#0:wybe.int, ?$#0:alias_type2.position):
+position(x##0:wybe.int, y##0:wybe.int, ?$##0:alias_type2.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:alias_type2.position)
-    foreign lpvm mutate(~$rec#0:alias_type2.position, ?$rec#1:alias_type2.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:alias_type2.position, ?$#0:alias_type2.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:alias_type2.position)
+    foreign lpvm mutate(~$rec##0:alias_type2.position, ?$rec##1:alias_type2.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:alias_type2.position, ?$##0:alias_type2.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: alias_type2.position.position<1>
-position(?x#0:wybe.int, ?y#0:wybe.int, $#0:alias_type2.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, $##0:alias_type2.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
-    foreign lpvm access(~$#0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y#0:wybe.int)
+    foreign lpvm access($##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~$##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: alias_type2.position.x<0>
-x($rec#0:alias_type2.position, ?$#0:wybe.int):
+x($rec##0:alias_type2.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 x > public {inline} (0 calls)
 1: alias_type2.position.x<1>
-x($rec#0:alias_type2.position, ?$rec#1:alias_type2.position, $field#0:wybe.int):
+x($rec##0:alias_type2.position, ?$rec##1:alias_type2.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:alias_type2.position, ?$rec#1:alias_type2.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:alias_type2.position, ?$rec##1:alias_type2.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: alias_type2.position.y<0>
-y($rec#0:alias_type2.position, ?$#0:wybe.int):
+y($rec##0:alias_type2.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 y > public {inline} (0 calls)
 1: alias_type2.position.y<1>
-y($rec#0:alias_type2.position, ?$rec#1:alias_type2.position, $field#0:wybe.int):
+y($rec##0:alias_type2.position, ?$rec##1:alias_type2.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:alias_type2.position, ?$rec#1:alias_type2.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:alias_type2.position, ?$rec##1:alias_type2.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: alias_type2.position.~=<0>
-~=($left#0:alias_type2.position, $right#0:alias_type2.position, ?$$#0:wybe.bool):
+~=($left##0:alias_type2.position, $right##0:alias_type2.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -244,54 +244,54 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"alias_type2.position.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"alias_type2.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$#0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = icmp eq i64 %7, %14 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"alias_type2.position.position<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"alias_type2.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"x#0", i64* %19 
+  store  i64 %"x##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"y#0", i64* %22 
+  store  i64 %"y##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64} @"alias_type2.position.position<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"alias_type2.position.position<1>"(i64  %"$##0")    {
 entry:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -301,34 +301,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type2.position.x<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"alias_type2.position.x<0>"(i64  %"$rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec#0" to i64* 
+  %32 = inttoptr i64 %"$rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"alias_type2.position.x<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"alias_type2.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec#0" to i8* 
+  %39 = inttoptr i64 %"$rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field#0", i64* %42 
+  store  i64 %"$field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"alias_type2.position.y<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"alias_type2.position.y<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = add   i64 %"$rec#0", 8 
+  %43 = add   i64 %"$rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -336,48 +336,48 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type2.position.y<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"alias_type2.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec#0" to i8* 
+  %51 = inttoptr i64 %"$rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field#0", i64* %55 
+  store  i64 %"$field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"alias_type2.position.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"alias_type2.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %58, %65 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = icmp eq i64 %62, %69 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$0##0" = icmp eq i64 %62, %69 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }
 --------------------------------------------------
  Module alias_type2.posrec
@@ -399,108 +399,108 @@ if.else:
 
 = > public {inline} (1 calls)
 0: alias_type2.posrec.=<0>
-=($left#0:alias_type2.posrec, $right#0:alias_type2.posrec, ?$$#0:wybe.bool):
+=($left##0:alias_type2.posrec, $right##0:alias_type2.posrec, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$p#0:alias_type2.position)
-    foreign lpvm access(~$left#0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$a#0:wybe.int)
-    foreign lpvm access($right#0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$p#0:alias_type2.position)
-    foreign lpvm access(~$right#0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$a#0:wybe.int)
-    foreign lpvm access($left$p#0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$7#0:wybe.int)
-    foreign lpvm access(~$left$p#0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.int)
-    foreign lpvm access($right$p#0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.int)
-    foreign lpvm access(~$right$p#0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$7#0:wybe.int, ~tmp$9#0:wybe.int, ?tmp$11#0:wybe.bool) @int:nn:nn
-    case ~tmp$11#0:wybe.bool of
+    foreign lpvm access($left##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$p##0:alias_type2.position)
+    foreign lpvm access(~$left##0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$a##0:wybe.int)
+    foreign lpvm access($right##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$p##0:alias_type2.position)
+    foreign lpvm access(~$right##0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$a##0:wybe.int)
+    foreign lpvm access($left$p##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.int)
+    foreign lpvm access(~$left$p##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
+    foreign lpvm access($right$p##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.int)
+    foreign lpvm access(~$right$p##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$7##0:wybe.int, ~tmp$9##0:wybe.int, ?tmp$11##0:wybe.bool) @int:nn:nn
+    case ~tmp$11##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$10#0:wybe.int, ~tmp$8#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm icmp_eq(~tmp$10##0:wybe.int, ~tmp$8##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~$left$a#0:wybe.int, ~$right$a#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+            foreign llvm icmp_eq(~$left$a##0:wybe.int, ~$right$a##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 
 a > public {inline} (0 calls)
 0: alias_type2.posrec.a<0>
-a($rec#0:alias_type2.posrec, ?$#0:wybe.int):
+a($rec##0:alias_type2.posrec, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 a > public {inline} (0 calls)
 1: alias_type2.posrec.a<1>
-a($rec#0:alias_type2.posrec, ?$rec#1:alias_type2.posrec, $field#0:wybe.int):
+a($rec##0:alias_type2.posrec, ?$rec##1:alias_type2.posrec, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec#0:alias_type2.posrec, ?$rec#1:alias_type2.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm mutate(~$rec##0:alias_type2.posrec, ?$rec##1:alias_type2.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 p > public {inline} (0 calls)
 0: alias_type2.posrec.p<0>
-p($rec#0:alias_type2.posrec, ?$#0:alias_type2.position):
+p($rec##0:alias_type2.posrec, ?$##0:alias_type2.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:alias_type2.position)
+    foreign lpvm access(~$rec##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:alias_type2.position)
 p > public {inline} (0 calls)
 1: alias_type2.posrec.p<1>
-p($rec#0:alias_type2.posrec, ?$rec#1:alias_type2.posrec, $field#0:alias_type2.position):
+p($rec##0:alias_type2.posrec, ?$rec##1:alias_type2.posrec, $field##0:alias_type2.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:alias_type2.posrec, ?$rec#1:alias_type2.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:alias_type2.position)
+    foreign lpvm {noalias} mutate(~$rec##0:alias_type2.posrec, ?$rec##1:alias_type2.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:alias_type2.position)
 
 
 posrec > public {inline} (0 calls)
 0: alias_type2.posrec.posrec<0>
-posrec(p#0:alias_type2.position, a#0:wybe.int, ?$#0:alias_type2.posrec):
+posrec(p##0:alias_type2.position, a##0:wybe.int, ?$##0:alias_type2.posrec):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:alias_type2.posrec)
-    foreign lpvm mutate(~$rec#0:alias_type2.posrec, ?$rec#1:alias_type2.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p#0:alias_type2.position)
-    foreign lpvm mutate(~$rec#1:alias_type2.posrec, ?$#0:alias_type2.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:alias_type2.posrec)
+    foreign lpvm mutate(~$rec##0:alias_type2.posrec, ?$rec##1:alias_type2.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p##0:alias_type2.position)
+    foreign lpvm mutate(~$rec##1:alias_type2.posrec, ?$##0:alias_type2.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a##0:wybe.int)
 posrec > public {inline} (6 calls)
 1: alias_type2.posrec.posrec<1>
-posrec(?p#0:alias_type2.position, ?a#0:wybe.int, $#0:alias_type2.posrec):
+posrec(?p##0:alias_type2.position, ?a##0:wybe.int, $##0:alias_type2.posrec):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?p#0:alias_type2.position)
-    foreign lpvm access(~$#0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?a#0:wybe.int)
+    foreign lpvm access($##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?p##0:alias_type2.position)
+    foreign lpvm access(~$##0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?a##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: alias_type2.posrec.~=<0>
-~=($left#0:alias_type2.posrec, $right#0:alias_type2.posrec, ?$$#0:wybe.bool):
+~=($left##0:alias_type2.posrec, $right##0:alias_type2.posrec, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:alias_type2.position)
-    foreign lpvm access(~$left#0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:alias_type2.position)
-    foreign lpvm access(~$right#0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign lpvm access(tmp$3#0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$7#0:wybe.int)
-    foreign lpvm access(~tmp$3#0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.int)
-    foreign lpvm access(tmp$5#0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.int)
-    foreign lpvm access(~tmp$5#0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$7#0:wybe.int, ~tmp$9#0:wybe.int, ?tmp$11#0:wybe.bool) @int:nn:nn
-    case ~tmp$11#0:wybe.bool of
+    foreign lpvm access($left##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:alias_type2.position)
+    foreign lpvm access(~$left##0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:alias_type2.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:alias_type2.position)
+    foreign lpvm access(~$right##0:alias_type2.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign lpvm access(tmp$3##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.int)
+    foreign lpvm access(~tmp$3##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
+    foreign lpvm access(tmp$5##0:alias_type2.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.int)
+    foreign lpvm access(~tmp$5##0:alias_type2.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$7##0:wybe.int, ~tmp$9##0:wybe.int, ?tmp$11##0:wybe.bool) @int:nn:nn
+    case ~tmp$11##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$10#0:wybe.int, ~tmp$8#0:wybe.int, ?tmp$12#0:wybe.bool) @int:nn:nn
-        case ~tmp$12#0:wybe.bool of
+        foreign llvm icmp_eq(~tmp$10##0:wybe.int, ~tmp$8##0:wybe.int, ?tmp$12##0:wybe.bool) @int:nn:nn
+        case ~tmp$12##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-            foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-            foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
@@ -518,19 +518,19 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"alias_type2.posrec.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"alias_type2.posrec.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
@@ -548,24 +548,24 @@ entry:
   %26 = inttoptr i64 %25 to i64* 
   %27 = getelementptr  i64, i64* %26, i64 0 
   %28 = load  i64, i64* %27 
-  %"1$tmp$11#0" = icmp eq i64 %17, %24 
-  br i1 %"1$tmp$11#0", label %if.then, label %if.else 
+  %"1$tmp$11##0" = icmp eq i64 %17, %24 
+  br i1 %"1$tmp$11##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$1#0" = icmp eq i64 %28, %21 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$1##0" = icmp eq i64 %28, %21 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %"4$$$#0" = icmp eq i64 %7, %14 
-  ret i1 %"4$$$#0" 
+  %"4$$$##0" = icmp eq i64 %7, %14 
+  ret i1 %"4$$$##0" 
 if.else1:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"alias_type2.posrec.a<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"alias_type2.posrec.a<0>"(i64  %"$rec##0")    {
 entry:
-  %29 = add   i64 %"$rec#0", 8 
+  %29 = add   i64 %"$rec##0", 8 
   %30 = inttoptr i64 %29 to i64* 
   %31 = getelementptr  i64, i64* %30, i64 0 
   %32 = load  i64, i64* %31 
@@ -573,70 +573,70 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type2.posrec.a<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"alias_type2.posrec.a<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %33 = trunc i64 16 to i32  
   %34 = tail call ccc  i8*  @wybe_malloc(i32  %33)  
   %35 = ptrtoint i8* %34 to i64 
   %36 = inttoptr i64 %35 to i8* 
-  %37 = inttoptr i64 %"$rec#0" to i8* 
+  %37 = inttoptr i64 %"$rec##0" to i8* 
   %38 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %36, i8*  %37, i32  %38, i32  8, i1  0)  
   %39 = add   i64 %35, 8 
   %40 = inttoptr i64 %39 to i64* 
   %41 = getelementptr  i64, i64* %40, i64 0 
-  store  i64 %"$field#0", i64* %41 
+  store  i64 %"$field##0", i64* %41 
   ret i64 %35 
 }
 
 
-define external fastcc  i64 @"alias_type2.posrec.p<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"alias_type2.posrec.p<0>"(i64  %"$rec##0")    {
 entry:
-  %42 = inttoptr i64 %"$rec#0" to i64* 
+  %42 = inttoptr i64 %"$rec##0" to i64* 
   %43 = getelementptr  i64, i64* %42, i64 0 
   %44 = load  i64, i64* %43 
   ret i64 %44 
 }
 
 
-define external fastcc  i64 @"alias_type2.posrec.p<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"alias_type2.posrec.p<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %45 = trunc i64 16 to i32  
   %46 = tail call ccc  i8*  @wybe_malloc(i32  %45)  
   %47 = ptrtoint i8* %46 to i64 
   %48 = inttoptr i64 %47 to i8* 
-  %49 = inttoptr i64 %"$rec#0" to i8* 
+  %49 = inttoptr i64 %"$rec##0" to i8* 
   %50 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %48, i8*  %49, i32  %50, i32  8, i1  0)  
   %51 = inttoptr i64 %47 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
-  store  i64 %"$field#0", i64* %52 
+  store  i64 %"$field##0", i64* %52 
   ret i64 %47 
 }
 
 
-define external fastcc  i64 @"alias_type2.posrec.posrec<0>"(i64  %"p#0", i64  %"a#0")    {
+define external fastcc  i64 @"alias_type2.posrec.posrec<0>"(i64  %"p##0", i64  %"a##0")    {
 entry:
   %53 = trunc i64 16 to i32  
   %54 = tail call ccc  i8*  @wybe_malloc(i32  %53)  
   %55 = ptrtoint i8* %54 to i64 
   %56 = inttoptr i64 %55 to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
-  store  i64 %"p#0", i64* %57 
+  store  i64 %"p##0", i64* %57 
   %58 = add   i64 %55, 8 
   %59 = inttoptr i64 %58 to i64* 
   %60 = getelementptr  i64, i64* %59, i64 0 
-  store  i64 %"a#0", i64* %60 
+  store  i64 %"a##0", i64* %60 
   ret i64 %55 
 }
 
 
-define external fastcc  {i64, i64} @"alias_type2.posrec.posrec<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"alias_type2.posrec.posrec<1>"(i64  %"$##0")    {
 entry:
-  %61 = inttoptr i64 %"$#0" to i64* 
+  %61 = inttoptr i64 %"$##0" to i64* 
   %62 = getelementptr  i64, i64* %61, i64 0 
   %63 = load  i64, i64* %62 
-  %64 = add   i64 %"$#0", 8 
+  %64 = add   i64 %"$##0", 8 
   %65 = inttoptr i64 %64 to i64* 
   %66 = getelementptr  i64, i64* %65, i64 0 
   %67 = load  i64, i64* %66 
@@ -646,19 +646,19 @@ entry:
 }
 
 
-define external fastcc  i1 @"alias_type2.posrec.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"alias_type2.posrec.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %70 = inttoptr i64 %"$left#0" to i64* 
+  %70 = inttoptr i64 %"$left##0" to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
   %72 = load  i64, i64* %71 
-  %73 = add   i64 %"$left#0", 8 
+  %73 = add   i64 %"$left##0", 8 
   %74 = inttoptr i64 %73 to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
   %76 = load  i64, i64* %75 
-  %77 = inttoptr i64 %"$right#0" to i64* 
+  %77 = inttoptr i64 %"$right##0" to i64* 
   %78 = getelementptr  i64, i64* %77, i64 0 
   %79 = load  i64, i64* %78 
-  %80 = add   i64 %"$right#0", 8 
+  %80 = add   i64 %"$right##0", 8 
   %81 = inttoptr i64 %80 to i64* 
   %82 = getelementptr  i64, i64* %81, i64 0 
   %83 = load  i64, i64* %82 
@@ -676,19 +676,19 @@ entry:
   %95 = inttoptr i64 %94 to i64* 
   %96 = getelementptr  i64, i64* %95, i64 0 
   %97 = load  i64, i64* %96 
-  %"1$tmp$11#0" = icmp eq i64 %86, %93 
-  br i1 %"1$tmp$11#0", label %if.then, label %if.else 
+  %"1$tmp$11##0" = icmp eq i64 %86, %93 
+  br i1 %"1$tmp$11##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$12#0" = icmp eq i64 %97, %90 
-  br i1 %"2$tmp$12#0", label %if.then1, label %if.else1 
+  %"2$tmp$12##0" = icmp eq i64 %97, %90 
+  br i1 %"2$tmp$12##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 if.then1:
-  %"4$tmp$0#0" = icmp eq i64 %76, %83 
-  %"4$$$#0" = xor i1 %"4$tmp$0#0", 1 
-  ret i1 %"4$$$#0" 
+  %"4$tmp$0##0" = icmp eq i64 %76, %83 
+  %"4$$$##0" = xor i1 %"4$tmp$0##0", 1 
+  ret i1 %"4$$$##0" 
 if.else1:
-  %"5$$$#0" = xor i1 0, 1 
-  ret i1 %"5$$$#0" 
+  %"5$$$##0" = xor i1 0, 1 
+  ret i1 %"5$$$##0" 
 }

--- a/test-cases/final-dump/alias_type3.exp
+++ b/test-cases/final-dump/alias_type3.exp
@@ -172,27 +172,27 @@ entry:
 
 position > public {inline} (0 calls)
 0: alias_type3.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?###0:alias_type3.position):
+position(x##0:wybe.int, y##0:wybe.int, ?#result##0:alias_type3.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type3.position)
     foreign lpvm mutate(~#rec##0:alias_type3.position, ?#rec##1:alias_type3.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:alias_type3.position, ?###0:alias_type3.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:alias_type3.position, ?#result##0:alias_type3.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: alias_type3.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, ###0:alias_type3.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:alias_type3.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~###0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~#result##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: alias_type3.position.x<0>
-x(#rec##0:alias_type3.position, ?###0:wybe.int):
+x(#rec##0:alias_type3.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 x > public {inline} (0 calls)
 1: alias_type3.position.x<1>
 x(#rec##0:alias_type3.position, ?#rec##1:alias_type3.position, #field##0:wybe.int):
@@ -203,10 +203,10 @@ x(#rec##0:alias_type3.position, ?#rec##1:alias_type3.position, #field##0:wybe.in
 
 y > public {inline} (0 calls)
 0: alias_type3.position.y<0>
-y(#rec##0:alias_type3.position, ?###0:wybe.int):
+y(#rec##0:alias_type3.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 y > public {inline} (0 calls)
 1: alias_type3.position.y<1>
 y(#rec##0:alias_type3.position, ?#rec##1:alias_type3.position, #field##0:wybe.int):
@@ -291,12 +291,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"alias_type3.position.position<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"alias_type3.position.position<1>"(i64  %"#result##0")    {
 entry:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -434,10 +434,10 @@ if.else:
 
 a > public {inline} (0 calls)
 0: alias_type3.posrec.a<0>
-a(#rec##0:alias_type3.posrec, ?###0:wybe.int):
+a(#rec##0:alias_type3.posrec, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 a > public {inline} (0 calls)
 1: alias_type3.posrec.a<1>
 a(#rec##0:alias_type3.posrec, ?#rec##1:alias_type3.posrec, #field##0:wybe.int):
@@ -448,10 +448,10 @@ a(#rec##0:alias_type3.posrec, ?#rec##1:alias_type3.posrec, #field##0:wybe.int):
 
 p > public {inline} (0 calls)
 0: alias_type3.posrec.p<0>
-p(#rec##0:alias_type3.posrec, ?###0:alias_type3.position):
+p(#rec##0:alias_type3.posrec, ?#result##0:alias_type3.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:alias_type3.position)
+    foreign lpvm access(~#rec##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:alias_type3.position)
 p > public {inline} (0 calls)
 1: alias_type3.posrec.p<1>
 p(#rec##0:alias_type3.posrec, ?#rec##1:alias_type3.posrec, #field##0:alias_type3.position):
@@ -462,19 +462,19 @@ p(#rec##0:alias_type3.posrec, ?#rec##1:alias_type3.posrec, #field##0:alias_type3
 
 posrec > public {inline} (0 calls)
 0: alias_type3.posrec.posrec<0>
-posrec(p##0:alias_type3.position, a##0:wybe.int, ?###0:alias_type3.posrec):
+posrec(p##0:alias_type3.position, a##0:wybe.int, ?#result##0:alias_type3.posrec):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type3.posrec)
     foreign lpvm mutate(~#rec##0:alias_type3.posrec, ?#rec##1:alias_type3.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p##0:alias_type3.position)
-    foreign lpvm mutate(~#rec##1:alias_type3.posrec, ?###0:alias_type3.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:alias_type3.posrec, ?#result##0:alias_type3.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a##0:wybe.int)
 posrec > public {inline} (6 calls)
 1: alias_type3.posrec.posrec<1>
-posrec(?p##0:alias_type3.position, ?a##0:wybe.int, ###0:alias_type3.posrec):
+posrec(?p##0:alias_type3.position, ?a##0:wybe.int, #result##0:alias_type3.posrec):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?p##0:alias_type3.position)
-    foreign lpvm access(~###0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?a##0:wybe.int)
+    foreign lpvm access(#result##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?p##0:alias_type3.position)
+    foreign lpvm access(~#result##0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?a##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
@@ -636,12 +636,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"alias_type3.posrec.posrec<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"alias_type3.posrec.posrec<1>"(i64  %"#result##0")    {
 entry:
-  %61 = inttoptr i64 %"###0" to i64* 
+  %61 = inttoptr i64 %"#result##0" to i64* 
   %62 = getelementptr  i64, i64* %61, i64 0 
   %63 = load  i64, i64* %62 
-  %64 = add   i64 %"###0", 8 
+  %64 = add   i64 %"#result##0", 8 
   %65 = inttoptr i64 %64 to i64* 
   %66 = getelementptr  i64, i64* %65, i64 0 
   %67 = load  i64, i64* %66 

--- a/test-cases/final-dump/alias_type3.exp
+++ b/test-cases/final-dump/alias_type3.exp
@@ -34,24 +34,24 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$8##0:alias_type3.position)
-    foreign lpvm mutate(~tmp$8##0:alias_type3.position, ?tmp$9##0:alias_type3.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm mutate(~tmp$9##0:alias_type3.position, ?tmp$10##0:alias_type3.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$13##0:alias_type3.posrec)
-    foreign lpvm mutate(~tmp$13##0:alias_type3.posrec, ?tmp$14##0:alias_type3.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$10##0:alias_type3.position)
-    foreign lpvm mutate(~tmp$14##0:alias_type3.posrec, ?tmp$15##0:alias_type3.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$18##0:alias_type3.position)
-    foreign lpvm mutate(~tmp$18##0:alias_type3.position, ?tmp$19##0:alias_type3.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm mutate(~tmp$19##0:alias_type3.position, ?tmp$20##0:alias_type3.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm {noalias} mutate(~tmp$15##0:alias_type3.posrec, ?%rec##1:alias_type3.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$20##0:alias_type3.position)
-    foreign lpvm {noalias} mutate(~tmp$10##0:alias_type3.position, ?%pos##1:alias_type3.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
-    foreign lpvm access(~pos##1:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign c print_int(~tmp$3##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$28##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$28##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~rec##1:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:alias_type3.position)
-    foreign lpvm access(~tmp$4##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign c print_int(~tmp$5##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$33##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$33##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#8##0:alias_type3.position)
+    foreign lpvm mutate(~tmp#8##0:alias_type3.position, ?tmp#9##0:alias_type3.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
+    foreign lpvm mutate(~tmp#9##0:alias_type3.position, ?tmp#10##0:alias_type3.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#13##0:alias_type3.posrec)
+    foreign lpvm mutate(~tmp#13##0:alias_type3.posrec, ?tmp#14##0:alias_type3.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#10##0:alias_type3.position)
+    foreign lpvm mutate(~tmp#14##0:alias_type3.posrec, ?tmp#15##0:alias_type3.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:alias_type3.position)
+    foreign lpvm mutate(~tmp#18##0:alias_type3.position, ?tmp#19##0:alias_type3.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+    foreign lpvm mutate(~tmp#19##0:alias_type3.position, ?tmp#20##0:alias_type3.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+    foreign lpvm {noalias} mutate(~tmp#15##0:alias_type3.posrec, ?%rec##1:alias_type3.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#20##0:alias_type3.position)
+    foreign lpvm {noalias} mutate(~tmp#10##0:alias_type3.position, ?%pos##1:alias_type3.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
+    foreign lpvm access(~pos##1:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign c print_int(~tmp#3##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#28##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#28##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~rec##1:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:alias_type3.position)
+    foreign lpvm access(~tmp#4##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign c print_int(~tmp#5##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#33##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#33##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -153,86 +153,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: alias_type3.position.=<0>
-=($left##0:alias_type3.position, $right##0:alias_type3.position, ?$$##0:wybe.bool):
+=(#left##0:alias_type3.position, #right##0:alias_type3.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
-    foreign lpvm access(~$left##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
-    foreign lpvm access($right##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
-    foreign lpvm access(~$right##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
-    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
+    foreign lpvm access(~#left##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
+    foreign lpvm access(#right##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
+    foreign lpvm access(~#right##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: alias_type3.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?$##0:alias_type3.position):
+position(x##0:wybe.int, y##0:wybe.int, ?###0:alias_type3.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:alias_type3.position)
-    foreign lpvm mutate(~$rec##0:alias_type3.position, ?$rec##1:alias_type3.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:alias_type3.position, ?$##0:alias_type3.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type3.position)
+    foreign lpvm mutate(~#rec##0:alias_type3.position, ?#rec##1:alias_type3.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:alias_type3.position, ?###0:alias_type3.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: alias_type3.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, $##0:alias_type3.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, ###0:alias_type3.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~$##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(###0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~###0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: alias_type3.position.x<0>
-x($rec##0:alias_type3.position, ?$##0:wybe.int):
+x(#rec##0:alias_type3.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 x > public {inline} (0 calls)
 1: alias_type3.position.x<1>
-x($rec##0:alias_type3.position, ?$rec##1:alias_type3.position, $field##0:wybe.int):
+x(#rec##0:alias_type3.position, ?#rec##1:alias_type3.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:alias_type3.position, ?$rec##1:alias_type3.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:alias_type3.position, ?#rec##1:alias_type3.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: alias_type3.position.y<0>
-y($rec##0:alias_type3.position, ?$##0:wybe.int):
+y(#rec##0:alias_type3.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 y > public {inline} (0 calls)
 1: alias_type3.position.y<1>
-y($rec##0:alias_type3.position, ?$rec##1:alias_type3.position, $field##0:wybe.int):
+y(#rec##0:alias_type3.position, ?#rec##1:alias_type3.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:alias_type3.position, ?$rec##1:alias_type3.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:alias_type3.position, ?#rec##1:alias_type3.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: alias_type3.position.~=<0>
-~=($left##0:alias_type3.position, $right##0:alias_type3.position, ?$$##0:wybe.bool):
+~=(#left##0:alias_type3.position, #right##0:alias_type3.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -249,27 +249,27 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"alias_type3.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"alias_type3.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$##0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$##0" 
+  %"2#####0" = icmp eq i64 %7, %14 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
@@ -291,12 +291,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"alias_type3.position.position<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"alias_type3.position.position<1>"(i64  %"###0")    {
 entry:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -306,34 +306,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type3.position.x<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"alias_type3.position.x<0>"(i64  %"#rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec##0" to i64* 
+  %32 = inttoptr i64 %"#rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"alias_type3.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"alias_type3.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec##0" to i8* 
+  %39 = inttoptr i64 %"#rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field##0", i64* %42 
+  store  i64 %"#field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"alias_type3.position.y<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"alias_type3.position.y<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = add   i64 %"$rec##0", 8 
+  %43 = add   i64 %"#rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -341,48 +341,48 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type3.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"alias_type3.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec##0" to i8* 
+  %51 = inttoptr i64 %"#rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field##0", i64* %55 
+  store  i64 %"#field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"alias_type3.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"alias_type3.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %58, %65 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = icmp eq i64 %62, %69 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#0##0" = icmp eq i64 %62, %69 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }
 --------------------------------------------------
  Module alias_type3.posrec
@@ -404,108 +404,108 @@ if.else:
 
 = > public {inline} (1 calls)
 0: alias_type3.posrec.=<0>
-=($left##0:alias_type3.posrec, $right##0:alias_type3.posrec, ?$$##0:wybe.bool):
+=(#left##0:alias_type3.posrec, #right##0:alias_type3.posrec, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$p##0:alias_type3.position)
-    foreign lpvm access(~$left##0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$a##0:wybe.int)
-    foreign lpvm access($right##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$p##0:alias_type3.position)
-    foreign lpvm access(~$right##0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$a##0:wybe.int)
-    foreign lpvm access($left$p##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.int)
-    foreign lpvm access(~$left$p##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
-    foreign lpvm access($right$p##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.int)
-    foreign lpvm access(~$right$p##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$7##0:wybe.int, ~tmp$9##0:wybe.int, ?tmp$11##0:wybe.bool) @int:nn:nn
-    case ~tmp$11##0:wybe.bool of
+    foreign lpvm access(#left##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#p##0:alias_type3.position)
+    foreign lpvm access(~#left##0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#a##0:wybe.int)
+    foreign lpvm access(#right##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#p##0:alias_type3.position)
+    foreign lpvm access(~#right##0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#a##0:wybe.int)
+    foreign lpvm access(#left#p##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int)
+    foreign lpvm access(~#left#p##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
+    foreign lpvm access(#right#p##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
+    foreign lpvm access(~#right#p##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#7##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#11##0:wybe.bool) @int:nn:nn
+    case ~tmp#11##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$10##0:wybe.int, ~tmp$8##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm icmp_eq(~tmp#10##0:wybe.int, ~tmp#8##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~$left$a##0:wybe.int, ~$right$a##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+            foreign llvm icmp_eq(~#left#a##0:wybe.int, ~#right#a##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 
 a > public {inline} (0 calls)
 0: alias_type3.posrec.a<0>
-a($rec##0:alias_type3.posrec, ?$##0:wybe.int):
+a(#rec##0:alias_type3.posrec, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 a > public {inline} (0 calls)
 1: alias_type3.posrec.a<1>
-a($rec##0:alias_type3.posrec, ?$rec##1:alias_type3.posrec, $field##0:wybe.int):
+a(#rec##0:alias_type3.posrec, ?#rec##1:alias_type3.posrec, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec##0:alias_type3.posrec, ?$rec##1:alias_type3.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm mutate(~#rec##0:alias_type3.posrec, ?#rec##1:alias_type3.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 p > public {inline} (0 calls)
 0: alias_type3.posrec.p<0>
-p($rec##0:alias_type3.posrec, ?$##0:alias_type3.position):
+p(#rec##0:alias_type3.posrec, ?###0:alias_type3.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:alias_type3.position)
+    foreign lpvm access(~#rec##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:alias_type3.position)
 p > public {inline} (0 calls)
 1: alias_type3.posrec.p<1>
-p($rec##0:alias_type3.posrec, ?$rec##1:alias_type3.posrec, $field##0:alias_type3.position):
+p(#rec##0:alias_type3.posrec, ?#rec##1:alias_type3.posrec, #field##0:alias_type3.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:alias_type3.posrec, ?$rec##1:alias_type3.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:alias_type3.position)
+    foreign lpvm {noalias} mutate(~#rec##0:alias_type3.posrec, ?#rec##1:alias_type3.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:alias_type3.position)
 
 
 posrec > public {inline} (0 calls)
 0: alias_type3.posrec.posrec<0>
-posrec(p##0:alias_type3.position, a##0:wybe.int, ?$##0:alias_type3.posrec):
+posrec(p##0:alias_type3.position, a##0:wybe.int, ?###0:alias_type3.posrec):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:alias_type3.posrec)
-    foreign lpvm mutate(~$rec##0:alias_type3.posrec, ?$rec##1:alias_type3.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p##0:alias_type3.position)
-    foreign lpvm mutate(~$rec##1:alias_type3.posrec, ?$##0:alias_type3.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type3.posrec)
+    foreign lpvm mutate(~#rec##0:alias_type3.posrec, ?#rec##1:alias_type3.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p##0:alias_type3.position)
+    foreign lpvm mutate(~#rec##1:alias_type3.posrec, ?###0:alias_type3.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a##0:wybe.int)
 posrec > public {inline} (6 calls)
 1: alias_type3.posrec.posrec<1>
-posrec(?p##0:alias_type3.position, ?a##0:wybe.int, $##0:alias_type3.posrec):
+posrec(?p##0:alias_type3.position, ?a##0:wybe.int, ###0:alias_type3.posrec):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?p##0:alias_type3.position)
-    foreign lpvm access(~$##0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?a##0:wybe.int)
+    foreign lpvm access(###0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?p##0:alias_type3.position)
+    foreign lpvm access(~###0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?a##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: alias_type3.posrec.~=<0>
-~=($left##0:alias_type3.posrec, $right##0:alias_type3.posrec, ?$$##0:wybe.bool):
+~=(#left##0:alias_type3.posrec, #right##0:alias_type3.posrec, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:alias_type3.position)
-    foreign lpvm access(~$left##0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:alias_type3.position)
-    foreign lpvm access(~$right##0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign lpvm access(tmp$3##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.int)
-    foreign lpvm access(~tmp$3##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
-    foreign lpvm access(tmp$5##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.int)
-    foreign lpvm access(~tmp$5##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$7##0:wybe.int, ~tmp$9##0:wybe.int, ?tmp$11##0:wybe.bool) @int:nn:nn
-    case ~tmp$11##0:wybe.bool of
+    foreign lpvm access(#left##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:alias_type3.position)
+    foreign lpvm access(~#left##0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:alias_type3.position)
+    foreign lpvm access(~#right##0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(tmp#3##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int)
+    foreign lpvm access(~tmp#3##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
+    foreign lpvm access(tmp#5##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
+    foreign lpvm access(~tmp#5##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#7##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#11##0:wybe.bool) @int:nn:nn
+    case ~tmp#11##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$10##0:wybe.int, ~tmp$8##0:wybe.int, ?tmp$12##0:wybe.bool) @int:nn:nn
-        case ~tmp$12##0:wybe.bool of
+        foreign llvm icmp_eq(~tmp#10##0:wybe.int, ~tmp#8##0:wybe.int, ?tmp#12##0:wybe.bool) @int:nn:nn
+        case ~tmp#12##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
 
@@ -523,19 +523,19 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"alias_type3.posrec.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"alias_type3.posrec.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
@@ -553,24 +553,24 @@ entry:
   %26 = inttoptr i64 %25 to i64* 
   %27 = getelementptr  i64, i64* %26, i64 0 
   %28 = load  i64, i64* %27 
-  %"1$tmp$11##0" = icmp eq i64 %17, %24 
-  br i1 %"1$tmp$11##0", label %if.then, label %if.else 
+  %"1#tmp#11##0" = icmp eq i64 %17, %24 
+  br i1 %"1#tmp#11##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$1##0" = icmp eq i64 %28, %21 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#1##0" = icmp eq i64 %28, %21 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %"4$$$##0" = icmp eq i64 %7, %14 
-  ret i1 %"4$$$##0" 
+  %"4#####0" = icmp eq i64 %7, %14 
+  ret i1 %"4#####0" 
 if.else1:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"alias_type3.posrec.a<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"alias_type3.posrec.a<0>"(i64  %"#rec##0")    {
 entry:
-  %29 = add   i64 %"$rec##0", 8 
+  %29 = add   i64 %"#rec##0", 8 
   %30 = inttoptr i64 %29 to i64* 
   %31 = getelementptr  i64, i64* %30, i64 0 
   %32 = load  i64, i64* %31 
@@ -578,44 +578,44 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type3.posrec.a<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"alias_type3.posrec.a<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %33 = trunc i64 16 to i32  
   %34 = tail call ccc  i8*  @wybe_malloc(i32  %33)  
   %35 = ptrtoint i8* %34 to i64 
   %36 = inttoptr i64 %35 to i8* 
-  %37 = inttoptr i64 %"$rec##0" to i8* 
+  %37 = inttoptr i64 %"#rec##0" to i8* 
   %38 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %36, i8*  %37, i32  %38, i32  8, i1  0)  
   %39 = add   i64 %35, 8 
   %40 = inttoptr i64 %39 to i64* 
   %41 = getelementptr  i64, i64* %40, i64 0 
-  store  i64 %"$field##0", i64* %41 
+  store  i64 %"#field##0", i64* %41 
   ret i64 %35 
 }
 
 
-define external fastcc  i64 @"alias_type3.posrec.p<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"alias_type3.posrec.p<0>"(i64  %"#rec##0")    {
 entry:
-  %42 = inttoptr i64 %"$rec##0" to i64* 
+  %42 = inttoptr i64 %"#rec##0" to i64* 
   %43 = getelementptr  i64, i64* %42, i64 0 
   %44 = load  i64, i64* %43 
   ret i64 %44 
 }
 
 
-define external fastcc  i64 @"alias_type3.posrec.p<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"alias_type3.posrec.p<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %45 = trunc i64 16 to i32  
   %46 = tail call ccc  i8*  @wybe_malloc(i32  %45)  
   %47 = ptrtoint i8* %46 to i64 
   %48 = inttoptr i64 %47 to i8* 
-  %49 = inttoptr i64 %"$rec##0" to i8* 
+  %49 = inttoptr i64 %"#rec##0" to i8* 
   %50 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %48, i8*  %49, i32  %50, i32  8, i1  0)  
   %51 = inttoptr i64 %47 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
-  store  i64 %"$field##0", i64* %52 
+  store  i64 %"#field##0", i64* %52 
   ret i64 %47 
 }
 
@@ -636,12 +636,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"alias_type3.posrec.posrec<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"alias_type3.posrec.posrec<1>"(i64  %"###0")    {
 entry:
-  %61 = inttoptr i64 %"$##0" to i64* 
+  %61 = inttoptr i64 %"###0" to i64* 
   %62 = getelementptr  i64, i64* %61, i64 0 
   %63 = load  i64, i64* %62 
-  %64 = add   i64 %"$##0", 8 
+  %64 = add   i64 %"###0", 8 
   %65 = inttoptr i64 %64 to i64* 
   %66 = getelementptr  i64, i64* %65, i64 0 
   %67 = load  i64, i64* %66 
@@ -651,19 +651,19 @@ entry:
 }
 
 
-define external fastcc  i1 @"alias_type3.posrec.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"alias_type3.posrec.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %70 = inttoptr i64 %"$left##0" to i64* 
+  %70 = inttoptr i64 %"#left##0" to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
   %72 = load  i64, i64* %71 
-  %73 = add   i64 %"$left##0", 8 
+  %73 = add   i64 %"#left##0", 8 
   %74 = inttoptr i64 %73 to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
   %76 = load  i64, i64* %75 
-  %77 = inttoptr i64 %"$right##0" to i64* 
+  %77 = inttoptr i64 %"#right##0" to i64* 
   %78 = getelementptr  i64, i64* %77, i64 0 
   %79 = load  i64, i64* %78 
-  %80 = add   i64 %"$right##0", 8 
+  %80 = add   i64 %"#right##0", 8 
   %81 = inttoptr i64 %80 to i64* 
   %82 = getelementptr  i64, i64* %81, i64 0 
   %83 = load  i64, i64* %82 
@@ -681,19 +681,19 @@ entry:
   %95 = inttoptr i64 %94 to i64* 
   %96 = getelementptr  i64, i64* %95, i64 0 
   %97 = load  i64, i64* %96 
-  %"1$tmp$11##0" = icmp eq i64 %86, %93 
-  br i1 %"1$tmp$11##0", label %if.then, label %if.else 
+  %"1#tmp#11##0" = icmp eq i64 %86, %93 
+  br i1 %"1#tmp#11##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$12##0" = icmp eq i64 %97, %90 
-  br i1 %"2$tmp$12##0", label %if.then1, label %if.else1 
+  %"2#tmp#12##0" = icmp eq i64 %97, %90 
+  br i1 %"2#tmp#12##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 if.then1:
-  %"4$tmp$0##0" = icmp eq i64 %76, %83 
-  %"4$$$##0" = xor i1 %"4$tmp$0##0", 1 
-  ret i1 %"4$$$##0" 
+  %"4#tmp#0##0" = icmp eq i64 %76, %83 
+  %"4#####0" = xor i1 %"4#tmp#0##0", 1 
+  ret i1 %"4#####0" 
 if.else1:
-  %"5$$$##0" = xor i1 0, 1 
-  ret i1 %"5$$$##0" 
+  %"5#####0" = xor i1 0, 1 
+  ret i1 %"5#####0" 
 }

--- a/test-cases/final-dump/alias_type3.exp
+++ b/test-cases/final-dump/alias_type3.exp
@@ -31,27 +31,27 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: alias_type3.<0>
-(io#0:wybe.phantom, ?io#2:wybe.phantom):
+(io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$8#0:alias_type3.position)
-    foreign lpvm mutate(~tmp$8#0:alias_type3.position, ?tmp$9#0:alias_type3.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm mutate(~tmp$9#0:alias_type3.position, ?tmp$10#0:alias_type3.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$13#0:alias_type3.posrec)
-    foreign lpvm mutate(~tmp$13#0:alias_type3.posrec, ?tmp$14#0:alias_type3.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$10#0:alias_type3.position)
-    foreign lpvm mutate(~tmp$14#0:alias_type3.posrec, ?tmp$15#0:alias_type3.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$18#0:alias_type3.position)
-    foreign lpvm mutate(~tmp$18#0:alias_type3.position, ?tmp$19#0:alias_type3.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm mutate(~tmp$19#0:alias_type3.position, ?tmp$20#0:alias_type3.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm {noalias} mutate(~tmp$15#0:alias_type3.posrec, ?%rec#1:alias_type3.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$20#0:alias_type3.position)
-    foreign lpvm {noalias} mutate(~tmp$10#0:alias_type3.position, ?%pos#1:alias_type3.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
-    foreign lpvm access(~pos#1:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign c print_int(~tmp$3#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$28#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$28#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~rec#1:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:alias_type3.position)
-    foreign lpvm access(~tmp$4#0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign c print_int(~tmp$5#0:wybe.int, ~#io#1:wybe.phantom, ?tmp$33#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$33#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$8##0:alias_type3.position)
+    foreign lpvm mutate(~tmp$8##0:alias_type3.position, ?tmp$9##0:alias_type3.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
+    foreign lpvm mutate(~tmp$9##0:alias_type3.position, ?tmp$10##0:alias_type3.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp$13##0:alias_type3.posrec)
+    foreign lpvm mutate(~tmp$13##0:alias_type3.posrec, ?tmp$14##0:alias_type3.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$10##0:alias_type3.position)
+    foreign lpvm mutate(~tmp$14##0:alias_type3.posrec, ?tmp$15##0:alias_type3.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp$18##0:alias_type3.position)
+    foreign lpvm mutate(~tmp$18##0:alias_type3.position, ?tmp$19##0:alias_type3.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+    foreign lpvm mutate(~tmp$19##0:alias_type3.position, ?tmp$20##0:alias_type3.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+    foreign lpvm {noalias} mutate(~tmp$15##0:alias_type3.posrec, ?%rec##1:alias_type3.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$20##0:alias_type3.position)
+    foreign lpvm {noalias} mutate(~tmp$10##0:alias_type3.position, ?%pos##1:alias_type3.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
+    foreign lpvm access(~pos##1:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign c print_int(~tmp$3##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$28##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$28##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~rec##1:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:alias_type3.position)
+    foreign lpvm access(~tmp$4##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign c print_int(~tmp$5##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$33##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$33##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -153,86 +153,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: alias_type3.position.=<0>
-=($left#0:alias_type3.position, $right#0:alias_type3.position, ?$$#0:wybe.bool):
+=($left##0:alias_type3.position, $right##0:alias_type3.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
-    foreign lpvm access(~$left#0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y#0:wybe.int)
-    foreign lpvm access($right#0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x#0:wybe.int)
-    foreign lpvm access(~$right#0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y#0:wybe.int)
-    foreign llvm icmp_eq(~$left$x#0:wybe.int, ~$right$x#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
+    foreign lpvm access(~$left##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
+    foreign lpvm access($right##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
+    foreign lpvm access(~$right##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
+    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y#0:wybe.int, ~$right$y#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: alias_type3.position.position<0>
-position(x#0:wybe.int, y#0:wybe.int, ?$#0:alias_type3.position):
+position(x##0:wybe.int, y##0:wybe.int, ?$##0:alias_type3.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:alias_type3.position)
-    foreign lpvm mutate(~$rec#0:alias_type3.position, ?$rec#1:alias_type3.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:alias_type3.position, ?$#0:alias_type3.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:alias_type3.position)
+    foreign lpvm mutate(~$rec##0:alias_type3.position, ?$rec##1:alias_type3.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:alias_type3.position, ?$##0:alias_type3.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: alias_type3.position.position<1>
-position(?x#0:wybe.int, ?y#0:wybe.int, $#0:alias_type3.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, $##0:alias_type3.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
-    foreign lpvm access(~$#0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y#0:wybe.int)
+    foreign lpvm access($##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~$##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: alias_type3.position.x<0>
-x($rec#0:alias_type3.position, ?$#0:wybe.int):
+x($rec##0:alias_type3.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 x > public {inline} (0 calls)
 1: alias_type3.position.x<1>
-x($rec#0:alias_type3.position, ?$rec#1:alias_type3.position, $field#0:wybe.int):
+x($rec##0:alias_type3.position, ?$rec##1:alias_type3.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:alias_type3.position, ?$rec#1:alias_type3.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:alias_type3.position, ?$rec##1:alias_type3.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: alias_type3.position.y<0>
-y($rec#0:alias_type3.position, ?$#0:wybe.int):
+y($rec##0:alias_type3.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 y > public {inline} (0 calls)
 1: alias_type3.position.y<1>
-y($rec#0:alias_type3.position, ?$rec#1:alias_type3.position, $field#0:wybe.int):
+y($rec##0:alias_type3.position, ?$rec##1:alias_type3.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:alias_type3.position, ?$rec#1:alias_type3.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:alias_type3.position, ?$rec##1:alias_type3.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: alias_type3.position.~=<0>
-~=($left#0:alias_type3.position, $right#0:alias_type3.position, ?$$#0:wybe.bool):
+~=($left##0:alias_type3.position, $right##0:alias_type3.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -249,54 +249,54 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"alias_type3.position.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"alias_type3.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$#0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = icmp eq i64 %7, %14 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"alias_type3.position.position<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"alias_type3.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"x#0", i64* %19 
+  store  i64 %"x##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"y#0", i64* %22 
+  store  i64 %"y##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64} @"alias_type3.position.position<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"alias_type3.position.position<1>"(i64  %"$##0")    {
 entry:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -306,34 +306,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type3.position.x<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"alias_type3.position.x<0>"(i64  %"$rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec#0" to i64* 
+  %32 = inttoptr i64 %"$rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"alias_type3.position.x<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"alias_type3.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec#0" to i8* 
+  %39 = inttoptr i64 %"$rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field#0", i64* %42 
+  store  i64 %"$field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"alias_type3.position.y<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"alias_type3.position.y<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = add   i64 %"$rec#0", 8 
+  %43 = add   i64 %"$rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -341,48 +341,48 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type3.position.y<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"alias_type3.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec#0" to i8* 
+  %51 = inttoptr i64 %"$rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field#0", i64* %55 
+  store  i64 %"$field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"alias_type3.position.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"alias_type3.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %58, %65 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = icmp eq i64 %62, %69 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$0##0" = icmp eq i64 %62, %69 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }
 --------------------------------------------------
  Module alias_type3.posrec
@@ -404,108 +404,108 @@ if.else:
 
 = > public {inline} (1 calls)
 0: alias_type3.posrec.=<0>
-=($left#0:alias_type3.posrec, $right#0:alias_type3.posrec, ?$$#0:wybe.bool):
+=($left##0:alias_type3.posrec, $right##0:alias_type3.posrec, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$p#0:alias_type3.position)
-    foreign lpvm access(~$left#0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$a#0:wybe.int)
-    foreign lpvm access($right#0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$p#0:alias_type3.position)
-    foreign lpvm access(~$right#0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$a#0:wybe.int)
-    foreign lpvm access($left$p#0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$7#0:wybe.int)
-    foreign lpvm access(~$left$p#0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.int)
-    foreign lpvm access($right$p#0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.int)
-    foreign lpvm access(~$right$p#0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$7#0:wybe.int, ~tmp$9#0:wybe.int, ?tmp$11#0:wybe.bool) @int:nn:nn
-    case ~tmp$11#0:wybe.bool of
+    foreign lpvm access($left##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$p##0:alias_type3.position)
+    foreign lpvm access(~$left##0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$a##0:wybe.int)
+    foreign lpvm access($right##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$p##0:alias_type3.position)
+    foreign lpvm access(~$right##0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$a##0:wybe.int)
+    foreign lpvm access($left$p##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.int)
+    foreign lpvm access(~$left$p##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
+    foreign lpvm access($right$p##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.int)
+    foreign lpvm access(~$right$p##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$7##0:wybe.int, ~tmp$9##0:wybe.int, ?tmp$11##0:wybe.bool) @int:nn:nn
+    case ~tmp$11##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$10#0:wybe.int, ~tmp$8#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm icmp_eq(~tmp$10##0:wybe.int, ~tmp$8##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~$left$a#0:wybe.int, ~$right$a#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+            foreign llvm icmp_eq(~$left$a##0:wybe.int, ~$right$a##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 
 a > public {inline} (0 calls)
 0: alias_type3.posrec.a<0>
-a($rec#0:alias_type3.posrec, ?$#0:wybe.int):
+a($rec##0:alias_type3.posrec, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 a > public {inline} (0 calls)
 1: alias_type3.posrec.a<1>
-a($rec#0:alias_type3.posrec, ?$rec#1:alias_type3.posrec, $field#0:wybe.int):
+a($rec##0:alias_type3.posrec, ?$rec##1:alias_type3.posrec, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec#0:alias_type3.posrec, ?$rec#1:alias_type3.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm mutate(~$rec##0:alias_type3.posrec, ?$rec##1:alias_type3.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 p > public {inline} (0 calls)
 0: alias_type3.posrec.p<0>
-p($rec#0:alias_type3.posrec, ?$#0:alias_type3.position):
+p($rec##0:alias_type3.posrec, ?$##0:alias_type3.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:alias_type3.position)
+    foreign lpvm access(~$rec##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:alias_type3.position)
 p > public {inline} (0 calls)
 1: alias_type3.posrec.p<1>
-p($rec#0:alias_type3.posrec, ?$rec#1:alias_type3.posrec, $field#0:alias_type3.position):
+p($rec##0:alias_type3.posrec, ?$rec##1:alias_type3.posrec, $field##0:alias_type3.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:alias_type3.posrec, ?$rec#1:alias_type3.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:alias_type3.position)
+    foreign lpvm {noalias} mutate(~$rec##0:alias_type3.posrec, ?$rec##1:alias_type3.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:alias_type3.position)
 
 
 posrec > public {inline} (0 calls)
 0: alias_type3.posrec.posrec<0>
-posrec(p#0:alias_type3.position, a#0:wybe.int, ?$#0:alias_type3.posrec):
+posrec(p##0:alias_type3.position, a##0:wybe.int, ?$##0:alias_type3.posrec):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:alias_type3.posrec)
-    foreign lpvm mutate(~$rec#0:alias_type3.posrec, ?$rec#1:alias_type3.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p#0:alias_type3.position)
-    foreign lpvm mutate(~$rec#1:alias_type3.posrec, ?$#0:alias_type3.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:alias_type3.posrec)
+    foreign lpvm mutate(~$rec##0:alias_type3.posrec, ?$rec##1:alias_type3.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p##0:alias_type3.position)
+    foreign lpvm mutate(~$rec##1:alias_type3.posrec, ?$##0:alias_type3.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a##0:wybe.int)
 posrec > public {inline} (6 calls)
 1: alias_type3.posrec.posrec<1>
-posrec(?p#0:alias_type3.position, ?a#0:wybe.int, $#0:alias_type3.posrec):
+posrec(?p##0:alias_type3.position, ?a##0:wybe.int, $##0:alias_type3.posrec):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?p#0:alias_type3.position)
-    foreign lpvm access(~$#0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?a#0:wybe.int)
+    foreign lpvm access($##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?p##0:alias_type3.position)
+    foreign lpvm access(~$##0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?a##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: alias_type3.posrec.~=<0>
-~=($left#0:alias_type3.posrec, $right#0:alias_type3.posrec, ?$$#0:wybe.bool):
+~=($left##0:alias_type3.posrec, $right##0:alias_type3.posrec, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:alias_type3.position)
-    foreign lpvm access(~$left#0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:alias_type3.position)
-    foreign lpvm access(~$right#0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign lpvm access(tmp$3#0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$7#0:wybe.int)
-    foreign lpvm access(~tmp$3#0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.int)
-    foreign lpvm access(tmp$5#0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.int)
-    foreign lpvm access(~tmp$5#0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$7#0:wybe.int, ~tmp$9#0:wybe.int, ?tmp$11#0:wybe.bool) @int:nn:nn
-    case ~tmp$11#0:wybe.bool of
+    foreign lpvm access($left##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:alias_type3.position)
+    foreign lpvm access(~$left##0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:alias_type3.position)
+    foreign lpvm access(~$right##0:alias_type3.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign lpvm access(tmp$3##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.int)
+    foreign lpvm access(~tmp$3##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
+    foreign lpvm access(tmp$5##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.int)
+    foreign lpvm access(~tmp$5##0:alias_type3.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$7##0:wybe.int, ~tmp$9##0:wybe.int, ?tmp$11##0:wybe.bool) @int:nn:nn
+    case ~tmp$11##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$10#0:wybe.int, ~tmp$8#0:wybe.int, ?tmp$12#0:wybe.bool) @int:nn:nn
-        case ~tmp$12#0:wybe.bool of
+        foreign llvm icmp_eq(~tmp$10##0:wybe.int, ~tmp$8##0:wybe.int, ?tmp$12##0:wybe.bool) @int:nn:nn
+        case ~tmp$12##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-            foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-            foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
@@ -523,19 +523,19 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"alias_type3.posrec.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"alias_type3.posrec.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
@@ -553,24 +553,24 @@ entry:
   %26 = inttoptr i64 %25 to i64* 
   %27 = getelementptr  i64, i64* %26, i64 0 
   %28 = load  i64, i64* %27 
-  %"1$tmp$11#0" = icmp eq i64 %17, %24 
-  br i1 %"1$tmp$11#0", label %if.then, label %if.else 
+  %"1$tmp$11##0" = icmp eq i64 %17, %24 
+  br i1 %"1$tmp$11##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$1#0" = icmp eq i64 %28, %21 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$1##0" = icmp eq i64 %28, %21 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %"4$$$#0" = icmp eq i64 %7, %14 
-  ret i1 %"4$$$#0" 
+  %"4$$$##0" = icmp eq i64 %7, %14 
+  ret i1 %"4$$$##0" 
 if.else1:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"alias_type3.posrec.a<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"alias_type3.posrec.a<0>"(i64  %"$rec##0")    {
 entry:
-  %29 = add   i64 %"$rec#0", 8 
+  %29 = add   i64 %"$rec##0", 8 
   %30 = inttoptr i64 %29 to i64* 
   %31 = getelementptr  i64, i64* %30, i64 0 
   %32 = load  i64, i64* %31 
@@ -578,70 +578,70 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type3.posrec.a<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"alias_type3.posrec.a<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %33 = trunc i64 16 to i32  
   %34 = tail call ccc  i8*  @wybe_malloc(i32  %33)  
   %35 = ptrtoint i8* %34 to i64 
   %36 = inttoptr i64 %35 to i8* 
-  %37 = inttoptr i64 %"$rec#0" to i8* 
+  %37 = inttoptr i64 %"$rec##0" to i8* 
   %38 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %36, i8*  %37, i32  %38, i32  8, i1  0)  
   %39 = add   i64 %35, 8 
   %40 = inttoptr i64 %39 to i64* 
   %41 = getelementptr  i64, i64* %40, i64 0 
-  store  i64 %"$field#0", i64* %41 
+  store  i64 %"$field##0", i64* %41 
   ret i64 %35 
 }
 
 
-define external fastcc  i64 @"alias_type3.posrec.p<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"alias_type3.posrec.p<0>"(i64  %"$rec##0")    {
 entry:
-  %42 = inttoptr i64 %"$rec#0" to i64* 
+  %42 = inttoptr i64 %"$rec##0" to i64* 
   %43 = getelementptr  i64, i64* %42, i64 0 
   %44 = load  i64, i64* %43 
   ret i64 %44 
 }
 
 
-define external fastcc  i64 @"alias_type3.posrec.p<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"alias_type3.posrec.p<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %45 = trunc i64 16 to i32  
   %46 = tail call ccc  i8*  @wybe_malloc(i32  %45)  
   %47 = ptrtoint i8* %46 to i64 
   %48 = inttoptr i64 %47 to i8* 
-  %49 = inttoptr i64 %"$rec#0" to i8* 
+  %49 = inttoptr i64 %"$rec##0" to i8* 
   %50 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %48, i8*  %49, i32  %50, i32  8, i1  0)  
   %51 = inttoptr i64 %47 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
-  store  i64 %"$field#0", i64* %52 
+  store  i64 %"$field##0", i64* %52 
   ret i64 %47 
 }
 
 
-define external fastcc  i64 @"alias_type3.posrec.posrec<0>"(i64  %"p#0", i64  %"a#0")    {
+define external fastcc  i64 @"alias_type3.posrec.posrec<0>"(i64  %"p##0", i64  %"a##0")    {
 entry:
   %53 = trunc i64 16 to i32  
   %54 = tail call ccc  i8*  @wybe_malloc(i32  %53)  
   %55 = ptrtoint i8* %54 to i64 
   %56 = inttoptr i64 %55 to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
-  store  i64 %"p#0", i64* %57 
+  store  i64 %"p##0", i64* %57 
   %58 = add   i64 %55, 8 
   %59 = inttoptr i64 %58 to i64* 
   %60 = getelementptr  i64, i64* %59, i64 0 
-  store  i64 %"a#0", i64* %60 
+  store  i64 %"a##0", i64* %60 
   ret i64 %55 
 }
 
 
-define external fastcc  {i64, i64} @"alias_type3.posrec.posrec<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"alias_type3.posrec.posrec<1>"(i64  %"$##0")    {
 entry:
-  %61 = inttoptr i64 %"$#0" to i64* 
+  %61 = inttoptr i64 %"$##0" to i64* 
   %62 = getelementptr  i64, i64* %61, i64 0 
   %63 = load  i64, i64* %62 
-  %64 = add   i64 %"$#0", 8 
+  %64 = add   i64 %"$##0", 8 
   %65 = inttoptr i64 %64 to i64* 
   %66 = getelementptr  i64, i64* %65, i64 0 
   %67 = load  i64, i64* %66 
@@ -651,19 +651,19 @@ entry:
 }
 
 
-define external fastcc  i1 @"alias_type3.posrec.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"alias_type3.posrec.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %70 = inttoptr i64 %"$left#0" to i64* 
+  %70 = inttoptr i64 %"$left##0" to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
   %72 = load  i64, i64* %71 
-  %73 = add   i64 %"$left#0", 8 
+  %73 = add   i64 %"$left##0", 8 
   %74 = inttoptr i64 %73 to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
   %76 = load  i64, i64* %75 
-  %77 = inttoptr i64 %"$right#0" to i64* 
+  %77 = inttoptr i64 %"$right##0" to i64* 
   %78 = getelementptr  i64, i64* %77, i64 0 
   %79 = load  i64, i64* %78 
-  %80 = add   i64 %"$right#0", 8 
+  %80 = add   i64 %"$right##0", 8 
   %81 = inttoptr i64 %80 to i64* 
   %82 = getelementptr  i64, i64* %81, i64 0 
   %83 = load  i64, i64* %82 
@@ -681,19 +681,19 @@ entry:
   %95 = inttoptr i64 %94 to i64* 
   %96 = getelementptr  i64, i64* %95, i64 0 
   %97 = load  i64, i64* %96 
-  %"1$tmp$11#0" = icmp eq i64 %86, %93 
-  br i1 %"1$tmp$11#0", label %if.then, label %if.else 
+  %"1$tmp$11##0" = icmp eq i64 %86, %93 
+  br i1 %"1$tmp$11##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$12#0" = icmp eq i64 %97, %90 
-  br i1 %"2$tmp$12#0", label %if.then1, label %if.else1 
+  %"2$tmp$12##0" = icmp eq i64 %97, %90 
+  br i1 %"2$tmp$12##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 if.then1:
-  %"4$tmp$0#0" = icmp eq i64 %76, %83 
-  %"4$$$#0" = xor i1 %"4$tmp$0#0", 1 
-  ret i1 %"4$$$#0" 
+  %"4$tmp$0##0" = icmp eq i64 %76, %83 
+  %"4$$$##0" = xor i1 %"4$tmp$0##0", 1 
+  ret i1 %"4$$$##0" 
 if.else1:
-  %"5$$$#0" = xor i1 0, 1 
-  ret i1 %"5$$$#0" 
+  %"5$$$##0" = xor i1 0, 1 
+  ret i1 %"5$$$##0" 
 }

--- a/test-cases/final-dump/alias_type3.exp
+++ b/test-cases/final-dump/alias_type3.exp
@@ -153,7 +153,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: alias_type3.position.=<0>
-=(#left##0:alias_type3.position, #right##0:alias_type3.position, ?####0:wybe.bool):
+=(#left##0:alias_type3.position, #right##0:alias_type3.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
@@ -163,10 +163,10 @@ entry:
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -217,7 +217,7 @@ y(#rec##0:alias_type3.position, ?#rec##1:alias_type3.position, #field##0:wybe.in
 
 ~= > public {inline} (0 calls)
 0: alias_type3.position.~=<0>
-~=(#left##0:alias_type3.position, #right##0:alias_type3.position, ?####0:wybe.bool):
+~=(#left##0:alias_type3.position, #right##0:alias_type3.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:alias_type3.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -228,11 +228,11 @@ y(#rec##0:alias_type3.position, ?#rec##1:alias_type3.position, #field##0:wybe.in
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -268,8 +268,8 @@ entry:
   %"1#tmp#1##0" = icmp eq i64 %3, %10 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2#####0" = icmp eq i64 %7, %14 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %7, %14 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -378,11 +378,11 @@ entry:
   br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#0##0" = icmp eq i64 %62, %69 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }
 --------------------------------------------------
  Module alias_type3.posrec
@@ -404,7 +404,7 @@ if.else:
 
 = > public {inline} (1 calls)
 0: alias_type3.posrec.=<0>
-=(#left##0:alias_type3.posrec, #right##0:alias_type3.posrec, ?####0:wybe.bool):
+=(#left##0:alias_type3.posrec, #right##0:alias_type3.posrec, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#p##0:alias_type3.position)
@@ -418,16 +418,16 @@ if.else:
     foreign llvm icmp_eq(~tmp#7##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#11##0:wybe.bool) @int:nn:nn
     case ~tmp#11##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#10##0:wybe.int, ~tmp#8##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~#left#a##0:wybe.int, ~#right#a##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+            foreign llvm icmp_eq(~#left#a##0:wybe.int, ~#right#a##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -479,7 +479,7 @@ posrec(?p##0:alias_type3.position, ?a##0:wybe.int, #result##0:alias_type3.posrec
 
 ~= > public {inline} (0 calls)
 0: alias_type3.posrec.~=<0>
-~=(#left##0:alias_type3.posrec, #right##0:alias_type3.posrec, ?####0:wybe.bool):
+~=(#left##0:alias_type3.posrec, #right##0:alias_type3.posrec, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:alias_type3.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:alias_type3.position)
@@ -494,18 +494,18 @@ posrec(?p##0:alias_type3.position, ?a##0:wybe.int, #result##0:alias_type3.posrec
     case ~tmp#11##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#10##0:wybe.int, ~tmp#8##0:wybe.int, ?tmp#12##0:wybe.bool) @int:nn:nn
         case ~tmp#12##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -561,8 +561,8 @@ if.then:
 if.else:
   ret i1 0 
 if.then1:
-  %"4#####0" = icmp eq i64 %7, %14 
-  ret i1 %"4#####0" 
+  %"4##success##0" = icmp eq i64 %7, %14 
+  ret i1 %"4##success##0" 
 if.else1:
   ret i1 0 
 }
@@ -687,13 +687,13 @@ if.then:
   %"2#tmp#12##0" = icmp eq i64 %97, %90 
   br i1 %"2#tmp#12##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 if.then1:
   %"4#tmp#0##0" = icmp eq i64 %76, %83 
-  %"4#####0" = xor i1 %"4#tmp#0##0", 1 
-  ret i1 %"4#####0" 
+  %"4##success##0" = xor i1 %"4#tmp#0##0", 1 
+  ret i1 %"4##success##0" 
 if.else1:
-  %"5#####0" = xor i1 0, 1 
-  ret i1 %"5#####0" 
+  %"5##success##0" = xor i1 0, 1 
+  ret i1 %"5##success##0" 
 }

--- a/test-cases/final-dump/alias_type4.exp
+++ b/test-cases/final-dump/alias_type4.exp
@@ -187,27 +187,27 @@ entry:
 
 position > public {inline} (0 calls)
 0: alias_type4.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?###0:alias_type4.position):
+position(x##0:wybe.int, y##0:wybe.int, ?#result##0:alias_type4.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type4.position)
     foreign lpvm mutate(~#rec##0:alias_type4.position, ?#rec##1:alias_type4.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:alias_type4.position, ?###0:alias_type4.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:alias_type4.position, ?#result##0:alias_type4.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: alias_type4.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, ###0:alias_type4.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:alias_type4.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~###0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~#result##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: alias_type4.position.x<0>
-x(#rec##0:alias_type4.position, ?###0:wybe.int):
+x(#rec##0:alias_type4.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 x > public {inline} (0 calls)
 1: alias_type4.position.x<1>
 x(#rec##0:alias_type4.position, ?#rec##1:alias_type4.position, #field##0:wybe.int):
@@ -218,10 +218,10 @@ x(#rec##0:alias_type4.position, ?#rec##1:alias_type4.position, #field##0:wybe.in
 
 y > public {inline} (0 calls)
 0: alias_type4.position.y<0>
-y(#rec##0:alias_type4.position, ?###0:wybe.int):
+y(#rec##0:alias_type4.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 y > public {inline} (0 calls)
 1: alias_type4.position.y<1>
 y(#rec##0:alias_type4.position, ?#rec##1:alias_type4.position, #field##0:wybe.int):
@@ -306,12 +306,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"alias_type4.position.position<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"alias_type4.position.position<1>"(i64  %"#result##0")    {
 entry:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -449,10 +449,10 @@ if.else:
 
 a > public {inline} (0 calls)
 0: alias_type4.posrec.a<0>
-a(#rec##0:alias_type4.posrec, ?###0:wybe.int):
+a(#rec##0:alias_type4.posrec, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 a > public {inline} (0 calls)
 1: alias_type4.posrec.a<1>
 a(#rec##0:alias_type4.posrec, ?#rec##1:alias_type4.posrec, #field##0:wybe.int):
@@ -463,10 +463,10 @@ a(#rec##0:alias_type4.posrec, ?#rec##1:alias_type4.posrec, #field##0:wybe.int):
 
 p > public {inline} (0 calls)
 0: alias_type4.posrec.p<0>
-p(#rec##0:alias_type4.posrec, ?###0:alias_type4.position):
+p(#rec##0:alias_type4.posrec, ?#result##0:alias_type4.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:alias_type4.position)
+    foreign lpvm access(~#rec##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:alias_type4.position)
 p > public {inline} (0 calls)
 1: alias_type4.posrec.p<1>
 p(#rec##0:alias_type4.posrec, ?#rec##1:alias_type4.posrec, #field##0:alias_type4.position):
@@ -477,19 +477,19 @@ p(#rec##0:alias_type4.posrec, ?#rec##1:alias_type4.posrec, #field##0:alias_type4
 
 posrec > public {inline} (0 calls)
 0: alias_type4.posrec.posrec<0>
-posrec(p##0:alias_type4.position, a##0:wybe.int, ?###0:alias_type4.posrec):
+posrec(p##0:alias_type4.position, a##0:wybe.int, ?#result##0:alias_type4.posrec):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type4.posrec)
     foreign lpvm mutate(~#rec##0:alias_type4.posrec, ?#rec##1:alias_type4.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p##0:alias_type4.position)
-    foreign lpvm mutate(~#rec##1:alias_type4.posrec, ?###0:alias_type4.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:alias_type4.posrec, ?#result##0:alias_type4.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a##0:wybe.int)
 posrec > public {inline} (6 calls)
 1: alias_type4.posrec.posrec<1>
-posrec(?p##0:alias_type4.position, ?a##0:wybe.int, ###0:alias_type4.posrec):
+posrec(?p##0:alias_type4.position, ?a##0:wybe.int, #result##0:alias_type4.posrec):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?p##0:alias_type4.position)
-    foreign lpvm access(~###0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?a##0:wybe.int)
+    foreign lpvm access(#result##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?p##0:alias_type4.position)
+    foreign lpvm access(~#result##0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?a##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
@@ -651,12 +651,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"alias_type4.posrec.posrec<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"alias_type4.posrec.posrec<1>"(i64  %"#result##0")    {
 entry:
-  %61 = inttoptr i64 %"###0" to i64* 
+  %61 = inttoptr i64 %"#result##0" to i64* 
   %62 = getelementptr  i64, i64* %61, i64 0 
   %63 = load  i64, i64* %62 
-  %64 = add   i64 %"###0", 8 
+  %64 = add   i64 %"#result##0", 8 
   %65 = inttoptr i64 %64 to i64* 
   %66 = getelementptr  i64, i64* %65, i64 0 
   %67 = load  i64, i64* %66 

--- a/test-cases/final-dump/alias_type4.exp
+++ b/test-cases/final-dump/alias_type4.exp
@@ -168,7 +168,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: alias_type4.position.=<0>
-=(#left##0:alias_type4.position, #right##0:alias_type4.position, ?####0:wybe.bool):
+=(#left##0:alias_type4.position, #right##0:alias_type4.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
@@ -178,10 +178,10 @@ entry:
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -232,7 +232,7 @@ y(#rec##0:alias_type4.position, ?#rec##1:alias_type4.position, #field##0:wybe.in
 
 ~= > public {inline} (0 calls)
 0: alias_type4.position.~=<0>
-~=(#left##0:alias_type4.position, #right##0:alias_type4.position, ?####0:wybe.bool):
+~=(#left##0:alias_type4.position, #right##0:alias_type4.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -243,11 +243,11 @@ y(#rec##0:alias_type4.position, ?#rec##1:alias_type4.position, #field##0:wybe.in
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -283,8 +283,8 @@ entry:
   %"1#tmp#1##0" = icmp eq i64 %3, %10 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2#####0" = icmp eq i64 %7, %14 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %7, %14 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -393,11 +393,11 @@ entry:
   br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#0##0" = icmp eq i64 %62, %69 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }
 --------------------------------------------------
  Module alias_type4.posrec
@@ -419,7 +419,7 @@ if.else:
 
 = > public {inline} (1 calls)
 0: alias_type4.posrec.=<0>
-=(#left##0:alias_type4.posrec, #right##0:alias_type4.posrec, ?####0:wybe.bool):
+=(#left##0:alias_type4.posrec, #right##0:alias_type4.posrec, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#p##0:alias_type4.position)
@@ -433,16 +433,16 @@ if.else:
     foreign llvm icmp_eq(~tmp#7##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#11##0:wybe.bool) @int:nn:nn
     case ~tmp#11##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#10##0:wybe.int, ~tmp#8##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~#left#a##0:wybe.int, ~#right#a##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+            foreign llvm icmp_eq(~#left#a##0:wybe.int, ~#right#a##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -494,7 +494,7 @@ posrec(?p##0:alias_type4.position, ?a##0:wybe.int, #result##0:alias_type4.posrec
 
 ~= > public {inline} (0 calls)
 0: alias_type4.posrec.~=<0>
-~=(#left##0:alias_type4.posrec, #right##0:alias_type4.posrec, ?####0:wybe.bool):
+~=(#left##0:alias_type4.posrec, #right##0:alias_type4.posrec, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:alias_type4.position)
@@ -509,18 +509,18 @@ posrec(?p##0:alias_type4.position, ?a##0:wybe.int, #result##0:alias_type4.posrec
     case ~tmp#11##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#10##0:wybe.int, ~tmp#8##0:wybe.int, ?tmp#12##0:wybe.bool) @int:nn:nn
         case ~tmp#12##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -576,8 +576,8 @@ if.then:
 if.else:
   ret i1 0 
 if.then1:
-  %"4#####0" = icmp eq i64 %7, %14 
-  ret i1 %"4#####0" 
+  %"4##success##0" = icmp eq i64 %7, %14 
+  ret i1 %"4##success##0" 
 if.else1:
   ret i1 0 
 }
@@ -702,13 +702,13 @@ if.then:
   %"2#tmp#12##0" = icmp eq i64 %97, %90 
   br i1 %"2#tmp#12##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 if.then1:
   %"4#tmp#0##0" = icmp eq i64 %76, %83 
-  %"4#####0" = xor i1 %"4#tmp#0##0", 1 
-  ret i1 %"4#####0" 
+  %"4##success##0" = xor i1 %"4#tmp#0##0", 1 
+  ret i1 %"4##success##0" 
 if.else1:
-  %"5#####0" = xor i1 0, 1 
-  ret i1 %"5#####0" 
+  %"5##success##0" = xor i1 0, 1 
+  ret i1 %"5##success##0" 
 }

--- a/test-cases/final-dump/alias_type4.exp
+++ b/test-cases/final-dump/alias_type4.exp
@@ -36,13 +36,13 @@ AFTER EVERYTHING:
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(2,(alias_type4.foo<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm alloc(16:wybe.int, ?tmp$4##0:alias_type4.position)
-    foreign lpvm mutate(~tmp$4##0:alias_type4.position, ?tmp$5##0:alias_type4.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm mutate(~tmp$5##0:alias_type4.position, ?tmp$6##0:alias_type4.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$9##0:alias_type4.posrec)
-    foreign lpvm mutate(~tmp$9##0:alias_type4.posrec, ?tmp$10##0:alias_type4.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$6##0:alias_type4.position)
-    foreign lpvm mutate(~tmp$10##0:alias_type4.posrec, ?tmp$11##0:alias_type4.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    alias_type4.foo<0>[410bae77d3](~tmp$11##0:alias_type4.posrec, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @alias_type4:16:2
+    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:alias_type4.position)
+    foreign lpvm mutate(~tmp#4##0:alias_type4.position, ?tmp#5##0:alias_type4.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
+    foreign lpvm mutate(~tmp#5##0:alias_type4.position, ?tmp#6##0:alias_type4.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#9##0:alias_type4.posrec)
+    foreign lpvm mutate(~tmp#9##0:alias_type4.posrec, ?tmp#10##0:alias_type4.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#6##0:alias_type4.position)
+    foreign lpvm mutate(~tmp#10##0:alias_type4.posrec, ?tmp#11##0:alias_type4.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    alias_type4.foo<0>[410bae77d3](~tmp#11##0:alias_type4.posrec, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @alias_type4:16:2
 
 
 foo > public (1 calls)
@@ -50,17 +50,17 @@ foo > public (1 calls)
 foo(r1##0:alias_type4.posrec, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
-    foreign lpvm access(~r1##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:alias_type4.position)
-    foreign lpvm {noalias} mutate(~tmp$0##0:alias_type4.position, ?%pos1##1:alias_type4.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 1111:wybe.int)
-    foreign lpvm access(~pos1##1:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$8##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$8##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~r1##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:alias_type4.position)
+    foreign lpvm {noalias} mutate(~tmp#0##0:alias_type4.position, ?%pos1##1:alias_type4.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 1111:wybe.int)
+    foreign lpvm access(~pos1##1:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#8##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(~r1##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:alias_type4.position)
-    foreign lpvm {noalias} mutate(~tmp$0##0:alias_type4.position, ?%pos1##1:alias_type4.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1111:wybe.int)
-    foreign lpvm access(~pos1##1:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$8##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$8##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~r1##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:alias_type4.position)
+    foreign lpvm {noalias} mutate(~tmp#0##0:alias_type4.position, ?%pos1##1:alias_type4.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1111:wybe.int)
+    foreign lpvm access(~pos1##1:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#8##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -168,86 +168,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: alias_type4.position.=<0>
-=($left##0:alias_type4.position, $right##0:alias_type4.position, ?$$##0:wybe.bool):
+=(#left##0:alias_type4.position, #right##0:alias_type4.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
-    foreign lpvm access(~$left##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
-    foreign lpvm access($right##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
-    foreign lpvm access(~$right##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
-    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
+    foreign lpvm access(~#left##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
+    foreign lpvm access(#right##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
+    foreign lpvm access(~#right##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: alias_type4.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?$##0:alias_type4.position):
+position(x##0:wybe.int, y##0:wybe.int, ?###0:alias_type4.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:alias_type4.position)
-    foreign lpvm mutate(~$rec##0:alias_type4.position, ?$rec##1:alias_type4.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:alias_type4.position, ?$##0:alias_type4.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type4.position)
+    foreign lpvm mutate(~#rec##0:alias_type4.position, ?#rec##1:alias_type4.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:alias_type4.position, ?###0:alias_type4.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: alias_type4.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, $##0:alias_type4.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, ###0:alias_type4.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~$##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(###0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~###0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: alias_type4.position.x<0>
-x($rec##0:alias_type4.position, ?$##0:wybe.int):
+x(#rec##0:alias_type4.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 x > public {inline} (0 calls)
 1: alias_type4.position.x<1>
-x($rec##0:alias_type4.position, ?$rec##1:alias_type4.position, $field##0:wybe.int):
+x(#rec##0:alias_type4.position, ?#rec##1:alias_type4.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:alias_type4.position, ?$rec##1:alias_type4.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:alias_type4.position, ?#rec##1:alias_type4.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: alias_type4.position.y<0>
-y($rec##0:alias_type4.position, ?$##0:wybe.int):
+y(#rec##0:alias_type4.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 y > public {inline} (0 calls)
 1: alias_type4.position.y<1>
-y($rec##0:alias_type4.position, ?$rec##1:alias_type4.position, $field##0:wybe.int):
+y(#rec##0:alias_type4.position, ?#rec##1:alias_type4.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:alias_type4.position, ?$rec##1:alias_type4.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:alias_type4.position, ?#rec##1:alias_type4.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: alias_type4.position.~=<0>
-~=($left##0:alias_type4.position, $right##0:alias_type4.position, ?$$##0:wybe.bool):
+~=(#left##0:alias_type4.position, #right##0:alias_type4.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -264,27 +264,27 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"alias_type4.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"alias_type4.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$##0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$##0" 
+  %"2#####0" = icmp eq i64 %7, %14 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
@@ -306,12 +306,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"alias_type4.position.position<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"alias_type4.position.position<1>"(i64  %"###0")    {
 entry:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -321,34 +321,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type4.position.x<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"alias_type4.position.x<0>"(i64  %"#rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec##0" to i64* 
+  %32 = inttoptr i64 %"#rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"alias_type4.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"alias_type4.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec##0" to i8* 
+  %39 = inttoptr i64 %"#rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field##0", i64* %42 
+  store  i64 %"#field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"alias_type4.position.y<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"alias_type4.position.y<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = add   i64 %"$rec##0", 8 
+  %43 = add   i64 %"#rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -356,48 +356,48 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type4.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"alias_type4.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec##0" to i8* 
+  %51 = inttoptr i64 %"#rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field##0", i64* %55 
+  store  i64 %"#field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"alias_type4.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"alias_type4.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %58, %65 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = icmp eq i64 %62, %69 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#0##0" = icmp eq i64 %62, %69 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }
 --------------------------------------------------
  Module alias_type4.posrec
@@ -419,108 +419,108 @@ if.else:
 
 = > public {inline} (1 calls)
 0: alias_type4.posrec.=<0>
-=($left##0:alias_type4.posrec, $right##0:alias_type4.posrec, ?$$##0:wybe.bool):
+=(#left##0:alias_type4.posrec, #right##0:alias_type4.posrec, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$p##0:alias_type4.position)
-    foreign lpvm access(~$left##0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$a##0:wybe.int)
-    foreign lpvm access($right##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$p##0:alias_type4.position)
-    foreign lpvm access(~$right##0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$a##0:wybe.int)
-    foreign lpvm access($left$p##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.int)
-    foreign lpvm access(~$left$p##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
-    foreign lpvm access($right$p##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.int)
-    foreign lpvm access(~$right$p##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$7##0:wybe.int, ~tmp$9##0:wybe.int, ?tmp$11##0:wybe.bool) @int:nn:nn
-    case ~tmp$11##0:wybe.bool of
+    foreign lpvm access(#left##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#p##0:alias_type4.position)
+    foreign lpvm access(~#left##0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#a##0:wybe.int)
+    foreign lpvm access(#right##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#p##0:alias_type4.position)
+    foreign lpvm access(~#right##0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#a##0:wybe.int)
+    foreign lpvm access(#left#p##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int)
+    foreign lpvm access(~#left#p##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
+    foreign lpvm access(#right#p##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
+    foreign lpvm access(~#right#p##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#7##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#11##0:wybe.bool) @int:nn:nn
+    case ~tmp#11##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$10##0:wybe.int, ~tmp$8##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm icmp_eq(~tmp#10##0:wybe.int, ~tmp#8##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~$left$a##0:wybe.int, ~$right$a##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+            foreign llvm icmp_eq(~#left#a##0:wybe.int, ~#right#a##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 
 a > public {inline} (0 calls)
 0: alias_type4.posrec.a<0>
-a($rec##0:alias_type4.posrec, ?$##0:wybe.int):
+a(#rec##0:alias_type4.posrec, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 a > public {inline} (0 calls)
 1: alias_type4.posrec.a<1>
-a($rec##0:alias_type4.posrec, ?$rec##1:alias_type4.posrec, $field##0:wybe.int):
+a(#rec##0:alias_type4.posrec, ?#rec##1:alias_type4.posrec, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec##0:alias_type4.posrec, ?$rec##1:alias_type4.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm mutate(~#rec##0:alias_type4.posrec, ?#rec##1:alias_type4.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 p > public {inline} (0 calls)
 0: alias_type4.posrec.p<0>
-p($rec##0:alias_type4.posrec, ?$##0:alias_type4.position):
+p(#rec##0:alias_type4.posrec, ?###0:alias_type4.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:alias_type4.position)
+    foreign lpvm access(~#rec##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:alias_type4.position)
 p > public {inline} (0 calls)
 1: alias_type4.posrec.p<1>
-p($rec##0:alias_type4.posrec, ?$rec##1:alias_type4.posrec, $field##0:alias_type4.position):
+p(#rec##0:alias_type4.posrec, ?#rec##1:alias_type4.posrec, #field##0:alias_type4.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:alias_type4.posrec, ?$rec##1:alias_type4.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:alias_type4.position)
+    foreign lpvm {noalias} mutate(~#rec##0:alias_type4.posrec, ?#rec##1:alias_type4.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:alias_type4.position)
 
 
 posrec > public {inline} (0 calls)
 0: alias_type4.posrec.posrec<0>
-posrec(p##0:alias_type4.position, a##0:wybe.int, ?$##0:alias_type4.posrec):
+posrec(p##0:alias_type4.position, a##0:wybe.int, ?###0:alias_type4.posrec):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:alias_type4.posrec)
-    foreign lpvm mutate(~$rec##0:alias_type4.posrec, ?$rec##1:alias_type4.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p##0:alias_type4.position)
-    foreign lpvm mutate(~$rec##1:alias_type4.posrec, ?$##0:alias_type4.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:alias_type4.posrec)
+    foreign lpvm mutate(~#rec##0:alias_type4.posrec, ?#rec##1:alias_type4.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p##0:alias_type4.position)
+    foreign lpvm mutate(~#rec##1:alias_type4.posrec, ?###0:alias_type4.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a##0:wybe.int)
 posrec > public {inline} (6 calls)
 1: alias_type4.posrec.posrec<1>
-posrec(?p##0:alias_type4.position, ?a##0:wybe.int, $##0:alias_type4.posrec):
+posrec(?p##0:alias_type4.position, ?a##0:wybe.int, ###0:alias_type4.posrec):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?p##0:alias_type4.position)
-    foreign lpvm access(~$##0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?a##0:wybe.int)
+    foreign lpvm access(###0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?p##0:alias_type4.position)
+    foreign lpvm access(~###0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?a##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: alias_type4.posrec.~=<0>
-~=($left##0:alias_type4.posrec, $right##0:alias_type4.posrec, ?$$##0:wybe.bool):
+~=(#left##0:alias_type4.posrec, #right##0:alias_type4.posrec, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:alias_type4.position)
-    foreign lpvm access(~$left##0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:alias_type4.position)
-    foreign lpvm access(~$right##0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign lpvm access(tmp$3##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.int)
-    foreign lpvm access(~tmp$3##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
-    foreign lpvm access(tmp$5##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.int)
-    foreign lpvm access(~tmp$5##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$7##0:wybe.int, ~tmp$9##0:wybe.int, ?tmp$11##0:wybe.bool) @int:nn:nn
-    case ~tmp$11##0:wybe.bool of
+    foreign lpvm access(#left##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:alias_type4.position)
+    foreign lpvm access(~#left##0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:alias_type4.position)
+    foreign lpvm access(~#right##0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(tmp#3##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int)
+    foreign lpvm access(~tmp#3##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
+    foreign lpvm access(tmp#5##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
+    foreign lpvm access(~tmp#5##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#7##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#11##0:wybe.bool) @int:nn:nn
+    case ~tmp#11##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$10##0:wybe.int, ~tmp$8##0:wybe.int, ?tmp$12##0:wybe.bool) @int:nn:nn
-        case ~tmp$12##0:wybe.bool of
+        foreign llvm icmp_eq(~tmp#10##0:wybe.int, ~tmp#8##0:wybe.int, ?tmp#12##0:wybe.bool) @int:nn:nn
+        case ~tmp#12##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
 
@@ -538,19 +538,19 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"alias_type4.posrec.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"alias_type4.posrec.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
@@ -568,24 +568,24 @@ entry:
   %26 = inttoptr i64 %25 to i64* 
   %27 = getelementptr  i64, i64* %26, i64 0 
   %28 = load  i64, i64* %27 
-  %"1$tmp$11##0" = icmp eq i64 %17, %24 
-  br i1 %"1$tmp$11##0", label %if.then, label %if.else 
+  %"1#tmp#11##0" = icmp eq i64 %17, %24 
+  br i1 %"1#tmp#11##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$1##0" = icmp eq i64 %28, %21 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#1##0" = icmp eq i64 %28, %21 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %"4$$$##0" = icmp eq i64 %7, %14 
-  ret i1 %"4$$$##0" 
+  %"4#####0" = icmp eq i64 %7, %14 
+  ret i1 %"4#####0" 
 if.else1:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"alias_type4.posrec.a<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"alias_type4.posrec.a<0>"(i64  %"#rec##0")    {
 entry:
-  %29 = add   i64 %"$rec##0", 8 
+  %29 = add   i64 %"#rec##0", 8 
   %30 = inttoptr i64 %29 to i64* 
   %31 = getelementptr  i64, i64* %30, i64 0 
   %32 = load  i64, i64* %31 
@@ -593,44 +593,44 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type4.posrec.a<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"alias_type4.posrec.a<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %33 = trunc i64 16 to i32  
   %34 = tail call ccc  i8*  @wybe_malloc(i32  %33)  
   %35 = ptrtoint i8* %34 to i64 
   %36 = inttoptr i64 %35 to i8* 
-  %37 = inttoptr i64 %"$rec##0" to i8* 
+  %37 = inttoptr i64 %"#rec##0" to i8* 
   %38 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %36, i8*  %37, i32  %38, i32  8, i1  0)  
   %39 = add   i64 %35, 8 
   %40 = inttoptr i64 %39 to i64* 
   %41 = getelementptr  i64, i64* %40, i64 0 
-  store  i64 %"$field##0", i64* %41 
+  store  i64 %"#field##0", i64* %41 
   ret i64 %35 
 }
 
 
-define external fastcc  i64 @"alias_type4.posrec.p<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"alias_type4.posrec.p<0>"(i64  %"#rec##0")    {
 entry:
-  %42 = inttoptr i64 %"$rec##0" to i64* 
+  %42 = inttoptr i64 %"#rec##0" to i64* 
   %43 = getelementptr  i64, i64* %42, i64 0 
   %44 = load  i64, i64* %43 
   ret i64 %44 
 }
 
 
-define external fastcc  i64 @"alias_type4.posrec.p<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"alias_type4.posrec.p<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %45 = trunc i64 16 to i32  
   %46 = tail call ccc  i8*  @wybe_malloc(i32  %45)  
   %47 = ptrtoint i8* %46 to i64 
   %48 = inttoptr i64 %47 to i8* 
-  %49 = inttoptr i64 %"$rec##0" to i8* 
+  %49 = inttoptr i64 %"#rec##0" to i8* 
   %50 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %48, i8*  %49, i32  %50, i32  8, i1  0)  
   %51 = inttoptr i64 %47 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
-  store  i64 %"$field##0", i64* %52 
+  store  i64 %"#field##0", i64* %52 
   ret i64 %47 
 }
 
@@ -651,12 +651,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"alias_type4.posrec.posrec<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"alias_type4.posrec.posrec<1>"(i64  %"###0")    {
 entry:
-  %61 = inttoptr i64 %"$##0" to i64* 
+  %61 = inttoptr i64 %"###0" to i64* 
   %62 = getelementptr  i64, i64* %61, i64 0 
   %63 = load  i64, i64* %62 
-  %64 = add   i64 %"$##0", 8 
+  %64 = add   i64 %"###0", 8 
   %65 = inttoptr i64 %64 to i64* 
   %66 = getelementptr  i64, i64* %65, i64 0 
   %67 = load  i64, i64* %66 
@@ -666,19 +666,19 @@ entry:
 }
 
 
-define external fastcc  i1 @"alias_type4.posrec.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"alias_type4.posrec.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %70 = inttoptr i64 %"$left##0" to i64* 
+  %70 = inttoptr i64 %"#left##0" to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
   %72 = load  i64, i64* %71 
-  %73 = add   i64 %"$left##0", 8 
+  %73 = add   i64 %"#left##0", 8 
   %74 = inttoptr i64 %73 to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
   %76 = load  i64, i64* %75 
-  %77 = inttoptr i64 %"$right##0" to i64* 
+  %77 = inttoptr i64 %"#right##0" to i64* 
   %78 = getelementptr  i64, i64* %77, i64 0 
   %79 = load  i64, i64* %78 
-  %80 = add   i64 %"$right##0", 8 
+  %80 = add   i64 %"#right##0", 8 
   %81 = inttoptr i64 %80 to i64* 
   %82 = getelementptr  i64, i64* %81, i64 0 
   %83 = load  i64, i64* %82 
@@ -696,19 +696,19 @@ entry:
   %95 = inttoptr i64 %94 to i64* 
   %96 = getelementptr  i64, i64* %95, i64 0 
   %97 = load  i64, i64* %96 
-  %"1$tmp$11##0" = icmp eq i64 %86, %93 
-  br i1 %"1$tmp$11##0", label %if.then, label %if.else 
+  %"1#tmp#11##0" = icmp eq i64 %86, %93 
+  br i1 %"1#tmp#11##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$12##0" = icmp eq i64 %97, %90 
-  br i1 %"2$tmp$12##0", label %if.then1, label %if.else1 
+  %"2#tmp#12##0" = icmp eq i64 %97, %90 
+  br i1 %"2#tmp#12##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 if.then1:
-  %"4$tmp$0##0" = icmp eq i64 %76, %83 
-  %"4$$$##0" = xor i1 %"4$tmp$0##0", 1 
-  ret i1 %"4$$$##0" 
+  %"4#tmp#0##0" = icmp eq i64 %76, %83 
+  %"4#####0" = xor i1 %"4#tmp#0##0", 1 
+  ret i1 %"4#####0" 
 if.else1:
-  %"5$$$##0" = xor i1 0, 1 
-  ret i1 %"5$$$##0" 
+  %"5#####0" = xor i1 0, 1 
+  ret i1 %"5#####0" 
 }

--- a/test-cases/final-dump/alias_type4.exp
+++ b/test-cases/final-dump/alias_type4.exp
@@ -32,35 +32,35 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: alias_type4.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(2,(alias_type4.foo<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm alloc(16:wybe.int, ?tmp$4#0:alias_type4.position)
-    foreign lpvm mutate(~tmp$4#0:alias_type4.position, ?tmp$5#0:alias_type4.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm mutate(~tmp$5#0:alias_type4.position, ?tmp$6#0:alias_type4.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$9#0:alias_type4.posrec)
-    foreign lpvm mutate(~tmp$9#0:alias_type4.posrec, ?tmp$10#0:alias_type4.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$6#0:alias_type4.position)
-    foreign lpvm mutate(~tmp$10#0:alias_type4.posrec, ?tmp$11#0:alias_type4.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    alias_type4.foo<0>[410bae77d3](~tmp$11#0:alias_type4.posrec, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #2 @alias_type4:16:2
+    foreign lpvm alloc(16:wybe.int, ?tmp$4##0:alias_type4.position)
+    foreign lpvm mutate(~tmp$4##0:alias_type4.position, ?tmp$5##0:alias_type4.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
+    foreign lpvm mutate(~tmp$5##0:alias_type4.position, ?tmp$6##0:alias_type4.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp$9##0:alias_type4.posrec)
+    foreign lpvm mutate(~tmp$9##0:alias_type4.posrec, ?tmp$10##0:alias_type4.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$6##0:alias_type4.position)
+    foreign lpvm mutate(~tmp$10##0:alias_type4.posrec, ?tmp$11##0:alias_type4.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    alias_type4.foo<0>[410bae77d3](~tmp$11##0:alias_type4.posrec, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @alias_type4:16:2
 
 
 foo > public (1 calls)
 0: alias_type4.foo<0>[410bae77d3]
-foo(r1#0:alias_type4.posrec, io#0:wybe.phantom, ?io#1:wybe.phantom):
+foo(r1##0:alias_type4.posrec, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
-    foreign lpvm access(~r1#0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:alias_type4.position)
-    foreign lpvm {noalias} mutate(~tmp$0#0:alias_type4.position, ?%pos1#1:alias_type4.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 1111:wybe.int)
-    foreign lpvm access(~pos1#1:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$8#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$8#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~r1##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:alias_type4.position)
+    foreign lpvm {noalias} mutate(~tmp$0##0:alias_type4.position, ?%pos1##1:alias_type4.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, 1111:wybe.int)
+    foreign lpvm access(~pos1##1:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$8##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$8##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(~r1#0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:alias_type4.position)
-    foreign lpvm {noalias} mutate(~tmp$0#0:alias_type4.position, ?%pos1#1:alias_type4.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1111:wybe.int)
-    foreign lpvm access(~pos1#1:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$8#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$8#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~r1##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:alias_type4.position)
+    foreign lpvm {noalias} mutate(~tmp$0##0:alias_type4.position, ?%pos1##1:alias_type4.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1111:wybe.int)
+    foreign lpvm access(~pos1##1:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$8##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$8##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -109,9 +109,9 @@ entry:
 }
 
 
-define external fastcc  void @"alias_type4.foo<0>"(i64  %"r1#0")    {
+define external fastcc  void @"alias_type4.foo<0>"(i64  %"r1##0")    {
 entry:
-  %17 = inttoptr i64 %"r1#0" to i64* 
+  %17 = inttoptr i64 %"r1##0" to i64* 
   %18 = getelementptr  i64, i64* %17, i64 0 
   %19 = load  i64, i64* %18 
   %20 = trunc i64 16 to i32  
@@ -133,9 +133,9 @@ entry:
 }
 
 
-define external fastcc  void @"alias_type4.foo<0>[410bae77d3]"(i64  %"r1#0")    {
+define external fastcc  void @"alias_type4.foo<0>[410bae77d3]"(i64  %"r1##0")    {
 entry:
-  %31 = inttoptr i64 %"r1#0" to i64* 
+  %31 = inttoptr i64 %"r1##0" to i64* 
   %32 = getelementptr  i64, i64* %31, i64 0 
   %33 = load  i64, i64* %32 
   %34 = inttoptr i64 %33 to i64* 
@@ -168,86 +168,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: alias_type4.position.=<0>
-=($left#0:alias_type4.position, $right#0:alias_type4.position, ?$$#0:wybe.bool):
+=($left##0:alias_type4.position, $right##0:alias_type4.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
-    foreign lpvm access(~$left#0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y#0:wybe.int)
-    foreign lpvm access($right#0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x#0:wybe.int)
-    foreign lpvm access(~$right#0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y#0:wybe.int)
-    foreign llvm icmp_eq(~$left$x#0:wybe.int, ~$right$x#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
+    foreign lpvm access(~$left##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
+    foreign lpvm access($right##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
+    foreign lpvm access(~$right##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
+    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y#0:wybe.int, ~$right$y#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: alias_type4.position.position<0>
-position(x#0:wybe.int, y#0:wybe.int, ?$#0:alias_type4.position):
+position(x##0:wybe.int, y##0:wybe.int, ?$##0:alias_type4.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:alias_type4.position)
-    foreign lpvm mutate(~$rec#0:alias_type4.position, ?$rec#1:alias_type4.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:alias_type4.position, ?$#0:alias_type4.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:alias_type4.position)
+    foreign lpvm mutate(~$rec##0:alias_type4.position, ?$rec##1:alias_type4.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:alias_type4.position, ?$##0:alias_type4.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: alias_type4.position.position<1>
-position(?x#0:wybe.int, ?y#0:wybe.int, $#0:alias_type4.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, $##0:alias_type4.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
-    foreign lpvm access(~$#0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y#0:wybe.int)
+    foreign lpvm access($##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~$##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: alias_type4.position.x<0>
-x($rec#0:alias_type4.position, ?$#0:wybe.int):
+x($rec##0:alias_type4.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 x > public {inline} (0 calls)
 1: alias_type4.position.x<1>
-x($rec#0:alias_type4.position, ?$rec#1:alias_type4.position, $field#0:wybe.int):
+x($rec##0:alias_type4.position, ?$rec##1:alias_type4.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:alias_type4.position, ?$rec#1:alias_type4.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:alias_type4.position, ?$rec##1:alias_type4.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: alias_type4.position.y<0>
-y($rec#0:alias_type4.position, ?$#0:wybe.int):
+y($rec##0:alias_type4.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 y > public {inline} (0 calls)
 1: alias_type4.position.y<1>
-y($rec#0:alias_type4.position, ?$rec#1:alias_type4.position, $field#0:wybe.int):
+y($rec##0:alias_type4.position, ?$rec##1:alias_type4.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:alias_type4.position, ?$rec#1:alias_type4.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:alias_type4.position, ?$rec##1:alias_type4.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: alias_type4.position.~=<0>
-~=($left#0:alias_type4.position, $right#0:alias_type4.position, ?$$#0:wybe.bool):
+~=($left##0:alias_type4.position, $right##0:alias_type4.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -264,54 +264,54 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"alias_type4.position.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"alias_type4.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$#0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = icmp eq i64 %7, %14 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"alias_type4.position.position<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"alias_type4.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"x#0", i64* %19 
+  store  i64 %"x##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"y#0", i64* %22 
+  store  i64 %"y##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64} @"alias_type4.position.position<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"alias_type4.position.position<1>"(i64  %"$##0")    {
 entry:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -321,34 +321,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type4.position.x<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"alias_type4.position.x<0>"(i64  %"$rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec#0" to i64* 
+  %32 = inttoptr i64 %"$rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"alias_type4.position.x<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"alias_type4.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec#0" to i8* 
+  %39 = inttoptr i64 %"$rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field#0", i64* %42 
+  store  i64 %"$field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"alias_type4.position.y<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"alias_type4.position.y<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = add   i64 %"$rec#0", 8 
+  %43 = add   i64 %"$rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -356,48 +356,48 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type4.position.y<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"alias_type4.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec#0" to i8* 
+  %51 = inttoptr i64 %"$rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field#0", i64* %55 
+  store  i64 %"$field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"alias_type4.position.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"alias_type4.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %58, %65 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = icmp eq i64 %62, %69 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$0##0" = icmp eq i64 %62, %69 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }
 --------------------------------------------------
  Module alias_type4.posrec
@@ -419,108 +419,108 @@ if.else:
 
 = > public {inline} (1 calls)
 0: alias_type4.posrec.=<0>
-=($left#0:alias_type4.posrec, $right#0:alias_type4.posrec, ?$$#0:wybe.bool):
+=($left##0:alias_type4.posrec, $right##0:alias_type4.posrec, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$p#0:alias_type4.position)
-    foreign lpvm access(~$left#0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$a#0:wybe.int)
-    foreign lpvm access($right#0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$p#0:alias_type4.position)
-    foreign lpvm access(~$right#0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$a#0:wybe.int)
-    foreign lpvm access($left$p#0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$7#0:wybe.int)
-    foreign lpvm access(~$left$p#0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.int)
-    foreign lpvm access($right$p#0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.int)
-    foreign lpvm access(~$right$p#0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$7#0:wybe.int, ~tmp$9#0:wybe.int, ?tmp$11#0:wybe.bool) @int:nn:nn
-    case ~tmp$11#0:wybe.bool of
+    foreign lpvm access($left##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$p##0:alias_type4.position)
+    foreign lpvm access(~$left##0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$a##0:wybe.int)
+    foreign lpvm access($right##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$p##0:alias_type4.position)
+    foreign lpvm access(~$right##0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$a##0:wybe.int)
+    foreign lpvm access($left$p##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.int)
+    foreign lpvm access(~$left$p##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
+    foreign lpvm access($right$p##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.int)
+    foreign lpvm access(~$right$p##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$7##0:wybe.int, ~tmp$9##0:wybe.int, ?tmp$11##0:wybe.bool) @int:nn:nn
+    case ~tmp$11##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$10#0:wybe.int, ~tmp$8#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm icmp_eq(~tmp$10##0:wybe.int, ~tmp$8##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~$left$a#0:wybe.int, ~$right$a#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+            foreign llvm icmp_eq(~$left$a##0:wybe.int, ~$right$a##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 
 a > public {inline} (0 calls)
 0: alias_type4.posrec.a<0>
-a($rec#0:alias_type4.posrec, ?$#0:wybe.int):
+a($rec##0:alias_type4.posrec, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 a > public {inline} (0 calls)
 1: alias_type4.posrec.a<1>
-a($rec#0:alias_type4.posrec, ?$rec#1:alias_type4.posrec, $field#0:wybe.int):
+a($rec##0:alias_type4.posrec, ?$rec##1:alias_type4.posrec, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec#0:alias_type4.posrec, ?$rec#1:alias_type4.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm mutate(~$rec##0:alias_type4.posrec, ?$rec##1:alias_type4.posrec, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 p > public {inline} (0 calls)
 0: alias_type4.posrec.p<0>
-p($rec#0:alias_type4.posrec, ?$#0:alias_type4.position):
+p($rec##0:alias_type4.posrec, ?$##0:alias_type4.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:alias_type4.position)
+    foreign lpvm access(~$rec##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:alias_type4.position)
 p > public {inline} (0 calls)
 1: alias_type4.posrec.p<1>
-p($rec#0:alias_type4.posrec, ?$rec#1:alias_type4.posrec, $field#0:alias_type4.position):
+p($rec##0:alias_type4.posrec, ?$rec##1:alias_type4.posrec, $field##0:alias_type4.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:alias_type4.posrec, ?$rec#1:alias_type4.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:alias_type4.position)
+    foreign lpvm {noalias} mutate(~$rec##0:alias_type4.posrec, ?$rec##1:alias_type4.posrec, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:alias_type4.position)
 
 
 posrec > public {inline} (0 calls)
 0: alias_type4.posrec.posrec<0>
-posrec(p#0:alias_type4.position, a#0:wybe.int, ?$#0:alias_type4.posrec):
+posrec(p##0:alias_type4.position, a##0:wybe.int, ?$##0:alias_type4.posrec):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:alias_type4.posrec)
-    foreign lpvm mutate(~$rec#0:alias_type4.posrec, ?$rec#1:alias_type4.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p#0:alias_type4.position)
-    foreign lpvm mutate(~$rec#1:alias_type4.posrec, ?$#0:alias_type4.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:alias_type4.posrec)
+    foreign lpvm mutate(~$rec##0:alias_type4.posrec, ?$rec##1:alias_type4.posrec, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~p##0:alias_type4.position)
+    foreign lpvm mutate(~$rec##1:alias_type4.posrec, ?$##0:alias_type4.posrec, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~a##0:wybe.int)
 posrec > public {inline} (6 calls)
 1: alias_type4.posrec.posrec<1>
-posrec(?p#0:alias_type4.position, ?a#0:wybe.int, $#0:alias_type4.posrec):
+posrec(?p##0:alias_type4.position, ?a##0:wybe.int, $##0:alias_type4.posrec):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?p#0:alias_type4.position)
-    foreign lpvm access(~$#0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?a#0:wybe.int)
+    foreign lpvm access($##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?p##0:alias_type4.position)
+    foreign lpvm access(~$##0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?a##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: alias_type4.posrec.~=<0>
-~=($left#0:alias_type4.posrec, $right#0:alias_type4.posrec, ?$$#0:wybe.bool):
+~=($left##0:alias_type4.posrec, $right##0:alias_type4.posrec, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:alias_type4.position)
-    foreign lpvm access(~$left#0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:alias_type4.position)
-    foreign lpvm access(~$right#0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign lpvm access(tmp$3#0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$7#0:wybe.int)
-    foreign lpvm access(~tmp$3#0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.int)
-    foreign lpvm access(tmp$5#0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.int)
-    foreign lpvm access(~tmp$5#0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$7#0:wybe.int, ~tmp$9#0:wybe.int, ?tmp$11#0:wybe.bool) @int:nn:nn
-    case ~tmp$11#0:wybe.bool of
+    foreign lpvm access($left##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:alias_type4.position)
+    foreign lpvm access(~$left##0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:alias_type4.posrec, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:alias_type4.position)
+    foreign lpvm access(~$right##0:alias_type4.posrec, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign lpvm access(tmp$3##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.int)
+    foreign lpvm access(~tmp$3##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
+    foreign lpvm access(tmp$5##0:alias_type4.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.int)
+    foreign lpvm access(~tmp$5##0:alias_type4.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$7##0:wybe.int, ~tmp$9##0:wybe.int, ?tmp$11##0:wybe.bool) @int:nn:nn
+    case ~tmp$11##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$10#0:wybe.int, ~tmp$8#0:wybe.int, ?tmp$12#0:wybe.bool) @int:nn:nn
-        case ~tmp$12#0:wybe.bool of
+        foreign llvm icmp_eq(~tmp$10##0:wybe.int, ~tmp$8##0:wybe.int, ?tmp$12##0:wybe.bool) @int:nn:nn
+        case ~tmp$12##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-            foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-            foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
@@ -538,19 +538,19 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"alias_type4.posrec.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"alias_type4.posrec.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
@@ -568,24 +568,24 @@ entry:
   %26 = inttoptr i64 %25 to i64* 
   %27 = getelementptr  i64, i64* %26, i64 0 
   %28 = load  i64, i64* %27 
-  %"1$tmp$11#0" = icmp eq i64 %17, %24 
-  br i1 %"1$tmp$11#0", label %if.then, label %if.else 
+  %"1$tmp$11##0" = icmp eq i64 %17, %24 
+  br i1 %"1$tmp$11##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$1#0" = icmp eq i64 %28, %21 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$1##0" = icmp eq i64 %28, %21 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %"4$$$#0" = icmp eq i64 %7, %14 
-  ret i1 %"4$$$#0" 
+  %"4$$$##0" = icmp eq i64 %7, %14 
+  ret i1 %"4$$$##0" 
 if.else1:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"alias_type4.posrec.a<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"alias_type4.posrec.a<0>"(i64  %"$rec##0")    {
 entry:
-  %29 = add   i64 %"$rec#0", 8 
+  %29 = add   i64 %"$rec##0", 8 
   %30 = inttoptr i64 %29 to i64* 
   %31 = getelementptr  i64, i64* %30, i64 0 
   %32 = load  i64, i64* %31 
@@ -593,70 +593,70 @@ entry:
 }
 
 
-define external fastcc  i64 @"alias_type4.posrec.a<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"alias_type4.posrec.a<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %33 = trunc i64 16 to i32  
   %34 = tail call ccc  i8*  @wybe_malloc(i32  %33)  
   %35 = ptrtoint i8* %34 to i64 
   %36 = inttoptr i64 %35 to i8* 
-  %37 = inttoptr i64 %"$rec#0" to i8* 
+  %37 = inttoptr i64 %"$rec##0" to i8* 
   %38 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %36, i8*  %37, i32  %38, i32  8, i1  0)  
   %39 = add   i64 %35, 8 
   %40 = inttoptr i64 %39 to i64* 
   %41 = getelementptr  i64, i64* %40, i64 0 
-  store  i64 %"$field#0", i64* %41 
+  store  i64 %"$field##0", i64* %41 
   ret i64 %35 
 }
 
 
-define external fastcc  i64 @"alias_type4.posrec.p<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"alias_type4.posrec.p<0>"(i64  %"$rec##0")    {
 entry:
-  %42 = inttoptr i64 %"$rec#0" to i64* 
+  %42 = inttoptr i64 %"$rec##0" to i64* 
   %43 = getelementptr  i64, i64* %42, i64 0 
   %44 = load  i64, i64* %43 
   ret i64 %44 
 }
 
 
-define external fastcc  i64 @"alias_type4.posrec.p<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"alias_type4.posrec.p<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %45 = trunc i64 16 to i32  
   %46 = tail call ccc  i8*  @wybe_malloc(i32  %45)  
   %47 = ptrtoint i8* %46 to i64 
   %48 = inttoptr i64 %47 to i8* 
-  %49 = inttoptr i64 %"$rec#0" to i8* 
+  %49 = inttoptr i64 %"$rec##0" to i8* 
   %50 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %48, i8*  %49, i32  %50, i32  8, i1  0)  
   %51 = inttoptr i64 %47 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
-  store  i64 %"$field#0", i64* %52 
+  store  i64 %"$field##0", i64* %52 
   ret i64 %47 
 }
 
 
-define external fastcc  i64 @"alias_type4.posrec.posrec<0>"(i64  %"p#0", i64  %"a#0")    {
+define external fastcc  i64 @"alias_type4.posrec.posrec<0>"(i64  %"p##0", i64  %"a##0")    {
 entry:
   %53 = trunc i64 16 to i32  
   %54 = tail call ccc  i8*  @wybe_malloc(i32  %53)  
   %55 = ptrtoint i8* %54 to i64 
   %56 = inttoptr i64 %55 to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
-  store  i64 %"p#0", i64* %57 
+  store  i64 %"p##0", i64* %57 
   %58 = add   i64 %55, 8 
   %59 = inttoptr i64 %58 to i64* 
   %60 = getelementptr  i64, i64* %59, i64 0 
-  store  i64 %"a#0", i64* %60 
+  store  i64 %"a##0", i64* %60 
   ret i64 %55 
 }
 
 
-define external fastcc  {i64, i64} @"alias_type4.posrec.posrec<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"alias_type4.posrec.posrec<1>"(i64  %"$##0")    {
 entry:
-  %61 = inttoptr i64 %"$#0" to i64* 
+  %61 = inttoptr i64 %"$##0" to i64* 
   %62 = getelementptr  i64, i64* %61, i64 0 
   %63 = load  i64, i64* %62 
-  %64 = add   i64 %"$#0", 8 
+  %64 = add   i64 %"$##0", 8 
   %65 = inttoptr i64 %64 to i64* 
   %66 = getelementptr  i64, i64* %65, i64 0 
   %67 = load  i64, i64* %66 
@@ -666,19 +666,19 @@ entry:
 }
 
 
-define external fastcc  i1 @"alias_type4.posrec.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"alias_type4.posrec.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %70 = inttoptr i64 %"$left#0" to i64* 
+  %70 = inttoptr i64 %"$left##0" to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
   %72 = load  i64, i64* %71 
-  %73 = add   i64 %"$left#0", 8 
+  %73 = add   i64 %"$left##0", 8 
   %74 = inttoptr i64 %73 to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
   %76 = load  i64, i64* %75 
-  %77 = inttoptr i64 %"$right#0" to i64* 
+  %77 = inttoptr i64 %"$right##0" to i64* 
   %78 = getelementptr  i64, i64* %77, i64 0 
   %79 = load  i64, i64* %78 
-  %80 = add   i64 %"$right#0", 8 
+  %80 = add   i64 %"$right##0", 8 
   %81 = inttoptr i64 %80 to i64* 
   %82 = getelementptr  i64, i64* %81, i64 0 
   %83 = load  i64, i64* %82 
@@ -696,19 +696,19 @@ entry:
   %95 = inttoptr i64 %94 to i64* 
   %96 = getelementptr  i64, i64* %95, i64 0 
   %97 = load  i64, i64* %96 
-  %"1$tmp$11#0" = icmp eq i64 %86, %93 
-  br i1 %"1$tmp$11#0", label %if.then, label %if.else 
+  %"1$tmp$11##0" = icmp eq i64 %86, %93 
+  br i1 %"1$tmp$11##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$12#0" = icmp eq i64 %97, %90 
-  br i1 %"2$tmp$12#0", label %if.then1, label %if.else1 
+  %"2$tmp$12##0" = icmp eq i64 %97, %90 
+  br i1 %"2$tmp$12##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 if.then1:
-  %"4$tmp$0#0" = icmp eq i64 %76, %83 
-  %"4$$$#0" = xor i1 %"4$tmp$0#0", 1 
-  ret i1 %"4$$$#0" 
+  %"4$tmp$0##0" = icmp eq i64 %76, %83 
+  %"4$$$##0" = xor i1 %"4$tmp$0##0", 1 
+  ret i1 %"4$$$##0" 
 if.else1:
-  %"5$$$#0" = xor i1 0, 1 
-  ret i1 %"5$$$#0" 
+  %"5$$$##0" = xor i1 0, 1 
+  ret i1 %"5$$$##0" 
 }

--- a/test-cases/final-dump/alloc_args.exp
+++ b/test-cases/final-dump/alloc_args.exp
@@ -11,21 +11,21 @@ AFTER EVERYTHING:
 
 *main* > public {inline} (0 calls)
 0: alloc_args.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    alloc_args.foo<0>(1:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @alloc_args:nn:nn
+    alloc_args.foo<0>(1:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @alloc_args:nn:nn
 
 
 foo > {noinline} (1 calls)
 0: alloc_args.foo<0>
-foo(size#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+foo(size##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(~size#0:wybe.int, ?str#0:wybe.string) @alloc_args:nn:nn
-    foreign lpvm mutate(~str#0:wybe.string, ?str#1:wybe.string, 0:wybe.int, 1:wybe.bool, 1:wybe.int, 0:wybe.int, 0:wybe.int) @alloc_args:nn:nn
-    foreign c print_string(~str#1:wybe.string, ~#io#0:wybe.phantom, ?tmp$3#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$3#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(~size##0:wybe.int, ?str##0:wybe.string) @alloc_args:nn:nn
+    foreign lpvm mutate(~str##0:wybe.string, ?str##1:wybe.string, 0:wybe.int, 1:wybe.bool, 1:wybe.int, 0:wybe.int, 0:wybe.int) @alloc_args:nn:nn
+    foreign c print_string(~str##1:wybe.string, ~#io##0:wybe.phantom, ?tmp$3##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$3##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -54,9 +54,9 @@ entry:
 }
 
 
-define external fastcc  void @"alloc_args.foo<0>"(i64  %"size#0")    {
+define external fastcc  void @"alloc_args.foo<0>"(i64  %"size##0")    {
 entry:
-  %1 = trunc i64 %"size#0" to i32  
+  %1 = trunc i64 %"size##0" to i32  
   %2 = tail call ccc  i8*  @wybe_malloc(i32  %1)  
   %3 = ptrtoint i8* %2 to i64 
   %4 = inttoptr i64 %3 to i64* 

--- a/test-cases/final-dump/alloc_args.exp
+++ b/test-cases/final-dump/alloc_args.exp
@@ -24,8 +24,8 @@ foo(size##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  InterestingCallProperties: []
     foreign lpvm alloc(~size##0:wybe.int, ?str##0:wybe.string) @alloc_args:nn:nn
     foreign lpvm mutate(~str##0:wybe.string, ?str##1:wybe.string, 0:wybe.int, 1:wybe.bool, 1:wybe.int, 0:wybe.int, 0:wybe.int) @alloc_args:nn:nn
-    foreign c print_string(~str##1:wybe.string, ~#io##0:wybe.phantom, ?tmp$3##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$3##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string(~str##1:wybe.string, ~#io##0:wybe.phantom, ?tmp#3##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#3##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/anon_field.exp
+++ b/test-cases/final-dump/anon_field.exp
@@ -19,100 +19,100 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: anon_field.<0>
-(io#0:wybe.phantom, ?io#2:wybe.phantom):
+(io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp$21#0:anon_field)
-    foreign lpvm mutate(~tmp$21#0:anon_field, ?tmp$22#0:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.bool)
-    foreign lpvm mutate(~tmp$22#0:anon_field, ?tmp$23#0:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp$23#0:anon_field, ?tmp$0#0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm alloc(8:wybe.int, ?tmp$25#0:anon_field)
-    foreign lpvm mutate(~tmp$25#0:anon_field, ?tmp$26#0:anon_field, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign llvm or(~tmp$26#0:anon_field, 1:wybe.int, ?tmp$2#0:anon_field)
-    anon_field.=<0>(~tmp$0#0:anon_field, ~tmp$2#0:anon_field, ?tmp$17#0:wybe.bool) #3 @anon_field:nn:nn
-    case ~tmp$17#0:wybe.bool of
+    foreign lpvm alloc(24:wybe.int, ?tmp$21##0:anon_field)
+    foreign lpvm mutate(~tmp$21##0:anon_field, ?tmp$22##0:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.bool)
+    foreign lpvm mutate(~tmp$22##0:anon_field, ?tmp$23##0:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp$23##0:anon_field, ?tmp$0##0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm alloc(8:wybe.int, ?tmp$25##0:anon_field)
+    foreign lpvm mutate(~tmp$25##0:anon_field, ?tmp$26##0:anon_field, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign llvm or(~tmp$26##0:anon_field, 1:wybe.int, ?tmp$2##0:anon_field)
+    anon_field.=<0>(~tmp$0##0:anon_field, ~tmp$2##0:anon_field, ?tmp$17##0:wybe.bool) #3 @anon_field:nn:nn
+    case ~tmp$17##0:wybe.bool of
     0:
-        anon_field.gen$1<0>(~io#0:wybe.phantom, ?io#2:wybe.phantom) #6
+        anon_field.gen$1<0>(~io##0:wybe.phantom, ?io##2:wybe.phantom) #6
 
     1:
-        foreign c print_string("uh oh":wybe.string, ~#io#0:wybe.phantom, ?tmp$29#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$29#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        anon_field.gen$1<0>(~io#1:wybe.phantom, ?io#2:wybe.phantom) #5
+        foreign c print_string("uh oh":wybe.string, ~#io##0:wybe.phantom, ?tmp$29##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$29##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        anon_field.gen$1<0>(~io##1:wybe.phantom, ?io##2:wybe.phantom) #5
 
 
 
 = > public (7 calls)
 0: anon_field.=<0>
-=($left#0:anon_field, $right#0:anon_field, ?$$#0:wybe.bool):
+=($left##0:anon_field, $right##0:anon_field, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($left#0:wybe.int, 3:wybe.int, ?tmp$13#0:wybe.int)
-    foreign llvm icmp_eq(tmp$13#0:wybe.int, 0:wybe.int, ?tmp$14#0:wybe.bool)
-    case ~tmp$14#0:wybe.bool of
+    foreign llvm and($left##0:wybe.int, 3:wybe.int, ?tmp$13##0:wybe.int)
+    foreign llvm icmp_eq(tmp$13##0:wybe.int, 0:wybe.int, ?tmp$14##0:wybe.bool)
+    case ~tmp$14##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(tmp$13#0:wybe.int, 1:wybe.int, ?tmp$17#0:wybe.bool)
-        case ~tmp$17#0:wybe.bool of
+        foreign llvm icmp_eq(tmp$13##0:wybe.int, 1:wybe.int, ?tmp$17##0:wybe.bool)
+        case ~tmp$17##0:wybe.bool of
         0:
-            foreign llvm icmp_eq(~tmp$13#0:wybe.int, 2:wybe.int, ?tmp$20#0:wybe.bool)
-            case ~tmp$20#0:wybe.bool of
+            foreign llvm icmp_eq(~tmp$13##0:wybe.int, 2:wybe.int, ?tmp$20##0:wybe.bool)
+            case ~tmp$20##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                foreign lpvm access(~$left#0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$left$field#0:wybe.int)
-                foreign llvm and($right#0:wybe.int, 3:wybe.int, ?tmp$22#0:wybe.int)
-                foreign llvm icmp_eq(~tmp$22#0:wybe.int, 2:wybe.int, ?tmp$23#0:wybe.bool)
-                case ~tmp$23#0:wybe.bool of
+                foreign lpvm access(~$left##0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$left$field##0:wybe.int)
+                foreign llvm and($right##0:wybe.int, 3:wybe.int, ?tmp$22##0:wybe.int)
+                foreign llvm icmp_eq(~tmp$22##0:wybe.int, 2:wybe.int, ?tmp$23##0:wybe.bool)
+                case ~tmp$23##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                 1:
-                    foreign lpvm access(~$right#0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$right$field#0:wybe.int)
-                    foreign llvm icmp_eq(~$left$field#0:wybe.int, ~$right$field#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+                    foreign lpvm access(~$right##0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$right$field##0:wybe.int)
+                    foreign llvm icmp_eq(~$left$field##0:wybe.int, ~$right$field##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
         1:
-            foreign lpvm access(~$left#0:anon_field, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$left$bar$1#0:wybe.int)
-            foreign llvm and($right#0:wybe.int, 3:wybe.int, ?tmp$19#0:wybe.int)
-            foreign llvm icmp_eq(~tmp$19#0:wybe.int, 1:wybe.int, ?tmp$20#0:wybe.bool)
-            case ~tmp$20#0:wybe.bool of
+            foreign lpvm access(~$left##0:anon_field, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$left$bar$1##0:wybe.int)
+            foreign llvm and($right##0:wybe.int, 3:wybe.int, ?tmp$19##0:wybe.int)
+            foreign llvm icmp_eq(~tmp$19##0:wybe.int, 1:wybe.int, ?tmp$20##0:wybe.bool)
+            case ~tmp$20##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                foreign lpvm access(~$right#0:anon_field, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$right$bar$1#0:wybe.int)
-                foreign llvm icmp_eq(~$left$bar$1#0:wybe.int, ~$right$bar$1#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+                foreign lpvm access(~$right##0:anon_field, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$right$bar$1##0:wybe.int)
+                foreign llvm icmp_eq(~$left$bar$1##0:wybe.int, ~$right$bar$1##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
     1:
-        foreign lpvm access($left#0:anon_field, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$foo$2#0:wybe.bool)
-        foreign lpvm access($left#0:anon_field, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$foo$1#0:wybe.int)
-        foreign lpvm access(~$left#0:anon_field, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$i#0:wybe.int)
-        foreign llvm and($right#0:wybe.int, 3:wybe.int, ?tmp$16#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$16#0:wybe.int, 0:wybe.int, ?tmp$17#0:wybe.bool)
-        case ~tmp$17#0:wybe.bool of
+        foreign lpvm access($left##0:anon_field, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$foo$2##0:wybe.bool)
+        foreign lpvm access($left##0:anon_field, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$foo$1##0:wybe.int)
+        foreign lpvm access(~$left##0:anon_field, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$i##0:wybe.int)
+        foreign llvm and($right##0:wybe.int, 3:wybe.int, ?tmp$16##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$16##0:wybe.int, 0:wybe.int, ?tmp$17##0:wybe.bool)
+        case ~tmp$17##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign lpvm access($right#0:anon_field, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$foo$2#0:wybe.bool)
-            foreign lpvm access($right#0:anon_field, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$foo$1#0:wybe.int)
-            foreign lpvm access(~$right#0:anon_field, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$i#0:wybe.int)
-            foreign llvm icmp_eq(~$left$foo$1#0:wybe.int, ~$right$foo$1#0:wybe.int, ?tmp$2#0:wybe.bool) @int:nn:nn
-            case ~tmp$2#0:wybe.bool of
+            foreign lpvm access($right##0:anon_field, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$foo$2##0:wybe.bool)
+            foreign lpvm access($right##0:anon_field, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$foo$1##0:wybe.int)
+            foreign lpvm access(~$right##0:anon_field, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$i##0:wybe.int)
+            foreign llvm icmp_eq(~$left$foo$1##0:wybe.int, ~$right$foo$1##0:wybe.int, ?tmp$2##0:wybe.bool) @int:nn:nn
+            case ~tmp$2##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                foreign llvm icmp_eq(~$left$foo$2#0:wybe.bool, ~$right$foo$2#0:wybe.bool, ?tmp$3#0:wybe.bool) @bool:nn:nn
-                case ~tmp$3#0:wybe.bool of
+                foreign llvm icmp_eq(~$left$foo$2##0:wybe.bool, ~$right$foo$2##0:wybe.bool, ?tmp$3##0:wybe.bool) @bool:nn:nn
+                case ~tmp$3##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                 1:
-                    foreign llvm icmp_eq(~$left$i#0:wybe.int, ~$right$i#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+                    foreign llvm icmp_eq(~$left$i##0:wybe.int, ~$right$i##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
@@ -121,237 +121,237 @@ AFTER EVERYTHING:
 
 bar > public {inline} (3 calls)
 0: anon_field.bar<0>
-bar(bar$1#0:wybe.int, ?$#0:anon_field):
+bar(bar$1##0:wybe.int, ?$##0:anon_field):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec#0:anon_field)
-    foreign lpvm mutate(~$rec#0:anon_field, ?$rec#1:anon_field, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~bar$1#0:wybe.int)
-    foreign llvm or(~$rec#1:anon_field, 1:wybe.int, ?$#0:anon_field)
+    foreign lpvm alloc(8:wybe.int, ?$rec##0:anon_field)
+    foreign lpvm mutate(~$rec##0:anon_field, ?$rec##1:anon_field, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~bar$1##0:wybe.int)
+    foreign llvm or(~$rec##1:anon_field, 1:wybe.int, ?$##0:anon_field)
 bar > public {inline} (7 calls)
 1: anon_field.bar<1>
-bar(?bar$1#0:wybe.int, $#0:anon_field, ?$$#0:wybe.bool):
+bar(?bar$1##0:wybe.int, $##0:anon_field, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($#0:wybe.int, 3:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 1:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($##0:wybe.int, 3:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?bar$1#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?bar$1##0:wybe.int)
 
     1:
-        foreign lpvm access(~$#0:anon_field, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?bar$1#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$##0:anon_field, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?bar$1##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 baz > public {inline} (5 calls)
 0: anon_field.baz<0>
-baz(field#0:wybe.int, ?$#0:anon_field):
+baz(field##0:wybe.int, ?$##0:anon_field):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec#0:anon_field)
-    foreign lpvm mutate(~$rec#0:anon_field, ?$rec#1:anon_field, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~field#0:wybe.int)
-    foreign llvm or(~$rec#1:anon_field, 2:wybe.int, ?$#0:anon_field)
+    foreign lpvm alloc(8:wybe.int, ?$rec##0:anon_field)
+    foreign lpvm mutate(~$rec##0:anon_field, ?$rec##1:anon_field, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~field##0:wybe.int)
+    foreign llvm or(~$rec##1:anon_field, 2:wybe.int, ?$##0:anon_field)
 baz > public {inline} (5 calls)
 1: anon_field.baz<1>
-baz(?field#0:wybe.int, $#0:anon_field, ?$$#0:wybe.bool):
+baz(?field##0:wybe.int, $##0:anon_field, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($#0:wybe.int, 3:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 2:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($##0:wybe.int, 3:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 2:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?field#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?field##0:wybe.int)
 
     1:
-        foreign lpvm access(~$#0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?field#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$##0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 field > {inline} (5 calls)
 0: anon_field.field<0>
-field($rec#0:anon_field, ?$#0:wybe.int, ?$$#0:wybe.bool):
+field($rec##0:anon_field, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec#0:wybe.int, 3:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 2:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($rec##0:wybe.int, 3:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 2:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec#0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 field > {inline} (0 calls)
 1: anon_field.field<1>
-field($rec#0:anon_field, ?$rec#1:anon_field, $field#0:wybe.int, ?$$#0:wybe.bool):
+field($rec##0:anon_field, ?$rec##1:anon_field, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec#0:wybe.int, 3:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 2:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($rec##0:wybe.int, 3:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 2:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:anon_field, ?$rec#1:anon_field)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:anon_field, ?$rec##1:anon_field)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec#0:anon_field, ?$rec#1:anon_field, -2:wybe.int, 0:wybe.int, 8:wybe.int, 2:wybe.int, ~$field#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm {noalias} mutate(~$rec##0:anon_field, ?$rec##1:anon_field, -2:wybe.int, 0:wybe.int, 8:wybe.int, 2:wybe.int, ~$field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 foo > public {inline} (14 calls)
 0: anon_field.foo<0>
-foo(foo$1#0:wybe.int, foo$2#0:wybe.bool, i#0:wybe.int, ?$#0:anon_field):
+foo(foo$1##0:wybe.int, foo$2##0:wybe.bool, i##0:wybe.int, ?$##0:anon_field):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?$rec#0:anon_field)
-    foreign lpvm mutate(~$rec#0:anon_field, ?$rec#1:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~foo$2#0:wybe.bool)
-    foreign lpvm mutate(~$rec#1:anon_field, ?$rec#2:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~foo$1#0:wybe.int)
-    foreign lpvm mutate(~$rec#2:anon_field, ?$#0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~i#0:wybe.int)
+    foreign lpvm alloc(24:wybe.int, ?$rec##0:anon_field)
+    foreign lpvm mutate(~$rec##0:anon_field, ?$rec##1:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~foo$2##0:wybe.bool)
+    foreign lpvm mutate(~$rec##1:anon_field, ?$rec##2:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~foo$1##0:wybe.int)
+    foreign lpvm mutate(~$rec##2:anon_field, ?$##0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~i##0:wybe.int)
 foo > public {inline} (20 calls)
 1: anon_field.foo<1>
-foo(?foo$1#0:wybe.int, ?foo$2#0:wybe.bool, ?i#0:wybe.int, $#0:anon_field, ?$$#0:wybe.bool):
+foo(?foo$1##0:wybe.int, ?foo$2##0:wybe.bool, ?i##0:wybe.int, $##0:anon_field, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($#0:wybe.int, 3:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($##0:wybe.int, 3:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?foo$1#0:wybe.int)
-        foreign llvm move(undef:wybe.bool, ?foo$2#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?i#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?foo$1##0:wybe.int)
+        foreign llvm move(undef:wybe.bool, ?foo$2##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?i##0:wybe.int)
 
     1:
-        foreign lpvm access($#0:anon_field, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?foo$2#0:wybe.bool)
-        foreign lpvm access($#0:anon_field, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?foo$1#0:wybe.int)
-        foreign lpvm access(~$#0:anon_field, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?i#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access($##0:anon_field, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?foo$2##0:wybe.bool)
+        foreign lpvm access($##0:anon_field, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?foo$1##0:wybe.int)
+        foreign lpvm access(~$##0:anon_field, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?i##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 gen$1 > (2 calls)
 0: anon_field.gen$1<0>
-gen$1(io#0:wybe.phantom, ?io#2:wybe.phantom):
+gen$1(io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp$20#0:anon_field)
-    foreign lpvm mutate(~tmp$20#0:anon_field, ?tmp$21#0:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.bool)
-    foreign lpvm mutate(~tmp$21#0:anon_field, ?tmp$22#0:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp$22#0:anon_field, ?tmp$4#0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign llvm and(~tmp$4#0:wybe.int, 3:wybe.int, ?tmp$24#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$24#0:wybe.int, 0:wybe.int, ?tmp$25#0:wybe.bool)
-    case ~tmp$25#0:wybe.bool of
+    foreign lpvm alloc(24:wybe.int, ?tmp$20##0:anon_field)
+    foreign lpvm mutate(~tmp$20##0:anon_field, ?tmp$21##0:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.bool)
+    foreign lpvm mutate(~tmp$21##0:anon_field, ?tmp$22##0:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp$22##0:anon_field, ?tmp$4##0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign llvm and(~tmp$4##0:wybe.int, 3:wybe.int, ?tmp$24##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$24##0:wybe.int, 0:wybe.int, ?tmp$25##0:wybe.bool)
+    case ~tmp$25##0:wybe.bool of
     0:
-        anon_field.gen$2<0>(~io#0:wybe.phantom, ?io#2:wybe.phantom) #7
+        anon_field.gen$2<0>(~io##0:wybe.phantom, ?io##2:wybe.phantom) #7
 
     1:
-        foreign c print_string("good":wybe.string, ~#io#0:wybe.phantom, ?tmp$30#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$30#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        anon_field.gen$2<0>(~io#1:wybe.phantom, ?io#2:wybe.phantom) #5
+        foreign c print_string("good":wybe.string, ~#io##0:wybe.phantom, ?tmp$30##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$30##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        anon_field.gen$2<0>(~io##1:wybe.phantom, ?io##2:wybe.phantom) #5
 
 
 
 gen$2 > (3 calls)
 0: anon_field.gen$2<0>
-gen$2(io#0:wybe.phantom, ?io#2:wybe.phantom):
+gen$2(io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp$18#0:anon_field)
-    foreign lpvm mutate(~tmp$18#0:anon_field, ?tmp$19#0:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.bool)
-    foreign lpvm mutate(~tmp$19#0:anon_field, ?tmp$20#0:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp$20#0:anon_field, ?tmp$6#0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm alloc(24:wybe.int, ?tmp$24#0:anon_field)
-    foreign lpvm mutate(~tmp$24#0:anon_field, ?tmp$25#0:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.bool)
-    foreign lpvm mutate(~tmp$25#0:anon_field, ?tmp$26#0:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm mutate(~tmp$26#0:anon_field, ?tmp$8#0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
-    anon_field.=<0>(~tmp$6#0:anon_field, ~tmp$8#0:anon_field, ?tmp$14#0:wybe.bool) #4 @anon_field:nn:nn
-    case ~tmp$14#0:wybe.bool of
+    foreign lpvm alloc(24:wybe.int, ?tmp$18##0:anon_field)
+    foreign lpvm mutate(~tmp$18##0:anon_field, ?tmp$19##0:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.bool)
+    foreign lpvm mutate(~tmp$19##0:anon_field, ?tmp$20##0:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp$20##0:anon_field, ?tmp$6##0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm alloc(24:wybe.int, ?tmp$24##0:anon_field)
+    foreign lpvm mutate(~tmp$24##0:anon_field, ?tmp$25##0:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.bool)
+    foreign lpvm mutate(~tmp$25##0:anon_field, ?tmp$26##0:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 2:wybe.int)
+    foreign lpvm mutate(~tmp$26##0:anon_field, ?tmp$8##0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
+    anon_field.=<0>(~tmp$6##0:anon_field, ~tmp$8##0:anon_field, ?tmp$14##0:wybe.bool) #4 @anon_field:nn:nn
+    case ~tmp$14##0:wybe.bool of
     0:
-        anon_field.gen$3<0>(~io#0:wybe.phantom, ?io#2:wybe.phantom) #7
+        anon_field.gen$3<0>(~io##0:wybe.phantom, ?io##2:wybe.phantom) #7
 
     1:
-        foreign c print_string("bad":wybe.string, ~#io#0:wybe.phantom, ?tmp$29#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$29#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        anon_field.gen$3<0>(~io#1:wybe.phantom, ?io#2:wybe.phantom) #6
+        foreign c print_string("bad":wybe.string, ~#io##0:wybe.phantom, ?tmp$29##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$29##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        anon_field.gen$3<0>(~io##1:wybe.phantom, ?io##2:wybe.phantom) #6
 
 
 
 gen$3 > (2 calls)
 0: anon_field.gen$3<0>
-gen$3(io#0:wybe.phantom, ?io#1:wybe.phantom):
+gen$3(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?tmp$15#0:anon_field)
-    foreign lpvm mutate(~tmp$15#0:anon_field, ?tmp$16#0:anon_field, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign llvm or(~tmp$16#0:anon_field, 2:wybe.int, ?tmp$11#0:anon_field)
-    foreign llvm and(tmp$11#0:wybe.int, 3:wybe.int, ?tmp$18#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$18#0:wybe.int, 2:wybe.int, ?tmp$19#0:wybe.bool)
-    case ~tmp$19#0:wybe.bool of
+    foreign lpvm alloc(8:wybe.int, ?tmp$15##0:anon_field)
+    foreign lpvm mutate(~tmp$15##0:anon_field, ?tmp$16##0:anon_field, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign llvm or(~tmp$16##0:anon_field, 2:wybe.int, ?tmp$11##0:anon_field)
+    foreign llvm and(tmp$11##0:wybe.int, 3:wybe.int, ?tmp$18##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$18##0:wybe.int, 2:wybe.int, ?tmp$19##0:wybe.bool)
+    case ~tmp$19##0:wybe.bool of
     0:
-        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(~tmp$11#0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?tmp$10#0:wybe.int)
-        foreign llvm icmp_ne(~tmp$10#0:wybe.int, 2:wybe.int, ?tmp$13#0:wybe.bool) @int:nn:nn
-        case ~tmp$13#0:wybe.bool of
+        foreign lpvm access(~tmp$11##0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?tmp$10##0:wybe.int)
+        foreign llvm icmp_ne(~tmp$10##0:wybe.int, 2:wybe.int, ?tmp$13##0:wybe.bool) @int:nn:nn
+        case ~tmp$13##0:wybe.bool of
         0:
-            foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+            foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
         1:
-            foreign c print_string("maybe":wybe.string, ~#io#0:wybe.phantom, ?tmp$24#0:wybe.phantom) @io:nn:nn
-            foreign c putchar('\n':wybe.char, ~tmp$24#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+            foreign c print_string("maybe":wybe.string, ~#io##0:wybe.phantom, ?tmp$24##0:wybe.phantom) @io:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp$24##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 
 
 i > {inline} (5 calls)
 0: anon_field.i<0>
-i($rec#0:anon_field, ?$#0:wybe.int, ?$$#0:wybe.bool):
+i($rec##0:anon_field, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec#0:wybe.int, 3:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($rec##0:wybe.int, 3:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec#0:anon_field, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:anon_field, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 i > {inline} (0 calls)
 1: anon_field.i<1>
-i($rec#0:anon_field, ?$rec#1:anon_field, $field#0:wybe.int, ?$$#0:wybe.bool):
+i($rec##0:anon_field, ?$rec##1:anon_field, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec#0:wybe.int, 3:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($rec##0:wybe.int, 3:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:anon_field, ?$rec#1:anon_field)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:anon_field, ?$rec##1:anon_field)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec#0:anon_field, ?$rec#1:anon_field, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm {noalias} mutate(~$rec##0:anon_field, ?$rec##1:anon_field, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: anon_field.~=<0>
-~=($left#0:anon_field, $right#0:anon_field, ?$$#0:wybe.bool):
+~=($left##0:anon_field, $right##0:anon_field, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    anon_field.=<0>(~$left#0:anon_field, ~$right#0:anon_field, ?tmp$0#0:wybe.bool) #0
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    anon_field.=<0>(~$left##0:anon_field, ~$right##0:anon_field, ?tmp$0##0:wybe.bool) #0
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
   LLVM code       :
 
@@ -407,9 +407,9 @@ entry:
   %15 = inttoptr i64 %14 to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
   store  i64 1, i64* %16 
-  %"1$tmp$2#0" = or i64 %14, 1 
-  %"1$tmp$17#0" = tail call fastcc  i1  @"anon_field.=<0>"(i64  %3, i64  %"1$tmp$2#0")  
-  br i1 %"1$tmp$17#0", label %if.then, label %if.else 
+  %"1$tmp$2##0" = or i64 %14, 1 
+  %"1$tmp$17##0" = tail call fastcc  i1  @"anon_field.=<0>"(i64  %3, i64  %"1$tmp$2##0")  
+  br i1 %"1$tmp$17##0", label %if.then, label %if.else 
 if.then:
   %18 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @anon_field.17, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %18)  
@@ -422,117 +422,117 @@ if.else:
 }
 
 
-define external fastcc  i1 @"anon_field.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"anon_field.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$13#0" = and i64 %"$left#0", 3 
-  %"1$tmp$14#0" = icmp eq i64 %"1$tmp$13#0", 0 
-  br i1 %"1$tmp$14#0", label %if.then, label %if.else 
+  %"1$tmp$13##0" = and i64 %"$left##0", 3 
+  %"1$tmp$14##0" = icmp eq i64 %"1$tmp$13##0", 0 
+  br i1 %"1$tmp$14##0", label %if.then, label %if.else 
 if.then:
-  %19 = inttoptr i64 %"$left#0" to i1* 
+  %19 = inttoptr i64 %"$left##0" to i1* 
   %20 = getelementptr  i1, i1* %19, i64 0 
   %21 = load  i1, i1* %20 
-  %22 = add   i64 %"$left#0", 8 
+  %22 = add   i64 %"$left##0", 8 
   %23 = inttoptr i64 %22 to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$left#0", 16 
+  %26 = add   i64 %"$left##0", 16 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
-  %"2$tmp$16#0" = and i64 %"$right#0", 3 
-  %"2$tmp$17#0" = icmp eq i64 %"2$tmp$16#0", 0 
-  br i1 %"2$tmp$17#0", label %if.then1, label %if.else1 
+  %"2$tmp$16##0" = and i64 %"$right##0", 3 
+  %"2$tmp$17##0" = icmp eq i64 %"2$tmp$16##0", 0 
+  br i1 %"2$tmp$17##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$tmp$17#0" = icmp eq i64 %"1$tmp$13#0", 1 
-  br i1 %"3$tmp$17#0", label %if.then4, label %if.else4 
+  %"3$tmp$17##0" = icmp eq i64 %"1$tmp$13##0", 1 
+  br i1 %"3$tmp$17##0", label %if.then4, label %if.else4 
 if.then1:
-  %30 = inttoptr i64 %"$right#0" to i1* 
+  %30 = inttoptr i64 %"$right##0" to i1* 
   %31 = getelementptr  i1, i1* %30, i64 0 
   %32 = load  i1, i1* %31 
-  %33 = add   i64 %"$right#0", 8 
+  %33 = add   i64 %"$right##0", 8 
   %34 = inttoptr i64 %33 to i64* 
   %35 = getelementptr  i64, i64* %34, i64 0 
   %36 = load  i64, i64* %35 
-  %37 = add   i64 %"$right#0", 16 
+  %37 = add   i64 %"$right##0", 16 
   %38 = inttoptr i64 %37 to i64* 
   %39 = getelementptr  i64, i64* %38, i64 0 
   %40 = load  i64, i64* %39 
-  %"4$tmp$2#0" = icmp eq i64 %25, %36 
-  br i1 %"4$tmp$2#0", label %if.then2, label %if.else2 
+  %"4$tmp$2##0" = icmp eq i64 %25, %36 
+  br i1 %"4$tmp$2##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$tmp$3#0" = icmp eq i1 %21, %32 
-  br i1 %"6$tmp$3#0", label %if.then3, label %if.else3 
+  %"6$tmp$3##0" = icmp eq i1 %21, %32 
+  br i1 %"6$tmp$3##0", label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %"8$$$#0" = icmp eq i64 %29, %40 
-  ret i1 %"8$$$#0" 
+  %"8$$$##0" = icmp eq i64 %29, %40 
+  ret i1 %"8$$$##0" 
 if.else3:
   ret i1 0 
 if.then4:
-  %41 = add   i64 %"$left#0", -1 
+  %41 = add   i64 %"$left##0", -1 
   %42 = inttoptr i64 %41 to i64* 
   %43 = getelementptr  i64, i64* %42, i64 0 
   %44 = load  i64, i64* %43 
-  %"10$tmp$19#0" = and i64 %"$right#0", 3 
-  %"10$tmp$20#0" = icmp eq i64 %"10$tmp$19#0", 1 
-  br i1 %"10$tmp$20#0", label %if.then5, label %if.else5 
+  %"10$tmp$19##0" = and i64 %"$right##0", 3 
+  %"10$tmp$20##0" = icmp eq i64 %"10$tmp$19##0", 1 
+  br i1 %"10$tmp$20##0", label %if.then5, label %if.else5 
 if.else4:
-  %"11$tmp$20#0" = icmp eq i64 %"1$tmp$13#0", 2 
-  br i1 %"11$tmp$20#0", label %if.then6, label %if.else6 
+  %"11$tmp$20##0" = icmp eq i64 %"1$tmp$13##0", 2 
+  br i1 %"11$tmp$20##0", label %if.then6, label %if.else6 
 if.then5:
-  %45 = add   i64 %"$right#0", -1 
+  %45 = add   i64 %"$right##0", -1 
   %46 = inttoptr i64 %45 to i64* 
   %47 = getelementptr  i64, i64* %46, i64 0 
   %48 = load  i64, i64* %47 
-  %"12$$$#0" = icmp eq i64 %44, %48 
-  ret i1 %"12$$$#0" 
+  %"12$$$##0" = icmp eq i64 %44, %48 
+  ret i1 %"12$$$##0" 
 if.else5:
   ret i1 0 
 if.then6:
-  %49 = add   i64 %"$left#0", -2 
+  %49 = add   i64 %"$left##0", -2 
   %50 = inttoptr i64 %49 to i64* 
   %51 = getelementptr  i64, i64* %50, i64 0 
   %52 = load  i64, i64* %51 
-  %"14$tmp$22#0" = and i64 %"$right#0", 3 
-  %"14$tmp$23#0" = icmp eq i64 %"14$tmp$22#0", 2 
-  br i1 %"14$tmp$23#0", label %if.then7, label %if.else7 
+  %"14$tmp$22##0" = and i64 %"$right##0", 3 
+  %"14$tmp$23##0" = icmp eq i64 %"14$tmp$22##0", 2 
+  br i1 %"14$tmp$23##0", label %if.then7, label %if.else7 
 if.else6:
   ret i1 0 
 if.then7:
-  %53 = add   i64 %"$right#0", -2 
+  %53 = add   i64 %"$right##0", -2 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
   %56 = load  i64, i64* %55 
-  %"16$$$#0" = icmp eq i64 %52, %56 
-  ret i1 %"16$$$#0" 
+  %"16$$$##0" = icmp eq i64 %52, %56 
+  ret i1 %"16$$$##0" 
 if.else7:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"anon_field.bar<0>"(i64  %"bar$1#0")    {
+define external fastcc  i64 @"anon_field.bar<0>"(i64  %"bar$1##0")    {
 entry:
   %57 = trunc i64 8 to i32  
   %58 = tail call ccc  i8*  @wybe_malloc(i32  %57)  
   %59 = ptrtoint i8* %58 to i64 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
-  store  i64 %"bar$1#0", i64* %61 
-  %"1$$#0" = or i64 %59, 1 
-  ret i64 %"1$$#0" 
+  store  i64 %"bar$1##0", i64* %61 
+  %"1$$##0" = or i64 %59, 1 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  {i64, i1} @"anon_field.bar<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"anon_field.bar<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$#0", 3 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 1 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$##0", 3 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 1 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %62 = add   i64 %"$#0", -1 
+  %62 = add   i64 %"$##0", -1 
   %63 = inttoptr i64 %62 to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
@@ -546,26 +546,26 @@ if.else:
 }
 
 
-define external fastcc  i64 @"anon_field.baz<0>"(i64  %"field#0")    {
+define external fastcc  i64 @"anon_field.baz<0>"(i64  %"field##0")    {
 entry:
   %70 = trunc i64 8 to i32  
   %71 = tail call ccc  i8*  @wybe_malloc(i32  %70)  
   %72 = ptrtoint i8* %71 to i64 
   %73 = inttoptr i64 %72 to i64* 
   %74 = getelementptr  i64, i64* %73, i64 0 
-  store  i64 %"field#0", i64* %74 
-  %"1$$#0" = or i64 %72, 2 
-  ret i64 %"1$$#0" 
+  store  i64 %"field##0", i64* %74 
+  %"1$$##0" = or i64 %72, 2 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  {i64, i1} @"anon_field.baz<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"anon_field.baz<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$#0", 3 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 2 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$##0", 3 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 2 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %75 = add   i64 %"$#0", -2 
+  %75 = add   i64 %"$##0", -2 
   %76 = inttoptr i64 %75 to i64* 
   %77 = getelementptr  i64, i64* %76, i64 0 
   %78 = load  i64, i64* %77 
@@ -579,13 +579,13 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"anon_field.field<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"anon_field.field<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$rec#0", 3 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 2 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$rec##0", 3 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 2 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %83 = add   i64 %"$rec#0", -2 
+  %83 = add   i64 %"$rec##0", -2 
   %84 = inttoptr i64 %83 to i64* 
   %85 = getelementptr  i64, i64* %84, i64 0 
   %86 = load  i64, i64* %85 
@@ -599,17 +599,17 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"anon_field.field<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"anon_field.field<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$rec#0", 3 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 2 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$rec##0", 3 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 2 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %91 = trunc i64 8 to i32  
   %92 = tail call ccc  i8*  @wybe_malloc(i32  %91)  
   %93 = ptrtoint i8* %92 to i64 
   %94 = add   i64 %93, 2 
-  %95 = sub   i64 %"$rec#0", 2 
+  %95 = sub   i64 %"$rec##0", 2 
   %96 = inttoptr i64 %93 to i8* 
   %97 = inttoptr i64 %95 to i8* 
   %98 = trunc i64 8 to i32  
@@ -617,51 +617,51 @@ if.then:
   %99 = add   i64 %94, -2 
   %100 = inttoptr i64 %99 to i64* 
   %101 = getelementptr  i64, i64* %100, i64 0 
-  store  i64 %"$field#0", i64* %101 
+  store  i64 %"$field##0", i64* %101 
   %102 = insertvalue {i64, i1} undef, i64 %94, 0 
   %103 = insertvalue {i64, i1} %102, i1 1, 1 
   ret {i64, i1} %103 
 if.else:
-  %104 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %104 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %105 = insertvalue {i64, i1} %104, i1 0, 1 
   ret {i64, i1} %105 
 }
 
 
-define external fastcc  i64 @"anon_field.foo<0>"(i64  %"foo$1#0", i1  %"foo$2#0", i64  %"i#0")    {
+define external fastcc  i64 @"anon_field.foo<0>"(i64  %"foo$1##0", i1  %"foo$2##0", i64  %"i##0")    {
 entry:
   %106 = trunc i64 24 to i32  
   %107 = tail call ccc  i8*  @wybe_malloc(i32  %106)  
   %108 = ptrtoint i8* %107 to i64 
   %109 = inttoptr i64 %108 to i1* 
   %110 = getelementptr  i1, i1* %109, i64 0 
-  store  i1 %"foo$2#0", i1* %110 
+  store  i1 %"foo$2##0", i1* %110 
   %111 = add   i64 %108, 8 
   %112 = inttoptr i64 %111 to i64* 
   %113 = getelementptr  i64, i64* %112, i64 0 
-  store  i64 %"foo$1#0", i64* %113 
+  store  i64 %"foo$1##0", i64* %113 
   %114 = add   i64 %108, 16 
   %115 = inttoptr i64 %114 to i64* 
   %116 = getelementptr  i64, i64* %115, i64 0 
-  store  i64 %"i#0", i64* %116 
+  store  i64 %"i##0", i64* %116 
   ret i64 %108 
 }
 
 
-define external fastcc  {i64, i1, i64, i1} @"anon_field.foo<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1, i64, i1} @"anon_field.foo<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$#0", 3 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$##0", 3 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %117 = inttoptr i64 %"$#0" to i1* 
+  %117 = inttoptr i64 %"$##0" to i1* 
   %118 = getelementptr  i1, i1* %117, i64 0 
   %119 = load  i1, i1* %118 
-  %120 = add   i64 %"$#0", 8 
+  %120 = add   i64 %"$##0", 8 
   %121 = inttoptr i64 %120 to i64* 
   %122 = getelementptr  i64, i64* %121, i64 0 
   %123 = load  i64, i64* %122 
-  %124 = add   i64 %"$#0", 16 
+  %124 = add   i64 %"$##0", 16 
   %125 = inttoptr i64 %124 to i64* 
   %126 = getelementptr  i64, i64* %125, i64 0 
   %127 = load  i64, i64* %126 
@@ -695,9 +695,9 @@ entry:
   %145 = inttoptr i64 %144 to i64* 
   %146 = getelementptr  i64, i64* %145, i64 0 
   store  i64 1, i64* %146 
-  %"1$tmp$24#0" = and i64 %138, 3 
-  %"1$tmp$25#0" = icmp eq i64 %"1$tmp$24#0", 0 
-  br i1 %"1$tmp$25#0", label %if.then, label %if.else 
+  %"1$tmp$24##0" = and i64 %138, 3 
+  %"1$tmp$25##0" = icmp eq i64 %"1$tmp$24##0", 0 
+  br i1 %"1$tmp$25##0", label %if.then, label %if.else 
 if.then:
   %148 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @anon_field.147, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %148)  
@@ -740,8 +740,8 @@ entry:
   %169 = inttoptr i64 %168 to i64* 
   %170 = getelementptr  i64, i64* %169, i64 0 
   store  i64 1, i64* %170 
-  %"1$tmp$14#0" = tail call fastcc  i1  @"anon_field.=<0>"(i64  %151, i64  %162)  
-  br i1 %"1$tmp$14#0", label %if.then, label %if.else 
+  %"1$tmp$14##0" = tail call fastcc  i1  @"anon_field.=<0>"(i64  %151, i64  %162)  
+  br i1 %"1$tmp$14##0", label %if.then, label %if.else 
 if.then:
   %172 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @anon_field.171, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %172)  
@@ -762,17 +762,17 @@ entry:
   %176 = inttoptr i64 %175 to i64* 
   %177 = getelementptr  i64, i64* %176, i64 0 
   store  i64 1, i64* %177 
-  %"1$tmp$11#0" = or i64 %175, 2 
-  %"1$tmp$18#0" = and i64 %"1$tmp$11#0", 3 
-  %"1$tmp$19#0" = icmp eq i64 %"1$tmp$18#0", 2 
-  br i1 %"1$tmp$19#0", label %if.then, label %if.else 
+  %"1$tmp$11##0" = or i64 %175, 2 
+  %"1$tmp$18##0" = and i64 %"1$tmp$11##0", 3 
+  %"1$tmp$19##0" = icmp eq i64 %"1$tmp$18##0", 2 
+  br i1 %"1$tmp$19##0", label %if.then, label %if.else 
 if.then:
-  %178 = add   i64 %"1$tmp$11#0", -2 
+  %178 = add   i64 %"1$tmp$11##0", -2 
   %179 = inttoptr i64 %178 to i64* 
   %180 = getelementptr  i64, i64* %179, i64 0 
   %181 = load  i64, i64* %180 
-  %"2$tmp$13#0" = icmp ne i64 %181, 2 
-  br i1 %"2$tmp$13#0", label %if.then1, label %if.else1 
+  %"2$tmp$13##0" = icmp ne i64 %181, 2 
+  br i1 %"2$tmp$13##0", label %if.then1, label %if.else1 
 if.else:
   ret void 
 if.then1:
@@ -785,13 +785,13 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"anon_field.i<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"anon_field.i<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$rec#0", 3 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$rec##0", 3 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %184 = add   i64 %"$rec#0", 16 
+  %184 = add   i64 %"$rec##0", 16 
   %185 = inttoptr i64 %184 to i64* 
   %186 = getelementptr  i64, i64* %185, i64 0 
   %187 = load  i64, i64* %186 
@@ -805,36 +805,36 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"anon_field.i<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"anon_field.i<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$rec#0", 3 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$rec##0", 3 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %192 = trunc i64 24 to i32  
   %193 = tail call ccc  i8*  @wybe_malloc(i32  %192)  
   %194 = ptrtoint i8* %193 to i64 
   %195 = inttoptr i64 %194 to i8* 
-  %196 = inttoptr i64 %"$rec#0" to i8* 
+  %196 = inttoptr i64 %"$rec##0" to i8* 
   %197 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %195, i8*  %196, i32  %197, i32  8, i1  0)  
   %198 = add   i64 %194, 16 
   %199 = inttoptr i64 %198 to i64* 
   %200 = getelementptr  i64, i64* %199, i64 0 
-  store  i64 %"$field#0", i64* %200 
+  store  i64 %"$field##0", i64* %200 
   %201 = insertvalue {i64, i1} undef, i64 %194, 0 
   %202 = insertvalue {i64, i1} %201, i1 1, 1 
   ret {i64, i1} %202 
 if.else:
-  %203 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %203 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %204 = insertvalue {i64, i1} %203, i1 0, 1 
   ret {i64, i1} %204 
 }
 
 
-define external fastcc  i1 @"anon_field.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"anon_field.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = tail call fastcc  i1  @"anon_field.=<0>"(i64  %"$left#0", i64  %"$right#0")  
-  %"1$$$#0" = xor i1 %"1$tmp$0#0", 1 
-  ret i1 %"1$$$#0" 
+  %"1$tmp$0##0" = tail call fastcc  i1  @"anon_field.=<0>"(i64  %"$left##0", i64  %"$right##0")  
+  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
+  ret i1 %"1$$$##0" 
 }

--- a/test-cases/final-dump/anon_field.exp
+++ b/test-cases/final-dump/anon_field.exp
@@ -121,18 +121,18 @@ AFTER EVERYTHING:
 
 bar > public {inline} (3 calls)
 0: anon_field.bar<0>
-bar(bar#1##0:wybe.int, ?###0:anon_field):
+bar(bar#1##0:wybe.int, ?#result##0:anon_field):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:anon_field)
     foreign lpvm mutate(~#rec##0:anon_field, ?#rec##1:anon_field, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~bar#1##0:wybe.int)
-    foreign llvm or(~#rec##1:anon_field, 1:wybe.int, ?###0:anon_field)
+    foreign llvm or(~#rec##1:anon_field, 1:wybe.int, ?#result##0:anon_field)
 bar > public {inline} (7 calls)
 1: anon_field.bar<1>
-bar(?bar#1##0:wybe.int, ###0:anon_field, ?####0:wybe.bool):
+bar(?bar#1##0:wybe.int, #result##0:anon_field, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and(###0:wybe.int, 3:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm and(#result##0:wybe.int, 3:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
@@ -140,25 +140,25 @@ bar(?bar#1##0:wybe.int, ###0:anon_field, ?####0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?bar#1##0:wybe.int)
 
     1:
-        foreign lpvm access(~###0:anon_field, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?bar#1##0:wybe.int)
+        foreign lpvm access(~#result##0:anon_field, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?bar#1##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 baz > public {inline} (5 calls)
 0: anon_field.baz<0>
-baz(field##0:wybe.int, ?###0:anon_field):
+baz(field##0:wybe.int, ?#result##0:anon_field):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:anon_field)
     foreign lpvm mutate(~#rec##0:anon_field, ?#rec##1:anon_field, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~field##0:wybe.int)
-    foreign llvm or(~#rec##1:anon_field, 2:wybe.int, ?###0:anon_field)
+    foreign llvm or(~#rec##1:anon_field, 2:wybe.int, ?#result##0:anon_field)
 baz > public {inline} (5 calls)
 1: anon_field.baz<1>
-baz(?field##0:wybe.int, ###0:anon_field, ?####0:wybe.bool):
+baz(?field##0:wybe.int, #result##0:anon_field, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and(###0:wybe.int, 3:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm and(#result##0:wybe.int, 3:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 2:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
@@ -166,14 +166,14 @@ baz(?field##0:wybe.int, ###0:anon_field, ?####0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?field##0:wybe.int)
 
     1:
-        foreign lpvm access(~###0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?field##0:wybe.int)
+        foreign lpvm access(~#result##0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?field##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 field > {inline} (5 calls)
 0: anon_field.field<0>
-field(#rec##0:anon_field, ?###0:wybe.int, ?####0:wybe.bool):
+field(#rec##0:anon_field, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 3:wybe.int, ?tmp#1##0:wybe.int)
@@ -181,10 +181,10 @@ field(#rec##0:anon_field, ?###0:wybe.int, ?####0:wybe.bool):
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?###0:wybe.int)
+        foreign lpvm access(~#rec##0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#result##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 field > {inline} (0 calls)
@@ -207,19 +207,19 @@ field(#rec##0:anon_field, ?#rec##1:anon_field, #field##0:wybe.int, ?####0:wybe.b
 
 foo > public {inline} (14 calls)
 0: anon_field.foo<0>
-foo(foo#1##0:wybe.int, foo#2##0:wybe.bool, i##0:wybe.int, ?###0:anon_field):
+foo(foo#1##0:wybe.int, foo#2##0:wybe.bool, i##0:wybe.int, ?#result##0:anon_field):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(24:wybe.int, ?#rec##0:anon_field)
     foreign lpvm mutate(~#rec##0:anon_field, ?#rec##1:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~foo#2##0:wybe.bool)
     foreign lpvm mutate(~#rec##1:anon_field, ?#rec##2:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~foo#1##0:wybe.int)
-    foreign lpvm mutate(~#rec##2:anon_field, ?###0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~i##0:wybe.int)
+    foreign lpvm mutate(~#rec##2:anon_field, ?#result##0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~i##0:wybe.int)
 foo > public {inline} (20 calls)
 1: anon_field.foo<1>
-foo(?foo#1##0:wybe.int, ?foo#2##0:wybe.bool, ?i##0:wybe.int, ###0:anon_field, ?####0:wybe.bool):
+foo(?foo#1##0:wybe.int, ?foo#2##0:wybe.bool, ?i##0:wybe.int, #result##0:anon_field, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and(###0:wybe.int, 3:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm and(#result##0:wybe.int, 3:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
@@ -229,9 +229,9 @@ foo(?foo#1##0:wybe.int, ?foo#2##0:wybe.bool, ?i##0:wybe.int, ###0:anon_field, ?#
         foreign llvm move(undef:wybe.int, ?i##0:wybe.int)
 
     1:
-        foreign lpvm access(###0:anon_field, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?foo#2##0:wybe.bool)
-        foreign lpvm access(###0:anon_field, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?foo#1##0:wybe.int)
-        foreign lpvm access(~###0:anon_field, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?i##0:wybe.int)
+        foreign lpvm access(#result##0:anon_field, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?foo#2##0:wybe.bool)
+        foreign lpvm access(#result##0:anon_field, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?foo#1##0:wybe.int)
+        foreign lpvm access(~#result##0:anon_field, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?i##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -313,7 +313,7 @@ gen#3(io##0:wybe.phantom, ?io##1:wybe.phantom):
 
 i > {inline} (5 calls)
 0: anon_field.i<0>
-i(#rec##0:anon_field, ?###0:wybe.int, ?####0:wybe.bool):
+i(#rec##0:anon_field, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 3:wybe.int, ?tmp#1##0:wybe.int)
@@ -321,10 +321,10 @@ i(#rec##0:anon_field, ?###0:wybe.int, ?####0:wybe.bool):
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:anon_field, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign lpvm access(~#rec##0:anon_field, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 i > {inline} (0 calls)
@@ -521,18 +521,18 @@ entry:
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   store  i64 %"bar#1##0", i64* %61 
-  %"1####0" = or i64 %59, 1 
-  ret i64 %"1####0" 
+  %"1##result##0" = or i64 %59, 1 
+  ret i64 %"1##result##0" 
 }
 
 
-define external fastcc  {i64, i1} @"anon_field.bar<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"anon_field.bar<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#1##0" = and i64 %"###0", 3 
+  %"1#tmp#1##0" = and i64 %"#result##0", 3 
   %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 1 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %62 = add   i64 %"###0", -1 
+  %62 = add   i64 %"#result##0", -1 
   %63 = inttoptr i64 %62 to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
@@ -554,18 +554,18 @@ entry:
   %73 = inttoptr i64 %72 to i64* 
   %74 = getelementptr  i64, i64* %73, i64 0 
   store  i64 %"field##0", i64* %74 
-  %"1####0" = or i64 %72, 2 
-  ret i64 %"1####0" 
+  %"1##result##0" = or i64 %72, 2 
+  ret i64 %"1##result##0" 
 }
 
 
-define external fastcc  {i64, i1} @"anon_field.baz<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"anon_field.baz<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#1##0" = and i64 %"###0", 3 
+  %"1#tmp#1##0" = and i64 %"#result##0", 3 
   %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 2 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %75 = add   i64 %"###0", -2 
+  %75 = add   i64 %"#result##0", -2 
   %76 = inttoptr i64 %75 to i64* 
   %77 = getelementptr  i64, i64* %76, i64 0 
   %78 = load  i64, i64* %77 
@@ -648,20 +648,20 @@ entry:
 }
 
 
-define external fastcc  {i64, i1, i64, i1} @"anon_field.foo<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1, i64, i1} @"anon_field.foo<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#1##0" = and i64 %"###0", 3 
+  %"1#tmp#1##0" = and i64 %"#result##0", 3 
   %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %117 = inttoptr i64 %"###0" to i1* 
+  %117 = inttoptr i64 %"#result##0" to i1* 
   %118 = getelementptr  i1, i1* %117, i64 0 
   %119 = load  i1, i1* %118 
-  %120 = add   i64 %"###0", 8 
+  %120 = add   i64 %"#result##0", 8 
   %121 = inttoptr i64 %120 to i64* 
   %122 = getelementptr  i64, i64* %121, i64 0 
   %123 = load  i64, i64* %122 
-  %124 = add   i64 %"###0", 16 
+  %124 = add   i64 %"#result##0", 16 
   %125 = inttoptr i64 %124 to i64* 
   %126 = getelementptr  i64, i64* %125, i64 0 
   %127 = load  i64, i64* %126 

--- a/test-cases/final-dump/anon_field.exp
+++ b/test-cases/final-dump/anon_field.exp
@@ -43,7 +43,7 @@ AFTER EVERYTHING:
 
 = > public (7 calls)
 0: anon_field.=<0>
-=(#left##0:anon_field, #right##0:anon_field, ?####0:wybe.bool):
+=(#left##0:anon_field, #right##0:anon_field, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#left##0:wybe.int, 3:wybe.int, ?tmp#13##0:wybe.int)
@@ -56,7 +56,7 @@ AFTER EVERYTHING:
             foreign llvm icmp_eq(~tmp#13##0:wybe.int, 2:wybe.int, ?tmp#20##0:wybe.bool)
             case ~tmp#20##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
                 foreign lpvm access(~#left##0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#left#field##0:wybe.int)
@@ -64,11 +64,11 @@ AFTER EVERYTHING:
                 foreign llvm icmp_eq(~tmp#22##0:wybe.int, 2:wybe.int, ?tmp#23##0:wybe.bool)
                 case ~tmp#23##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                 1:
                     foreign lpvm access(~#right##0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#right#field##0:wybe.int)
-                    foreign llvm icmp_eq(~#left#field##0:wybe.int, ~#right#field##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+                    foreign llvm icmp_eq(~#left#field##0:wybe.int, ~#right#field##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -78,11 +78,11 @@ AFTER EVERYTHING:
             foreign llvm icmp_eq(~tmp#19##0:wybe.int, 1:wybe.int, ?tmp#20##0:wybe.bool)
             case ~tmp#20##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
                 foreign lpvm access(~#right##0:anon_field, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#right#bar#1##0:wybe.int)
-                foreign llvm icmp_eq(~#left#bar#1##0:wybe.int, ~#right#bar#1##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+                foreign llvm icmp_eq(~#left#bar#1##0:wybe.int, ~#right#bar#1##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -94,7 +94,7 @@ AFTER EVERYTHING:
         foreign llvm icmp_eq(~tmp#16##0:wybe.int, 0:wybe.int, ?tmp#17##0:wybe.bool)
         case ~tmp#17##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign lpvm access(#right##0:anon_field, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#foo#2##0:wybe.bool)
@@ -103,16 +103,16 @@ AFTER EVERYTHING:
             foreign llvm icmp_eq(~#left#foo#1##0:wybe.int, ~#right#foo#1##0:wybe.int, ?tmp#2##0:wybe.bool) @int:nn:nn
             case ~tmp#2##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
                 foreign llvm icmp_eq(~#left#foo#2##0:wybe.bool, ~#right#foo#2##0:wybe.bool, ?tmp#3##0:wybe.bool) @bool:nn:nn
                 case ~tmp#3##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                 1:
-                    foreign llvm icmp_eq(~#left#i##0:wybe.int, ~#right#i##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+                    foreign llvm icmp_eq(~#left#i##0:wybe.int, ~#right#i##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -129,19 +129,19 @@ bar(bar#1##0:wybe.int, ?#result##0:anon_field):
     foreign llvm or(~#rec##1:anon_field, 1:wybe.int, ?#result##0:anon_field)
 bar > public {inline} (7 calls)
 1: anon_field.bar<1>
-bar(?bar#1##0:wybe.int, #result##0:anon_field, ?####0:wybe.bool):
+bar(?bar#1##0:wybe.int, #result##0:anon_field, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#result##0:wybe.int, 3:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?bar#1##0:wybe.int)
 
     1:
         foreign lpvm access(~#result##0:anon_field, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?bar#1##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -155,53 +155,53 @@ baz(field##0:wybe.int, ?#result##0:anon_field):
     foreign llvm or(~#rec##1:anon_field, 2:wybe.int, ?#result##0:anon_field)
 baz > public {inline} (5 calls)
 1: anon_field.baz<1>
-baz(?field##0:wybe.int, #result##0:anon_field, ?####0:wybe.bool):
+baz(?field##0:wybe.int, #result##0:anon_field, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#result##0:wybe.int, 3:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 2:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?field##0:wybe.int)
 
     1:
         foreign lpvm access(~#result##0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 field > {inline} (5 calls)
 0: anon_field.field<0>
-field(#rec##0:anon_field, ?#result##0:wybe.int, ?####0:wybe.bool):
+field(#rec##0:anon_field, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 3:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 2:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign lpvm access(~#rec##0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#result##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 field > {inline} (0 calls)
 1: anon_field.field<1>
-field(#rec##0:anon_field, ?#rec##1:anon_field, #field##0:wybe.int, ?####0:wybe.bool):
+field(#rec##0:anon_field, ?#rec##1:anon_field, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 3:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 2:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:anon_field, ?#rec##1:anon_field)
 
     1:
         foreign lpvm {noalias} mutate(~#rec##0:anon_field, ?#rec##1:anon_field, -2:wybe.int, 0:wybe.int, 8:wybe.int, 2:wybe.int, ~#field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -216,14 +216,14 @@ foo(foo#1##0:wybe.int, foo#2##0:wybe.bool, i##0:wybe.int, ?#result##0:anon_field
     foreign lpvm mutate(~#rec##2:anon_field, ?#result##0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~i##0:wybe.int)
 foo > public {inline} (20 calls)
 1: anon_field.foo<1>
-foo(?foo#1##0:wybe.int, ?foo#2##0:wybe.bool, ?i##0:wybe.int, #result##0:anon_field, ?####0:wybe.bool):
+foo(?foo#1##0:wybe.int, ?foo#2##0:wybe.bool, ?i##0:wybe.int, #result##0:anon_field, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#result##0:wybe.int, 3:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?foo#1##0:wybe.int)
         foreign llvm move(undef:wybe.bool, ?foo#2##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?i##0:wybe.int)
@@ -232,7 +232,7 @@ foo(?foo#1##0:wybe.int, ?foo#2##0:wybe.bool, ?i##0:wybe.int, #result##0:anon_fie
         foreign lpvm access(#result##0:anon_field, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?foo#2##0:wybe.bool)
         foreign lpvm access(#result##0:anon_field, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?foo#1##0:wybe.int)
         foreign lpvm access(~#result##0:anon_field, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?i##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -313,45 +313,45 @@ gen#3(io##0:wybe.phantom, ?io##1:wybe.phantom):
 
 i > {inline} (5 calls)
 0: anon_field.i<0>
-i(#rec##0:anon_field, ?#result##0:wybe.int, ?####0:wybe.bool):
+i(#rec##0:anon_field, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 3:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign lpvm access(~#rec##0:anon_field, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 i > {inline} (0 calls)
 1: anon_field.i<1>
-i(#rec##0:anon_field, ?#rec##1:anon_field, #field##0:wybe.int, ?####0:wybe.bool):
+i(#rec##0:anon_field, ?#rec##1:anon_field, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 3:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:anon_field, ?#rec##1:anon_field)
 
     1:
         foreign lpvm {noalias} mutate(~#rec##0:anon_field, ?#rec##1:anon_field, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: anon_field.~=<0>
-~=(#left##0:anon_field, #right##0:anon_field, ?####0:wybe.bool):
+~=(#left##0:anon_field, #right##0:anon_field, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     anon_field.=<0>(~#left##0:anon_field, ~#right##0:anon_field, ?tmp#0##0:wybe.bool) #0
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 
@@ -467,8 +467,8 @@ if.then2:
 if.else2:
   ret i1 0 
 if.then3:
-  %"8#####0" = icmp eq i64 %29, %40 
-  ret i1 %"8#####0" 
+  %"8##success##0" = icmp eq i64 %29, %40 
+  ret i1 %"8##success##0" 
 if.else3:
   ret i1 0 
 if.then4:
@@ -487,8 +487,8 @@ if.then5:
   %46 = inttoptr i64 %45 to i64* 
   %47 = getelementptr  i64, i64* %46, i64 0 
   %48 = load  i64, i64* %47 
-  %"12#####0" = icmp eq i64 %44, %48 
-  ret i1 %"12#####0" 
+  %"12##success##0" = icmp eq i64 %44, %48 
+  ret i1 %"12##success##0" 
 if.else5:
   ret i1 0 
 if.then6:
@@ -506,8 +506,8 @@ if.then7:
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
   %56 = load  i64, i64* %55 
-  %"16#####0" = icmp eq i64 %52, %56 
-  ret i1 %"16#####0" 
+  %"16##success##0" = icmp eq i64 %52, %56 
+  ret i1 %"16##success##0" 
 if.else7:
   ret i1 0 
 }
@@ -835,6 +835,6 @@ if.else:
 define external fastcc  i1 @"anon_field.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %"1#tmp#0##0" = tail call fastcc  i1  @"anon_field.=<0>"(i64  %"#left##0", i64  %"#right##0")  
-  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
-  ret i1 %"1#####0" 
+  %"1##success##0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1##success##0" 
 }

--- a/test-cases/final-dump/anon_field.exp
+++ b/test-cases/final-dump/anon_field.exp
@@ -22,97 +22,97 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp$21##0:anon_field)
-    foreign lpvm mutate(~tmp$21##0:anon_field, ?tmp$22##0:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.bool)
-    foreign lpvm mutate(~tmp$22##0:anon_field, ?tmp$23##0:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp$23##0:anon_field, ?tmp$0##0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm alloc(8:wybe.int, ?tmp$25##0:anon_field)
-    foreign lpvm mutate(~tmp$25##0:anon_field, ?tmp$26##0:anon_field, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign llvm or(~tmp$26##0:anon_field, 1:wybe.int, ?tmp$2##0:anon_field)
-    anon_field.=<0>(~tmp$0##0:anon_field, ~tmp$2##0:anon_field, ?tmp$17##0:wybe.bool) #3 @anon_field:nn:nn
-    case ~tmp$17##0:wybe.bool of
+    foreign lpvm alloc(24:wybe.int, ?tmp#21##0:anon_field)
+    foreign lpvm mutate(~tmp#21##0:anon_field, ?tmp#22##0:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.bool)
+    foreign lpvm mutate(~tmp#22##0:anon_field, ?tmp#23##0:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp#23##0:anon_field, ?tmp#0##0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm alloc(8:wybe.int, ?tmp#25##0:anon_field)
+    foreign lpvm mutate(~tmp#25##0:anon_field, ?tmp#26##0:anon_field, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign llvm or(~tmp#26##0:anon_field, 1:wybe.int, ?tmp#2##0:anon_field)
+    anon_field.=<0>(~tmp#0##0:anon_field, ~tmp#2##0:anon_field, ?tmp#17##0:wybe.bool) #3 @anon_field:nn:nn
+    case ~tmp#17##0:wybe.bool of
     0:
-        anon_field.gen$1<0>(~io##0:wybe.phantom, ?io##2:wybe.phantom) #6
+        anon_field.gen#1<0>(~io##0:wybe.phantom, ?io##2:wybe.phantom) #6
 
     1:
-        foreign c print_string("uh oh":wybe.string, ~#io##0:wybe.phantom, ?tmp$29##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$29##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        anon_field.gen$1<0>(~io##1:wybe.phantom, ?io##2:wybe.phantom) #5
+        foreign c print_string("uh oh":wybe.string, ~#io##0:wybe.phantom, ?tmp#29##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#29##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        anon_field.gen#1<0>(~io##1:wybe.phantom, ?io##2:wybe.phantom) #5
 
 
 
 = > public (7 calls)
 0: anon_field.=<0>
-=($left##0:anon_field, $right##0:anon_field, ?$$##0:wybe.bool):
+=(#left##0:anon_field, #right##0:anon_field, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($left##0:wybe.int, 3:wybe.int, ?tmp$13##0:wybe.int)
-    foreign llvm icmp_eq(tmp$13##0:wybe.int, 0:wybe.int, ?tmp$14##0:wybe.bool)
-    case ~tmp$14##0:wybe.bool of
+    foreign llvm and(#left##0:wybe.int, 3:wybe.int, ?tmp#13##0:wybe.int)
+    foreign llvm icmp_eq(tmp#13##0:wybe.int, 0:wybe.int, ?tmp#14##0:wybe.bool)
+    case ~tmp#14##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(tmp$13##0:wybe.int, 1:wybe.int, ?tmp$17##0:wybe.bool)
-        case ~tmp$17##0:wybe.bool of
+        foreign llvm icmp_eq(tmp#13##0:wybe.int, 1:wybe.int, ?tmp#17##0:wybe.bool)
+        case ~tmp#17##0:wybe.bool of
         0:
-            foreign llvm icmp_eq(~tmp$13##0:wybe.int, 2:wybe.int, ?tmp$20##0:wybe.bool)
-            case ~tmp$20##0:wybe.bool of
+            foreign llvm icmp_eq(~tmp#13##0:wybe.int, 2:wybe.int, ?tmp#20##0:wybe.bool)
+            case ~tmp#20##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
             1:
-                foreign lpvm access(~$left##0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$left$field##0:wybe.int)
-                foreign llvm and($right##0:wybe.int, 3:wybe.int, ?tmp$22##0:wybe.int)
-                foreign llvm icmp_eq(~tmp$22##0:wybe.int, 2:wybe.int, ?tmp$23##0:wybe.bool)
-                case ~tmp$23##0:wybe.bool of
+                foreign lpvm access(~#left##0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#left#field##0:wybe.int)
+                foreign llvm and(#right##0:wybe.int, 3:wybe.int, ?tmp#22##0:wybe.int)
+                foreign llvm icmp_eq(~tmp#22##0:wybe.int, 2:wybe.int, ?tmp#23##0:wybe.bool)
+                case ~tmp#23##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                 1:
-                    foreign lpvm access(~$right##0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$right$field##0:wybe.int)
-                    foreign llvm icmp_eq(~$left$field##0:wybe.int, ~$right$field##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+                    foreign lpvm access(~#right##0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#right#field##0:wybe.int)
+                    foreign llvm icmp_eq(~#left#field##0:wybe.int, ~#right#field##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
         1:
-            foreign lpvm access(~$left##0:anon_field, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$left$bar$1##0:wybe.int)
-            foreign llvm and($right##0:wybe.int, 3:wybe.int, ?tmp$19##0:wybe.int)
-            foreign llvm icmp_eq(~tmp$19##0:wybe.int, 1:wybe.int, ?tmp$20##0:wybe.bool)
-            case ~tmp$20##0:wybe.bool of
+            foreign lpvm access(~#left##0:anon_field, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#left#bar#1##0:wybe.int)
+            foreign llvm and(#right##0:wybe.int, 3:wybe.int, ?tmp#19##0:wybe.int)
+            foreign llvm icmp_eq(~tmp#19##0:wybe.int, 1:wybe.int, ?tmp#20##0:wybe.bool)
+            case ~tmp#20##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
             1:
-                foreign lpvm access(~$right##0:anon_field, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$right$bar$1##0:wybe.int)
-                foreign llvm icmp_eq(~$left$bar$1##0:wybe.int, ~$right$bar$1##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+                foreign lpvm access(~#right##0:anon_field, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#right#bar#1##0:wybe.int)
+                foreign llvm icmp_eq(~#left#bar#1##0:wybe.int, ~#right#bar#1##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
     1:
-        foreign lpvm access($left##0:anon_field, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$foo$2##0:wybe.bool)
-        foreign lpvm access($left##0:anon_field, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$foo$1##0:wybe.int)
-        foreign lpvm access(~$left##0:anon_field, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$i##0:wybe.int)
-        foreign llvm and($right##0:wybe.int, 3:wybe.int, ?tmp$16##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$16##0:wybe.int, 0:wybe.int, ?tmp$17##0:wybe.bool)
-        case ~tmp$17##0:wybe.bool of
+        foreign lpvm access(#left##0:anon_field, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#foo#2##0:wybe.bool)
+        foreign lpvm access(#left##0:anon_field, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#foo#1##0:wybe.int)
+        foreign lpvm access(~#left##0:anon_field, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#i##0:wybe.int)
+        foreign llvm and(#right##0:wybe.int, 3:wybe.int, ?tmp#16##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#16##0:wybe.int, 0:wybe.int, ?tmp#17##0:wybe.bool)
+        case ~tmp#17##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign lpvm access($right##0:anon_field, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$foo$2##0:wybe.bool)
-            foreign lpvm access($right##0:anon_field, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$foo$1##0:wybe.int)
-            foreign lpvm access(~$right##0:anon_field, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$i##0:wybe.int)
-            foreign llvm icmp_eq(~$left$foo$1##0:wybe.int, ~$right$foo$1##0:wybe.int, ?tmp$2##0:wybe.bool) @int:nn:nn
-            case ~tmp$2##0:wybe.bool of
+            foreign lpvm access(#right##0:anon_field, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#foo#2##0:wybe.bool)
+            foreign lpvm access(#right##0:anon_field, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#foo#1##0:wybe.int)
+            foreign lpvm access(~#right##0:anon_field, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#i##0:wybe.int)
+            foreign llvm icmp_eq(~#left#foo#1##0:wybe.int, ~#right#foo#1##0:wybe.int, ?tmp#2##0:wybe.bool) @int:nn:nn
+            case ~tmp#2##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
             1:
-                foreign llvm icmp_eq(~$left$foo$2##0:wybe.bool, ~$right$foo$2##0:wybe.bool, ?tmp$3##0:wybe.bool) @bool:nn:nn
-                case ~tmp$3##0:wybe.bool of
+                foreign llvm icmp_eq(~#left#foo#2##0:wybe.bool, ~#right#foo#2##0:wybe.bool, ?tmp#3##0:wybe.bool) @bool:nn:nn
+                case ~tmp#3##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                 1:
-                    foreign llvm icmp_eq(~$left$i##0:wybe.int, ~$right$i##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+                    foreign llvm icmp_eq(~#left#i##0:wybe.int, ~#right#i##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
@@ -121,237 +121,237 @@ AFTER EVERYTHING:
 
 bar > public {inline} (3 calls)
 0: anon_field.bar<0>
-bar(bar$1##0:wybe.int, ?$##0:anon_field):
+bar(bar#1##0:wybe.int, ?###0:anon_field):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec##0:anon_field)
-    foreign lpvm mutate(~$rec##0:anon_field, ?$rec##1:anon_field, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~bar$1##0:wybe.int)
-    foreign llvm or(~$rec##1:anon_field, 1:wybe.int, ?$##0:anon_field)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:anon_field)
+    foreign lpvm mutate(~#rec##0:anon_field, ?#rec##1:anon_field, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~bar#1##0:wybe.int)
+    foreign llvm or(~#rec##1:anon_field, 1:wybe.int, ?###0:anon_field)
 bar > public {inline} (7 calls)
 1: anon_field.bar<1>
-bar(?bar$1##0:wybe.int, $##0:anon_field, ?$$##0:wybe.bool):
+bar(?bar#1##0:wybe.int, ###0:anon_field, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($##0:wybe.int, 3:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(###0:wybe.int, 3:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?bar$1##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?bar#1##0:wybe.int)
 
     1:
-        foreign lpvm access(~$##0:anon_field, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?bar$1##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~###0:anon_field, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?bar#1##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 baz > public {inline} (5 calls)
 0: anon_field.baz<0>
-baz(field##0:wybe.int, ?$##0:anon_field):
+baz(field##0:wybe.int, ?###0:anon_field):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec##0:anon_field)
-    foreign lpvm mutate(~$rec##0:anon_field, ?$rec##1:anon_field, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~field##0:wybe.int)
-    foreign llvm or(~$rec##1:anon_field, 2:wybe.int, ?$##0:anon_field)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:anon_field)
+    foreign lpvm mutate(~#rec##0:anon_field, ?#rec##1:anon_field, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~field##0:wybe.int)
+    foreign llvm or(~#rec##1:anon_field, 2:wybe.int, ?###0:anon_field)
 baz > public {inline} (5 calls)
 1: anon_field.baz<1>
-baz(?field##0:wybe.int, $##0:anon_field, ?$$##0:wybe.bool):
+baz(?field##0:wybe.int, ###0:anon_field, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($##0:wybe.int, 3:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 2:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(###0:wybe.int, 3:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 2:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?field##0:wybe.int)
 
     1:
-        foreign lpvm access(~$##0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~###0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 field > {inline} (5 calls)
 0: anon_field.field<0>
-field($rec##0:anon_field, ?$##0:wybe.int, ?$$##0:wybe.bool):
+field(#rec##0:anon_field, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec##0:wybe.int, 3:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 2:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(#rec##0:wybe.int, 3:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 2:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec##0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?###0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 field > {inline} (0 calls)
 1: anon_field.field<1>
-field($rec##0:anon_field, ?$rec##1:anon_field, $field##0:wybe.int, ?$$##0:wybe.bool):
+field(#rec##0:anon_field, ?#rec##1:anon_field, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec##0:wybe.int, 3:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 2:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(#rec##0:wybe.int, 3:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 2:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:anon_field, ?$rec##1:anon_field)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:anon_field, ?#rec##1:anon_field)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec##0:anon_field, ?$rec##1:anon_field, -2:wybe.int, 0:wybe.int, 8:wybe.int, 2:wybe.int, ~$field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm {noalias} mutate(~#rec##0:anon_field, ?#rec##1:anon_field, -2:wybe.int, 0:wybe.int, 8:wybe.int, 2:wybe.int, ~#field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 foo > public {inline} (14 calls)
 0: anon_field.foo<0>
-foo(foo$1##0:wybe.int, foo$2##0:wybe.bool, i##0:wybe.int, ?$##0:anon_field):
+foo(foo#1##0:wybe.int, foo#2##0:wybe.bool, i##0:wybe.int, ?###0:anon_field):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?$rec##0:anon_field)
-    foreign lpvm mutate(~$rec##0:anon_field, ?$rec##1:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~foo$2##0:wybe.bool)
-    foreign lpvm mutate(~$rec##1:anon_field, ?$rec##2:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~foo$1##0:wybe.int)
-    foreign lpvm mutate(~$rec##2:anon_field, ?$##0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~i##0:wybe.int)
+    foreign lpvm alloc(24:wybe.int, ?#rec##0:anon_field)
+    foreign lpvm mutate(~#rec##0:anon_field, ?#rec##1:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~foo#2##0:wybe.bool)
+    foreign lpvm mutate(~#rec##1:anon_field, ?#rec##2:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~foo#1##0:wybe.int)
+    foreign lpvm mutate(~#rec##2:anon_field, ?###0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~i##0:wybe.int)
 foo > public {inline} (20 calls)
 1: anon_field.foo<1>
-foo(?foo$1##0:wybe.int, ?foo$2##0:wybe.bool, ?i##0:wybe.int, $##0:anon_field, ?$$##0:wybe.bool):
+foo(?foo#1##0:wybe.int, ?foo#2##0:wybe.bool, ?i##0:wybe.int, ###0:anon_field, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($##0:wybe.int, 3:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(###0:wybe.int, 3:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?foo$1##0:wybe.int)
-        foreign llvm move(undef:wybe.bool, ?foo$2##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?foo#1##0:wybe.int)
+        foreign llvm move(undef:wybe.bool, ?foo#2##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?i##0:wybe.int)
 
     1:
-        foreign lpvm access($##0:anon_field, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?foo$2##0:wybe.bool)
-        foreign lpvm access($##0:anon_field, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?foo$1##0:wybe.int)
-        foreign lpvm access(~$##0:anon_field, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?i##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(###0:anon_field, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?foo#2##0:wybe.bool)
+        foreign lpvm access(###0:anon_field, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?foo#1##0:wybe.int)
+        foreign lpvm access(~###0:anon_field, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?i##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
-gen$1 > (2 calls)
-0: anon_field.gen$1<0>
-gen$1(io##0:wybe.phantom, ?io##2:wybe.phantom):
+gen#1 > (2 calls)
+0: anon_field.gen#1<0>
+gen#1(io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp$20##0:anon_field)
-    foreign lpvm mutate(~tmp$20##0:anon_field, ?tmp$21##0:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.bool)
-    foreign lpvm mutate(~tmp$21##0:anon_field, ?tmp$22##0:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp$22##0:anon_field, ?tmp$4##0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign llvm and(~tmp$4##0:wybe.int, 3:wybe.int, ?tmp$24##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$24##0:wybe.int, 0:wybe.int, ?tmp$25##0:wybe.bool)
-    case ~tmp$25##0:wybe.bool of
+    foreign lpvm alloc(24:wybe.int, ?tmp#20##0:anon_field)
+    foreign lpvm mutate(~tmp#20##0:anon_field, ?tmp#21##0:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.bool)
+    foreign lpvm mutate(~tmp#21##0:anon_field, ?tmp#22##0:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp#22##0:anon_field, ?tmp#4##0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign llvm and(~tmp#4##0:wybe.int, 3:wybe.int, ?tmp#24##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#24##0:wybe.int, 0:wybe.int, ?tmp#25##0:wybe.bool)
+    case ~tmp#25##0:wybe.bool of
     0:
-        anon_field.gen$2<0>(~io##0:wybe.phantom, ?io##2:wybe.phantom) #7
+        anon_field.gen#2<0>(~io##0:wybe.phantom, ?io##2:wybe.phantom) #7
 
     1:
-        foreign c print_string("good":wybe.string, ~#io##0:wybe.phantom, ?tmp$30##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$30##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        anon_field.gen$2<0>(~io##1:wybe.phantom, ?io##2:wybe.phantom) #5
+        foreign c print_string("good":wybe.string, ~#io##0:wybe.phantom, ?tmp#30##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#30##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        anon_field.gen#2<0>(~io##1:wybe.phantom, ?io##2:wybe.phantom) #5
 
 
 
-gen$2 > (3 calls)
-0: anon_field.gen$2<0>
-gen$2(io##0:wybe.phantom, ?io##2:wybe.phantom):
+gen#2 > (3 calls)
+0: anon_field.gen#2<0>
+gen#2(io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp$18##0:anon_field)
-    foreign lpvm mutate(~tmp$18##0:anon_field, ?tmp$19##0:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.bool)
-    foreign lpvm mutate(~tmp$19##0:anon_field, ?tmp$20##0:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp$20##0:anon_field, ?tmp$6##0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm alloc(24:wybe.int, ?tmp$24##0:anon_field)
-    foreign lpvm mutate(~tmp$24##0:anon_field, ?tmp$25##0:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.bool)
-    foreign lpvm mutate(~tmp$25##0:anon_field, ?tmp$26##0:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm mutate(~tmp$26##0:anon_field, ?tmp$8##0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
-    anon_field.=<0>(~tmp$6##0:anon_field, ~tmp$8##0:anon_field, ?tmp$14##0:wybe.bool) #4 @anon_field:nn:nn
-    case ~tmp$14##0:wybe.bool of
+    foreign lpvm alloc(24:wybe.int, ?tmp#18##0:anon_field)
+    foreign lpvm mutate(~tmp#18##0:anon_field, ?tmp#19##0:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.bool)
+    foreign lpvm mutate(~tmp#19##0:anon_field, ?tmp#20##0:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp#20##0:anon_field, ?tmp#6##0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm alloc(24:wybe.int, ?tmp#24##0:anon_field)
+    foreign lpvm mutate(~tmp#24##0:anon_field, ?tmp#25##0:anon_field, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:wybe.bool)
+    foreign lpvm mutate(~tmp#25##0:anon_field, ?tmp#26##0:anon_field, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 2:wybe.int)
+    foreign lpvm mutate(~tmp#26##0:anon_field, ?tmp#8##0:anon_field, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
+    anon_field.=<0>(~tmp#6##0:anon_field, ~tmp#8##0:anon_field, ?tmp#14##0:wybe.bool) #4 @anon_field:nn:nn
+    case ~tmp#14##0:wybe.bool of
     0:
-        anon_field.gen$3<0>(~io##0:wybe.phantom, ?io##2:wybe.phantom) #7
+        anon_field.gen#3<0>(~io##0:wybe.phantom, ?io##2:wybe.phantom) #7
 
     1:
-        foreign c print_string("bad":wybe.string, ~#io##0:wybe.phantom, ?tmp$29##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$29##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        anon_field.gen$3<0>(~io##1:wybe.phantom, ?io##2:wybe.phantom) #6
+        foreign c print_string("bad":wybe.string, ~#io##0:wybe.phantom, ?tmp#29##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#29##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        anon_field.gen#3<0>(~io##1:wybe.phantom, ?io##2:wybe.phantom) #6
 
 
 
-gen$3 > (2 calls)
-0: anon_field.gen$3<0>
-gen$3(io##0:wybe.phantom, ?io##1:wybe.phantom):
+gen#3 > (2 calls)
+0: anon_field.gen#3<0>
+gen#3(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?tmp$15##0:anon_field)
-    foreign lpvm mutate(~tmp$15##0:anon_field, ?tmp$16##0:anon_field, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign llvm or(~tmp$16##0:anon_field, 2:wybe.int, ?tmp$11##0:anon_field)
-    foreign llvm and(tmp$11##0:wybe.int, 3:wybe.int, ?tmp$18##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$18##0:wybe.int, 2:wybe.int, ?tmp$19##0:wybe.bool)
-    case ~tmp$19##0:wybe.bool of
+    foreign lpvm alloc(8:wybe.int, ?tmp#15##0:anon_field)
+    foreign lpvm mutate(~tmp#15##0:anon_field, ?tmp#16##0:anon_field, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign llvm or(~tmp#16##0:anon_field, 2:wybe.int, ?tmp#11##0:anon_field)
+    foreign llvm and(tmp#11##0:wybe.int, 3:wybe.int, ?tmp#18##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#18##0:wybe.int, 2:wybe.int, ?tmp#19##0:wybe.bool)
+    case ~tmp#19##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(~tmp$11##0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?tmp$10##0:wybe.int)
-        foreign llvm icmp_ne(~tmp$10##0:wybe.int, 2:wybe.int, ?tmp$13##0:wybe.bool) @int:nn:nn
-        case ~tmp$13##0:wybe.bool of
+        foreign lpvm access(~tmp#11##0:anon_field, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?tmp#10##0:wybe.int)
+        foreign llvm icmp_ne(~tmp#10##0:wybe.int, 2:wybe.int, ?tmp#13##0:wybe.bool) @int:nn:nn
+        case ~tmp#13##0:wybe.bool of
         0:
             foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
         1:
-            foreign c print_string("maybe":wybe.string, ~#io##0:wybe.phantom, ?tmp$24##0:wybe.phantom) @io:nn:nn
-            foreign c putchar('\n':wybe.char, ~tmp$24##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+            foreign c print_string("maybe":wybe.string, ~#io##0:wybe.phantom, ?tmp#24##0:wybe.phantom) @io:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#24##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 
 
 i > {inline} (5 calls)
 0: anon_field.i<0>
-i($rec##0:anon_field, ?$##0:wybe.int, ?$$##0:wybe.bool):
+i(#rec##0:anon_field, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec##0:wybe.int, 3:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(#rec##0:wybe.int, 3:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec##0:anon_field, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:anon_field, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 i > {inline} (0 calls)
 1: anon_field.i<1>
-i($rec##0:anon_field, ?$rec##1:anon_field, $field##0:wybe.int, ?$$##0:wybe.bool):
+i(#rec##0:anon_field, ?#rec##1:anon_field, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec##0:wybe.int, 3:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(#rec##0:wybe.int, 3:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:anon_field, ?$rec##1:anon_field)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:anon_field, ?#rec##1:anon_field)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec##0:anon_field, ?$rec##1:anon_field, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm {noalias} mutate(~#rec##0:anon_field, ?#rec##1:anon_field, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: anon_field.~=<0>
-~=($left##0:anon_field, $right##0:anon_field, ?$$##0:wybe.bool):
+~=(#left##0:anon_field, #right##0:anon_field, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    anon_field.=<0>(~$left##0:anon_field, ~$right##0:anon_field, ?tmp$0##0:wybe.bool) #0
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    anon_field.=<0>(~#left##0:anon_field, ~#right##0:anon_field, ?tmp#0##0:wybe.bool) #0
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
   LLVM code       :
 
@@ -407,132 +407,132 @@ entry:
   %15 = inttoptr i64 %14 to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
   store  i64 1, i64* %16 
-  %"1$tmp$2##0" = or i64 %14, 1 
-  %"1$tmp$17##0" = tail call fastcc  i1  @"anon_field.=<0>"(i64  %3, i64  %"1$tmp$2##0")  
-  br i1 %"1$tmp$17##0", label %if.then, label %if.else 
+  %"1#tmp#2##0" = or i64 %14, 1 
+  %"1#tmp#17##0" = tail call fastcc  i1  @"anon_field.=<0>"(i64  %3, i64  %"1#tmp#2##0")  
+  br i1 %"1#tmp#17##0", label %if.then, label %if.else 
 if.then:
   %18 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @anon_field.17, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %18)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"anon_field.gen$1<0>"()  
+  tail call fastcc  void  @"anon_field.gen#1<0>"()  
   ret void 
 if.else:
-  tail call fastcc  void  @"anon_field.gen$1<0>"()  
+  tail call fastcc  void  @"anon_field.gen#1<0>"()  
   ret void 
 }
 
 
-define external fastcc  i1 @"anon_field.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"anon_field.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$13##0" = and i64 %"$left##0", 3 
-  %"1$tmp$14##0" = icmp eq i64 %"1$tmp$13##0", 0 
-  br i1 %"1$tmp$14##0", label %if.then, label %if.else 
+  %"1#tmp#13##0" = and i64 %"#left##0", 3 
+  %"1#tmp#14##0" = icmp eq i64 %"1#tmp#13##0", 0 
+  br i1 %"1#tmp#14##0", label %if.then, label %if.else 
 if.then:
-  %19 = inttoptr i64 %"$left##0" to i1* 
+  %19 = inttoptr i64 %"#left##0" to i1* 
   %20 = getelementptr  i1, i1* %19, i64 0 
   %21 = load  i1, i1* %20 
-  %22 = add   i64 %"$left##0", 8 
+  %22 = add   i64 %"#left##0", 8 
   %23 = inttoptr i64 %22 to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$left##0", 16 
+  %26 = add   i64 %"#left##0", 16 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
-  %"2$tmp$16##0" = and i64 %"$right##0", 3 
-  %"2$tmp$17##0" = icmp eq i64 %"2$tmp$16##0", 0 
-  br i1 %"2$tmp$17##0", label %if.then1, label %if.else1 
+  %"2#tmp#16##0" = and i64 %"#right##0", 3 
+  %"2#tmp#17##0" = icmp eq i64 %"2#tmp#16##0", 0 
+  br i1 %"2#tmp#17##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$tmp$17##0" = icmp eq i64 %"1$tmp$13##0", 1 
-  br i1 %"3$tmp$17##0", label %if.then4, label %if.else4 
+  %"3#tmp#17##0" = icmp eq i64 %"1#tmp#13##0", 1 
+  br i1 %"3#tmp#17##0", label %if.then4, label %if.else4 
 if.then1:
-  %30 = inttoptr i64 %"$right##0" to i1* 
+  %30 = inttoptr i64 %"#right##0" to i1* 
   %31 = getelementptr  i1, i1* %30, i64 0 
   %32 = load  i1, i1* %31 
-  %33 = add   i64 %"$right##0", 8 
+  %33 = add   i64 %"#right##0", 8 
   %34 = inttoptr i64 %33 to i64* 
   %35 = getelementptr  i64, i64* %34, i64 0 
   %36 = load  i64, i64* %35 
-  %37 = add   i64 %"$right##0", 16 
+  %37 = add   i64 %"#right##0", 16 
   %38 = inttoptr i64 %37 to i64* 
   %39 = getelementptr  i64, i64* %38, i64 0 
   %40 = load  i64, i64* %39 
-  %"4$tmp$2##0" = icmp eq i64 %25, %36 
-  br i1 %"4$tmp$2##0", label %if.then2, label %if.else2 
+  %"4#tmp#2##0" = icmp eq i64 %25, %36 
+  br i1 %"4#tmp#2##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$tmp$3##0" = icmp eq i1 %21, %32 
-  br i1 %"6$tmp$3##0", label %if.then3, label %if.else3 
+  %"6#tmp#3##0" = icmp eq i1 %21, %32 
+  br i1 %"6#tmp#3##0", label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %"8$$$##0" = icmp eq i64 %29, %40 
-  ret i1 %"8$$$##0" 
+  %"8#####0" = icmp eq i64 %29, %40 
+  ret i1 %"8#####0" 
 if.else3:
   ret i1 0 
 if.then4:
-  %41 = add   i64 %"$left##0", -1 
+  %41 = add   i64 %"#left##0", -1 
   %42 = inttoptr i64 %41 to i64* 
   %43 = getelementptr  i64, i64* %42, i64 0 
   %44 = load  i64, i64* %43 
-  %"10$tmp$19##0" = and i64 %"$right##0", 3 
-  %"10$tmp$20##0" = icmp eq i64 %"10$tmp$19##0", 1 
-  br i1 %"10$tmp$20##0", label %if.then5, label %if.else5 
+  %"10#tmp#19##0" = and i64 %"#right##0", 3 
+  %"10#tmp#20##0" = icmp eq i64 %"10#tmp#19##0", 1 
+  br i1 %"10#tmp#20##0", label %if.then5, label %if.else5 
 if.else4:
-  %"11$tmp$20##0" = icmp eq i64 %"1$tmp$13##0", 2 
-  br i1 %"11$tmp$20##0", label %if.then6, label %if.else6 
+  %"11#tmp#20##0" = icmp eq i64 %"1#tmp#13##0", 2 
+  br i1 %"11#tmp#20##0", label %if.then6, label %if.else6 
 if.then5:
-  %45 = add   i64 %"$right##0", -1 
+  %45 = add   i64 %"#right##0", -1 
   %46 = inttoptr i64 %45 to i64* 
   %47 = getelementptr  i64, i64* %46, i64 0 
   %48 = load  i64, i64* %47 
-  %"12$$$##0" = icmp eq i64 %44, %48 
-  ret i1 %"12$$$##0" 
+  %"12#####0" = icmp eq i64 %44, %48 
+  ret i1 %"12#####0" 
 if.else5:
   ret i1 0 
 if.then6:
-  %49 = add   i64 %"$left##0", -2 
+  %49 = add   i64 %"#left##0", -2 
   %50 = inttoptr i64 %49 to i64* 
   %51 = getelementptr  i64, i64* %50, i64 0 
   %52 = load  i64, i64* %51 
-  %"14$tmp$22##0" = and i64 %"$right##0", 3 
-  %"14$tmp$23##0" = icmp eq i64 %"14$tmp$22##0", 2 
-  br i1 %"14$tmp$23##0", label %if.then7, label %if.else7 
+  %"14#tmp#22##0" = and i64 %"#right##0", 3 
+  %"14#tmp#23##0" = icmp eq i64 %"14#tmp#22##0", 2 
+  br i1 %"14#tmp#23##0", label %if.then7, label %if.else7 
 if.else6:
   ret i1 0 
 if.then7:
-  %53 = add   i64 %"$right##0", -2 
+  %53 = add   i64 %"#right##0", -2 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
   %56 = load  i64, i64* %55 
-  %"16$$$##0" = icmp eq i64 %52, %56 
-  ret i1 %"16$$$##0" 
+  %"16#####0" = icmp eq i64 %52, %56 
+  ret i1 %"16#####0" 
 if.else7:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"anon_field.bar<0>"(i64  %"bar$1##0")    {
+define external fastcc  i64 @"anon_field.bar<0>"(i64  %"bar#1##0")    {
 entry:
   %57 = trunc i64 8 to i32  
   %58 = tail call ccc  i8*  @wybe_malloc(i32  %57)  
   %59 = ptrtoint i8* %58 to i64 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
-  store  i64 %"bar$1##0", i64* %61 
-  %"1$$##0" = or i64 %59, 1 
-  ret i64 %"1$$##0" 
+  store  i64 %"bar#1##0", i64* %61 
+  %"1####0" = or i64 %59, 1 
+  ret i64 %"1####0" 
 }
 
 
-define external fastcc  {i64, i1} @"anon_field.bar<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"anon_field.bar<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$##0", 3 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 1 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"###0", 3 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 1 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %62 = add   i64 %"$##0", -1 
+  %62 = add   i64 %"###0", -1 
   %63 = inttoptr i64 %62 to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
@@ -554,18 +554,18 @@ entry:
   %73 = inttoptr i64 %72 to i64* 
   %74 = getelementptr  i64, i64* %73, i64 0 
   store  i64 %"field##0", i64* %74 
-  %"1$$##0" = or i64 %72, 2 
-  ret i64 %"1$$##0" 
+  %"1####0" = or i64 %72, 2 
+  ret i64 %"1####0" 
 }
 
 
-define external fastcc  {i64, i1} @"anon_field.baz<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"anon_field.baz<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$##0", 3 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 2 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"###0", 3 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 2 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %75 = add   i64 %"$##0", -2 
+  %75 = add   i64 %"###0", -2 
   %76 = inttoptr i64 %75 to i64* 
   %77 = getelementptr  i64, i64* %76, i64 0 
   %78 = load  i64, i64* %77 
@@ -579,13 +579,13 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"anon_field.field<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"anon_field.field<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$rec##0", 3 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 2 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"#rec##0", 3 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 2 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %83 = add   i64 %"$rec##0", -2 
+  %83 = add   i64 %"#rec##0", -2 
   %84 = inttoptr i64 %83 to i64* 
   %85 = getelementptr  i64, i64* %84, i64 0 
   %86 = load  i64, i64* %85 
@@ -599,17 +599,17 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"anon_field.field<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"anon_field.field<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$rec##0", 3 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 2 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"#rec##0", 3 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 2 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %91 = trunc i64 8 to i32  
   %92 = tail call ccc  i8*  @wybe_malloc(i32  %91)  
   %93 = ptrtoint i8* %92 to i64 
   %94 = add   i64 %93, 2 
-  %95 = sub   i64 %"$rec##0", 2 
+  %95 = sub   i64 %"#rec##0", 2 
   %96 = inttoptr i64 %93 to i8* 
   %97 = inttoptr i64 %95 to i8* 
   %98 = trunc i64 8 to i32  
@@ -617,29 +617,29 @@ if.then:
   %99 = add   i64 %94, -2 
   %100 = inttoptr i64 %99 to i64* 
   %101 = getelementptr  i64, i64* %100, i64 0 
-  store  i64 %"$field##0", i64* %101 
+  store  i64 %"#field##0", i64* %101 
   %102 = insertvalue {i64, i1} undef, i64 %94, 0 
   %103 = insertvalue {i64, i1} %102, i1 1, 1 
   ret {i64, i1} %103 
 if.else:
-  %104 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %104 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %105 = insertvalue {i64, i1} %104, i1 0, 1 
   ret {i64, i1} %105 
 }
 
 
-define external fastcc  i64 @"anon_field.foo<0>"(i64  %"foo$1##0", i1  %"foo$2##0", i64  %"i##0")    {
+define external fastcc  i64 @"anon_field.foo<0>"(i64  %"foo#1##0", i1  %"foo#2##0", i64  %"i##0")    {
 entry:
   %106 = trunc i64 24 to i32  
   %107 = tail call ccc  i8*  @wybe_malloc(i32  %106)  
   %108 = ptrtoint i8* %107 to i64 
   %109 = inttoptr i64 %108 to i1* 
   %110 = getelementptr  i1, i1* %109, i64 0 
-  store  i1 %"foo$2##0", i1* %110 
+  store  i1 %"foo#2##0", i1* %110 
   %111 = add   i64 %108, 8 
   %112 = inttoptr i64 %111 to i64* 
   %113 = getelementptr  i64, i64* %112, i64 0 
-  store  i64 %"foo$1##0", i64* %113 
+  store  i64 %"foo#1##0", i64* %113 
   %114 = add   i64 %108, 16 
   %115 = inttoptr i64 %114 to i64* 
   %116 = getelementptr  i64, i64* %115, i64 0 
@@ -648,20 +648,20 @@ entry:
 }
 
 
-define external fastcc  {i64, i1, i64, i1} @"anon_field.foo<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1, i64, i1} @"anon_field.foo<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$##0", 3 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"###0", 3 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %117 = inttoptr i64 %"$##0" to i1* 
+  %117 = inttoptr i64 %"###0" to i1* 
   %118 = getelementptr  i1, i1* %117, i64 0 
   %119 = load  i1, i1* %118 
-  %120 = add   i64 %"$##0", 8 
+  %120 = add   i64 %"###0", 8 
   %121 = inttoptr i64 %120 to i64* 
   %122 = getelementptr  i64, i64* %121, i64 0 
   %123 = load  i64, i64* %122 
-  %124 = add   i64 %"$##0", 16 
+  %124 = add   i64 %"###0", 16 
   %125 = inttoptr i64 %124 to i64* 
   %126 = getelementptr  i64, i64* %125, i64 0 
   %127 = load  i64, i64* %126 
@@ -679,7 +679,7 @@ if.else:
 }
 
 
-define external fastcc  void @"anon_field.gen$1<0>"()    {
+define external fastcc  void @"anon_field.gen#1<0>"()    {
 entry:
   %136 = trunc i64 24 to i32  
   %137 = tail call ccc  i8*  @wybe_malloc(i32  %136)  
@@ -695,22 +695,22 @@ entry:
   %145 = inttoptr i64 %144 to i64* 
   %146 = getelementptr  i64, i64* %145, i64 0 
   store  i64 1, i64* %146 
-  %"1$tmp$24##0" = and i64 %138, 3 
-  %"1$tmp$25##0" = icmp eq i64 %"1$tmp$24##0", 0 
-  br i1 %"1$tmp$25##0", label %if.then, label %if.else 
+  %"1#tmp#24##0" = and i64 %138, 3 
+  %"1#tmp#25##0" = icmp eq i64 %"1#tmp#24##0", 0 
+  br i1 %"1#tmp#25##0", label %if.then, label %if.else 
 if.then:
   %148 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @anon_field.147, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %148)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"anon_field.gen$2<0>"()  
+  tail call fastcc  void  @"anon_field.gen#2<0>"()  
   ret void 
 if.else:
-  tail call fastcc  void  @"anon_field.gen$2<0>"()  
+  tail call fastcc  void  @"anon_field.gen#2<0>"()  
   ret void 
 }
 
 
-define external fastcc  void @"anon_field.gen$2<0>"()    {
+define external fastcc  void @"anon_field.gen#2<0>"()    {
 entry:
   %149 = trunc i64 24 to i32  
   %150 = tail call ccc  i8*  @wybe_malloc(i32  %149)  
@@ -740,21 +740,21 @@ entry:
   %169 = inttoptr i64 %168 to i64* 
   %170 = getelementptr  i64, i64* %169, i64 0 
   store  i64 1, i64* %170 
-  %"1$tmp$14##0" = tail call fastcc  i1  @"anon_field.=<0>"(i64  %151, i64  %162)  
-  br i1 %"1$tmp$14##0", label %if.then, label %if.else 
+  %"1#tmp#14##0" = tail call fastcc  i1  @"anon_field.=<0>"(i64  %151, i64  %162)  
+  br i1 %"1#tmp#14##0", label %if.then, label %if.else 
 if.then:
   %172 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @anon_field.171, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %172)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"anon_field.gen$3<0>"()  
+  tail call fastcc  void  @"anon_field.gen#3<0>"()  
   ret void 
 if.else:
-  tail call fastcc  void  @"anon_field.gen$3<0>"()  
+  tail call fastcc  void  @"anon_field.gen#3<0>"()  
   ret void 
 }
 
 
-define external fastcc  void @"anon_field.gen$3<0>"()    {
+define external fastcc  void @"anon_field.gen#3<0>"()    {
 entry:
   %173 = trunc i64 8 to i32  
   %174 = tail call ccc  i8*  @wybe_malloc(i32  %173)  
@@ -762,17 +762,17 @@ entry:
   %176 = inttoptr i64 %175 to i64* 
   %177 = getelementptr  i64, i64* %176, i64 0 
   store  i64 1, i64* %177 
-  %"1$tmp$11##0" = or i64 %175, 2 
-  %"1$tmp$18##0" = and i64 %"1$tmp$11##0", 3 
-  %"1$tmp$19##0" = icmp eq i64 %"1$tmp$18##0", 2 
-  br i1 %"1$tmp$19##0", label %if.then, label %if.else 
+  %"1#tmp#11##0" = or i64 %175, 2 
+  %"1#tmp#18##0" = and i64 %"1#tmp#11##0", 3 
+  %"1#tmp#19##0" = icmp eq i64 %"1#tmp#18##0", 2 
+  br i1 %"1#tmp#19##0", label %if.then, label %if.else 
 if.then:
-  %178 = add   i64 %"1$tmp$11##0", -2 
+  %178 = add   i64 %"1#tmp#11##0", -2 
   %179 = inttoptr i64 %178 to i64* 
   %180 = getelementptr  i64, i64* %179, i64 0 
   %181 = load  i64, i64* %180 
-  %"2$tmp$13##0" = icmp ne i64 %181, 2 
-  br i1 %"2$tmp$13##0", label %if.then1, label %if.else1 
+  %"2#tmp#13##0" = icmp ne i64 %181, 2 
+  br i1 %"2#tmp#13##0", label %if.then1, label %if.else1 
 if.else:
   ret void 
 if.then1:
@@ -785,13 +785,13 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"anon_field.i<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"anon_field.i<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$rec##0", 3 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"#rec##0", 3 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %184 = add   i64 %"$rec##0", 16 
+  %184 = add   i64 %"#rec##0", 16 
   %185 = inttoptr i64 %184 to i64* 
   %186 = getelementptr  i64, i64* %185, i64 0 
   %187 = load  i64, i64* %186 
@@ -805,36 +805,36 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"anon_field.i<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"anon_field.i<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$rec##0", 3 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"#rec##0", 3 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %192 = trunc i64 24 to i32  
   %193 = tail call ccc  i8*  @wybe_malloc(i32  %192)  
   %194 = ptrtoint i8* %193 to i64 
   %195 = inttoptr i64 %194 to i8* 
-  %196 = inttoptr i64 %"$rec##0" to i8* 
+  %196 = inttoptr i64 %"#rec##0" to i8* 
   %197 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %195, i8*  %196, i32  %197, i32  8, i1  0)  
   %198 = add   i64 %194, 16 
   %199 = inttoptr i64 %198 to i64* 
   %200 = getelementptr  i64, i64* %199, i64 0 
-  store  i64 %"$field##0", i64* %200 
+  store  i64 %"#field##0", i64* %200 
   %201 = insertvalue {i64, i1} undef, i64 %194, 0 
   %202 = insertvalue {i64, i1} %201, i1 1, 1 
   ret {i64, i1} %202 
 if.else:
-  %203 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %203 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %204 = insertvalue {i64, i1} %203, i1 0, 1 
   ret {i64, i1} %204 
 }
 
 
-define external fastcc  i1 @"anon_field.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"anon_field.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = tail call fastcc  i1  @"anon_field.=<0>"(i64  %"$left##0", i64  %"$right##0")  
-  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
-  ret i1 %"1$$$##0" 
+  %"1#tmp#0##0" = tail call fastcc  i1  @"anon_field.=<0>"(i64  %"#left##0", i64  %"#right##0")  
+  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1#####0" 
 }

--- a/test-cases/final-dump/assert_error.exp
+++ b/test-cases/final-dump/assert_error.exp
@@ -11,7 +11,7 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: assert_error.<0>
-(io#0:wybe.phantom, [?io#0:wybe.phantom]):
+(io##0:wybe.phantom, [?io##0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
     wybe.control.assert<0>(0:wybe.bool, "assert_error:3:2":wybe.string) #1 @assert_error:nn:nn

--- a/test-cases/final-dump/backquote_OK.exp
+++ b/test-cases/final-dump/backquote_OK.exp
@@ -11,10 +11,10 @@ AFTER EVERYTHING:
 
 OK backquote use! > {inline} (0 calls)
 0: backquote_OK.OK backquote use!<0>
-OK backquote use!(?$#0:wybe.int):
+OK backquote use!(?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(1:wybe.int, ?$#0:wybe.int) @backquote_OK:3:1
+    foreign llvm move(1:wybe.int, ?$##0:wybe.int) @backquote_OK:3:1
 
   LLVM code       :
 

--- a/test-cases/final-dump/backquote_OK.exp
+++ b/test-cases/final-dump/backquote_OK.exp
@@ -11,10 +11,10 @@ AFTER EVERYTHING:
 
 OK backquote use! > {inline} (0 calls)
 0: backquote_OK.OK backquote use!<0>
-OK backquote use!(?$##0:wybe.int):
+OK backquote use!(?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(1:wybe.int, ?$##0:wybe.int) @backquote_OK:3:1
+    foreign llvm move(1:wybe.int, ?###0:wybe.int) @backquote_OK:3:1
 
   LLVM code       :
 

--- a/test-cases/final-dump/backquote_OK.exp
+++ b/test-cases/final-dump/backquote_OK.exp
@@ -1,0 +1,36 @@
+======================================================================
+AFTER EVERYTHING:
+ Module backquote_OK
+  representation  : (not a type)
+  public submods  : 
+  public resources: 
+  public procs    : 
+  imports         : use wybe
+  resources       : 
+  procs           : 
+
+OK backquote use! > {inline} (0 calls)
+0: backquote_OK.OK backquote use!<0>
+OK backquote use!(?$#0:wybe.int):
+ AliasPairs: []
+ InterestingCallProperties: []
+    foreign llvm move(1:wybe.int, ?$#0:wybe.int) @backquote_OK:3:1
+
+  LLVM code       :
+
+; ModuleID = 'backquote_OK'
+
+
+ 
+
+
+declare external ccc  i8* @wybe_malloc(i32)    
+
+
+declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
+
+
+define external fastcc  i64 @"backquote_OK.OK backquote use!<0>"()    {
+entry:
+  ret i64 1 
+}

--- a/test-cases/final-dump/backquote_OK.exp
+++ b/test-cases/final-dump/backquote_OK.exp
@@ -11,10 +11,10 @@ AFTER EVERYTHING:
 
 OK backquote use! > {inline} (0 calls)
 0: backquote_OK.OK backquote use!<0>
-OK backquote use!(?###0:wybe.int):
+OK backquote use!(?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(1:wybe.int, ?###0:wybe.int) @backquote_OK:3:1
+    foreign llvm move(1:wybe.int, ?#result##0:wybe.int) @backquote_OK:3:1
 
   LLVM code       :
 

--- a/test-cases/final-dump/backquote_OK.wybe
+++ b/test-cases/final-dump/backquote_OK.wybe
@@ -1,0 +1,3 @@
+# Test case for use of backticks
+
+def `OK backquote use!` = 1

--- a/test-cases/final-dump/backquote_control_char.exp
+++ b/test-cases/final-dump/backquote_control_char.exp
@@ -1,0 +1,4 @@
+Error detected during loading module: backquote_control_char
+[91mfinal-dump/backquote_control_char.wybe:1:5: Syntax error: unexpected control character in a backquoted symbol
+expecting simple expression
+[0m

--- a/test-cases/final-dump/backquote_control_char.wybe
+++ b/test-cases/final-dump/backquote_control_char.wybe
@@ -1,0 +1,1 @@
+def `backquoted with tab	character` = 1

--- a/test-cases/final-dump/backquote_empty.exp
+++ b/test-cases/final-dump/backquote_empty.exp
@@ -1,0 +1,4 @@
+Error detected during loading module: backquote_empty
+[91mfinal-dump/backquote_empty.wybe:1:5: Syntax error: unexpected empty backquoted symbol
+expecting simple expression
+[0m

--- a/test-cases/final-dump/backquote_empty.wybe
+++ b/test-cases/final-dump/backquote_empty.wybe
@@ -1,0 +1,1 @@
+def `` = 1 # empty backquoted symbol

--- a/test-cases/final-dump/backquote_hash.exp
+++ b/test-cases/final-dump/backquote_hash.exp
@@ -1,0 +1,4 @@
+Error detected during loading module: backquote_hash
+[91mfinal-dump/backquote_hash.wybe:1:5: Syntax error: unexpected hash character (#) in backquoted symbol
+expecting simple expression
+[0m

--- a/test-cases/final-dump/backquote_hash.wybe
+++ b/test-cases/final-dump/backquote_hash.wybe
@@ -1,0 +1,1 @@
+def `backquoted with # character` = 1

--- a/test-cases/final-dump/backquote_multiline.exp
+++ b/test-cases/final-dump/backquote_multiline.exp
@@ -1,0 +1,4 @@
+Error detected during loading module: backquote_multiline
+[91mfinal-dump/backquote_multiline.wybe:1:5: Syntax error: unexpected multiline backquoted symbol
+expecting simple expression
+[0m

--- a/test-cases/final-dump/backquote_multiline.wybe
+++ b/test-cases/final-dump/backquote_multiline.wybe
@@ -1,0 +1,2 @@
+def `multiline
+ident is an error` = 1

--- a/test-cases/final-dump/backquote_unclosed.exp
+++ b/test-cases/final-dump/backquote_unclosed.exp
@@ -1,0 +1,4 @@
+Error detected during loading module: backquote_unclosed
+[91mfinal-dump/backquote_unclosed.wybe:1:5: Syntax error: unexpected multiline backquoted symbol
+expecting simple expression
+[0m

--- a/test-cases/final-dump/backquote_unclosed.wybe
+++ b/test-cases/final-dump/backquote_unclosed.wybe
@@ -1,0 +1,1 @@
+def `unclosed backtick = 1

--- a/test-cases/final-dump/backwards_assign.exp
+++ b/test-cases/final-dump/backwards_assign.exp
@@ -14,7 +14,7 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    backwards_assign.gen$1<0>(0:wybe.int, ~io##0:wybe.phantom, ?io##1:wybe.phantom) #0 @backwards_assign:nn:nn
+    backwards_assign.gen#1<0>(0:wybe.int, ~io##0:wybe.phantom, ?io##1:wybe.phantom) #0 @backwards_assign:nn:nn
 
 
 backwards_assign > {inline} (3 calls)
@@ -25,21 +25,21 @@ backwards_assign(?output##0:wybe.int, input##0:wybe.int):
     foreign llvm add(~input##0:wybe.int, 1:wybe.int, ?output##0:wybe.int) @int:nn:nn
 
 
-gen$1 > (2 calls)
-0: backwards_assign.gen$1<0>
-gen$1(i##0:wybe.int, io##0:wybe.phantom, ?io##2:wybe.phantom):
+gen#1 > (2 calls)
+0: backwards_assign.gen#1<0>
+gen#1(i##0:wybe.int, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$3##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$3##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#3##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#3##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     foreign llvm add(~i##0:wybe.int, 1:wybe.int, ?i##1:wybe.int) @int:nn:nn
-    foreign llvm icmp_slt(i##1:wybe.int, 10:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_slt(i##1:wybe.int, 10:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+    case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(~io##1:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        backwards_assign.gen$1<0>(~i##1:wybe.int, ~io##1:wybe.phantom, ?io##2:wybe.phantom) #3 @backwards_assign:nn:nn
+        backwards_assign.gen#1<0>(~i##1:wybe.int, ~io##1:wybe.phantom, ?io##2:wybe.phantom) #3 @backwards_assign:nn:nn
 
 
   LLVM code       :
@@ -64,27 +64,27 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"backwards_assign.<0>"()    {
 entry:
-  tail call fastcc  void  @"backwards_assign.gen$1<0>"(i64  0)  
+  tail call fastcc  void  @"backwards_assign.gen#1<0>"(i64  0)  
   ret void 
 }
 
 
 define external fastcc  i64 @"backwards_assign.backwards_assign<0>"(i64  %"input##0")    {
 entry:
-  %"1$output##0" = add   i64 %"input##0", 1 
-  ret i64 %"1$output##0" 
+  %"1#output##0" = add   i64 %"input##0", 1 
+  ret i64 %"1#output##0" 
 }
 
 
-define external fastcc  void @"backwards_assign.gen$1<0>"(i64  %"i##0")    {
+define external fastcc  void @"backwards_assign.gen#1<0>"(i64  %"i##0")    {
 entry:
   tail call ccc  void  @print_int(i64  %"i##0")  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$i##1" = add   i64 %"i##0", 1 
-  %"1$tmp$0##0" = icmp slt i64 %"1$i##1", 10 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#i##1" = add   i64 %"i##0", 1 
+  %"1#tmp#0##0" = icmp slt i64 %"1#i##1", 10 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"backwards_assign.gen$1<0>"(i64  %"1$i##1")  
+  tail call fastcc  void  @"backwards_assign.gen#1<0>"(i64  %"1#i##1")  
   ret void 
 if.else:
   ret void 

--- a/test-cases/final-dump/backwards_assign.exp
+++ b/test-cases/final-dump/backwards_assign.exp
@@ -11,35 +11,35 @@ AFTER EVERYTHING:
 
 *main* > public {inline} (0 calls)
 0: backwards_assign.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    backwards_assign.gen$1<0>(0:wybe.int, ~io#0:wybe.phantom, ?io#1:wybe.phantom) #0 @backwards_assign:nn:nn
+    backwards_assign.gen$1<0>(0:wybe.int, ~io##0:wybe.phantom, ?io##1:wybe.phantom) #0 @backwards_assign:nn:nn
 
 
 backwards_assign > {inline} (3 calls)
 0: backwards_assign.backwards_assign<0>
-backwards_assign(?output#0:wybe.int, input#0:wybe.int):
+backwards_assign(?output##0:wybe.int, input##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~input#0:wybe.int, 1:wybe.int, ?output#0:wybe.int) @int:nn:nn
+    foreign llvm add(~input##0:wybe.int, 1:wybe.int, ?output##0:wybe.int) @int:nn:nn
 
 
 gen$1 > (2 calls)
 0: backwards_assign.gen$1<0>
-gen$1(i#0:wybe.int, io#0:wybe.phantom, ?io#2:wybe.phantom):
+gen$1(i##0:wybe.int, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(i#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$3#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$3#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign llvm add(~i#0:wybe.int, 1:wybe.int, ?i#1:wybe.int) @int:nn:nn
-    foreign llvm icmp_slt(i#1:wybe.int, 10:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-    case ~tmp$0#0:wybe.bool of
+    foreign c print_int(i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$3##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$3##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign llvm add(~i##0:wybe.int, 1:wybe.int, ?i##1:wybe.int) @int:nn:nn
+    foreign llvm icmp_slt(i##1:wybe.int, 10:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(~io#1:wybe.phantom, ?io#2:wybe.phantom)
+        foreign llvm move(~io##1:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        backwards_assign.gen$1<0>(~i#1:wybe.int, ~io#1:wybe.phantom, ?io#2:wybe.phantom) #3 @backwards_assign:nn:nn
+        backwards_assign.gen$1<0>(~i##1:wybe.int, ~io##1:wybe.phantom, ?io##2:wybe.phantom) #3 @backwards_assign:nn:nn
 
 
   LLVM code       :
@@ -69,22 +69,22 @@ entry:
 }
 
 
-define external fastcc  i64 @"backwards_assign.backwards_assign<0>"(i64  %"input#0")    {
+define external fastcc  i64 @"backwards_assign.backwards_assign<0>"(i64  %"input##0")    {
 entry:
-  %"1$output#0" = add   i64 %"input#0", 1 
-  ret i64 %"1$output#0" 
+  %"1$output##0" = add   i64 %"input##0", 1 
+  ret i64 %"1$output##0" 
 }
 
 
-define external fastcc  void @"backwards_assign.gen$1<0>"(i64  %"i#0")    {
+define external fastcc  void @"backwards_assign.gen$1<0>"(i64  %"i##0")    {
 entry:
-  tail call ccc  void  @print_int(i64  %"i#0")  
+  tail call ccc  void  @print_int(i64  %"i##0")  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$i#1" = add   i64 %"i#0", 1 
-  %"1$tmp$0#0" = icmp slt i64 %"1$i#1", 10 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$i##1" = add   i64 %"i##0", 1 
+  %"1$tmp$0##0" = icmp slt i64 %"1$i##1", 10 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"backwards_assign.gen$1<0>"(i64  %"1$i#1")  
+  tail call fastcc  void  @"backwards_assign.gen$1<0>"(i64  %"1$i##1")  
   ret void 
 if.else:
   ret void 

--- a/test-cases/final-dump/bar.exp
+++ b/test-cases/final-dump/bar.exp
@@ -15,11 +15,11 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    numbers.factorial<0>(4:wybe.int, ?tmp$0##0:wybe.int) #0 @bar:nn:nn
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$4##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$4##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign c print_float(35.0:wybe.float, ~#io##1:wybe.phantom, ?tmp$9##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$9##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    numbers.factorial<0>(4:wybe.int, ?tmp#0##0:wybe.int) #0 @bar:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#4##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#4##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_float(35.0:wybe.float, ~#io##1:wybe.phantom, ?tmp#9##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#9##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -49,8 +49,8 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"bar.<0>"()    {
 entry:
-  %"1$tmp$0##0" = tail call fastcc  i64  @"numbers.factorial<0>"(i64  4)  
-  tail call ccc  void  @print_int(i64  %"1$tmp$0##0")  
+  %"1#tmp#0##0" = tail call fastcc  i64  @"numbers.factorial<0>"(i64  4)  
+  tail call ccc  void  @print_int(i64  %"1#tmp#0##0")  
   tail call ccc  void  @putchar(i8  10)  
   tail call ccc  void  @print_float(double  3.500000e1)  
   tail call ccc  void  @putchar(i8  10)  
@@ -73,34 +73,34 @@ entry:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("Numbers has been initialised.":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("Numbers has been initialised.":wybe.string, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 factorial > public (1 calls)
 0: numbers.factorial<0>
-factorial(n##0:wybe.int, ?$##0:wybe.int):
+factorial(n##0:wybe.int, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_sle(n##0:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
-    case ~tmp$4##0:wybe.bool of
+    foreign llvm icmp_sle(n##0:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
+    case ~tmp#4##0:wybe.bool of
     0:
-        foreign llvm sub(n##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
-        numbers.factorial<0>(~tmp$3##0:wybe.int, ?tmp$2##0:wybe.int) #2 @numbers:nn:nn
-        foreign llvm mul(~n##0:wybe.int, ~tmp$2##0:wybe.int, ?$##0:wybe.int) @int:nn:nn
+        foreign llvm sub(n##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
+        numbers.factorial<0>(~tmp#3##0:wybe.int, ?tmp#2##0:wybe.int) #2 @numbers:nn:nn
+        foreign llvm mul(~n##0:wybe.int, ~tmp#2##0:wybe.int, ?###0:wybe.int) @int:nn:nn
 
     1:
-        foreign llvm move(1:wybe.int, ?$##0:wybe.int) @numbers:nn:nn
+        foreign llvm move(1:wybe.int, ?###0:wybe.int) @numbers:nn:nn
 
 
 
 toCelsius > public {inline} (0 calls)
 0: numbers.toCelsius<0>
-toCelsius(f##0:wybe.float, ?$##0:wybe.float):
+toCelsius(f##0:wybe.float, ?###0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm fsub(~f##0:wybe.float, 32.0:wybe.float, ?tmp$1##0:wybe.float) @float:nn:nn
-    foreign llvm fdiv(~tmp$1##0:wybe.float, 1.8:wybe.float, ?$##0:wybe.float) @float:nn:nn
+    foreign llvm fsub(~f##0:wybe.float, 32.0:wybe.float, ?tmp#1##0:wybe.float) @float:nn:nn
+    foreign llvm fdiv(~tmp#1##0:wybe.float, 1.8:wybe.float, ?###0:wybe.float) @float:nn:nn
 
   LLVM code       :
 
@@ -136,21 +136,21 @@ entry:
 
 define external fastcc  i64 @"numbers.factorial<0>"(i64  %"n##0")    {
 entry:
-  %"1$tmp$4##0" = icmp sle i64 %"n##0", 0 
-  br i1 %"1$tmp$4##0", label %if.then, label %if.else 
+  %"1#tmp#4##0" = icmp sle i64 %"n##0", 0 
+  br i1 %"1#tmp#4##0", label %if.then, label %if.else 
 if.then:
   ret i64 1 
 if.else:
-  %"3$tmp$3##0" = sub   i64 %"n##0", 1 
-  %"3$tmp$2##0" = tail call fastcc  i64  @"numbers.factorial<0>"(i64  %"3$tmp$3##0")  
-  %"3$$##0" = mul   i64 %"n##0", %"3$tmp$2##0" 
-  ret i64 %"3$$##0" 
+  %"3#tmp#3##0" = sub   i64 %"n##0", 1 
+  %"3#tmp#2##0" = tail call fastcc  i64  @"numbers.factorial<0>"(i64  %"3#tmp#3##0")  
+  %"3####0" = mul   i64 %"n##0", %"3#tmp#2##0" 
+  ret i64 %"3####0" 
 }
 
 
 define external fastcc  double @"numbers.toCelsius<0>"(double  %"f##0")    {
 entry:
-  %"1$tmp$1##0" = fsub double %"f##0", 3.200000e1 
-  %"1$$##0" = fdiv double %"1$tmp$1##0", 1.800000e0 
-  ret double %"1$$##0" 
+  %"1#tmp#1##0" = fsub double %"f##0", 3.200000e1 
+  %"1####0" = fdiv double %"1#tmp#1##0", 1.800000e0 
+  ret double %"1####0" 
 }

--- a/test-cases/final-dump/bar.exp
+++ b/test-cases/final-dump/bar.exp
@@ -12,14 +12,14 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: bar.<0>
-(io#0:wybe.phantom, ?io#2:wybe.phantom):
+(io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    numbers.factorial<0>(4:wybe.int, ?tmp$0#0:wybe.int) #0 @bar:nn:nn
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$4#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$4#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_float(35.0:wybe.float, ~#io#1:wybe.phantom, ?tmp$9#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$9#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
+    numbers.factorial<0>(4:wybe.int, ?tmp$0##0:wybe.int) #0 @bar:nn:nn
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$4##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$4##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_float(35.0:wybe.float, ~#io##1:wybe.phantom, ?tmp$9##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$9##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -49,8 +49,8 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"bar.<0>"()    {
 entry:
-  %"1$tmp$0#0" = tail call fastcc  i64  @"numbers.factorial<0>"(i64  4)  
-  tail call ccc  void  @print_int(i64  %"1$tmp$0#0")  
+  %"1$tmp$0##0" = tail call fastcc  i64  @"numbers.factorial<0>"(i64  4)  
+  tail call ccc  void  @print_int(i64  %"1$tmp$0##0")  
   tail call ccc  void  @putchar(i8  10)  
   tail call ccc  void  @print_float(double  3.500000e1)  
   tail call ccc  void  @putchar(i8  10)  
@@ -70,37 +70,37 @@ entry:
 
 *main* > public {inline} (0 calls)
 0: numbers.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("Numbers has been initialised.":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_string("Numbers has been initialised.":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 factorial > public (1 calls)
 0: numbers.factorial<0>
-factorial(n#0:wybe.int, ?$#0:wybe.int):
+factorial(n##0:wybe.int, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_sle(n#0:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.bool) @int:nn:nn
-    case ~tmp$4#0:wybe.bool of
+    foreign llvm icmp_sle(n##0:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
+    case ~tmp$4##0:wybe.bool of
     0:
-        foreign llvm sub(n#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.int) @int:nn:nn
-        numbers.factorial<0>(~tmp$3#0:wybe.int, ?tmp$2#0:wybe.int) #2 @numbers:nn:nn
-        foreign llvm mul(~n#0:wybe.int, ~tmp$2#0:wybe.int, ?$#0:wybe.int) @int:nn:nn
+        foreign llvm sub(n##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
+        numbers.factorial<0>(~tmp$3##0:wybe.int, ?tmp$2##0:wybe.int) #2 @numbers:nn:nn
+        foreign llvm mul(~n##0:wybe.int, ~tmp$2##0:wybe.int, ?$##0:wybe.int) @int:nn:nn
 
     1:
-        foreign llvm move(1:wybe.int, ?$#0:wybe.int) @numbers:nn:nn
+        foreign llvm move(1:wybe.int, ?$##0:wybe.int) @numbers:nn:nn
 
 
 
 toCelsius > public {inline} (0 calls)
 0: numbers.toCelsius<0>
-toCelsius(f#0:wybe.float, ?$#0:wybe.float):
+toCelsius(f##0:wybe.float, ?$##0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm fsub(~f#0:wybe.float, 32.0:wybe.float, ?tmp$1#0:wybe.float) @float:nn:nn
-    foreign llvm fdiv(~tmp$1#0:wybe.float, 1.8:wybe.float, ?$#0:wybe.float) @float:nn:nn
+    foreign llvm fsub(~f##0:wybe.float, 32.0:wybe.float, ?tmp$1##0:wybe.float) @float:nn:nn
+    foreign llvm fdiv(~tmp$1##0:wybe.float, 1.8:wybe.float, ?$##0:wybe.float) @float:nn:nn
 
   LLVM code       :
 
@@ -134,23 +134,23 @@ entry:
 }
 
 
-define external fastcc  i64 @"numbers.factorial<0>"(i64  %"n#0")    {
+define external fastcc  i64 @"numbers.factorial<0>"(i64  %"n##0")    {
 entry:
-  %"1$tmp$4#0" = icmp sle i64 %"n#0", 0 
-  br i1 %"1$tmp$4#0", label %if.then, label %if.else 
+  %"1$tmp$4##0" = icmp sle i64 %"n##0", 0 
+  br i1 %"1$tmp$4##0", label %if.then, label %if.else 
 if.then:
   ret i64 1 
 if.else:
-  %"3$tmp$3#0" = sub   i64 %"n#0", 1 
-  %"3$tmp$2#0" = tail call fastcc  i64  @"numbers.factorial<0>"(i64  %"3$tmp$3#0")  
-  %"3$$#0" = mul   i64 %"n#0", %"3$tmp$2#0" 
-  ret i64 %"3$$#0" 
+  %"3$tmp$3##0" = sub   i64 %"n##0", 1 
+  %"3$tmp$2##0" = tail call fastcc  i64  @"numbers.factorial<0>"(i64  %"3$tmp$3##0")  
+  %"3$$##0" = mul   i64 %"n##0", %"3$tmp$2##0" 
+  ret i64 %"3$$##0" 
 }
 
 
-define external fastcc  double @"numbers.toCelsius<0>"(double  %"f#0")    {
+define external fastcc  double @"numbers.toCelsius<0>"(double  %"f##0")    {
 entry:
-  %"1$tmp$1#0" = fsub double %"f#0", 3.200000e1 
-  %"1$$#0" = fdiv double %"1$tmp$1#0", 1.800000e0 
-  ret double %"1$$#0" 
+  %"1$tmp$1##0" = fsub double %"f##0", 3.200000e1 
+  %"1$$##0" = fdiv double %"1$tmp$1##0", 1.800000e0 
+  ret double %"1$$##0" 
 }

--- a/test-cases/final-dump/bar.exp
+++ b/test-cases/final-dump/bar.exp
@@ -79,7 +79,7 @@ entry:
 
 factorial > public (1 calls)
 0: numbers.factorial<0>
-factorial(n##0:wybe.int, ?###0:wybe.int):
+factorial(n##0:wybe.int, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_sle(n##0:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
@@ -87,20 +87,20 @@ factorial(n##0:wybe.int, ?###0:wybe.int):
     0:
         foreign llvm sub(n##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
         numbers.factorial<0>(~tmp#3##0:wybe.int, ?tmp#2##0:wybe.int) #2 @numbers:nn:nn
-        foreign llvm mul(~n##0:wybe.int, ~tmp#2##0:wybe.int, ?###0:wybe.int) @int:nn:nn
+        foreign llvm mul(~n##0:wybe.int, ~tmp#2##0:wybe.int, ?#result##0:wybe.int) @int:nn:nn
 
     1:
-        foreign llvm move(1:wybe.int, ?###0:wybe.int) @numbers:nn:nn
+        foreign llvm move(1:wybe.int, ?#result##0:wybe.int) @numbers:nn:nn
 
 
 
 toCelsius > public {inline} (0 calls)
 0: numbers.toCelsius<0>
-toCelsius(f##0:wybe.float, ?###0:wybe.float):
+toCelsius(f##0:wybe.float, ?#result##0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm fsub(~f##0:wybe.float, 32.0:wybe.float, ?tmp#1##0:wybe.float) @float:nn:nn
-    foreign llvm fdiv(~tmp#1##0:wybe.float, 1.8:wybe.float, ?###0:wybe.float) @float:nn:nn
+    foreign llvm fdiv(~tmp#1##0:wybe.float, 1.8:wybe.float, ?#result##0:wybe.float) @float:nn:nn
 
   LLVM code       :
 
@@ -143,14 +143,14 @@ if.then:
 if.else:
   %"3#tmp#3##0" = sub   i64 %"n##0", 1 
   %"3#tmp#2##0" = tail call fastcc  i64  @"numbers.factorial<0>"(i64  %"3#tmp#3##0")  
-  %"3####0" = mul   i64 %"n##0", %"3#tmp#2##0" 
-  ret i64 %"3####0" 
+  %"3##result##0" = mul   i64 %"n##0", %"3#tmp#2##0" 
+  ret i64 %"3##result##0" 
 }
 
 
 define external fastcc  double @"numbers.toCelsius<0>"(double  %"f##0")    {
 entry:
   %"1#tmp#1##0" = fsub double %"f##0", 3.200000e1 
-  %"1####0" = fdiv double %"1#tmp#1##0", 1.800000e0 
-  ret double %"1####0" 
+  %"1##result##0" = fdiv double %"1#tmp#1##0", 1.800000e0 
+  ret double %"1##result##0" 
 }

--- a/test-cases/final-dump/bbb.exp
+++ b/test-cases/final-dump/bbb.exp
@@ -15,8 +15,8 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("BBB: Init":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("BBB: Init":wybe.string, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -63,8 +63,8 @@ entry:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("DDD: Init":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("DDD: Init":wybe.string, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/bbb.exp
+++ b/test-cases/final-dump/bbb.exp
@@ -12,11 +12,11 @@ AFTER EVERYTHING:
 
 *main* > public {inline} (0 calls)
 0: bbb.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("BBB: Init":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_string("BBB: Init":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -60,11 +60,11 @@ entry:
 
 *main* > public {inline} (0 calls)
 0: ddd.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("DDD: Init":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_string("DDD: Init":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/block_comment.exp
+++ b/test-cases/final-dump/block_comment.exp
@@ -15,14 +15,14 @@ AFTER EVERYTHING:
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("print(x:string) creates a newline already":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign c print_string("println(x:string) generates an extra newline?":wybe.string, ~#io##1:wybe.phantom, ?tmp$4##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$4##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    foreign c print_string("println(x:string) generates an extra newline?":wybe.string, ~#io##2:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign c putchar('c':wybe.char, ~#io##3:wybe.phantom, ?tmp$10##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$10##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign c print_int(1:wybe.int, ~#io##4:wybe.phantom, ?tmp$13##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$13##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign c print_string("println(x:string) generates an extra newline?":wybe.string, ~#io##1:wybe.phantom, ?tmp#4##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#4##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string("println(x:string) generates an extra newline?":wybe.string, ~#io##2:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign c putchar('c':wybe.char, ~#io##3:wybe.phantom, ?tmp#10##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_int(1:wybe.int, ~#io##4:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
     foreign c print_int(1:wybe.int, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
 
   LLVM code       :

--- a/test-cases/final-dump/block_comment.exp
+++ b/test-cases/final-dump/block_comment.exp
@@ -11,19 +11,19 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: block_comment.<0>
-(io#0:wybe.phantom, ?io#6:wybe.phantom):
+(io##0:wybe.phantom, ?io##6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("print(x:string) creates a newline already":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_string("println(x:string) generates an extra newline?":wybe.string, ~#io#1:wybe.phantom, ?tmp$4#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$4#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string("println(x:string) generates an extra newline?":wybe.string, ~#io#2:wybe.phantom, ?tmp$7#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$7#0:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign c putchar('c':wybe.char, ~#io#3:wybe.phantom, ?tmp$10#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$10#0:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_int(1:wybe.int, ~#io#4:wybe.phantom, ?tmp$13#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$13#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-    foreign c print_int(1:wybe.int, ~#io#5:wybe.phantom, ?#io#6:wybe.phantom) @io:nn:nn
+    foreign c print_string("print(x:string) creates a newline already":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("println(x:string) generates an extra newline?":wybe.string, ~#io##1:wybe.phantom, ?tmp$4##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$4##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string("println(x:string) generates an extra newline?":wybe.string, ~#io##2:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign c putchar('c':wybe.char, ~#io##3:wybe.phantom, ?tmp$10##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$10##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_int(1:wybe.int, ~#io##4:wybe.phantom, ?tmp$13##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$13##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign c print_int(1:wybe.int, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/call_site_id.exp
+++ b/test-cases/final-dump/call_site_id.exp
@@ -18,16 +18,16 @@ AFTER EVERYTHING:
  InterestingCallProperties: []
     foreign c read_int(?x##0:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     foreign c read_int(?y##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    foreign llvm icmp_sgt(x##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
-    case ~tmp$5##0:wybe.bool of
+    foreign llvm icmp_sgt(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
+    case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm sub(0:wybe.int, ~x##0:wybe.int, ?tmp$1##0:wybe.int) @int:nn:nn
-        call_site_id.foo<0>(~tmp$1##0:wybe.int, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #14 @call_site_id:nn:nn
-        foreign llvm icmp_sgt(y##0:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
-        case ~tmp$4##0:wybe.bool of
+        foreign llvm sub(0:wybe.int, ~x##0:wybe.int, ?tmp#1##0:wybe.int) @int:nn:nn
+        call_site_id.foo<0>(~tmp#1##0:wybe.int, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #14 @call_site_id:nn:nn
+        foreign llvm icmp_sgt(y##0:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
+        case ~tmp#4##0:wybe.bool of
         0:
-            foreign llvm sub(0:wybe.int, ~y##0:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
-            call_site_id.foo<0>(~tmp$2##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #15 @call_site_id:nn:nn
+            foreign llvm sub(0:wybe.int, ~y##0:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
+            call_site_id.foo<0>(~tmp#2##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #15 @call_site_id:nn:nn
 
         1:
             call_site_id.foo<0>(~y##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #16 @call_site_id:nn:nn
@@ -35,11 +35,11 @@ AFTER EVERYTHING:
 
     1:
         call_site_id.foo<0>(~x##0:wybe.int, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #17 @call_site_id:nn:nn
-        foreign llvm icmp_sgt(y##0:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
-        case ~tmp$3##0:wybe.bool of
+        foreign llvm icmp_sgt(y##0:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
+        case ~tmp#3##0:wybe.bool of
         0:
-            foreign llvm sub(0:wybe.int, ~y##0:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
-            call_site_id.foo<0>(~tmp$0##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #18 @call_site_id:nn:nn
+            foreign llvm sub(0:wybe.int, ~y##0:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
+            call_site_id.foo<0>(~tmp#0##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #18 @call_site_id:nn:nn
 
         1:
             call_site_id.foo<0>(~y##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #19 @call_site_id:nn:nn
@@ -67,10 +67,10 @@ foo(x##0:wybe.int, io##0:wybe.phantom, ?io##8:wybe.phantom):
     foreign c print_string(" ":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
     foreign c print_string(" ":wybe.string, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
     foreign c print_string(" ":wybe.string, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
-    foreign llvm mul(~x##0:wybe.int, 5:wybe.int, ?tmp$1##0:wybe.int) @int:nn:nn
-    foreign llvm add(~tmp$1##0:wybe.int, 10:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##7:wybe.phantom, ?tmp$22##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$22##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
+    foreign llvm mul(~x##0:wybe.int, 5:wybe.int, ?tmp#1##0:wybe.int) @int:nn:nn
+    foreign llvm add(~tmp#1##0:wybe.int, 10:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##7:wybe.phantom, ?tmp#22##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#22##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -121,32 +121,32 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"call_site_id.<0>"()    {
 entry:
-  %"1$x##0" = tail call ccc  i64  @read_int()  
-  %"1$y##0" = tail call ccc  i64  @read_int()  
-  %"1$tmp$5##0" = icmp sgt i64 %"1$x##0", 0 
-  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
+  %"1#x##0" = tail call ccc  i64  @read_int()  
+  %"1#y##0" = tail call ccc  i64  @read_int()  
+  %"1#tmp#5##0" = icmp sgt i64 %"1#x##0", 0 
+  br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"call_site_id.foo<0>"(i64  %"1$x##0")  
-  %"2$tmp$3##0" = icmp sgt i64 %"1$y##0", 0 
-  br i1 %"2$tmp$3##0", label %if.then1, label %if.else1 
+  tail call fastcc  void  @"call_site_id.foo<0>"(i64  %"1#x##0")  
+  %"2#tmp#3##0" = icmp sgt i64 %"1#y##0", 0 
+  br i1 %"2#tmp#3##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$tmp$1##0" = sub   i64 0, %"1$x##0" 
-  tail call fastcc  void  @"call_site_id.foo<0>"(i64  %"3$tmp$1##0")  
-  %"3$tmp$4##0" = icmp sgt i64 %"1$y##0", 0 
-  br i1 %"3$tmp$4##0", label %if.then2, label %if.else2 
+  %"3#tmp#1##0" = sub   i64 0, %"1#x##0" 
+  tail call fastcc  void  @"call_site_id.foo<0>"(i64  %"3#tmp#1##0")  
+  %"3#tmp#4##0" = icmp sgt i64 %"1#y##0", 0 
+  br i1 %"3#tmp#4##0", label %if.then2, label %if.else2 
 if.then1:
-  tail call fastcc  void  @"call_site_id.foo<0>"(i64  %"1$y##0")  
+  tail call fastcc  void  @"call_site_id.foo<0>"(i64  %"1#y##0")  
   ret void 
 if.else1:
-  %"5$tmp$0##0" = sub   i64 0, %"1$y##0" 
-  tail call fastcc  void  @"call_site_id.foo<0>"(i64  %"5$tmp$0##0")  
+  %"5#tmp#0##0" = sub   i64 0, %"1#y##0" 
+  tail call fastcc  void  @"call_site_id.foo<0>"(i64  %"5#tmp#0##0")  
   ret void 
 if.then2:
-  tail call fastcc  void  @"call_site_id.foo<0>"(i64  %"1$y##0")  
+  tail call fastcc  void  @"call_site_id.foo<0>"(i64  %"1#y##0")  
   ret void 
 if.else2:
-  %"7$tmp$2##0" = sub   i64 0, %"1$y##0" 
-  tail call fastcc  void  @"call_site_id.foo<0>"(i64  %"7$tmp$2##0")  
+  %"7#tmp#2##0" = sub   i64 0, %"1#y##0" 
+  tail call fastcc  void  @"call_site_id.foo<0>"(i64  %"7#tmp#2##0")  
   ret void 
 }
 
@@ -174,9 +174,9 @@ entry:
   tail call ccc  void  @print_string(i64  %12)  
   %14 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @call_site_id.13, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %14)  
-  %"1$tmp$1##0" = mul   i64 %"x##0", 5 
-  %"1$tmp$0##0" = add   i64 %"1$tmp$1##0", 10 
-  tail call ccc  void  @print_int(i64  %"1$tmp$0##0")  
+  %"1#tmp#1##0" = mul   i64 %"x##0", 5 
+  %"1#tmp#0##0" = add   i64 %"1#tmp#1##0", 10 
+  tail call ccc  void  @print_int(i64  %"1#tmp#0##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/call_site_id.exp
+++ b/test-cases/final-dump/call_site_id.exp
@@ -13,64 +13,64 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: call_site_id.<0>
-(io#0:wybe.phantom, ?io#4:wybe.phantom):
+(io##0:wybe.phantom, ?io##4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c read_int(?x#0:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c read_int(?y#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign llvm icmp_sgt(x#0:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.bool) @int:nn:nn
-    case ~tmp$5#0:wybe.bool of
+    foreign c read_int(?x##0:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c read_int(?y##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign llvm icmp_sgt(x##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
+    case ~tmp$5##0:wybe.bool of
     0:
-        foreign llvm sub(0:wybe.int, ~x#0:wybe.int, ?tmp$1#0:wybe.int) @int:nn:nn
-        call_site_id.foo<0>(~tmp$1#0:wybe.int, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) #14 @call_site_id:nn:nn
-        foreign llvm icmp_sgt(y#0:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.bool) @int:nn:nn
-        case ~tmp$4#0:wybe.bool of
+        foreign llvm sub(0:wybe.int, ~x##0:wybe.int, ?tmp$1##0:wybe.int) @int:nn:nn
+        call_site_id.foo<0>(~tmp$1##0:wybe.int, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #14 @call_site_id:nn:nn
+        foreign llvm icmp_sgt(y##0:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
+        case ~tmp$4##0:wybe.bool of
         0:
-            foreign llvm sub(0:wybe.int, ~y#0:wybe.int, ?tmp$2#0:wybe.int) @int:nn:nn
-            call_site_id.foo<0>(~tmp$2#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #15 @call_site_id:nn:nn
+            foreign llvm sub(0:wybe.int, ~y##0:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
+            call_site_id.foo<0>(~tmp$2##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #15 @call_site_id:nn:nn
 
         1:
-            call_site_id.foo<0>(~y#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #16 @call_site_id:nn:nn
+            call_site_id.foo<0>(~y##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #16 @call_site_id:nn:nn
 
 
     1:
-        call_site_id.foo<0>(~x#0:wybe.int, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) #17 @call_site_id:nn:nn
-        foreign llvm icmp_sgt(y#0:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.bool) @int:nn:nn
-        case ~tmp$3#0:wybe.bool of
+        call_site_id.foo<0>(~x##0:wybe.int, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #17 @call_site_id:nn:nn
+        foreign llvm icmp_sgt(y##0:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
+        case ~tmp$3##0:wybe.bool of
         0:
-            foreign llvm sub(0:wybe.int, ~y#0:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn
-            call_site_id.foo<0>(~tmp$0#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #18 @call_site_id:nn:nn
+            foreign llvm sub(0:wybe.int, ~y##0:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
+            call_site_id.foo<0>(~tmp$0##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #18 @call_site_id:nn:nn
 
         1:
-            call_site_id.foo<0>(~y#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #19 @call_site_id:nn:nn
+            call_site_id.foo<0>(~y##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #19 @call_site_id:nn:nn
 
 
 
 
 bar > public {inline} (9 calls)
 0: call_site_id.bar<0>
-bar(x#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+bar(x##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    call_site_id.foo<0>(~x#0:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @call_site_id:nn:nn
+    call_site_id.foo<0>(~x##0:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @call_site_id:nn:nn
 
 
 foo > public (1 calls)
 0: call_site_id.foo<0>
-foo(x#0:wybe.int, io#0:wybe.phantom, ?io#8:wybe.phantom):
+foo(x##0:wybe.int, io##0:wybe.phantom, ?io##8:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(" ":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_string(" ":wybe.string, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string(" ":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign c print_string(" ":wybe.string, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_string(" ":wybe.string, ~#io#4:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-    foreign c print_string(" ":wybe.string, ~#io#5:wybe.phantom, ?#io#6:wybe.phantom) @io:nn:nn
-    foreign c print_string(" ":wybe.string, ~#io#6:wybe.phantom, ?#io#7:wybe.phantom) @io:nn:nn
-    foreign llvm mul(~x#0:wybe.int, 5:wybe.int, ?tmp$1#0:wybe.int) @int:nn:nn
-    foreign llvm add(~tmp$1#0:wybe.int, 10:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#7:wybe.phantom, ?tmp$22#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$22#0:wybe.phantom, ?#io#8:wybe.phantom) @io:nn:nn
+    foreign c print_string(" ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string(" ":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(" ":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign c print_string(" ":wybe.string, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(" ":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign c print_string(" ":wybe.string, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+    foreign c print_string(" ":wybe.string, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
+    foreign llvm mul(~x##0:wybe.int, 5:wybe.int, ?tmp$1##0:wybe.int) @int:nn:nn
+    foreign llvm add(~tmp$1##0:wybe.int, 10:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##7:wybe.phantom, ?tmp$22##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$22##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -121,44 +121,44 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"call_site_id.<0>"()    {
 entry:
-  %"1$x#0" = tail call ccc  i64  @read_int()  
-  %"1$y#0" = tail call ccc  i64  @read_int()  
-  %"1$tmp$5#0" = icmp sgt i64 %"1$x#0", 0 
-  br i1 %"1$tmp$5#0", label %if.then, label %if.else 
+  %"1$x##0" = tail call ccc  i64  @read_int()  
+  %"1$y##0" = tail call ccc  i64  @read_int()  
+  %"1$tmp$5##0" = icmp sgt i64 %"1$x##0", 0 
+  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"call_site_id.foo<0>"(i64  %"1$x#0")  
-  %"2$tmp$3#0" = icmp sgt i64 %"1$y#0", 0 
-  br i1 %"2$tmp$3#0", label %if.then1, label %if.else1 
+  tail call fastcc  void  @"call_site_id.foo<0>"(i64  %"1$x##0")  
+  %"2$tmp$3##0" = icmp sgt i64 %"1$y##0", 0 
+  br i1 %"2$tmp$3##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$tmp$1#0" = sub   i64 0, %"1$x#0" 
-  tail call fastcc  void  @"call_site_id.foo<0>"(i64  %"3$tmp$1#0")  
-  %"3$tmp$4#0" = icmp sgt i64 %"1$y#0", 0 
-  br i1 %"3$tmp$4#0", label %if.then2, label %if.else2 
+  %"3$tmp$1##0" = sub   i64 0, %"1$x##0" 
+  tail call fastcc  void  @"call_site_id.foo<0>"(i64  %"3$tmp$1##0")  
+  %"3$tmp$4##0" = icmp sgt i64 %"1$y##0", 0 
+  br i1 %"3$tmp$4##0", label %if.then2, label %if.else2 
 if.then1:
-  tail call fastcc  void  @"call_site_id.foo<0>"(i64  %"1$y#0")  
+  tail call fastcc  void  @"call_site_id.foo<0>"(i64  %"1$y##0")  
   ret void 
 if.else1:
-  %"5$tmp$0#0" = sub   i64 0, %"1$y#0" 
-  tail call fastcc  void  @"call_site_id.foo<0>"(i64  %"5$tmp$0#0")  
+  %"5$tmp$0##0" = sub   i64 0, %"1$y##0" 
+  tail call fastcc  void  @"call_site_id.foo<0>"(i64  %"5$tmp$0##0")  
   ret void 
 if.then2:
-  tail call fastcc  void  @"call_site_id.foo<0>"(i64  %"1$y#0")  
+  tail call fastcc  void  @"call_site_id.foo<0>"(i64  %"1$y##0")  
   ret void 
 if.else2:
-  %"7$tmp$2#0" = sub   i64 0, %"1$y#0" 
-  tail call fastcc  void  @"call_site_id.foo<0>"(i64  %"7$tmp$2#0")  
+  %"7$tmp$2##0" = sub   i64 0, %"1$y##0" 
+  tail call fastcc  void  @"call_site_id.foo<0>"(i64  %"7$tmp$2##0")  
   ret void 
 }
 
 
-define external fastcc  void @"call_site_id.bar<0>"(i64  %"x#0")    {
+define external fastcc  void @"call_site_id.bar<0>"(i64  %"x##0")    {
 entry:
-  tail call fastcc  void  @"call_site_id.foo<0>"(i64  %"x#0")  
+  tail call fastcc  void  @"call_site_id.foo<0>"(i64  %"x##0")  
   ret void 
 }
 
 
-define external fastcc  void @"call_site_id.foo<0>"(i64  %"x#0")    {
+define external fastcc  void @"call_site_id.foo<0>"(i64  %"x##0")    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @call_site_id.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
@@ -174,9 +174,9 @@ entry:
   tail call ccc  void  @print_string(i64  %12)  
   %14 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @call_site_id.13, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %14)  
-  %"1$tmp$1#0" = mul   i64 %"x#0", 5 
-  %"1$tmp$0#0" = add   i64 %"1$tmp$1#0", 10 
-  tail call ccc  void  @print_int(i64  %"1$tmp$0#0")  
+  %"1$tmp$1##0" = mul   i64 %"x##0", 5 
+  %"1$tmp$0##0" = add   i64 %"1$tmp$1##0", 10 
+  tail call ccc  void  @print_int(i64  %"1$tmp$0##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/caret.exp
+++ b/test-cases/final-dump/caret.exp
@@ -15,75 +15,75 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: caret.<0>
-(io#0:wybe.phantom, ?io#3:wybe.phantom):
+(io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(8,(caret.gen$1<0>,fromList [NonAliasedParamCond 1 []]))]
-    foreign lpvm alloc(16:wybe.int, ?tmp$13#0:position.position)
-    foreign lpvm mutate(~tmp$13#0:position.position, ?tmp$14#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$14#0:position.position, ?tmp$1#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$17#0:position.position)
-    foreign lpvm mutate(~tmp$17#0:position.position, ?tmp$18#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    foreign lpvm mutate(~tmp$18#0:position.position, ?tmp$2#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 12:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$21#0:caret.region)
-    foreign lpvm mutate(~tmp$21#0:caret.region, ?tmp$22#0:caret.region, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$1#0:position.position)
-    foreign lpvm mutate(~tmp$22#0:caret.region, ?tmp$23#0:caret.region, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$2#0:position.position)
-    foreign lpvm access(~tmp$2#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ten#0:wybe.int)
-    foreign c print_string("ten = ":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_int(~ten#0:wybe.int, ~#io#1:wybe.phantom, ?tmp$32#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$32#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    caret.gen$1<0>[6dacb8fd25](~io#2:wybe.phantom, ~tmp$23#0:caret.region, _:caret.region, _:position.position, _:position.position, ?io#3:wybe.phantom) #8
+    foreign lpvm alloc(16:wybe.int, ?tmp$13##0:position.position)
+    foreign lpvm mutate(~tmp$13##0:position.position, ?tmp$14##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp$14##0:position.position, ?tmp$1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp$17##0:position.position)
+    foreign lpvm mutate(~tmp$17##0:position.position, ?tmp$18##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    foreign lpvm mutate(~tmp$18##0:position.position, ?tmp$2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 12:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp$21##0:caret.region)
+    foreign lpvm mutate(~tmp$21##0:caret.region, ?tmp$22##0:caret.region, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$1##0:position.position)
+    foreign lpvm mutate(~tmp$22##0:caret.region, ?tmp$23##0:caret.region, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$2##0:position.position)
+    foreign lpvm access(~tmp$2##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ten##0:wybe.int)
+    foreign c print_string("ten = ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~ten##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$32##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$32##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    caret.gen$1<0>[6dacb8fd25](~io##2:wybe.phantom, ~tmp$23##0:caret.region, _:caret.region, _:position.position, _:position.position, ?io##3:wybe.phantom) #8
 
 
 expand_region > public (0 calls)
 0: caret.expand_region<0>
-expand_region(reg#0:caret.region, ?reg#4:caret.region, point#0:position.position):
- AliasPairs: [(reg#0,reg#4)]
+expand_region(reg##0:caret.region, ?reg##4:caret.region, point##0:position.position):
+ AliasPairs: [(reg##0,reg##4)]
  InterestingCallProperties: [InterestingUnaliased 0]
-    foreign lpvm access(reg#0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:position.position)
-    foreign lpvm access(tmp$0#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$2#0:wybe.int)
-    foreign lpvm access(point#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    wybe.int.min<0>(~tmp$2#0:wybe.int, tmp$4#0:wybe.int, ?tmp$1#0:wybe.int) #4 @caret:nn:nn
-    foreign lpvm {noalias} mutate(~%tmp$0#0:position.position, ?%tmp$0#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$1#0:wybe.int)
-    foreign lpvm mutate(~%reg#0:caret.region, ?%reg#1:caret.region, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, tmp$0#1:position.position)
-    foreign lpvm access(tmp$0#1:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$7#0:wybe.int)
-    foreign lpvm access(~point#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.int)
-    wybe.int.min<0>(~tmp$7#0:wybe.int, tmp$9#0:wybe.int, ?tmp$6#0:wybe.int) #11 @caret:nn:nn
-    foreign lpvm {noalias} mutate(~tmp$0#1:position.position, ?%tmp$5#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$6#0:wybe.int)
-    foreign lpvm mutate(~%reg#1:caret.region, ?%reg#2:caret.region, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$5#1:position.position)
-    foreign lpvm access(reg#2:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10#0:position.position)
-    foreign lpvm access(tmp$10#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$12#0:wybe.int)
-    wybe.int.max<0>(~tmp$12#0:wybe.int, ~tmp$4#0:wybe.int, ?tmp$11#0:wybe.int) #18 @caret:nn:nn
-    foreign lpvm {noalias} mutate(~%tmp$10#0:position.position, ?%tmp$10#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$11#0:wybe.int)
-    foreign lpvm mutate(~%reg#2:caret.region, ?%reg#3:caret.region, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, tmp$10#1:position.position)
-    foreign lpvm access(tmp$10#1:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$17#0:wybe.int)
-    wybe.int.max<0>(~tmp$17#0:wybe.int, ~tmp$9#0:wybe.int, ?tmp$16#0:wybe.int) #25 @caret:nn:nn
-    foreign lpvm {noalias} mutate(~tmp$10#1:position.position, ?%tmp$15#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$16#0:wybe.int)
-    foreign lpvm mutate(~%reg#3:caret.region, ?%reg#4:caret.region, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$15#1:position.position)
+    foreign lpvm access(reg##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:position.position)
+    foreign lpvm access(tmp$0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.int)
+    foreign lpvm access(point##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    wybe.int.min<0>(~tmp$2##0:wybe.int, tmp$4##0:wybe.int, ?tmp$1##0:wybe.int) #4 @caret:nn:nn
+    foreign lpvm {noalias} mutate(~%tmp$0##0:position.position, ?%tmp$0##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$1##0:wybe.int)
+    foreign lpvm mutate(~%reg##0:caret.region, ?%reg##1:caret.region, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, tmp$0##1:position.position)
+    foreign lpvm access(tmp$0##1:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.int)
+    foreign lpvm access(~point##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.int)
+    wybe.int.min<0>(~tmp$7##0:wybe.int, tmp$9##0:wybe.int, ?tmp$6##0:wybe.int) #11 @caret:nn:nn
+    foreign lpvm {noalias} mutate(~tmp$0##1:position.position, ?%tmp$5##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$6##0:wybe.int)
+    foreign lpvm mutate(~%reg##1:caret.region, ?%reg##2:caret.region, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$5##1:position.position)
+    foreign lpvm access(reg##2:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10##0:position.position)
+    foreign lpvm access(tmp$10##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$12##0:wybe.int)
+    wybe.int.max<0>(~tmp$12##0:wybe.int, ~tmp$4##0:wybe.int, ?tmp$11##0:wybe.int) #18 @caret:nn:nn
+    foreign lpvm {noalias} mutate(~%tmp$10##0:position.position, ?%tmp$10##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$11##0:wybe.int)
+    foreign lpvm mutate(~%reg##2:caret.region, ?%reg##3:caret.region, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, tmp$10##1:position.position)
+    foreign lpvm access(tmp$10##1:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$17##0:wybe.int)
+    wybe.int.max<0>(~tmp$17##0:wybe.int, ~tmp$9##0:wybe.int, ?tmp$16##0:wybe.int) #25 @caret:nn:nn
+    foreign lpvm {noalias} mutate(~tmp$10##1:position.position, ?%tmp$15##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$16##0:wybe.int)
+    foreign lpvm mutate(~%reg##3:caret.region, ?%reg##4:caret.region, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$15##1:position.position)
 
 
 gen$1 > (2 calls)
 0: caret.gen$1<0>[6dacb8fd25]
-gen$1(io#0:wybe.phantom, reg#0:caret.region, [tmp$0#0:caret.region], [tmp$1#0:position.position], [tmp$2#0:position.position], ?io#2:wybe.phantom):
+gen$1(io##0:wybe.phantom, reg##0:caret.region, [tmp$0##0:caret.region], [tmp$1##0:position.position], [tmp$2##0:position.position], ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 1]
-    foreign lpvm access(~reg#0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:position.position)
-    foreign lpvm access(tmp$6#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign llvm add(~%tmp$5#0:wybe.int, 1:wybe.int, ?%tmp$5#1:wybe.int) @int:nn:nn
-    foreign lpvm {noalias} mutate(~%tmp$6#0:position.position, ?%tmp$6#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$5#1:wybe.int)
-    foreign lpvm access(~tmp$6#1:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ten#0:wybe.int)
-    foreign c print_string("now ten = ":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_int(~ten#0:wybe.int, ~#io#1:wybe.phantom, ?tmp$23#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$23#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~reg##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:position.position)
+    foreign lpvm access(tmp$6##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign llvm add(~%tmp$5##0:wybe.int, 1:wybe.int, ?%tmp$5##1:wybe.int) @int:nn:nn
+    foreign lpvm {noalias} mutate(~%tmp$6##0:position.position, ?%tmp$6##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$5##1:wybe.int)
+    foreign lpvm access(~tmp$6##1:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ten##0:wybe.int)
+    foreign c print_string("now ten = ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~ten##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$23##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$23##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
  [6dacb8fd25] [NonAliasedParam 1] :
-    foreign lpvm access(~reg#0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:position.position)
-    foreign lpvm access(tmp$6#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign llvm add(~%tmp$5#0:wybe.int, 1:wybe.int, ?%tmp$5#1:wybe.int) @int:nn:nn
-    foreign lpvm {noalias} mutate(~%tmp$6#0:position.position, ?%tmp$6#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$5#1:wybe.int)
-    foreign lpvm access(~tmp$6#1:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ten#0:wybe.int)
-    foreign c print_string("now ten = ":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_int(~ten#0:wybe.int, ~#io#1:wybe.phantom, ?tmp$23#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$23#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~reg##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:position.position)
+    foreign lpvm access(tmp$6##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign llvm add(~%tmp$5##0:wybe.int, 1:wybe.int, ?%tmp$5##1:wybe.int) @int:nn:nn
+    foreign lpvm {noalias} mutate(~%tmp$6##0:position.position, ?%tmp$6##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$5##1:wybe.int)
+    foreign lpvm access(~tmp$6##1:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ten##0:wybe.int)
+    foreign c print_string("now ten = ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~ten##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$23##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$23##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -167,18 +167,18 @@ entry:
 }
 
 
-define external fastcc  i64 @"caret.expand_region<0>"(i64  %"reg#0", i64  %"point#0")    {
+define external fastcc  i64 @"caret.expand_region<0>"(i64  %"reg##0", i64  %"point##0")    {
 entry:
-  %30 = inttoptr i64 %"reg#0" to i64* 
+  %30 = inttoptr i64 %"reg##0" to i64* 
   %31 = getelementptr  i64, i64* %30, i64 0 
   %32 = load  i64, i64* %31 
   %33 = inttoptr i64 %32 to i64* 
   %34 = getelementptr  i64, i64* %33, i64 0 
   %35 = load  i64, i64* %34 
-  %36 = inttoptr i64 %"point#0" to i64* 
+  %36 = inttoptr i64 %"point##0" to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
-  %"1$tmp$1#0" = tail call fastcc  i64  @"wybe.int.min<0>"(i64  %35, i64  %38)  
+  %"1$tmp$1##0" = tail call fastcc  i64  @"wybe.int.min<0>"(i64  %35, i64  %38)  
   %39 = trunc i64 16 to i32  
   %40 = tail call ccc  i8*  @wybe_malloc(i32  %39)  
   %41 = ptrtoint i8* %40 to i64 
@@ -188,12 +188,12 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %42, i8*  %43, i32  %44, i32  8, i1  0)  
   %45 = inttoptr i64 %41 to i64* 
   %46 = getelementptr  i64, i64* %45, i64 0 
-  store  i64 %"1$tmp$1#0", i64* %46 
+  store  i64 %"1$tmp$1##0", i64* %46 
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"reg#0" to i8* 
+  %51 = inttoptr i64 %"reg##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = inttoptr i64 %49 to i64* 
@@ -203,11 +203,11 @@ entry:
   %56 = inttoptr i64 %55 to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"point#0", 8 
+  %59 = add   i64 %"point##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %"1$tmp$6#0" = tail call fastcc  i64  @"wybe.int.min<0>"(i64  %58, i64  %62)  
+  %"1$tmp$6##0" = tail call fastcc  i64  @"wybe.int.min<0>"(i64  %58, i64  %62)  
   %63 = trunc i64 16 to i32  
   %64 = tail call ccc  i8*  @wybe_malloc(i32  %63)  
   %65 = ptrtoint i8* %64 to i64 
@@ -218,7 +218,7 @@ entry:
   %69 = add   i64 %65, 8 
   %70 = inttoptr i64 %69 to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
-  store  i64 %"1$tmp$6#0", i64* %71 
+  store  i64 %"1$tmp$6##0", i64* %71 
   %72 = trunc i64 16 to i32  
   %73 = tail call ccc  i8*  @wybe_malloc(i32  %72)  
   %74 = ptrtoint i8* %73 to i64 
@@ -236,7 +236,7 @@ entry:
   %84 = inttoptr i64 %83 to i64* 
   %85 = getelementptr  i64, i64* %84, i64 0 
   %86 = load  i64, i64* %85 
-  %"1$tmp$11#0" = tail call fastcc  i64  @"wybe.int.max<0>"(i64  %86, i64  %38)  
+  %"1$tmp$11##0" = tail call fastcc  i64  @"wybe.int.max<0>"(i64  %86, i64  %38)  
   %87 = trunc i64 16 to i32  
   %88 = tail call ccc  i8*  @wybe_malloc(i32  %87)  
   %89 = ptrtoint i8* %88 to i64 
@@ -246,7 +246,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %90, i8*  %91, i32  %92, i32  8, i1  0)  
   %93 = inttoptr i64 %89 to i64* 
   %94 = getelementptr  i64, i64* %93, i64 0 
-  store  i64 %"1$tmp$11#0", i64* %94 
+  store  i64 %"1$tmp$11##0", i64* %94 
   %95 = trunc i64 16 to i32  
   %96 = tail call ccc  i8*  @wybe_malloc(i32  %95)  
   %97 = ptrtoint i8* %96 to i64 
@@ -262,7 +262,7 @@ entry:
   %105 = inttoptr i64 %104 to i64* 
   %106 = getelementptr  i64, i64* %105, i64 0 
   %107 = load  i64, i64* %106 
-  %"1$tmp$16#0" = tail call fastcc  i64  @"wybe.int.max<0>"(i64  %107, i64  %62)  
+  %"1$tmp$16##0" = tail call fastcc  i64  @"wybe.int.max<0>"(i64  %107, i64  %62)  
   %108 = trunc i64 16 to i32  
   %109 = tail call ccc  i8*  @wybe_malloc(i32  %108)  
   %110 = ptrtoint i8* %109 to i64 
@@ -273,7 +273,7 @@ entry:
   %114 = add   i64 %110, 8 
   %115 = inttoptr i64 %114 to i64* 
   %116 = getelementptr  i64, i64* %115, i64 0 
-  store  i64 %"1$tmp$16#0", i64* %116 
+  store  i64 %"1$tmp$16##0", i64* %116 
   %117 = trunc i64 16 to i32  
   %118 = tail call ccc  i8*  @wybe_malloc(i32  %117)  
   %119 = ptrtoint i8* %118 to i64 
@@ -289,16 +289,16 @@ entry:
 }
 
 
-define external fastcc  void @"caret.gen$1<0>"(i64  %"reg#0")    {
+define external fastcc  void @"caret.gen$1<0>"(i64  %"reg##0")    {
 entry:
-  %126 = add   i64 %"reg#0", 8 
+  %126 = add   i64 %"reg##0", 8 
   %127 = inttoptr i64 %126 to i64* 
   %128 = getelementptr  i64, i64* %127, i64 0 
   %129 = load  i64, i64* %128 
   %130 = inttoptr i64 %129 to i64* 
   %131 = getelementptr  i64, i64* %130, i64 0 
   %132 = load  i64, i64* %131 
-  %"1$tmp$5#1" = add   i64 %132, 1 
+  %"1$tmp$5##1" = add   i64 %132, 1 
   %133 = trunc i64 16 to i32  
   %134 = tail call ccc  i8*  @wybe_malloc(i32  %133)  
   %135 = ptrtoint i8* %134 to i64 
@@ -308,7 +308,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %136, i8*  %137, i32  %138, i32  8, i1  0)  
   %139 = inttoptr i64 %135 to i64* 
   %140 = getelementptr  i64, i64* %139, i64 0 
-  store  i64 %"1$tmp$5#1", i64* %140 
+  store  i64 %"1$tmp$5##1", i64* %140 
   %141 = inttoptr i64 %135 to i64* 
   %142 = getelementptr  i64, i64* %141, i64 0 
   %143 = load  i64, i64* %142 
@@ -320,19 +320,19 @@ entry:
 }
 
 
-define external fastcc  void @"caret.gen$1<0>[6dacb8fd25]"(i64  %"reg#0")    {
+define external fastcc  void @"caret.gen$1<0>[6dacb8fd25]"(i64  %"reg##0")    {
 entry:
-  %146 = add   i64 %"reg#0", 8 
+  %146 = add   i64 %"reg##0", 8 
   %147 = inttoptr i64 %146 to i64* 
   %148 = getelementptr  i64, i64* %147, i64 0 
   %149 = load  i64, i64* %148 
   %150 = inttoptr i64 %149 to i64* 
   %151 = getelementptr  i64, i64* %150, i64 0 
   %152 = load  i64, i64* %151 
-  %"1$tmp$5#1" = add   i64 %152, 1 
+  %"1$tmp$5##1" = add   i64 %152, 1 
   %153 = inttoptr i64 %149 to i64* 
   %154 = getelementptr  i64, i64* %153, i64 0 
-  store  i64 %"1$tmp$5#1", i64* %154 
+  store  i64 %"1$tmp$5##1", i64* %154 
   %155 = inttoptr i64 %149 to i64* 
   %156 = getelementptr  i64, i64* %155, i64 0 
   %157 = load  i64, i64* %156 
@@ -362,40 +362,40 @@ entry:
 
 = > public {inline} (1 calls)
 0: caret.region.=<0>
-=($left#0:caret.region, $right#0:caret.region, ?$$#0:wybe.bool):
+=($left##0:caret.region, $right##0:caret.region, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$lower_left#0:position.position)
-    foreign lpvm access(~$left#0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$upper_right#0:position.position)
-    foreign lpvm access($right#0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$lower_left#0:position.position)
-    foreign lpvm access(~$right#0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$upper_right#0:position.position)
-    foreign lpvm access($left$lower_left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$7#0:wybe.int)
-    foreign lpvm access(~$left$lower_left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.int)
-    foreign lpvm access($right$lower_left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.int)
-    foreign lpvm access(~$right$lower_left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$7#0:wybe.int, ~tmp$9#0:wybe.int, ?tmp$11#0:wybe.bool) @int:nn:nn
-    case ~tmp$11#0:wybe.bool of
+    foreign lpvm access($left##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$lower_left##0:position.position)
+    foreign lpvm access(~$left##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$upper_right##0:position.position)
+    foreign lpvm access($right##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$lower_left##0:position.position)
+    foreign lpvm access(~$right##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$upper_right##0:position.position)
+    foreign lpvm access($left$lower_left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.int)
+    foreign lpvm access(~$left$lower_left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
+    foreign lpvm access($right$lower_left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.int)
+    foreign lpvm access(~$right$lower_left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$7##0:wybe.int, ~tmp$9##0:wybe.int, ?tmp$11##0:wybe.bool) @int:nn:nn
+    case ~tmp$11##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$10#0:wybe.int, ~tmp$8#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm icmp_eq(~tmp$10##0:wybe.int, ~tmp$8##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign lpvm access($left$upper_right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$14#0:wybe.int)
-            foreign lpvm access(~$left$upper_right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$15#0:wybe.int)
-            foreign lpvm access($right$upper_right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$16#0:wybe.int)
-            foreign lpvm access(~$right$upper_right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$17#0:wybe.int)
-            foreign llvm icmp_eq(~tmp$14#0:wybe.int, ~tmp$16#0:wybe.int, ?tmp$18#0:wybe.bool) @int:nn:nn
-            case ~tmp$18#0:wybe.bool of
+            foreign lpvm access($left$upper_right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$14##0:wybe.int)
+            foreign lpvm access(~$left$upper_right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$15##0:wybe.int)
+            foreign lpvm access($right$upper_right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$16##0:wybe.int)
+            foreign lpvm access(~$right$upper_right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$17##0:wybe.int)
+            foreign llvm icmp_eq(~tmp$14##0:wybe.int, ~tmp$16##0:wybe.int, ?tmp$18##0:wybe.bool) @int:nn:nn
+            case ~tmp$18##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                foreign llvm icmp_eq(~tmp$15#0:wybe.int, ~tmp$17#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+                foreign llvm icmp_eq(~tmp$15##0:wybe.int, ~tmp$17##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
@@ -403,89 +403,89 @@ entry:
 
 lower_left > public {inline} (0 calls)
 0: caret.region.lower_left<0>
-lower_left($rec#0:caret.region, ?$#0:position.position):
+lower_left($rec##0:caret.region, ?$##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:position.position)
+    foreign lpvm access(~$rec##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:position.position)
 lower_left > public {inline} (0 calls)
 1: caret.region.lower_left<1>
-lower_left($rec#0:caret.region, ?$rec#1:caret.region, $field#0:position.position):
+lower_left($rec##0:caret.region, ?$rec##1:caret.region, $field##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec#0:caret.region, ?$rec#1:caret.region, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:position.position)
+    foreign lpvm mutate(~$rec##0:caret.region, ?$rec##1:caret.region, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:position.position)
 
 
 region > public {inline} (0 calls)
 0: caret.region.region<0>
-region(lower_left#0:position.position, upper_right#0:position.position, ?$#0:caret.region):
+region(lower_left##0:position.position, upper_right##0:position.position, ?$##0:caret.region):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:caret.region)
-    foreign lpvm mutate(~$rec#0:caret.region, ?$rec#1:caret.region, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lower_left#0:position.position)
-    foreign lpvm mutate(~$rec#1:caret.region, ?$#0:caret.region, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~upper_right#0:position.position)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:caret.region)
+    foreign lpvm mutate(~$rec##0:caret.region, ?$rec##1:caret.region, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lower_left##0:position.position)
+    foreign lpvm mutate(~$rec##1:caret.region, ?$##0:caret.region, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~upper_right##0:position.position)
 region > public {inline} (6 calls)
 1: caret.region.region<1>
-region(?lower_left#0:position.position, ?upper_right#0:position.position, $#0:caret.region):
+region(?lower_left##0:position.position, ?upper_right##0:position.position, $##0:caret.region):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?lower_left#0:position.position)
-    foreign lpvm access(~$#0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?upper_right#0:position.position)
+    foreign lpvm access($##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?lower_left##0:position.position)
+    foreign lpvm access(~$##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?upper_right##0:position.position)
 
 
 upper_right > public {inline} (0 calls)
 0: caret.region.upper_right<0>
-upper_right($rec#0:caret.region, ?$#0:position.position):
+upper_right($rec##0:caret.region, ?$##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:position.position)
+    foreign lpvm access(~$rec##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:position.position)
 upper_right > public {inline} (0 calls)
 1: caret.region.upper_right<1>
-upper_right($rec#0:caret.region, ?$rec#1:caret.region, $field#0:position.position):
+upper_right($rec##0:caret.region, ?$rec##1:caret.region, $field##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec#0:caret.region, ?$rec#1:caret.region, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:position.position)
+    foreign lpvm mutate(~$rec##0:caret.region, ?$rec##1:caret.region, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:position.position)
 
 
 ~= > public {inline} (0 calls)
 0: caret.region.~=<0>
-~=($left#0:caret.region, $right#0:caret.region, ?$$#0:wybe.bool):
+~=($left##0:caret.region, $right##0:caret.region, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:position.position)
-    foreign lpvm access(~$left#0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:position.position)
-    foreign lpvm access($right#0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:position.position)
-    foreign lpvm access(~$right#0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:position.position)
-    foreign lpvm access(tmp$3#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$7#0:wybe.int)
-    foreign lpvm access(~tmp$3#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.int)
-    foreign lpvm access(tmp$5#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.int)
-    foreign lpvm access(~tmp$5#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$7#0:wybe.int, ~tmp$9#0:wybe.int, ?tmp$11#0:wybe.bool) @int:nn:nn
-    case ~tmp$11#0:wybe.bool of
+    foreign lpvm access($left##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:position.position)
+    foreign lpvm access(~$left##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:position.position)
+    foreign lpvm access($right##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:position.position)
+    foreign lpvm access(~$right##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:position.position)
+    foreign lpvm access(tmp$3##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.int)
+    foreign lpvm access(~tmp$3##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
+    foreign lpvm access(tmp$5##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.int)
+    foreign lpvm access(~tmp$5##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$7##0:wybe.int, ~tmp$9##0:wybe.int, ?tmp$11##0:wybe.bool) @int:nn:nn
+    case ~tmp$11##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$10#0:wybe.int, ~tmp$8#0:wybe.int, ?tmp$12#0:wybe.bool) @int:nn:nn
-        case ~tmp$12#0:wybe.bool of
+        foreign llvm icmp_eq(~tmp$10##0:wybe.int, ~tmp$8##0:wybe.int, ?tmp$12##0:wybe.bool) @int:nn:nn
+        case ~tmp$12##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-            foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign lpvm access(tmp$4#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$13#0:wybe.int)
-            foreign lpvm access(~tmp$4#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$14#0:wybe.int)
-            foreign lpvm access(tmp$6#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$15#0:wybe.int)
-            foreign lpvm access(~tmp$6#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$16#0:wybe.int)
-            foreign llvm icmp_eq(~tmp$13#0:wybe.int, ~tmp$15#0:wybe.int, ?tmp$17#0:wybe.bool) @int:nn:nn
-            case ~tmp$17#0:wybe.bool of
+            foreign lpvm access(tmp$4##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$13##0:wybe.int)
+            foreign lpvm access(~tmp$4##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$14##0:wybe.int)
+            foreign lpvm access(tmp$6##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$15##0:wybe.int)
+            foreign lpvm access(~tmp$6##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$16##0:wybe.int)
+            foreign llvm icmp_eq(~tmp$13##0:wybe.int, ~tmp$15##0:wybe.int, ?tmp$17##0:wybe.bool) @int:nn:nn
+            case ~tmp$17##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-                foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+                foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                foreign llvm icmp_eq(~tmp$14#0:wybe.int, ~tmp$16#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-                foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm icmp_eq(~tmp$14##0:wybe.int, ~tmp$16##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+                foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
@@ -504,19 +504,19 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"caret.region.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"caret.region.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
@@ -534,11 +534,11 @@ entry:
   %26 = inttoptr i64 %25 to i64* 
   %27 = getelementptr  i64, i64* %26, i64 0 
   %28 = load  i64, i64* %27 
-  %"1$tmp$11#0" = icmp eq i64 %17, %24 
-  br i1 %"1$tmp$11#0", label %if.then, label %if.else 
+  %"1$tmp$11##0" = icmp eq i64 %17, %24 
+  br i1 %"1$tmp$11##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$1#0" = icmp eq i64 %28, %21 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$1##0" = icmp eq i64 %28, %21 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
@@ -556,65 +556,65 @@ if.then1:
   %40 = inttoptr i64 %39 to i64* 
   %41 = getelementptr  i64, i64* %40, i64 0 
   %42 = load  i64, i64* %41 
-  %"4$tmp$18#0" = icmp eq i64 %31, %38 
-  br i1 %"4$tmp$18#0", label %if.then2, label %if.else2 
+  %"4$tmp$18##0" = icmp eq i64 %31, %38 
+  br i1 %"4$tmp$18##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$$$#0" = icmp eq i64 %35, %42 
-  ret i1 %"6$$$#0" 
+  %"6$$$##0" = icmp eq i64 %35, %42 
+  ret i1 %"6$$$##0" 
 if.else2:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"caret.region.lower_left<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"caret.region.lower_left<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = inttoptr i64 %"$rec#0" to i64* 
+  %43 = inttoptr i64 %"$rec##0" to i64* 
   %44 = getelementptr  i64, i64* %43, i64 0 
   %45 = load  i64, i64* %44 
   ret i64 %45 
 }
 
 
-define external fastcc  i64 @"caret.region.lower_left<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"caret.region.lower_left<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %46 = trunc i64 16 to i32  
   %47 = tail call ccc  i8*  @wybe_malloc(i32  %46)  
   %48 = ptrtoint i8* %47 to i64 
   %49 = inttoptr i64 %48 to i8* 
-  %50 = inttoptr i64 %"$rec#0" to i8* 
+  %50 = inttoptr i64 %"$rec##0" to i8* 
   %51 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %49, i8*  %50, i32  %51, i32  8, i1  0)  
   %52 = inttoptr i64 %48 to i64* 
   %53 = getelementptr  i64, i64* %52, i64 0 
-  store  i64 %"$field#0", i64* %53 
+  store  i64 %"$field##0", i64* %53 
   ret i64 %48 
 }
 
 
-define external fastcc  i64 @"caret.region.region<0>"(i64  %"lower_left#0", i64  %"upper_right#0")    {
+define external fastcc  i64 @"caret.region.region<0>"(i64  %"lower_left##0", i64  %"upper_right##0")    {
 entry:
   %54 = trunc i64 16 to i32  
   %55 = tail call ccc  i8*  @wybe_malloc(i32  %54)  
   %56 = ptrtoint i8* %55 to i64 
   %57 = inttoptr i64 %56 to i64* 
   %58 = getelementptr  i64, i64* %57, i64 0 
-  store  i64 %"lower_left#0", i64* %58 
+  store  i64 %"lower_left##0", i64* %58 
   %59 = add   i64 %56, 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
-  store  i64 %"upper_right#0", i64* %61 
+  store  i64 %"upper_right##0", i64* %61 
   ret i64 %56 
 }
 
 
-define external fastcc  {i64, i64} @"caret.region.region<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"caret.region.region<1>"(i64  %"$##0")    {
 entry:
-  %62 = inttoptr i64 %"$#0" to i64* 
+  %62 = inttoptr i64 %"$##0" to i64* 
   %63 = getelementptr  i64, i64* %62, i64 0 
   %64 = load  i64, i64* %63 
-  %65 = add   i64 %"$#0", 8 
+  %65 = add   i64 %"$##0", 8 
   %66 = inttoptr i64 %65 to i64* 
   %67 = getelementptr  i64, i64* %66, i64 0 
   %68 = load  i64, i64* %67 
@@ -624,9 +624,9 @@ entry:
 }
 
 
-define external fastcc  i64 @"caret.region.upper_right<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"caret.region.upper_right<0>"(i64  %"$rec##0")    {
 entry:
-  %71 = add   i64 %"$rec#0", 8 
+  %71 = add   i64 %"$rec##0", 8 
   %72 = inttoptr i64 %71 to i64* 
   %73 = getelementptr  i64, i64* %72, i64 0 
   %74 = load  i64, i64* %73 
@@ -634,36 +634,36 @@ entry:
 }
 
 
-define external fastcc  i64 @"caret.region.upper_right<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"caret.region.upper_right<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %75 = trunc i64 16 to i32  
   %76 = tail call ccc  i8*  @wybe_malloc(i32  %75)  
   %77 = ptrtoint i8* %76 to i64 
   %78 = inttoptr i64 %77 to i8* 
-  %79 = inttoptr i64 %"$rec#0" to i8* 
+  %79 = inttoptr i64 %"$rec##0" to i8* 
   %80 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %78, i8*  %79, i32  %80, i32  8, i1  0)  
   %81 = add   i64 %77, 8 
   %82 = inttoptr i64 %81 to i64* 
   %83 = getelementptr  i64, i64* %82, i64 0 
-  store  i64 %"$field#0", i64* %83 
+  store  i64 %"$field##0", i64* %83 
   ret i64 %77 
 }
 
 
-define external fastcc  i1 @"caret.region.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"caret.region.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %84 = inttoptr i64 %"$left#0" to i64* 
+  %84 = inttoptr i64 %"$left##0" to i64* 
   %85 = getelementptr  i64, i64* %84, i64 0 
   %86 = load  i64, i64* %85 
-  %87 = add   i64 %"$left#0", 8 
+  %87 = add   i64 %"$left##0", 8 
   %88 = inttoptr i64 %87 to i64* 
   %89 = getelementptr  i64, i64* %88, i64 0 
   %90 = load  i64, i64* %89 
-  %91 = inttoptr i64 %"$right#0" to i64* 
+  %91 = inttoptr i64 %"$right##0" to i64* 
   %92 = getelementptr  i64, i64* %91, i64 0 
   %93 = load  i64, i64* %92 
-  %94 = add   i64 %"$right#0", 8 
+  %94 = add   i64 %"$right##0", 8 
   %95 = inttoptr i64 %94 to i64* 
   %96 = getelementptr  i64, i64* %95, i64 0 
   %97 = load  i64, i64* %96 
@@ -681,14 +681,14 @@ entry:
   %109 = inttoptr i64 %108 to i64* 
   %110 = getelementptr  i64, i64* %109, i64 0 
   %111 = load  i64, i64* %110 
-  %"1$tmp$11#0" = icmp eq i64 %100, %107 
-  br i1 %"1$tmp$11#0", label %if.then, label %if.else 
+  %"1$tmp$11##0" = icmp eq i64 %100, %107 
+  br i1 %"1$tmp$11##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$12#0" = icmp eq i64 %111, %104 
-  br i1 %"2$tmp$12#0", label %if.then1, label %if.else1 
+  %"2$tmp$12##0" = icmp eq i64 %111, %104 
+  br i1 %"2$tmp$12##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 if.then1:
   %112 = inttoptr i64 %90 to i64* 
   %113 = getelementptr  i64, i64* %112, i64 0 
@@ -704,18 +704,18 @@ if.then1:
   %123 = inttoptr i64 %122 to i64* 
   %124 = getelementptr  i64, i64* %123, i64 0 
   %125 = load  i64, i64* %124 
-  %"4$tmp$17#0" = icmp eq i64 %114, %121 
-  br i1 %"4$tmp$17#0", label %if.then2, label %if.else2 
+  %"4$tmp$17##0" = icmp eq i64 %114, %121 
+  br i1 %"4$tmp$17##0", label %if.then2, label %if.else2 
 if.else1:
-  %"5$$$#0" = xor i1 0, 1 
-  ret i1 %"5$$$#0" 
+  %"5$$$##0" = xor i1 0, 1 
+  ret i1 %"5$$$##0" 
 if.then2:
-  %"6$tmp$0#0" = icmp eq i64 %118, %125 
-  %"6$$$#0" = xor i1 %"6$tmp$0#0", 1 
-  ret i1 %"6$$$#0" 
+  %"6$tmp$0##0" = icmp eq i64 %118, %125 
+  %"6$$$##0" = xor i1 %"6$tmp$0##0", 1 
+  ret i1 %"6$$$##0" 
 if.else2:
-  %"7$$$#0" = xor i1 0, 1 
-  ret i1 %"7$$$#0" 
+  %"7$$$##0" = xor i1 0, 1 
+  ret i1 %"7$$$##0" 
 }
 --------------------------------------------------
  Module position
@@ -739,17 +739,17 @@ if.else2:
 
 printPosition > public (0 calls)
 0: position.printPosition<0>
-printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string(",":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io#4:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -783,17 +783,17 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"position.printPosition<0>"(i64  %"pos#0")    {
+define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
-  %3 = inttoptr i64 %"pos#0" to i64* 
+  %3 = inttoptr i64 %"pos##0" to i64* 
   %4 = getelementptr  i64, i64* %3, i64 0 
   %5 = load  i64, i64* %4 
   tail call ccc  void  @print_int(i64  %5)  
   %7 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.6, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %7)  
-  %8 = add   i64 %"pos#0", 8 
+  %8 = add   i64 %"pos##0", 8 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
@@ -823,86 +823,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y#0:wybe.int)
-    foreign llvm icmp_eq(~$left$x#0:wybe.int, ~$right$x#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
+    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y#0:wybe.int, ~$right$y#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
-    foreign lpvm mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:position.position, ?$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
+    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
-    foreign lpvm access(~$#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y#0:wybe.int)
+    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec#0:position.position, ?$#0:wybe.int):
+x($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec#0:position.position, ?$#0:wybe.int):
+y($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -919,54 +919,54 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$#0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = icmp eq i64 %7, %14 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"x#0", i64* %19 
+  store  i64 %"x##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"y#0", i64* %22 
+  store  i64 %"y##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
 entry:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -976,34 +976,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec#0" to i64* 
+  %32 = inttoptr i64 %"$rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec#0" to i8* 
+  %39 = inttoptr i64 %"$rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field#0", i64* %42 
+  store  i64 %"$field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = add   i64 %"$rec#0", 8 
+  %43 = add   i64 %"$rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -1011,46 +1011,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec#0" to i8* 
+  %51 = inttoptr i64 %"$rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field#0", i64* %55 
+  store  i64 %"$field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %58, %65 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = icmp eq i64 %62, %69 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$0##0" = icmp eq i64 %62, %69 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }

--- a/test-cases/final-dump/caret.exp
+++ b/test-cases/final-dump/caret.exp
@@ -18,21 +18,21 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
- MultiSpeczDepInfo: [(8,(caret.gen$1<0>,fromList [NonAliasedParamCond 1 []]))]
-    foreign lpvm alloc(16:wybe.int, ?tmp$13##0:position.position)
-    foreign lpvm mutate(~tmp$13##0:position.position, ?tmp$14##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$14##0:position.position, ?tmp$1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$17##0:position.position)
-    foreign lpvm mutate(~tmp$17##0:position.position, ?tmp$18##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    foreign lpvm mutate(~tmp$18##0:position.position, ?tmp$2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 12:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$21##0:caret.region)
-    foreign lpvm mutate(~tmp$21##0:caret.region, ?tmp$22##0:caret.region, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$1##0:position.position)
-    foreign lpvm mutate(~tmp$22##0:caret.region, ?tmp$23##0:caret.region, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$2##0:position.position)
-    foreign lpvm access(~tmp$2##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ten##0:wybe.int)
+ MultiSpeczDepInfo: [(8,(caret.gen#1<0>,fromList [NonAliasedParamCond 1 []]))]
+    foreign lpvm alloc(16:wybe.int, ?tmp#13##0:position.position)
+    foreign lpvm mutate(~tmp#13##0:position.position, ?tmp#14##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp#14##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#17##0:position.position)
+    foreign lpvm mutate(~tmp#17##0:position.position, ?tmp#18##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    foreign lpvm mutate(~tmp#18##0:position.position, ?tmp#2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 12:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#21##0:caret.region)
+    foreign lpvm mutate(~tmp#21##0:caret.region, ?tmp#22##0:caret.region, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:position.position)
+    foreign lpvm mutate(~tmp#22##0:caret.region, ?tmp#23##0:caret.region, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:position.position)
+    foreign lpvm access(~tmp#2##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ten##0:wybe.int)
     foreign c print_string("ten = ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign c print_int(~ten##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$32##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$32##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    caret.gen$1<0>[6dacb8fd25](~io##2:wybe.phantom, ~tmp$23##0:caret.region, _:caret.region, _:position.position, _:position.position, ?io##3:wybe.phantom) #8
+    foreign c print_int(~ten##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#32##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#32##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    caret.gen#1<0>[6dacb8fd25](~io##2:wybe.phantom, ~tmp#23##0:caret.region, _:caret.region, _:position.position, _:position.position, ?io##3:wybe.phantom) #8
 
 
 expand_region > public (0 calls)
@@ -40,50 +40,50 @@ expand_region > public (0 calls)
 expand_region(reg##0:caret.region, ?reg##4:caret.region, point##0:position.position):
  AliasPairs: [(reg##0,reg##4)]
  InterestingCallProperties: [InterestingUnaliased 0]
-    foreign lpvm access(reg##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:position.position)
-    foreign lpvm access(tmp$0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.int)
-    foreign lpvm access(point##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    wybe.int.min<0>(~tmp$2##0:wybe.int, tmp$4##0:wybe.int, ?tmp$1##0:wybe.int) #4 @caret:nn:nn
-    foreign lpvm {noalias} mutate(~%tmp$0##0:position.position, ?%tmp$0##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$1##0:wybe.int)
-    foreign lpvm mutate(~%reg##0:caret.region, ?%reg##1:caret.region, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, tmp$0##1:position.position)
-    foreign lpvm access(tmp$0##1:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.int)
-    foreign lpvm access(~point##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.int)
-    wybe.int.min<0>(~tmp$7##0:wybe.int, tmp$9##0:wybe.int, ?tmp$6##0:wybe.int) #11 @caret:nn:nn
-    foreign lpvm {noalias} mutate(~tmp$0##1:position.position, ?%tmp$5##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$6##0:wybe.int)
-    foreign lpvm mutate(~%reg##1:caret.region, ?%reg##2:caret.region, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$5##1:position.position)
-    foreign lpvm access(reg##2:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10##0:position.position)
-    foreign lpvm access(tmp$10##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$12##0:wybe.int)
-    wybe.int.max<0>(~tmp$12##0:wybe.int, ~tmp$4##0:wybe.int, ?tmp$11##0:wybe.int) #18 @caret:nn:nn
-    foreign lpvm {noalias} mutate(~%tmp$10##0:position.position, ?%tmp$10##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$11##0:wybe.int)
-    foreign lpvm mutate(~%reg##2:caret.region, ?%reg##3:caret.region, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, tmp$10##1:position.position)
-    foreign lpvm access(tmp$10##1:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$17##0:wybe.int)
-    wybe.int.max<0>(~tmp$17##0:wybe.int, ~tmp$9##0:wybe.int, ?tmp$16##0:wybe.int) #25 @caret:nn:nn
-    foreign lpvm {noalias} mutate(~tmp$10##1:position.position, ?%tmp$15##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$16##0:wybe.int)
-    foreign lpvm mutate(~%reg##3:caret.region, ?%reg##4:caret.region, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$15##1:position.position)
+    foreign lpvm access(reg##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:position.position)
+    foreign lpvm access(tmp#0##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int)
+    foreign lpvm access(point##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    wybe.int.min<0>(~tmp#2##0:wybe.int, tmp#4##0:wybe.int, ?tmp#1##0:wybe.int) #4 @caret:nn:nn
+    foreign lpvm {noalias} mutate(~%tmp#0##0:position.position, ?%tmp#0##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int)
+    foreign lpvm mutate(~%reg##0:caret.region, ?%reg##1:caret.region, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, tmp#0##1:position.position)
+    foreign lpvm access(tmp#0##1:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int)
+    foreign lpvm access(~point##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
+    wybe.int.min<0>(~tmp#7##0:wybe.int, tmp#9##0:wybe.int, ?tmp#6##0:wybe.int) #11 @caret:nn:nn
+    foreign lpvm {noalias} mutate(~tmp#0##1:position.position, ?%tmp#5##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#6##0:wybe.int)
+    foreign lpvm mutate(~%reg##1:caret.region, ?%reg##2:caret.region, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##1:position.position)
+    foreign lpvm access(reg##2:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:position.position)
+    foreign lpvm access(tmp#10##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#12##0:wybe.int)
+    wybe.int.max<0>(~tmp#12##0:wybe.int, ~tmp#4##0:wybe.int, ?tmp#11##0:wybe.int) #18 @caret:nn:nn
+    foreign lpvm {noalias} mutate(~%tmp#10##0:position.position, ?%tmp#10##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#11##0:wybe.int)
+    foreign lpvm mutate(~%reg##2:caret.region, ?%reg##3:caret.region, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, tmp#10##1:position.position)
+    foreign lpvm access(tmp#10##1:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#17##0:wybe.int)
+    wybe.int.max<0>(~tmp#17##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#16##0:wybe.int) #25 @caret:nn:nn
+    foreign lpvm {noalias} mutate(~tmp#10##1:position.position, ?%tmp#15##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#16##0:wybe.int)
+    foreign lpvm mutate(~%reg##3:caret.region, ?%reg##4:caret.region, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#15##1:position.position)
 
 
-gen$1 > (2 calls)
-0: caret.gen$1<0>[6dacb8fd25]
-gen$1(io##0:wybe.phantom, reg##0:caret.region, [tmp$0##0:caret.region], [tmp$1##0:position.position], [tmp$2##0:position.position], ?io##2:wybe.phantom):
+gen#1 > (2 calls)
+0: caret.gen#1<0>[6dacb8fd25]
+gen#1(io##0:wybe.phantom, reg##0:caret.region, [tmp#0##0:caret.region], [tmp#1##0:position.position], [tmp#2##0:position.position], ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 1]
-    foreign lpvm access(~reg##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:position.position)
-    foreign lpvm access(tmp$6##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign llvm add(~%tmp$5##0:wybe.int, 1:wybe.int, ?%tmp$5##1:wybe.int) @int:nn:nn
-    foreign lpvm {noalias} mutate(~%tmp$6##0:position.position, ?%tmp$6##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$5##1:wybe.int)
-    foreign lpvm access(~tmp$6##1:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ten##0:wybe.int)
+    foreign lpvm access(~reg##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:position.position)
+    foreign lpvm access(tmp#6##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign llvm add(~%tmp#5##0:wybe.int, 1:wybe.int, ?%tmp#5##1:wybe.int) @int:nn:nn
+    foreign lpvm {noalias} mutate(~%tmp#6##0:position.position, ?%tmp#6##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##1:wybe.int)
+    foreign lpvm access(~tmp#6##1:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ten##0:wybe.int)
     foreign c print_string("now ten = ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign c print_int(~ten##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$23##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$23##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_int(~ten##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#23##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#23##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
  [6dacb8fd25] [NonAliasedParam 1] :
-    foreign lpvm access(~reg##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:position.position)
-    foreign lpvm access(tmp$6##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign llvm add(~%tmp$5##0:wybe.int, 1:wybe.int, ?%tmp$5##1:wybe.int) @int:nn:nn
-    foreign lpvm {noalias} mutate(~%tmp$6##0:position.position, ?%tmp$6##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$5##1:wybe.int)
-    foreign lpvm access(~tmp$6##1:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ten##0:wybe.int)
+    foreign lpvm access(~reg##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:position.position)
+    foreign lpvm access(tmp#6##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign llvm add(~%tmp#5##0:wybe.int, 1:wybe.int, ?%tmp#5##1:wybe.int) @int:nn:nn
+    foreign lpvm {noalias} mutate(~%tmp#6##0:position.position, ?%tmp#6##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##1:wybe.int)
+    foreign lpvm access(~tmp#6##1:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ten##0:wybe.int)
     foreign c print_string("now ten = ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign c print_int(~ten##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$23##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$23##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_int(~ten##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#23##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#23##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -162,7 +162,7 @@ entry:
   tail call ccc  void  @print_string(i64  %29)  
   tail call ccc  void  @print_int(i64  %27)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"caret.gen$1<0>[6dacb8fd25]"(i64  %19)  
+  tail call fastcc  void  @"caret.gen#1<0>[6dacb8fd25]"(i64  %19)  
   ret void 
 }
 
@@ -178,7 +178,7 @@ entry:
   %36 = inttoptr i64 %"point##0" to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
-  %"1$tmp$1##0" = tail call fastcc  i64  @"wybe.int.min<0>"(i64  %35, i64  %38)  
+  %"1#tmp#1##0" = tail call fastcc  i64  @"wybe.int.min<0>"(i64  %35, i64  %38)  
   %39 = trunc i64 16 to i32  
   %40 = tail call ccc  i8*  @wybe_malloc(i32  %39)  
   %41 = ptrtoint i8* %40 to i64 
@@ -188,7 +188,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %42, i8*  %43, i32  %44, i32  8, i1  0)  
   %45 = inttoptr i64 %41 to i64* 
   %46 = getelementptr  i64, i64* %45, i64 0 
-  store  i64 %"1$tmp$1##0", i64* %46 
+  store  i64 %"1#tmp#1##0", i64* %46 
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
@@ -207,7 +207,7 @@ entry:
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %"1$tmp$6##0" = tail call fastcc  i64  @"wybe.int.min<0>"(i64  %58, i64  %62)  
+  %"1#tmp#6##0" = tail call fastcc  i64  @"wybe.int.min<0>"(i64  %58, i64  %62)  
   %63 = trunc i64 16 to i32  
   %64 = tail call ccc  i8*  @wybe_malloc(i32  %63)  
   %65 = ptrtoint i8* %64 to i64 
@@ -218,7 +218,7 @@ entry:
   %69 = add   i64 %65, 8 
   %70 = inttoptr i64 %69 to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
-  store  i64 %"1$tmp$6##0", i64* %71 
+  store  i64 %"1#tmp#6##0", i64* %71 
   %72 = trunc i64 16 to i32  
   %73 = tail call ccc  i8*  @wybe_malloc(i32  %72)  
   %74 = ptrtoint i8* %73 to i64 
@@ -236,7 +236,7 @@ entry:
   %84 = inttoptr i64 %83 to i64* 
   %85 = getelementptr  i64, i64* %84, i64 0 
   %86 = load  i64, i64* %85 
-  %"1$tmp$11##0" = tail call fastcc  i64  @"wybe.int.max<0>"(i64  %86, i64  %38)  
+  %"1#tmp#11##0" = tail call fastcc  i64  @"wybe.int.max<0>"(i64  %86, i64  %38)  
   %87 = trunc i64 16 to i32  
   %88 = tail call ccc  i8*  @wybe_malloc(i32  %87)  
   %89 = ptrtoint i8* %88 to i64 
@@ -246,7 +246,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %90, i8*  %91, i32  %92, i32  8, i1  0)  
   %93 = inttoptr i64 %89 to i64* 
   %94 = getelementptr  i64, i64* %93, i64 0 
-  store  i64 %"1$tmp$11##0", i64* %94 
+  store  i64 %"1#tmp#11##0", i64* %94 
   %95 = trunc i64 16 to i32  
   %96 = tail call ccc  i8*  @wybe_malloc(i32  %95)  
   %97 = ptrtoint i8* %96 to i64 
@@ -262,7 +262,7 @@ entry:
   %105 = inttoptr i64 %104 to i64* 
   %106 = getelementptr  i64, i64* %105, i64 0 
   %107 = load  i64, i64* %106 
-  %"1$tmp$16##0" = tail call fastcc  i64  @"wybe.int.max<0>"(i64  %107, i64  %62)  
+  %"1#tmp#16##0" = tail call fastcc  i64  @"wybe.int.max<0>"(i64  %107, i64  %62)  
   %108 = trunc i64 16 to i32  
   %109 = tail call ccc  i8*  @wybe_malloc(i32  %108)  
   %110 = ptrtoint i8* %109 to i64 
@@ -273,7 +273,7 @@ entry:
   %114 = add   i64 %110, 8 
   %115 = inttoptr i64 %114 to i64* 
   %116 = getelementptr  i64, i64* %115, i64 0 
-  store  i64 %"1$tmp$16##0", i64* %116 
+  store  i64 %"1#tmp#16##0", i64* %116 
   %117 = trunc i64 16 to i32  
   %118 = tail call ccc  i8*  @wybe_malloc(i32  %117)  
   %119 = ptrtoint i8* %118 to i64 
@@ -289,7 +289,7 @@ entry:
 }
 
 
-define external fastcc  void @"caret.gen$1<0>"(i64  %"reg##0")    {
+define external fastcc  void @"caret.gen#1<0>"(i64  %"reg##0")    {
 entry:
   %126 = add   i64 %"reg##0", 8 
   %127 = inttoptr i64 %126 to i64* 
@@ -298,7 +298,7 @@ entry:
   %130 = inttoptr i64 %129 to i64* 
   %131 = getelementptr  i64, i64* %130, i64 0 
   %132 = load  i64, i64* %131 
-  %"1$tmp$5##1" = add   i64 %132, 1 
+  %"1#tmp#5##1" = add   i64 %132, 1 
   %133 = trunc i64 16 to i32  
   %134 = tail call ccc  i8*  @wybe_malloc(i32  %133)  
   %135 = ptrtoint i8* %134 to i64 
@@ -308,7 +308,7 @@ entry:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %136, i8*  %137, i32  %138, i32  8, i1  0)  
   %139 = inttoptr i64 %135 to i64* 
   %140 = getelementptr  i64, i64* %139, i64 0 
-  store  i64 %"1$tmp$5##1", i64* %140 
+  store  i64 %"1#tmp#5##1", i64* %140 
   %141 = inttoptr i64 %135 to i64* 
   %142 = getelementptr  i64, i64* %141, i64 0 
   %143 = load  i64, i64* %142 
@@ -320,7 +320,7 @@ entry:
 }
 
 
-define external fastcc  void @"caret.gen$1<0>[6dacb8fd25]"(i64  %"reg##0")    {
+define external fastcc  void @"caret.gen#1<0>[6dacb8fd25]"(i64  %"reg##0")    {
 entry:
   %146 = add   i64 %"reg##0", 8 
   %147 = inttoptr i64 %146 to i64* 
@@ -329,10 +329,10 @@ entry:
   %150 = inttoptr i64 %149 to i64* 
   %151 = getelementptr  i64, i64* %150, i64 0 
   %152 = load  i64, i64* %151 
-  %"1$tmp$5##1" = add   i64 %152, 1 
+  %"1#tmp#5##1" = add   i64 %152, 1 
   %153 = inttoptr i64 %149 to i64* 
   %154 = getelementptr  i64, i64* %153, i64 0 
-  store  i64 %"1$tmp$5##1", i64* %154 
+  store  i64 %"1#tmp#5##1", i64* %154 
   %155 = inttoptr i64 %149 to i64* 
   %156 = getelementptr  i64, i64* %155, i64 0 
   %157 = load  i64, i64* %156 
@@ -362,40 +362,40 @@ entry:
 
 = > public {inline} (1 calls)
 0: caret.region.=<0>
-=($left##0:caret.region, $right##0:caret.region, ?$$##0:wybe.bool):
+=(#left##0:caret.region, #right##0:caret.region, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$lower_left##0:position.position)
-    foreign lpvm access(~$left##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$upper_right##0:position.position)
-    foreign lpvm access($right##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$lower_left##0:position.position)
-    foreign lpvm access(~$right##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$upper_right##0:position.position)
-    foreign lpvm access($left$lower_left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.int)
-    foreign lpvm access(~$left$lower_left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
-    foreign lpvm access($right$lower_left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.int)
-    foreign lpvm access(~$right$lower_left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$7##0:wybe.int, ~tmp$9##0:wybe.int, ?tmp$11##0:wybe.bool) @int:nn:nn
-    case ~tmp$11##0:wybe.bool of
+    foreign lpvm access(#left##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#lower_left##0:position.position)
+    foreign lpvm access(~#left##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#upper_right##0:position.position)
+    foreign lpvm access(#right##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#lower_left##0:position.position)
+    foreign lpvm access(~#right##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#upper_right##0:position.position)
+    foreign lpvm access(#left#lower_left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int)
+    foreign lpvm access(~#left#lower_left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
+    foreign lpvm access(#right#lower_left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
+    foreign lpvm access(~#right#lower_left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#7##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#11##0:wybe.bool) @int:nn:nn
+    case ~tmp#11##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$10##0:wybe.int, ~tmp$8##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm icmp_eq(~tmp#10##0:wybe.int, ~tmp#8##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign lpvm access($left$upper_right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$14##0:wybe.int)
-            foreign lpvm access(~$left$upper_right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$15##0:wybe.int)
-            foreign lpvm access($right$upper_right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$16##0:wybe.int)
-            foreign lpvm access(~$right$upper_right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$17##0:wybe.int)
-            foreign llvm icmp_eq(~tmp$14##0:wybe.int, ~tmp$16##0:wybe.int, ?tmp$18##0:wybe.bool) @int:nn:nn
-            case ~tmp$18##0:wybe.bool of
+            foreign lpvm access(#left#upper_right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#14##0:wybe.int)
+            foreign lpvm access(~#left#upper_right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.int)
+            foreign lpvm access(#right#upper_right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#16##0:wybe.int)
+            foreign lpvm access(~#right#upper_right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#17##0:wybe.int)
+            foreign llvm icmp_eq(~tmp#14##0:wybe.int, ~tmp#16##0:wybe.int, ?tmp#18##0:wybe.bool) @int:nn:nn
+            case ~tmp#18##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
             1:
-                foreign llvm icmp_eq(~tmp$15##0:wybe.int, ~tmp$17##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+                foreign llvm icmp_eq(~tmp#15##0:wybe.int, ~tmp#17##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
@@ -403,89 +403,89 @@ entry:
 
 lower_left > public {inline} (0 calls)
 0: caret.region.lower_left<0>
-lower_left($rec##0:caret.region, ?$##0:position.position):
+lower_left(#rec##0:caret.region, ?###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:position.position)
+    foreign lpvm access(~#rec##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:position.position)
 lower_left > public {inline} (0 calls)
 1: caret.region.lower_left<1>
-lower_left($rec##0:caret.region, ?$rec##1:caret.region, $field##0:position.position):
+lower_left(#rec##0:caret.region, ?#rec##1:caret.region, #field##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec##0:caret.region, ?$rec##1:caret.region, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:position.position)
+    foreign lpvm mutate(~#rec##0:caret.region, ?#rec##1:caret.region, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:position.position)
 
 
 region > public {inline} (0 calls)
 0: caret.region.region<0>
-region(lower_left##0:position.position, upper_right##0:position.position, ?$##0:caret.region):
+region(lower_left##0:position.position, upper_right##0:position.position, ?###0:caret.region):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:caret.region)
-    foreign lpvm mutate(~$rec##0:caret.region, ?$rec##1:caret.region, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lower_left##0:position.position)
-    foreign lpvm mutate(~$rec##1:caret.region, ?$##0:caret.region, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~upper_right##0:position.position)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:caret.region)
+    foreign lpvm mutate(~#rec##0:caret.region, ?#rec##1:caret.region, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lower_left##0:position.position)
+    foreign lpvm mutate(~#rec##1:caret.region, ?###0:caret.region, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~upper_right##0:position.position)
 region > public {inline} (6 calls)
 1: caret.region.region<1>
-region(?lower_left##0:position.position, ?upper_right##0:position.position, $##0:caret.region):
+region(?lower_left##0:position.position, ?upper_right##0:position.position, ###0:caret.region):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?lower_left##0:position.position)
-    foreign lpvm access(~$##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?upper_right##0:position.position)
+    foreign lpvm access(###0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?lower_left##0:position.position)
+    foreign lpvm access(~###0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?upper_right##0:position.position)
 
 
 upper_right > public {inline} (0 calls)
 0: caret.region.upper_right<0>
-upper_right($rec##0:caret.region, ?$##0:position.position):
+upper_right(#rec##0:caret.region, ?###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:position.position)
+    foreign lpvm access(~#rec##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:position.position)
 upper_right > public {inline} (0 calls)
 1: caret.region.upper_right<1>
-upper_right($rec##0:caret.region, ?$rec##1:caret.region, $field##0:position.position):
+upper_right(#rec##0:caret.region, ?#rec##1:caret.region, #field##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec##0:caret.region, ?$rec##1:caret.region, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:position.position)
+    foreign lpvm mutate(~#rec##0:caret.region, ?#rec##1:caret.region, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:position.position)
 
 
 ~= > public {inline} (0 calls)
 0: caret.region.~=<0>
-~=($left##0:caret.region, $right##0:caret.region, ?$$##0:wybe.bool):
+~=(#left##0:caret.region, #right##0:caret.region, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:position.position)
-    foreign lpvm access(~$left##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:position.position)
-    foreign lpvm access($right##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:position.position)
-    foreign lpvm access(~$right##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:position.position)
-    foreign lpvm access(tmp$3##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.int)
-    foreign lpvm access(~tmp$3##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
-    foreign lpvm access(tmp$5##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.int)
-    foreign lpvm access(~tmp$5##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$7##0:wybe.int, ~tmp$9##0:wybe.int, ?tmp$11##0:wybe.bool) @int:nn:nn
-    case ~tmp$11##0:wybe.bool of
+    foreign lpvm access(#left##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:position.position)
+    foreign lpvm access(~#left##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:position.position)
+    foreign lpvm access(#right##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:position.position)
+    foreign lpvm access(~#right##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:position.position)
+    foreign lpvm access(tmp#3##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int)
+    foreign lpvm access(~tmp#3##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
+    foreign lpvm access(tmp#5##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
+    foreign lpvm access(~tmp#5##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#7##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#11##0:wybe.bool) @int:nn:nn
+    case ~tmp#11##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$10##0:wybe.int, ~tmp$8##0:wybe.int, ?tmp$12##0:wybe.bool) @int:nn:nn
-        case ~tmp$12##0:wybe.bool of
+        foreign llvm icmp_eq(~tmp#10##0:wybe.int, ~tmp#8##0:wybe.int, ?tmp#12##0:wybe.bool) @int:nn:nn
+        case ~tmp#12##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign lpvm access(tmp$4##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$13##0:wybe.int)
-            foreign lpvm access(~tmp$4##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$14##0:wybe.int)
-            foreign lpvm access(tmp$6##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$15##0:wybe.int)
-            foreign lpvm access(~tmp$6##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$16##0:wybe.int)
-            foreign llvm icmp_eq(~tmp$13##0:wybe.int, ~tmp$15##0:wybe.int, ?tmp$17##0:wybe.bool) @int:nn:nn
-            case ~tmp$17##0:wybe.bool of
+            foreign lpvm access(tmp#4##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#13##0:wybe.int)
+            foreign lpvm access(~tmp#4##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#14##0:wybe.int)
+            foreign lpvm access(tmp#6##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.int)
+            foreign lpvm access(~tmp#6##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#16##0:wybe.int)
+            foreign llvm icmp_eq(~tmp#13##0:wybe.int, ~tmp#15##0:wybe.int, ?tmp#17##0:wybe.bool) @int:nn:nn
+            case ~tmp#17##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-                foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+                foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
             1:
-                foreign llvm icmp_eq(~tmp$14##0:wybe.int, ~tmp$16##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-                foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm icmp_eq(~tmp#14##0:wybe.int, ~tmp#16##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+                foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
 
@@ -504,19 +504,19 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"caret.region.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"caret.region.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
@@ -534,11 +534,11 @@ entry:
   %26 = inttoptr i64 %25 to i64* 
   %27 = getelementptr  i64, i64* %26, i64 0 
   %28 = load  i64, i64* %27 
-  %"1$tmp$11##0" = icmp eq i64 %17, %24 
-  br i1 %"1$tmp$11##0", label %if.then, label %if.else 
+  %"1#tmp#11##0" = icmp eq i64 %17, %24 
+  br i1 %"1#tmp#11##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$1##0" = icmp eq i64 %28, %21 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#1##0" = icmp eq i64 %28, %21 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
@@ -556,39 +556,39 @@ if.then1:
   %40 = inttoptr i64 %39 to i64* 
   %41 = getelementptr  i64, i64* %40, i64 0 
   %42 = load  i64, i64* %41 
-  %"4$tmp$18##0" = icmp eq i64 %31, %38 
-  br i1 %"4$tmp$18##0", label %if.then2, label %if.else2 
+  %"4#tmp#18##0" = icmp eq i64 %31, %38 
+  br i1 %"4#tmp#18##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$$$##0" = icmp eq i64 %35, %42 
-  ret i1 %"6$$$##0" 
+  %"6#####0" = icmp eq i64 %35, %42 
+  ret i1 %"6#####0" 
 if.else2:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"caret.region.lower_left<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"caret.region.lower_left<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = inttoptr i64 %"$rec##0" to i64* 
+  %43 = inttoptr i64 %"#rec##0" to i64* 
   %44 = getelementptr  i64, i64* %43, i64 0 
   %45 = load  i64, i64* %44 
   ret i64 %45 
 }
 
 
-define external fastcc  i64 @"caret.region.lower_left<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"caret.region.lower_left<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %46 = trunc i64 16 to i32  
   %47 = tail call ccc  i8*  @wybe_malloc(i32  %46)  
   %48 = ptrtoint i8* %47 to i64 
   %49 = inttoptr i64 %48 to i8* 
-  %50 = inttoptr i64 %"$rec##0" to i8* 
+  %50 = inttoptr i64 %"#rec##0" to i8* 
   %51 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %49, i8*  %50, i32  %51, i32  8, i1  0)  
   %52 = inttoptr i64 %48 to i64* 
   %53 = getelementptr  i64, i64* %52, i64 0 
-  store  i64 %"$field##0", i64* %53 
+  store  i64 %"#field##0", i64* %53 
   ret i64 %48 
 }
 
@@ -609,12 +609,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"caret.region.region<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"caret.region.region<1>"(i64  %"###0")    {
 entry:
-  %62 = inttoptr i64 %"$##0" to i64* 
+  %62 = inttoptr i64 %"###0" to i64* 
   %63 = getelementptr  i64, i64* %62, i64 0 
   %64 = load  i64, i64* %63 
-  %65 = add   i64 %"$##0", 8 
+  %65 = add   i64 %"###0", 8 
   %66 = inttoptr i64 %65 to i64* 
   %67 = getelementptr  i64, i64* %66, i64 0 
   %68 = load  i64, i64* %67 
@@ -624,9 +624,9 @@ entry:
 }
 
 
-define external fastcc  i64 @"caret.region.upper_right<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"caret.region.upper_right<0>"(i64  %"#rec##0")    {
 entry:
-  %71 = add   i64 %"$rec##0", 8 
+  %71 = add   i64 %"#rec##0", 8 
   %72 = inttoptr i64 %71 to i64* 
   %73 = getelementptr  i64, i64* %72, i64 0 
   %74 = load  i64, i64* %73 
@@ -634,36 +634,36 @@ entry:
 }
 
 
-define external fastcc  i64 @"caret.region.upper_right<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"caret.region.upper_right<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %75 = trunc i64 16 to i32  
   %76 = tail call ccc  i8*  @wybe_malloc(i32  %75)  
   %77 = ptrtoint i8* %76 to i64 
   %78 = inttoptr i64 %77 to i8* 
-  %79 = inttoptr i64 %"$rec##0" to i8* 
+  %79 = inttoptr i64 %"#rec##0" to i8* 
   %80 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %78, i8*  %79, i32  %80, i32  8, i1  0)  
   %81 = add   i64 %77, 8 
   %82 = inttoptr i64 %81 to i64* 
   %83 = getelementptr  i64, i64* %82, i64 0 
-  store  i64 %"$field##0", i64* %83 
+  store  i64 %"#field##0", i64* %83 
   ret i64 %77 
 }
 
 
-define external fastcc  i1 @"caret.region.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"caret.region.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %84 = inttoptr i64 %"$left##0" to i64* 
+  %84 = inttoptr i64 %"#left##0" to i64* 
   %85 = getelementptr  i64, i64* %84, i64 0 
   %86 = load  i64, i64* %85 
-  %87 = add   i64 %"$left##0", 8 
+  %87 = add   i64 %"#left##0", 8 
   %88 = inttoptr i64 %87 to i64* 
   %89 = getelementptr  i64, i64* %88, i64 0 
   %90 = load  i64, i64* %89 
-  %91 = inttoptr i64 %"$right##0" to i64* 
+  %91 = inttoptr i64 %"#right##0" to i64* 
   %92 = getelementptr  i64, i64* %91, i64 0 
   %93 = load  i64, i64* %92 
-  %94 = add   i64 %"$right##0", 8 
+  %94 = add   i64 %"#right##0", 8 
   %95 = inttoptr i64 %94 to i64* 
   %96 = getelementptr  i64, i64* %95, i64 0 
   %97 = load  i64, i64* %96 
@@ -681,14 +681,14 @@ entry:
   %109 = inttoptr i64 %108 to i64* 
   %110 = getelementptr  i64, i64* %109, i64 0 
   %111 = load  i64, i64* %110 
-  %"1$tmp$11##0" = icmp eq i64 %100, %107 
-  br i1 %"1$tmp$11##0", label %if.then, label %if.else 
+  %"1#tmp#11##0" = icmp eq i64 %100, %107 
+  br i1 %"1#tmp#11##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$12##0" = icmp eq i64 %111, %104 
-  br i1 %"2$tmp$12##0", label %if.then1, label %if.else1 
+  %"2#tmp#12##0" = icmp eq i64 %111, %104 
+  br i1 %"2#tmp#12##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 if.then1:
   %112 = inttoptr i64 %90 to i64* 
   %113 = getelementptr  i64, i64* %112, i64 0 
@@ -704,18 +704,18 @@ if.then1:
   %123 = inttoptr i64 %122 to i64* 
   %124 = getelementptr  i64, i64* %123, i64 0 
   %125 = load  i64, i64* %124 
-  %"4$tmp$17##0" = icmp eq i64 %114, %121 
-  br i1 %"4$tmp$17##0", label %if.then2, label %if.else2 
+  %"4#tmp#17##0" = icmp eq i64 %114, %121 
+  br i1 %"4#tmp#17##0", label %if.then2, label %if.else2 
 if.else1:
-  %"5$$$##0" = xor i1 0, 1 
-  ret i1 %"5$$$##0" 
+  %"5#####0" = xor i1 0, 1 
+  ret i1 %"5#####0" 
 if.then2:
-  %"6$tmp$0##0" = icmp eq i64 %118, %125 
-  %"6$$$##0" = xor i1 %"6$tmp$0##0", 1 
-  ret i1 %"6$$$##0" 
+  %"6#tmp#0##0" = icmp eq i64 %118, %125 
+  %"6#####0" = xor i1 %"6#tmp#0##0", 1 
+  ret i1 %"6#####0" 
 if.else2:
-  %"7$$$##0" = xor i1 0, 1 
-  ret i1 %"7$$$##0" 
+  %"7#####0" = xor i1 0, 1 
+  ret i1 %"7#####0" 
 }
 --------------------------------------------------
  Module position
@@ -743,13 +743,13 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -823,86 +823,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
-    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
-    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec##0:position.position, ?$##0:wybe.int):
+x(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec##0:position.position, ?$##0:wybe.int):
+y(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -919,27 +919,27 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$##0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$##0" 
+  %"2#####0" = icmp eq i64 %7, %14 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
@@ -961,12 +961,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
 entry:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -976,34 +976,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec##0" to i64* 
+  %32 = inttoptr i64 %"#rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec##0" to i8* 
+  %39 = inttoptr i64 %"#rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field##0", i64* %42 
+  store  i64 %"#field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = add   i64 %"$rec##0", 8 
+  %43 = add   i64 %"#rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -1011,46 +1011,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec##0" to i8* 
+  %51 = inttoptr i64 %"#rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field##0", i64* %55 
+  store  i64 %"#field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %58, %65 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = icmp eq i64 %62, %69 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#0##0" = icmp eq i64 %62, %69 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }

--- a/test-cases/final-dump/caret.exp
+++ b/test-cases/final-dump/caret.exp
@@ -362,7 +362,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: caret.region.=<0>
-=(#left##0:caret.region, #right##0:caret.region, ?####0:wybe.bool):
+=(#left##0:caret.region, #right##0:caret.region, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#lower_left##0:position.position)
@@ -376,13 +376,13 @@ entry:
     foreign llvm icmp_eq(~tmp#7##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#11##0:wybe.bool) @int:nn:nn
     case ~tmp#11##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#10##0:wybe.int, ~tmp#8##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign lpvm access(#left#upper_right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#14##0:wybe.int)
@@ -392,10 +392,10 @@ entry:
             foreign llvm icmp_eq(~tmp#14##0:wybe.int, ~tmp#16##0:wybe.int, ?tmp#18##0:wybe.bool) @int:nn:nn
             case ~tmp#18##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
-                foreign llvm icmp_eq(~tmp#15##0:wybe.int, ~tmp#17##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+                foreign llvm icmp_eq(~tmp#15##0:wybe.int, ~tmp#17##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -448,7 +448,7 @@ upper_right(#rec##0:caret.region, ?#rec##1:caret.region, #field##0:position.posi
 
 ~= > public {inline} (0 calls)
 0: caret.region.~=<0>
-~=(#left##0:caret.region, #right##0:caret.region, ?####0:wybe.bool):
+~=(#left##0:caret.region, #right##0:caret.region, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:position.position)
@@ -463,14 +463,14 @@ upper_right(#rec##0:caret.region, ?#rec##1:caret.region, #field##0:position.posi
     case ~tmp#11##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#10##0:wybe.int, ~tmp#8##0:wybe.int, ?tmp#12##0:wybe.bool) @int:nn:nn
         case ~tmp#12##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign lpvm access(tmp#4##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#13##0:wybe.int)
@@ -481,11 +481,11 @@ upper_right(#rec##0:caret.region, ?#rec##1:caret.region, #field##0:position.posi
             case ~tmp#17##0:wybe.bool of
             0:
                 foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-                foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
             1:
                 foreign llvm icmp_eq(~tmp#14##0:wybe.int, ~tmp#16##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-                foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -561,8 +561,8 @@ if.then1:
 if.else1:
   ret i1 0 
 if.then2:
-  %"6#####0" = icmp eq i64 %35, %42 
-  ret i1 %"6#####0" 
+  %"6##success##0" = icmp eq i64 %35, %42 
+  ret i1 %"6##success##0" 
 if.else2:
   ret i1 0 
 }
@@ -687,8 +687,8 @@ if.then:
   %"2#tmp#12##0" = icmp eq i64 %111, %104 
   br i1 %"2#tmp#12##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 if.then1:
   %112 = inttoptr i64 %90 to i64* 
   %113 = getelementptr  i64, i64* %112, i64 0 
@@ -707,15 +707,15 @@ if.then1:
   %"4#tmp#17##0" = icmp eq i64 %114, %121 
   br i1 %"4#tmp#17##0", label %if.then2, label %if.else2 
 if.else1:
-  %"5#####0" = xor i1 0, 1 
-  ret i1 %"5#####0" 
+  %"5##success##0" = xor i1 0, 1 
+  ret i1 %"5##success##0" 
 if.then2:
   %"6#tmp#0##0" = icmp eq i64 %118, %125 
-  %"6#####0" = xor i1 %"6#tmp#0##0", 1 
-  ret i1 %"6#####0" 
+  %"6##success##0" = xor i1 %"6#tmp#0##0", 1 
+  ret i1 %"6##success##0" 
 if.else2:
-  %"7#####0" = xor i1 0, 1 
-  ret i1 %"7#####0" 
+  %"7##success##0" = xor i1 0, 1 
+  ret i1 %"7##success##0" 
 }
 --------------------------------------------------
  Module position
@@ -823,7 +823,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
@@ -833,10 +833,10 @@ entry:
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -887,7 +887,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -898,11 +898,11 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -938,8 +938,8 @@ entry:
   %"1#tmp#1##0" = icmp eq i64 %3, %10 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2#####0" = icmp eq i64 %7, %14 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %7, %14 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -1048,9 +1048,9 @@ entry:
   br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#0##0" = icmp eq i64 %62, %69 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }

--- a/test-cases/final-dump/caret.exp
+++ b/test-cases/final-dump/caret.exp
@@ -403,10 +403,10 @@ entry:
 
 lower_left > public {inline} (0 calls)
 0: caret.region.lower_left<0>
-lower_left(#rec##0:caret.region, ?###0:position.position):
+lower_left(#rec##0:caret.region, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:position.position)
+    foreign lpvm access(~#rec##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:position.position)
 lower_left > public {inline} (0 calls)
 1: caret.region.lower_left<1>
 lower_left(#rec##0:caret.region, ?#rec##1:caret.region, #field##0:position.position):
@@ -417,27 +417,27 @@ lower_left(#rec##0:caret.region, ?#rec##1:caret.region, #field##0:position.posit
 
 region > public {inline} (0 calls)
 0: caret.region.region<0>
-region(lower_left##0:position.position, upper_right##0:position.position, ?###0:caret.region):
+region(lower_left##0:position.position, upper_right##0:position.position, ?#result##0:caret.region):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:caret.region)
     foreign lpvm mutate(~#rec##0:caret.region, ?#rec##1:caret.region, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lower_left##0:position.position)
-    foreign lpvm mutate(~#rec##1:caret.region, ?###0:caret.region, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~upper_right##0:position.position)
+    foreign lpvm mutate(~#rec##1:caret.region, ?#result##0:caret.region, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~upper_right##0:position.position)
 region > public {inline} (6 calls)
 1: caret.region.region<1>
-region(?lower_left##0:position.position, ?upper_right##0:position.position, ###0:caret.region):
+region(?lower_left##0:position.position, ?upper_right##0:position.position, #result##0:caret.region):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?lower_left##0:position.position)
-    foreign lpvm access(~###0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?upper_right##0:position.position)
+    foreign lpvm access(#result##0:caret.region, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?lower_left##0:position.position)
+    foreign lpvm access(~#result##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?upper_right##0:position.position)
 
 
 upper_right > public {inline} (0 calls)
 0: caret.region.upper_right<0>
-upper_right(#rec##0:caret.region, ?###0:position.position):
+upper_right(#rec##0:caret.region, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:position.position)
+    foreign lpvm access(~#rec##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:position.position)
 upper_right > public {inline} (0 calls)
 1: caret.region.upper_right<1>
 upper_right(#rec##0:caret.region, ?#rec##1:caret.region, #field##0:position.position):
@@ -609,12 +609,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"caret.region.region<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"caret.region.region<1>"(i64  %"#result##0")    {
 entry:
-  %62 = inttoptr i64 %"###0" to i64* 
+  %62 = inttoptr i64 %"#result##0" to i64* 
   %63 = getelementptr  i64, i64* %62, i64 0 
   %64 = load  i64, i64* %63 
-  %65 = add   i64 %"###0", 8 
+  %65 = add   i64 %"#result##0", 8 
   %66 = inttoptr i64 %65 to i64* 
   %67 = getelementptr  i64, i64* %66, i64 0 
   %68 = load  i64, i64* %67 
@@ -842,27 +842,27 @@ entry:
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x(#rec##0:position.position, ?###0:wybe.int):
+x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -873,10 +873,10 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y(#rec##0:position.position, ?###0:wybe.int):
+y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -961,12 +961,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 

--- a/test-cases/final-dump/ccc.exp
+++ b/test-cases/final-dump/ccc.exp
@@ -12,11 +12,11 @@ AFTER EVERYTHING:
 
 *main* > public {inline} (0 calls)
 0: ccc.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("CCC: Init":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_string("CCC: Init":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -60,11 +60,11 @@ entry:
 
 *main* > public {inline} (0 calls)
 0: ddd.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("DDD: Init":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_string("DDD: Init":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/ccc.exp
+++ b/test-cases/final-dump/ccc.exp
@@ -15,8 +15,8 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("CCC: Init":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("CCC: Init":wybe.string, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -63,8 +63,8 @@ entry:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("DDD: Init":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("DDD: Init":wybe.string, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/chain_assign.exp
+++ b/test-cases/final-dump/chain_assign.exp
@@ -11,10 +11,10 @@ AFTER EVERYTHING:
 
 chain > {inline} (0 calls)
 0: chain_assign.chain<0>
-chain(?z#0:wybe.int):
+chain(?z##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(1:wybe.int, ?z#0:wybe.int) @chain_assign:nn:nn
+    foreign llvm move(1:wybe.int, ?z##0:wybe.int) @chain_assign:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/commonsubexpr.exp
+++ b/test-cases/final-dump/commonsubexpr.exp
@@ -11,32 +11,32 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: commonsubexpr.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(198:wybe.int, ~#io#0:wybe.phantom, ?tmp$6#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$6#0:wybe.phantom, ?tmp$7#0:wybe.phantom) @io:nn:nn
-    foreign c print_int(198:wybe.int, ~tmp$7#0:wybe.phantom, ?tmp$8#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$8#0:wybe.phantom, ?tmp$9#0:wybe.phantom) @io:nn:nn
-    foreign c print_int(11:wybe.int, ~tmp$9#0:wybe.phantom, ?tmp$10#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$10#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_int(198:wybe.int, ~#io##0:wybe.phantom, ?tmp$6##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$6##0:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
+    foreign c print_int(198:wybe.int, ~tmp$7##0:wybe.phantom, ?tmp$8##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$8##0:wybe.phantom, ?tmp$9##0:wybe.phantom) @io:nn:nn
+    foreign c print_int(11:wybe.int, ~tmp$9##0:wybe.phantom, ?tmp$10##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 common_subexpr > {inline} (1 calls)
 0: commonsubexpr.common_subexpr<0>
-common_subexpr(x#0:wybe.int, io#0:wybe.phantom, ?io#3:wybe.phantom):
+common_subexpr(x##0:wybe.int, io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(x#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int) @int:nn:nn
-    foreign llvm sub(~x#0:wybe.int, 1:wybe.int, ?tmp$62#0:wybe.int) @int:nn:nn
-    foreign llvm mul(tmp$2#0:wybe.int, ~tmp$62#0:wybe.int, ?tmp$49#0:wybe.int) @int:nn:nn
-    foreign llvm add(~tmp$49#0:wybe.int, ~tmp$49#0:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn
-    foreign c print_int(tmp$0#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$35#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$35#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#1:wybe.phantom, ?tmp$52#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$52#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_int(~tmp$2#0:wybe.int, ~#io#2:wybe.phantom, ?tmp$65#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$65#0:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
+    foreign llvm add(x##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
+    foreign llvm sub(~x##0:wybe.int, 1:wybe.int, ?tmp$62##0:wybe.int) @int:nn:nn
+    foreign llvm mul(tmp$2##0:wybe.int, ~tmp$62##0:wybe.int, ?tmp$49##0:wybe.int) @int:nn:nn
+    foreign llvm add(~tmp$49##0:wybe.int, ~tmp$49##0:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
+    foreign c print_int(tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$35##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$35##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$52##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$52##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_int(~tmp$2##0:wybe.int, ~#io##2:wybe.phantom, ?tmp$65##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$65##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -70,17 +70,17 @@ entry:
 }
 
 
-define external fastcc  void @"commonsubexpr.common_subexpr<0>"(i64  %"x#0")    {
+define external fastcc  void @"commonsubexpr.common_subexpr<0>"(i64  %"x##0")    {
 entry:
-  %"1$tmp$2#0" = add   i64 %"x#0", 1 
-  %"1$tmp$62#0" = sub   i64 %"x#0", 1 
-  %"1$tmp$49#0" = mul   i64 %"1$tmp$2#0", %"1$tmp$62#0" 
-  %"1$tmp$0#0" = add   i64 %"1$tmp$49#0", %"1$tmp$49#0" 
-  tail call ccc  void  @print_int(i64  %"1$tmp$0#0")  
+  %"1$tmp$2##0" = add   i64 %"x##0", 1 
+  %"1$tmp$62##0" = sub   i64 %"x##0", 1 
+  %"1$tmp$49##0" = mul   i64 %"1$tmp$2##0", %"1$tmp$62##0" 
+  %"1$tmp$0##0" = add   i64 %"1$tmp$49##0", %"1$tmp$49##0" 
+  tail call ccc  void  @print_int(i64  %"1$tmp$0##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call ccc  void  @print_int(i64  %"1$tmp$0#0")  
+  tail call ccc  void  @print_int(i64  %"1$tmp$0##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call ccc  void  @print_int(i64  %"1$tmp$2#0")  
+  tail call ccc  void  @print_int(i64  %"1$tmp$2##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/commonsubexpr.exp
+++ b/test-cases/final-dump/commonsubexpr.exp
@@ -14,12 +14,12 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(198:wybe.int, ~#io##0:wybe.phantom, ?tmp$6##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$6##0:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
-    foreign c print_int(198:wybe.int, ~tmp$7##0:wybe.phantom, ?tmp$8##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$8##0:wybe.phantom, ?tmp$9##0:wybe.phantom) @io:nn:nn
-    foreign c print_int(11:wybe.int, ~tmp$9##0:wybe.phantom, ?tmp$10##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(198:wybe.int, ~#io##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
+    foreign c print_int(198:wybe.int, ~tmp#7##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @io:nn:nn
+    foreign c print_int(11:wybe.int, ~tmp#9##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 common_subexpr > {inline} (1 calls)
@@ -27,16 +27,16 @@ common_subexpr > {inline} (1 calls)
 common_subexpr(x##0:wybe.int, io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(x##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
-    foreign llvm sub(~x##0:wybe.int, 1:wybe.int, ?tmp$62##0:wybe.int) @int:nn:nn
-    foreign llvm mul(tmp$2##0:wybe.int, ~tmp$62##0:wybe.int, ?tmp$49##0:wybe.int) @int:nn:nn
-    foreign llvm add(~tmp$49##0:wybe.int, ~tmp$49##0:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
-    foreign c print_int(tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$35##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$35##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$52##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$52##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    foreign c print_int(~tmp$2##0:wybe.int, ~#io##2:wybe.phantom, ?tmp$65##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$65##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign llvm add(x##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
+    foreign llvm sub(~x##0:wybe.int, 1:wybe.int, ?tmp#62##0:wybe.int) @int:nn:nn
+    foreign llvm mul(tmp#2##0:wybe.int, ~tmp#62##0:wybe.int, ?tmp#49##0:wybe.int) @int:nn:nn
+    foreign llvm add(~tmp#49##0:wybe.int, ~tmp#49##0:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
+    foreign c print_int(tmp#0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#35##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#35##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#52##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#52##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~#io##2:wybe.phantom, ?tmp#65##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#65##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -72,15 +72,15 @@ entry:
 
 define external fastcc  void @"commonsubexpr.common_subexpr<0>"(i64  %"x##0")    {
 entry:
-  %"1$tmp$2##0" = add   i64 %"x##0", 1 
-  %"1$tmp$62##0" = sub   i64 %"x##0", 1 
-  %"1$tmp$49##0" = mul   i64 %"1$tmp$2##0", %"1$tmp$62##0" 
-  %"1$tmp$0##0" = add   i64 %"1$tmp$49##0", %"1$tmp$49##0" 
-  tail call ccc  void  @print_int(i64  %"1$tmp$0##0")  
+  %"1#tmp#2##0" = add   i64 %"x##0", 1 
+  %"1#tmp#62##0" = sub   i64 %"x##0", 1 
+  %"1#tmp#49##0" = mul   i64 %"1#tmp#2##0", %"1#tmp#62##0" 
+  %"1#tmp#0##0" = add   i64 %"1#tmp#49##0", %"1#tmp#49##0" 
+  tail call ccc  void  @print_int(i64  %"1#tmp#0##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call ccc  void  @print_int(i64  %"1$tmp$0##0")  
+  tail call ccc  void  @print_int(i64  %"1#tmp#0##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call ccc  void  @print_int(i64  %"1$tmp$2##0")  
+  tail call ccc  void  @print_int(i64  %"1#tmp#2##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/compute.exp
+++ b/test-cases/final-dump/compute.exp
@@ -12,14 +12,14 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: compute.<0>
-(io#0:wybe.phantom, ?io#2:wybe.phantom):
+(io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    math.utils.factorial<0>(4:wybe.int, ?tmp$0#0:wybe.int) #0 @compute:nn:nn
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$4#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$4#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_float(65.55555555555556:wybe.float, ~#io#1:wybe.phantom, ?tmp$9#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$9#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
+    math.utils.factorial<0>(4:wybe.int, ?tmp$0##0:wybe.int) #0 @compute:nn:nn
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$4##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$4##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_float(65.55555555555556:wybe.float, ~#io##1:wybe.phantom, ?tmp$9##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$9##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -49,8 +49,8 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"compute.<0>"()    {
 entry:
-  %"1$tmp$0#0" = tail call fastcc  i64  @"math.utils.factorial<0>"(i64  4)  
-  tail call ccc  void  @print_int(i64  %"1$tmp$0#0")  
+  %"1$tmp$0##0" = tail call fastcc  i64  @"math.utils.factorial<0>"(i64  4)  
+  tail call ccc  void  @print_int(i64  %"1$tmp$0##0")  
   tail call ccc  void  @putchar(i8  10)  
   tail call ccc  void  @print_float(double  6.555556e1)  
   tail call ccc  void  @putchar(i8  10)  
@@ -97,11 +97,11 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 toCelsius > public {inline} (0 calls)
 0: math.temperature.toCelsius<0>
-toCelsius(f#0:wybe.float, ?$#0:wybe.float):
+toCelsius(f##0:wybe.float, ?$##0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm fsub(~f#0:wybe.float, 32.0:wybe.float, ?tmp$1#0:wybe.float) @float:nn:nn
-    foreign llvm fdiv(~tmp$1#0:wybe.float, 1.8:wybe.float, ?$#0:wybe.float) @float:nn:nn
+    foreign llvm fsub(~f##0:wybe.float, 32.0:wybe.float, ?tmp$1##0:wybe.float) @float:nn:nn
+    foreign llvm fdiv(~tmp$1##0:wybe.float, 1.8:wybe.float, ?$##0:wybe.float) @float:nn:nn
 
   LLVM code       :
 
@@ -117,11 +117,11 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  double @"math.temperature.toCelsius<0>"(double  %"f#0")    {
+define external fastcc  double @"math.temperature.toCelsius<0>"(double  %"f##0")    {
 entry:
-  %"1$tmp$1#0" = fsub double %"f#0", 3.200000e1 
-  %"1$$#0" = fdiv double %"1$tmp$1#0", 1.800000e0 
-  ret double %"1$$#0" 
+  %"1$tmp$1##0" = fsub double %"f##0", 3.200000e1 
+  %"1$$##0" = fdiv double %"1$tmp$1##0", 1.800000e0 
+  ret double %"1$$##0" 
 }
 --------------------------------------------------
  Module math.utils
@@ -136,27 +136,27 @@ entry:
 
 *main* > public {inline} (0 calls)
 0: math.utils.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("Utils has been initialised.":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_string("Utils has been initialised.":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 factorial > public (1 calls)
 0: math.utils.factorial<0>
-factorial(n#0:wybe.int, ?$#0:wybe.int):
+factorial(n##0:wybe.int, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_sle(n#0:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.bool) @int:nn:nn
-    case ~tmp$4#0:wybe.bool of
+    foreign llvm icmp_sle(n##0:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
+    case ~tmp$4##0:wybe.bool of
     0:
-        foreign llvm sub(n#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.int) @int:nn:nn
-        math.utils.factorial<0>(~tmp$3#0:wybe.int, ?tmp$2#0:wybe.int) #2 @utils:nn:nn
-        foreign llvm mul(~n#0:wybe.int, ~tmp$2#0:wybe.int, ?$#0:wybe.int) @int:nn:nn
+        foreign llvm sub(n##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
+        math.utils.factorial<0>(~tmp$3##0:wybe.int, ?tmp$2##0:wybe.int) #2 @utils:nn:nn
+        foreign llvm mul(~n##0:wybe.int, ~tmp$2##0:wybe.int, ?$##0:wybe.int) @int:nn:nn
 
     1:
-        foreign llvm move(1:wybe.int, ?$#0:wybe.int) @utils:nn:nn
+        foreign llvm move(1:wybe.int, ?$##0:wybe.int) @utils:nn:nn
 
 
   LLVM code       :
@@ -191,15 +191,15 @@ entry:
 }
 
 
-define external fastcc  i64 @"math.utils.factorial<0>"(i64  %"n#0")    {
+define external fastcc  i64 @"math.utils.factorial<0>"(i64  %"n##0")    {
 entry:
-  %"1$tmp$4#0" = icmp sle i64 %"n#0", 0 
-  br i1 %"1$tmp$4#0", label %if.then, label %if.else 
+  %"1$tmp$4##0" = icmp sle i64 %"n##0", 0 
+  br i1 %"1$tmp$4##0", label %if.then, label %if.else 
 if.then:
   ret i64 1 
 if.else:
-  %"3$tmp$3#0" = sub   i64 %"n#0", 1 
-  %"3$tmp$2#0" = tail call fastcc  i64  @"math.utils.factorial<0>"(i64  %"3$tmp$3#0")  
-  %"3$$#0" = mul   i64 %"n#0", %"3$tmp$2#0" 
-  ret i64 %"3$$#0" 
+  %"3$tmp$3##0" = sub   i64 %"n##0", 1 
+  %"3$tmp$2##0" = tail call fastcc  i64  @"math.utils.factorial<0>"(i64  %"3$tmp$3##0")  
+  %"3$$##0" = mul   i64 %"n##0", %"3$tmp$2##0" 
+  ret i64 %"3$$##0" 
 }

--- a/test-cases/final-dump/compute.exp
+++ b/test-cases/final-dump/compute.exp
@@ -15,11 +15,11 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    math.utils.factorial<0>(4:wybe.int, ?tmp$0##0:wybe.int) #0 @compute:nn:nn
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$4##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$4##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign c print_float(65.55555555555556:wybe.float, ~#io##1:wybe.phantom, ?tmp$9##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$9##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    math.utils.factorial<0>(4:wybe.int, ?tmp#0##0:wybe.int) #0 @compute:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#4##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#4##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_float(65.55555555555556:wybe.float, ~#io##1:wybe.phantom, ?tmp#9##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#9##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -49,8 +49,8 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"compute.<0>"()    {
 entry:
-  %"1$tmp$0##0" = tail call fastcc  i64  @"math.utils.factorial<0>"(i64  4)  
-  tail call ccc  void  @print_int(i64  %"1$tmp$0##0")  
+  %"1#tmp#0##0" = tail call fastcc  i64  @"math.utils.factorial<0>"(i64  4)  
+  tail call ccc  void  @print_int(i64  %"1#tmp#0##0")  
   tail call ccc  void  @putchar(i8  10)  
   tail call ccc  void  @print_float(double  6.555556e1)  
   tail call ccc  void  @putchar(i8  10)  
@@ -97,11 +97,11 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 toCelsius > public {inline} (0 calls)
 0: math.temperature.toCelsius<0>
-toCelsius(f##0:wybe.float, ?$##0:wybe.float):
+toCelsius(f##0:wybe.float, ?###0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm fsub(~f##0:wybe.float, 32.0:wybe.float, ?tmp$1##0:wybe.float) @float:nn:nn
-    foreign llvm fdiv(~tmp$1##0:wybe.float, 1.8:wybe.float, ?$##0:wybe.float) @float:nn:nn
+    foreign llvm fsub(~f##0:wybe.float, 32.0:wybe.float, ?tmp#1##0:wybe.float) @float:nn:nn
+    foreign llvm fdiv(~tmp#1##0:wybe.float, 1.8:wybe.float, ?###0:wybe.float) @float:nn:nn
 
   LLVM code       :
 
@@ -119,9 +119,9 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  double @"math.temperature.toCelsius<0>"(double  %"f##0")    {
 entry:
-  %"1$tmp$1##0" = fsub double %"f##0", 3.200000e1 
-  %"1$$##0" = fdiv double %"1$tmp$1##0", 1.800000e0 
-  ret double %"1$$##0" 
+  %"1#tmp#1##0" = fsub double %"f##0", 3.200000e1 
+  %"1####0" = fdiv double %"1#tmp#1##0", 1.800000e0 
+  ret double %"1####0" 
 }
 --------------------------------------------------
  Module math.utils
@@ -139,24 +139,24 @@ entry:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("Utils has been initialised.":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("Utils has been initialised.":wybe.string, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 factorial > public (1 calls)
 0: math.utils.factorial<0>
-factorial(n##0:wybe.int, ?$##0:wybe.int):
+factorial(n##0:wybe.int, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_sle(n##0:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
-    case ~tmp$4##0:wybe.bool of
+    foreign llvm icmp_sle(n##0:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
+    case ~tmp#4##0:wybe.bool of
     0:
-        foreign llvm sub(n##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
-        math.utils.factorial<0>(~tmp$3##0:wybe.int, ?tmp$2##0:wybe.int) #2 @utils:nn:nn
-        foreign llvm mul(~n##0:wybe.int, ~tmp$2##0:wybe.int, ?$##0:wybe.int) @int:nn:nn
+        foreign llvm sub(n##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
+        math.utils.factorial<0>(~tmp#3##0:wybe.int, ?tmp#2##0:wybe.int) #2 @utils:nn:nn
+        foreign llvm mul(~n##0:wybe.int, ~tmp#2##0:wybe.int, ?###0:wybe.int) @int:nn:nn
 
     1:
-        foreign llvm move(1:wybe.int, ?$##0:wybe.int) @utils:nn:nn
+        foreign llvm move(1:wybe.int, ?###0:wybe.int) @utils:nn:nn
 
 
   LLVM code       :
@@ -193,13 +193,13 @@ entry:
 
 define external fastcc  i64 @"math.utils.factorial<0>"(i64  %"n##0")    {
 entry:
-  %"1$tmp$4##0" = icmp sle i64 %"n##0", 0 
-  br i1 %"1$tmp$4##0", label %if.then, label %if.else 
+  %"1#tmp#4##0" = icmp sle i64 %"n##0", 0 
+  br i1 %"1#tmp#4##0", label %if.then, label %if.else 
 if.then:
   ret i64 1 
 if.else:
-  %"3$tmp$3##0" = sub   i64 %"n##0", 1 
-  %"3$tmp$2##0" = tail call fastcc  i64  @"math.utils.factorial<0>"(i64  %"3$tmp$3##0")  
-  %"3$$##0" = mul   i64 %"n##0", %"3$tmp$2##0" 
-  ret i64 %"3$$##0" 
+  %"3#tmp#3##0" = sub   i64 %"n##0", 1 
+  %"3#tmp#2##0" = tail call fastcc  i64  @"math.utils.factorial<0>"(i64  %"3#tmp#3##0")  
+  %"3####0" = mul   i64 %"n##0", %"3#tmp#2##0" 
+  ret i64 %"3####0" 
 }

--- a/test-cases/final-dump/compute.exp
+++ b/test-cases/final-dump/compute.exp
@@ -97,11 +97,11 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 toCelsius > public {inline} (0 calls)
 0: math.temperature.toCelsius<0>
-toCelsius(f##0:wybe.float, ?###0:wybe.float):
+toCelsius(f##0:wybe.float, ?#result##0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm fsub(~f##0:wybe.float, 32.0:wybe.float, ?tmp#1##0:wybe.float) @float:nn:nn
-    foreign llvm fdiv(~tmp#1##0:wybe.float, 1.8:wybe.float, ?###0:wybe.float) @float:nn:nn
+    foreign llvm fdiv(~tmp#1##0:wybe.float, 1.8:wybe.float, ?#result##0:wybe.float) @float:nn:nn
 
   LLVM code       :
 
@@ -120,8 +120,8 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 define external fastcc  double @"math.temperature.toCelsius<0>"(double  %"f##0")    {
 entry:
   %"1#tmp#1##0" = fsub double %"f##0", 3.200000e1 
-  %"1####0" = fdiv double %"1#tmp#1##0", 1.800000e0 
-  ret double %"1####0" 
+  %"1##result##0" = fdiv double %"1#tmp#1##0", 1.800000e0 
+  ret double %"1##result##0" 
 }
 --------------------------------------------------
  Module math.utils
@@ -145,7 +145,7 @@ entry:
 
 factorial > public (1 calls)
 0: math.utils.factorial<0>
-factorial(n##0:wybe.int, ?###0:wybe.int):
+factorial(n##0:wybe.int, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_sle(n##0:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
@@ -153,10 +153,10 @@ factorial(n##0:wybe.int, ?###0:wybe.int):
     0:
         foreign llvm sub(n##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
         math.utils.factorial<0>(~tmp#3##0:wybe.int, ?tmp#2##0:wybe.int) #2 @utils:nn:nn
-        foreign llvm mul(~n##0:wybe.int, ~tmp#2##0:wybe.int, ?###0:wybe.int) @int:nn:nn
+        foreign llvm mul(~n##0:wybe.int, ~tmp#2##0:wybe.int, ?#result##0:wybe.int) @int:nn:nn
 
     1:
-        foreign llvm move(1:wybe.int, ?###0:wybe.int) @utils:nn:nn
+        foreign llvm move(1:wybe.int, ?#result##0:wybe.int) @utils:nn:nn
 
 
   LLVM code       :
@@ -200,6 +200,6 @@ if.then:
 if.else:
   %"3#tmp#3##0" = sub   i64 %"n##0", 1 
   %"3#tmp#2##0" = tail call fastcc  i64  @"math.utils.factorial<0>"(i64  %"3#tmp#3##0")  
-  %"3####0" = mul   i64 %"n##0", %"3#tmp#2##0" 
-  ret i64 %"3####0" 
+  %"3##result##0" = mul   i64 %"n##0", %"3#tmp#2##0" 
+  ret i64 %"3##result##0" 
 }

--- a/test-cases/final-dump/constfold.exp
+++ b/test-cases/final-dump/constfold.exp
@@ -14,34 +14,34 @@ AFTER EVERYTHING:
 
 fold_add > public {inline} (3 calls)
 0: constfold.fold_add<0>
-fold_add(?$##0:wybe.int):
+fold_add(?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(42:wybe.int, ?$##0:wybe.int) @constfold:nn:nn
+    foreign llvm move(42:wybe.int, ?###0:wybe.int) @constfold:nn:nn
 
 
 fold_mult > public {inline} (3 calls)
 0: constfold.fold_mult<0>
-fold_mult(?$##0:wybe.int):
+fold_mult(?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(42:wybe.int, ?$##0:wybe.int) @constfold:nn:nn
+    foreign llvm move(42:wybe.int, ?###0:wybe.int) @constfold:nn:nn
 
 
 fold_test > public {inline} (0 calls)
 0: constfold.fold_test<0>
-fold_test(?$##0:wybe.int):
+fold_test(?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(42:wybe.int, ?$##0:wybe.int) @constfold:nn:nn
+    foreign llvm move(42:wybe.int, ?###0:wybe.int) @constfold:nn:nn
 
 
 fortytwo > public {inline} (0 calls)
 0: constfold.fortytwo<0>
-fortytwo(?$##0:wybe.int):
+fortytwo(?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(42:wybe.int, ?$##0:wybe.int) @constfold:nn:nn
+    foreign llvm move(42:wybe.int, ?###0:wybe.int) @constfold:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/constfold.exp
+++ b/test-cases/final-dump/constfold.exp
@@ -14,34 +14,34 @@ AFTER EVERYTHING:
 
 fold_add > public {inline} (3 calls)
 0: constfold.fold_add<0>
-fold_add(?$#0:wybe.int):
+fold_add(?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(42:wybe.int, ?$#0:wybe.int) @constfold:nn:nn
+    foreign llvm move(42:wybe.int, ?$##0:wybe.int) @constfold:nn:nn
 
 
 fold_mult > public {inline} (3 calls)
 0: constfold.fold_mult<0>
-fold_mult(?$#0:wybe.int):
+fold_mult(?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(42:wybe.int, ?$#0:wybe.int) @constfold:nn:nn
+    foreign llvm move(42:wybe.int, ?$##0:wybe.int) @constfold:nn:nn
 
 
 fold_test > public {inline} (0 calls)
 0: constfold.fold_test<0>
-fold_test(?$#0:wybe.int):
+fold_test(?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(42:wybe.int, ?$#0:wybe.int) @constfold:nn:nn
+    foreign llvm move(42:wybe.int, ?$##0:wybe.int) @constfold:nn:nn
 
 
 fortytwo > public {inline} (0 calls)
 0: constfold.fortytwo<0>
-fortytwo(?$#0:wybe.int):
+fortytwo(?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(42:wybe.int, ?$#0:wybe.int) @constfold:nn:nn
+    foreign llvm move(42:wybe.int, ?$##0:wybe.int) @constfold:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/constfold.exp
+++ b/test-cases/final-dump/constfold.exp
@@ -14,34 +14,34 @@ AFTER EVERYTHING:
 
 fold_add > public {inline} (3 calls)
 0: constfold.fold_add<0>
-fold_add(?###0:wybe.int):
+fold_add(?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(42:wybe.int, ?###0:wybe.int) @constfold:nn:nn
+    foreign llvm move(42:wybe.int, ?#result##0:wybe.int) @constfold:nn:nn
 
 
 fold_mult > public {inline} (3 calls)
 0: constfold.fold_mult<0>
-fold_mult(?###0:wybe.int):
+fold_mult(?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(42:wybe.int, ?###0:wybe.int) @constfold:nn:nn
+    foreign llvm move(42:wybe.int, ?#result##0:wybe.int) @constfold:nn:nn
 
 
 fold_test > public {inline} (0 calls)
 0: constfold.fold_test<0>
-fold_test(?###0:wybe.int):
+fold_test(?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(42:wybe.int, ?###0:wybe.int) @constfold:nn:nn
+    foreign llvm move(42:wybe.int, ?#result##0:wybe.int) @constfold:nn:nn
 
 
 fortytwo > public {inline} (0 calls)
 0: constfold.fortytwo<0>
-fortytwo(?###0:wybe.int):
+fortytwo(?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(42:wybe.int, ?###0:wybe.int) @constfold:nn:nn
+    foreign llvm move(42:wybe.int, ?#result##0:wybe.int) @constfold:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/constructors.exp
+++ b/test-cases/final-dump/constructors.exp
@@ -17,99 +17,99 @@ AFTER EVERYTHING:
 
 = > public (1 calls)
 0: constructors.=<0>
-=($left#0:constructors, $right#0:constructors, ?$$#0:wybe.bool):
+=($left##0:constructors, $right##0:constructors, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left#0:constructors, ~$right#0:constructors, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~$left##0:constructors, ~$right##0:constructors, ?$$##0:wybe.bool)
 
     1:
-        foreign lpvm access(~$left#0:constructors, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$left$value#0:wybe.int)
-        foreign llvm icmp_ne($right#0:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.bool)
-        case ~tmp$8#0:wybe.bool of
+        foreign lpvm access(~$left##0:constructors, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$left$value##0:wybe.int)
+        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.bool)
+        case ~tmp$8##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign lpvm access(~$right#0:constructors, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$right$value#0:wybe.int)
-            foreign llvm icmp_eq(~$left$value#0:wybe.int, ~$right$value#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+            foreign lpvm access(~$right##0:constructors, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$right$value##0:wybe.int)
+            foreign llvm icmp_eq(~$left$value##0:wybe.int, ~$right$value##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 
 just > public {inline} (0 calls)
 0: constructors.just<0>
-just(value#0:wybe.int, ?$#0:constructors):
+just(value##0:wybe.int, ?$##0:constructors):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec#0:constructors)
-    foreign lpvm mutate(~$rec#0:constructors, ?$#0:constructors, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~value#0:wybe.int)
+    foreign lpvm alloc(8:wybe.int, ?$rec##0:constructors)
+    foreign lpvm mutate(~$rec##0:constructors, ?$##0:constructors, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~value##0:wybe.int)
 just > public {inline} (8 calls)
 1: constructors.just<1>
-just(?value#0:wybe.int, $#0:constructors, ?$$#0:wybe.bool):
+just(?value##0:wybe.int, $##0:constructors, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?value#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?value##0:wybe.int)
 
     1:
-        foreign lpvm access(~$#0:constructors, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?value#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$##0:constructors, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?value##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 nothing > public {inline} (0 calls)
 0: constructors.nothing<0>
-nothing(?$#0:constructors):
+nothing(?$##0:constructors):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:constructors, ?$#0:constructors)
+    foreign llvm move(0:constructors, ?$##0:constructors)
 
 
 value > public {inline} (0 calls)
 0: constructors.value<0>
-value($rec#0:constructors, ?$#0:wybe.int, ?$$#0:wybe.bool):
+value($rec##0:constructors, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec#0:constructors, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:constructors, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 value > public {inline} (0 calls)
 1: constructors.value<1>
-value($rec#0:constructors, ?$rec#1:constructors, $field#0:wybe.int, ?$$#0:wybe.bool):
+value($rec##0:constructors, ?$rec##1:constructors, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:constructors, ?$rec#1:constructors)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:constructors, ?$rec##1:constructors)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec#0:constructors, ?$rec#1:constructors, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm {noalias} mutate(~$rec##0:constructors, ?$rec##1:constructors, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: constructors.~=<0>
-~=($left#0:constructors, $right#0:constructors, ?$$#0:wybe.bool):
+~=($left##0:constructors, $right##0:constructors, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    constructors.=<0>(~$left#0:constructors, ~$right#0:constructors, ?tmp$0#0:wybe.bool) #0
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    constructors.=<0>(~$left##0:constructors, ~$right##0:constructors, ?tmp$0##0:wybe.bool) #0
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
   LLVM code       :
 
@@ -125,48 +125,48 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"constructors.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"constructors.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$left#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %"2$tmp$8#0" = icmp ne i64 %"$right#0", 0 
-  br i1 %"2$tmp$8#0", label %if.then1, label %if.else1 
+  %"2$tmp$8##0" = icmp ne i64 %"$right##0", 0 
+  br i1 %"2$tmp$8##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = icmp eq i64 %"$left#0", %"$right#0" 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
+  ret i1 %"3$$$##0" 
 if.then1:
-  %4 = inttoptr i64 %"$right#0" to i64* 
+  %4 = inttoptr i64 %"$right##0" to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
   %6 = load  i64, i64* %5 
-  %"4$$$#0" = icmp eq i64 %3, %6 
-  ret i1 %"4$$$#0" 
+  %"4$$$##0" = icmp eq i64 %3, %6 
+  ret i1 %"4$$$##0" 
 if.else1:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"constructors.just<0>"(i64  %"value#0")    {
+define external fastcc  i64 @"constructors.just<0>"(i64  %"value##0")    {
 entry:
   %7 = trunc i64 8 to i32  
   %8 = tail call ccc  i8*  @wybe_malloc(i32  %7)  
   %9 = ptrtoint i8* %8 to i64 
   %10 = inttoptr i64 %9 to i64* 
   %11 = getelementptr  i64, i64* %10, i64 0 
-  store  i64 %"value#0", i64* %11 
+  store  i64 %"value##0", i64* %11 
   ret i64 %9 
 }
 
 
-define external fastcc  {i64, i1} @"constructors.just<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"constructors.just<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %12 = inttoptr i64 %"$#0" to i64* 
+  %12 = inttoptr i64 %"$##0" to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
   %15 = insertvalue {i64, i1} undef, i64 %14, 0 
@@ -185,12 +185,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"constructors.value<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"constructors.value<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %19 = inttoptr i64 %"$rec#0" to i64* 
+  %19 = inttoptr i64 %"$rec##0" to i64* 
   %20 = getelementptr  i64, i64* %19, i64 0 
   %21 = load  i64, i64* %20 
   %22 = insertvalue {i64, i1} undef, i64 %21, 0 
@@ -203,34 +203,34 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"constructors.value<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"constructors.value<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %26 = trunc i64 8 to i32  
   %27 = tail call ccc  i8*  @wybe_malloc(i32  %26)  
   %28 = ptrtoint i8* %27 to i64 
   %29 = inttoptr i64 %28 to i8* 
-  %30 = inttoptr i64 %"$rec#0" to i8* 
+  %30 = inttoptr i64 %"$rec##0" to i8* 
   %31 = trunc i64 8 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %29, i8*  %30, i32  %31, i32  8, i1  0)  
   %32 = inttoptr i64 %28 to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
-  store  i64 %"$field#0", i64* %33 
+  store  i64 %"$field##0", i64* %33 
   %34 = insertvalue {i64, i1} undef, i64 %28, 0 
   %35 = insertvalue {i64, i1} %34, i1 1, 1 
   ret {i64, i1} %35 
 if.else:
-  %36 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %36 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %37 = insertvalue {i64, i1} %36, i1 0, 1 
   ret {i64, i1} %37 
 }
 
 
-define external fastcc  i1 @"constructors.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"constructors.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = tail call fastcc  i1  @"constructors.=<0>"(i64  %"$left#0", i64  %"$right#0")  
-  %"1$$$#0" = xor i1 %"1$tmp$0#0", 1 
-  ret i1 %"1$$$#0" 
+  %"1$tmp$0##0" = tail call fastcc  i1  @"constructors.=<0>"(i64  %"$left##0", i64  %"$right##0")  
+  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
+  ret i1 %"1$$$##0" 
 }

--- a/test-cases/final-dump/constructors.exp
+++ b/test-cases/final-dump/constructors.exp
@@ -41,49 +41,49 @@ AFTER EVERYTHING:
 
 just > public {inline} (0 calls)
 0: constructors.just<0>
-just(value##0:wybe.int, ?###0:constructors):
+just(value##0:wybe.int, ?#result##0:constructors):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:constructors)
-    foreign lpvm mutate(~#rec##0:constructors, ?###0:constructors, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~value##0:wybe.int)
+    foreign lpvm mutate(~#rec##0:constructors, ?#result##0:constructors, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~value##0:wybe.int)
 just > public {inline} (8 calls)
 1: constructors.just<1>
-just(?value##0:wybe.int, ###0:constructors, ?####0:wybe.bool):
+just(?value##0:wybe.int, #result##0:constructors, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?value##0:wybe.int)
 
     1:
-        foreign lpvm access(~###0:constructors, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?value##0:wybe.int)
+        foreign lpvm access(~#result##0:constructors, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?value##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 nothing > public {inline} (0 calls)
 0: constructors.nothing<0>
-nothing(?###0:constructors):
+nothing(?#result##0:constructors):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:constructors, ?###0:constructors)
+    foreign llvm move(0:constructors, ?#result##0:constructors)
 
 
 value > public {inline} (0 calls)
 0: constructors.value<0>
-value(#rec##0:constructors, ?###0:wybe.int, ?####0:wybe.bool):
+value(#rec##0:constructors, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:constructors, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign lpvm access(~#rec##0:constructors, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 value > public {inline} (0 calls)
@@ -161,12 +161,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"constructors.just<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"constructors.just<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  %"1#tmp#0##0" = icmp ne i64 %"#result##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %12 = inttoptr i64 %"###0" to i64* 
+  %12 = inttoptr i64 %"#result##0" to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
   %15 = insertvalue {i64, i1} undef, i64 %14, 0 

--- a/test-cases/final-dump/constructors.exp
+++ b/test-cases/final-dump/constructors.exp
@@ -17,24 +17,24 @@ AFTER EVERYTHING:
 
 = > public (1 calls)
 0: constructors.=<0>
-=(#left##0:constructors, #right##0:constructors, ?####0:wybe.bool):
+=(#left##0:constructors, #right##0:constructors, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~#left##0:constructors, ~#right##0:constructors, ?####0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:constructors, ~#right##0:constructors, ?#success##0:wybe.bool)
 
     1:
         foreign lpvm access(~#left##0:constructors, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#left#value##0:wybe.int)
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool)
         case ~tmp#8##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign lpvm access(~#right##0:constructors, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#right#value##0:wybe.int)
-            foreign llvm icmp_eq(~#left#value##0:wybe.int, ~#right#value##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+            foreign llvm icmp_eq(~#left#value##0:wybe.int, ~#right#value##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -48,18 +48,18 @@ just(value##0:wybe.int, ?#result##0:constructors):
     foreign lpvm mutate(~#rec##0:constructors, ?#result##0:constructors, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~value##0:wybe.int)
 just > public {inline} (8 calls)
 1: constructors.just<1>
-just(?value##0:wybe.int, #result##0:constructors, ?####0:wybe.bool):
+just(?value##0:wybe.int, #result##0:constructors, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?value##0:wybe.int)
 
     1:
         foreign lpvm access(~#result##0:constructors, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?value##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -73,43 +73,43 @@ nothing(?#result##0:constructors):
 
 value > public {inline} (0 calls)
 0: constructors.value<0>
-value(#rec##0:constructors, ?#result##0:wybe.int, ?####0:wybe.bool):
+value(#rec##0:constructors, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign lpvm access(~#rec##0:constructors, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 value > public {inline} (0 calls)
 1: constructors.value<1>
-value(#rec##0:constructors, ?#rec##1:constructors, #field##0:wybe.int, ?####0:wybe.bool):
+value(#rec##0:constructors, ?#rec##1:constructors, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:constructors, ?#rec##1:constructors)
 
     1:
         foreign lpvm {noalias} mutate(~#rec##0:constructors, ?#rec##1:constructors, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: constructors.~=<0>
-~=(#left##0:constructors, #right##0:constructors, ?####0:wybe.bool):
+~=(#left##0:constructors, #right##0:constructors, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     constructors.=<0>(~#left##0:constructors, ~#right##0:constructors, ?tmp#0##0:wybe.bool) #0
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 
@@ -136,14 +136,14 @@ if.then:
   %"2#tmp#8##0" = icmp ne i64 %"#right##0", 0 
   br i1 %"2#tmp#8##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %"3#####0" 
+  %"3##success##0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3##success##0" 
 if.then1:
   %4 = inttoptr i64 %"#right##0" to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
   %6 = load  i64, i64* %5 
-  %"4#####0" = icmp eq i64 %3, %6 
-  ret i1 %"4#####0" 
+  %"4##success##0" = icmp eq i64 %3, %6 
+  ret i1 %"4##success##0" 
 if.else1:
   ret i1 0 
 }
@@ -231,6 +231,6 @@ if.else:
 define external fastcc  i1 @"constructors.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %"1#tmp#0##0" = tail call fastcc  i1  @"constructors.=<0>"(i64  %"#left##0", i64  %"#right##0")  
-  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
-  ret i1 %"1#####0" 
+  %"1##success##0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1##success##0" 
 }

--- a/test-cases/final-dump/constructors.exp
+++ b/test-cases/final-dump/constructors.exp
@@ -17,99 +17,99 @@ AFTER EVERYTHING:
 
 = > public (1 calls)
 0: constructors.=<0>
-=($left##0:constructors, $right##0:constructors, ?$$##0:wybe.bool):
+=(#left##0:constructors, #right##0:constructors, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left##0:constructors, ~$right##0:constructors, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:constructors, ~#right##0:constructors, ?####0:wybe.bool)
 
     1:
-        foreign lpvm access(~$left##0:constructors, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$left$value##0:wybe.int)
-        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.bool)
-        case ~tmp$8##0:wybe.bool of
+        foreign lpvm access(~#left##0:constructors, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#left#value##0:wybe.int)
+        foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool)
+        case ~tmp#8##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign lpvm access(~$right##0:constructors, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$right$value##0:wybe.int)
-            foreign llvm icmp_eq(~$left$value##0:wybe.int, ~$right$value##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+            foreign lpvm access(~#right##0:constructors, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#right#value##0:wybe.int)
+            foreign llvm icmp_eq(~#left#value##0:wybe.int, ~#right#value##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 
 just > public {inline} (0 calls)
 0: constructors.just<0>
-just(value##0:wybe.int, ?$##0:constructors):
+just(value##0:wybe.int, ?###0:constructors):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec##0:constructors)
-    foreign lpvm mutate(~$rec##0:constructors, ?$##0:constructors, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~value##0:wybe.int)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:constructors)
+    foreign lpvm mutate(~#rec##0:constructors, ?###0:constructors, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~value##0:wybe.int)
 just > public {inline} (8 calls)
 1: constructors.just<1>
-just(?value##0:wybe.int, $##0:constructors, ?$$##0:wybe.bool):
+just(?value##0:wybe.int, ###0:constructors, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?value##0:wybe.int)
 
     1:
-        foreign lpvm access(~$##0:constructors, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?value##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~###0:constructors, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?value##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 nothing > public {inline} (0 calls)
 0: constructors.nothing<0>
-nothing(?$##0:constructors):
+nothing(?###0:constructors):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:constructors, ?$##0:constructors)
+    foreign llvm move(0:constructors, ?###0:constructors)
 
 
 value > public {inline} (0 calls)
 0: constructors.value<0>
-value($rec##0:constructors, ?$##0:wybe.int, ?$$##0:wybe.bool):
+value(#rec##0:constructors, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec##0:constructors, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:constructors, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 value > public {inline} (0 calls)
 1: constructors.value<1>
-value($rec##0:constructors, ?$rec##1:constructors, $field##0:wybe.int, ?$$##0:wybe.bool):
+value(#rec##0:constructors, ?#rec##1:constructors, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:constructors, ?$rec##1:constructors)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:constructors, ?#rec##1:constructors)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec##0:constructors, ?$rec##1:constructors, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm {noalias} mutate(~#rec##0:constructors, ?#rec##1:constructors, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: constructors.~=<0>
-~=($left##0:constructors, $right##0:constructors, ?$$##0:wybe.bool):
+~=(#left##0:constructors, #right##0:constructors, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    constructors.=<0>(~$left##0:constructors, ~$right##0:constructors, ?tmp$0##0:wybe.bool) #0
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    constructors.=<0>(~#left##0:constructors, ~#right##0:constructors, ?tmp#0##0:wybe.bool) #0
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
   LLVM code       :
 
@@ -125,25 +125,25 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"constructors.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"constructors.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#left##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %"2$tmp$8##0" = icmp ne i64 %"$right##0", 0 
-  br i1 %"2$tmp$8##0", label %if.then1, label %if.else1 
+  %"2#tmp#8##0" = icmp ne i64 %"#right##0", 0 
+  br i1 %"2#tmp#8##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3#####0" 
 if.then1:
-  %4 = inttoptr i64 %"$right##0" to i64* 
+  %4 = inttoptr i64 %"#right##0" to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
   %6 = load  i64, i64* %5 
-  %"4$$$##0" = icmp eq i64 %3, %6 
-  ret i1 %"4$$$##0" 
+  %"4#####0" = icmp eq i64 %3, %6 
+  ret i1 %"4#####0" 
 if.else1:
   ret i1 0 
 }
@@ -161,12 +161,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"constructors.just<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"constructors.just<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %12 = inttoptr i64 %"$##0" to i64* 
+  %12 = inttoptr i64 %"###0" to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
   %15 = insertvalue {i64, i1} undef, i64 %14, 0 
@@ -185,12 +185,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"constructors.value<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"constructors.value<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %19 = inttoptr i64 %"$rec##0" to i64* 
+  %19 = inttoptr i64 %"#rec##0" to i64* 
   %20 = getelementptr  i64, i64* %19, i64 0 
   %21 = load  i64, i64* %20 
   %22 = insertvalue {i64, i1} undef, i64 %21, 0 
@@ -203,34 +203,34 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"constructors.value<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"constructors.value<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %26 = trunc i64 8 to i32  
   %27 = tail call ccc  i8*  @wybe_malloc(i32  %26)  
   %28 = ptrtoint i8* %27 to i64 
   %29 = inttoptr i64 %28 to i8* 
-  %30 = inttoptr i64 %"$rec##0" to i8* 
+  %30 = inttoptr i64 %"#rec##0" to i8* 
   %31 = trunc i64 8 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %29, i8*  %30, i32  %31, i32  8, i1  0)  
   %32 = inttoptr i64 %28 to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
-  store  i64 %"$field##0", i64* %33 
+  store  i64 %"#field##0", i64* %33 
   %34 = insertvalue {i64, i1} undef, i64 %28, 0 
   %35 = insertvalue {i64, i1} %34, i1 1, 1 
   ret {i64, i1} %35 
 if.else:
-  %36 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %36 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %37 = insertvalue {i64, i1} %36, i1 0, 1 
   ret {i64, i1} %37 
 }
 
 
-define external fastcc  i1 @"constructors.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"constructors.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = tail call fastcc  i1  @"constructors.=<0>"(i64  %"$left##0", i64  %"$right##0")  
-  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
-  ret i1 %"1$$$##0" 
+  %"1#tmp#0##0" = tail call fastcc  i1  @"constructors.=<0>"(i64  %"#left##0", i64  %"#right##0")  
+  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1#####0" 
 }

--- a/test-cases/final-dump/coordinate.exp
+++ b/test-cases/final-dump/coordinate.exp
@@ -27,26 +27,26 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp$7##0:coordinate.Coordinate)
-    foreign lpvm mutate(~tmp$7##0:coordinate.Coordinate, ?tmp$8##0:coordinate.Coordinate, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1000:wybe.int)
-    foreign lpvm mutate(~tmp$8##0:coordinate.Coordinate, ?tmp$9##0:coordinate.Coordinate, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1000:wybe.int)
-    foreign lpvm mutate(~tmp$9##0:coordinate.Coordinate, ?tmp$22##0:coordinate.Coordinate, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1000:wybe.int)
-    foreign lpvm {noalias} mutate(~tmp$22##0:coordinate.Coordinate, ?%crd1##1:coordinate.Coordinate, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 8000:wybe.int)
+    foreign lpvm alloc(24:wybe.int, ?tmp#7##0:coordinate.Coordinate)
+    foreign lpvm mutate(~tmp#7##0:coordinate.Coordinate, ?tmp#8##0:coordinate.Coordinate, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1000:wybe.int)
+    foreign lpvm mutate(~tmp#8##0:coordinate.Coordinate, ?tmp#9##0:coordinate.Coordinate, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1000:wybe.int)
+    foreign lpvm mutate(~tmp#9##0:coordinate.Coordinate, ?tmp#22##0:coordinate.Coordinate, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1000:wybe.int)
+    foreign lpvm {noalias} mutate(~tmp#22##0:coordinate.Coordinate, ?%crd1##1:coordinate.Coordinate, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 8000:wybe.int)
     foreign c print_string("expect crd1^z=8000: ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~crd1##1:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.int)
-    foreign c print_int(~tmp$2##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$19##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$19##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~crd1##1:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int)
+    foreign c print_int(~tmp#2##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#19##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#19##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string("expect crd2^z=1000: ":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign c print_int(1000:wybe.int, ~#io##3:wybe.phantom, ?tmp$25##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$25##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_int(1000:wybe.int, ~#io##3:wybe.phantom, ?tmp#25##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#25##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
 
 
 fcopy > public {inline} (1 calls)
 0: coordinate.fcopy<0>
-fcopy(crd1##0:coordinate.Coordinate, ?$##0:coordinate.Coordinate):
+fcopy(crd1##0:coordinate.Coordinate, ?###0:coordinate.Coordinate):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(~crd1##0:coordinate.Coordinate, ?$##0:coordinate.Coordinate) @coordinate:nn:nn
+    foreign llvm move(~crd1##0:coordinate.Coordinate, ?###0:coordinate.Coordinate) @coordinate:nn:nn
 
   LLVM code       :
 
@@ -139,120 +139,120 @@ entry:
 
 = > public {inline} (1 calls)
 0: coordinate.Coordinate.=<0>
-=($left##0:coordinate.Coordinate, $right##0:coordinate.Coordinate, ?$$##0:wybe.bool):
+=(#left##0:coordinate.Coordinate, #right##0:coordinate.Coordinate, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
-    foreign lpvm access($left##0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
-    foreign lpvm access(~$left##0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$z##0:wybe.int)
-    foreign lpvm access($right##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
-    foreign lpvm access($right##0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
-    foreign lpvm access(~$right##0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$z##0:wybe.int)
-    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
+    foreign lpvm access(#left##0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
+    foreign lpvm access(~#left##0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#z##0:wybe.int)
+    foreign lpvm access(#right##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
+    foreign lpvm access(#right##0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign lpvm access(~#right##0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#z##0:wybe.int)
+    foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?tmp$2##0:wybe.bool) @int:nn:nn
-        case ~tmp$2##0:wybe.bool of
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?tmp#2##0:wybe.bool) @int:nn:nn
+        case ~tmp#2##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~$left$z##0:wybe.int, ~$right$z##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+            foreign llvm icmp_eq(~#left#z##0:wybe.int, ~#right#z##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 
 Coordinate > public {inline} (0 calls)
 0: coordinate.Coordinate.Coordinate<0>
-Coordinate(x##0:wybe.int, y##0:wybe.int, z##0:wybe.int, ?$##0:coordinate.Coordinate):
+Coordinate(x##0:wybe.int, y##0:wybe.int, z##0:wybe.int, ?###0:coordinate.Coordinate):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?$rec##0:coordinate.Coordinate)
-    foreign lpvm mutate(~$rec##0:coordinate.Coordinate, ?$rec##1:coordinate.Coordinate, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:coordinate.Coordinate, ?$rec##2:coordinate.Coordinate, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~y##0:wybe.int)
-    foreign lpvm mutate(~$rec##2:coordinate.Coordinate, ?$##0:coordinate.Coordinate, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~z##0:wybe.int)
+    foreign lpvm alloc(24:wybe.int, ?#rec##0:coordinate.Coordinate)
+    foreign lpvm mutate(~#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:coordinate.Coordinate, ?#rec##2:coordinate.Coordinate, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~#rec##2:coordinate.Coordinate, ?###0:coordinate.Coordinate, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~z##0:wybe.int)
 Coordinate > public {inline} (10 calls)
 1: coordinate.Coordinate.Coordinate<1>
-Coordinate(?x##0:wybe.int, ?y##0:wybe.int, ?z##0:wybe.int, $##0:coordinate.Coordinate):
+Coordinate(?x##0:wybe.int, ?y##0:wybe.int, ?z##0:wybe.int, ###0:coordinate.Coordinate):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access($##0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?y##0:wybe.int)
-    foreign lpvm access(~$##0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?z##0:wybe.int)
+    foreign lpvm access(###0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(###0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(~###0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?z##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: coordinate.Coordinate.x<0>
-x($rec##0:coordinate.Coordinate, ?$##0:wybe.int):
+x(#rec##0:coordinate.Coordinate, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:wybe.int)
 x > public {inline} (0 calls)
 1: coordinate.Coordinate.x<1>
-x($rec##0:coordinate.Coordinate, ?$rec##1:coordinate.Coordinate, $field##0:wybe.int):
+x(#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:coordinate.Coordinate, ?$rec##1:coordinate.Coordinate, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: coordinate.Coordinate.y<0>
-y($rec##0:coordinate.Coordinate, ?$##0:wybe.int):
+y(#rec##0:coordinate.Coordinate, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:wybe.int)
 y > public {inline} (0 calls)
 1: coordinate.Coordinate.y<1>
-y($rec##0:coordinate.Coordinate, ?$rec##1:coordinate.Coordinate, $field##0:wybe.int):
+y(#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:coordinate.Coordinate, ?$rec##1:coordinate.Coordinate, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 z > public {inline} (0 calls)
 0: coordinate.Coordinate.z<0>
-z($rec##0:coordinate.Coordinate, ?$##0:wybe.int):
+z(#rec##0:coordinate.Coordinate, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:wybe.int)
 z > public {inline} (0 calls)
 1: coordinate.Coordinate.z<1>
-z($rec##0:coordinate.Coordinate, ?$rec##1:coordinate.Coordinate, $field##0:wybe.int):
+z(#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:coordinate.Coordinate, ?$rec##1:coordinate.Coordinate, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: coordinate.Coordinate.~=<0>
-~=($left##0:coordinate.Coordinate, $right##0:coordinate.Coordinate, ?$$##0:wybe.bool):
+~=(#left##0:coordinate.Coordinate, #right##0:coordinate.Coordinate, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access($left##0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access(~$left##0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access($right##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign lpvm access($right##0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.int)
-    foreign lpvm access(~$right##0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$9##0:wybe.bool) @int:nn:nn
-    case ~tmp$9##0:wybe.bool of
+    foreign lpvm access(#left##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(#left##0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(~#left##0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(#right##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#right##0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int)
+    foreign lpvm access(~#right##0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#9##0:wybe.bool) @int:nn:nn
+    case ~tmp#9##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$7##0:wybe.int, ?tmp$10##0:wybe.bool) @int:nn:nn
-        case ~tmp$10##0:wybe.bool of
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#7##0:wybe.int, ?tmp#10##0:wybe.bool) @int:nn:nn
+        case ~tmp#10##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~tmp$5##0:wybe.int, ~tmp$8##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm icmp_eq(~tmp#5##0:wybe.int, ~tmp#8##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
 
@@ -270,40 +270,40 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"coordinate.Coordinate.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"coordinate.Coordinate.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = add   i64 %"$left##0", 16 
+  %8 = add   i64 %"#left##0", 16 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
-  %12 = inttoptr i64 %"$right##0" to i64* 
+  %12 = inttoptr i64 %"#right##0" to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %15 = add   i64 %"$right##0", 8 
+  %15 = add   i64 %"#right##0", 8 
   %16 = inttoptr i64 %15 to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
-  %19 = add   i64 %"$right##0", 16 
+  %19 = add   i64 %"#right##0", 16 
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %"1$tmp$1##0" = icmp eq i64 %3, %14 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %14 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = icmp eq i64 %7, %18 
-  br i1 %"2$tmp$2##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = icmp eq i64 %7, %18 
+  br i1 %"2#tmp#2##0", label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %"4$$$##0" = icmp eq i64 %11, %22 
-  ret i1 %"4$$$##0" 
+  %"4#####0" = icmp eq i64 %11, %22 
+  ret i1 %"4#####0" 
 if.else1:
   ret i1 0 
 }
@@ -329,16 +329,16 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64} @"coordinate.Coordinate.Coordinate<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64, i64} @"coordinate.Coordinate.Coordinate<1>"(i64  %"###0")    {
 entry:
-  %34 = inttoptr i64 %"$##0" to i64* 
+  %34 = inttoptr i64 %"###0" to i64* 
   %35 = getelementptr  i64, i64* %34, i64 0 
   %36 = load  i64, i64* %35 
-  %37 = add   i64 %"$##0", 8 
+  %37 = add   i64 %"###0", 8 
   %38 = inttoptr i64 %37 to i64* 
   %39 = getelementptr  i64, i64* %38, i64 0 
   %40 = load  i64, i64* %39 
-  %41 = add   i64 %"$##0", 16 
+  %41 = add   i64 %"###0", 16 
   %42 = inttoptr i64 %41 to i64* 
   %43 = getelementptr  i64, i64* %42, i64 0 
   %44 = load  i64, i64* %43 
@@ -349,34 +349,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"coordinate.Coordinate.x<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"coordinate.Coordinate.x<0>"(i64  %"#rec##0")    {
 entry:
-  %48 = inttoptr i64 %"$rec##0" to i64* 
+  %48 = inttoptr i64 %"#rec##0" to i64* 
   %49 = getelementptr  i64, i64* %48, i64 0 
   %50 = load  i64, i64* %49 
   ret i64 %50 
 }
 
 
-define external fastcc  i64 @"coordinate.Coordinate.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"coordinate.Coordinate.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %51 = trunc i64 24 to i32  
   %52 = tail call ccc  i8*  @wybe_malloc(i32  %51)  
   %53 = ptrtoint i8* %52 to i64 
   %54 = inttoptr i64 %53 to i8* 
-  %55 = inttoptr i64 %"$rec##0" to i8* 
+  %55 = inttoptr i64 %"#rec##0" to i8* 
   %56 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %54, i8*  %55, i32  %56, i32  8, i1  0)  
   %57 = inttoptr i64 %53 to i64* 
   %58 = getelementptr  i64, i64* %57, i64 0 
-  store  i64 %"$field##0", i64* %58 
+  store  i64 %"#field##0", i64* %58 
   ret i64 %53 
 }
 
 
-define external fastcc  i64 @"coordinate.Coordinate.y<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"coordinate.Coordinate.y<0>"(i64  %"#rec##0")    {
 entry:
-  %59 = add   i64 %"$rec##0", 8 
+  %59 = add   i64 %"#rec##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
@@ -384,26 +384,26 @@ entry:
 }
 
 
-define external fastcc  i64 @"coordinate.Coordinate.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"coordinate.Coordinate.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %63 = trunc i64 24 to i32  
   %64 = tail call ccc  i8*  @wybe_malloc(i32  %63)  
   %65 = ptrtoint i8* %64 to i64 
   %66 = inttoptr i64 %65 to i8* 
-  %67 = inttoptr i64 %"$rec##0" to i8* 
+  %67 = inttoptr i64 %"#rec##0" to i8* 
   %68 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %66, i8*  %67, i32  %68, i32  8, i1  0)  
   %69 = add   i64 %65, 8 
   %70 = inttoptr i64 %69 to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
-  store  i64 %"$field##0", i64* %71 
+  store  i64 %"#field##0", i64* %71 
   ret i64 %65 
 }
 
 
-define external fastcc  i64 @"coordinate.Coordinate.z<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"coordinate.Coordinate.z<0>"(i64  %"#rec##0")    {
 entry:
-  %72 = add   i64 %"$rec##0", 16 
+  %72 = add   i64 %"#rec##0", 16 
   %73 = inttoptr i64 %72 to i64* 
   %74 = getelementptr  i64, i64* %73, i64 0 
   %75 = load  i64, i64* %74 
@@ -411,60 +411,60 @@ entry:
 }
 
 
-define external fastcc  i64 @"coordinate.Coordinate.z<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"coordinate.Coordinate.z<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %76 = trunc i64 24 to i32  
   %77 = tail call ccc  i8*  @wybe_malloc(i32  %76)  
   %78 = ptrtoint i8* %77 to i64 
   %79 = inttoptr i64 %78 to i8* 
-  %80 = inttoptr i64 %"$rec##0" to i8* 
+  %80 = inttoptr i64 %"#rec##0" to i8* 
   %81 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %79, i8*  %80, i32  %81, i32  8, i1  0)  
   %82 = add   i64 %78, 16 
   %83 = inttoptr i64 %82 to i64* 
   %84 = getelementptr  i64, i64* %83, i64 0 
-  store  i64 %"$field##0", i64* %84 
+  store  i64 %"#field##0", i64* %84 
   ret i64 %78 
 }
 
 
-define external fastcc  i1 @"coordinate.Coordinate.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"coordinate.Coordinate.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %85 = inttoptr i64 %"$left##0" to i64* 
+  %85 = inttoptr i64 %"#left##0" to i64* 
   %86 = getelementptr  i64, i64* %85, i64 0 
   %87 = load  i64, i64* %86 
-  %88 = add   i64 %"$left##0", 8 
+  %88 = add   i64 %"#left##0", 8 
   %89 = inttoptr i64 %88 to i64* 
   %90 = getelementptr  i64, i64* %89, i64 0 
   %91 = load  i64, i64* %90 
-  %92 = add   i64 %"$left##0", 16 
+  %92 = add   i64 %"#left##0", 16 
   %93 = inttoptr i64 %92 to i64* 
   %94 = getelementptr  i64, i64* %93, i64 0 
   %95 = load  i64, i64* %94 
-  %96 = inttoptr i64 %"$right##0" to i64* 
+  %96 = inttoptr i64 %"#right##0" to i64* 
   %97 = getelementptr  i64, i64* %96, i64 0 
   %98 = load  i64, i64* %97 
-  %99 = add   i64 %"$right##0", 8 
+  %99 = add   i64 %"#right##0", 8 
   %100 = inttoptr i64 %99 to i64* 
   %101 = getelementptr  i64, i64* %100, i64 0 
   %102 = load  i64, i64* %101 
-  %103 = add   i64 %"$right##0", 16 
+  %103 = add   i64 %"#right##0", 16 
   %104 = inttoptr i64 %103 to i64* 
   %105 = getelementptr  i64, i64* %104, i64 0 
   %106 = load  i64, i64* %105 
-  %"1$tmp$9##0" = icmp eq i64 %87, %98 
-  br i1 %"1$tmp$9##0", label %if.then, label %if.else 
+  %"1#tmp#9##0" = icmp eq i64 %87, %98 
+  br i1 %"1#tmp#9##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$10##0" = icmp eq i64 %91, %102 
-  br i1 %"2$tmp$10##0", label %if.then1, label %if.else1 
+  %"2#tmp#10##0" = icmp eq i64 %91, %102 
+  br i1 %"2#tmp#10##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 if.then1:
-  %"4$tmp$0##0" = icmp eq i64 %95, %106 
-  %"4$$$##0" = xor i1 %"4$tmp$0##0", 1 
-  ret i1 %"4$$$##0" 
+  %"4#tmp#0##0" = icmp eq i64 %95, %106 
+  %"4#####0" = xor i1 %"4#tmp#0##0", 1 
+  ret i1 %"4#####0" 
 if.else1:
-  %"5$$$##0" = xor i1 0, 1 
-  ret i1 %"5$$$##0" 
+  %"5#####0" = xor i1 0, 1 
+  ret i1 %"5#####0" 
 }

--- a/test-cases/final-dump/coordinate.exp
+++ b/test-cases/final-dump/coordinate.exp
@@ -43,10 +43,10 @@ AFTER EVERYTHING:
 
 fcopy > public {inline} (1 calls)
 0: coordinate.fcopy<0>
-fcopy(crd1##0:coordinate.Coordinate, ?###0:coordinate.Coordinate):
+fcopy(crd1##0:coordinate.Coordinate, ?#result##0:coordinate.Coordinate):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(~crd1##0:coordinate.Coordinate, ?###0:coordinate.Coordinate) @coordinate:nn:nn
+    foreign llvm move(~crd1##0:coordinate.Coordinate, ?#result##0:coordinate.Coordinate) @coordinate:nn:nn
 
   LLVM code       :
 
@@ -167,29 +167,29 @@ entry:
 
 Coordinate > public {inline} (0 calls)
 0: coordinate.Coordinate.Coordinate<0>
-Coordinate(x##0:wybe.int, y##0:wybe.int, z##0:wybe.int, ?###0:coordinate.Coordinate):
+Coordinate(x##0:wybe.int, y##0:wybe.int, z##0:wybe.int, ?#result##0:coordinate.Coordinate):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(24:wybe.int, ?#rec##0:coordinate.Coordinate)
     foreign lpvm mutate(~#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~x##0:wybe.int)
     foreign lpvm mutate(~#rec##1:coordinate.Coordinate, ?#rec##2:coordinate.Coordinate, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~y##0:wybe.int)
-    foreign lpvm mutate(~#rec##2:coordinate.Coordinate, ?###0:coordinate.Coordinate, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~z##0:wybe.int)
+    foreign lpvm mutate(~#rec##2:coordinate.Coordinate, ?#result##0:coordinate.Coordinate, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~z##0:wybe.int)
 Coordinate > public {inline} (10 calls)
 1: coordinate.Coordinate.Coordinate<1>
-Coordinate(?x##0:wybe.int, ?y##0:wybe.int, ?z##0:wybe.int, ###0:coordinate.Coordinate):
+Coordinate(?x##0:wybe.int, ?y##0:wybe.int, ?z##0:wybe.int, #result##0:coordinate.Coordinate):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(###0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?y##0:wybe.int)
-    foreign lpvm access(~###0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?z##0:wybe.int)
+    foreign lpvm access(#result##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(#result##0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(~#result##0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?z##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: coordinate.Coordinate.x<0>
-x(#rec##0:coordinate.Coordinate, ?###0:wybe.int):
+x(#rec##0:coordinate.Coordinate, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 x > public {inline} (0 calls)
 1: coordinate.Coordinate.x<1>
 x(#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, #field##0:wybe.int):
@@ -200,10 +200,10 @@ x(#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, #field##0:wybe.
 
 y > public {inline} (0 calls)
 0: coordinate.Coordinate.y<0>
-y(#rec##0:coordinate.Coordinate, ?###0:wybe.int):
+y(#rec##0:coordinate.Coordinate, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 y > public {inline} (0 calls)
 1: coordinate.Coordinate.y<1>
 y(#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, #field##0:wybe.int):
@@ -214,10 +214,10 @@ y(#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, #field##0:wybe.
 
 z > public {inline} (0 calls)
 0: coordinate.Coordinate.z<0>
-z(#rec##0:coordinate.Coordinate, ?###0:wybe.int):
+z(#rec##0:coordinate.Coordinate, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 z > public {inline} (0 calls)
 1: coordinate.Coordinate.z<1>
 z(#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, #field##0:wybe.int):
@@ -329,16 +329,16 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64} @"coordinate.Coordinate.Coordinate<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64, i64} @"coordinate.Coordinate.Coordinate<1>"(i64  %"#result##0")    {
 entry:
-  %34 = inttoptr i64 %"###0" to i64* 
+  %34 = inttoptr i64 %"#result##0" to i64* 
   %35 = getelementptr  i64, i64* %34, i64 0 
   %36 = load  i64, i64* %35 
-  %37 = add   i64 %"###0", 8 
+  %37 = add   i64 %"#result##0", 8 
   %38 = inttoptr i64 %37 to i64* 
   %39 = getelementptr  i64, i64* %38, i64 0 
   %40 = load  i64, i64* %39 
-  %41 = add   i64 %"###0", 16 
+  %41 = add   i64 %"#result##0", 16 
   %42 = inttoptr i64 %41 to i64* 
   %43 = getelementptr  i64, i64* %42, i64 0 
   %44 = load  i64, i64* %43 

--- a/test-cases/final-dump/coordinate.exp
+++ b/test-cases/final-dump/coordinate.exp
@@ -24,29 +24,29 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: coordinate.<0>
-(io#0:wybe.phantom, ?io#4:wybe.phantom):
+(io##0:wybe.phantom, ?io##4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp$7#0:coordinate.Coordinate)
-    foreign lpvm mutate(~tmp$7#0:coordinate.Coordinate, ?tmp$8#0:coordinate.Coordinate, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1000:wybe.int)
-    foreign lpvm mutate(~tmp$8#0:coordinate.Coordinate, ?tmp$9#0:coordinate.Coordinate, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1000:wybe.int)
-    foreign lpvm mutate(~tmp$9#0:coordinate.Coordinate, ?tmp$22#0:coordinate.Coordinate, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1000:wybe.int)
-    foreign lpvm {noalias} mutate(~tmp$22#0:coordinate.Coordinate, ?%crd1#1:coordinate.Coordinate, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 8000:wybe.int)
-    foreign c print_string("expect crd1^z=8000: ":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~crd1#1:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$2#0:wybe.int)
-    foreign c print_int(~tmp$2#0:wybe.int, ~#io#1:wybe.phantom, ?tmp$19#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$19#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string("expect crd2^z=1000: ":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign c print_int(1000:wybe.int, ~#io#3:wybe.phantom, ?tmp$25#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$25#0:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(24:wybe.int, ?tmp$7##0:coordinate.Coordinate)
+    foreign lpvm mutate(~tmp$7##0:coordinate.Coordinate, ?tmp$8##0:coordinate.Coordinate, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1000:wybe.int)
+    foreign lpvm mutate(~tmp$8##0:coordinate.Coordinate, ?tmp$9##0:coordinate.Coordinate, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1000:wybe.int)
+    foreign lpvm mutate(~tmp$9##0:coordinate.Coordinate, ?tmp$22##0:coordinate.Coordinate, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1000:wybe.int)
+    foreign lpvm {noalias} mutate(~tmp$22##0:coordinate.Coordinate, ?%crd1##1:coordinate.Coordinate, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 8000:wybe.int)
+    foreign c print_string("expect crd1^z=8000: ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~crd1##1:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.int)
+    foreign c print_int(~tmp$2##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$19##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$19##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect crd2^z=1000: ":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign c print_int(1000:wybe.int, ~#io##3:wybe.phantom, ?tmp$25##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$25##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
 
 
 fcopy > public {inline} (1 calls)
 0: coordinate.fcopy<0>
-fcopy(crd1#0:coordinate.Coordinate, ?$#0:coordinate.Coordinate):
+fcopy(crd1##0:coordinate.Coordinate, ?$##0:coordinate.Coordinate):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(~crd1#0:coordinate.Coordinate, ?$#0:coordinate.Coordinate) @coordinate:nn:nn
+    foreign llvm move(~crd1##0:coordinate.Coordinate, ?$##0:coordinate.Coordinate) @coordinate:nn:nn
 
   LLVM code       :
 
@@ -113,9 +113,9 @@ entry:
 }
 
 
-define external fastcc  i64 @"coordinate.fcopy<0>"(i64  %"crd1#0")    {
+define external fastcc  i64 @"coordinate.fcopy<0>"(i64  %"crd1##0")    {
 entry:
-  ret i64 %"crd1#0" 
+  ret i64 %"crd1##0" 
 }
 --------------------------------------------------
  Module coordinate.Coordinate
@@ -139,120 +139,120 @@ entry:
 
 = > public {inline} (1 calls)
 0: coordinate.Coordinate.=<0>
-=($left#0:coordinate.Coordinate, $right#0:coordinate.Coordinate, ?$$#0:wybe.bool):
+=($left##0:coordinate.Coordinate, $right##0:coordinate.Coordinate, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
-    foreign lpvm access($left#0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$y#0:wybe.int)
-    foreign lpvm access(~$left#0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$z#0:wybe.int)
-    foreign lpvm access($right#0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$x#0:wybe.int)
-    foreign lpvm access($right#0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$y#0:wybe.int)
-    foreign lpvm access(~$right#0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$z#0:wybe.int)
-    foreign llvm icmp_eq(~$left$x#0:wybe.int, ~$right$x#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
+    foreign lpvm access($left##0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
+    foreign lpvm access(~$left##0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$z##0:wybe.int)
+    foreign lpvm access($right##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
+    foreign lpvm access($right##0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
+    foreign lpvm access(~$right##0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$z##0:wybe.int)
+    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y#0:wybe.int, ~$right$y#0:wybe.int, ?tmp$2#0:wybe.bool) @int:nn:nn
-        case ~tmp$2#0:wybe.bool of
+        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?tmp$2##0:wybe.bool) @int:nn:nn
+        case ~tmp$2##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~$left$z#0:wybe.int, ~$right$z#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+            foreign llvm icmp_eq(~$left$z##0:wybe.int, ~$right$z##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 
 Coordinate > public {inline} (0 calls)
 0: coordinate.Coordinate.Coordinate<0>
-Coordinate(x#0:wybe.int, y#0:wybe.int, z#0:wybe.int, ?$#0:coordinate.Coordinate):
+Coordinate(x##0:wybe.int, y##0:wybe.int, z##0:wybe.int, ?$##0:coordinate.Coordinate):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?$rec#0:coordinate.Coordinate)
-    foreign lpvm mutate(~$rec#0:coordinate.Coordinate, ?$rec#1:coordinate.Coordinate, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~x#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:coordinate.Coordinate, ?$rec#2:coordinate.Coordinate, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~y#0:wybe.int)
-    foreign lpvm mutate(~$rec#2:coordinate.Coordinate, ?$#0:coordinate.Coordinate, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~z#0:wybe.int)
+    foreign lpvm alloc(24:wybe.int, ?$rec##0:coordinate.Coordinate)
+    foreign lpvm mutate(~$rec##0:coordinate.Coordinate, ?$rec##1:coordinate.Coordinate, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:coordinate.Coordinate, ?$rec##2:coordinate.Coordinate, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~$rec##2:coordinate.Coordinate, ?$##0:coordinate.Coordinate, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~z##0:wybe.int)
 Coordinate > public {inline} (10 calls)
 1: coordinate.Coordinate.Coordinate<1>
-Coordinate(?x#0:wybe.int, ?y#0:wybe.int, ?z#0:wybe.int, $#0:coordinate.Coordinate):
+Coordinate(?x##0:wybe.int, ?y##0:wybe.int, ?z##0:wybe.int, $##0:coordinate.Coordinate):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?x#0:wybe.int)
-    foreign lpvm access($#0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?y#0:wybe.int)
-    foreign lpvm access(~$#0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?z#0:wybe.int)
+    foreign lpvm access($##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access($##0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(~$##0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?z##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: coordinate.Coordinate.x<0>
-x($rec#0:coordinate.Coordinate, ?$#0:wybe.int):
+x($rec##0:coordinate.Coordinate, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 x > public {inline} (0 calls)
 1: coordinate.Coordinate.x<1>
-x($rec#0:coordinate.Coordinate, ?$rec#1:coordinate.Coordinate, $field#0:wybe.int):
+x($rec##0:coordinate.Coordinate, ?$rec##1:coordinate.Coordinate, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:coordinate.Coordinate, ?$rec#1:coordinate.Coordinate, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:coordinate.Coordinate, ?$rec##1:coordinate.Coordinate, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: coordinate.Coordinate.y<0>
-y($rec#0:coordinate.Coordinate, ?$#0:wybe.int):
+y($rec##0:coordinate.Coordinate, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 y > public {inline} (0 calls)
 1: coordinate.Coordinate.y<1>
-y($rec#0:coordinate.Coordinate, ?$rec#1:coordinate.Coordinate, $field#0:wybe.int):
+y($rec##0:coordinate.Coordinate, ?$rec##1:coordinate.Coordinate, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:coordinate.Coordinate, ?$rec#1:coordinate.Coordinate, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:coordinate.Coordinate, ?$rec##1:coordinate.Coordinate, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 z > public {inline} (0 calls)
 0: coordinate.Coordinate.z<0>
-z($rec#0:coordinate.Coordinate, ?$#0:wybe.int):
+z($rec##0:coordinate.Coordinate, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 z > public {inline} (0 calls)
 1: coordinate.Coordinate.z<1>
-z($rec#0:coordinate.Coordinate, ?$rec#1:coordinate.Coordinate, $field#0:wybe.int):
+z($rec##0:coordinate.Coordinate, ?$rec##1:coordinate.Coordinate, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:coordinate.Coordinate, ?$rec#1:coordinate.Coordinate, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:coordinate.Coordinate, ?$rec##1:coordinate.Coordinate, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: coordinate.Coordinate.~=<0>
-~=($left#0:coordinate.Coordinate, $right#0:coordinate.Coordinate, ?$$#0:wybe.bool):
+~=($left##0:coordinate.Coordinate, $right##0:coordinate.Coordinate, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access($left#0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access(~$left#0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access($right#0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign lpvm access($right#0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$7#0:wybe.int)
-    foreign lpvm access(~$right#0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$9#0:wybe.bool) @int:nn:nn
-    case ~tmp$9#0:wybe.bool of
+    foreign lpvm access($left##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access($left##0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access(~$left##0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access($right##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign lpvm access($right##0:coordinate.Coordinate, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.int)
+    foreign lpvm access(~$right##0:coordinate.Coordinate, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$9##0:wybe.bool) @int:nn:nn
+    case ~tmp$9##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$7#0:wybe.int, ?tmp$10#0:wybe.bool) @int:nn:nn
-        case ~tmp$10#0:wybe.bool of
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$7##0:wybe.int, ?tmp$10##0:wybe.bool) @int:nn:nn
+        case ~tmp$10##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-            foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~tmp$5#0:wybe.int, ~tmp$8#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-            foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm icmp_eq(~tmp$5##0:wybe.int, ~tmp$8##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
@@ -270,75 +270,75 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"coordinate.Coordinate.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"coordinate.Coordinate.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = add   i64 %"$left#0", 16 
+  %8 = add   i64 %"$left##0", 16 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
-  %12 = inttoptr i64 %"$right#0" to i64* 
+  %12 = inttoptr i64 %"$right##0" to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %15 = add   i64 %"$right#0", 8 
+  %15 = add   i64 %"$right##0", 8 
   %16 = inttoptr i64 %15 to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
-  %19 = add   i64 %"$right#0", 16 
+  %19 = add   i64 %"$right##0", 16 
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %"1$tmp$1#0" = icmp eq i64 %3, %14 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %14 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = icmp eq i64 %7, %18 
-  br i1 %"2$tmp$2#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = icmp eq i64 %7, %18 
+  br i1 %"2$tmp$2##0", label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %"4$$$#0" = icmp eq i64 %11, %22 
-  ret i1 %"4$$$#0" 
+  %"4$$$##0" = icmp eq i64 %11, %22 
+  ret i1 %"4$$$##0" 
 if.else1:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"coordinate.Coordinate.Coordinate<0>"(i64  %"x#0", i64  %"y#0", i64  %"z#0")    {
+define external fastcc  i64 @"coordinate.Coordinate.Coordinate<0>"(i64  %"x##0", i64  %"y##0", i64  %"z##0")    {
 entry:
   %23 = trunc i64 24 to i32  
   %24 = tail call ccc  i8*  @wybe_malloc(i32  %23)  
   %25 = ptrtoint i8* %24 to i64 
   %26 = inttoptr i64 %25 to i64* 
   %27 = getelementptr  i64, i64* %26, i64 0 
-  store  i64 %"x#0", i64* %27 
+  store  i64 %"x##0", i64* %27 
   %28 = add   i64 %25, 8 
   %29 = inttoptr i64 %28 to i64* 
   %30 = getelementptr  i64, i64* %29, i64 0 
-  store  i64 %"y#0", i64* %30 
+  store  i64 %"y##0", i64* %30 
   %31 = add   i64 %25, 16 
   %32 = inttoptr i64 %31 to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
-  store  i64 %"z#0", i64* %33 
+  store  i64 %"z##0", i64* %33 
   ret i64 %25 
 }
 
 
-define external fastcc  {i64, i64, i64} @"coordinate.Coordinate.Coordinate<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64, i64} @"coordinate.Coordinate.Coordinate<1>"(i64  %"$##0")    {
 entry:
-  %34 = inttoptr i64 %"$#0" to i64* 
+  %34 = inttoptr i64 %"$##0" to i64* 
   %35 = getelementptr  i64, i64* %34, i64 0 
   %36 = load  i64, i64* %35 
-  %37 = add   i64 %"$#0", 8 
+  %37 = add   i64 %"$##0", 8 
   %38 = inttoptr i64 %37 to i64* 
   %39 = getelementptr  i64, i64* %38, i64 0 
   %40 = load  i64, i64* %39 
-  %41 = add   i64 %"$#0", 16 
+  %41 = add   i64 %"$##0", 16 
   %42 = inttoptr i64 %41 to i64* 
   %43 = getelementptr  i64, i64* %42, i64 0 
   %44 = load  i64, i64* %43 
@@ -349,34 +349,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"coordinate.Coordinate.x<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"coordinate.Coordinate.x<0>"(i64  %"$rec##0")    {
 entry:
-  %48 = inttoptr i64 %"$rec#0" to i64* 
+  %48 = inttoptr i64 %"$rec##0" to i64* 
   %49 = getelementptr  i64, i64* %48, i64 0 
   %50 = load  i64, i64* %49 
   ret i64 %50 
 }
 
 
-define external fastcc  i64 @"coordinate.Coordinate.x<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"coordinate.Coordinate.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %51 = trunc i64 24 to i32  
   %52 = tail call ccc  i8*  @wybe_malloc(i32  %51)  
   %53 = ptrtoint i8* %52 to i64 
   %54 = inttoptr i64 %53 to i8* 
-  %55 = inttoptr i64 %"$rec#0" to i8* 
+  %55 = inttoptr i64 %"$rec##0" to i8* 
   %56 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %54, i8*  %55, i32  %56, i32  8, i1  0)  
   %57 = inttoptr i64 %53 to i64* 
   %58 = getelementptr  i64, i64* %57, i64 0 
-  store  i64 %"$field#0", i64* %58 
+  store  i64 %"$field##0", i64* %58 
   ret i64 %53 
 }
 
 
-define external fastcc  i64 @"coordinate.Coordinate.y<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"coordinate.Coordinate.y<0>"(i64  %"$rec##0")    {
 entry:
-  %59 = add   i64 %"$rec#0", 8 
+  %59 = add   i64 %"$rec##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
@@ -384,26 +384,26 @@ entry:
 }
 
 
-define external fastcc  i64 @"coordinate.Coordinate.y<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"coordinate.Coordinate.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %63 = trunc i64 24 to i32  
   %64 = tail call ccc  i8*  @wybe_malloc(i32  %63)  
   %65 = ptrtoint i8* %64 to i64 
   %66 = inttoptr i64 %65 to i8* 
-  %67 = inttoptr i64 %"$rec#0" to i8* 
+  %67 = inttoptr i64 %"$rec##0" to i8* 
   %68 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %66, i8*  %67, i32  %68, i32  8, i1  0)  
   %69 = add   i64 %65, 8 
   %70 = inttoptr i64 %69 to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
-  store  i64 %"$field#0", i64* %71 
+  store  i64 %"$field##0", i64* %71 
   ret i64 %65 
 }
 
 
-define external fastcc  i64 @"coordinate.Coordinate.z<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"coordinate.Coordinate.z<0>"(i64  %"$rec##0")    {
 entry:
-  %72 = add   i64 %"$rec#0", 16 
+  %72 = add   i64 %"$rec##0", 16 
   %73 = inttoptr i64 %72 to i64* 
   %74 = getelementptr  i64, i64* %73, i64 0 
   %75 = load  i64, i64* %74 
@@ -411,60 +411,60 @@ entry:
 }
 
 
-define external fastcc  i64 @"coordinate.Coordinate.z<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"coordinate.Coordinate.z<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %76 = trunc i64 24 to i32  
   %77 = tail call ccc  i8*  @wybe_malloc(i32  %76)  
   %78 = ptrtoint i8* %77 to i64 
   %79 = inttoptr i64 %78 to i8* 
-  %80 = inttoptr i64 %"$rec#0" to i8* 
+  %80 = inttoptr i64 %"$rec##0" to i8* 
   %81 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %79, i8*  %80, i32  %81, i32  8, i1  0)  
   %82 = add   i64 %78, 16 
   %83 = inttoptr i64 %82 to i64* 
   %84 = getelementptr  i64, i64* %83, i64 0 
-  store  i64 %"$field#0", i64* %84 
+  store  i64 %"$field##0", i64* %84 
   ret i64 %78 
 }
 
 
-define external fastcc  i1 @"coordinate.Coordinate.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"coordinate.Coordinate.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %85 = inttoptr i64 %"$left#0" to i64* 
+  %85 = inttoptr i64 %"$left##0" to i64* 
   %86 = getelementptr  i64, i64* %85, i64 0 
   %87 = load  i64, i64* %86 
-  %88 = add   i64 %"$left#0", 8 
+  %88 = add   i64 %"$left##0", 8 
   %89 = inttoptr i64 %88 to i64* 
   %90 = getelementptr  i64, i64* %89, i64 0 
   %91 = load  i64, i64* %90 
-  %92 = add   i64 %"$left#0", 16 
+  %92 = add   i64 %"$left##0", 16 
   %93 = inttoptr i64 %92 to i64* 
   %94 = getelementptr  i64, i64* %93, i64 0 
   %95 = load  i64, i64* %94 
-  %96 = inttoptr i64 %"$right#0" to i64* 
+  %96 = inttoptr i64 %"$right##0" to i64* 
   %97 = getelementptr  i64, i64* %96, i64 0 
   %98 = load  i64, i64* %97 
-  %99 = add   i64 %"$right#0", 8 
+  %99 = add   i64 %"$right##0", 8 
   %100 = inttoptr i64 %99 to i64* 
   %101 = getelementptr  i64, i64* %100, i64 0 
   %102 = load  i64, i64* %101 
-  %103 = add   i64 %"$right#0", 16 
+  %103 = add   i64 %"$right##0", 16 
   %104 = inttoptr i64 %103 to i64* 
   %105 = getelementptr  i64, i64* %104, i64 0 
   %106 = load  i64, i64* %105 
-  %"1$tmp$9#0" = icmp eq i64 %87, %98 
-  br i1 %"1$tmp$9#0", label %if.then, label %if.else 
+  %"1$tmp$9##0" = icmp eq i64 %87, %98 
+  br i1 %"1$tmp$9##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$10#0" = icmp eq i64 %91, %102 
-  br i1 %"2$tmp$10#0", label %if.then1, label %if.else1 
+  %"2$tmp$10##0" = icmp eq i64 %91, %102 
+  br i1 %"2$tmp$10##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 if.then1:
-  %"4$tmp$0#0" = icmp eq i64 %95, %106 
-  %"4$$$#0" = xor i1 %"4$tmp$0#0", 1 
-  ret i1 %"4$$$#0" 
+  %"4$tmp$0##0" = icmp eq i64 %95, %106 
+  %"4$$$##0" = xor i1 %"4$tmp$0##0", 1 
+  ret i1 %"4$$$##0" 
 if.else1:
-  %"5$$$#0" = xor i1 0, 1 
-  ret i1 %"5$$$#0" 
+  %"5$$$##0" = xor i1 0, 1 
+  ret i1 %"5$$$##0" 
 }

--- a/test-cases/final-dump/coordinate.exp
+++ b/test-cases/final-dump/coordinate.exp
@@ -139,7 +139,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: coordinate.Coordinate.=<0>
-=(#left##0:coordinate.Coordinate, #right##0:coordinate.Coordinate, ?####0:wybe.bool):
+=(#left##0:coordinate.Coordinate, #right##0:coordinate.Coordinate, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
@@ -151,16 +151,16 @@ entry:
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?tmp#2##0:wybe.bool) @int:nn:nn
         case ~tmp#2##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~#left#z##0:wybe.int, ~#right#z##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+            foreign llvm icmp_eq(~#left#z##0:wybe.int, ~#right#z##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -228,7 +228,7 @@ z(#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, #field##0:wybe.
 
 ~= > public {inline} (0 calls)
 0: coordinate.Coordinate.~=<0>
-~=(#left##0:coordinate.Coordinate, #right##0:coordinate.Coordinate, ?####0:wybe.bool):
+~=(#left##0:coordinate.Coordinate, #right##0:coordinate.Coordinate, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:coordinate.Coordinate, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -241,18 +241,18 @@ z(#rec##0:coordinate.Coordinate, ?#rec##1:coordinate.Coordinate, #field##0:wybe.
     case ~tmp#9##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#7##0:wybe.int, ?tmp#10##0:wybe.bool) @int:nn:nn
         case ~tmp#10##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign llvm icmp_eq(~tmp#5##0:wybe.int, ~tmp#8##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -302,8 +302,8 @@ if.then:
 if.else:
   ret i1 0 
 if.then1:
-  %"4#####0" = icmp eq i64 %11, %22 
-  ret i1 %"4#####0" 
+  %"4##success##0" = icmp eq i64 %11, %22 
+  ret i1 %"4##success##0" 
 if.else1:
   ret i1 0 
 }
@@ -458,13 +458,13 @@ if.then:
   %"2#tmp#10##0" = icmp eq i64 %91, %102 
   br i1 %"2#tmp#10##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 if.then1:
   %"4#tmp#0##0" = icmp eq i64 %95, %106 
-  %"4#####0" = xor i1 %"4#tmp#0##0", 1 
-  ret i1 %"4#####0" 
+  %"4##success##0" = xor i1 %"4#tmp#0##0", 1 
+  ret i1 %"4##success##0" 
 if.else1:
-  %"5#####0" = xor i1 0, 1 
-  ret i1 %"5#####0" 
+  %"5##success##0" = xor i1 0, 1 
+  ret i1 %"5##success##0" 
 }

--- a/test-cases/final-dump/ctor_char.exp
+++ b/test-cases/final-dump/ctor_char.exp
@@ -140,8 +140,8 @@ c($rec#0:ctor_char, ?$rec#2:ctor_char, $field#0:wybe.char, ?$$#0:wybe.bool):
 
         1:
             foreign llvm and(~$rec#0:ctor_char, -511:ctor_char, ?$rec#1:ctor_char)
-            foreign llvm shl(~$field#0:ctor_char, 1:ctor_char, ?$tmp#0:ctor_char)
-            foreign llvm or(~$rec#1:ctor_char, ~$tmp#0:ctor_char, ?$rec#2:ctor_char)
+            foreign llvm shl(~$field#0:ctor_char, 1:ctor_char, ?$temp#0:ctor_char)
+            foreign llvm or(~$rec#1:ctor_char, ~$temp#0:ctor_char, ?$rec#2:ctor_char)
             foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 
@@ -387,8 +387,8 @@ if.else:
 if.then1:
   %"4$$rec#1" = and i64 %"$rec#0", -511 
   %18 = zext i8 %"$field#0" to i64  
-  %"4$$tmp#0" = shl   i64 %18, 1 
-  %"4$$rec#2" = or i64 %"4$$rec#1", %"4$$tmp#0" 
+  %"4$$temp#0" = shl   i64 %18, 1 
+  %"4$$rec#2" = or i64 %"4$$rec#1", %"4$$temp#0" 
   %19 = insertvalue {i64, i1} undef, i64 %"4$$rec#2", 0 
   %20 = insertvalue {i64, i1} %19, i1 1, 1 
   ret {i64, i1} %20 

--- a/test-cases/final-dump/ctor_char.exp
+++ b/test-cases/final-dump/ctor_char.exp
@@ -15,78 +15,78 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: ctor_char.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm shl('a':ctor_char, 1:ctor_char, ?tmp$3#0:ctor_char)
-    foreign llvm or(~tmp$3#0:ctor_char, 512:ctor_char, ?tmp$1#0:ctor_char)
-    ctor_char.foo<0>(~tmp$1#0:ctor_char, ?tmp$0#0:wybe.char) #1 @ctor_char:nn:nn
-    foreign c putchar(~tmp$0#0:wybe.char, ~#io#0:wybe.phantom, ?tmp$6#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$6#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign llvm shl('a':ctor_char, 1:ctor_char, ?tmp$3##0:ctor_char)
+    foreign llvm or(~tmp$3##0:ctor_char, 512:ctor_char, ?tmp$1##0:ctor_char)
+    ctor_char.foo<0>(~tmp$1##0:ctor_char, ?tmp$0##0:wybe.char) #1 @ctor_char:nn:nn
+    foreign c putchar(~tmp$0##0:wybe.char, ~#io##0:wybe.phantom, ?tmp$6##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 = > public (2 calls)
 0: ctor_char.=<0>
-=($left#0:ctor_char, $right#0:ctor_char, ?$$#0:wybe.bool):
+=($left##0:ctor_char, $right##0:ctor_char, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left#0:ctor_char, ~$right#0:ctor_char, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~$left##0:ctor_char, ~$right##0:ctor_char, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm and($left#0:wybe.int, 1:wybe.int, ?tmp$10#0:wybe.int)
-        foreign llvm icmp_eq(tmp$10#0:wybe.int, 0:wybe.int, ?tmp$11#0:wybe.bool)
-        case ~tmp$11#0:wybe.bool of
+        foreign llvm and($left##0:wybe.int, 1:wybe.int, ?tmp$10##0:wybe.int)
+        foreign llvm icmp_eq(tmp$10##0:wybe.int, 0:wybe.int, ?tmp$11##0:wybe.bool)
+        case ~tmp$11##0:wybe.bool of
         0:
-            foreign llvm icmp_eq(~tmp$10#0:wybe.int, 1:wybe.int, ?tmp$17#0:wybe.bool)
-            case ~tmp$17#0:wybe.bool of
+            foreign llvm icmp_eq(~tmp$10##0:wybe.int, 1:wybe.int, ?tmp$17##0:wybe.bool)
+            case ~tmp$17##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                foreign lpvm access(~$left#0:ctor_char, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$left$other_ctor$1#0:ctor_char)
-                foreign llvm icmp_ne($right#0:wybe.int, 0:wybe.int, ?tmp$19#0:wybe.bool)
-                case ~tmp$19#0:wybe.bool of
+                foreign lpvm access(~$left##0:ctor_char, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$left$other_ctor$1##0:ctor_char)
+                foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$19##0:wybe.bool)
+                case ~tmp$19##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                 1:
-                    foreign llvm and($right#0:wybe.int, 1:wybe.int, ?tmp$20#0:wybe.int)
-                    foreign llvm icmp_eq(~tmp$20#0:wybe.int, 1:wybe.int, ?tmp$21#0:wybe.bool)
-                    case ~tmp$21#0:wybe.bool of
+                    foreign llvm and($right##0:wybe.int, 1:wybe.int, ?tmp$20##0:wybe.int)
+                    foreign llvm icmp_eq(~tmp$20##0:wybe.int, 1:wybe.int, ?tmp$21##0:wybe.bool)
+                    case ~tmp$21##0:wybe.bool of
                     0:
-                        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                     1:
-                        foreign lpvm access(~$right#0:ctor_char, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$right$other_ctor$1#0:ctor_char)
-                        ctor_char.=<0>(~$left$other_ctor$1#0:ctor_char, ~$right$other_ctor$1#0:ctor_char, ?$$#0:wybe.bool) #5
+                        foreign lpvm access(~$right##0:ctor_char, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$right$other_ctor$1##0:ctor_char)
+                        ctor_char.=<0>(~$left$other_ctor$1##0:ctor_char, ~$right$other_ctor$1##0:ctor_char, ?$$##0:wybe.bool) #5
 
 
 
 
         1:
-            foreign llvm lshr(~$left#0:ctor_char, 1:ctor_char, ?tmp$12#0:ctor_char)
-            foreign llvm and(~tmp$12#0:ctor_char, 255:ctor_char, ?tmp$13#0:ctor_char)
-            foreign lpvm cast(~tmp$13#0:ctor_char, ?$left$c#0:wybe.char)
-            foreign llvm icmp_ne($right#0:wybe.int, 0:wybe.int, ?tmp$15#0:wybe.bool)
-            case ~tmp$15#0:wybe.bool of
+            foreign llvm lshr(~$left##0:ctor_char, 1:ctor_char, ?tmp$12##0:ctor_char)
+            foreign llvm and(~tmp$12##0:ctor_char, 255:ctor_char, ?tmp$13##0:ctor_char)
+            foreign lpvm cast(~tmp$13##0:ctor_char, ?$left$c##0:wybe.char)
+            foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$15##0:wybe.bool)
+            case ~tmp$15##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                foreign llvm and($right#0:wybe.int, 1:wybe.int, ?tmp$16#0:wybe.int)
-                foreign llvm icmp_eq(~tmp$16#0:wybe.int, 0:wybe.int, ?tmp$17#0:wybe.bool)
-                case ~tmp$17#0:wybe.bool of
+                foreign llvm and($right##0:wybe.int, 1:wybe.int, ?tmp$16##0:wybe.int)
+                foreign llvm icmp_eq(~tmp$16##0:wybe.int, 0:wybe.int, ?tmp$17##0:wybe.bool)
+                case ~tmp$17##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                 1:
-                    foreign llvm lshr(~$right#0:ctor_char, 1:ctor_char, ?tmp$18#0:ctor_char)
-                    foreign llvm and(~tmp$18#0:ctor_char, 255:ctor_char, ?tmp$19#0:ctor_char)
-                    foreign lpvm cast(~tmp$19#0:ctor_char, ?$right$c#0:wybe.char)
-                    foreign llvm icmp_eq(~$left$c#0:wybe.char, ~$right$c#0:wybe.char, ?$$#0:wybe.bool) @char:nn:nn
+                    foreign llvm lshr(~$right##0:ctor_char, 1:ctor_char, ?tmp$18##0:ctor_char)
+                    foreign llvm and(~tmp$18##0:ctor_char, 255:ctor_char, ?tmp$19##0:ctor_char)
+                    foreign lpvm cast(~tmp$19##0:ctor_char, ?$right$c##0:wybe.char)
+                    foreign llvm icmp_eq(~$left$c##0:wybe.char, ~$right$c##0:wybe.char, ?$$##0:wybe.bool) @char:nn:nn
 
 
 
@@ -95,167 +95,167 @@ AFTER EVERYTHING:
 
 c > {inline} (0 calls)
 0: ctor_char.c<0>
-c($rec#0:ctor_char, ?$#0:wybe.char, ?$$#0:wybe.bool):
+c($rec##0:ctor_char, ?$##0:wybe.char, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.char, ?$#0:wybe.char)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.char, ?$##0:wybe.char)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.char, ?$#0:wybe.char)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.char, ?$##0:wybe.char)
 
         1:
-            foreign llvm lshr(~$rec#0:ctor_char, 1:ctor_char, ?$rec#1:ctor_char)
-            foreign llvm and(~$rec#1:ctor_char, 255:ctor_char, ?$field#0:ctor_char)
-            foreign lpvm cast(~$field#0:ctor_char, ?$#0:wybe.char)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm lshr(~$rec##0:ctor_char, 1:ctor_char, ?$rec##1:ctor_char)
+            foreign llvm and(~$rec##1:ctor_char, 255:ctor_char, ?$field##0:ctor_char)
+            foreign lpvm cast(~$field##0:ctor_char, ?$##0:wybe.char)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 c > {inline} (0 calls)
 1: ctor_char.c<1>
-c($rec#0:ctor_char, ?$rec#2:ctor_char, $field#0:wybe.char, ?$$#0:wybe.bool):
+c($rec##0:ctor_char, ?$rec##2:ctor_char, $field##0:wybe.char, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:ctor_char, ?$rec#2:ctor_char)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:ctor_char, ?$rec##2:ctor_char)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(~$rec#0:ctor_char, ?$rec#2:ctor_char)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(~$rec##0:ctor_char, ?$rec##2:ctor_char)
 
         1:
-            foreign llvm and(~$rec#0:ctor_char, -511:ctor_char, ?$rec#1:ctor_char)
-            foreign llvm shl(~$field#0:ctor_char, 1:ctor_char, ?$temp#0:ctor_char)
-            foreign llvm or(~$rec#1:ctor_char, ~$temp#0:ctor_char, ?$rec#2:ctor_char)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm and(~$rec##0:ctor_char, -511:ctor_char, ?$rec##1:ctor_char)
+            foreign llvm shl(~$field##0:ctor_char, 1:ctor_char, ?$temp##0:ctor_char)
+            foreign llvm or(~$rec##1:ctor_char, ~$temp##0:ctor_char, ?$rec##2:ctor_char)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 const > {inline} (0 calls)
 0: ctor_char.const<0>
-const(?$#0:ctor_char):
+const(?$##0:ctor_char):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:ctor_char, ?$#0:ctor_char)
+    foreign llvm move(0:ctor_char, ?$##0:ctor_char)
 
 
 ctor > {inline} (1 calls)
 0: ctor_char.ctor<0>
-ctor(c#0:wybe.char, ?$#3:ctor_char):
+ctor(c##0:wybe.char, ?$##3:ctor_char):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm shl(~c#0:ctor_char, 1:ctor_char, ?$temp#0:ctor_char)
-    foreign llvm or(~$temp#0:ctor_char, 512:ctor_char, ?$#3:ctor_char)
+    foreign llvm shl(~c##0:ctor_char, 1:ctor_char, ?$temp##0:ctor_char)
+    foreign llvm or(~$temp##0:ctor_char, 512:ctor_char, ?$##3:ctor_char)
 ctor > {inline} (13 calls)
 1: ctor_char.ctor<1>
-ctor(?c#0:wybe.char, $#0:ctor_char, ?$$#0:wybe.bool):
+ctor(?c##0:wybe.char, $##0:ctor_char, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.char, ?c#0:wybe.char)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.char, ?c##0:wybe.char)
 
     1:
-        foreign llvm and($#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.char, ?c#0:wybe.char)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.char, ?c##0:wybe.char)
 
         1:
-            foreign llvm lshr(~$#0:ctor_char, 1:ctor_char, ?$temp#0:ctor_char)
-            foreign llvm and(~$temp#0:ctor_char, 255:ctor_char, ?$temp2#0:ctor_char)
-            foreign lpvm cast(~$temp2#0:ctor_char, ?c#0:wybe.char)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm lshr(~$##0:ctor_char, 1:ctor_char, ?$temp##0:ctor_char)
+            foreign llvm and(~$temp##0:ctor_char, 255:ctor_char, ?$temp2##0:ctor_char)
+            foreign lpvm cast(~$temp2##0:ctor_char, ?c##0:wybe.char)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 foo > (1 calls)
 0: ctor_char.foo<0>
-foo(this#0:ctor_char, ?$#0:wybe.char):
+foo(this##0:ctor_char, ?$##0:wybe.char):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(this#0:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.bool)
-    case ~tmp$3#0:wybe.bool of
+    foreign llvm icmp_ne(this##0:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.bool)
+    case ~tmp$3##0:wybe.bool of
     0:
-        foreign llvm move('0':wybe.char, ?$#0:wybe.char) @ctor_char:nn:nn
+        foreign llvm move('0':wybe.char, ?$##0:wybe.char) @ctor_char:nn:nn
 
     1:
-        foreign llvm and(this#0:wybe.int, 1:wybe.int, ?tmp$4#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.bool)
-        case ~tmp$5#0:wybe.bool of
+        foreign llvm and(this##0:wybe.int, 1:wybe.int, ?tmp$4##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
+        case ~tmp$5##0:wybe.bool of
         0:
-            foreign llvm move('0':wybe.char, ?$#0:wybe.char) @ctor_char:nn:nn
+            foreign llvm move('0':wybe.char, ?$##0:wybe.char) @ctor_char:nn:nn
 
         1:
-            foreign llvm lshr(~this#0:ctor_char, 1:ctor_char, ?tmp$6#0:ctor_char)
-            foreign llvm and(~tmp$6#0:ctor_char, 255:ctor_char, ?tmp$7#0:ctor_char)
-            foreign lpvm cast(~tmp$7#0:ctor_char, ?$#0:wybe.char)
+            foreign llvm lshr(~this##0:ctor_char, 1:ctor_char, ?tmp$6##0:ctor_char)
+            foreign llvm and(~tmp$6##0:ctor_char, 255:ctor_char, ?tmp$7##0:ctor_char)
+            foreign lpvm cast(~tmp$7##0:ctor_char, ?$##0:wybe.char)
 
 
 
 
 other_ctor > public {inline} (0 calls)
 0: ctor_char.other_ctor<0>
-other_ctor(other_ctor$1#0:ctor_char, ?$#0:ctor_char):
+other_ctor(other_ctor$1##0:ctor_char, ?$##0:ctor_char):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec#0:ctor_char)
-    foreign lpvm mutate(~$rec#0:ctor_char, ?$rec#1:ctor_char, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~other_ctor$1#0:ctor_char)
-    foreign llvm or(~$rec#1:ctor_char, 1:wybe.int, ?$#0:ctor_char)
+    foreign lpvm alloc(8:wybe.int, ?$rec##0:ctor_char)
+    foreign lpvm mutate(~$rec##0:ctor_char, ?$rec##1:ctor_char, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~other_ctor$1##0:ctor_char)
+    foreign llvm or(~$rec##1:ctor_char, 1:wybe.int, ?$##0:ctor_char)
 other_ctor > public {inline} (5 calls)
 1: ctor_char.other_ctor<1>
-other_ctor(?other_ctor$1#0:ctor_char, $#0:ctor_char, ?$$#0:wybe.bool):
+other_ctor(?other_ctor$1##0:ctor_char, $##0:ctor_char, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:ctor_char, ?other_ctor$1#0:ctor_char)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:ctor_char, ?other_ctor$1##0:ctor_char)
 
     1:
-        foreign llvm and($#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 1:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:ctor_char, ?other_ctor$1#0:ctor_char)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:ctor_char, ?other_ctor$1##0:ctor_char)
 
         1:
-            foreign lpvm access(~$#0:ctor_char, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?other_ctor$1#0:ctor_char)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm access(~$##0:ctor_char, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?other_ctor$1##0:ctor_char)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 ~= > public {inline} (0 calls)
 0: ctor_char.~=<0>
-~=($left#0:ctor_char, $right#0:ctor_char, ?$$#0:wybe.bool):
+~=($left##0:ctor_char, $right##0:ctor_char, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    ctor_char.=<0>(~$left#0:ctor_char, ~$right#0:ctor_char, ?tmp$0#0:wybe.bool) #0
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    ctor_char.=<0>(~$left##0:ctor_char, ~$right##0:ctor_char, ?tmp$0##0:wybe.bool) #0
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
   LLVM code       :
 
@@ -276,92 +276,92 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"ctor_char.<0>"()    {
 entry:
-  %"1$tmp$3#0" = shl   i64 97, 1 
-  %"1$tmp$1#0" = or i64 %"1$tmp$3#0", 512 
-  %"1$tmp$0#0" = tail call fastcc  i8  @"ctor_char.foo<0>"(i64  %"1$tmp$1#0")  
-  tail call ccc  void  @putchar(i8  %"1$tmp$0#0")  
+  %"1$tmp$3##0" = shl   i64 97, 1 
+  %"1$tmp$1##0" = or i64 %"1$tmp$3##0", 512 
+  %"1$tmp$0##0" = tail call fastcc  i8  @"ctor_char.foo<0>"(i64  %"1$tmp$1##0")  
+  tail call ccc  void  @putchar(i8  %"1$tmp$0##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  i1 @"ctor_char.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"ctor_char.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$left#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$10#0" = and i64 %"$left#0", 1 
-  %"2$tmp$11#0" = icmp eq i64 %"2$tmp$10#0", 0 
-  br i1 %"2$tmp$11#0", label %if.then1, label %if.else1 
+  %"2$tmp$10##0" = and i64 %"$left##0", 1 
+  %"2$tmp$11##0" = icmp eq i64 %"2$tmp$10##0", 0 
+  br i1 %"2$tmp$11##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = icmp eq i64 %"$left#0", %"$right#0" 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
+  ret i1 %"3$$$##0" 
 if.then1:
-  %"4$tmp$12#0" = lshr  i64 %"$left#0", 1 
-  %"4$tmp$13#0" = and i64 %"4$tmp$12#0", 255 
-  %1 = trunc i64 %"4$tmp$13#0" to i8  
-  %"4$tmp$15#0" = icmp ne i64 %"$right#0", 0 
-  br i1 %"4$tmp$15#0", label %if.then2, label %if.else2 
+  %"4$tmp$12##0" = lshr  i64 %"$left##0", 1 
+  %"4$tmp$13##0" = and i64 %"4$tmp$12##0", 255 
+  %1 = trunc i64 %"4$tmp$13##0" to i8  
+  %"4$tmp$15##0" = icmp ne i64 %"$right##0", 0 
+  br i1 %"4$tmp$15##0", label %if.then2, label %if.else2 
 if.else1:
-  %"5$tmp$17#0" = icmp eq i64 %"2$tmp$10#0", 1 
-  br i1 %"5$tmp$17#0", label %if.then4, label %if.else4 
+  %"5$tmp$17##0" = icmp eq i64 %"2$tmp$10##0", 1 
+  br i1 %"5$tmp$17##0", label %if.then4, label %if.else4 
 if.then2:
-  %"6$tmp$16#0" = and i64 %"$right#0", 1 
-  %"6$tmp$17#0" = icmp eq i64 %"6$tmp$16#0", 0 
-  br i1 %"6$tmp$17#0", label %if.then3, label %if.else3 
+  %"6$tmp$16##0" = and i64 %"$right##0", 1 
+  %"6$tmp$17##0" = icmp eq i64 %"6$tmp$16##0", 0 
+  br i1 %"6$tmp$17##0", label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %"8$tmp$18#0" = lshr  i64 %"$right#0", 1 
-  %"8$tmp$19#0" = and i64 %"8$tmp$18#0", 255 
-  %2 = trunc i64 %"8$tmp$19#0" to i8  
-  %"8$$$#0" = icmp eq i8 %1, %2 
-  ret i1 %"8$$$#0" 
+  %"8$tmp$18##0" = lshr  i64 %"$right##0", 1 
+  %"8$tmp$19##0" = and i64 %"8$tmp$18##0", 255 
+  %2 = trunc i64 %"8$tmp$19##0" to i8  
+  %"8$$$##0" = icmp eq i8 %1, %2 
+  ret i1 %"8$$$##0" 
 if.else3:
   ret i1 0 
 if.then4:
-  %3 = add   i64 %"$left#0", -1 
+  %3 = add   i64 %"$left##0", -1 
   %4 = inttoptr i64 %3 to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
   %6 = load  i64, i64* %5 
-  %"10$tmp$19#0" = icmp ne i64 %"$right#0", 0 
-  br i1 %"10$tmp$19#0", label %if.then5, label %if.else5 
+  %"10$tmp$19##0" = icmp ne i64 %"$right##0", 0 
+  br i1 %"10$tmp$19##0", label %if.then5, label %if.else5 
 if.else4:
   ret i1 0 
 if.then5:
-  %"12$tmp$20#0" = and i64 %"$right#0", 1 
-  %"12$tmp$21#0" = icmp eq i64 %"12$tmp$20#0", 1 
-  br i1 %"12$tmp$21#0", label %if.then6, label %if.else6 
+  %"12$tmp$20##0" = and i64 %"$right##0", 1 
+  %"12$tmp$21##0" = icmp eq i64 %"12$tmp$20##0", 1 
+  br i1 %"12$tmp$21##0", label %if.then6, label %if.else6 
 if.else5:
   ret i1 0 
 if.then6:
-  %7 = add   i64 %"$right#0", -1 
+  %7 = add   i64 %"$right##0", -1 
   %8 = inttoptr i64 %7 to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %"14$$$#0" = tail call fastcc  i1  @"ctor_char.=<0>"(i64  %6, i64  %10)  
-  ret i1 %"14$$$#0" 
+  %"14$$$##0" = tail call fastcc  i1  @"ctor_char.=<0>"(i64  %6, i64  %10)  
+  ret i1 %"14$$$##0" 
 if.else6:
   ret i1 0 
 }
 
 
-define external fastcc  {i8, i1} @"ctor_char.c<0>"(i64  %"$rec#0")    {
+define external fastcc  {i8, i1} @"ctor_char.c<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 1 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 0 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 1 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 0 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %16 = insertvalue {i8, i1} undef, i8 undef, 0 
   %17 = insertvalue {i8, i1} %16, i1 0, 1 
   ret {i8, i1} %17 
 if.then1:
-  %"4$$rec#1" = lshr  i64 %"$rec#0", 1 
-  %"4$$field#0" = and i64 %"4$$rec#1", 255 
-  %11 = trunc i64 %"4$$field#0" to i8  
+  %"4$$rec##1" = lshr  i64 %"$rec##0", 1 
+  %"4$$field##0" = and i64 %"4$$rec##1", 255 
+  %11 = trunc i64 %"4$$field##0" to i8  
   %12 = insertvalue {i8, i1} undef, i8 %11, 0 
   %13 = insertvalue {i8, i1} %12, i1 1, 1 
   ret {i8, i1} %13 
@@ -372,28 +372,28 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"ctor_char.c<1>"(i64  %"$rec#0", i8  %"$field#0")    {
+define external fastcc  {i64, i1} @"ctor_char.c<1>"(i64  %"$rec##0", i8  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 1 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 0 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 1 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 0 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
-  %23 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %23 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %24 = insertvalue {i64, i1} %23, i1 0, 1 
   ret {i64, i1} %24 
 if.then1:
-  %"4$$rec#1" = and i64 %"$rec#0", -511 
-  %18 = zext i8 %"$field#0" to i64  
-  %"4$$temp#0" = shl   i64 %18, 1 
-  %"4$$rec#2" = or i64 %"4$$rec#1", %"4$$temp#0" 
-  %19 = insertvalue {i64, i1} undef, i64 %"4$$rec#2", 0 
+  %"4$$rec##1" = and i64 %"$rec##0", -511 
+  %18 = zext i8 %"$field##0" to i64  
+  %"4$$temp##0" = shl   i64 %18, 1 
+  %"4$$rec##2" = or i64 %"4$$rec##1", %"4$$temp##0" 
+  %19 = insertvalue {i64, i1} undef, i64 %"4$$rec##2", 0 
   %20 = insertvalue {i64, i1} %19, i1 1, 1 
   ret {i64, i1} %20 
 if.else1:
-  %21 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %21 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %22 = insertvalue {i64, i1} %21, i1 0, 1 
   ret {i64, i1} %22 
 }
@@ -405,31 +405,31 @@ entry:
 }
 
 
-define external fastcc  i64 @"ctor_char.ctor<0>"(i8  %"c#0")    {
+define external fastcc  i64 @"ctor_char.ctor<0>"(i8  %"c##0")    {
 entry:
-  %25 = zext i8 %"c#0" to i64  
-  %"1$$temp#0" = shl   i64 %25, 1 
-  %"1$$#3" = or i64 %"1$$temp#0", 512 
-  ret i64 %"1$$#3" 
+  %25 = zext i8 %"c##0" to i64  
+  %"1$$temp##0" = shl   i64 %25, 1 
+  %"1$$##3" = or i64 %"1$$temp##0", 512 
+  ret i64 %"1$$##3" 
 }
 
 
-define external fastcc  {i8, i1} @"ctor_char.ctor<1>"(i64  %"$#0")    {
+define external fastcc  {i8, i1} @"ctor_char.ctor<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$#0", 1 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 0 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$##0", 1 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 0 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %31 = insertvalue {i8, i1} undef, i8 undef, 0 
   %32 = insertvalue {i8, i1} %31, i1 0, 1 
   ret {i8, i1} %32 
 if.then1:
-  %"4$$temp#0" = lshr  i64 %"$#0", 1 
-  %"4$$temp2#0" = and i64 %"4$$temp#0", 255 
-  %26 = trunc i64 %"4$$temp2#0" to i8  
+  %"4$$temp##0" = lshr  i64 %"$##0", 1 
+  %"4$$temp2##0" = and i64 %"4$$temp##0", 255 
+  %26 = trunc i64 %"4$$temp2##0" to i8  
   %27 = insertvalue {i8, i1} undef, i8 %26, 0 
   %28 = insertvalue {i8, i1} %27, i1 1, 1 
   ret {i8, i1} %28 
@@ -440,53 +440,53 @@ if.else1:
 }
 
 
-define external fastcc  i8 @"ctor_char.foo<0>"(i64  %"this#0")    {
+define external fastcc  i8 @"ctor_char.foo<0>"(i64  %"this##0")    {
 entry:
-  %"1$tmp$3#0" = icmp ne i64 %"this#0", 0 
-  br i1 %"1$tmp$3#0", label %if.then, label %if.else 
+  %"1$tmp$3##0" = icmp ne i64 %"this##0", 0 
+  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$4#0" = and i64 %"this#0", 1 
-  %"2$tmp$5#0" = icmp eq i64 %"2$tmp$4#0", 0 
-  br i1 %"2$tmp$5#0", label %if.then1, label %if.else1 
+  %"2$tmp$4##0" = and i64 %"this##0", 1 
+  %"2$tmp$5##0" = icmp eq i64 %"2$tmp$4##0", 0 
+  br i1 %"2$tmp$5##0", label %if.then1, label %if.else1 
 if.else:
   ret i8 48 
 if.then1:
-  %"4$tmp$6#0" = lshr  i64 %"this#0", 1 
-  %"4$tmp$7#0" = and i64 %"4$tmp$6#0", 255 
-  %33 = trunc i64 %"4$tmp$7#0" to i8  
+  %"4$tmp$6##0" = lshr  i64 %"this##0", 1 
+  %"4$tmp$7##0" = and i64 %"4$tmp$6##0", 255 
+  %33 = trunc i64 %"4$tmp$7##0" to i8  
   ret i8 %33 
 if.else1:
   ret i8 48 
 }
 
 
-define external fastcc  i64 @"ctor_char.other_ctor<0>"(i64  %"other_ctor$1#0")    {
+define external fastcc  i64 @"ctor_char.other_ctor<0>"(i64  %"other_ctor$1##0")    {
 entry:
   %34 = trunc i64 8 to i32  
   %35 = tail call ccc  i8*  @wybe_malloc(i32  %34)  
   %36 = ptrtoint i8* %35 to i64 
   %37 = inttoptr i64 %36 to i64* 
   %38 = getelementptr  i64, i64* %37, i64 0 
-  store  i64 %"other_ctor$1#0", i64* %38 
-  %"1$$#0" = or i64 %36, 1 
-  ret i64 %"1$$#0" 
+  store  i64 %"other_ctor$1##0", i64* %38 
+  %"1$$##0" = or i64 %36, 1 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  {i64, i1} @"ctor_char.other_ctor<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"ctor_char.other_ctor<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$#0", 1 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 1 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$##0", 1 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 1 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %47 = insertvalue {i64, i1} undef, i64 undef, 0 
   %48 = insertvalue {i64, i1} %47, i1 0, 1 
   ret {i64, i1} %48 
 if.then1:
-  %39 = add   i64 %"$#0", -1 
+  %39 = add   i64 %"$##0", -1 
   %40 = inttoptr i64 %39 to i64* 
   %41 = getelementptr  i64, i64* %40, i64 0 
   %42 = load  i64, i64* %41 
@@ -500,9 +500,9 @@ if.else1:
 }
 
 
-define external fastcc  i1 @"ctor_char.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"ctor_char.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = tail call fastcc  i1  @"ctor_char.=<0>"(i64  %"$left#0", i64  %"$right#0")  
-  %"1$$$#0" = xor i1 %"1$tmp$0#0", 1 
-  ret i1 %"1$$$#0" 
+  %"1$tmp$0##0" = tail call fastcc  i1  @"ctor_char.=<0>"(i64  %"$left##0", i64  %"$right##0")  
+  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
+  ret i1 %"1$$$##0" 
 }

--- a/test-cases/final-dump/ctor_char.exp
+++ b/test-cases/final-dump/ctor_char.exp
@@ -27,13 +27,13 @@ AFTER EVERYTHING:
 
 = > public (2 calls)
 0: ctor_char.=<0>
-=(#left##0:ctor_char, #right##0:ctor_char, ?####0:wybe.bool):
+=(#left##0:ctor_char, #right##0:ctor_char, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~#left##0:ctor_char, ~#right##0:ctor_char, ?####0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:ctor_char, ~#right##0:ctor_char, ?#success##0:wybe.bool)
 
     1:
         foreign llvm and(#left##0:wybe.int, 1:wybe.int, ?tmp#10##0:wybe.int)
@@ -43,25 +43,25 @@ AFTER EVERYTHING:
             foreign llvm icmp_eq(~tmp#10##0:wybe.int, 1:wybe.int, ?tmp#17##0:wybe.bool)
             case ~tmp#17##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
                 foreign lpvm access(~#left##0:ctor_char, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#left#other_ctor#1##0:ctor_char)
                 foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#19##0:wybe.bool)
                 case ~tmp#19##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                 1:
                     foreign llvm and(#right##0:wybe.int, 1:wybe.int, ?tmp#20##0:wybe.int)
                     foreign llvm icmp_eq(~tmp#20##0:wybe.int, 1:wybe.int, ?tmp#21##0:wybe.bool)
                     case ~tmp#21##0:wybe.bool of
                     0:
-                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                     1:
                         foreign lpvm access(~#right##0:ctor_char, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#right#other_ctor#1##0:ctor_char)
-                        ctor_char.=<0>(~#left#other_ctor#1##0:ctor_char, ~#right#other_ctor#1##0:ctor_char, ?####0:wybe.bool) #5
+                        ctor_char.=<0>(~#left#other_ctor#1##0:ctor_char, ~#right#other_ctor#1##0:ctor_char, ?#success##0:wybe.bool) #5
 
 
 
@@ -73,20 +73,20 @@ AFTER EVERYTHING:
             foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.bool)
             case ~tmp#15##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
                 foreign llvm and(#right##0:wybe.int, 1:wybe.int, ?tmp#16##0:wybe.int)
                 foreign llvm icmp_eq(~tmp#16##0:wybe.int, 0:wybe.int, ?tmp#17##0:wybe.bool)
                 case ~tmp#17##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                 1:
                     foreign llvm lshr(~#right##0:ctor_char, 1:ctor_char, ?tmp#18##0:ctor_char)
                     foreign llvm and(~tmp#18##0:ctor_char, 255:ctor_char, ?tmp#19##0:ctor_char)
                     foreign lpvm cast(~tmp#19##0:ctor_char, ?#right#c##0:wybe.char)
-                    foreign llvm icmp_eq(~#left#c##0:wybe.char, ~#right#c##0:wybe.char, ?####0:wybe.bool) @char:nn:nn
+                    foreign llvm icmp_eq(~#left#c##0:wybe.char, ~#right#c##0:wybe.char, ?#success##0:wybe.bool) @char:nn:nn
 
 
 
@@ -95,13 +95,13 @@ AFTER EVERYTHING:
 
 c > {inline} (0 calls)
 0: ctor_char.c<0>
-c(#rec##0:ctor_char, ?#result##0:wybe.char, ?####0:wybe.bool):
+c(#rec##0:ctor_char, ?#result##0:wybe.char, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.char, ?#result##0:wybe.char)
 
     1:
@@ -109,25 +109,25 @@ c(#rec##0:ctor_char, ?#result##0:wybe.char, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.char, ?#result##0:wybe.char)
 
         1:
             foreign llvm lshr(~#rec##0:ctor_char, 1:ctor_char, ?#rec##1:ctor_char)
             foreign llvm and(~#rec##1:ctor_char, 255:ctor_char, ?#field##0:ctor_char)
             foreign lpvm cast(~#field##0:ctor_char, ?#result##0:wybe.char)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 c > {inline} (0 calls)
 1: ctor_char.c<1>
-c(#rec##0:ctor_char, ?#rec##2:ctor_char, #field##0:wybe.char, ?####0:wybe.bool):
+c(#rec##0:ctor_char, ?#rec##2:ctor_char, #field##0:wybe.char, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:ctor_char, ?#rec##2:ctor_char)
 
     1:
@@ -135,14 +135,14 @@ c(#rec##0:ctor_char, ?#rec##2:ctor_char, #field##0:wybe.char, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(~#rec##0:ctor_char, ?#rec##2:ctor_char)
 
         1:
             foreign llvm and(~#rec##0:ctor_char, -511:ctor_char, ?#rec##1:ctor_char)
             foreign llvm shl(~#field##0:ctor_char, 1:ctor_char, ?#temp##0:ctor_char)
             foreign llvm or(~#rec##1:ctor_char, ~#temp##0:ctor_char, ?#rec##2:ctor_char)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -164,13 +164,13 @@ ctor(c##0:wybe.char, ?#result##3:ctor_char):
     foreign llvm or(~#temp##0:ctor_char, 512:ctor_char, ?#result##3:ctor_char)
 ctor > {inline} (13 calls)
 1: ctor_char.ctor<1>
-ctor(?c##0:wybe.char, #result##0:ctor_char, ?####0:wybe.bool):
+ctor(?c##0:wybe.char, #result##0:ctor_char, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.char, ?c##0:wybe.char)
 
     1:
@@ -178,14 +178,14 @@ ctor(?c##0:wybe.char, #result##0:ctor_char, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.char, ?c##0:wybe.char)
 
         1:
             foreign llvm lshr(~#result##0:ctor_char, 1:ctor_char, ?#temp##0:ctor_char)
             foreign llvm and(~#temp##0:ctor_char, 255:ctor_char, ?#temp2##0:ctor_char)
             foreign lpvm cast(~#temp2##0:ctor_char, ?c##0:wybe.char)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -225,13 +225,13 @@ other_ctor(other_ctor#1##0:ctor_char, ?#result##0:ctor_char):
     foreign llvm or(~#rec##1:ctor_char, 1:wybe.int, ?#result##0:ctor_char)
 other_ctor > public {inline} (5 calls)
 1: ctor_char.other_ctor<1>
-other_ctor(?other_ctor#1##0:ctor_char, #result##0:ctor_char, ?####0:wybe.bool):
+other_ctor(?other_ctor#1##0:ctor_char, #result##0:ctor_char, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:ctor_char, ?other_ctor#1##0:ctor_char)
 
     1:
@@ -239,23 +239,23 @@ other_ctor(?other_ctor#1##0:ctor_char, #result##0:ctor_char, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:ctor_char, ?other_ctor#1##0:ctor_char)
 
         1:
             foreign lpvm access(~#result##0:ctor_char, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?other_ctor#1##0:ctor_char)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 
 ~= > public {inline} (0 calls)
 0: ctor_char.~=<0>
-~=(#left##0:ctor_char, #right##0:ctor_char, ?####0:wybe.bool):
+~=(#left##0:ctor_char, #right##0:ctor_char, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     ctor_char.=<0>(~#left##0:ctor_char, ~#right##0:ctor_char, ?tmp#0##0:wybe.bool) #0
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 
@@ -294,8 +294,8 @@ if.then:
   %"2#tmp#11##0" = icmp eq i64 %"2#tmp#10##0", 0 
   br i1 %"2#tmp#11##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %"3#####0" 
+  %"3##success##0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3##success##0" 
 if.then1:
   %"4#tmp#12##0" = lshr  i64 %"#left##0", 1 
   %"4#tmp#13##0" = and i64 %"4#tmp#12##0", 255 
@@ -315,8 +315,8 @@ if.then3:
   %"8#tmp#18##0" = lshr  i64 %"#right##0", 1 
   %"8#tmp#19##0" = and i64 %"8#tmp#18##0", 255 
   %2 = trunc i64 %"8#tmp#19##0" to i8  
-  %"8#####0" = icmp eq i8 %1, %2 
-  ret i1 %"8#####0" 
+  %"8##success##0" = icmp eq i8 %1, %2 
+  ret i1 %"8##success##0" 
 if.else3:
   ret i1 0 
 if.then4:
@@ -339,8 +339,8 @@ if.then6:
   %8 = inttoptr i64 %7 to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %"14#####0" = tail call fastcc  i1  @"ctor_char.=<0>"(i64  %6, i64  %10)  
-  ret i1 %"14#####0" 
+  %"14##success##0" = tail call fastcc  i1  @"ctor_char.=<0>"(i64  %6, i64  %10)  
+  ret i1 %"14##success##0" 
 if.else6:
   ret i1 0 
 }
@@ -503,6 +503,6 @@ if.else1:
 define external fastcc  i1 @"ctor_char.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %"1#tmp#0##0" = tail call fastcc  i1  @"ctor_char.=<0>"(i64  %"#left##0", i64  %"#right##0")  
-  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
-  ret i1 %"1#####0" 
+  %"1##success##0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1##success##0" 
 }

--- a/test-cases/final-dump/ctor_char.exp
+++ b/test-cases/final-dump/ctor_char.exp
@@ -18,75 +18,75 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm shl('a':ctor_char, 1:ctor_char, ?tmp$3##0:ctor_char)
-    foreign llvm or(~tmp$3##0:ctor_char, 512:ctor_char, ?tmp$1##0:ctor_char)
-    ctor_char.foo<0>(~tmp$1##0:ctor_char, ?tmp$0##0:wybe.char) #1 @ctor_char:nn:nn
-    foreign c putchar(~tmp$0##0:wybe.char, ~#io##0:wybe.phantom, ?tmp$6##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign llvm shl('a':ctor_char, 1:ctor_char, ?tmp#3##0:ctor_char)
+    foreign llvm or(~tmp#3##0:ctor_char, 512:ctor_char, ?tmp#1##0:ctor_char)
+    ctor_char.foo<0>(~tmp#1##0:ctor_char, ?tmp#0##0:wybe.char) #1 @ctor_char:nn:nn
+    foreign c putchar(~tmp#0##0:wybe.char, ~#io##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 = > public (2 calls)
 0: ctor_char.=<0>
-=($left##0:ctor_char, $right##0:ctor_char, ?$$##0:wybe.bool):
+=(#left##0:ctor_char, #right##0:ctor_char, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left##0:ctor_char, ~$right##0:ctor_char, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:ctor_char, ~#right##0:ctor_char, ?####0:wybe.bool)
 
     1:
-        foreign llvm and($left##0:wybe.int, 1:wybe.int, ?tmp$10##0:wybe.int)
-        foreign llvm icmp_eq(tmp$10##0:wybe.int, 0:wybe.int, ?tmp$11##0:wybe.bool)
-        case ~tmp$11##0:wybe.bool of
+        foreign llvm and(#left##0:wybe.int, 1:wybe.int, ?tmp#10##0:wybe.int)
+        foreign llvm icmp_eq(tmp#10##0:wybe.int, 0:wybe.int, ?tmp#11##0:wybe.bool)
+        case ~tmp#11##0:wybe.bool of
         0:
-            foreign llvm icmp_eq(~tmp$10##0:wybe.int, 1:wybe.int, ?tmp$17##0:wybe.bool)
-            case ~tmp$17##0:wybe.bool of
+            foreign llvm icmp_eq(~tmp#10##0:wybe.int, 1:wybe.int, ?tmp#17##0:wybe.bool)
+            case ~tmp#17##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
             1:
-                foreign lpvm access(~$left##0:ctor_char, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$left$other_ctor$1##0:ctor_char)
-                foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$19##0:wybe.bool)
-                case ~tmp$19##0:wybe.bool of
+                foreign lpvm access(~#left##0:ctor_char, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#left#other_ctor#1##0:ctor_char)
+                foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#19##0:wybe.bool)
+                case ~tmp#19##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                 1:
-                    foreign llvm and($right##0:wybe.int, 1:wybe.int, ?tmp$20##0:wybe.int)
-                    foreign llvm icmp_eq(~tmp$20##0:wybe.int, 1:wybe.int, ?tmp$21##0:wybe.bool)
-                    case ~tmp$21##0:wybe.bool of
+                    foreign llvm and(#right##0:wybe.int, 1:wybe.int, ?tmp#20##0:wybe.int)
+                    foreign llvm icmp_eq(~tmp#20##0:wybe.int, 1:wybe.int, ?tmp#21##0:wybe.bool)
+                    case ~tmp#21##0:wybe.bool of
                     0:
-                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                     1:
-                        foreign lpvm access(~$right##0:ctor_char, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$right$other_ctor$1##0:ctor_char)
-                        ctor_char.=<0>(~$left$other_ctor$1##0:ctor_char, ~$right$other_ctor$1##0:ctor_char, ?$$##0:wybe.bool) #5
+                        foreign lpvm access(~#right##0:ctor_char, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#right#other_ctor#1##0:ctor_char)
+                        ctor_char.=<0>(~#left#other_ctor#1##0:ctor_char, ~#right#other_ctor#1##0:ctor_char, ?####0:wybe.bool) #5
 
 
 
 
         1:
-            foreign llvm lshr(~$left##0:ctor_char, 1:ctor_char, ?tmp$12##0:ctor_char)
-            foreign llvm and(~tmp$12##0:ctor_char, 255:ctor_char, ?tmp$13##0:ctor_char)
-            foreign lpvm cast(~tmp$13##0:ctor_char, ?$left$c##0:wybe.char)
-            foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$15##0:wybe.bool)
-            case ~tmp$15##0:wybe.bool of
+            foreign llvm lshr(~#left##0:ctor_char, 1:ctor_char, ?tmp#12##0:ctor_char)
+            foreign llvm and(~tmp#12##0:ctor_char, 255:ctor_char, ?tmp#13##0:ctor_char)
+            foreign lpvm cast(~tmp#13##0:ctor_char, ?#left#c##0:wybe.char)
+            foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.bool)
+            case ~tmp#15##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
             1:
-                foreign llvm and($right##0:wybe.int, 1:wybe.int, ?tmp$16##0:wybe.int)
-                foreign llvm icmp_eq(~tmp$16##0:wybe.int, 0:wybe.int, ?tmp$17##0:wybe.bool)
-                case ~tmp$17##0:wybe.bool of
+                foreign llvm and(#right##0:wybe.int, 1:wybe.int, ?tmp#16##0:wybe.int)
+                foreign llvm icmp_eq(~tmp#16##0:wybe.int, 0:wybe.int, ?tmp#17##0:wybe.bool)
+                case ~tmp#17##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                 1:
-                    foreign llvm lshr(~$right##0:ctor_char, 1:ctor_char, ?tmp$18##0:ctor_char)
-                    foreign llvm and(~tmp$18##0:ctor_char, 255:ctor_char, ?tmp$19##0:ctor_char)
-                    foreign lpvm cast(~tmp$19##0:ctor_char, ?$right$c##0:wybe.char)
-                    foreign llvm icmp_eq(~$left$c##0:wybe.char, ~$right$c##0:wybe.char, ?$$##0:wybe.bool) @char:nn:nn
+                    foreign llvm lshr(~#right##0:ctor_char, 1:ctor_char, ?tmp#18##0:ctor_char)
+                    foreign llvm and(~tmp#18##0:ctor_char, 255:ctor_char, ?tmp#19##0:ctor_char)
+                    foreign lpvm cast(~tmp#19##0:ctor_char, ?#right#c##0:wybe.char)
+                    foreign llvm icmp_eq(~#left#c##0:wybe.char, ~#right#c##0:wybe.char, ?####0:wybe.bool) @char:nn:nn
 
 
 
@@ -95,167 +95,167 @@ AFTER EVERYTHING:
 
 c > {inline} (0 calls)
 0: ctor_char.c<0>
-c($rec##0:ctor_char, ?$##0:wybe.char, ?$$##0:wybe.bool):
+c(#rec##0:ctor_char, ?###0:wybe.char, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.char, ?$##0:wybe.char)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.char, ?###0:wybe.char)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(undef:wybe.char, ?$##0:wybe.char)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(undef:wybe.char, ?###0:wybe.char)
 
         1:
-            foreign llvm lshr(~$rec##0:ctor_char, 1:ctor_char, ?$rec##1:ctor_char)
-            foreign llvm and(~$rec##1:ctor_char, 255:ctor_char, ?$field##0:ctor_char)
-            foreign lpvm cast(~$field##0:ctor_char, ?$##0:wybe.char)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm lshr(~#rec##0:ctor_char, 1:ctor_char, ?#rec##1:ctor_char)
+            foreign llvm and(~#rec##1:ctor_char, 255:ctor_char, ?#field##0:ctor_char)
+            foreign lpvm cast(~#field##0:ctor_char, ?###0:wybe.char)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 c > {inline} (0 calls)
 1: ctor_char.c<1>
-c($rec##0:ctor_char, ?$rec##2:ctor_char, $field##0:wybe.char, ?$$##0:wybe.bool):
+c(#rec##0:ctor_char, ?#rec##2:ctor_char, #field##0:wybe.char, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:ctor_char, ?$rec##2:ctor_char)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:ctor_char, ?#rec##2:ctor_char)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(~$rec##0:ctor_char, ?$rec##2:ctor_char)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(~#rec##0:ctor_char, ?#rec##2:ctor_char)
 
         1:
-            foreign llvm and(~$rec##0:ctor_char, -511:ctor_char, ?$rec##1:ctor_char)
-            foreign llvm shl(~$field##0:ctor_char, 1:ctor_char, ?$temp##0:ctor_char)
-            foreign llvm or(~$rec##1:ctor_char, ~$temp##0:ctor_char, ?$rec##2:ctor_char)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm and(~#rec##0:ctor_char, -511:ctor_char, ?#rec##1:ctor_char)
+            foreign llvm shl(~#field##0:ctor_char, 1:ctor_char, ?#temp##0:ctor_char)
+            foreign llvm or(~#rec##1:ctor_char, ~#temp##0:ctor_char, ?#rec##2:ctor_char)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 const > {inline} (0 calls)
 0: ctor_char.const<0>
-const(?$##0:ctor_char):
+const(?###0:ctor_char):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:ctor_char, ?$##0:ctor_char)
+    foreign llvm move(0:ctor_char, ?###0:ctor_char)
 
 
 ctor > {inline} (1 calls)
 0: ctor_char.ctor<0>
-ctor(c##0:wybe.char, ?$##3:ctor_char):
+ctor(c##0:wybe.char, ?###3:ctor_char):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm shl(~c##0:ctor_char, 1:ctor_char, ?$temp##0:ctor_char)
-    foreign llvm or(~$temp##0:ctor_char, 512:ctor_char, ?$##3:ctor_char)
+    foreign llvm shl(~c##0:ctor_char, 1:ctor_char, ?#temp##0:ctor_char)
+    foreign llvm or(~#temp##0:ctor_char, 512:ctor_char, ?###3:ctor_char)
 ctor > {inline} (13 calls)
 1: ctor_char.ctor<1>
-ctor(?c##0:wybe.char, $##0:ctor_char, ?$$##0:wybe.bool):
+ctor(?c##0:wybe.char, ###0:ctor_char, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.char, ?c##0:wybe.char)
 
     1:
-        foreign llvm and($##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(###0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
             foreign llvm move(undef:wybe.char, ?c##0:wybe.char)
 
         1:
-            foreign llvm lshr(~$##0:ctor_char, 1:ctor_char, ?$temp##0:ctor_char)
-            foreign llvm and(~$temp##0:ctor_char, 255:ctor_char, ?$temp2##0:ctor_char)
-            foreign lpvm cast(~$temp2##0:ctor_char, ?c##0:wybe.char)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm lshr(~###0:ctor_char, 1:ctor_char, ?#temp##0:ctor_char)
+            foreign llvm and(~#temp##0:ctor_char, 255:ctor_char, ?#temp2##0:ctor_char)
+            foreign lpvm cast(~#temp2##0:ctor_char, ?c##0:wybe.char)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 foo > (1 calls)
 0: ctor_char.foo<0>
-foo(this##0:ctor_char, ?$##0:wybe.char):
+foo(this##0:ctor_char, ?###0:wybe.char):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(this##0:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.bool)
-    case ~tmp$3##0:wybe.bool of
+    foreign llvm icmp_ne(this##0:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.bool)
+    case ~tmp#3##0:wybe.bool of
     0:
-        foreign llvm move('0':wybe.char, ?$##0:wybe.char) @ctor_char:nn:nn
+        foreign llvm move('0':wybe.char, ?###0:wybe.char) @ctor_char:nn:nn
 
     1:
-        foreign llvm and(this##0:wybe.int, 1:wybe.int, ?tmp$4##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
-        case ~tmp$5##0:wybe.bool of
+        foreign llvm and(this##0:wybe.int, 1:wybe.int, ?tmp#4##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
+        case ~tmp#5##0:wybe.bool of
         0:
-            foreign llvm move('0':wybe.char, ?$##0:wybe.char) @ctor_char:nn:nn
+            foreign llvm move('0':wybe.char, ?###0:wybe.char) @ctor_char:nn:nn
 
         1:
-            foreign llvm lshr(~this##0:ctor_char, 1:ctor_char, ?tmp$6##0:ctor_char)
-            foreign llvm and(~tmp$6##0:ctor_char, 255:ctor_char, ?tmp$7##0:ctor_char)
-            foreign lpvm cast(~tmp$7##0:ctor_char, ?$##0:wybe.char)
+            foreign llvm lshr(~this##0:ctor_char, 1:ctor_char, ?tmp#6##0:ctor_char)
+            foreign llvm and(~tmp#6##0:ctor_char, 255:ctor_char, ?tmp#7##0:ctor_char)
+            foreign lpvm cast(~tmp#7##0:ctor_char, ?###0:wybe.char)
 
 
 
 
 other_ctor > public {inline} (0 calls)
 0: ctor_char.other_ctor<0>
-other_ctor(other_ctor$1##0:ctor_char, ?$##0:ctor_char):
+other_ctor(other_ctor#1##0:ctor_char, ?###0:ctor_char):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec##0:ctor_char)
-    foreign lpvm mutate(~$rec##0:ctor_char, ?$rec##1:ctor_char, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~other_ctor$1##0:ctor_char)
-    foreign llvm or(~$rec##1:ctor_char, 1:wybe.int, ?$##0:ctor_char)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:ctor_char)
+    foreign lpvm mutate(~#rec##0:ctor_char, ?#rec##1:ctor_char, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~other_ctor#1##0:ctor_char)
+    foreign llvm or(~#rec##1:ctor_char, 1:wybe.int, ?###0:ctor_char)
 other_ctor > public {inline} (5 calls)
 1: ctor_char.other_ctor<1>
-other_ctor(?other_ctor$1##0:ctor_char, $##0:ctor_char, ?$$##0:wybe.bool):
+other_ctor(?other_ctor#1##0:ctor_char, ###0:ctor_char, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:ctor_char, ?other_ctor$1##0:ctor_char)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:ctor_char, ?other_ctor#1##0:ctor_char)
 
     1:
-        foreign llvm and($##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(###0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(undef:ctor_char, ?other_ctor$1##0:ctor_char)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(undef:ctor_char, ?other_ctor#1##0:ctor_char)
 
         1:
-            foreign lpvm access(~$##0:ctor_char, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?other_ctor$1##0:ctor_char)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm access(~###0:ctor_char, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?other_ctor#1##0:ctor_char)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 ~= > public {inline} (0 calls)
 0: ctor_char.~=<0>
-~=($left##0:ctor_char, $right##0:ctor_char, ?$$##0:wybe.bool):
+~=(#left##0:ctor_char, #right##0:ctor_char, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    ctor_char.=<0>(~$left##0:ctor_char, ~$right##0:ctor_char, ?tmp$0##0:wybe.bool) #0
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    ctor_char.=<0>(~#left##0:ctor_char, ~#right##0:ctor_char, ?tmp#0##0:wybe.bool) #0
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
   LLVM code       :
 
@@ -276,92 +276,92 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"ctor_char.<0>"()    {
 entry:
-  %"1$tmp$3##0" = shl   i64 97, 1 
-  %"1$tmp$1##0" = or i64 %"1$tmp$3##0", 512 
-  %"1$tmp$0##0" = tail call fastcc  i8  @"ctor_char.foo<0>"(i64  %"1$tmp$1##0")  
-  tail call ccc  void  @putchar(i8  %"1$tmp$0##0")  
+  %"1#tmp#3##0" = shl   i64 97, 1 
+  %"1#tmp#1##0" = or i64 %"1#tmp#3##0", 512 
+  %"1#tmp#0##0" = tail call fastcc  i8  @"ctor_char.foo<0>"(i64  %"1#tmp#1##0")  
+  tail call ccc  void  @putchar(i8  %"1#tmp#0##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  i1 @"ctor_char.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"ctor_char.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#left##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$10##0" = and i64 %"$left##0", 1 
-  %"2$tmp$11##0" = icmp eq i64 %"2$tmp$10##0", 0 
-  br i1 %"2$tmp$11##0", label %if.then1, label %if.else1 
+  %"2#tmp#10##0" = and i64 %"#left##0", 1 
+  %"2#tmp#11##0" = icmp eq i64 %"2#tmp#10##0", 0 
+  br i1 %"2#tmp#11##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3#####0" 
 if.then1:
-  %"4$tmp$12##0" = lshr  i64 %"$left##0", 1 
-  %"4$tmp$13##0" = and i64 %"4$tmp$12##0", 255 
-  %1 = trunc i64 %"4$tmp$13##0" to i8  
-  %"4$tmp$15##0" = icmp ne i64 %"$right##0", 0 
-  br i1 %"4$tmp$15##0", label %if.then2, label %if.else2 
+  %"4#tmp#12##0" = lshr  i64 %"#left##0", 1 
+  %"4#tmp#13##0" = and i64 %"4#tmp#12##0", 255 
+  %1 = trunc i64 %"4#tmp#13##0" to i8  
+  %"4#tmp#15##0" = icmp ne i64 %"#right##0", 0 
+  br i1 %"4#tmp#15##0", label %if.then2, label %if.else2 
 if.else1:
-  %"5$tmp$17##0" = icmp eq i64 %"2$tmp$10##0", 1 
-  br i1 %"5$tmp$17##0", label %if.then4, label %if.else4 
+  %"5#tmp#17##0" = icmp eq i64 %"2#tmp#10##0", 1 
+  br i1 %"5#tmp#17##0", label %if.then4, label %if.else4 
 if.then2:
-  %"6$tmp$16##0" = and i64 %"$right##0", 1 
-  %"6$tmp$17##0" = icmp eq i64 %"6$tmp$16##0", 0 
-  br i1 %"6$tmp$17##0", label %if.then3, label %if.else3 
+  %"6#tmp#16##0" = and i64 %"#right##0", 1 
+  %"6#tmp#17##0" = icmp eq i64 %"6#tmp#16##0", 0 
+  br i1 %"6#tmp#17##0", label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %"8$tmp$18##0" = lshr  i64 %"$right##0", 1 
-  %"8$tmp$19##0" = and i64 %"8$tmp$18##0", 255 
-  %2 = trunc i64 %"8$tmp$19##0" to i8  
-  %"8$$$##0" = icmp eq i8 %1, %2 
-  ret i1 %"8$$$##0" 
+  %"8#tmp#18##0" = lshr  i64 %"#right##0", 1 
+  %"8#tmp#19##0" = and i64 %"8#tmp#18##0", 255 
+  %2 = trunc i64 %"8#tmp#19##0" to i8  
+  %"8#####0" = icmp eq i8 %1, %2 
+  ret i1 %"8#####0" 
 if.else3:
   ret i1 0 
 if.then4:
-  %3 = add   i64 %"$left##0", -1 
+  %3 = add   i64 %"#left##0", -1 
   %4 = inttoptr i64 %3 to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
   %6 = load  i64, i64* %5 
-  %"10$tmp$19##0" = icmp ne i64 %"$right##0", 0 
-  br i1 %"10$tmp$19##0", label %if.then5, label %if.else5 
+  %"10#tmp#19##0" = icmp ne i64 %"#right##0", 0 
+  br i1 %"10#tmp#19##0", label %if.then5, label %if.else5 
 if.else4:
   ret i1 0 
 if.then5:
-  %"12$tmp$20##0" = and i64 %"$right##0", 1 
-  %"12$tmp$21##0" = icmp eq i64 %"12$tmp$20##0", 1 
-  br i1 %"12$tmp$21##0", label %if.then6, label %if.else6 
+  %"12#tmp#20##0" = and i64 %"#right##0", 1 
+  %"12#tmp#21##0" = icmp eq i64 %"12#tmp#20##0", 1 
+  br i1 %"12#tmp#21##0", label %if.then6, label %if.else6 
 if.else5:
   ret i1 0 
 if.then6:
-  %7 = add   i64 %"$right##0", -1 
+  %7 = add   i64 %"#right##0", -1 
   %8 = inttoptr i64 %7 to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %"14$$$##0" = tail call fastcc  i1  @"ctor_char.=<0>"(i64  %6, i64  %10)  
-  ret i1 %"14$$$##0" 
+  %"14#####0" = tail call fastcc  i1  @"ctor_char.=<0>"(i64  %6, i64  %10)  
+  ret i1 %"14#####0" 
 if.else6:
   ret i1 0 
 }
 
 
-define external fastcc  {i8, i1} @"ctor_char.c<0>"(i64  %"$rec##0")    {
+define external fastcc  {i8, i1} @"ctor_char.c<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 1 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 0 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 1 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 0 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %16 = insertvalue {i8, i1} undef, i8 undef, 0 
   %17 = insertvalue {i8, i1} %16, i1 0, 1 
   ret {i8, i1} %17 
 if.then1:
-  %"4$$rec##1" = lshr  i64 %"$rec##0", 1 
-  %"4$$field##0" = and i64 %"4$$rec##1", 255 
-  %11 = trunc i64 %"4$$field##0" to i8  
+  %"4##rec##1" = lshr  i64 %"#rec##0", 1 
+  %"4##field##0" = and i64 %"4##rec##1", 255 
+  %11 = trunc i64 %"4##field##0" to i8  
   %12 = insertvalue {i8, i1} undef, i8 %11, 0 
   %13 = insertvalue {i8, i1} %12, i1 1, 1 
   ret {i8, i1} %13 
@@ -372,28 +372,28 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"ctor_char.c<1>"(i64  %"$rec##0", i8  %"$field##0")    {
+define external fastcc  {i64, i1} @"ctor_char.c<1>"(i64  %"#rec##0", i8  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 1 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 0 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 1 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 0 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
-  %23 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %23 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %24 = insertvalue {i64, i1} %23, i1 0, 1 
   ret {i64, i1} %24 
 if.then1:
-  %"4$$rec##1" = and i64 %"$rec##0", -511 
-  %18 = zext i8 %"$field##0" to i64  
-  %"4$$temp##0" = shl   i64 %18, 1 
-  %"4$$rec##2" = or i64 %"4$$rec##1", %"4$$temp##0" 
-  %19 = insertvalue {i64, i1} undef, i64 %"4$$rec##2", 0 
+  %"4##rec##1" = and i64 %"#rec##0", -511 
+  %18 = zext i8 %"#field##0" to i64  
+  %"4##temp##0" = shl   i64 %18, 1 
+  %"4##rec##2" = or i64 %"4##rec##1", %"4##temp##0" 
+  %19 = insertvalue {i64, i1} undef, i64 %"4##rec##2", 0 
   %20 = insertvalue {i64, i1} %19, i1 1, 1 
   ret {i64, i1} %20 
 if.else1:
-  %21 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %21 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %22 = insertvalue {i64, i1} %21, i1 0, 1 
   ret {i64, i1} %22 
 }
@@ -408,28 +408,28 @@ entry:
 define external fastcc  i64 @"ctor_char.ctor<0>"(i8  %"c##0")    {
 entry:
   %25 = zext i8 %"c##0" to i64  
-  %"1$$temp##0" = shl   i64 %25, 1 
-  %"1$$##3" = or i64 %"1$$temp##0", 512 
-  ret i64 %"1$$##3" 
+  %"1##temp##0" = shl   i64 %25, 1 
+  %"1####3" = or i64 %"1##temp##0", 512 
+  ret i64 %"1####3" 
 }
 
 
-define external fastcc  {i8, i1} @"ctor_char.ctor<1>"(i64  %"$##0")    {
+define external fastcc  {i8, i1} @"ctor_char.ctor<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$##0", 1 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 0 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"###0", 1 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 0 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %31 = insertvalue {i8, i1} undef, i8 undef, 0 
   %32 = insertvalue {i8, i1} %31, i1 0, 1 
   ret {i8, i1} %32 
 if.then1:
-  %"4$$temp##0" = lshr  i64 %"$##0", 1 
-  %"4$$temp2##0" = and i64 %"4$$temp##0", 255 
-  %26 = trunc i64 %"4$$temp2##0" to i8  
+  %"4##temp##0" = lshr  i64 %"###0", 1 
+  %"4##temp2##0" = and i64 %"4##temp##0", 255 
+  %26 = trunc i64 %"4##temp2##0" to i8  
   %27 = insertvalue {i8, i1} undef, i8 %26, 0 
   %28 = insertvalue {i8, i1} %27, i1 1, 1 
   ret {i8, i1} %28 
@@ -442,51 +442,51 @@ if.else1:
 
 define external fastcc  i8 @"ctor_char.foo<0>"(i64  %"this##0")    {
 entry:
-  %"1$tmp$3##0" = icmp ne i64 %"this##0", 0 
-  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
+  %"1#tmp#3##0" = icmp ne i64 %"this##0", 0 
+  br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$4##0" = and i64 %"this##0", 1 
-  %"2$tmp$5##0" = icmp eq i64 %"2$tmp$4##0", 0 
-  br i1 %"2$tmp$5##0", label %if.then1, label %if.else1 
+  %"2#tmp#4##0" = and i64 %"this##0", 1 
+  %"2#tmp#5##0" = icmp eq i64 %"2#tmp#4##0", 0 
+  br i1 %"2#tmp#5##0", label %if.then1, label %if.else1 
 if.else:
   ret i8 48 
 if.then1:
-  %"4$tmp$6##0" = lshr  i64 %"this##0", 1 
-  %"4$tmp$7##0" = and i64 %"4$tmp$6##0", 255 
-  %33 = trunc i64 %"4$tmp$7##0" to i8  
+  %"4#tmp#6##0" = lshr  i64 %"this##0", 1 
+  %"4#tmp#7##0" = and i64 %"4#tmp#6##0", 255 
+  %33 = trunc i64 %"4#tmp#7##0" to i8  
   ret i8 %33 
 if.else1:
   ret i8 48 
 }
 
 
-define external fastcc  i64 @"ctor_char.other_ctor<0>"(i64  %"other_ctor$1##0")    {
+define external fastcc  i64 @"ctor_char.other_ctor<0>"(i64  %"other_ctor#1##0")    {
 entry:
   %34 = trunc i64 8 to i32  
   %35 = tail call ccc  i8*  @wybe_malloc(i32  %34)  
   %36 = ptrtoint i8* %35 to i64 
   %37 = inttoptr i64 %36 to i64* 
   %38 = getelementptr  i64, i64* %37, i64 0 
-  store  i64 %"other_ctor$1##0", i64* %38 
-  %"1$$##0" = or i64 %36, 1 
-  ret i64 %"1$$##0" 
+  store  i64 %"other_ctor#1##0", i64* %38 
+  %"1####0" = or i64 %36, 1 
+  ret i64 %"1####0" 
 }
 
 
-define external fastcc  {i64, i1} @"ctor_char.other_ctor<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"ctor_char.other_ctor<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$##0", 1 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 1 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"###0", 1 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 1 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %47 = insertvalue {i64, i1} undef, i64 undef, 0 
   %48 = insertvalue {i64, i1} %47, i1 0, 1 
   ret {i64, i1} %48 
 if.then1:
-  %39 = add   i64 %"$##0", -1 
+  %39 = add   i64 %"###0", -1 
   %40 = inttoptr i64 %39 to i64* 
   %41 = getelementptr  i64, i64* %40, i64 0 
   %42 = load  i64, i64* %41 
@@ -500,9 +500,9 @@ if.else1:
 }
 
 
-define external fastcc  i1 @"ctor_char.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"ctor_char.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = tail call fastcc  i1  @"ctor_char.=<0>"(i64  %"$left##0", i64  %"$right##0")  
-  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
-  ret i1 %"1$$$##0" 
+  %"1#tmp#0##0" = tail call fastcc  i1  @"ctor_char.=<0>"(i64  %"#left##0", i64  %"#right##0")  
+  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1#####0" 
 }

--- a/test-cases/final-dump/ctor_char.exp
+++ b/test-cases/final-dump/ctor_char.exp
@@ -95,14 +95,14 @@ AFTER EVERYTHING:
 
 c > {inline} (0 calls)
 0: ctor_char.c<0>
-c(#rec##0:ctor_char, ?###0:wybe.char, ?####0:wybe.bool):
+c(#rec##0:ctor_char, ?#result##0:wybe.char, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.char, ?###0:wybe.char)
+        foreign llvm move(undef:wybe.char, ?#result##0:wybe.char)
 
     1:
         foreign llvm and(#rec##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int)
@@ -110,12 +110,12 @@ c(#rec##0:ctor_char, ?###0:wybe.char, ?####0:wybe.bool):
         case ~tmp#1##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-            foreign llvm move(undef:wybe.char, ?###0:wybe.char)
+            foreign llvm move(undef:wybe.char, ?#result##0:wybe.char)
 
         1:
             foreign llvm lshr(~#rec##0:ctor_char, 1:ctor_char, ?#rec##1:ctor_char)
             foreign llvm and(~#rec##1:ctor_char, 255:ctor_char, ?#field##0:ctor_char)
-            foreign lpvm cast(~#field##0:ctor_char, ?###0:wybe.char)
+            foreign lpvm cast(~#field##0:ctor_char, ?#result##0:wybe.char)
             foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -149,32 +149,32 @@ c(#rec##0:ctor_char, ?#rec##2:ctor_char, #field##0:wybe.char, ?####0:wybe.bool):
 
 const > {inline} (0 calls)
 0: ctor_char.const<0>
-const(?###0:ctor_char):
+const(?#result##0:ctor_char):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:ctor_char, ?###0:ctor_char)
+    foreign llvm move(0:ctor_char, ?#result##0:ctor_char)
 
 
 ctor > {inline} (1 calls)
 0: ctor_char.ctor<0>
-ctor(c##0:wybe.char, ?###3:ctor_char):
+ctor(c##0:wybe.char, ?#result##3:ctor_char):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm shl(~c##0:ctor_char, 1:ctor_char, ?#temp##0:ctor_char)
-    foreign llvm or(~#temp##0:ctor_char, 512:ctor_char, ?###3:ctor_char)
+    foreign llvm or(~#temp##0:ctor_char, 512:ctor_char, ?#result##3:ctor_char)
 ctor > {inline} (13 calls)
 1: ctor_char.ctor<1>
-ctor(?c##0:wybe.char, ###0:ctor_char, ?####0:wybe.bool):
+ctor(?c##0:wybe.char, #result##0:ctor_char, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.char, ?c##0:wybe.char)
 
     1:
-        foreign llvm and(###0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm and(#result##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int)
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
@@ -182,7 +182,7 @@ ctor(?c##0:wybe.char, ###0:ctor_char, ?####0:wybe.bool):
             foreign llvm move(undef:wybe.char, ?c##0:wybe.char)
 
         1:
-            foreign llvm lshr(~###0:ctor_char, 1:ctor_char, ?#temp##0:ctor_char)
+            foreign llvm lshr(~#result##0:ctor_char, 1:ctor_char, ?#temp##0:ctor_char)
             foreign llvm and(~#temp##0:ctor_char, 255:ctor_char, ?#temp2##0:ctor_char)
             foreign lpvm cast(~#temp2##0:ctor_char, ?c##0:wybe.char)
             foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
@@ -192,50 +192,50 @@ ctor(?c##0:wybe.char, ###0:ctor_char, ?####0:wybe.bool):
 
 foo > (1 calls)
 0: ctor_char.foo<0>
-foo(this##0:ctor_char, ?###0:wybe.char):
+foo(this##0:ctor_char, ?#result##0:wybe.char):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(this##0:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.bool)
     case ~tmp#3##0:wybe.bool of
     0:
-        foreign llvm move('0':wybe.char, ?###0:wybe.char) @ctor_char:nn:nn
+        foreign llvm move('0':wybe.char, ?#result##0:wybe.char) @ctor_char:nn:nn
 
     1:
         foreign llvm and(this##0:wybe.int, 1:wybe.int, ?tmp#4##0:wybe.int)
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
         case ~tmp#5##0:wybe.bool of
         0:
-            foreign llvm move('0':wybe.char, ?###0:wybe.char) @ctor_char:nn:nn
+            foreign llvm move('0':wybe.char, ?#result##0:wybe.char) @ctor_char:nn:nn
 
         1:
             foreign llvm lshr(~this##0:ctor_char, 1:ctor_char, ?tmp#6##0:ctor_char)
             foreign llvm and(~tmp#6##0:ctor_char, 255:ctor_char, ?tmp#7##0:ctor_char)
-            foreign lpvm cast(~tmp#7##0:ctor_char, ?###0:wybe.char)
+            foreign lpvm cast(~tmp#7##0:ctor_char, ?#result##0:wybe.char)
 
 
 
 
 other_ctor > public {inline} (0 calls)
 0: ctor_char.other_ctor<0>
-other_ctor(other_ctor#1##0:ctor_char, ?###0:ctor_char):
+other_ctor(other_ctor#1##0:ctor_char, ?#result##0:ctor_char):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:ctor_char)
     foreign lpvm mutate(~#rec##0:ctor_char, ?#rec##1:ctor_char, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~other_ctor#1##0:ctor_char)
-    foreign llvm or(~#rec##1:ctor_char, 1:wybe.int, ?###0:ctor_char)
+    foreign llvm or(~#rec##1:ctor_char, 1:wybe.int, ?#result##0:ctor_char)
 other_ctor > public {inline} (5 calls)
 1: ctor_char.other_ctor<1>
-other_ctor(?other_ctor#1##0:ctor_char, ###0:ctor_char, ?####0:wybe.bool):
+other_ctor(?other_ctor#1##0:ctor_char, #result##0:ctor_char, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:ctor_char, ?other_ctor#1##0:ctor_char)
 
     1:
-        foreign llvm and(###0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm and(#result##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int)
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
@@ -243,7 +243,7 @@ other_ctor(?other_ctor#1##0:ctor_char, ###0:ctor_char, ?####0:wybe.bool):
             foreign llvm move(undef:ctor_char, ?other_ctor#1##0:ctor_char)
 
         1:
-            foreign lpvm access(~###0:ctor_char, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?other_ctor#1##0:ctor_char)
+            foreign lpvm access(~#result##0:ctor_char, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?other_ctor#1##0:ctor_char)
             foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -409,17 +409,17 @@ define external fastcc  i64 @"ctor_char.ctor<0>"(i8  %"c##0")    {
 entry:
   %25 = zext i8 %"c##0" to i64  
   %"1##temp##0" = shl   i64 %25, 1 
-  %"1####3" = or i64 %"1##temp##0", 512 
-  ret i64 %"1####3" 
+  %"1##result##3" = or i64 %"1##temp##0", 512 
+  ret i64 %"1##result##3" 
 }
 
 
-define external fastcc  {i8, i1} @"ctor_char.ctor<1>"(i64  %"###0")    {
+define external fastcc  {i8, i1} @"ctor_char.ctor<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  %"1#tmp#0##0" = icmp ne i64 %"#result##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2#tmp#2##0" = and i64 %"###0", 1 
+  %"2#tmp#2##0" = and i64 %"#result##0", 1 
   %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 0 
   br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
@@ -427,7 +427,7 @@ if.else:
   %32 = insertvalue {i8, i1} %31, i1 0, 1 
   ret {i8, i1} %32 
 if.then1:
-  %"4##temp##0" = lshr  i64 %"###0", 1 
+  %"4##temp##0" = lshr  i64 %"#result##0", 1 
   %"4##temp2##0" = and i64 %"4##temp##0", 255 
   %26 = trunc i64 %"4##temp2##0" to i8  
   %27 = insertvalue {i8, i1} undef, i8 %26, 0 
@@ -468,17 +468,17 @@ entry:
   %37 = inttoptr i64 %36 to i64* 
   %38 = getelementptr  i64, i64* %37, i64 0 
   store  i64 %"other_ctor#1##0", i64* %38 
-  %"1####0" = or i64 %36, 1 
-  ret i64 %"1####0" 
+  %"1##result##0" = or i64 %36, 1 
+  ret i64 %"1##result##0" 
 }
 
 
-define external fastcc  {i64, i1} @"ctor_char.other_ctor<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"ctor_char.other_ctor<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  %"1#tmp#0##0" = icmp ne i64 %"#result##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2#tmp#2##0" = and i64 %"###0", 1 
+  %"2#tmp#2##0" = and i64 %"#result##0", 1 
   %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 1 
   br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
@@ -486,7 +486,7 @@ if.else:
   %48 = insertvalue {i64, i1} %47, i1 0, 1 
   ret {i64, i1} %48 
 if.then1:
-  %39 = add   i64 %"###0", -1 
+  %39 = add   i64 %"#result##0", -1 
   %40 = inttoptr i64 %39 to i64* 
   %41 = getelementptr  i64, i64* %40, i64 0 
   %42 = load  i64, i64* %41 

--- a/test-cases/final-dump/ctor_char2.exp
+++ b/test-cases/final-dump/ctor_char2.exp
@@ -200,8 +200,8 @@ c($rec#0:ctor_char2, ?$rec#2:ctor_char2, $field#0:wybe.char, ?$$#0:wybe.bool):
 
         1:
             foreign llvm and(~$rec#0:ctor_char2, -1021:ctor_char2, ?$rec#1:ctor_char2)
-            foreign llvm shl(~$field#0:ctor_char2, 2:ctor_char2, ?$tmp#0:ctor_char2)
-            foreign llvm or(~$rec#1:ctor_char2, ~$tmp#0:ctor_char2, ?$rec#2:ctor_char2)
+            foreign llvm shl(~$field#0:ctor_char2, 2:ctor_char2, ?$temp#0:ctor_char2)
+            foreign llvm or(~$rec#1:ctor_char2, ~$temp#0:ctor_char2, ?$rec#2:ctor_char2)
             foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
 
 
@@ -512,8 +512,8 @@ if.else:
 if.then1:
   %"4$$rec#1" = and i64 %"$rec#0", -1021 
   %41 = zext i8 %"$field#0" to i64  
-  %"4$$tmp#0" = shl   i64 %41, 2 
-  %"4$$rec#2" = or i64 %"4$$rec#1", %"4$$tmp#0" 
+  %"4$$temp#0" = shl   i64 %41, 2 
+  %"4$$rec#2" = or i64 %"4$$rec#1", %"4$$temp#0" 
   %42 = insertvalue {i64, i1} undef, i64 %"4$$rec#2", 0 
   %43 = insertvalue {i64, i1} %42, i1 1, 1 
   ret {i64, i1} %43 

--- a/test-cases/final-dump/ctor_char2.exp
+++ b/test-cases/final-dump/ctor_char2.exp
@@ -29,13 +29,13 @@ AFTER EVERYTHING:
 
 = > public (3 calls)
 0: ctor_char2.=<0>
-=(#left##0:ctor_char2, #right##0:ctor_char2, ?####0:wybe.bool):
+=(#left##0:ctor_char2, #right##0:ctor_char2, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~#left##0:ctor_char2, ~#right##0:ctor_char2, ?####0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:ctor_char2, ~#right##0:ctor_char2, ?#success##0:wybe.bool)
 
     1:
         foreign llvm and(#left##0:wybe.int, 3:wybe.int, ?tmp#13##0:wybe.int)
@@ -48,25 +48,25 @@ AFTER EVERYTHING:
                 foreign llvm icmp_eq(~tmp#13##0:wybe.int, 2:wybe.int, ?tmp#24##0:wybe.bool)
                 case ~tmp#24##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                 1:
                     foreign lpvm access(~#left##0:ctor_char2, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#left#another_ctor#1##0:ctor_char2)
                     foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#26##0:wybe.bool)
                     case ~tmp#26##0:wybe.bool of
                     0:
-                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                     1:
                         foreign llvm and(#right##0:wybe.int, 3:wybe.int, ?tmp#27##0:wybe.int)
                         foreign llvm icmp_eq(~tmp#27##0:wybe.int, 2:wybe.int, ?tmp#28##0:wybe.bool)
                         case ~tmp#28##0:wybe.bool of
                         0:
-                            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                         1:
                             foreign lpvm access(~#right##0:ctor_char2, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#right#another_ctor#1##0:ctor_char2)
-                            ctor_char2.=<0>(~#left#another_ctor#1##0:ctor_char2, ~#right#another_ctor#1##0:ctor_char2, ?####0:wybe.bool) #8
+                            ctor_char2.=<0>(~#left#another_ctor#1##0:ctor_char2, ~#right#another_ctor#1##0:ctor_char2, ?#success##0:wybe.bool) #8
 
 
 
@@ -76,18 +76,18 @@ AFTER EVERYTHING:
                 foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#22##0:wybe.bool)
                 case ~tmp#22##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                 1:
                     foreign llvm and(#right##0:wybe.int, 3:wybe.int, ?tmp#23##0:wybe.int)
                     foreign llvm icmp_eq(~tmp#23##0:wybe.int, 1:wybe.int, ?tmp#24##0:wybe.bool)
                     case ~tmp#24##0:wybe.bool of
                     0:
-                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                     1:
                         foreign lpvm access(~#right##0:ctor_char2, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#right#other_ctor#1##0:ctor_char2)
-                        ctor_char2.=<0>(~#left#other_ctor#1##0:ctor_char2, ~#right#other_ctor#1##0:ctor_char2, ?####0:wybe.bool) #5
+                        ctor_char2.=<0>(~#left#other_ctor#1##0:ctor_char2, ~#right#other_ctor#1##0:ctor_char2, ?#success##0:wybe.bool) #5
 
 
 
@@ -99,20 +99,20 @@ AFTER EVERYTHING:
             foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#18##0:wybe.bool)
             case ~tmp#18##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
                 foreign llvm and(#right##0:wybe.int, 3:wybe.int, ?tmp#19##0:wybe.int)
                 foreign llvm icmp_eq(~tmp#19##0:wybe.int, 0:wybe.int, ?tmp#20##0:wybe.bool)
                 case ~tmp#20##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                 1:
                     foreign llvm lshr(~#right##0:ctor_char2, 2:ctor_char2, ?tmp#21##0:ctor_char2)
                     foreign llvm and(~tmp#21##0:ctor_char2, 255:ctor_char2, ?tmp#22##0:ctor_char2)
                     foreign lpvm cast(~tmp#22##0:ctor_char2, ?#right#c##0:wybe.char)
-                    foreign llvm icmp_eq(~#left#c##0:wybe.char, ~#right#c##0:wybe.char, ?####0:wybe.bool) @char:nn:nn
+                    foreign llvm icmp_eq(~#left#c##0:wybe.char, ~#right#c##0:wybe.char, ?#success##0:wybe.bool) @char:nn:nn
 
 
 
@@ -129,13 +129,13 @@ another_ctor(another_ctor#1##0:ctor_char2, ?#result##0:ctor_char2):
     foreign llvm or(~#rec##1:ctor_char2, 2:wybe.int, ?#result##0:ctor_char2)
 another_ctor > public {inline} (5 calls)
 1: ctor_char2.another_ctor<1>
-another_ctor(?another_ctor#1##0:ctor_char2, #result##0:ctor_char2, ?####0:wybe.bool):
+another_ctor(?another_ctor#1##0:ctor_char2, #result##0:ctor_char2, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:ctor_char2, ?another_ctor#1##0:ctor_char2)
 
     1:
@@ -143,25 +143,25 @@ another_ctor(?another_ctor#1##0:ctor_char2, #result##0:ctor_char2, ?####0:wybe.b
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 2:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:ctor_char2, ?another_ctor#1##0:ctor_char2)
 
         1:
             foreign lpvm access(~#result##0:ctor_char2, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?another_ctor#1##0:ctor_char2)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 
 c > {inline} (0 calls)
 0: ctor_char2.c<0>
-c(#rec##0:ctor_char2, ?#result##0:wybe.char, ?####0:wybe.bool):
+c(#rec##0:ctor_char2, ?#result##0:wybe.char, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.char, ?#result##0:wybe.char)
 
     1:
@@ -169,25 +169,25 @@ c(#rec##0:ctor_char2, ?#result##0:wybe.char, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.char, ?#result##0:wybe.char)
 
         1:
             foreign llvm lshr(~#rec##0:ctor_char2, 2:ctor_char2, ?#rec##1:ctor_char2)
             foreign llvm and(~#rec##1:ctor_char2, 255:ctor_char2, ?#field##0:ctor_char2)
             foreign lpvm cast(~#field##0:ctor_char2, ?#result##0:wybe.char)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 c > {inline} (0 calls)
 1: ctor_char2.c<1>
-c(#rec##0:ctor_char2, ?#rec##2:ctor_char2, #field##0:wybe.char, ?####0:wybe.bool):
+c(#rec##0:ctor_char2, ?#rec##2:ctor_char2, #field##0:wybe.char, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:ctor_char2, ?#rec##2:ctor_char2)
 
     1:
@@ -195,14 +195,14 @@ c(#rec##0:ctor_char2, ?#rec##2:ctor_char2, #field##0:wybe.char, ?####0:wybe.bool
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(~#rec##0:ctor_char2, ?#rec##2:ctor_char2)
 
         1:
             foreign llvm and(~#rec##0:ctor_char2, -1021:ctor_char2, ?#rec##1:ctor_char2)
             foreign llvm shl(~#field##0:ctor_char2, 2:ctor_char2, ?#temp##0:ctor_char2)
             foreign llvm or(~#rec##1:ctor_char2, ~#temp##0:ctor_char2, ?#rec##2:ctor_char2)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -224,13 +224,13 @@ ctor(c##0:wybe.char, ?#result##3:ctor_char2):
     foreign llvm or(~#temp##0:ctor_char2, 1024:ctor_char2, ?#result##3:ctor_char2)
 ctor > {inline} (15 calls)
 1: ctor_char2.ctor<1>
-ctor(?c##0:wybe.char, #result##0:ctor_char2, ?####0:wybe.bool):
+ctor(?c##0:wybe.char, #result##0:ctor_char2, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.char, ?c##0:wybe.char)
 
     1:
@@ -238,14 +238,14 @@ ctor(?c##0:wybe.char, #result##0:ctor_char2, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.char, ?c##0:wybe.char)
 
         1:
             foreign llvm lshr(~#result##0:ctor_char2, 2:ctor_char2, ?#temp##0:ctor_char2)
             foreign llvm and(~#temp##0:ctor_char2, 255:ctor_char2, ?#temp2##0:ctor_char2)
             foreign lpvm cast(~#temp2##0:ctor_char2, ?c##0:wybe.char)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -285,13 +285,13 @@ other_ctor(other_ctor#1##0:ctor_char2, ?#result##0:ctor_char2):
     foreign llvm or(~#rec##1:ctor_char2, 1:wybe.int, ?#result##0:ctor_char2)
 other_ctor > public {inline} (7 calls)
 1: ctor_char2.other_ctor<1>
-other_ctor(?other_ctor#1##0:ctor_char2, #result##0:ctor_char2, ?####0:wybe.bool):
+other_ctor(?other_ctor#1##0:ctor_char2, #result##0:ctor_char2, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:ctor_char2, ?other_ctor#1##0:ctor_char2)
 
     1:
@@ -299,23 +299,23 @@ other_ctor(?other_ctor#1##0:ctor_char2, #result##0:ctor_char2, ?####0:wybe.bool)
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:ctor_char2, ?other_ctor#1##0:ctor_char2)
 
         1:
             foreign lpvm access(~#result##0:ctor_char2, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?other_ctor#1##0:ctor_char2)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 
 ~= > public {inline} (0 calls)
 0: ctor_char2.~=<0>
-~=(#left##0:ctor_char2, #right##0:ctor_char2, ?####0:wybe.bool):
+~=(#left##0:ctor_char2, #right##0:ctor_char2, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     ctor_char2.=<0>(~#left##0:ctor_char2, ~#right##0:ctor_char2, ?tmp#0##0:wybe.bool) #0
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 
@@ -354,8 +354,8 @@ if.then:
   %"2#tmp#14##0" = icmp eq i64 %"2#tmp#13##0", 0 
   br i1 %"2#tmp#14##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %"3#####0" 
+  %"3##success##0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3##success##0" 
 if.then1:
   %"4#tmp#15##0" = lshr  i64 %"#left##0", 2 
   %"4#tmp#16##0" = and i64 %"4#tmp#15##0", 255 
@@ -375,8 +375,8 @@ if.then3:
   %"8#tmp#21##0" = lshr  i64 %"#right##0", 2 
   %"8#tmp#22##0" = and i64 %"8#tmp#21##0", 255 
   %2 = trunc i64 %"8#tmp#22##0" to i8  
-  %"8#####0" = icmp eq i8 %1, %2 
-  ret i1 %"8#####0" 
+  %"8##success##0" = icmp eq i8 %1, %2 
+  ret i1 %"8##success##0" 
 if.else3:
   ret i1 0 
 if.then4:
@@ -400,8 +400,8 @@ if.then6:
   %8 = inttoptr i64 %7 to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %"14#####0" = tail call fastcc  i1  @"ctor_char2.=<0>"(i64  %6, i64  %10)  
-  ret i1 %"14#####0" 
+  %"14##success##0" = tail call fastcc  i1  @"ctor_char2.=<0>"(i64  %6, i64  %10)  
+  ret i1 %"14##success##0" 
 if.else6:
   ret i1 0 
 if.then7:
@@ -424,8 +424,8 @@ if.then9:
   %16 = inttoptr i64 %15 to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
-  %"20#####0" = tail call fastcc  i1  @"ctor_char2.=<0>"(i64  %14, i64  %18)  
-  ret i1 %"20#####0" 
+  %"20##success##0" = tail call fastcc  i1  @"ctor_char2.=<0>"(i64  %14, i64  %18)  
+  ret i1 %"20##success##0" 
 if.else9:
   ret i1 0 
 }
@@ -628,6 +628,6 @@ if.else1:
 define external fastcc  i1 @"ctor_char2.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %"1#tmp#0##0" = tail call fastcc  i1  @"ctor_char2.=<0>"(i64  %"#left##0", i64  %"#right##0")  
-  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
-  ret i1 %"1#####0" 
+  %"1##success##0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1##success##0" 
 }

--- a/test-cases/final-dump/ctor_char2.exp
+++ b/test-cases/final-dump/ctor_char2.exp
@@ -17,102 +17,102 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: ctor_char2.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm shl('a':ctor_char2, 2:ctor_char2, ?tmp$3#0:ctor_char2)
-    foreign llvm or(~tmp$3#0:ctor_char2, 1024:ctor_char2, ?tmp$1#0:ctor_char2)
-    ctor_char2.foo<0>(~tmp$1#0:ctor_char2, ?tmp$0#0:wybe.char) #1 @ctor_char2:5:10
-    foreign c putchar(~tmp$0#0:wybe.char, ~#io#0:wybe.phantom, ?tmp$6#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$6#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign llvm shl('a':ctor_char2, 2:ctor_char2, ?tmp$3##0:ctor_char2)
+    foreign llvm or(~tmp$3##0:ctor_char2, 1024:ctor_char2, ?tmp$1##0:ctor_char2)
+    ctor_char2.foo<0>(~tmp$1##0:ctor_char2, ?tmp$0##0:wybe.char) #1 @ctor_char2:5:10
+    foreign c putchar(~tmp$0##0:wybe.char, ~#io##0:wybe.phantom, ?tmp$6##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 = > public (3 calls)
 0: ctor_char2.=<0>
-=($left#0:ctor_char2, $right#0:ctor_char2, ?$$#0:wybe.bool):
+=($left##0:ctor_char2, $right##0:ctor_char2, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left#0:ctor_char2, ~$right#0:ctor_char2, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~$left##0:ctor_char2, ~$right##0:ctor_char2, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm and($left#0:wybe.int, 3:wybe.int, ?tmp$13#0:wybe.int)
-        foreign llvm icmp_eq(tmp$13#0:wybe.int, 0:wybe.int, ?tmp$14#0:wybe.bool)
-        case ~tmp$14#0:wybe.bool of
+        foreign llvm and($left##0:wybe.int, 3:wybe.int, ?tmp$13##0:wybe.int)
+        foreign llvm icmp_eq(tmp$13##0:wybe.int, 0:wybe.int, ?tmp$14##0:wybe.bool)
+        case ~tmp$14##0:wybe.bool of
         0:
-            foreign llvm icmp_eq(tmp$13#0:wybe.int, 1:wybe.int, ?tmp$20#0:wybe.bool)
-            case ~tmp$20#0:wybe.bool of
+            foreign llvm icmp_eq(tmp$13##0:wybe.int, 1:wybe.int, ?tmp$20##0:wybe.bool)
+            case ~tmp$20##0:wybe.bool of
             0:
-                foreign llvm icmp_eq(~tmp$13#0:wybe.int, 2:wybe.int, ?tmp$24#0:wybe.bool)
-                case ~tmp$24#0:wybe.bool of
+                foreign llvm icmp_eq(~tmp$13##0:wybe.int, 2:wybe.int, ?tmp$24##0:wybe.bool)
+                case ~tmp$24##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                 1:
-                    foreign lpvm access(~$left#0:ctor_char2, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$left$another_ctor$1#0:ctor_char2)
-                    foreign llvm icmp_ne($right#0:wybe.int, 0:wybe.int, ?tmp$26#0:wybe.bool)
-                    case ~tmp$26#0:wybe.bool of
+                    foreign lpvm access(~$left##0:ctor_char2, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$left$another_ctor$1##0:ctor_char2)
+                    foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$26##0:wybe.bool)
+                    case ~tmp$26##0:wybe.bool of
                     0:
-                        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                     1:
-                        foreign llvm and($right#0:wybe.int, 3:wybe.int, ?tmp$27#0:wybe.int)
-                        foreign llvm icmp_eq(~tmp$27#0:wybe.int, 2:wybe.int, ?tmp$28#0:wybe.bool)
-                        case ~tmp$28#0:wybe.bool of
+                        foreign llvm and($right##0:wybe.int, 3:wybe.int, ?tmp$27##0:wybe.int)
+                        foreign llvm icmp_eq(~tmp$27##0:wybe.int, 2:wybe.int, ?tmp$28##0:wybe.bool)
+                        case ~tmp$28##0:wybe.bool of
                         0:
-                            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                         1:
-                            foreign lpvm access(~$right#0:ctor_char2, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$right$another_ctor$1#0:ctor_char2)
-                            ctor_char2.=<0>(~$left$another_ctor$1#0:ctor_char2, ~$right$another_ctor$1#0:ctor_char2, ?$$#0:wybe.bool) #8
+                            foreign lpvm access(~$right##0:ctor_char2, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$right$another_ctor$1##0:ctor_char2)
+                            ctor_char2.=<0>(~$left$another_ctor$1##0:ctor_char2, ~$right$another_ctor$1##0:ctor_char2, ?$$##0:wybe.bool) #8
 
 
 
 
             1:
-                foreign lpvm access(~$left#0:ctor_char2, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$left$other_ctor$1#0:ctor_char2)
-                foreign llvm icmp_ne($right#0:wybe.int, 0:wybe.int, ?tmp$22#0:wybe.bool)
-                case ~tmp$22#0:wybe.bool of
+                foreign lpvm access(~$left##0:ctor_char2, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$left$other_ctor$1##0:ctor_char2)
+                foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$22##0:wybe.bool)
+                case ~tmp$22##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                 1:
-                    foreign llvm and($right#0:wybe.int, 3:wybe.int, ?tmp$23#0:wybe.int)
-                    foreign llvm icmp_eq(~tmp$23#0:wybe.int, 1:wybe.int, ?tmp$24#0:wybe.bool)
-                    case ~tmp$24#0:wybe.bool of
+                    foreign llvm and($right##0:wybe.int, 3:wybe.int, ?tmp$23##0:wybe.int)
+                    foreign llvm icmp_eq(~tmp$23##0:wybe.int, 1:wybe.int, ?tmp$24##0:wybe.bool)
+                    case ~tmp$24##0:wybe.bool of
                     0:
-                        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                     1:
-                        foreign lpvm access(~$right#0:ctor_char2, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$right$other_ctor$1#0:ctor_char2)
-                        ctor_char2.=<0>(~$left$other_ctor$1#0:ctor_char2, ~$right$other_ctor$1#0:ctor_char2, ?$$#0:wybe.bool) #5
+                        foreign lpvm access(~$right##0:ctor_char2, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$right$other_ctor$1##0:ctor_char2)
+                        ctor_char2.=<0>(~$left$other_ctor$1##0:ctor_char2, ~$right$other_ctor$1##0:ctor_char2, ?$$##0:wybe.bool) #5
 
 
 
 
         1:
-            foreign llvm lshr(~$left#0:ctor_char2, 2:ctor_char2, ?tmp$15#0:ctor_char2)
-            foreign llvm and(~tmp$15#0:ctor_char2, 255:ctor_char2, ?tmp$16#0:ctor_char2)
-            foreign lpvm cast(~tmp$16#0:ctor_char2, ?$left$c#0:wybe.char)
-            foreign llvm icmp_ne($right#0:wybe.int, 0:wybe.int, ?tmp$18#0:wybe.bool)
-            case ~tmp$18#0:wybe.bool of
+            foreign llvm lshr(~$left##0:ctor_char2, 2:ctor_char2, ?tmp$15##0:ctor_char2)
+            foreign llvm and(~tmp$15##0:ctor_char2, 255:ctor_char2, ?tmp$16##0:ctor_char2)
+            foreign lpvm cast(~tmp$16##0:ctor_char2, ?$left$c##0:wybe.char)
+            foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$18##0:wybe.bool)
+            case ~tmp$18##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                foreign llvm and($right#0:wybe.int, 3:wybe.int, ?tmp$19#0:wybe.int)
-                foreign llvm icmp_eq(~tmp$19#0:wybe.int, 0:wybe.int, ?tmp$20#0:wybe.bool)
-                case ~tmp$20#0:wybe.bool of
+                foreign llvm and($right##0:wybe.int, 3:wybe.int, ?tmp$19##0:wybe.int)
+                foreign llvm icmp_eq(~tmp$19##0:wybe.int, 0:wybe.int, ?tmp$20##0:wybe.bool)
+                case ~tmp$20##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                 1:
-                    foreign llvm lshr(~$right#0:ctor_char2, 2:ctor_char2, ?tmp$21#0:ctor_char2)
-                    foreign llvm and(~tmp$21#0:ctor_char2, 255:ctor_char2, ?tmp$22#0:ctor_char2)
-                    foreign lpvm cast(~tmp$22#0:ctor_char2, ?$right$c#0:wybe.char)
-                    foreign llvm icmp_eq(~$left$c#0:wybe.char, ~$right$c#0:wybe.char, ?$$#0:wybe.bool) @char:nn:nn
+                    foreign llvm lshr(~$right##0:ctor_char2, 2:ctor_char2, ?tmp$21##0:ctor_char2)
+                    foreign llvm and(~tmp$21##0:ctor_char2, 255:ctor_char2, ?tmp$22##0:ctor_char2)
+                    foreign lpvm cast(~tmp$22##0:ctor_char2, ?$right$c##0:wybe.char)
+                    foreign llvm icmp_eq(~$left$c##0:wybe.char, ~$right$c##0:wybe.char, ?$$##0:wybe.bool) @char:nn:nn
 
 
 
@@ -121,201 +121,201 @@ AFTER EVERYTHING:
 
 another_ctor > public {inline} (0 calls)
 0: ctor_char2.another_ctor<0>
-another_ctor(another_ctor$1#0:ctor_char2, ?$#0:ctor_char2):
+another_ctor(another_ctor$1##0:ctor_char2, ?$##0:ctor_char2):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec#0:ctor_char2)
-    foreign lpvm mutate(~$rec#0:ctor_char2, ?$rec#1:ctor_char2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~another_ctor$1#0:ctor_char2)
-    foreign llvm or(~$rec#1:ctor_char2, 2:wybe.int, ?$#0:ctor_char2)
+    foreign lpvm alloc(8:wybe.int, ?$rec##0:ctor_char2)
+    foreign lpvm mutate(~$rec##0:ctor_char2, ?$rec##1:ctor_char2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~another_ctor$1##0:ctor_char2)
+    foreign llvm or(~$rec##1:ctor_char2, 2:wybe.int, ?$##0:ctor_char2)
 another_ctor > public {inline} (5 calls)
 1: ctor_char2.another_ctor<1>
-another_ctor(?another_ctor$1#0:ctor_char2, $#0:ctor_char2, ?$$#0:wybe.bool):
+another_ctor(?another_ctor$1##0:ctor_char2, $##0:ctor_char2, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:ctor_char2, ?another_ctor$1#0:ctor_char2)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:ctor_char2, ?another_ctor$1##0:ctor_char2)
 
     1:
-        foreign llvm and($#0:wybe.int, 3:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 2:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 2:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:ctor_char2, ?another_ctor$1#0:ctor_char2)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:ctor_char2, ?another_ctor$1##0:ctor_char2)
 
         1:
-            foreign lpvm access(~$#0:ctor_char2, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?another_ctor$1#0:ctor_char2)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm access(~$##0:ctor_char2, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?another_ctor$1##0:ctor_char2)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 c > {inline} (0 calls)
 0: ctor_char2.c<0>
-c($rec#0:ctor_char2, ?$#0:wybe.char, ?$$#0:wybe.bool):
+c($rec##0:ctor_char2, ?$##0:wybe.char, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.char, ?$#0:wybe.char)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.char, ?$##0:wybe.char)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 3:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.char, ?$#0:wybe.char)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.char, ?$##0:wybe.char)
 
         1:
-            foreign llvm lshr(~$rec#0:ctor_char2, 2:ctor_char2, ?$rec#1:ctor_char2)
-            foreign llvm and(~$rec#1:ctor_char2, 255:ctor_char2, ?$field#0:ctor_char2)
-            foreign lpvm cast(~$field#0:ctor_char2, ?$#0:wybe.char)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm lshr(~$rec##0:ctor_char2, 2:ctor_char2, ?$rec##1:ctor_char2)
+            foreign llvm and(~$rec##1:ctor_char2, 255:ctor_char2, ?$field##0:ctor_char2)
+            foreign lpvm cast(~$field##0:ctor_char2, ?$##0:wybe.char)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 c > {inline} (0 calls)
 1: ctor_char2.c<1>
-c($rec#0:ctor_char2, ?$rec#2:ctor_char2, $field#0:wybe.char, ?$$#0:wybe.bool):
+c($rec##0:ctor_char2, ?$rec##2:ctor_char2, $field##0:wybe.char, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:ctor_char2, ?$rec#2:ctor_char2)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:ctor_char2, ?$rec##2:ctor_char2)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 3:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(~$rec#0:ctor_char2, ?$rec#2:ctor_char2)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(~$rec##0:ctor_char2, ?$rec##2:ctor_char2)
 
         1:
-            foreign llvm and(~$rec#0:ctor_char2, -1021:ctor_char2, ?$rec#1:ctor_char2)
-            foreign llvm shl(~$field#0:ctor_char2, 2:ctor_char2, ?$temp#0:ctor_char2)
-            foreign llvm or(~$rec#1:ctor_char2, ~$temp#0:ctor_char2, ?$rec#2:ctor_char2)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm and(~$rec##0:ctor_char2, -1021:ctor_char2, ?$rec##1:ctor_char2)
+            foreign llvm shl(~$field##0:ctor_char2, 2:ctor_char2, ?$temp##0:ctor_char2)
+            foreign llvm or(~$rec##1:ctor_char2, ~$temp##0:ctor_char2, ?$rec##2:ctor_char2)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 const > {inline} (0 calls)
 0: ctor_char2.const<0>
-const(?$#0:ctor_char2):
+const(?$##0:ctor_char2):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:ctor_char2, ?$#0:ctor_char2)
+    foreign llvm move(0:ctor_char2, ?$##0:ctor_char2)
 
 
 ctor > {inline} (1 calls)
 0: ctor_char2.ctor<0>
-ctor(c#0:wybe.char, ?$#3:ctor_char2):
+ctor(c##0:wybe.char, ?$##3:ctor_char2):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm shl(~c#0:ctor_char2, 2:ctor_char2, ?$temp#0:ctor_char2)
-    foreign llvm or(~$temp#0:ctor_char2, 1024:ctor_char2, ?$#3:ctor_char2)
+    foreign llvm shl(~c##0:ctor_char2, 2:ctor_char2, ?$temp##0:ctor_char2)
+    foreign llvm or(~$temp##0:ctor_char2, 1024:ctor_char2, ?$##3:ctor_char2)
 ctor > {inline} (15 calls)
 1: ctor_char2.ctor<1>
-ctor(?c#0:wybe.char, $#0:ctor_char2, ?$$#0:wybe.bool):
+ctor(?c##0:wybe.char, $##0:ctor_char2, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.char, ?c#0:wybe.char)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.char, ?c##0:wybe.char)
 
     1:
-        foreign llvm and($#0:wybe.int, 3:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.char, ?c#0:wybe.char)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.char, ?c##0:wybe.char)
 
         1:
-            foreign llvm lshr(~$#0:ctor_char2, 2:ctor_char2, ?$temp#0:ctor_char2)
-            foreign llvm and(~$temp#0:ctor_char2, 255:ctor_char2, ?$temp2#0:ctor_char2)
-            foreign lpvm cast(~$temp2#0:ctor_char2, ?c#0:wybe.char)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm lshr(~$##0:ctor_char2, 2:ctor_char2, ?$temp##0:ctor_char2)
+            foreign llvm and(~$temp##0:ctor_char2, 255:ctor_char2, ?$temp2##0:ctor_char2)
+            foreign lpvm cast(~$temp2##0:ctor_char2, ?c##0:wybe.char)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 foo > (1 calls)
 0: ctor_char2.foo<0>
-foo(this#0:ctor_char2, ?$#0:wybe.char):
+foo(this##0:ctor_char2, ?$##0:wybe.char):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(this#0:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.bool)
-    case ~tmp$3#0:wybe.bool of
+    foreign llvm icmp_ne(this##0:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.bool)
+    case ~tmp$3##0:wybe.bool of
     0:
-        foreign llvm move('0':wybe.char, ?$#0:wybe.char) @ctor_char2:3:1
+        foreign llvm move('0':wybe.char, ?$##0:wybe.char) @ctor_char2:3:1
 
     1:
-        foreign llvm and(this#0:wybe.int, 3:wybe.int, ?tmp$4#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.bool)
-        case ~tmp$5#0:wybe.bool of
+        foreign llvm and(this##0:wybe.int, 3:wybe.int, ?tmp$4##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
+        case ~tmp$5##0:wybe.bool of
         0:
-            foreign llvm move('0':wybe.char, ?$#0:wybe.char) @ctor_char2:3:1
+            foreign llvm move('0':wybe.char, ?$##0:wybe.char) @ctor_char2:3:1
 
         1:
-            foreign llvm lshr(~this#0:ctor_char2, 2:ctor_char2, ?tmp$6#0:ctor_char2)
-            foreign llvm and(~tmp$6#0:ctor_char2, 255:ctor_char2, ?tmp$7#0:ctor_char2)
-            foreign lpvm cast(~tmp$7#0:ctor_char2, ?$#0:wybe.char)
+            foreign llvm lshr(~this##0:ctor_char2, 2:ctor_char2, ?tmp$6##0:ctor_char2)
+            foreign llvm and(~tmp$6##0:ctor_char2, 255:ctor_char2, ?tmp$7##0:ctor_char2)
+            foreign lpvm cast(~tmp$7##0:ctor_char2, ?$##0:wybe.char)
 
 
 
 
 other_ctor > public {inline} (0 calls)
 0: ctor_char2.other_ctor<0>
-other_ctor(other_ctor$1#0:ctor_char2, ?$#0:ctor_char2):
+other_ctor(other_ctor$1##0:ctor_char2, ?$##0:ctor_char2):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec#0:ctor_char2)
-    foreign lpvm mutate(~$rec#0:ctor_char2, ?$rec#1:ctor_char2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~other_ctor$1#0:ctor_char2)
-    foreign llvm or(~$rec#1:ctor_char2, 1:wybe.int, ?$#0:ctor_char2)
+    foreign lpvm alloc(8:wybe.int, ?$rec##0:ctor_char2)
+    foreign lpvm mutate(~$rec##0:ctor_char2, ?$rec##1:ctor_char2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~other_ctor$1##0:ctor_char2)
+    foreign llvm or(~$rec##1:ctor_char2, 1:wybe.int, ?$##0:ctor_char2)
 other_ctor > public {inline} (7 calls)
 1: ctor_char2.other_ctor<1>
-other_ctor(?other_ctor$1#0:ctor_char2, $#0:ctor_char2, ?$$#0:wybe.bool):
+other_ctor(?other_ctor$1##0:ctor_char2, $##0:ctor_char2, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:ctor_char2, ?other_ctor$1#0:ctor_char2)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:ctor_char2, ?other_ctor$1##0:ctor_char2)
 
     1:
-        foreign llvm and($#0:wybe.int, 3:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 1:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:ctor_char2, ?other_ctor$1#0:ctor_char2)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:ctor_char2, ?other_ctor$1##0:ctor_char2)
 
         1:
-            foreign lpvm access(~$#0:ctor_char2, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?other_ctor$1#0:ctor_char2)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm access(~$##0:ctor_char2, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?other_ctor$1##0:ctor_char2)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 ~= > public {inline} (0 calls)
 0: ctor_char2.~=<0>
-~=($left#0:ctor_char2, $right#0:ctor_char2, ?$$#0:wybe.bool):
+~=($left##0:ctor_char2, $right##0:ctor_char2, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    ctor_char2.=<0>(~$left#0:ctor_char2, ~$right#0:ctor_char2, ?tmp$0#0:wybe.bool) #0
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    ctor_char2.=<0>(~$left##0:ctor_char2, ~$right##0:ctor_char2, ?tmp$0##0:wybe.bool) #0
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
   LLVM code       :
 
@@ -336,128 +336,128 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"ctor_char2.<0>"()    {
 entry:
-  %"1$tmp$3#0" = shl   i64 97, 2 
-  %"1$tmp$1#0" = or i64 %"1$tmp$3#0", 1024 
-  %"1$tmp$0#0" = tail call fastcc  i8  @"ctor_char2.foo<0>"(i64  %"1$tmp$1#0")  
-  tail call ccc  void  @putchar(i8  %"1$tmp$0#0")  
+  %"1$tmp$3##0" = shl   i64 97, 2 
+  %"1$tmp$1##0" = or i64 %"1$tmp$3##0", 1024 
+  %"1$tmp$0##0" = tail call fastcc  i8  @"ctor_char2.foo<0>"(i64  %"1$tmp$1##0")  
+  tail call ccc  void  @putchar(i8  %"1$tmp$0##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  i1 @"ctor_char2.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"ctor_char2.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$left#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$13#0" = and i64 %"$left#0", 3 
-  %"2$tmp$14#0" = icmp eq i64 %"2$tmp$13#0", 0 
-  br i1 %"2$tmp$14#0", label %if.then1, label %if.else1 
+  %"2$tmp$13##0" = and i64 %"$left##0", 3 
+  %"2$tmp$14##0" = icmp eq i64 %"2$tmp$13##0", 0 
+  br i1 %"2$tmp$14##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = icmp eq i64 %"$left#0", %"$right#0" 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
+  ret i1 %"3$$$##0" 
 if.then1:
-  %"4$tmp$15#0" = lshr  i64 %"$left#0", 2 
-  %"4$tmp$16#0" = and i64 %"4$tmp$15#0", 255 
-  %1 = trunc i64 %"4$tmp$16#0" to i8  
-  %"4$tmp$18#0" = icmp ne i64 %"$right#0", 0 
-  br i1 %"4$tmp$18#0", label %if.then2, label %if.else2 
+  %"4$tmp$15##0" = lshr  i64 %"$left##0", 2 
+  %"4$tmp$16##0" = and i64 %"4$tmp$15##0", 255 
+  %1 = trunc i64 %"4$tmp$16##0" to i8  
+  %"4$tmp$18##0" = icmp ne i64 %"$right##0", 0 
+  br i1 %"4$tmp$18##0", label %if.then2, label %if.else2 
 if.else1:
-  %"5$tmp$20#0" = icmp eq i64 %"2$tmp$13#0", 1 
-  br i1 %"5$tmp$20#0", label %if.then4, label %if.else4 
+  %"5$tmp$20##0" = icmp eq i64 %"2$tmp$13##0", 1 
+  br i1 %"5$tmp$20##0", label %if.then4, label %if.else4 
 if.then2:
-  %"6$tmp$19#0" = and i64 %"$right#0", 3 
-  %"6$tmp$20#0" = icmp eq i64 %"6$tmp$19#0", 0 
-  br i1 %"6$tmp$20#0", label %if.then3, label %if.else3 
+  %"6$tmp$19##0" = and i64 %"$right##0", 3 
+  %"6$tmp$20##0" = icmp eq i64 %"6$tmp$19##0", 0 
+  br i1 %"6$tmp$20##0", label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %"8$tmp$21#0" = lshr  i64 %"$right#0", 2 
-  %"8$tmp$22#0" = and i64 %"8$tmp$21#0", 255 
-  %2 = trunc i64 %"8$tmp$22#0" to i8  
-  %"8$$$#0" = icmp eq i8 %1, %2 
-  ret i1 %"8$$$#0" 
+  %"8$tmp$21##0" = lshr  i64 %"$right##0", 2 
+  %"8$tmp$22##0" = and i64 %"8$tmp$21##0", 255 
+  %2 = trunc i64 %"8$tmp$22##0" to i8  
+  %"8$$$##0" = icmp eq i8 %1, %2 
+  ret i1 %"8$$$##0" 
 if.else3:
   ret i1 0 
 if.then4:
-  %3 = add   i64 %"$left#0", -1 
+  %3 = add   i64 %"$left##0", -1 
   %4 = inttoptr i64 %3 to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
   %6 = load  i64, i64* %5 
-  %"10$tmp$22#0" = icmp ne i64 %"$right#0", 0 
-  br i1 %"10$tmp$22#0", label %if.then5, label %if.else5 
+  %"10$tmp$22##0" = icmp ne i64 %"$right##0", 0 
+  br i1 %"10$tmp$22##0", label %if.then5, label %if.else5 
 if.else4:
-  %"11$tmp$24#0" = icmp eq i64 %"2$tmp$13#0", 2 
-  br i1 %"11$tmp$24#0", label %if.then7, label %if.else7 
+  %"11$tmp$24##0" = icmp eq i64 %"2$tmp$13##0", 2 
+  br i1 %"11$tmp$24##0", label %if.then7, label %if.else7 
 if.then5:
-  %"12$tmp$23#0" = and i64 %"$right#0", 3 
-  %"12$tmp$24#0" = icmp eq i64 %"12$tmp$23#0", 1 
-  br i1 %"12$tmp$24#0", label %if.then6, label %if.else6 
+  %"12$tmp$23##0" = and i64 %"$right##0", 3 
+  %"12$tmp$24##0" = icmp eq i64 %"12$tmp$23##0", 1 
+  br i1 %"12$tmp$24##0", label %if.then6, label %if.else6 
 if.else5:
   ret i1 0 
 if.then6:
-  %7 = add   i64 %"$right#0", -1 
+  %7 = add   i64 %"$right##0", -1 
   %8 = inttoptr i64 %7 to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %"14$$$#0" = tail call fastcc  i1  @"ctor_char2.=<0>"(i64  %6, i64  %10)  
-  ret i1 %"14$$$#0" 
+  %"14$$$##0" = tail call fastcc  i1  @"ctor_char2.=<0>"(i64  %6, i64  %10)  
+  ret i1 %"14$$$##0" 
 if.else6:
   ret i1 0 
 if.then7:
-  %11 = add   i64 %"$left#0", -2 
+  %11 = add   i64 %"$left##0", -2 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"16$tmp$26#0" = icmp ne i64 %"$right#0", 0 
-  br i1 %"16$tmp$26#0", label %if.then8, label %if.else8 
+  %"16$tmp$26##0" = icmp ne i64 %"$right##0", 0 
+  br i1 %"16$tmp$26##0", label %if.then8, label %if.else8 
 if.else7:
   ret i1 0 
 if.then8:
-  %"18$tmp$27#0" = and i64 %"$right#0", 3 
-  %"18$tmp$28#0" = icmp eq i64 %"18$tmp$27#0", 2 
-  br i1 %"18$tmp$28#0", label %if.then9, label %if.else9 
+  %"18$tmp$27##0" = and i64 %"$right##0", 3 
+  %"18$tmp$28##0" = icmp eq i64 %"18$tmp$27##0", 2 
+  br i1 %"18$tmp$28##0", label %if.then9, label %if.else9 
 if.else8:
   ret i1 0 
 if.then9:
-  %15 = add   i64 %"$right#0", -2 
+  %15 = add   i64 %"$right##0", -2 
   %16 = inttoptr i64 %15 to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
-  %"20$$$#0" = tail call fastcc  i1  @"ctor_char2.=<0>"(i64  %14, i64  %18)  
-  ret i1 %"20$$$#0" 
+  %"20$$$##0" = tail call fastcc  i1  @"ctor_char2.=<0>"(i64  %14, i64  %18)  
+  ret i1 %"20$$$##0" 
 if.else9:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"ctor_char2.another_ctor<0>"(i64  %"another_ctor$1#0")    {
+define external fastcc  i64 @"ctor_char2.another_ctor<0>"(i64  %"another_ctor$1##0")    {
 entry:
   %19 = trunc i64 8 to i32  
   %20 = tail call ccc  i8*  @wybe_malloc(i32  %19)  
   %21 = ptrtoint i8* %20 to i64 
   %22 = inttoptr i64 %21 to i64* 
   %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 %"another_ctor$1#0", i64* %23 
-  %"1$$#0" = or i64 %21, 2 
-  ret i64 %"1$$#0" 
+  store  i64 %"another_ctor$1##0", i64* %23 
+  %"1$$##0" = or i64 %21, 2 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  {i64, i1} @"ctor_char2.another_ctor<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"ctor_char2.another_ctor<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$#0", 3 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 2 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$##0", 3 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 2 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %32 = insertvalue {i64, i1} undef, i64 undef, 0 
   %33 = insertvalue {i64, i1} %32, i1 0, 1 
   ret {i64, i1} %33 
 if.then1:
-  %24 = add   i64 %"$#0", -2 
+  %24 = add   i64 %"$##0", -2 
   %25 = inttoptr i64 %24 to i64* 
   %26 = getelementptr  i64, i64* %25, i64 0 
   %27 = load  i64, i64* %26 
@@ -471,22 +471,22 @@ if.else1:
 }
 
 
-define external fastcc  {i8, i1} @"ctor_char2.c<0>"(i64  %"$rec#0")    {
+define external fastcc  {i8, i1} @"ctor_char2.c<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 3 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 0 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 3 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 0 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %39 = insertvalue {i8, i1} undef, i8 undef, 0 
   %40 = insertvalue {i8, i1} %39, i1 0, 1 
   ret {i8, i1} %40 
 if.then1:
-  %"4$$rec#1" = lshr  i64 %"$rec#0", 2 
-  %"4$$field#0" = and i64 %"4$$rec#1", 255 
-  %34 = trunc i64 %"4$$field#0" to i8  
+  %"4$$rec##1" = lshr  i64 %"$rec##0", 2 
+  %"4$$field##0" = and i64 %"4$$rec##1", 255 
+  %34 = trunc i64 %"4$$field##0" to i8  
   %35 = insertvalue {i8, i1} undef, i8 %34, 0 
   %36 = insertvalue {i8, i1} %35, i1 1, 1 
   ret {i8, i1} %36 
@@ -497,28 +497,28 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"ctor_char2.c<1>"(i64  %"$rec#0", i8  %"$field#0")    {
+define external fastcc  {i64, i1} @"ctor_char2.c<1>"(i64  %"$rec##0", i8  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 3 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 0 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 3 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 0 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
-  %46 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %46 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %47 = insertvalue {i64, i1} %46, i1 0, 1 
   ret {i64, i1} %47 
 if.then1:
-  %"4$$rec#1" = and i64 %"$rec#0", -1021 
-  %41 = zext i8 %"$field#0" to i64  
-  %"4$$temp#0" = shl   i64 %41, 2 
-  %"4$$rec#2" = or i64 %"4$$rec#1", %"4$$temp#0" 
-  %42 = insertvalue {i64, i1} undef, i64 %"4$$rec#2", 0 
+  %"4$$rec##1" = and i64 %"$rec##0", -1021 
+  %41 = zext i8 %"$field##0" to i64  
+  %"4$$temp##0" = shl   i64 %41, 2 
+  %"4$$rec##2" = or i64 %"4$$rec##1", %"4$$temp##0" 
+  %42 = insertvalue {i64, i1} undef, i64 %"4$$rec##2", 0 
   %43 = insertvalue {i64, i1} %42, i1 1, 1 
   ret {i64, i1} %43 
 if.else1:
-  %44 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %44 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %45 = insertvalue {i64, i1} %44, i1 0, 1 
   ret {i64, i1} %45 
 }
@@ -530,31 +530,31 @@ entry:
 }
 
 
-define external fastcc  i64 @"ctor_char2.ctor<0>"(i8  %"c#0")    {
+define external fastcc  i64 @"ctor_char2.ctor<0>"(i8  %"c##0")    {
 entry:
-  %48 = zext i8 %"c#0" to i64  
-  %"1$$temp#0" = shl   i64 %48, 2 
-  %"1$$#3" = or i64 %"1$$temp#0", 1024 
-  ret i64 %"1$$#3" 
+  %48 = zext i8 %"c##0" to i64  
+  %"1$$temp##0" = shl   i64 %48, 2 
+  %"1$$##3" = or i64 %"1$$temp##0", 1024 
+  ret i64 %"1$$##3" 
 }
 
 
-define external fastcc  {i8, i1} @"ctor_char2.ctor<1>"(i64  %"$#0")    {
+define external fastcc  {i8, i1} @"ctor_char2.ctor<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$#0", 3 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 0 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$##0", 3 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 0 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %54 = insertvalue {i8, i1} undef, i8 undef, 0 
   %55 = insertvalue {i8, i1} %54, i1 0, 1 
   ret {i8, i1} %55 
 if.then1:
-  %"4$$temp#0" = lshr  i64 %"$#0", 2 
-  %"4$$temp2#0" = and i64 %"4$$temp#0", 255 
-  %49 = trunc i64 %"4$$temp2#0" to i8  
+  %"4$$temp##0" = lshr  i64 %"$##0", 2 
+  %"4$$temp2##0" = and i64 %"4$$temp##0", 255 
+  %49 = trunc i64 %"4$$temp2##0" to i8  
   %50 = insertvalue {i8, i1} undef, i8 %49, 0 
   %51 = insertvalue {i8, i1} %50, i1 1, 1 
   ret {i8, i1} %51 
@@ -565,53 +565,53 @@ if.else1:
 }
 
 
-define external fastcc  i8 @"ctor_char2.foo<0>"(i64  %"this#0")    {
+define external fastcc  i8 @"ctor_char2.foo<0>"(i64  %"this##0")    {
 entry:
-  %"1$tmp$3#0" = icmp ne i64 %"this#0", 0 
-  br i1 %"1$tmp$3#0", label %if.then, label %if.else 
+  %"1$tmp$3##0" = icmp ne i64 %"this##0", 0 
+  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$4#0" = and i64 %"this#0", 3 
-  %"2$tmp$5#0" = icmp eq i64 %"2$tmp$4#0", 0 
-  br i1 %"2$tmp$5#0", label %if.then1, label %if.else1 
+  %"2$tmp$4##0" = and i64 %"this##0", 3 
+  %"2$tmp$5##0" = icmp eq i64 %"2$tmp$4##0", 0 
+  br i1 %"2$tmp$5##0", label %if.then1, label %if.else1 
 if.else:
   ret i8 48 
 if.then1:
-  %"4$tmp$6#0" = lshr  i64 %"this#0", 2 
-  %"4$tmp$7#0" = and i64 %"4$tmp$6#0", 255 
-  %56 = trunc i64 %"4$tmp$7#0" to i8  
+  %"4$tmp$6##0" = lshr  i64 %"this##0", 2 
+  %"4$tmp$7##0" = and i64 %"4$tmp$6##0", 255 
+  %56 = trunc i64 %"4$tmp$7##0" to i8  
   ret i8 %56 
 if.else1:
   ret i8 48 
 }
 
 
-define external fastcc  i64 @"ctor_char2.other_ctor<0>"(i64  %"other_ctor$1#0")    {
+define external fastcc  i64 @"ctor_char2.other_ctor<0>"(i64  %"other_ctor$1##0")    {
 entry:
   %57 = trunc i64 8 to i32  
   %58 = tail call ccc  i8*  @wybe_malloc(i32  %57)  
   %59 = ptrtoint i8* %58 to i64 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
-  store  i64 %"other_ctor$1#0", i64* %61 
-  %"1$$#0" = or i64 %59, 1 
-  ret i64 %"1$$#0" 
+  store  i64 %"other_ctor$1##0", i64* %61 
+  %"1$$##0" = or i64 %59, 1 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  {i64, i1} @"ctor_char2.other_ctor<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"ctor_char2.other_ctor<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$#0", 3 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 1 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$##0", 3 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 1 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %70 = insertvalue {i64, i1} undef, i64 undef, 0 
   %71 = insertvalue {i64, i1} %70, i1 0, 1 
   ret {i64, i1} %71 
 if.then1:
-  %62 = add   i64 %"$#0", -1 
+  %62 = add   i64 %"$##0", -1 
   %63 = inttoptr i64 %62 to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
@@ -625,9 +625,9 @@ if.else1:
 }
 
 
-define external fastcc  i1 @"ctor_char2.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"ctor_char2.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = tail call fastcc  i1  @"ctor_char2.=<0>"(i64  %"$left#0", i64  %"$right#0")  
-  %"1$$$#0" = xor i1 %"1$tmp$0#0", 1 
-  ret i1 %"1$$$#0" 
+  %"1$tmp$0##0" = tail call fastcc  i1  @"ctor_char2.=<0>"(i64  %"$left##0", i64  %"$right##0")  
+  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
+  ret i1 %"1$$$##0" 
 }

--- a/test-cases/final-dump/ctor_char2.exp
+++ b/test-cases/final-dump/ctor_char2.exp
@@ -121,25 +121,25 @@ AFTER EVERYTHING:
 
 another_ctor > public {inline} (0 calls)
 0: ctor_char2.another_ctor<0>
-another_ctor(another_ctor#1##0:ctor_char2, ?###0:ctor_char2):
+another_ctor(another_ctor#1##0:ctor_char2, ?#result##0:ctor_char2):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:ctor_char2)
     foreign lpvm mutate(~#rec##0:ctor_char2, ?#rec##1:ctor_char2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~another_ctor#1##0:ctor_char2)
-    foreign llvm or(~#rec##1:ctor_char2, 2:wybe.int, ?###0:ctor_char2)
+    foreign llvm or(~#rec##1:ctor_char2, 2:wybe.int, ?#result##0:ctor_char2)
 another_ctor > public {inline} (5 calls)
 1: ctor_char2.another_ctor<1>
-another_ctor(?another_ctor#1##0:ctor_char2, ###0:ctor_char2, ?####0:wybe.bool):
+another_ctor(?another_ctor#1##0:ctor_char2, #result##0:ctor_char2, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:ctor_char2, ?another_ctor#1##0:ctor_char2)
 
     1:
-        foreign llvm and(###0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm and(#result##0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 2:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
@@ -147,7 +147,7 @@ another_ctor(?another_ctor#1##0:ctor_char2, ###0:ctor_char2, ?####0:wybe.bool):
             foreign llvm move(undef:ctor_char2, ?another_ctor#1##0:ctor_char2)
 
         1:
-            foreign lpvm access(~###0:ctor_char2, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?another_ctor#1##0:ctor_char2)
+            foreign lpvm access(~#result##0:ctor_char2, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?another_ctor#1##0:ctor_char2)
             foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -155,14 +155,14 @@ another_ctor(?another_ctor#1##0:ctor_char2, ###0:ctor_char2, ?####0:wybe.bool):
 
 c > {inline} (0 calls)
 0: ctor_char2.c<0>
-c(#rec##0:ctor_char2, ?###0:wybe.char, ?####0:wybe.bool):
+c(#rec##0:ctor_char2, ?#result##0:wybe.char, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.char, ?###0:wybe.char)
+        foreign llvm move(undef:wybe.char, ?#result##0:wybe.char)
 
     1:
         foreign llvm and(#rec##0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
@@ -170,12 +170,12 @@ c(#rec##0:ctor_char2, ?###0:wybe.char, ?####0:wybe.bool):
         case ~tmp#1##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-            foreign llvm move(undef:wybe.char, ?###0:wybe.char)
+            foreign llvm move(undef:wybe.char, ?#result##0:wybe.char)
 
         1:
             foreign llvm lshr(~#rec##0:ctor_char2, 2:ctor_char2, ?#rec##1:ctor_char2)
             foreign llvm and(~#rec##1:ctor_char2, 255:ctor_char2, ?#field##0:ctor_char2)
-            foreign lpvm cast(~#field##0:ctor_char2, ?###0:wybe.char)
+            foreign lpvm cast(~#field##0:ctor_char2, ?#result##0:wybe.char)
             foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -209,32 +209,32 @@ c(#rec##0:ctor_char2, ?#rec##2:ctor_char2, #field##0:wybe.char, ?####0:wybe.bool
 
 const > {inline} (0 calls)
 0: ctor_char2.const<0>
-const(?###0:ctor_char2):
+const(?#result##0:ctor_char2):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:ctor_char2, ?###0:ctor_char2)
+    foreign llvm move(0:ctor_char2, ?#result##0:ctor_char2)
 
 
 ctor > {inline} (1 calls)
 0: ctor_char2.ctor<0>
-ctor(c##0:wybe.char, ?###3:ctor_char2):
+ctor(c##0:wybe.char, ?#result##3:ctor_char2):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm shl(~c##0:ctor_char2, 2:ctor_char2, ?#temp##0:ctor_char2)
-    foreign llvm or(~#temp##0:ctor_char2, 1024:ctor_char2, ?###3:ctor_char2)
+    foreign llvm or(~#temp##0:ctor_char2, 1024:ctor_char2, ?#result##3:ctor_char2)
 ctor > {inline} (15 calls)
 1: ctor_char2.ctor<1>
-ctor(?c##0:wybe.char, ###0:ctor_char2, ?####0:wybe.bool):
+ctor(?c##0:wybe.char, #result##0:ctor_char2, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.char, ?c##0:wybe.char)
 
     1:
-        foreign llvm and(###0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm and(#result##0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
@@ -242,7 +242,7 @@ ctor(?c##0:wybe.char, ###0:ctor_char2, ?####0:wybe.bool):
             foreign llvm move(undef:wybe.char, ?c##0:wybe.char)
 
         1:
-            foreign llvm lshr(~###0:ctor_char2, 2:ctor_char2, ?#temp##0:ctor_char2)
+            foreign llvm lshr(~#result##0:ctor_char2, 2:ctor_char2, ?#temp##0:ctor_char2)
             foreign llvm and(~#temp##0:ctor_char2, 255:ctor_char2, ?#temp2##0:ctor_char2)
             foreign lpvm cast(~#temp2##0:ctor_char2, ?c##0:wybe.char)
             foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
@@ -252,50 +252,50 @@ ctor(?c##0:wybe.char, ###0:ctor_char2, ?####0:wybe.bool):
 
 foo > (1 calls)
 0: ctor_char2.foo<0>
-foo(this##0:ctor_char2, ?###0:wybe.char):
+foo(this##0:ctor_char2, ?#result##0:wybe.char):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(this##0:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.bool)
     case ~tmp#3##0:wybe.bool of
     0:
-        foreign llvm move('0':wybe.char, ?###0:wybe.char) @ctor_char2:3:1
+        foreign llvm move('0':wybe.char, ?#result##0:wybe.char) @ctor_char2:3:1
 
     1:
         foreign llvm and(this##0:wybe.int, 3:wybe.int, ?tmp#4##0:wybe.int)
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
         case ~tmp#5##0:wybe.bool of
         0:
-            foreign llvm move('0':wybe.char, ?###0:wybe.char) @ctor_char2:3:1
+            foreign llvm move('0':wybe.char, ?#result##0:wybe.char) @ctor_char2:3:1
 
         1:
             foreign llvm lshr(~this##0:ctor_char2, 2:ctor_char2, ?tmp#6##0:ctor_char2)
             foreign llvm and(~tmp#6##0:ctor_char2, 255:ctor_char2, ?tmp#7##0:ctor_char2)
-            foreign lpvm cast(~tmp#7##0:ctor_char2, ?###0:wybe.char)
+            foreign lpvm cast(~tmp#7##0:ctor_char2, ?#result##0:wybe.char)
 
 
 
 
 other_ctor > public {inline} (0 calls)
 0: ctor_char2.other_ctor<0>
-other_ctor(other_ctor#1##0:ctor_char2, ?###0:ctor_char2):
+other_ctor(other_ctor#1##0:ctor_char2, ?#result##0:ctor_char2):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:ctor_char2)
     foreign lpvm mutate(~#rec##0:ctor_char2, ?#rec##1:ctor_char2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~other_ctor#1##0:ctor_char2)
-    foreign llvm or(~#rec##1:ctor_char2, 1:wybe.int, ?###0:ctor_char2)
+    foreign llvm or(~#rec##1:ctor_char2, 1:wybe.int, ?#result##0:ctor_char2)
 other_ctor > public {inline} (7 calls)
 1: ctor_char2.other_ctor<1>
-other_ctor(?other_ctor#1##0:ctor_char2, ###0:ctor_char2, ?####0:wybe.bool):
+other_ctor(?other_ctor#1##0:ctor_char2, #result##0:ctor_char2, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:ctor_char2, ?other_ctor#1##0:ctor_char2)
 
     1:
-        foreign llvm and(###0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm and(#result##0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
@@ -303,7 +303,7 @@ other_ctor(?other_ctor#1##0:ctor_char2, ###0:ctor_char2, ?####0:wybe.bool):
             foreign llvm move(undef:ctor_char2, ?other_ctor#1##0:ctor_char2)
 
         1:
-            foreign lpvm access(~###0:ctor_char2, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?other_ctor#1##0:ctor_char2)
+            foreign lpvm access(~#result##0:ctor_char2, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?other_ctor#1##0:ctor_char2)
             foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -439,17 +439,17 @@ entry:
   %22 = inttoptr i64 %21 to i64* 
   %23 = getelementptr  i64, i64* %22, i64 0 
   store  i64 %"another_ctor#1##0", i64* %23 
-  %"1####0" = or i64 %21, 2 
-  ret i64 %"1####0" 
+  %"1##result##0" = or i64 %21, 2 
+  ret i64 %"1##result##0" 
 }
 
 
-define external fastcc  {i64, i1} @"ctor_char2.another_ctor<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"ctor_char2.another_ctor<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  %"1#tmp#0##0" = icmp ne i64 %"#result##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2#tmp#2##0" = and i64 %"###0", 3 
+  %"2#tmp#2##0" = and i64 %"#result##0", 3 
   %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 2 
   br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
@@ -457,7 +457,7 @@ if.else:
   %33 = insertvalue {i64, i1} %32, i1 0, 1 
   ret {i64, i1} %33 
 if.then1:
-  %24 = add   i64 %"###0", -2 
+  %24 = add   i64 %"#result##0", -2 
   %25 = inttoptr i64 %24 to i64* 
   %26 = getelementptr  i64, i64* %25, i64 0 
   %27 = load  i64, i64* %26 
@@ -534,17 +534,17 @@ define external fastcc  i64 @"ctor_char2.ctor<0>"(i8  %"c##0")    {
 entry:
   %48 = zext i8 %"c##0" to i64  
   %"1##temp##0" = shl   i64 %48, 2 
-  %"1####3" = or i64 %"1##temp##0", 1024 
-  ret i64 %"1####3" 
+  %"1##result##3" = or i64 %"1##temp##0", 1024 
+  ret i64 %"1##result##3" 
 }
 
 
-define external fastcc  {i8, i1} @"ctor_char2.ctor<1>"(i64  %"###0")    {
+define external fastcc  {i8, i1} @"ctor_char2.ctor<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  %"1#tmp#0##0" = icmp ne i64 %"#result##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2#tmp#2##0" = and i64 %"###0", 3 
+  %"2#tmp#2##0" = and i64 %"#result##0", 3 
   %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 0 
   br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
@@ -552,7 +552,7 @@ if.else:
   %55 = insertvalue {i8, i1} %54, i1 0, 1 
   ret {i8, i1} %55 
 if.then1:
-  %"4##temp##0" = lshr  i64 %"###0", 2 
+  %"4##temp##0" = lshr  i64 %"#result##0", 2 
   %"4##temp2##0" = and i64 %"4##temp##0", 255 
   %49 = trunc i64 %"4##temp2##0" to i8  
   %50 = insertvalue {i8, i1} undef, i8 %49, 0 
@@ -593,17 +593,17 @@ entry:
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   store  i64 %"other_ctor#1##0", i64* %61 
-  %"1####0" = or i64 %59, 1 
-  ret i64 %"1####0" 
+  %"1##result##0" = or i64 %59, 1 
+  ret i64 %"1##result##0" 
 }
 
 
-define external fastcc  {i64, i1} @"ctor_char2.other_ctor<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"ctor_char2.other_ctor<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  %"1#tmp#0##0" = icmp ne i64 %"#result##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2#tmp#2##0" = and i64 %"###0", 3 
+  %"2#tmp#2##0" = and i64 %"#result##0", 3 
   %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 1 
   br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
@@ -611,7 +611,7 @@ if.else:
   %71 = insertvalue {i64, i1} %70, i1 0, 1 
   ret {i64, i1} %71 
 if.then1:
-  %62 = add   i64 %"###0", -1 
+  %62 = add   i64 %"#result##0", -1 
   %63 = inttoptr i64 %62 to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 

--- a/test-cases/final-dump/ctor_char2.exp
+++ b/test-cases/final-dump/ctor_char2.exp
@@ -20,99 +20,99 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm shl('a':ctor_char2, 2:ctor_char2, ?tmp$3##0:ctor_char2)
-    foreign llvm or(~tmp$3##0:ctor_char2, 1024:ctor_char2, ?tmp$1##0:ctor_char2)
-    ctor_char2.foo<0>(~tmp$1##0:ctor_char2, ?tmp$0##0:wybe.char) #1 @ctor_char2:5:10
-    foreign c putchar(~tmp$0##0:wybe.char, ~#io##0:wybe.phantom, ?tmp$6##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign llvm shl('a':ctor_char2, 2:ctor_char2, ?tmp#3##0:ctor_char2)
+    foreign llvm or(~tmp#3##0:ctor_char2, 1024:ctor_char2, ?tmp#1##0:ctor_char2)
+    ctor_char2.foo<0>(~tmp#1##0:ctor_char2, ?tmp#0##0:wybe.char) #1 @ctor_char2:5:10
+    foreign c putchar(~tmp#0##0:wybe.char, ~#io##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 = > public (3 calls)
 0: ctor_char2.=<0>
-=($left##0:ctor_char2, $right##0:ctor_char2, ?$$##0:wybe.bool):
+=(#left##0:ctor_char2, #right##0:ctor_char2, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left##0:ctor_char2, ~$right##0:ctor_char2, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:ctor_char2, ~#right##0:ctor_char2, ?####0:wybe.bool)
 
     1:
-        foreign llvm and($left##0:wybe.int, 3:wybe.int, ?tmp$13##0:wybe.int)
-        foreign llvm icmp_eq(tmp$13##0:wybe.int, 0:wybe.int, ?tmp$14##0:wybe.bool)
-        case ~tmp$14##0:wybe.bool of
+        foreign llvm and(#left##0:wybe.int, 3:wybe.int, ?tmp#13##0:wybe.int)
+        foreign llvm icmp_eq(tmp#13##0:wybe.int, 0:wybe.int, ?tmp#14##0:wybe.bool)
+        case ~tmp#14##0:wybe.bool of
         0:
-            foreign llvm icmp_eq(tmp$13##0:wybe.int, 1:wybe.int, ?tmp$20##0:wybe.bool)
-            case ~tmp$20##0:wybe.bool of
+            foreign llvm icmp_eq(tmp#13##0:wybe.int, 1:wybe.int, ?tmp#20##0:wybe.bool)
+            case ~tmp#20##0:wybe.bool of
             0:
-                foreign llvm icmp_eq(~tmp$13##0:wybe.int, 2:wybe.int, ?tmp$24##0:wybe.bool)
-                case ~tmp$24##0:wybe.bool of
+                foreign llvm icmp_eq(~tmp#13##0:wybe.int, 2:wybe.int, ?tmp#24##0:wybe.bool)
+                case ~tmp#24##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                 1:
-                    foreign lpvm access(~$left##0:ctor_char2, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$left$another_ctor$1##0:ctor_char2)
-                    foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$26##0:wybe.bool)
-                    case ~tmp$26##0:wybe.bool of
+                    foreign lpvm access(~#left##0:ctor_char2, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#left#another_ctor#1##0:ctor_char2)
+                    foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#26##0:wybe.bool)
+                    case ~tmp#26##0:wybe.bool of
                     0:
-                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                     1:
-                        foreign llvm and($right##0:wybe.int, 3:wybe.int, ?tmp$27##0:wybe.int)
-                        foreign llvm icmp_eq(~tmp$27##0:wybe.int, 2:wybe.int, ?tmp$28##0:wybe.bool)
-                        case ~tmp$28##0:wybe.bool of
+                        foreign llvm and(#right##0:wybe.int, 3:wybe.int, ?tmp#27##0:wybe.int)
+                        foreign llvm icmp_eq(~tmp#27##0:wybe.int, 2:wybe.int, ?tmp#28##0:wybe.bool)
+                        case ~tmp#28##0:wybe.bool of
                         0:
-                            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                         1:
-                            foreign lpvm access(~$right##0:ctor_char2, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$right$another_ctor$1##0:ctor_char2)
-                            ctor_char2.=<0>(~$left$another_ctor$1##0:ctor_char2, ~$right$another_ctor$1##0:ctor_char2, ?$$##0:wybe.bool) #8
+                            foreign lpvm access(~#right##0:ctor_char2, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#right#another_ctor#1##0:ctor_char2)
+                            ctor_char2.=<0>(~#left#another_ctor#1##0:ctor_char2, ~#right#another_ctor#1##0:ctor_char2, ?####0:wybe.bool) #8
 
 
 
 
             1:
-                foreign lpvm access(~$left##0:ctor_char2, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$left$other_ctor$1##0:ctor_char2)
-                foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$22##0:wybe.bool)
-                case ~tmp$22##0:wybe.bool of
+                foreign lpvm access(~#left##0:ctor_char2, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#left#other_ctor#1##0:ctor_char2)
+                foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#22##0:wybe.bool)
+                case ~tmp#22##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                 1:
-                    foreign llvm and($right##0:wybe.int, 3:wybe.int, ?tmp$23##0:wybe.int)
-                    foreign llvm icmp_eq(~tmp$23##0:wybe.int, 1:wybe.int, ?tmp$24##0:wybe.bool)
-                    case ~tmp$24##0:wybe.bool of
+                    foreign llvm and(#right##0:wybe.int, 3:wybe.int, ?tmp#23##0:wybe.int)
+                    foreign llvm icmp_eq(~tmp#23##0:wybe.int, 1:wybe.int, ?tmp#24##0:wybe.bool)
+                    case ~tmp#24##0:wybe.bool of
                     0:
-                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                     1:
-                        foreign lpvm access(~$right##0:ctor_char2, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$right$other_ctor$1##0:ctor_char2)
-                        ctor_char2.=<0>(~$left$other_ctor$1##0:ctor_char2, ~$right$other_ctor$1##0:ctor_char2, ?$$##0:wybe.bool) #5
+                        foreign lpvm access(~#right##0:ctor_char2, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#right#other_ctor#1##0:ctor_char2)
+                        ctor_char2.=<0>(~#left#other_ctor#1##0:ctor_char2, ~#right#other_ctor#1##0:ctor_char2, ?####0:wybe.bool) #5
 
 
 
 
         1:
-            foreign llvm lshr(~$left##0:ctor_char2, 2:ctor_char2, ?tmp$15##0:ctor_char2)
-            foreign llvm and(~tmp$15##0:ctor_char2, 255:ctor_char2, ?tmp$16##0:ctor_char2)
-            foreign lpvm cast(~tmp$16##0:ctor_char2, ?$left$c##0:wybe.char)
-            foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$18##0:wybe.bool)
-            case ~tmp$18##0:wybe.bool of
+            foreign llvm lshr(~#left##0:ctor_char2, 2:ctor_char2, ?tmp#15##0:ctor_char2)
+            foreign llvm and(~tmp#15##0:ctor_char2, 255:ctor_char2, ?tmp#16##0:ctor_char2)
+            foreign lpvm cast(~tmp#16##0:ctor_char2, ?#left#c##0:wybe.char)
+            foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#18##0:wybe.bool)
+            case ~tmp#18##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
             1:
-                foreign llvm and($right##0:wybe.int, 3:wybe.int, ?tmp$19##0:wybe.int)
-                foreign llvm icmp_eq(~tmp$19##0:wybe.int, 0:wybe.int, ?tmp$20##0:wybe.bool)
-                case ~tmp$20##0:wybe.bool of
+                foreign llvm and(#right##0:wybe.int, 3:wybe.int, ?tmp#19##0:wybe.int)
+                foreign llvm icmp_eq(~tmp#19##0:wybe.int, 0:wybe.int, ?tmp#20##0:wybe.bool)
+                case ~tmp#20##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                 1:
-                    foreign llvm lshr(~$right##0:ctor_char2, 2:ctor_char2, ?tmp$21##0:ctor_char2)
-                    foreign llvm and(~tmp$21##0:ctor_char2, 255:ctor_char2, ?tmp$22##0:ctor_char2)
-                    foreign lpvm cast(~tmp$22##0:ctor_char2, ?$right$c##0:wybe.char)
-                    foreign llvm icmp_eq(~$left$c##0:wybe.char, ~$right$c##0:wybe.char, ?$$##0:wybe.bool) @char:nn:nn
+                    foreign llvm lshr(~#right##0:ctor_char2, 2:ctor_char2, ?tmp#21##0:ctor_char2)
+                    foreign llvm and(~tmp#21##0:ctor_char2, 255:ctor_char2, ?tmp#22##0:ctor_char2)
+                    foreign lpvm cast(~tmp#22##0:ctor_char2, ?#right#c##0:wybe.char)
+                    foreign llvm icmp_eq(~#left#c##0:wybe.char, ~#right#c##0:wybe.char, ?####0:wybe.bool) @char:nn:nn
 
 
 
@@ -121,201 +121,201 @@ AFTER EVERYTHING:
 
 another_ctor > public {inline} (0 calls)
 0: ctor_char2.another_ctor<0>
-another_ctor(another_ctor$1##0:ctor_char2, ?$##0:ctor_char2):
+another_ctor(another_ctor#1##0:ctor_char2, ?###0:ctor_char2):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec##0:ctor_char2)
-    foreign lpvm mutate(~$rec##0:ctor_char2, ?$rec##1:ctor_char2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~another_ctor$1##0:ctor_char2)
-    foreign llvm or(~$rec##1:ctor_char2, 2:wybe.int, ?$##0:ctor_char2)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:ctor_char2)
+    foreign lpvm mutate(~#rec##0:ctor_char2, ?#rec##1:ctor_char2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~another_ctor#1##0:ctor_char2)
+    foreign llvm or(~#rec##1:ctor_char2, 2:wybe.int, ?###0:ctor_char2)
 another_ctor > public {inline} (5 calls)
 1: ctor_char2.another_ctor<1>
-another_ctor(?another_ctor$1##0:ctor_char2, $##0:ctor_char2, ?$$##0:wybe.bool):
+another_ctor(?another_ctor#1##0:ctor_char2, ###0:ctor_char2, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:ctor_char2, ?another_ctor$1##0:ctor_char2)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:ctor_char2, ?another_ctor#1##0:ctor_char2)
 
     1:
-        foreign llvm and($##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 2:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(###0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 2:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(undef:ctor_char2, ?another_ctor$1##0:ctor_char2)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(undef:ctor_char2, ?another_ctor#1##0:ctor_char2)
 
         1:
-            foreign lpvm access(~$##0:ctor_char2, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?another_ctor$1##0:ctor_char2)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm access(~###0:ctor_char2, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?another_ctor#1##0:ctor_char2)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 c > {inline} (0 calls)
 0: ctor_char2.c<0>
-c($rec##0:ctor_char2, ?$##0:wybe.char, ?$$##0:wybe.bool):
+c(#rec##0:ctor_char2, ?###0:wybe.char, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.char, ?$##0:wybe.char)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.char, ?###0:wybe.char)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(undef:wybe.char, ?$##0:wybe.char)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(undef:wybe.char, ?###0:wybe.char)
 
         1:
-            foreign llvm lshr(~$rec##0:ctor_char2, 2:ctor_char2, ?$rec##1:ctor_char2)
-            foreign llvm and(~$rec##1:ctor_char2, 255:ctor_char2, ?$field##0:ctor_char2)
-            foreign lpvm cast(~$field##0:ctor_char2, ?$##0:wybe.char)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm lshr(~#rec##0:ctor_char2, 2:ctor_char2, ?#rec##1:ctor_char2)
+            foreign llvm and(~#rec##1:ctor_char2, 255:ctor_char2, ?#field##0:ctor_char2)
+            foreign lpvm cast(~#field##0:ctor_char2, ?###0:wybe.char)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 c > {inline} (0 calls)
 1: ctor_char2.c<1>
-c($rec##0:ctor_char2, ?$rec##2:ctor_char2, $field##0:wybe.char, ?$$##0:wybe.bool):
+c(#rec##0:ctor_char2, ?#rec##2:ctor_char2, #field##0:wybe.char, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:ctor_char2, ?$rec##2:ctor_char2)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:ctor_char2, ?#rec##2:ctor_char2)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(~$rec##0:ctor_char2, ?$rec##2:ctor_char2)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(~#rec##0:ctor_char2, ?#rec##2:ctor_char2)
 
         1:
-            foreign llvm and(~$rec##0:ctor_char2, -1021:ctor_char2, ?$rec##1:ctor_char2)
-            foreign llvm shl(~$field##0:ctor_char2, 2:ctor_char2, ?$temp##0:ctor_char2)
-            foreign llvm or(~$rec##1:ctor_char2, ~$temp##0:ctor_char2, ?$rec##2:ctor_char2)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm and(~#rec##0:ctor_char2, -1021:ctor_char2, ?#rec##1:ctor_char2)
+            foreign llvm shl(~#field##0:ctor_char2, 2:ctor_char2, ?#temp##0:ctor_char2)
+            foreign llvm or(~#rec##1:ctor_char2, ~#temp##0:ctor_char2, ?#rec##2:ctor_char2)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 const > {inline} (0 calls)
 0: ctor_char2.const<0>
-const(?$##0:ctor_char2):
+const(?###0:ctor_char2):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:ctor_char2, ?$##0:ctor_char2)
+    foreign llvm move(0:ctor_char2, ?###0:ctor_char2)
 
 
 ctor > {inline} (1 calls)
 0: ctor_char2.ctor<0>
-ctor(c##0:wybe.char, ?$##3:ctor_char2):
+ctor(c##0:wybe.char, ?###3:ctor_char2):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm shl(~c##0:ctor_char2, 2:ctor_char2, ?$temp##0:ctor_char2)
-    foreign llvm or(~$temp##0:ctor_char2, 1024:ctor_char2, ?$##3:ctor_char2)
+    foreign llvm shl(~c##0:ctor_char2, 2:ctor_char2, ?#temp##0:ctor_char2)
+    foreign llvm or(~#temp##0:ctor_char2, 1024:ctor_char2, ?###3:ctor_char2)
 ctor > {inline} (15 calls)
 1: ctor_char2.ctor<1>
-ctor(?c##0:wybe.char, $##0:ctor_char2, ?$$##0:wybe.bool):
+ctor(?c##0:wybe.char, ###0:ctor_char2, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.char, ?c##0:wybe.char)
 
     1:
-        foreign llvm and($##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(###0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
             foreign llvm move(undef:wybe.char, ?c##0:wybe.char)
 
         1:
-            foreign llvm lshr(~$##0:ctor_char2, 2:ctor_char2, ?$temp##0:ctor_char2)
-            foreign llvm and(~$temp##0:ctor_char2, 255:ctor_char2, ?$temp2##0:ctor_char2)
-            foreign lpvm cast(~$temp2##0:ctor_char2, ?c##0:wybe.char)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm lshr(~###0:ctor_char2, 2:ctor_char2, ?#temp##0:ctor_char2)
+            foreign llvm and(~#temp##0:ctor_char2, 255:ctor_char2, ?#temp2##0:ctor_char2)
+            foreign lpvm cast(~#temp2##0:ctor_char2, ?c##0:wybe.char)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 foo > (1 calls)
 0: ctor_char2.foo<0>
-foo(this##0:ctor_char2, ?$##0:wybe.char):
+foo(this##0:ctor_char2, ?###0:wybe.char):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(this##0:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.bool)
-    case ~tmp$3##0:wybe.bool of
+    foreign llvm icmp_ne(this##0:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.bool)
+    case ~tmp#3##0:wybe.bool of
     0:
-        foreign llvm move('0':wybe.char, ?$##0:wybe.char) @ctor_char2:3:1
+        foreign llvm move('0':wybe.char, ?###0:wybe.char) @ctor_char2:3:1
 
     1:
-        foreign llvm and(this##0:wybe.int, 3:wybe.int, ?tmp$4##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
-        case ~tmp$5##0:wybe.bool of
+        foreign llvm and(this##0:wybe.int, 3:wybe.int, ?tmp#4##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
+        case ~tmp#5##0:wybe.bool of
         0:
-            foreign llvm move('0':wybe.char, ?$##0:wybe.char) @ctor_char2:3:1
+            foreign llvm move('0':wybe.char, ?###0:wybe.char) @ctor_char2:3:1
 
         1:
-            foreign llvm lshr(~this##0:ctor_char2, 2:ctor_char2, ?tmp$6##0:ctor_char2)
-            foreign llvm and(~tmp$6##0:ctor_char2, 255:ctor_char2, ?tmp$7##0:ctor_char2)
-            foreign lpvm cast(~tmp$7##0:ctor_char2, ?$##0:wybe.char)
+            foreign llvm lshr(~this##0:ctor_char2, 2:ctor_char2, ?tmp#6##0:ctor_char2)
+            foreign llvm and(~tmp#6##0:ctor_char2, 255:ctor_char2, ?tmp#7##0:ctor_char2)
+            foreign lpvm cast(~tmp#7##0:ctor_char2, ?###0:wybe.char)
 
 
 
 
 other_ctor > public {inline} (0 calls)
 0: ctor_char2.other_ctor<0>
-other_ctor(other_ctor$1##0:ctor_char2, ?$##0:ctor_char2):
+other_ctor(other_ctor#1##0:ctor_char2, ?###0:ctor_char2):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec##0:ctor_char2)
-    foreign lpvm mutate(~$rec##0:ctor_char2, ?$rec##1:ctor_char2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~other_ctor$1##0:ctor_char2)
-    foreign llvm or(~$rec##1:ctor_char2, 1:wybe.int, ?$##0:ctor_char2)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:ctor_char2)
+    foreign lpvm mutate(~#rec##0:ctor_char2, ?#rec##1:ctor_char2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~other_ctor#1##0:ctor_char2)
+    foreign llvm or(~#rec##1:ctor_char2, 1:wybe.int, ?###0:ctor_char2)
 other_ctor > public {inline} (7 calls)
 1: ctor_char2.other_ctor<1>
-other_ctor(?other_ctor$1##0:ctor_char2, $##0:ctor_char2, ?$$##0:wybe.bool):
+other_ctor(?other_ctor#1##0:ctor_char2, ###0:ctor_char2, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:ctor_char2, ?other_ctor$1##0:ctor_char2)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:ctor_char2, ?other_ctor#1##0:ctor_char2)
 
     1:
-        foreign llvm and($##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(###0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(undef:ctor_char2, ?other_ctor$1##0:ctor_char2)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(undef:ctor_char2, ?other_ctor#1##0:ctor_char2)
 
         1:
-            foreign lpvm access(~$##0:ctor_char2, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?other_ctor$1##0:ctor_char2)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm access(~###0:ctor_char2, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?other_ctor#1##0:ctor_char2)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 ~= > public {inline} (0 calls)
 0: ctor_char2.~=<0>
-~=($left##0:ctor_char2, $right##0:ctor_char2, ?$$##0:wybe.bool):
+~=(#left##0:ctor_char2, #right##0:ctor_char2, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    ctor_char2.=<0>(~$left##0:ctor_char2, ~$right##0:ctor_char2, ?tmp$0##0:wybe.bool) #0
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    ctor_char2.=<0>(~#left##0:ctor_char2, ~#right##0:ctor_char2, ?tmp#0##0:wybe.bool) #0
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
   LLVM code       :
 
@@ -336,128 +336,128 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"ctor_char2.<0>"()    {
 entry:
-  %"1$tmp$3##0" = shl   i64 97, 2 
-  %"1$tmp$1##0" = or i64 %"1$tmp$3##0", 1024 
-  %"1$tmp$0##0" = tail call fastcc  i8  @"ctor_char2.foo<0>"(i64  %"1$tmp$1##0")  
-  tail call ccc  void  @putchar(i8  %"1$tmp$0##0")  
+  %"1#tmp#3##0" = shl   i64 97, 2 
+  %"1#tmp#1##0" = or i64 %"1#tmp#3##0", 1024 
+  %"1#tmp#0##0" = tail call fastcc  i8  @"ctor_char2.foo<0>"(i64  %"1#tmp#1##0")  
+  tail call ccc  void  @putchar(i8  %"1#tmp#0##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  i1 @"ctor_char2.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"ctor_char2.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#left##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$13##0" = and i64 %"$left##0", 3 
-  %"2$tmp$14##0" = icmp eq i64 %"2$tmp$13##0", 0 
-  br i1 %"2$tmp$14##0", label %if.then1, label %if.else1 
+  %"2#tmp#13##0" = and i64 %"#left##0", 3 
+  %"2#tmp#14##0" = icmp eq i64 %"2#tmp#13##0", 0 
+  br i1 %"2#tmp#14##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3#####0" 
 if.then1:
-  %"4$tmp$15##0" = lshr  i64 %"$left##0", 2 
-  %"4$tmp$16##0" = and i64 %"4$tmp$15##0", 255 
-  %1 = trunc i64 %"4$tmp$16##0" to i8  
-  %"4$tmp$18##0" = icmp ne i64 %"$right##0", 0 
-  br i1 %"4$tmp$18##0", label %if.then2, label %if.else2 
+  %"4#tmp#15##0" = lshr  i64 %"#left##0", 2 
+  %"4#tmp#16##0" = and i64 %"4#tmp#15##0", 255 
+  %1 = trunc i64 %"4#tmp#16##0" to i8  
+  %"4#tmp#18##0" = icmp ne i64 %"#right##0", 0 
+  br i1 %"4#tmp#18##0", label %if.then2, label %if.else2 
 if.else1:
-  %"5$tmp$20##0" = icmp eq i64 %"2$tmp$13##0", 1 
-  br i1 %"5$tmp$20##0", label %if.then4, label %if.else4 
+  %"5#tmp#20##0" = icmp eq i64 %"2#tmp#13##0", 1 
+  br i1 %"5#tmp#20##0", label %if.then4, label %if.else4 
 if.then2:
-  %"6$tmp$19##0" = and i64 %"$right##0", 3 
-  %"6$tmp$20##0" = icmp eq i64 %"6$tmp$19##0", 0 
-  br i1 %"6$tmp$20##0", label %if.then3, label %if.else3 
+  %"6#tmp#19##0" = and i64 %"#right##0", 3 
+  %"6#tmp#20##0" = icmp eq i64 %"6#tmp#19##0", 0 
+  br i1 %"6#tmp#20##0", label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %"8$tmp$21##0" = lshr  i64 %"$right##0", 2 
-  %"8$tmp$22##0" = and i64 %"8$tmp$21##0", 255 
-  %2 = trunc i64 %"8$tmp$22##0" to i8  
-  %"8$$$##0" = icmp eq i8 %1, %2 
-  ret i1 %"8$$$##0" 
+  %"8#tmp#21##0" = lshr  i64 %"#right##0", 2 
+  %"8#tmp#22##0" = and i64 %"8#tmp#21##0", 255 
+  %2 = trunc i64 %"8#tmp#22##0" to i8  
+  %"8#####0" = icmp eq i8 %1, %2 
+  ret i1 %"8#####0" 
 if.else3:
   ret i1 0 
 if.then4:
-  %3 = add   i64 %"$left##0", -1 
+  %3 = add   i64 %"#left##0", -1 
   %4 = inttoptr i64 %3 to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
   %6 = load  i64, i64* %5 
-  %"10$tmp$22##0" = icmp ne i64 %"$right##0", 0 
-  br i1 %"10$tmp$22##0", label %if.then5, label %if.else5 
+  %"10#tmp#22##0" = icmp ne i64 %"#right##0", 0 
+  br i1 %"10#tmp#22##0", label %if.then5, label %if.else5 
 if.else4:
-  %"11$tmp$24##0" = icmp eq i64 %"2$tmp$13##0", 2 
-  br i1 %"11$tmp$24##0", label %if.then7, label %if.else7 
+  %"11#tmp#24##0" = icmp eq i64 %"2#tmp#13##0", 2 
+  br i1 %"11#tmp#24##0", label %if.then7, label %if.else7 
 if.then5:
-  %"12$tmp$23##0" = and i64 %"$right##0", 3 
-  %"12$tmp$24##0" = icmp eq i64 %"12$tmp$23##0", 1 
-  br i1 %"12$tmp$24##0", label %if.then6, label %if.else6 
+  %"12#tmp#23##0" = and i64 %"#right##0", 3 
+  %"12#tmp#24##0" = icmp eq i64 %"12#tmp#23##0", 1 
+  br i1 %"12#tmp#24##0", label %if.then6, label %if.else6 
 if.else5:
   ret i1 0 
 if.then6:
-  %7 = add   i64 %"$right##0", -1 
+  %7 = add   i64 %"#right##0", -1 
   %8 = inttoptr i64 %7 to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %"14$$$##0" = tail call fastcc  i1  @"ctor_char2.=<0>"(i64  %6, i64  %10)  
-  ret i1 %"14$$$##0" 
+  %"14#####0" = tail call fastcc  i1  @"ctor_char2.=<0>"(i64  %6, i64  %10)  
+  ret i1 %"14#####0" 
 if.else6:
   ret i1 0 
 if.then7:
-  %11 = add   i64 %"$left##0", -2 
+  %11 = add   i64 %"#left##0", -2 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"16$tmp$26##0" = icmp ne i64 %"$right##0", 0 
-  br i1 %"16$tmp$26##0", label %if.then8, label %if.else8 
+  %"16#tmp#26##0" = icmp ne i64 %"#right##0", 0 
+  br i1 %"16#tmp#26##0", label %if.then8, label %if.else8 
 if.else7:
   ret i1 0 
 if.then8:
-  %"18$tmp$27##0" = and i64 %"$right##0", 3 
-  %"18$tmp$28##0" = icmp eq i64 %"18$tmp$27##0", 2 
-  br i1 %"18$tmp$28##0", label %if.then9, label %if.else9 
+  %"18#tmp#27##0" = and i64 %"#right##0", 3 
+  %"18#tmp#28##0" = icmp eq i64 %"18#tmp#27##0", 2 
+  br i1 %"18#tmp#28##0", label %if.then9, label %if.else9 
 if.else8:
   ret i1 0 
 if.then9:
-  %15 = add   i64 %"$right##0", -2 
+  %15 = add   i64 %"#right##0", -2 
   %16 = inttoptr i64 %15 to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
-  %"20$$$##0" = tail call fastcc  i1  @"ctor_char2.=<0>"(i64  %14, i64  %18)  
-  ret i1 %"20$$$##0" 
+  %"20#####0" = tail call fastcc  i1  @"ctor_char2.=<0>"(i64  %14, i64  %18)  
+  ret i1 %"20#####0" 
 if.else9:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"ctor_char2.another_ctor<0>"(i64  %"another_ctor$1##0")    {
+define external fastcc  i64 @"ctor_char2.another_ctor<0>"(i64  %"another_ctor#1##0")    {
 entry:
   %19 = trunc i64 8 to i32  
   %20 = tail call ccc  i8*  @wybe_malloc(i32  %19)  
   %21 = ptrtoint i8* %20 to i64 
   %22 = inttoptr i64 %21 to i64* 
   %23 = getelementptr  i64, i64* %22, i64 0 
-  store  i64 %"another_ctor$1##0", i64* %23 
-  %"1$$##0" = or i64 %21, 2 
-  ret i64 %"1$$##0" 
+  store  i64 %"another_ctor#1##0", i64* %23 
+  %"1####0" = or i64 %21, 2 
+  ret i64 %"1####0" 
 }
 
 
-define external fastcc  {i64, i1} @"ctor_char2.another_ctor<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"ctor_char2.another_ctor<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$##0", 3 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 2 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"###0", 3 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 2 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %32 = insertvalue {i64, i1} undef, i64 undef, 0 
   %33 = insertvalue {i64, i1} %32, i1 0, 1 
   ret {i64, i1} %33 
 if.then1:
-  %24 = add   i64 %"$##0", -2 
+  %24 = add   i64 %"###0", -2 
   %25 = inttoptr i64 %24 to i64* 
   %26 = getelementptr  i64, i64* %25, i64 0 
   %27 = load  i64, i64* %26 
@@ -471,22 +471,22 @@ if.else1:
 }
 
 
-define external fastcc  {i8, i1} @"ctor_char2.c<0>"(i64  %"$rec##0")    {
+define external fastcc  {i8, i1} @"ctor_char2.c<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 3 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 0 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 3 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 0 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %39 = insertvalue {i8, i1} undef, i8 undef, 0 
   %40 = insertvalue {i8, i1} %39, i1 0, 1 
   ret {i8, i1} %40 
 if.then1:
-  %"4$$rec##1" = lshr  i64 %"$rec##0", 2 
-  %"4$$field##0" = and i64 %"4$$rec##1", 255 
-  %34 = trunc i64 %"4$$field##0" to i8  
+  %"4##rec##1" = lshr  i64 %"#rec##0", 2 
+  %"4##field##0" = and i64 %"4##rec##1", 255 
+  %34 = trunc i64 %"4##field##0" to i8  
   %35 = insertvalue {i8, i1} undef, i8 %34, 0 
   %36 = insertvalue {i8, i1} %35, i1 1, 1 
   ret {i8, i1} %36 
@@ -497,28 +497,28 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"ctor_char2.c<1>"(i64  %"$rec##0", i8  %"$field##0")    {
+define external fastcc  {i64, i1} @"ctor_char2.c<1>"(i64  %"#rec##0", i8  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 3 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 0 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 3 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 0 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
-  %46 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %46 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %47 = insertvalue {i64, i1} %46, i1 0, 1 
   ret {i64, i1} %47 
 if.then1:
-  %"4$$rec##1" = and i64 %"$rec##0", -1021 
-  %41 = zext i8 %"$field##0" to i64  
-  %"4$$temp##0" = shl   i64 %41, 2 
-  %"4$$rec##2" = or i64 %"4$$rec##1", %"4$$temp##0" 
-  %42 = insertvalue {i64, i1} undef, i64 %"4$$rec##2", 0 
+  %"4##rec##1" = and i64 %"#rec##0", -1021 
+  %41 = zext i8 %"#field##0" to i64  
+  %"4##temp##0" = shl   i64 %41, 2 
+  %"4##rec##2" = or i64 %"4##rec##1", %"4##temp##0" 
+  %42 = insertvalue {i64, i1} undef, i64 %"4##rec##2", 0 
   %43 = insertvalue {i64, i1} %42, i1 1, 1 
   ret {i64, i1} %43 
 if.else1:
-  %44 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %44 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %45 = insertvalue {i64, i1} %44, i1 0, 1 
   ret {i64, i1} %45 
 }
@@ -533,28 +533,28 @@ entry:
 define external fastcc  i64 @"ctor_char2.ctor<0>"(i8  %"c##0")    {
 entry:
   %48 = zext i8 %"c##0" to i64  
-  %"1$$temp##0" = shl   i64 %48, 2 
-  %"1$$##3" = or i64 %"1$$temp##0", 1024 
-  ret i64 %"1$$##3" 
+  %"1##temp##0" = shl   i64 %48, 2 
+  %"1####3" = or i64 %"1##temp##0", 1024 
+  ret i64 %"1####3" 
 }
 
 
-define external fastcc  {i8, i1} @"ctor_char2.ctor<1>"(i64  %"$##0")    {
+define external fastcc  {i8, i1} @"ctor_char2.ctor<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$##0", 3 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 0 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"###0", 3 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 0 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %54 = insertvalue {i8, i1} undef, i8 undef, 0 
   %55 = insertvalue {i8, i1} %54, i1 0, 1 
   ret {i8, i1} %55 
 if.then1:
-  %"4$$temp##0" = lshr  i64 %"$##0", 2 
-  %"4$$temp2##0" = and i64 %"4$$temp##0", 255 
-  %49 = trunc i64 %"4$$temp2##0" to i8  
+  %"4##temp##0" = lshr  i64 %"###0", 2 
+  %"4##temp2##0" = and i64 %"4##temp##0", 255 
+  %49 = trunc i64 %"4##temp2##0" to i8  
   %50 = insertvalue {i8, i1} undef, i8 %49, 0 
   %51 = insertvalue {i8, i1} %50, i1 1, 1 
   ret {i8, i1} %51 
@@ -567,51 +567,51 @@ if.else1:
 
 define external fastcc  i8 @"ctor_char2.foo<0>"(i64  %"this##0")    {
 entry:
-  %"1$tmp$3##0" = icmp ne i64 %"this##0", 0 
-  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
+  %"1#tmp#3##0" = icmp ne i64 %"this##0", 0 
+  br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$4##0" = and i64 %"this##0", 3 
-  %"2$tmp$5##0" = icmp eq i64 %"2$tmp$4##0", 0 
-  br i1 %"2$tmp$5##0", label %if.then1, label %if.else1 
+  %"2#tmp#4##0" = and i64 %"this##0", 3 
+  %"2#tmp#5##0" = icmp eq i64 %"2#tmp#4##0", 0 
+  br i1 %"2#tmp#5##0", label %if.then1, label %if.else1 
 if.else:
   ret i8 48 
 if.then1:
-  %"4$tmp$6##0" = lshr  i64 %"this##0", 2 
-  %"4$tmp$7##0" = and i64 %"4$tmp$6##0", 255 
-  %56 = trunc i64 %"4$tmp$7##0" to i8  
+  %"4#tmp#6##0" = lshr  i64 %"this##0", 2 
+  %"4#tmp#7##0" = and i64 %"4#tmp#6##0", 255 
+  %56 = trunc i64 %"4#tmp#7##0" to i8  
   ret i8 %56 
 if.else1:
   ret i8 48 
 }
 
 
-define external fastcc  i64 @"ctor_char2.other_ctor<0>"(i64  %"other_ctor$1##0")    {
+define external fastcc  i64 @"ctor_char2.other_ctor<0>"(i64  %"other_ctor#1##0")    {
 entry:
   %57 = trunc i64 8 to i32  
   %58 = tail call ccc  i8*  @wybe_malloc(i32  %57)  
   %59 = ptrtoint i8* %58 to i64 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
-  store  i64 %"other_ctor$1##0", i64* %61 
-  %"1$$##0" = or i64 %59, 1 
-  ret i64 %"1$$##0" 
+  store  i64 %"other_ctor#1##0", i64* %61 
+  %"1####0" = or i64 %59, 1 
+  ret i64 %"1####0" 
 }
 
 
-define external fastcc  {i64, i1} @"ctor_char2.other_ctor<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"ctor_char2.other_ctor<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$##0", 3 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 1 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"###0", 3 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 1 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %70 = insertvalue {i64, i1} undef, i64 undef, 0 
   %71 = insertvalue {i64, i1} %70, i1 0, 1 
   ret {i64, i1} %71 
 if.then1:
-  %62 = add   i64 %"$##0", -1 
+  %62 = add   i64 %"###0", -1 
   %63 = inttoptr i64 %62 to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
@@ -625,9 +625,9 @@ if.else1:
 }
 
 
-define external fastcc  i1 @"ctor_char2.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"ctor_char2.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = tail call fastcc  i1  @"ctor_char2.=<0>"(i64  %"$left##0", i64  %"$right##0")  
-  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
-  ret i1 %"1$$$##0" 
+  %"1#tmp#0##0" = tail call fastcc  i1  @"ctor_char2.=<0>"(i64  %"#left##0", i64  %"#right##0")  
+  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1#####0" 
 }

--- a/test-cases/final-dump/ddd.exp
+++ b/test-cases/final-dump/ddd.exp
@@ -11,11 +11,11 @@ AFTER EVERYTHING:
 
 *main* > public {inline} (0 calls)
 0: ddd.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("DDD: Init":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_string("DDD: Init":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/ddd.exp
+++ b/test-cases/final-dump/ddd.exp
@@ -14,8 +14,8 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("DDD: Init":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("DDD: Init":wybe.string, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/dead_cell_size.exp
+++ b/test-cases/final-dump/dead_cell_size.exp
@@ -46,228 +46,228 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: dead_cell_size.<0>
-(io#0:wybe.phantom, ?io#3:wybe.phantom):
+(io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(4,(dead_cell_size.bar<0>,fromList [NonAliasedParamCond 0 []])),(7,(dead_cell_size.diff_type<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm alloc(8:wybe.int, ?tmp$7#0:dead_cell_size.t)
-    foreign lpvm mutate(~tmp$7#0:dead_cell_size.t, ?tmp$8#0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 9:wybe.int)
-    dead_cell_size.foo<0>(~tmp$8#0:dead_cell_size.t, ?tmp$0#0:dead_cell_size.t) #1 @dead_cell_size:nn:nn
-    dead_cell_size.print_t<0>(~tmp$0#0:dead_cell_size.t, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #2 @dead_cell_size:nn:nn
-    foreign lpvm alloc(8:wybe.int, ?tmp$10#0:dead_cell_size.t)
-    foreign lpvm mutate(~tmp$10#0:dead_cell_size.t, ?tmp$11#0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 9:wybe.int)
-    dead_cell_size.bar<0>[410bae77d3](~tmp$11#0:dead_cell_size.t, ?tmp$2#0:dead_cell_size.t) #4 @dead_cell_size:nn:nn
-    dead_cell_size.print_t<0>(~tmp$2#0:dead_cell_size.t, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #5 @dead_cell_size:nn:nn
-    foreign lpvm alloc(8:wybe.int, ?tmp$13#0:dead_cell_size.t)
-    foreign lpvm mutate(~tmp$13#0:dead_cell_size.t, ?tmp$14#0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 9:wybe.int)
-    dead_cell_size.diff_type<0>[410bae77d3](~tmp$14#0:dead_cell_size.t, ?tmp$4#0:dead_cell_size.t2) #7 @dead_cell_size:nn:nn
-    dead_cell_size.print_t2<0>(~tmp$4#0:dead_cell_size.t2, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) #8 @dead_cell_size:nn:nn
+    foreign lpvm alloc(8:wybe.int, ?tmp$7##0:dead_cell_size.t)
+    foreign lpvm mutate(~tmp$7##0:dead_cell_size.t, ?tmp$8##0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 9:wybe.int)
+    dead_cell_size.foo<0>(~tmp$8##0:dead_cell_size.t, ?tmp$0##0:dead_cell_size.t) #1 @dead_cell_size:nn:nn
+    dead_cell_size.print_t<0>(~tmp$0##0:dead_cell_size.t, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @dead_cell_size:nn:nn
+    foreign lpvm alloc(8:wybe.int, ?tmp$10##0:dead_cell_size.t)
+    foreign lpvm mutate(~tmp$10##0:dead_cell_size.t, ?tmp$11##0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 9:wybe.int)
+    dead_cell_size.bar<0>[410bae77d3](~tmp$11##0:dead_cell_size.t, ?tmp$2##0:dead_cell_size.t) #4 @dead_cell_size:nn:nn
+    dead_cell_size.print_t<0>(~tmp$2##0:dead_cell_size.t, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #5 @dead_cell_size:nn:nn
+    foreign lpvm alloc(8:wybe.int, ?tmp$13##0:dead_cell_size.t)
+    foreign lpvm mutate(~tmp$13##0:dead_cell_size.t, ?tmp$14##0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 9:wybe.int)
+    dead_cell_size.diff_type<0>[410bae77d3](~tmp$14##0:dead_cell_size.t, ?tmp$4##0:dead_cell_size.t2) #7 @dead_cell_size:nn:nn
+    dead_cell_size.print_t2<0>(~tmp$4##0:dead_cell_size.t2, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #8 @dead_cell_size:nn:nn
 
 
 bar > public (1 calls)
 0: dead_cell_size.bar<0>[410bae77d3]
-bar(x#0:dead_cell_size.t, ?x#1:dead_cell_size.t):
- AliasPairs: [(x#0,x#1)]
+bar(x##0:dead_cell_size.t, ?x##1:dead_cell_size.t):
+ AliasPairs: [(x##0,x##1)]
  InterestingCallProperties: [InterestingUnaliased 0]
-    foreign llvm icmp_ne(x#0:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.bool)
-    case ~tmp$3#0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.bool)
+    case ~tmp$3##0:wybe.bool of
     0:
-        foreign llvm move(~x#0:dead_cell_size.t, ?x#1:dead_cell_size.t)
+        foreign llvm move(~x##0:dead_cell_size.t, ?x##1:dead_cell_size.t)
 
     1:
-        foreign llvm and(x#0:wybe.int, 3:wybe.int, ?tmp$4#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.bool)
-        case ~tmp$5#0:wybe.bool of
+        foreign llvm and(x##0:wybe.int, 3:wybe.int, ?tmp$4##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
+        case ~tmp$5##0:wybe.bool of
         0:
-            foreign llvm move(~x#0:dead_cell_size.t, ?x#1:dead_cell_size.t)
+            foreign llvm move(~x##0:dead_cell_size.t, ?x##1:dead_cell_size.t)
 
         1:
-            foreign lpvm access(~x#0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a#0:wybe.int)
-            foreign lpvm alloc(8:wybe.int, ?tmp$7#0:dead_cell_size.t)
-            foreign lpvm mutate(~tmp$7#0:dead_cell_size.t, ?tmp$8#0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~a#0:wybe.int)
-            foreign llvm or(~tmp$8#0:dead_cell_size.t, 2:wybe.int, ?x#1:dead_cell_size.t)
+            foreign lpvm access(~x##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int)
+            foreign lpvm alloc(8:wybe.int, ?tmp$7##0:dead_cell_size.t)
+            foreign lpvm mutate(~tmp$7##0:dead_cell_size.t, ?tmp$8##0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~a##0:wybe.int)
+            foreign llvm or(~tmp$8##0:dead_cell_size.t, 2:wybe.int, ?x##1:dead_cell_size.t)
 
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_ne(x#0:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.bool)
-    case ~tmp$3#0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.bool)
+    case ~tmp$3##0:wybe.bool of
     0:
-        foreign llvm move(~x#0:dead_cell_size.t, ?x#1:dead_cell_size.t)
+        foreign llvm move(~x##0:dead_cell_size.t, ?x##1:dead_cell_size.t)
 
     1:
-        foreign llvm and(x#0:wybe.int, 3:wybe.int, ?tmp$4#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.bool)
-        case ~tmp$5#0:wybe.bool of
+        foreign llvm and(x##0:wybe.int, 3:wybe.int, ?tmp$4##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
+        case ~tmp$5##0:wybe.bool of
         0:
-            foreign llvm move(~x#0:dead_cell_size.t, ?x#1:dead_cell_size.t)
+            foreign llvm move(~x##0:dead_cell_size.t, ?x##1:dead_cell_size.t)
 
         1:
-            foreign llvm or(~x#0:dead_cell_size.t, 2:wybe.int, ?x#1:dead_cell_size.t)
+            foreign llvm or(~x##0:dead_cell_size.t, 2:wybe.int, ?x##1:dead_cell_size.t)
 
 
 
 
 diff_type > public (1 calls)
 0: dead_cell_size.diff_type<0>[410bae77d3]
-diff_type(x#0:dead_cell_size.t, ?y#0:dead_cell_size.t2):
+diff_type(x##0:dead_cell_size.t, ?y##0:dead_cell_size.t2):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
-    foreign llvm icmp_ne(x#0:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.bool)
-    case ~tmp$4#0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.bool)
+    case ~tmp$4##0:wybe.bool of
     0:
-        foreign lpvm alloc(8:wybe.int, ?tmp$8#0:dead_cell_size.t2)
-        foreign lpvm mutate(~tmp$8#0:dead_cell_size.t2, ?y#0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, -1:wybe.int)
+        foreign lpvm alloc(8:wybe.int, ?tmp$8##0:dead_cell_size.t2)
+        foreign lpvm mutate(~tmp$8##0:dead_cell_size.t2, ?y##0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, -1:wybe.int)
 
     1:
-        foreign llvm and(x#0:wybe.int, 3:wybe.int, ?tmp$5#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$5#0:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.bool)
-        case ~tmp$6#0:wybe.bool of
+        foreign llvm and(x##0:wybe.int, 3:wybe.int, ?tmp$5##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$5##0:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.bool)
+        case ~tmp$6##0:wybe.bool of
         0:
-            foreign lpvm alloc(8:wybe.int, ?tmp$8#0:dead_cell_size.t2)
-            foreign lpvm mutate(~tmp$8#0:dead_cell_size.t2, ?y#0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, -1:wybe.int)
+            foreign lpvm alloc(8:wybe.int, ?tmp$8##0:dead_cell_size.t2)
+            foreign lpvm mutate(~tmp$8##0:dead_cell_size.t2, ?y##0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, -1:wybe.int)
 
         1:
-            foreign lpvm access(~x#0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a#0:wybe.int)
-            foreign lpvm alloc(8:wybe.int, ?tmp$8#0:dead_cell_size.t2)
-            foreign lpvm mutate(~tmp$8#0:dead_cell_size.t2, ?y#0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~a#0:wybe.int)
+            foreign lpvm access(~x##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int)
+            foreign lpvm alloc(8:wybe.int, ?tmp$8##0:dead_cell_size.t2)
+            foreign lpvm mutate(~tmp$8##0:dead_cell_size.t2, ?y##0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~a##0:wybe.int)
 
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_ne(x#0:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.bool)
-    case ~tmp$4#0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.bool)
+    case ~tmp$4##0:wybe.bool of
     0:
-        foreign lpvm alloc(8:wybe.int, ?tmp$8#0:dead_cell_size.t2)
-        foreign lpvm mutate(~tmp$8#0:dead_cell_size.t2, ?y#0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, -1:wybe.int)
+        foreign lpvm alloc(8:wybe.int, ?tmp$8##0:dead_cell_size.t2)
+        foreign lpvm mutate(~tmp$8##0:dead_cell_size.t2, ?y##0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, -1:wybe.int)
 
     1:
-        foreign llvm and(x#0:wybe.int, 3:wybe.int, ?tmp$5#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$5#0:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.bool)
-        case ~tmp$6#0:wybe.bool of
+        foreign llvm and(x##0:wybe.int, 3:wybe.int, ?tmp$5##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$5##0:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.bool)
+        case ~tmp$6##0:wybe.bool of
         0:
-            foreign lpvm alloc(8:wybe.int, ?tmp$8#0:dead_cell_size.t2)
-            foreign lpvm mutate(~tmp$8#0:dead_cell_size.t2, ?y#0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, -1:wybe.int)
+            foreign lpvm alloc(8:wybe.int, ?tmp$8##0:dead_cell_size.t2)
+            foreign lpvm mutate(~tmp$8##0:dead_cell_size.t2, ?y##0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, -1:wybe.int)
 
         1:
-            foreign llvm move(~x#0:dead_cell_size.t, ?y#0:dead_cell_size.t2)
+            foreign llvm move(~x##0:dead_cell_size.t, ?y##0:dead_cell_size.t2)
 
 
 
 
 foo > public (1 calls)
 0: dead_cell_size.foo<0>
-foo(x#0:dead_cell_size.t, ?x#1:dead_cell_size.t):
- AliasPairs: [(x#0,x#1)]
+foo(x##0:dead_cell_size.t, ?x##1:dead_cell_size.t):
+ AliasPairs: [(x##0,x##1)]
  InterestingCallProperties: []
-    foreign llvm icmp_ne(x#0:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.bool)
-    case ~tmp$3#0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.bool)
+    case ~tmp$3##0:wybe.bool of
     0:
-        foreign llvm move(~x#0:dead_cell_size.t, ?x#1:dead_cell_size.t)
+        foreign llvm move(~x##0:dead_cell_size.t, ?x##1:dead_cell_size.t)
 
     1:
-        foreign llvm and(x#0:wybe.int, 3:wybe.int, ?tmp$4#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.bool)
-        case ~tmp$5#0:wybe.bool of
+        foreign llvm and(x##0:wybe.int, 3:wybe.int, ?tmp$4##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
+        case ~tmp$5##0:wybe.bool of
         0:
-            foreign llvm move(~x#0:dead_cell_size.t, ?x#1:dead_cell_size.t)
+            foreign llvm move(~x##0:dead_cell_size.t, ?x##1:dead_cell_size.t)
 
         1:
-            foreign lpvm access(~x#0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a#0:wybe.int)
-            foreign lpvm alloc(24:wybe.int, ?tmp$9#0:dead_cell_size.t)
-            foreign lpvm mutate(~tmp$9#0:dead_cell_size.t, ?tmp$10#0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~a#0:wybe.int)
-            foreign lpvm mutate(~tmp$10#0:dead_cell_size.t, ?tmp$11#0:dead_cell_size.t, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 2:wybe.int)
-            foreign lpvm mutate(~tmp$11#0:dead_cell_size.t, ?tmp$12#0:dead_cell_size.t, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 3:wybe.int)
-            foreign llvm or(~tmp$12#0:dead_cell_size.t, 1:wybe.int, ?x#1:dead_cell_size.t)
+            foreign lpvm access(~x##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int)
+            foreign lpvm alloc(24:wybe.int, ?tmp$9##0:dead_cell_size.t)
+            foreign lpvm mutate(~tmp$9##0:dead_cell_size.t, ?tmp$10##0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~a##0:wybe.int)
+            foreign lpvm mutate(~tmp$10##0:dead_cell_size.t, ?tmp$11##0:dead_cell_size.t, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 2:wybe.int)
+            foreign lpvm mutate(~tmp$11##0:dead_cell_size.t, ?tmp$12##0:dead_cell_size.t, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 3:wybe.int)
+            foreign llvm or(~tmp$12##0:dead_cell_size.t, 1:wybe.int, ?x##1:dead_cell_size.t)
 
 
 
 
 print_t > public (2 calls)
 0: dead_cell_size.print_t<0>
-print_t(x#0:dead_cell_size.t, io#0:wybe.phantom, ?io#8:wybe.phantom):
+print_t(x##0:dead_cell_size.t, io##0:wybe.phantom, ?io##8:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    dead_cell_size.t.=<0>(0:dead_cell_size.t, x#0:dead_cell_size.t, ?tmp$4#0:wybe.bool) #1 @dead_cell_size:nn:nn
-    case ~tmp$4#0:wybe.bool of
+    dead_cell_size.t.=<0>(0:dead_cell_size.t, x##0:dead_cell_size.t, ?tmp$4##0:wybe.bool) #1 @dead_cell_size:nn:nn
+    case ~tmp$4##0:wybe.bool of
     0:
-        foreign llvm icmp_ne(x#0:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.bool)
-        case ~tmp$6#0:wybe.bool of
+        foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.bool)
+        case ~tmp$6##0:wybe.bool of
         0:
-            foreign c putchar('\n':wybe.char, ~#io#0:wybe.phantom, ?#io#8:wybe.phantom) @io:nn:nn
+            foreign c putchar('\n':wybe.char, ~#io##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
 
         1:
-            foreign llvm and(x#0:wybe.int, 3:wybe.int, ?tmp$7#0:wybe.int)
-            foreign llvm icmp_eq(tmp$7#0:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.bool)
-            case ~tmp$8#0:wybe.bool of
+            foreign llvm and(x##0:wybe.int, 3:wybe.int, ?tmp$7##0:wybe.int)
+            foreign llvm icmp_eq(tmp$7##0:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.bool)
+            case ~tmp$8##0:wybe.bool of
             0:
-                foreign llvm icmp_eq(tmp$7#0:wybe.int, 1:wybe.int, ?tmp$12#0:wybe.bool)
-                case ~tmp$12#0:wybe.bool of
+                foreign llvm icmp_eq(tmp$7##0:wybe.int, 1:wybe.int, ?tmp$12##0:wybe.bool)
+                case ~tmp$12##0:wybe.bool of
                 0:
-                    foreign llvm icmp_eq(~tmp$7#0:wybe.int, 2:wybe.int, ?tmp$16#0:wybe.bool)
-                    case ~tmp$16#0:wybe.bool of
+                    foreign llvm icmp_eq(~tmp$7##0:wybe.int, 2:wybe.int, ?tmp$16##0:wybe.bool)
+                    case ~tmp$16##0:wybe.bool of
                     0:
-                        foreign c putchar('\n':wybe.char, ~#io#0:wybe.phantom, ?#io#8:wybe.phantom) @io:nn:nn
+                        foreign c putchar('\n':wybe.char, ~#io##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
 
                     1:
-                        foreign lpvm access(~x#0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?a#2:wybe.int)
-                        foreign c print_string("td(":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-                        foreign c print_int(~a#2:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-                        foreign c print_string(")":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-                        foreign c putchar('\n':wybe.char, ~#io#3:wybe.phantom, ?#io#8:wybe.phantom) @io:nn:nn
+                        foreign lpvm access(~x##0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?a##2:wybe.int)
+                        foreign c print_string("td(":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+                        foreign c print_int(~a##2:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+                        foreign c print_string(")":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+                        foreign c putchar('\n':wybe.char, ~#io##3:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
 
 
                 1:
-                    foreign lpvm access(x#0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?a#1:wybe.int)
-                    foreign lpvm access(x#0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?b#0:wybe.int)
-                    foreign lpvm access(~x#0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?c#0:wybe.int)
-                    foreign c print_string("tc(":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-                    foreign c print_int(~a#1:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-                    foreign c print_string(",":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-                    foreign c print_int(~b#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-                    foreign c print_string(",":wybe.string, ~#io#4:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-                    foreign c print_int(~c#0:wybe.int, ~#io#5:wybe.phantom, ?#io#6:wybe.phantom) @io:nn:nn
-                    foreign c print_string(")":wybe.string, ~#io#6:wybe.phantom, ?#io#7:wybe.phantom) @io:nn:nn
-                    foreign c putchar('\n':wybe.char, ~#io#7:wybe.phantom, ?#io#8:wybe.phantom) @io:nn:nn
+                    foreign lpvm access(x##0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?a##1:wybe.int)
+                    foreign lpvm access(x##0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?b##0:wybe.int)
+                    foreign lpvm access(~x##0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?c##0:wybe.int)
+                    foreign c print_string("tc(":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+                    foreign c print_int(~a##1:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+                    foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+                    foreign c print_int(~b##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+                    foreign c print_string(",":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+                    foreign c print_int(~c##0:wybe.int, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+                    foreign c print_string(")":wybe.string, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
+                    foreign c putchar('\n':wybe.char, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
 
 
             1:
-                foreign lpvm access(~x#0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a#0:wybe.int)
-                foreign c print_string("tb(":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-                foreign c print_int(~a#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-                foreign c print_string(")":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-                foreign c putchar('\n':wybe.char, ~#io#3:wybe.phantom, ?#io#8:wybe.phantom) @io:nn:nn
+                foreign lpvm access(~x##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int)
+                foreign c print_string("tb(":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+                foreign c print_int(~a##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+                foreign c print_string(")":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+                foreign c putchar('\n':wybe.char, ~#io##3:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
 
 
 
     1:
-        foreign c print_string("ta":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~#io#1:wybe.phantom, ?#io#8:wybe.phantom) @io:nn:nn
+        foreign c print_string("ta":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~#io##1:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
 
 
 
 print_t2 > public (1 calls)
 0: dead_cell_size.print_t2<0>
-print_t2(x#0:dead_cell_size.t2, io#0:wybe.phantom, ?io#4:wybe.phantom):
+print_t2(x##0:dead_cell_size.t2, io##0:wybe.phantom, ?io##4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    dead_cell_size.t2.=<0>(0:dead_cell_size.t2, x#0:dead_cell_size.t2, ?tmp$2#0:wybe.bool) #1 @dead_cell_size:nn:nn
-    case ~tmp$2#0:wybe.bool of
+    dead_cell_size.t2.=<0>(0:dead_cell_size.t2, x##0:dead_cell_size.t2, ?tmp$2##0:wybe.bool) #1 @dead_cell_size:nn:nn
+    case ~tmp$2##0:wybe.bool of
     0:
-        foreign llvm icmp_ne(x#0:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.bool)
-        case ~tmp$4#0:wybe.bool of
+        foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.bool)
+        case ~tmp$4##0:wybe.bool of
         0:
-            foreign c putchar('\n':wybe.char, ~#io#0:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
+            foreign c putchar('\n':wybe.char, ~#io##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
 
         1:
-            foreign lpvm access(~x#0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a#0:wybe.int)
-            foreign c print_string("t2b(":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-            foreign c print_int(~a#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-            foreign c print_string(")":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-            foreign c putchar('\n':wybe.char, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
+            foreign lpvm access(~x##0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int)
+            foreign c print_string("t2b(":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+            foreign c print_int(~a##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+            foreign c print_string(")":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+            foreign c putchar('\n':wybe.char, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
 
 
     1:
-        foreign c print_string("t2a":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~#io#1:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
+        foreign c print_string("t2a":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~#io##1:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
 
 
   LLVM code       :
@@ -337,40 +337,40 @@ entry:
   %4 = inttoptr i64 %3 to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
   store  i64 9, i64* %5 
-  %"1$tmp$0#0" = tail call fastcc  i64  @"dead_cell_size.foo<0>"(i64  %3)  
-  tail call fastcc  void  @"dead_cell_size.print_t<0>"(i64  %"1$tmp$0#0")  
+  %"1$tmp$0##0" = tail call fastcc  i64  @"dead_cell_size.foo<0>"(i64  %3)  
+  tail call fastcc  void  @"dead_cell_size.print_t<0>"(i64  %"1$tmp$0##0")  
   %6 = trunc i64 8 to i32  
   %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
   %8 = ptrtoint i8* %7 to i64 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   store  i64 9, i64* %10 
-  %"1$tmp$2#0" = tail call fastcc  i64  @"dead_cell_size.bar<0>[410bae77d3]"(i64  %8)  
-  tail call fastcc  void  @"dead_cell_size.print_t<0>"(i64  %"1$tmp$2#0")  
+  %"1$tmp$2##0" = tail call fastcc  i64  @"dead_cell_size.bar<0>[410bae77d3]"(i64  %8)  
+  tail call fastcc  void  @"dead_cell_size.print_t<0>"(i64  %"1$tmp$2##0")  
   %11 = trunc i64 8 to i32  
   %12 = tail call ccc  i8*  @wybe_malloc(i32  %11)  
   %13 = ptrtoint i8* %12 to i64 
   %14 = inttoptr i64 %13 to i64* 
   %15 = getelementptr  i64, i64* %14, i64 0 
   store  i64 9, i64* %15 
-  %"1$tmp$4#0" = tail call fastcc  i64  @"dead_cell_size.diff_type<0>[410bae77d3]"(i64  %13)  
-  tail call fastcc  void  @"dead_cell_size.print_t2<0>"(i64  %"1$tmp$4#0")  
+  %"1$tmp$4##0" = tail call fastcc  i64  @"dead_cell_size.diff_type<0>[410bae77d3]"(i64  %13)  
+  tail call fastcc  void  @"dead_cell_size.print_t2<0>"(i64  %"1$tmp$4##0")  
   ret void 
 }
 
 
-define external fastcc  i64 @"dead_cell_size.bar<0>"(i64  %"x#0")    {
+define external fastcc  i64 @"dead_cell_size.bar<0>"(i64  %"x##0")    {
 entry:
-  %"1$tmp$3#0" = icmp ne i64 %"x#0", 0 
-  br i1 %"1$tmp$3#0", label %if.then, label %if.else 
+  %"1$tmp$3##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$4#0" = and i64 %"x#0", 3 
-  %"2$tmp$5#0" = icmp eq i64 %"2$tmp$4#0", 0 
-  br i1 %"2$tmp$5#0", label %if.then1, label %if.else1 
+  %"2$tmp$4##0" = and i64 %"x##0", 3 
+  %"2$tmp$5##0" = icmp eq i64 %"2$tmp$4##0", 0 
+  br i1 %"2$tmp$5##0", label %if.then1, label %if.else1 
 if.else:
-  ret i64 %"x#0" 
+  ret i64 %"x##0" 
 if.then1:
-  %16 = inttoptr i64 %"x#0" to i64* 
+  %16 = inttoptr i64 %"x##0" to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
   %19 = trunc i64 8 to i32  
@@ -379,39 +379,39 @@ if.then1:
   %22 = inttoptr i64 %21 to i64* 
   %23 = getelementptr  i64, i64* %22, i64 0 
   store  i64 %18, i64* %23 
-  %"4$x#1" = or i64 %21, 2 
-  ret i64 %"4$x#1" 
+  %"4$x##1" = or i64 %21, 2 
+  ret i64 %"4$x##1" 
 if.else1:
-  ret i64 %"x#0" 
+  ret i64 %"x##0" 
 }
 
 
-define external fastcc  i64 @"dead_cell_size.bar<0>[410bae77d3]"(i64  %"x#0")    {
+define external fastcc  i64 @"dead_cell_size.bar<0>[410bae77d3]"(i64  %"x##0")    {
 entry:
-  %"1$tmp$3#0" = icmp ne i64 %"x#0", 0 
-  br i1 %"1$tmp$3#0", label %if.then, label %if.else 
+  %"1$tmp$3##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$4#0" = and i64 %"x#0", 3 
-  %"2$tmp$5#0" = icmp eq i64 %"2$tmp$4#0", 0 
-  br i1 %"2$tmp$5#0", label %if.then1, label %if.else1 
+  %"2$tmp$4##0" = and i64 %"x##0", 3 
+  %"2$tmp$5##0" = icmp eq i64 %"2$tmp$4##0", 0 
+  br i1 %"2$tmp$5##0", label %if.then1, label %if.else1 
 if.else:
-  ret i64 %"x#0" 
+  ret i64 %"x##0" 
 if.then1:
-  %"4$x#1" = or i64 %"x#0", 2 
-  ret i64 %"4$x#1" 
+  %"4$x##1" = or i64 %"x##0", 2 
+  ret i64 %"4$x##1" 
 if.else1:
-  ret i64 %"x#0" 
+  ret i64 %"x##0" 
 }
 
 
-define external fastcc  i64 @"dead_cell_size.diff_type<0>"(i64  %"x#0")    {
+define external fastcc  i64 @"dead_cell_size.diff_type<0>"(i64  %"x##0")    {
 entry:
-  %"1$tmp$4#0" = icmp ne i64 %"x#0", 0 
-  br i1 %"1$tmp$4#0", label %if.then, label %if.else 
+  %"1$tmp$4##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1$tmp$4##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$5#0" = and i64 %"x#0", 3 
-  %"2$tmp$6#0" = icmp eq i64 %"2$tmp$5#0", 0 
-  br i1 %"2$tmp$6#0", label %if.then1, label %if.else1 
+  %"2$tmp$5##0" = and i64 %"x##0", 3 
+  %"2$tmp$6##0" = icmp eq i64 %"2$tmp$5##0", 0 
+  br i1 %"2$tmp$6##0", label %if.then1, label %if.else1 
 if.else:
   %37 = trunc i64 8 to i32  
   %38 = tail call ccc  i8*  @wybe_malloc(i32  %37)  
@@ -421,7 +421,7 @@ if.else:
   store  i64 -1, i64* %41 
   ret i64 %39 
 if.then1:
-  %24 = inttoptr i64 %"x#0" to i64* 
+  %24 = inttoptr i64 %"x##0" to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
   %26 = load  i64, i64* %25 
   %27 = trunc i64 8 to i32  
@@ -442,14 +442,14 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"dead_cell_size.diff_type<0>[410bae77d3]"(i64  %"x#0")    {
+define external fastcc  i64 @"dead_cell_size.diff_type<0>[410bae77d3]"(i64  %"x##0")    {
 entry:
-  %"1$tmp$4#0" = icmp ne i64 %"x#0", 0 
-  br i1 %"1$tmp$4#0", label %if.then, label %if.else 
+  %"1$tmp$4##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1$tmp$4##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$5#0" = and i64 %"x#0", 3 
-  %"2$tmp$6#0" = icmp eq i64 %"2$tmp$5#0", 0 
-  br i1 %"2$tmp$6#0", label %if.then1, label %if.else1 
+  %"2$tmp$5##0" = and i64 %"x##0", 3 
+  %"2$tmp$6##0" = icmp eq i64 %"2$tmp$5##0", 0 
+  br i1 %"2$tmp$6##0", label %if.then1, label %if.else1 
 if.else:
   %47 = trunc i64 8 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
@@ -459,7 +459,7 @@ if.else:
   store  i64 -1, i64* %51 
   ret i64 %49 
 if.then1:
-  ret i64 %"x#0" 
+  ret i64 %"x##0" 
 if.else1:
   %42 = trunc i64 8 to i32  
   %43 = tail call ccc  i8*  @wybe_malloc(i32  %42)  
@@ -471,18 +471,18 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"dead_cell_size.foo<0>"(i64  %"x#0")    {
+define external fastcc  i64 @"dead_cell_size.foo<0>"(i64  %"x##0")    {
 entry:
-  %"1$tmp$3#0" = icmp ne i64 %"x#0", 0 
-  br i1 %"1$tmp$3#0", label %if.then, label %if.else 
+  %"1$tmp$3##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$4#0" = and i64 %"x#0", 3 
-  %"2$tmp$5#0" = icmp eq i64 %"2$tmp$4#0", 0 
-  br i1 %"2$tmp$5#0", label %if.then1, label %if.else1 
+  %"2$tmp$4##0" = and i64 %"x##0", 3 
+  %"2$tmp$5##0" = icmp eq i64 %"2$tmp$4##0", 0 
+  br i1 %"2$tmp$5##0", label %if.then1, label %if.else1 
 if.else:
-  ret i64 %"x#0" 
+  ret i64 %"x##0" 
 if.then1:
-  %52 = inttoptr i64 %"x#0" to i64* 
+  %52 = inttoptr i64 %"x##0" to i64* 
   %53 = getelementptr  i64, i64* %52, i64 0 
   %54 = load  i64, i64* %53 
   %55 = trunc i64 24 to i32  
@@ -499,34 +499,34 @@ if.then1:
   %64 = inttoptr i64 %63 to i64* 
   %65 = getelementptr  i64, i64* %64, i64 0 
   store  i64 3, i64* %65 
-  %"4$x#1" = or i64 %57, 1 
-  ret i64 %"4$x#1" 
+  %"4$x##1" = or i64 %57, 1 
+  ret i64 %"4$x##1" 
 if.else1:
-  ret i64 %"x#0" 
+  ret i64 %"x##0" 
 }
 
 
-define external fastcc  void @"dead_cell_size.print_t<0>"(i64  %"x#0")    {
+define external fastcc  void @"dead_cell_size.print_t<0>"(i64  %"x##0")    {
 entry:
-  %"1$tmp$4#0" = tail call fastcc  i1  @"dead_cell_size.t.=<0>"(i64  0, i64  %"x#0")  
-  br i1 %"1$tmp$4#0", label %if.then, label %if.else 
+  %"1$tmp$4##0" = tail call fastcc  i1  @"dead_cell_size.t.=<0>"(i64  0, i64  %"x##0")  
+  br i1 %"1$tmp$4##0", label %if.then, label %if.else 
 if.then:
   %67 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @dead_cell_size.66, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %67)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else:
-  %"3$tmp$6#0" = icmp ne i64 %"x#0", 0 
-  br i1 %"3$tmp$6#0", label %if.then1, label %if.else1 
+  %"3$tmp$6##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"3$tmp$6##0", label %if.then1, label %if.else1 
 if.then1:
-  %"4$tmp$7#0" = and i64 %"x#0", 3 
-  %"4$tmp$8#0" = icmp eq i64 %"4$tmp$7#0", 0 
-  br i1 %"4$tmp$8#0", label %if.then2, label %if.else2 
+  %"4$tmp$7##0" = and i64 %"x##0", 3 
+  %"4$tmp$8##0" = icmp eq i64 %"4$tmp$7##0", 0 
+  br i1 %"4$tmp$8##0", label %if.then2, label %if.else2 
 if.else1:
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.then2:
-  %68 = inttoptr i64 %"x#0" to i64* 
+  %68 = inttoptr i64 %"x##0" to i64* 
   %69 = getelementptr  i64, i64* %68, i64 0 
   %70 = load  i64, i64* %69 
   %72 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @dead_cell_size.71, i32 0, i32 0) to i64 
@@ -537,18 +537,18 @@ if.then2:
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else2:
-  %"7$tmp$12#0" = icmp eq i64 %"4$tmp$7#0", 1 
-  br i1 %"7$tmp$12#0", label %if.then3, label %if.else3 
+  %"7$tmp$12##0" = icmp eq i64 %"4$tmp$7##0", 1 
+  br i1 %"7$tmp$12##0", label %if.then3, label %if.else3 
 if.then3:
-  %75 = add   i64 %"x#0", -1 
+  %75 = add   i64 %"x##0", -1 
   %76 = inttoptr i64 %75 to i64* 
   %77 = getelementptr  i64, i64* %76, i64 0 
   %78 = load  i64, i64* %77 
-  %79 = add   i64 %"x#0", 7 
+  %79 = add   i64 %"x##0", 7 
   %80 = inttoptr i64 %79 to i64* 
   %81 = getelementptr  i64, i64* %80, i64 0 
   %82 = load  i64, i64* %81 
-  %83 = add   i64 %"x#0", 15 
+  %83 = add   i64 %"x##0", 15 
   %84 = inttoptr i64 %83 to i64* 
   %85 = getelementptr  i64, i64* %84, i64 0 
   %86 = load  i64, i64* %85 
@@ -566,10 +566,10 @@ if.then3:
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else3:
-  %"9$tmp$16#0" = icmp eq i64 %"4$tmp$7#0", 2 
-  br i1 %"9$tmp$16#0", label %if.then4, label %if.else4 
+  %"9$tmp$16##0" = icmp eq i64 %"4$tmp$7##0", 2 
+  br i1 %"9$tmp$16##0", label %if.then4, label %if.else4 
 if.then4:
-  %95 = add   i64 %"x#0", -2 
+  %95 = add   i64 %"x##0", -2 
   %96 = inttoptr i64 %95 to i64* 
   %97 = getelementptr  i64, i64* %96, i64 0 
   %98 = load  i64, i64* %97 
@@ -586,20 +586,20 @@ if.else4:
 }
 
 
-define external fastcc  void @"dead_cell_size.print_t2<0>"(i64  %"x#0")    {
+define external fastcc  void @"dead_cell_size.print_t2<0>"(i64  %"x##0")    {
 entry:
-  %"1$tmp$2#0" = tail call fastcc  i1  @"dead_cell_size.t2.=<0>"(i64  0, i64  %"x#0")  
-  br i1 %"1$tmp$2#0", label %if.then, label %if.else 
+  %"1$tmp$2##0" = tail call fastcc  i1  @"dead_cell_size.t2.=<0>"(i64  0, i64  %"x##0")  
+  br i1 %"1$tmp$2##0", label %if.then, label %if.else 
 if.then:
   %104 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @dead_cell_size.103, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %104)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else:
-  %"3$tmp$4#0" = icmp ne i64 %"x#0", 0 
-  br i1 %"3$tmp$4#0", label %if.then1, label %if.else1 
+  %"3$tmp$4##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"3$tmp$4##0", label %if.then1, label %if.else1 
 if.then1:
-  %105 = inttoptr i64 %"x#0" to i64* 
+  %105 = inttoptr i64 %"x##0" to i64* 
   %106 = getelementptr  i64, i64* %105, i64 0 
   %107 = load  i64, i64* %106 
   %109 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @dead_cell_size.108, i32 0, i32 0) to i64 
@@ -644,81 +644,81 @@ if.else1:
 
 = > public (1 calls)
 0: dead_cell_size.t.=<0>
-=($left#0:dead_cell_size.t, $right#0:dead_cell_size.t, ?$$#0:wybe.bool):
+=($left##0:dead_cell_size.t, $right##0:dead_cell_size.t, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left#0:dead_cell_size.t, ~$right#0:dead_cell_size.t, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~$left##0:dead_cell_size.t, ~$right##0:dead_cell_size.t, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm and($left#0:wybe.int, 3:wybe.int, ?tmp$15#0:wybe.int)
-        foreign llvm icmp_eq(tmp$15#0:wybe.int, 0:wybe.int, ?tmp$16#0:wybe.bool)
-        case ~tmp$16#0:wybe.bool of
+        foreign llvm and($left##0:wybe.int, 3:wybe.int, ?tmp$15##0:wybe.int)
+        foreign llvm icmp_eq(tmp$15##0:wybe.int, 0:wybe.int, ?tmp$16##0:wybe.bool)
+        case ~tmp$16##0:wybe.bool of
         0:
-            foreign llvm icmp_eq(tmp$15#0:wybe.int, 1:wybe.int, ?tmp$20#0:wybe.bool)
-            case ~tmp$20#0:wybe.bool of
+            foreign llvm icmp_eq(tmp$15##0:wybe.int, 1:wybe.int, ?tmp$20##0:wybe.bool)
+            case ~tmp$20##0:wybe.bool of
             0:
-                foreign llvm icmp_eq(~tmp$15#0:wybe.int, 2:wybe.int, ?tmp$24#0:wybe.bool)
-                case ~tmp$24#0:wybe.bool of
+                foreign llvm icmp_eq(~tmp$15##0:wybe.int, 2:wybe.int, ?tmp$24##0:wybe.bool)
+                case ~tmp$24##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                 1:
-                    foreign lpvm access(~$left#0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$left$td1#0:wybe.int)
-                    foreign llvm icmp_ne($right#0:wybe.int, 0:wybe.int, ?tmp$26#0:wybe.bool)
-                    case ~tmp$26#0:wybe.bool of
+                    foreign lpvm access(~$left##0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$left$td1##0:wybe.int)
+                    foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$26##0:wybe.bool)
+                    case ~tmp$26##0:wybe.bool of
                     0:
-                        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                     1:
-                        foreign llvm and($right#0:wybe.int, 3:wybe.int, ?tmp$27#0:wybe.int)
-                        foreign llvm icmp_eq(~tmp$27#0:wybe.int, 2:wybe.int, ?tmp$28#0:wybe.bool)
-                        case ~tmp$28#0:wybe.bool of
+                        foreign llvm and($right##0:wybe.int, 3:wybe.int, ?tmp$27##0:wybe.int)
+                        foreign llvm icmp_eq(~tmp$27##0:wybe.int, 2:wybe.int, ?tmp$28##0:wybe.bool)
+                        case ~tmp$28##0:wybe.bool of
                         0:
-                            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                         1:
-                            foreign lpvm access(~$right#0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$right$td1#0:wybe.int)
-                            foreign llvm icmp_eq(~$left$td1#0:wybe.int, ~$right$td1#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+                            foreign lpvm access(~$right##0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$right$td1##0:wybe.int)
+                            foreign llvm icmp_eq(~$left$td1##0:wybe.int, ~$right$td1##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 
             1:
-                foreign lpvm access($left#0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?$left$tc1#0:wybe.int)
-                foreign lpvm access($left#0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?$left$tc2#0:wybe.int)
-                foreign lpvm access(~$left#0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?$left$tc3#0:wybe.int)
-                foreign llvm icmp_ne($right#0:wybe.int, 0:wybe.int, ?tmp$22#0:wybe.bool)
-                case ~tmp$22#0:wybe.bool of
+                foreign lpvm access($left##0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?$left$tc1##0:wybe.int)
+                foreign lpvm access($left##0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?$left$tc2##0:wybe.int)
+                foreign lpvm access(~$left##0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?$left$tc3##0:wybe.int)
+                foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$22##0:wybe.bool)
+                case ~tmp$22##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                 1:
-                    foreign llvm and($right#0:wybe.int, 3:wybe.int, ?tmp$23#0:wybe.int)
-                    foreign llvm icmp_eq(~tmp$23#0:wybe.int, 1:wybe.int, ?tmp$24#0:wybe.bool)
-                    case ~tmp$24#0:wybe.bool of
+                    foreign llvm and($right##0:wybe.int, 3:wybe.int, ?tmp$23##0:wybe.int)
+                    foreign llvm icmp_eq(~tmp$23##0:wybe.int, 1:wybe.int, ?tmp$24##0:wybe.bool)
+                    case ~tmp$24##0:wybe.bool of
                     0:
-                        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                     1:
-                        foreign lpvm access($right#0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?$right$tc1#0:wybe.int)
-                        foreign lpvm access($right#0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?$right$tc2#0:wybe.int)
-                        foreign lpvm access(~$right#0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?$right$tc3#0:wybe.int)
-                        foreign llvm icmp_eq(~$left$tc1#0:wybe.int, ~$right$tc1#0:wybe.int, ?tmp$5#0:wybe.bool) @int:nn:nn
-                        case ~tmp$5#0:wybe.bool of
+                        foreign lpvm access($right##0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?$right$tc1##0:wybe.int)
+                        foreign lpvm access($right##0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?$right$tc2##0:wybe.int)
+                        foreign lpvm access(~$right##0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?$right$tc3##0:wybe.int)
+                        foreign llvm icmp_eq(~$left$tc1##0:wybe.int, ~$right$tc1##0:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
+                        case ~tmp$5##0:wybe.bool of
                         0:
-                            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                         1:
-                            foreign llvm icmp_eq(~$left$tc2#0:wybe.int, ~$right$tc2#0:wybe.int, ?tmp$6#0:wybe.bool) @int:nn:nn
-                            case ~tmp$6#0:wybe.bool of
+                            foreign llvm icmp_eq(~$left$tc2##0:wybe.int, ~$right$tc2##0:wybe.int, ?tmp$6##0:wybe.bool) @int:nn:nn
+                            case ~tmp$6##0:wybe.bool of
                             0:
-                                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                             1:
-                                foreign llvm icmp_eq(~$left$tc3#0:wybe.int, ~$right$tc3#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+                                foreign llvm icmp_eq(~$left$tc3##0:wybe.int, ~$right$tc3##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
@@ -726,22 +726,22 @@ if.else1:
 
 
         1:
-            foreign lpvm access(~$left#0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$left$tb1#0:wybe.int)
-            foreign llvm icmp_ne($right#0:wybe.int, 0:wybe.int, ?tmp$18#0:wybe.bool)
-            case ~tmp$18#0:wybe.bool of
+            foreign lpvm access(~$left##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$left$tb1##0:wybe.int)
+            foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$18##0:wybe.bool)
+            case ~tmp$18##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                foreign llvm and($right#0:wybe.int, 3:wybe.int, ?tmp$19#0:wybe.int)
-                foreign llvm icmp_eq(~tmp$19#0:wybe.int, 0:wybe.int, ?tmp$20#0:wybe.bool)
-                case ~tmp$20#0:wybe.bool of
+                foreign llvm and($right##0:wybe.int, 3:wybe.int, ?tmp$19##0:wybe.int)
+                foreign llvm icmp_eq(~tmp$19##0:wybe.int, 0:wybe.int, ?tmp$20##0:wybe.bool)
+                case ~tmp$20##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                 1:
-                    foreign lpvm access(~$right#0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$right$tb1#0:wybe.int)
-                    foreign llvm icmp_eq(~$left$tb1#0:wybe.int, ~$right$tb1#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+                    foreign lpvm access(~$right##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$right$tb1##0:wybe.int)
+                    foreign llvm icmp_eq(~$left$tb1##0:wybe.int, ~$right$tb1##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
@@ -750,378 +750,378 @@ if.else1:
 
 ta > public {inline} (0 calls)
 0: dead_cell_size.t.ta<0>
-ta(?$#0:dead_cell_size.t):
+ta(?$##0:dead_cell_size.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:dead_cell_size.t, ?$#0:dead_cell_size.t)
+    foreign llvm move(0:dead_cell_size.t, ?$##0:dead_cell_size.t)
 
 
 tb > public {inline} (0 calls)
 0: dead_cell_size.t.tb<0>
-tb(tb1#0:wybe.int, ?$#0:dead_cell_size.t):
+tb(tb1##0:wybe.int, ?$##0:dead_cell_size.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec#0:dead_cell_size.t)
-    foreign lpvm mutate(~$rec#0:dead_cell_size.t, ?$#0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~tb1#0:wybe.int)
+    foreign lpvm alloc(8:wybe.int, ?$rec##0:dead_cell_size.t)
+    foreign lpvm mutate(~$rec##0:dead_cell_size.t, ?$##0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~tb1##0:wybe.int)
 tb > public {inline} (14 calls)
 1: dead_cell_size.t.tb<1>
-tb(?tb1#0:wybe.int, $#0:dead_cell_size.t, ?$$#0:wybe.bool):
+tb(?tb1##0:wybe.int, $##0:dead_cell_size.t, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?tb1#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?tb1##0:wybe.int)
 
     1:
-        foreign llvm and($#0:wybe.int, 3:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?tb1#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?tb1##0:wybe.int)
 
         1:
-            foreign lpvm access(~$#0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?tb1#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm access(~$##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?tb1##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 tb1 > public {inline} (0 calls)
 0: dead_cell_size.t.tb1<0>
-tb1($rec#0:dead_cell_size.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
+tb1($rec##0:dead_cell_size.t, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 3:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
         1:
-            foreign lpvm access(~$rec#0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm access(~$rec##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 tb1 > public {inline} (0 calls)
 1: dead_cell_size.t.tb1<1>
-tb1($rec#0:dead_cell_size.t, ?$rec#1:dead_cell_size.t, $field#0:wybe.int, ?$$#0:wybe.bool):
+tb1($rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:dead_cell_size.t, ?$rec#1:dead_cell_size.t)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 3:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(~$rec#0:dead_cell_size.t, ?$rec#1:dead_cell_size.t)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(~$rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t)
 
         1:
-            foreign lpvm {noalias} mutate(~$rec#0:dead_cell_size.t, ?$rec#1:dead_cell_size.t, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm {noalias} mutate(~$rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 tc > public {inline} (0 calls)
 0: dead_cell_size.t.tc<0>
-tc(tc1#0:wybe.int, tc2#0:wybe.int, tc3#0:wybe.int, ?$#0:dead_cell_size.t):
+tc(tc1##0:wybe.int, tc2##0:wybe.int, tc3##0:wybe.int, ?$##0:dead_cell_size.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?$rec#0:dead_cell_size.t)
-    foreign lpvm mutate(~$rec#0:dead_cell_size.t, ?$rec#1:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tc1#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:dead_cell_size.t, ?$rec#2:dead_cell_size.t, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tc2#0:wybe.int)
-    foreign lpvm mutate(~$rec#2:dead_cell_size.t, ?$rec#3:dead_cell_size.t, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tc3#0:wybe.int)
-    foreign llvm or(~$rec#3:dead_cell_size.t, 1:wybe.int, ?$#0:dead_cell_size.t)
+    foreign lpvm alloc(24:wybe.int, ?$rec##0:dead_cell_size.t)
+    foreign lpvm mutate(~$rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tc1##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:dead_cell_size.t, ?$rec##2:dead_cell_size.t, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tc2##0:wybe.int)
+    foreign lpvm mutate(~$rec##2:dead_cell_size.t, ?$rec##3:dead_cell_size.t, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tc3##0:wybe.int)
+    foreign llvm or(~$rec##3:dead_cell_size.t, 1:wybe.int, ?$##0:dead_cell_size.t)
 tc > public {inline} (11 calls)
 1: dead_cell_size.t.tc<1>
-tc(?tc1#0:wybe.int, ?tc2#0:wybe.int, ?tc3#0:wybe.int, $#0:dead_cell_size.t, ?$$#0:wybe.bool):
+tc(?tc1##0:wybe.int, ?tc2##0:wybe.int, ?tc3##0:wybe.int, $##0:dead_cell_size.t, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?tc1#0:wybe.int)
-        foreign llvm move(undef:wybe.int, ?tc2#0:wybe.int)
-        foreign llvm move(undef:wybe.int, ?tc3#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?tc1##0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?tc2##0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?tc3##0:wybe.int)
 
     1:
-        foreign llvm and($#0:wybe.int, 3:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 1:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?tc1#0:wybe.int)
-            foreign llvm move(undef:wybe.int, ?tc2#0:wybe.int)
-            foreign llvm move(undef:wybe.int, ?tc3#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?tc1##0:wybe.int)
+            foreign llvm move(undef:wybe.int, ?tc2##0:wybe.int)
+            foreign llvm move(undef:wybe.int, ?tc3##0:wybe.int)
 
         1:
-            foreign lpvm access($#0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?tc1#0:wybe.int)
-            foreign lpvm access($#0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?tc2#0:wybe.int)
-            foreign lpvm access(~$#0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?tc3#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm access($##0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?tc1##0:wybe.int)
+            foreign lpvm access($##0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?tc2##0:wybe.int)
+            foreign lpvm access(~$##0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?tc3##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 tc1 > public {inline} (0 calls)
 0: dead_cell_size.t.tc1<0>
-tc1($rec#0:dead_cell_size.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
+tc1($rec##0:dead_cell_size.t, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 3:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 1:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
         1:
-            foreign lpvm access(~$rec#0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?$#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm access(~$rec##0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 tc1 > public {inline} (0 calls)
 1: dead_cell_size.t.tc1<1>
-tc1($rec#0:dead_cell_size.t, ?$rec#1:dead_cell_size.t, $field#0:wybe.int, ?$$#0:wybe.bool):
+tc1($rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:dead_cell_size.t, ?$rec#1:dead_cell_size.t)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 3:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 1:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(~$rec#0:dead_cell_size.t, ?$rec#1:dead_cell_size.t)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(~$rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t)
 
         1:
-            foreign lpvm {noalias} mutate(~$rec#0:dead_cell_size.t, ?$rec#1:dead_cell_size.t, -1:wybe.int, 0:wybe.int, 24:wybe.int, 1:wybe.int, ~$field#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm {noalias} mutate(~$rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t, -1:wybe.int, 0:wybe.int, 24:wybe.int, 1:wybe.int, ~$field##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 tc2 > public {inline} (0 calls)
 0: dead_cell_size.t.tc2<0>
-tc2($rec#0:dead_cell_size.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
+tc2($rec##0:dead_cell_size.t, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 3:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 1:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
         1:
-            foreign lpvm access(~$rec#0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?$#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm access(~$rec##0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 tc2 > public {inline} (0 calls)
 1: dead_cell_size.t.tc2<1>
-tc2($rec#0:dead_cell_size.t, ?$rec#1:dead_cell_size.t, $field#0:wybe.int, ?$$#0:wybe.bool):
+tc2($rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:dead_cell_size.t, ?$rec#1:dead_cell_size.t)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 3:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 1:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(~$rec#0:dead_cell_size.t, ?$rec#1:dead_cell_size.t)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(~$rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t)
 
         1:
-            foreign lpvm {noalias} mutate(~$rec#0:dead_cell_size.t, ?$rec#1:dead_cell_size.t, 7:wybe.int, 0:wybe.int, 24:wybe.int, 1:wybe.int, ~$field#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm {noalias} mutate(~$rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t, 7:wybe.int, 0:wybe.int, 24:wybe.int, 1:wybe.int, ~$field##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 tc3 > public {inline} (0 calls)
 0: dead_cell_size.t.tc3<0>
-tc3($rec#0:dead_cell_size.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
+tc3($rec##0:dead_cell_size.t, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 3:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 1:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
         1:
-            foreign lpvm access(~$rec#0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?$#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm access(~$rec##0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 tc3 > public {inline} (0 calls)
 1: dead_cell_size.t.tc3<1>
-tc3($rec#0:dead_cell_size.t, ?$rec#1:dead_cell_size.t, $field#0:wybe.int, ?$$#0:wybe.bool):
+tc3($rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:dead_cell_size.t, ?$rec#1:dead_cell_size.t)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 3:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 1:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(~$rec#0:dead_cell_size.t, ?$rec#1:dead_cell_size.t)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(~$rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t)
 
         1:
-            foreign lpvm {noalias} mutate(~$rec#0:dead_cell_size.t, ?$rec#1:dead_cell_size.t, 15:wybe.int, 0:wybe.int, 24:wybe.int, 1:wybe.int, ~$field#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm {noalias} mutate(~$rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t, 15:wybe.int, 0:wybe.int, 24:wybe.int, 1:wybe.int, ~$field##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 td > public {inline} (0 calls)
 0: dead_cell_size.t.td<0>
-td(td1#0:wybe.int, ?$#0:dead_cell_size.t):
+td(td1##0:wybe.int, ?$##0:dead_cell_size.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec#0:dead_cell_size.t)
-    foreign lpvm mutate(~$rec#0:dead_cell_size.t, ?$rec#1:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~td1#0:wybe.int)
-    foreign llvm or(~$rec#1:dead_cell_size.t, 2:wybe.int, ?$#0:dead_cell_size.t)
+    foreign lpvm alloc(8:wybe.int, ?$rec##0:dead_cell_size.t)
+    foreign lpvm mutate(~$rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~td1##0:wybe.int)
+    foreign llvm or(~$rec##1:dead_cell_size.t, 2:wybe.int, ?$##0:dead_cell_size.t)
 td > public {inline} (5 calls)
 1: dead_cell_size.t.td<1>
-td(?td1#0:wybe.int, $#0:dead_cell_size.t, ?$$#0:wybe.bool):
+td(?td1##0:wybe.int, $##0:dead_cell_size.t, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?td1#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?td1##0:wybe.int)
 
     1:
-        foreign llvm and($#0:wybe.int, 3:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 2:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 2:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?td1#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?td1##0:wybe.int)
 
         1:
-            foreign lpvm access(~$#0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?td1#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm access(~$##0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?td1##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 td1 > public {inline} (0 calls)
 0: dead_cell_size.t.td1<0>
-td1($rec#0:dead_cell_size.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
+td1($rec##0:dead_cell_size.t, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 3:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 2:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 2:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
         1:
-            foreign lpvm access(~$rec#0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm access(~$rec##0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 td1 > public {inline} (0 calls)
 1: dead_cell_size.t.td1<1>
-td1($rec#0:dead_cell_size.t, ?$rec#1:dead_cell_size.t, $field#0:wybe.int, ?$$#0:wybe.bool):
+td1($rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:dead_cell_size.t, ?$rec#1:dead_cell_size.t)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 3:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 2:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 2:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(~$rec#0:dead_cell_size.t, ?$rec#1:dead_cell_size.t)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(~$rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t)
 
         1:
-            foreign lpvm {noalias} mutate(~$rec#0:dead_cell_size.t, ?$rec#1:dead_cell_size.t, -2:wybe.int, 0:wybe.int, 8:wybe.int, 2:wybe.int, ~$field#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm {noalias} mutate(~$rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t, -2:wybe.int, 0:wybe.int, 8:wybe.int, 2:wybe.int, ~$field##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 ~= > public {inline} (0 calls)
 0: dead_cell_size.t.~=<0>
-~=($left#0:dead_cell_size.t, $right#0:dead_cell_size.t, ?$$#0:wybe.bool):
+~=($left##0:dead_cell_size.t, $right##0:dead_cell_size.t, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    dead_cell_size.t.=<0>(~$left#0:dead_cell_size.t, ~$right#0:dead_cell_size.t, ?tmp$0#0:wybe.bool) #0
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    dead_cell_size.t.=<0>(~$left##0:dead_cell_size.t, ~$right##0:dead_cell_size.t, ?tmp$0##0:wybe.bool) #0
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
   LLVM code       :
 
@@ -1137,113 +1137,113 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"dead_cell_size.t.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"dead_cell_size.t.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$left#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$15#0" = and i64 %"$left#0", 3 
-  %"2$tmp$16#0" = icmp eq i64 %"2$tmp$15#0", 0 
-  br i1 %"2$tmp$16#0", label %if.then1, label %if.else1 
+  %"2$tmp$15##0" = and i64 %"$left##0", 3 
+  %"2$tmp$16##0" = icmp eq i64 %"2$tmp$15##0", 0 
+  br i1 %"2$tmp$16##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = icmp eq i64 %"$left#0", %"$right#0" 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
+  ret i1 %"3$$$##0" 
 if.then1:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %"4$tmp$18#0" = icmp ne i64 %"$right#0", 0 
-  br i1 %"4$tmp$18#0", label %if.then2, label %if.else2 
+  %"4$tmp$18##0" = icmp ne i64 %"$right##0", 0 
+  br i1 %"4$tmp$18##0", label %if.then2, label %if.else2 
 if.else1:
-  %"5$tmp$20#0" = icmp eq i64 %"2$tmp$15#0", 1 
-  br i1 %"5$tmp$20#0", label %if.then4, label %if.else4 
+  %"5$tmp$20##0" = icmp eq i64 %"2$tmp$15##0", 1 
+  br i1 %"5$tmp$20##0", label %if.then4, label %if.else4 
 if.then2:
-  %"6$tmp$19#0" = and i64 %"$right#0", 3 
-  %"6$tmp$20#0" = icmp eq i64 %"6$tmp$19#0", 0 
-  br i1 %"6$tmp$20#0", label %if.then3, label %if.else3 
+  %"6$tmp$19##0" = and i64 %"$right##0", 3 
+  %"6$tmp$20##0" = icmp eq i64 %"6$tmp$19##0", 0 
+  br i1 %"6$tmp$20##0", label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %4 = inttoptr i64 %"$right#0" to i64* 
+  %4 = inttoptr i64 %"$right##0" to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
   %6 = load  i64, i64* %5 
-  %"8$$$#0" = icmp eq i64 %3, %6 
-  ret i1 %"8$$$#0" 
+  %"8$$$##0" = icmp eq i64 %3, %6 
+  ret i1 %"8$$$##0" 
 if.else3:
   ret i1 0 
 if.then4:
-  %7 = add   i64 %"$left#0", -1 
+  %7 = add   i64 %"$left##0", -1 
   %8 = inttoptr i64 %7 to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$left#0", 7 
+  %11 = add   i64 %"$left##0", 7 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %15 = add   i64 %"$left#0", 15 
+  %15 = add   i64 %"$left##0", 15 
   %16 = inttoptr i64 %15 to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
-  %"10$tmp$22#0" = icmp ne i64 %"$right#0", 0 
-  br i1 %"10$tmp$22#0", label %if.then5, label %if.else5 
+  %"10$tmp$22##0" = icmp ne i64 %"$right##0", 0 
+  br i1 %"10$tmp$22##0", label %if.then5, label %if.else5 
 if.else4:
-  %"11$tmp$24#0" = icmp eq i64 %"2$tmp$15#0", 2 
-  br i1 %"11$tmp$24#0", label %if.then9, label %if.else9 
+  %"11$tmp$24##0" = icmp eq i64 %"2$tmp$15##0", 2 
+  br i1 %"11$tmp$24##0", label %if.then9, label %if.else9 
 if.then5:
-  %"12$tmp$23#0" = and i64 %"$right#0", 3 
-  %"12$tmp$24#0" = icmp eq i64 %"12$tmp$23#0", 1 
-  br i1 %"12$tmp$24#0", label %if.then6, label %if.else6 
+  %"12$tmp$23##0" = and i64 %"$right##0", 3 
+  %"12$tmp$24##0" = icmp eq i64 %"12$tmp$23##0", 1 
+  br i1 %"12$tmp$24##0", label %if.then6, label %if.else6 
 if.else5:
   ret i1 0 
 if.then6:
-  %19 = add   i64 %"$right#0", -1 
+  %19 = add   i64 %"$right##0", -1 
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %23 = add   i64 %"$right#0", 7 
+  %23 = add   i64 %"$right##0", 7 
   %24 = inttoptr i64 %23 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
   %26 = load  i64, i64* %25 
-  %27 = add   i64 %"$right#0", 15 
+  %27 = add   i64 %"$right##0", 15 
   %28 = inttoptr i64 %27 to i64* 
   %29 = getelementptr  i64, i64* %28, i64 0 
   %30 = load  i64, i64* %29 
-  %"14$tmp$5#0" = icmp eq i64 %10, %22 
-  br i1 %"14$tmp$5#0", label %if.then7, label %if.else7 
+  %"14$tmp$5##0" = icmp eq i64 %10, %22 
+  br i1 %"14$tmp$5##0", label %if.then7, label %if.else7 
 if.else6:
   ret i1 0 
 if.then7:
-  %"16$tmp$6#0" = icmp eq i64 %14, %26 
-  br i1 %"16$tmp$6#0", label %if.then8, label %if.else8 
+  %"16$tmp$6##0" = icmp eq i64 %14, %26 
+  br i1 %"16$tmp$6##0", label %if.then8, label %if.else8 
 if.else7:
   ret i1 0 
 if.then8:
-  %"18$$$#0" = icmp eq i64 %18, %30 
-  ret i1 %"18$$$#0" 
+  %"18$$$##0" = icmp eq i64 %18, %30 
+  ret i1 %"18$$$##0" 
 if.else8:
   ret i1 0 
 if.then9:
-  %31 = add   i64 %"$left#0", -2 
+  %31 = add   i64 %"$left##0", -2 
   %32 = inttoptr i64 %31 to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
-  %"20$tmp$26#0" = icmp ne i64 %"$right#0", 0 
-  br i1 %"20$tmp$26#0", label %if.then10, label %if.else10 
+  %"20$tmp$26##0" = icmp ne i64 %"$right##0", 0 
+  br i1 %"20$tmp$26##0", label %if.then10, label %if.else10 
 if.else9:
   ret i1 0 
 if.then10:
-  %"22$tmp$27#0" = and i64 %"$right#0", 3 
-  %"22$tmp$28#0" = icmp eq i64 %"22$tmp$27#0", 2 
-  br i1 %"22$tmp$28#0", label %if.then11, label %if.else11 
+  %"22$tmp$27##0" = and i64 %"$right##0", 3 
+  %"22$tmp$28##0" = icmp eq i64 %"22$tmp$27##0", 2 
+  br i1 %"22$tmp$28##0", label %if.then11, label %if.else11 
 if.else10:
   ret i1 0 
 if.then11:
-  %35 = add   i64 %"$right#0", -2 
+  %35 = add   i64 %"$right##0", -2 
   %36 = inttoptr i64 %35 to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
-  %"24$$$#0" = icmp eq i64 %34, %38 
-  ret i1 %"24$$$#0" 
+  %"24$$$##0" = icmp eq i64 %34, %38 
+  ret i1 %"24$$$##0" 
 if.else11:
   ret i1 0 
 }
@@ -1255,32 +1255,32 @@ entry:
 }
 
 
-define external fastcc  i64 @"dead_cell_size.t.tb<0>"(i64  %"tb1#0")    {
+define external fastcc  i64 @"dead_cell_size.t.tb<0>"(i64  %"tb1##0")    {
 entry:
   %39 = trunc i64 8 to i32  
   %40 = tail call ccc  i8*  @wybe_malloc(i32  %39)  
   %41 = ptrtoint i8* %40 to i64 
   %42 = inttoptr i64 %41 to i64* 
   %43 = getelementptr  i64, i64* %42, i64 0 
-  store  i64 %"tb1#0", i64* %43 
+  store  i64 %"tb1##0", i64* %43 
   ret i64 %41 
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.tb<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.tb<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$#0", 3 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 0 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$##0", 3 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 0 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %51 = insertvalue {i64, i1} undef, i64 undef, 0 
   %52 = insertvalue {i64, i1} %51, i1 0, 1 
   ret {i64, i1} %52 
 if.then1:
-  %44 = inttoptr i64 %"$#0" to i64* 
+  %44 = inttoptr i64 %"$##0" to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
   %47 = insertvalue {i64, i1} undef, i64 %46, 0 
@@ -1293,20 +1293,20 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.tb1<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.tb1<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 3 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 0 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 3 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 0 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %60 = insertvalue {i64, i1} undef, i64 undef, 0 
   %61 = insertvalue {i64, i1} %60, i1 0, 1 
   ret {i64, i1} %61 
 if.then1:
-  %53 = inttoptr i64 %"$rec#0" to i64* 
+  %53 = inttoptr i64 %"$rec##0" to i64* 
   %54 = getelementptr  i64, i64* %53, i64 0 
   %55 = load  i64, i64* %54 
   %56 = insertvalue {i64, i1} undef, i64 %55, 0 
@@ -1319,16 +1319,16 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.tb1<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.tb1<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 3 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 0 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 3 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 0 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
-  %74 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %74 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %75 = insertvalue {i64, i1} %74, i1 0, 1 
   ret {i64, i1} %75 
 if.then1:
@@ -1336,51 +1336,51 @@ if.then1:
   %63 = tail call ccc  i8*  @wybe_malloc(i32  %62)  
   %64 = ptrtoint i8* %63 to i64 
   %65 = inttoptr i64 %64 to i8* 
-  %66 = inttoptr i64 %"$rec#0" to i8* 
+  %66 = inttoptr i64 %"$rec##0" to i8* 
   %67 = trunc i64 8 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %65, i8*  %66, i32  %67, i32  8, i1  0)  
   %68 = inttoptr i64 %64 to i64* 
   %69 = getelementptr  i64, i64* %68, i64 0 
-  store  i64 %"$field#0", i64* %69 
+  store  i64 %"$field##0", i64* %69 
   %70 = insertvalue {i64, i1} undef, i64 %64, 0 
   %71 = insertvalue {i64, i1} %70, i1 1, 1 
   ret {i64, i1} %71 
 if.else1:
-  %72 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %72 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %73 = insertvalue {i64, i1} %72, i1 0, 1 
   ret {i64, i1} %73 
 }
 
 
-define external fastcc  i64 @"dead_cell_size.t.tc<0>"(i64  %"tc1#0", i64  %"tc2#0", i64  %"tc3#0")    {
+define external fastcc  i64 @"dead_cell_size.t.tc<0>"(i64  %"tc1##0", i64  %"tc2##0", i64  %"tc3##0")    {
 entry:
   %76 = trunc i64 24 to i32  
   %77 = tail call ccc  i8*  @wybe_malloc(i32  %76)  
   %78 = ptrtoint i8* %77 to i64 
   %79 = inttoptr i64 %78 to i64* 
   %80 = getelementptr  i64, i64* %79, i64 0 
-  store  i64 %"tc1#0", i64* %80 
+  store  i64 %"tc1##0", i64* %80 
   %81 = add   i64 %78, 8 
   %82 = inttoptr i64 %81 to i64* 
   %83 = getelementptr  i64, i64* %82, i64 0 
-  store  i64 %"tc2#0", i64* %83 
+  store  i64 %"tc2##0", i64* %83 
   %84 = add   i64 %78, 16 
   %85 = inttoptr i64 %84 to i64* 
   %86 = getelementptr  i64, i64* %85, i64 0 
-  store  i64 %"tc3#0", i64* %86 
-  %"1$$#0" = or i64 %78, 1 
-  ret i64 %"1$$#0" 
+  store  i64 %"tc3##0", i64* %86 
+  %"1$$##0" = or i64 %78, 1 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  {i64, i64, i64, i1} @"dead_cell_size.t.tc<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64, i64, i1} @"dead_cell_size.t.tc<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$#0", 3 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 1 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$##0", 3 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 1 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %107 = insertvalue {i64, i64, i64, i1} undef, i64 undef, 0 
   %108 = insertvalue {i64, i64, i64, i1} %107, i64 undef, 1 
@@ -1388,15 +1388,15 @@ if.else:
   %110 = insertvalue {i64, i64, i64, i1} %109, i1 0, 3 
   ret {i64, i64, i64, i1} %110 
 if.then1:
-  %87 = add   i64 %"$#0", -1 
+  %87 = add   i64 %"$##0", -1 
   %88 = inttoptr i64 %87 to i64* 
   %89 = getelementptr  i64, i64* %88, i64 0 
   %90 = load  i64, i64* %89 
-  %91 = add   i64 %"$#0", 7 
+  %91 = add   i64 %"$##0", 7 
   %92 = inttoptr i64 %91 to i64* 
   %93 = getelementptr  i64, i64* %92, i64 0 
   %94 = load  i64, i64* %93 
-  %95 = add   i64 %"$#0", 15 
+  %95 = add   i64 %"$##0", 15 
   %96 = inttoptr i64 %95 to i64* 
   %97 = getelementptr  i64, i64* %96, i64 0 
   %98 = load  i64, i64* %97 
@@ -1414,20 +1414,20 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.tc1<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.tc1<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 3 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 1 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 3 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 1 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %119 = insertvalue {i64, i1} undef, i64 undef, 0 
   %120 = insertvalue {i64, i1} %119, i1 0, 1 
   ret {i64, i1} %120 
 if.then1:
-  %111 = add   i64 %"$rec#0", -1 
+  %111 = add   i64 %"$rec##0", -1 
   %112 = inttoptr i64 %111 to i64* 
   %113 = getelementptr  i64, i64* %112, i64 0 
   %114 = load  i64, i64* %113 
@@ -1441,16 +1441,16 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.tc1<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.tc1<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 3 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 1 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 3 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 1 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
-  %136 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %136 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %137 = insertvalue {i64, i1} %136, i1 0, 1 
   ret {i64, i1} %137 
 if.then1:
@@ -1458,7 +1458,7 @@ if.then1:
   %122 = tail call ccc  i8*  @wybe_malloc(i32  %121)  
   %123 = ptrtoint i8* %122 to i64 
   %124 = add   i64 %123, 1 
-  %125 = sub   i64 %"$rec#0", 1 
+  %125 = sub   i64 %"$rec##0", 1 
   %126 = inttoptr i64 %123 to i8* 
   %127 = inttoptr i64 %125 to i8* 
   %128 = trunc i64 24 to i32  
@@ -1466,31 +1466,31 @@ if.then1:
   %129 = add   i64 %124, -1 
   %130 = inttoptr i64 %129 to i64* 
   %131 = getelementptr  i64, i64* %130, i64 0 
-  store  i64 %"$field#0", i64* %131 
+  store  i64 %"$field##0", i64* %131 
   %132 = insertvalue {i64, i1} undef, i64 %124, 0 
   %133 = insertvalue {i64, i1} %132, i1 1, 1 
   ret {i64, i1} %133 
 if.else1:
-  %134 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %134 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %135 = insertvalue {i64, i1} %134, i1 0, 1 
   ret {i64, i1} %135 
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.tc2<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.tc2<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 3 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 1 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 3 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 1 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %146 = insertvalue {i64, i1} undef, i64 undef, 0 
   %147 = insertvalue {i64, i1} %146, i1 0, 1 
   ret {i64, i1} %147 
 if.then1:
-  %138 = add   i64 %"$rec#0", 7 
+  %138 = add   i64 %"$rec##0", 7 
   %139 = inttoptr i64 %138 to i64* 
   %140 = getelementptr  i64, i64* %139, i64 0 
   %141 = load  i64, i64* %140 
@@ -1504,16 +1504,16 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.tc2<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.tc2<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 3 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 1 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 3 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 1 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
-  %163 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %163 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %164 = insertvalue {i64, i1} %163, i1 0, 1 
   ret {i64, i1} %164 
 if.then1:
@@ -1521,7 +1521,7 @@ if.then1:
   %149 = tail call ccc  i8*  @wybe_malloc(i32  %148)  
   %150 = ptrtoint i8* %149 to i64 
   %151 = add   i64 %150, 1 
-  %152 = sub   i64 %"$rec#0", 1 
+  %152 = sub   i64 %"$rec##0", 1 
   %153 = inttoptr i64 %150 to i8* 
   %154 = inttoptr i64 %152 to i8* 
   %155 = trunc i64 24 to i32  
@@ -1529,31 +1529,31 @@ if.then1:
   %156 = add   i64 %151, 7 
   %157 = inttoptr i64 %156 to i64* 
   %158 = getelementptr  i64, i64* %157, i64 0 
-  store  i64 %"$field#0", i64* %158 
+  store  i64 %"$field##0", i64* %158 
   %159 = insertvalue {i64, i1} undef, i64 %151, 0 
   %160 = insertvalue {i64, i1} %159, i1 1, 1 
   ret {i64, i1} %160 
 if.else1:
-  %161 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %161 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %162 = insertvalue {i64, i1} %161, i1 0, 1 
   ret {i64, i1} %162 
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.tc3<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.tc3<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 3 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 1 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 3 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 1 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %173 = insertvalue {i64, i1} undef, i64 undef, 0 
   %174 = insertvalue {i64, i1} %173, i1 0, 1 
   ret {i64, i1} %174 
 if.then1:
-  %165 = add   i64 %"$rec#0", 15 
+  %165 = add   i64 %"$rec##0", 15 
   %166 = inttoptr i64 %165 to i64* 
   %167 = getelementptr  i64, i64* %166, i64 0 
   %168 = load  i64, i64* %167 
@@ -1567,16 +1567,16 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.tc3<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.tc3<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 3 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 1 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 3 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 1 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
-  %190 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %190 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %191 = insertvalue {i64, i1} %190, i1 0, 1 
   ret {i64, i1} %191 
 if.then1:
@@ -1584,7 +1584,7 @@ if.then1:
   %176 = tail call ccc  i8*  @wybe_malloc(i32  %175)  
   %177 = ptrtoint i8* %176 to i64 
   %178 = add   i64 %177, 1 
-  %179 = sub   i64 %"$rec#0", 1 
+  %179 = sub   i64 %"$rec##0", 1 
   %180 = inttoptr i64 %177 to i8* 
   %181 = inttoptr i64 %179 to i8* 
   %182 = trunc i64 24 to i32  
@@ -1592,44 +1592,44 @@ if.then1:
   %183 = add   i64 %178, 15 
   %184 = inttoptr i64 %183 to i64* 
   %185 = getelementptr  i64, i64* %184, i64 0 
-  store  i64 %"$field#0", i64* %185 
+  store  i64 %"$field##0", i64* %185 
   %186 = insertvalue {i64, i1} undef, i64 %178, 0 
   %187 = insertvalue {i64, i1} %186, i1 1, 1 
   ret {i64, i1} %187 
 if.else1:
-  %188 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %188 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %189 = insertvalue {i64, i1} %188, i1 0, 1 
   ret {i64, i1} %189 
 }
 
 
-define external fastcc  i64 @"dead_cell_size.t.td<0>"(i64  %"td1#0")    {
+define external fastcc  i64 @"dead_cell_size.t.td<0>"(i64  %"td1##0")    {
 entry:
   %192 = trunc i64 8 to i32  
   %193 = tail call ccc  i8*  @wybe_malloc(i32  %192)  
   %194 = ptrtoint i8* %193 to i64 
   %195 = inttoptr i64 %194 to i64* 
   %196 = getelementptr  i64, i64* %195, i64 0 
-  store  i64 %"td1#0", i64* %196 
-  %"1$$#0" = or i64 %194, 2 
-  ret i64 %"1$$#0" 
+  store  i64 %"td1##0", i64* %196 
+  %"1$$##0" = or i64 %194, 2 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.td<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.td<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$#0", 3 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 2 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$##0", 3 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 2 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %205 = insertvalue {i64, i1} undef, i64 undef, 0 
   %206 = insertvalue {i64, i1} %205, i1 0, 1 
   ret {i64, i1} %206 
 if.then1:
-  %197 = add   i64 %"$#0", -2 
+  %197 = add   i64 %"$##0", -2 
   %198 = inttoptr i64 %197 to i64* 
   %199 = getelementptr  i64, i64* %198, i64 0 
   %200 = load  i64, i64* %199 
@@ -1643,20 +1643,20 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.td1<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.td1<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 3 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 2 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 3 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 2 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %215 = insertvalue {i64, i1} undef, i64 undef, 0 
   %216 = insertvalue {i64, i1} %215, i1 0, 1 
   ret {i64, i1} %216 
 if.then1:
-  %207 = add   i64 %"$rec#0", -2 
+  %207 = add   i64 %"$rec##0", -2 
   %208 = inttoptr i64 %207 to i64* 
   %209 = getelementptr  i64, i64* %208, i64 0 
   %210 = load  i64, i64* %209 
@@ -1670,16 +1670,16 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.td1<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.td1<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 3 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 2 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 3 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 2 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
-  %232 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %232 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %233 = insertvalue {i64, i1} %232, i1 0, 1 
   ret {i64, i1} %233 
 if.then1:
@@ -1687,7 +1687,7 @@ if.then1:
   %218 = tail call ccc  i8*  @wybe_malloc(i32  %217)  
   %219 = ptrtoint i8* %218 to i64 
   %220 = add   i64 %219, 2 
-  %221 = sub   i64 %"$rec#0", 2 
+  %221 = sub   i64 %"$rec##0", 2 
   %222 = inttoptr i64 %219 to i8* 
   %223 = inttoptr i64 %221 to i8* 
   %224 = trunc i64 8 to i32  
@@ -1695,22 +1695,22 @@ if.then1:
   %225 = add   i64 %220, -2 
   %226 = inttoptr i64 %225 to i64* 
   %227 = getelementptr  i64, i64* %226, i64 0 
-  store  i64 %"$field#0", i64* %227 
+  store  i64 %"$field##0", i64* %227 
   %228 = insertvalue {i64, i1} undef, i64 %220, 0 
   %229 = insertvalue {i64, i1} %228, i1 1, 1 
   ret {i64, i1} %229 
 if.else1:
-  %230 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %230 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %231 = insertvalue {i64, i1} %230, i1 0, 1 
   ret {i64, i1} %231 
 }
 
 
-define external fastcc  i1 @"dead_cell_size.t.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"dead_cell_size.t.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = tail call fastcc  i1  @"dead_cell_size.t.=<0>"(i64  %"$left#0", i64  %"$right#0")  
-  %"1$$$#0" = xor i1 %"1$tmp$0#0", 1 
-  ret i1 %"1$$$#0" 
+  %"1$tmp$0##0" = tail call fastcc  i1  @"dead_cell_size.t.=<0>"(i64  %"$left##0", i64  %"$right##0")  
+  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
+  ret i1 %"1$$$##0" 
 }
 --------------------------------------------------
  Module dead_cell_size.t2
@@ -1731,99 +1731,99 @@ entry:
 
 = > public (1 calls)
 0: dead_cell_size.t2.=<0>
-=($left#0:dead_cell_size.t2, $right#0:dead_cell_size.t2, ?$$#0:wybe.bool):
+=($left##0:dead_cell_size.t2, $right##0:dead_cell_size.t2, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left#0:dead_cell_size.t2, ~$right#0:dead_cell_size.t2, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~$left##0:dead_cell_size.t2, ~$right##0:dead_cell_size.t2, ?$$##0:wybe.bool)
 
     1:
-        foreign lpvm access(~$left#0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$left$a#0:wybe.int)
-        foreign llvm icmp_ne($right#0:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.bool)
-        case ~tmp$8#0:wybe.bool of
+        foreign lpvm access(~$left##0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$left$a##0:wybe.int)
+        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.bool)
+        case ~tmp$8##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign lpvm access(~$right#0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$right$a#0:wybe.int)
-            foreign llvm icmp_eq(~$left$a#0:wybe.int, ~$right$a#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+            foreign lpvm access(~$right##0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$right$a##0:wybe.int)
+            foreign llvm icmp_eq(~$left$a##0:wybe.int, ~$right$a##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 
 a > public {inline} (0 calls)
 0: dead_cell_size.t2.a<0>
-a($rec#0:dead_cell_size.t2, ?$#0:wybe.int, ?$$#0:wybe.bool):
+a($rec##0:dead_cell_size.t2, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec#0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 a > public {inline} (0 calls)
 1: dead_cell_size.t2.a<1>
-a($rec#0:dead_cell_size.t2, ?$rec#1:dead_cell_size.t2, $field#0:wybe.int, ?$$#0:wybe.bool):
+a($rec##0:dead_cell_size.t2, ?$rec##1:dead_cell_size.t2, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:dead_cell_size.t2, ?$rec#1:dead_cell_size.t2)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:dead_cell_size.t2, ?$rec##1:dead_cell_size.t2)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec#0:dead_cell_size.t2, ?$rec#1:dead_cell_size.t2, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm {noalias} mutate(~$rec##0:dead_cell_size.t2, ?$rec##1:dead_cell_size.t2, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 t2a > public {inline} (0 calls)
 0: dead_cell_size.t2.t2a<0>
-t2a(?$#0:dead_cell_size.t2):
+t2a(?$##0:dead_cell_size.t2):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:dead_cell_size.t2, ?$#0:dead_cell_size.t2)
+    foreign llvm move(0:dead_cell_size.t2, ?$##0:dead_cell_size.t2)
 
 
 t2b > public {inline} (0 calls)
 0: dead_cell_size.t2.t2b<0>
-t2b(a#0:wybe.int, ?$#0:dead_cell_size.t2):
+t2b(a##0:wybe.int, ?$##0:dead_cell_size.t2):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec#0:dead_cell_size.t2)
-    foreign lpvm mutate(~$rec#0:dead_cell_size.t2, ?$#0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~a#0:wybe.int)
+    foreign lpvm alloc(8:wybe.int, ?$rec##0:dead_cell_size.t2)
+    foreign lpvm mutate(~$rec##0:dead_cell_size.t2, ?$##0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~a##0:wybe.int)
 t2b > public {inline} (8 calls)
 1: dead_cell_size.t2.t2b<1>
-t2b(?a#0:wybe.int, $#0:dead_cell_size.t2, ?$$#0:wybe.bool):
+t2b(?a##0:wybe.int, $##0:dead_cell_size.t2, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?a#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?a##0:wybe.int)
 
     1:
-        foreign lpvm access(~$#0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$##0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: dead_cell_size.t2.~=<0>
-~=($left#0:dead_cell_size.t2, $right#0:dead_cell_size.t2, ?$$#0:wybe.bool):
+~=($left##0:dead_cell_size.t2, $right##0:dead_cell_size.t2, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    dead_cell_size.t2.=<0>(~$left#0:dead_cell_size.t2, ~$right#0:dead_cell_size.t2, ?tmp$0#0:wybe.bool) #0
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    dead_cell_size.t2.=<0>(~$left##0:dead_cell_size.t2, ~$right##0:dead_cell_size.t2, ?tmp$0##0:wybe.bool) #0
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
   LLVM code       :
 
@@ -1839,36 +1839,36 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"dead_cell_size.t2.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"dead_cell_size.t2.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$left#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %"2$tmp$8#0" = icmp ne i64 %"$right#0", 0 
-  br i1 %"2$tmp$8#0", label %if.then1, label %if.else1 
+  %"2$tmp$8##0" = icmp ne i64 %"$right##0", 0 
+  br i1 %"2$tmp$8##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = icmp eq i64 %"$left#0", %"$right#0" 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
+  ret i1 %"3$$$##0" 
 if.then1:
-  %4 = inttoptr i64 %"$right#0" to i64* 
+  %4 = inttoptr i64 %"$right##0" to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
   %6 = load  i64, i64* %5 
-  %"4$$$#0" = icmp eq i64 %3, %6 
-  ret i1 %"4$$$#0" 
+  %"4$$$##0" = icmp eq i64 %3, %6 
+  ret i1 %"4$$$##0" 
 if.else1:
   ret i1 0 
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t2.a<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t2.a<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %7 = inttoptr i64 %"$rec#0" to i64* 
+  %7 = inttoptr i64 %"$rec##0" to i64* 
   %8 = getelementptr  i64, i64* %7, i64 0 
   %9 = load  i64, i64* %8 
   %10 = insertvalue {i64, i1} undef, i64 %9, 0 
@@ -1881,26 +1881,26 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t2.a<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t2.a<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %14 = trunc i64 8 to i32  
   %15 = tail call ccc  i8*  @wybe_malloc(i32  %14)  
   %16 = ptrtoint i8* %15 to i64 
   %17 = inttoptr i64 %16 to i8* 
-  %18 = inttoptr i64 %"$rec#0" to i8* 
+  %18 = inttoptr i64 %"$rec##0" to i8* 
   %19 = trunc i64 8 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %17, i8*  %18, i32  %19, i32  8, i1  0)  
   %20 = inttoptr i64 %16 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
-  store  i64 %"$field#0", i64* %21 
+  store  i64 %"$field##0", i64* %21 
   %22 = insertvalue {i64, i1} undef, i64 %16, 0 
   %23 = insertvalue {i64, i1} %22, i1 1, 1 
   ret {i64, i1} %23 
 if.else:
-  %24 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %24 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %25 = insertvalue {i64, i1} %24, i1 0, 1 
   ret {i64, i1} %25 
 }
@@ -1912,24 +1912,24 @@ entry:
 }
 
 
-define external fastcc  i64 @"dead_cell_size.t2.t2b<0>"(i64  %"a#0")    {
+define external fastcc  i64 @"dead_cell_size.t2.t2b<0>"(i64  %"a##0")    {
 entry:
   %26 = trunc i64 8 to i32  
   %27 = tail call ccc  i8*  @wybe_malloc(i32  %26)  
   %28 = ptrtoint i8* %27 to i64 
   %29 = inttoptr i64 %28 to i64* 
   %30 = getelementptr  i64, i64* %29, i64 0 
-  store  i64 %"a#0", i64* %30 
+  store  i64 %"a##0", i64* %30 
   ret i64 %28 
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t2.t2b<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t2.t2b<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %31 = inttoptr i64 %"$#0" to i64* 
+  %31 = inttoptr i64 %"$##0" to i64* 
   %32 = getelementptr  i64, i64* %31, i64 0 
   %33 = load  i64, i64* %32 
   %34 = insertvalue {i64, i1} undef, i64 %33, 0 
@@ -1942,9 +1942,9 @@ if.else:
 }
 
 
-define external fastcc  i1 @"dead_cell_size.t2.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"dead_cell_size.t2.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = tail call fastcc  i1  @"dead_cell_size.t2.=<0>"(i64  %"$left#0", i64  %"$right#0")  
-  %"1$$$#0" = xor i1 %"1$tmp$0#0", 1 
-  ret i1 %"1$$$#0" 
+  %"1$tmp$0##0" = tail call fastcc  i1  @"dead_cell_size.t2.=<0>"(i64  %"$left##0", i64  %"$right##0")  
+  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
+  ret i1 %"1$$$##0" 
 }

--- a/test-cases/final-dump/dead_cell_size.exp
+++ b/test-cases/final-dump/dead_cell_size.exp
@@ -644,13 +644,13 @@ if.else1:
 
 = > public (1 calls)
 0: dead_cell_size.t.=<0>
-=(#left##0:dead_cell_size.t, #right##0:dead_cell_size.t, ?####0:wybe.bool):
+=(#left##0:dead_cell_size.t, #right##0:dead_cell_size.t, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~#left##0:dead_cell_size.t, ~#right##0:dead_cell_size.t, ?####0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:dead_cell_size.t, ~#right##0:dead_cell_size.t, ?#success##0:wybe.bool)
 
     1:
         foreign llvm and(#left##0:wybe.int, 3:wybe.int, ?tmp#15##0:wybe.int)
@@ -663,25 +663,25 @@ if.else1:
                 foreign llvm icmp_eq(~tmp#15##0:wybe.int, 2:wybe.int, ?tmp#24##0:wybe.bool)
                 case ~tmp#24##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                 1:
                     foreign lpvm access(~#left##0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#left#td1##0:wybe.int)
                     foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#26##0:wybe.bool)
                     case ~tmp#26##0:wybe.bool of
                     0:
-                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                     1:
                         foreign llvm and(#right##0:wybe.int, 3:wybe.int, ?tmp#27##0:wybe.int)
                         foreign llvm icmp_eq(~tmp#27##0:wybe.int, 2:wybe.int, ?tmp#28##0:wybe.bool)
                         case ~tmp#28##0:wybe.bool of
                         0:
-                            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                         1:
                             foreign lpvm access(~#right##0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#right#td1##0:wybe.int)
-                            foreign llvm icmp_eq(~#left#td1##0:wybe.int, ~#right#td1##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+                            foreign llvm icmp_eq(~#left#td1##0:wybe.int, ~#right#td1##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -693,14 +693,14 @@ if.else1:
                 foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#22##0:wybe.bool)
                 case ~tmp#22##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                 1:
                     foreign llvm and(#right##0:wybe.int, 3:wybe.int, ?tmp#23##0:wybe.int)
                     foreign llvm icmp_eq(~tmp#23##0:wybe.int, 1:wybe.int, ?tmp#24##0:wybe.bool)
                     case ~tmp#24##0:wybe.bool of
                     0:
-                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                     1:
                         foreign lpvm access(#right##0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?#right#tc1##0:wybe.int)
@@ -709,16 +709,16 @@ if.else1:
                         foreign llvm icmp_eq(~#left#tc1##0:wybe.int, ~#right#tc1##0:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
                         case ~tmp#5##0:wybe.bool of
                         0:
-                            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                         1:
                             foreign llvm icmp_eq(~#left#tc2##0:wybe.int, ~#right#tc2##0:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
                             case ~tmp#6##0:wybe.bool of
                             0:
-                                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                             1:
-                                foreign llvm icmp_eq(~#left#tc3##0:wybe.int, ~#right#tc3##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+                                foreign llvm icmp_eq(~#left#tc3##0:wybe.int, ~#right#tc3##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -730,18 +730,18 @@ if.else1:
             foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#18##0:wybe.bool)
             case ~tmp#18##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
                 foreign llvm and(#right##0:wybe.int, 3:wybe.int, ?tmp#19##0:wybe.int)
                 foreign llvm icmp_eq(~tmp#19##0:wybe.int, 0:wybe.int, ?tmp#20##0:wybe.bool)
                 case ~tmp#20##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                 1:
                     foreign lpvm access(~#right##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#right#tb1##0:wybe.int)
-                    foreign llvm icmp_eq(~#left#tb1##0:wybe.int, ~#right#tb1##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+                    foreign llvm icmp_eq(~#left#tb1##0:wybe.int, ~#right#tb1##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -765,13 +765,13 @@ tb(tb1##0:wybe.int, ?#result##0:dead_cell_size.t):
     foreign lpvm mutate(~#rec##0:dead_cell_size.t, ?#result##0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~tb1##0:wybe.int)
 tb > public {inline} (14 calls)
 1: dead_cell_size.t.tb<1>
-tb(?tb1##0:wybe.int, #result##0:dead_cell_size.t, ?####0:wybe.bool):
+tb(?tb1##0:wybe.int, #result##0:dead_cell_size.t, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?tb1##0:wybe.int)
 
     1:
@@ -779,25 +779,25 @@ tb(?tb1##0:wybe.int, #result##0:dead_cell_size.t, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?tb1##0:wybe.int)
 
         1:
             foreign lpvm access(~#result##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?tb1##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 
 tb1 > public {inline} (0 calls)
 0: dead_cell_size.t.tb1<0>
-tb1(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?####0:wybe.bool):
+tb1(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
@@ -805,23 +805,23 @@ tb1(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
             foreign lpvm access(~#rec##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 tb1 > public {inline} (0 calls)
 1: dead_cell_size.t.tb1<1>
-tb1(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?####0:wybe.bool):
+tb1(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t)
 
     1:
@@ -829,12 +829,12 @@ tb1(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?##
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t)
 
         1:
             foreign lpvm {noalias} mutate(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -851,13 +851,13 @@ tc(tc1##0:wybe.int, tc2##0:wybe.int, tc3##0:wybe.int, ?#result##0:dead_cell_size
     foreign llvm or(~#rec##3:dead_cell_size.t, 1:wybe.int, ?#result##0:dead_cell_size.t)
 tc > public {inline} (11 calls)
 1: dead_cell_size.t.tc<1>
-tc(?tc1##0:wybe.int, ?tc2##0:wybe.int, ?tc3##0:wybe.int, #result##0:dead_cell_size.t, ?####0:wybe.bool):
+tc(?tc1##0:wybe.int, ?tc2##0:wybe.int, ?tc3##0:wybe.int, #result##0:dead_cell_size.t, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?tc1##0:wybe.int)
         foreign llvm move(undef:wybe.int, ?tc2##0:wybe.int)
         foreign llvm move(undef:wybe.int, ?tc3##0:wybe.int)
@@ -867,7 +867,7 @@ tc(?tc1##0:wybe.int, ?tc2##0:wybe.int, ?tc3##0:wybe.int, #result##0:dead_cell_si
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?tc1##0:wybe.int)
             foreign llvm move(undef:wybe.int, ?tc2##0:wybe.int)
             foreign llvm move(undef:wybe.int, ?tc3##0:wybe.int)
@@ -876,20 +876,20 @@ tc(?tc1##0:wybe.int, ?tc2##0:wybe.int, ?tc3##0:wybe.int, #result##0:dead_cell_si
             foreign lpvm access(#result##0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?tc1##0:wybe.int)
             foreign lpvm access(#result##0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?tc2##0:wybe.int)
             foreign lpvm access(~#result##0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?tc3##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 
 tc1 > public {inline} (0 calls)
 0: dead_cell_size.t.tc1<0>
-tc1(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?####0:wybe.bool):
+tc1(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
@@ -897,23 +897,23 @@ tc1(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
             foreign lpvm access(~#rec##0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?#result##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 tc1 > public {inline} (0 calls)
 1: dead_cell_size.t.tc1<1>
-tc1(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?####0:wybe.bool):
+tc1(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t)
 
     1:
@@ -921,25 +921,25 @@ tc1(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?##
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t)
 
         1:
             foreign lpvm {noalias} mutate(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, -1:wybe.int, 0:wybe.int, 24:wybe.int, 1:wybe.int, ~#field##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 
 tc2 > public {inline} (0 calls)
 0: dead_cell_size.t.tc2<0>
-tc2(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?####0:wybe.bool):
+tc2(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
@@ -947,23 +947,23 @@ tc2(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
             foreign lpvm access(~#rec##0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?#result##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 tc2 > public {inline} (0 calls)
 1: dead_cell_size.t.tc2<1>
-tc2(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?####0:wybe.bool):
+tc2(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t)
 
     1:
@@ -971,25 +971,25 @@ tc2(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?##
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t)
 
         1:
             foreign lpvm {noalias} mutate(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, 7:wybe.int, 0:wybe.int, 24:wybe.int, 1:wybe.int, ~#field##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 
 tc3 > public {inline} (0 calls)
 0: dead_cell_size.t.tc3<0>
-tc3(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?####0:wybe.bool):
+tc3(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
@@ -997,23 +997,23 @@ tc3(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
             foreign lpvm access(~#rec##0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?#result##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 tc3 > public {inline} (0 calls)
 1: dead_cell_size.t.tc3<1>
-tc3(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?####0:wybe.bool):
+tc3(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t)
 
     1:
@@ -1021,12 +1021,12 @@ tc3(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?##
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t)
 
         1:
             foreign lpvm {noalias} mutate(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, 15:wybe.int, 0:wybe.int, 24:wybe.int, 1:wybe.int, ~#field##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -1041,13 +1041,13 @@ td(td1##0:wybe.int, ?#result##0:dead_cell_size.t):
     foreign llvm or(~#rec##1:dead_cell_size.t, 2:wybe.int, ?#result##0:dead_cell_size.t)
 td > public {inline} (5 calls)
 1: dead_cell_size.t.td<1>
-td(?td1##0:wybe.int, #result##0:dead_cell_size.t, ?####0:wybe.bool):
+td(?td1##0:wybe.int, #result##0:dead_cell_size.t, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?td1##0:wybe.int)
 
     1:
@@ -1055,25 +1055,25 @@ td(?td1##0:wybe.int, #result##0:dead_cell_size.t, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 2:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?td1##0:wybe.int)
 
         1:
             foreign lpvm access(~#result##0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?td1##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 
 td1 > public {inline} (0 calls)
 0: dead_cell_size.t.td1<0>
-td1(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?####0:wybe.bool):
+td1(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
@@ -1081,23 +1081,23 @@ td1(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 2:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
             foreign lpvm access(~#rec##0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#result##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 td1 > public {inline} (0 calls)
 1: dead_cell_size.t.td1<1>
-td1(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?####0:wybe.bool):
+td1(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t)
 
     1:
@@ -1105,23 +1105,23 @@ td1(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?##
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 2:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t)
 
         1:
             foreign lpvm {noalias} mutate(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, -2:wybe.int, 0:wybe.int, 8:wybe.int, 2:wybe.int, ~#field##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 
 ~= > public {inline} (0 calls)
 0: dead_cell_size.t.~=<0>
-~=(#left##0:dead_cell_size.t, #right##0:dead_cell_size.t, ?####0:wybe.bool):
+~=(#left##0:dead_cell_size.t, #right##0:dead_cell_size.t, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     dead_cell_size.t.=<0>(~#left##0:dead_cell_size.t, ~#right##0:dead_cell_size.t, ?tmp#0##0:wybe.bool) #0
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 
@@ -1146,8 +1146,8 @@ if.then:
   %"2#tmp#16##0" = icmp eq i64 %"2#tmp#15##0", 0 
   br i1 %"2#tmp#16##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %"3#####0" 
+  %"3##success##0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3##success##0" 
 if.then1:
   %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
@@ -1167,8 +1167,8 @@ if.then3:
   %4 = inttoptr i64 %"#right##0" to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
   %6 = load  i64, i64* %5 
-  %"8#####0" = icmp eq i64 %3, %6 
-  ret i1 %"8#####0" 
+  %"8##success##0" = icmp eq i64 %3, %6 
+  ret i1 %"8##success##0" 
 if.else3:
   ret i1 0 
 if.then4:
@@ -1218,8 +1218,8 @@ if.then7:
 if.else7:
   ret i1 0 
 if.then8:
-  %"18#####0" = icmp eq i64 %18, %30 
-  ret i1 %"18#####0" 
+  %"18##success##0" = icmp eq i64 %18, %30 
+  ret i1 %"18##success##0" 
 if.else8:
   ret i1 0 
 if.then9:
@@ -1242,8 +1242,8 @@ if.then11:
   %36 = inttoptr i64 %35 to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
-  %"24#####0" = icmp eq i64 %34, %38 
-  ret i1 %"24#####0" 
+  %"24##success##0" = icmp eq i64 %34, %38 
+  ret i1 %"24##success##0" 
 if.else11:
   ret i1 0 
 }
@@ -1709,8 +1709,8 @@ if.else1:
 define external fastcc  i1 @"dead_cell_size.t.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %"1#tmp#0##0" = tail call fastcc  i1  @"dead_cell_size.t.=<0>"(i64  %"#left##0", i64  %"#right##0")  
-  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
-  ret i1 %"1#####0" 
+  %"1##success##0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1##success##0" 
 }
 --------------------------------------------------
  Module dead_cell_size.t2
@@ -1731,57 +1731,57 @@ entry:
 
 = > public (1 calls)
 0: dead_cell_size.t2.=<0>
-=(#left##0:dead_cell_size.t2, #right##0:dead_cell_size.t2, ?####0:wybe.bool):
+=(#left##0:dead_cell_size.t2, #right##0:dead_cell_size.t2, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~#left##0:dead_cell_size.t2, ~#right##0:dead_cell_size.t2, ?####0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:dead_cell_size.t2, ~#right##0:dead_cell_size.t2, ?#success##0:wybe.bool)
 
     1:
         foreign lpvm access(~#left##0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#left#a##0:wybe.int)
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool)
         case ~tmp#8##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign lpvm access(~#right##0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#right#a##0:wybe.int)
-            foreign llvm icmp_eq(~#left#a##0:wybe.int, ~#right#a##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+            foreign llvm icmp_eq(~#left#a##0:wybe.int, ~#right#a##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
 
 a > public {inline} (0 calls)
 0: dead_cell_size.t2.a<0>
-a(#rec##0:dead_cell_size.t2, ?#result##0:wybe.int, ?####0:wybe.bool):
+a(#rec##0:dead_cell_size.t2, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign lpvm access(~#rec##0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 a > public {inline} (0 calls)
 1: dead_cell_size.t2.a<1>
-a(#rec##0:dead_cell_size.t2, ?#rec##1:dead_cell_size.t2, #field##0:wybe.int, ?####0:wybe.bool):
+a(#rec##0:dead_cell_size.t2, ?#rec##1:dead_cell_size.t2, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:dead_cell_size.t2, ?#rec##1:dead_cell_size.t2)
 
     1:
         foreign lpvm {noalias} mutate(~#rec##0:dead_cell_size.t2, ?#rec##1:dead_cell_size.t2, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -1802,28 +1802,28 @@ t2b(a##0:wybe.int, ?#result##0:dead_cell_size.t2):
     foreign lpvm mutate(~#rec##0:dead_cell_size.t2, ?#result##0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~a##0:wybe.int)
 t2b > public {inline} (8 calls)
 1: dead_cell_size.t2.t2b<1>
-t2b(?a##0:wybe.int, #result##0:dead_cell_size.t2, ?####0:wybe.bool):
+t2b(?a##0:wybe.int, #result##0:dead_cell_size.t2, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?a##0:wybe.int)
 
     1:
         foreign lpvm access(~#result##0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: dead_cell_size.t2.~=<0>
-~=(#left##0:dead_cell_size.t2, #right##0:dead_cell_size.t2, ?####0:wybe.bool):
+~=(#left##0:dead_cell_size.t2, #right##0:dead_cell_size.t2, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     dead_cell_size.t2.=<0>(~#left##0:dead_cell_size.t2, ~#right##0:dead_cell_size.t2, ?tmp#0##0:wybe.bool) #0
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 
@@ -1850,14 +1850,14 @@ if.then:
   %"2#tmp#8##0" = icmp ne i64 %"#right##0", 0 
   br i1 %"2#tmp#8##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %"3#####0" 
+  %"3##success##0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3##success##0" 
 if.then1:
   %4 = inttoptr i64 %"#right##0" to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
   %6 = load  i64, i64* %5 
-  %"4#####0" = icmp eq i64 %3, %6 
-  ret i1 %"4#####0" 
+  %"4##success##0" = icmp eq i64 %3, %6 
+  ret i1 %"4##success##0" 
 if.else1:
   ret i1 0 
 }
@@ -1945,6 +1945,6 @@ if.else:
 define external fastcc  i1 @"dead_cell_size.t2.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %"1#tmp#0##0" = tail call fastcc  i1  @"dead_cell_size.t2.=<0>"(i64  %"#left##0", i64  %"#right##0")  
-  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
-  ret i1 %"1#####0" 
+  %"1##success##0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1##success##0" 
 }

--- a/test-cases/final-dump/dead_cell_size.exp
+++ b/test-cases/final-dump/dead_cell_size.exp
@@ -750,32 +750,32 @@ if.else1:
 
 ta > public {inline} (0 calls)
 0: dead_cell_size.t.ta<0>
-ta(?###0:dead_cell_size.t):
+ta(?#result##0:dead_cell_size.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:dead_cell_size.t, ?###0:dead_cell_size.t)
+    foreign llvm move(0:dead_cell_size.t, ?#result##0:dead_cell_size.t)
 
 
 tb > public {inline} (0 calls)
 0: dead_cell_size.t.tb<0>
-tb(tb1##0:wybe.int, ?###0:dead_cell_size.t):
+tb(tb1##0:wybe.int, ?#result##0:dead_cell_size.t):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:dead_cell_size.t)
-    foreign lpvm mutate(~#rec##0:dead_cell_size.t, ?###0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~tb1##0:wybe.int)
+    foreign lpvm mutate(~#rec##0:dead_cell_size.t, ?#result##0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~tb1##0:wybe.int)
 tb > public {inline} (14 calls)
 1: dead_cell_size.t.tb<1>
-tb(?tb1##0:wybe.int, ###0:dead_cell_size.t, ?####0:wybe.bool):
+tb(?tb1##0:wybe.int, #result##0:dead_cell_size.t, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?tb1##0:wybe.int)
 
     1:
-        foreign llvm and(###0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm and(#result##0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
@@ -783,7 +783,7 @@ tb(?tb1##0:wybe.int, ###0:dead_cell_size.t, ?####0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?tb1##0:wybe.int)
 
         1:
-            foreign lpvm access(~###0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?tb1##0:wybe.int)
+            foreign lpvm access(~#result##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?tb1##0:wybe.int)
             foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -791,14 +791,14 @@ tb(?tb1##0:wybe.int, ###0:dead_cell_size.t, ?####0:wybe.bool):
 
 tb1 > public {inline} (0 calls)
 0: dead_cell_size.t.tb1<0>
-tb1(#rec##0:dead_cell_size.t, ?###0:wybe.int, ?####0:wybe.bool):
+tb1(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign llvm and(#rec##0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
@@ -806,10 +806,10 @@ tb1(#rec##0:dead_cell_size.t, ?###0:wybe.int, ?####0:wybe.bool):
         case ~tmp#1##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+            foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(~#rec##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?###0:wybe.int)
+            foreign lpvm access(~#rec##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
             foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -841,20 +841,20 @@ tb1(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?##
 
 tc > public {inline} (0 calls)
 0: dead_cell_size.t.tc<0>
-tc(tc1##0:wybe.int, tc2##0:wybe.int, tc3##0:wybe.int, ?###0:dead_cell_size.t):
+tc(tc1##0:wybe.int, tc2##0:wybe.int, tc3##0:wybe.int, ?#result##0:dead_cell_size.t):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(24:wybe.int, ?#rec##0:dead_cell_size.t)
     foreign lpvm mutate(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tc1##0:wybe.int)
     foreign lpvm mutate(~#rec##1:dead_cell_size.t, ?#rec##2:dead_cell_size.t, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tc2##0:wybe.int)
     foreign lpvm mutate(~#rec##2:dead_cell_size.t, ?#rec##3:dead_cell_size.t, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tc3##0:wybe.int)
-    foreign llvm or(~#rec##3:dead_cell_size.t, 1:wybe.int, ?###0:dead_cell_size.t)
+    foreign llvm or(~#rec##3:dead_cell_size.t, 1:wybe.int, ?#result##0:dead_cell_size.t)
 tc > public {inline} (11 calls)
 1: dead_cell_size.t.tc<1>
-tc(?tc1##0:wybe.int, ?tc2##0:wybe.int, ?tc3##0:wybe.int, ###0:dead_cell_size.t, ?####0:wybe.bool):
+tc(?tc1##0:wybe.int, ?tc2##0:wybe.int, ?tc3##0:wybe.int, #result##0:dead_cell_size.t, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
@@ -863,7 +863,7 @@ tc(?tc1##0:wybe.int, ?tc2##0:wybe.int, ?tc3##0:wybe.int, ###0:dead_cell_size.t, 
         foreign llvm move(undef:wybe.int, ?tc3##0:wybe.int)
 
     1:
-        foreign llvm and(###0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm and(#result##0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
@@ -873,9 +873,9 @@ tc(?tc1##0:wybe.int, ?tc2##0:wybe.int, ?tc3##0:wybe.int, ###0:dead_cell_size.t, 
             foreign llvm move(undef:wybe.int, ?tc3##0:wybe.int)
 
         1:
-            foreign lpvm access(###0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?tc1##0:wybe.int)
-            foreign lpvm access(###0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?tc2##0:wybe.int)
-            foreign lpvm access(~###0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?tc3##0:wybe.int)
+            foreign lpvm access(#result##0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?tc1##0:wybe.int)
+            foreign lpvm access(#result##0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?tc2##0:wybe.int)
+            foreign lpvm access(~#result##0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?tc3##0:wybe.int)
             foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -883,14 +883,14 @@ tc(?tc1##0:wybe.int, ?tc2##0:wybe.int, ?tc3##0:wybe.int, ###0:dead_cell_size.t, 
 
 tc1 > public {inline} (0 calls)
 0: dead_cell_size.t.tc1<0>
-tc1(#rec##0:dead_cell_size.t, ?###0:wybe.int, ?####0:wybe.bool):
+tc1(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign llvm and(#rec##0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
@@ -898,10 +898,10 @@ tc1(#rec##0:dead_cell_size.t, ?###0:wybe.int, ?####0:wybe.bool):
         case ~tmp#1##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+            foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(~#rec##0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?###0:wybe.int)
+            foreign lpvm access(~#rec##0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?#result##0:wybe.int)
             foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -933,14 +933,14 @@ tc1(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?##
 
 tc2 > public {inline} (0 calls)
 0: dead_cell_size.t.tc2<0>
-tc2(#rec##0:dead_cell_size.t, ?###0:wybe.int, ?####0:wybe.bool):
+tc2(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign llvm and(#rec##0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
@@ -948,10 +948,10 @@ tc2(#rec##0:dead_cell_size.t, ?###0:wybe.int, ?####0:wybe.bool):
         case ~tmp#1##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+            foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(~#rec##0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?###0:wybe.int)
+            foreign lpvm access(~#rec##0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?#result##0:wybe.int)
             foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -983,14 +983,14 @@ tc2(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?##
 
 tc3 > public {inline} (0 calls)
 0: dead_cell_size.t.tc3<0>
-tc3(#rec##0:dead_cell_size.t, ?###0:wybe.int, ?####0:wybe.bool):
+tc3(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign llvm and(#rec##0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
@@ -998,10 +998,10 @@ tc3(#rec##0:dead_cell_size.t, ?###0:wybe.int, ?####0:wybe.bool):
         case ~tmp#1##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+            foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(~#rec##0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?###0:wybe.int)
+            foreign lpvm access(~#rec##0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?#result##0:wybe.int)
             foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -1033,25 +1033,25 @@ tc3(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?##
 
 td > public {inline} (0 calls)
 0: dead_cell_size.t.td<0>
-td(td1##0:wybe.int, ?###0:dead_cell_size.t):
+td(td1##0:wybe.int, ?#result##0:dead_cell_size.t):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:dead_cell_size.t)
     foreign lpvm mutate(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~td1##0:wybe.int)
-    foreign llvm or(~#rec##1:dead_cell_size.t, 2:wybe.int, ?###0:dead_cell_size.t)
+    foreign llvm or(~#rec##1:dead_cell_size.t, 2:wybe.int, ?#result##0:dead_cell_size.t)
 td > public {inline} (5 calls)
 1: dead_cell_size.t.td<1>
-td(?td1##0:wybe.int, ###0:dead_cell_size.t, ?####0:wybe.bool):
+td(?td1##0:wybe.int, #result##0:dead_cell_size.t, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?td1##0:wybe.int)
 
     1:
-        foreign llvm and(###0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm and(#result##0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 2:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
@@ -1059,7 +1059,7 @@ td(?td1##0:wybe.int, ###0:dead_cell_size.t, ?####0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?td1##0:wybe.int)
 
         1:
-            foreign lpvm access(~###0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?td1##0:wybe.int)
+            foreign lpvm access(~#result##0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?td1##0:wybe.int)
             foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -1067,14 +1067,14 @@ td(?td1##0:wybe.int, ###0:dead_cell_size.t, ?####0:wybe.bool):
 
 td1 > public {inline} (0 calls)
 0: dead_cell_size.t.td1<0>
-td1(#rec##0:dead_cell_size.t, ?###0:wybe.int, ?####0:wybe.bool):
+td1(#rec##0:dead_cell_size.t, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign llvm and(#rec##0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
@@ -1082,10 +1082,10 @@ td1(#rec##0:dead_cell_size.t, ?###0:wybe.int, ?####0:wybe.bool):
         case ~tmp#1##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+            foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(~#rec##0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?###0:wybe.int)
+            foreign lpvm access(~#rec##0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#result##0:wybe.int)
             foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -1267,12 +1267,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.tb<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.tb<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  %"1#tmp#0##0" = icmp ne i64 %"#result##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2#tmp#2##0" = and i64 %"###0", 3 
+  %"2#tmp#2##0" = and i64 %"#result##0", 3 
   %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 0 
   br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
@@ -1280,7 +1280,7 @@ if.else:
   %52 = insertvalue {i64, i1} %51, i1 0, 1 
   ret {i64, i1} %52 
 if.then1:
-  %44 = inttoptr i64 %"###0" to i64* 
+  %44 = inttoptr i64 %"#result##0" to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
   %47 = insertvalue {i64, i1} undef, i64 %46, 0 
@@ -1368,17 +1368,17 @@ entry:
   %85 = inttoptr i64 %84 to i64* 
   %86 = getelementptr  i64, i64* %85, i64 0 
   store  i64 %"tc3##0", i64* %86 
-  %"1####0" = or i64 %78, 1 
-  ret i64 %"1####0" 
+  %"1##result##0" = or i64 %78, 1 
+  ret i64 %"1##result##0" 
 }
 
 
-define external fastcc  {i64, i64, i64, i1} @"dead_cell_size.t.tc<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64, i64, i1} @"dead_cell_size.t.tc<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  %"1#tmp#0##0" = icmp ne i64 %"#result##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2#tmp#2##0" = and i64 %"###0", 3 
+  %"2#tmp#2##0" = and i64 %"#result##0", 3 
   %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 1 
   br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
@@ -1388,15 +1388,15 @@ if.else:
   %110 = insertvalue {i64, i64, i64, i1} %109, i1 0, 3 
   ret {i64, i64, i64, i1} %110 
 if.then1:
-  %87 = add   i64 %"###0", -1 
+  %87 = add   i64 %"#result##0", -1 
   %88 = inttoptr i64 %87 to i64* 
   %89 = getelementptr  i64, i64* %88, i64 0 
   %90 = load  i64, i64* %89 
-  %91 = add   i64 %"###0", 7 
+  %91 = add   i64 %"#result##0", 7 
   %92 = inttoptr i64 %91 to i64* 
   %93 = getelementptr  i64, i64* %92, i64 0 
   %94 = load  i64, i64* %93 
-  %95 = add   i64 %"###0", 15 
+  %95 = add   i64 %"#result##0", 15 
   %96 = inttoptr i64 %95 to i64* 
   %97 = getelementptr  i64, i64* %96, i64 0 
   %98 = load  i64, i64* %97 
@@ -1611,17 +1611,17 @@ entry:
   %195 = inttoptr i64 %194 to i64* 
   %196 = getelementptr  i64, i64* %195, i64 0 
   store  i64 %"td1##0", i64* %196 
-  %"1####0" = or i64 %194, 2 
-  ret i64 %"1####0" 
+  %"1##result##0" = or i64 %194, 2 
+  ret i64 %"1##result##0" 
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.td<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.td<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  %"1#tmp#0##0" = icmp ne i64 %"#result##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2#tmp#2##0" = and i64 %"###0", 3 
+  %"2#tmp#2##0" = and i64 %"#result##0", 3 
   %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 2 
   br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
@@ -1629,7 +1629,7 @@ if.else:
   %206 = insertvalue {i64, i1} %205, i1 0, 1 
   ret {i64, i1} %206 
 if.then1:
-  %197 = add   i64 %"###0", -2 
+  %197 = add   i64 %"#result##0", -2 
   %198 = inttoptr i64 %197 to i64* 
   %199 = getelementptr  i64, i64* %198, i64 0 
   %200 = load  i64, i64* %199 
@@ -1755,17 +1755,17 @@ entry:
 
 a > public {inline} (0 calls)
 0: dead_cell_size.t2.a<0>
-a(#rec##0:dead_cell_size.t2, ?###0:wybe.int, ?####0:wybe.bool):
+a(#rec##0:dead_cell_size.t2, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign lpvm access(~#rec##0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 a > public {inline} (0 calls)
@@ -1787,32 +1787,32 @@ a(#rec##0:dead_cell_size.t2, ?#rec##1:dead_cell_size.t2, #field##0:wybe.int, ?##
 
 t2a > public {inline} (0 calls)
 0: dead_cell_size.t2.t2a<0>
-t2a(?###0:dead_cell_size.t2):
+t2a(?#result##0:dead_cell_size.t2):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:dead_cell_size.t2, ?###0:dead_cell_size.t2)
+    foreign llvm move(0:dead_cell_size.t2, ?#result##0:dead_cell_size.t2)
 
 
 t2b > public {inline} (0 calls)
 0: dead_cell_size.t2.t2b<0>
-t2b(a##0:wybe.int, ?###0:dead_cell_size.t2):
+t2b(a##0:wybe.int, ?#result##0:dead_cell_size.t2):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:dead_cell_size.t2)
-    foreign lpvm mutate(~#rec##0:dead_cell_size.t2, ?###0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~a##0:wybe.int)
+    foreign lpvm mutate(~#rec##0:dead_cell_size.t2, ?#result##0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~a##0:wybe.int)
 t2b > public {inline} (8 calls)
 1: dead_cell_size.t2.t2b<1>
-t2b(?a##0:wybe.int, ###0:dead_cell_size.t2, ?####0:wybe.bool):
+t2b(?a##0:wybe.int, #result##0:dead_cell_size.t2, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?a##0:wybe.int)
 
     1:
-        foreign lpvm access(~###0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int)
+        foreign lpvm access(~#result##0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -1924,12 +1924,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t2.t2b<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t2.t2b<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  %"1#tmp#0##0" = icmp ne i64 %"#result##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %31 = inttoptr i64 %"###0" to i64* 
+  %31 = inttoptr i64 %"#result##0" to i64* 
   %32 = getelementptr  i64, i64* %31, i64 0 
   %33 = load  i64, i64* %32 
   %34 = insertvalue {i64, i1} undef, i64 %33, 0 

--- a/test-cases/final-dump/dead_cell_size.exp
+++ b/test-cases/final-dump/dead_cell_size.exp
@@ -50,18 +50,18 @@ AFTER EVERYTHING:
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(4,(dead_cell_size.bar<0>,fromList [NonAliasedParamCond 0 []])),(7,(dead_cell_size.diff_type<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm alloc(8:wybe.int, ?tmp$7##0:dead_cell_size.t)
-    foreign lpvm mutate(~tmp$7##0:dead_cell_size.t, ?tmp$8##0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 9:wybe.int)
-    dead_cell_size.foo<0>(~tmp$8##0:dead_cell_size.t, ?tmp$0##0:dead_cell_size.t) #1 @dead_cell_size:nn:nn
-    dead_cell_size.print_t<0>(~tmp$0##0:dead_cell_size.t, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @dead_cell_size:nn:nn
-    foreign lpvm alloc(8:wybe.int, ?tmp$10##0:dead_cell_size.t)
-    foreign lpvm mutate(~tmp$10##0:dead_cell_size.t, ?tmp$11##0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 9:wybe.int)
-    dead_cell_size.bar<0>[410bae77d3](~tmp$11##0:dead_cell_size.t, ?tmp$2##0:dead_cell_size.t) #4 @dead_cell_size:nn:nn
-    dead_cell_size.print_t<0>(~tmp$2##0:dead_cell_size.t, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #5 @dead_cell_size:nn:nn
-    foreign lpvm alloc(8:wybe.int, ?tmp$13##0:dead_cell_size.t)
-    foreign lpvm mutate(~tmp$13##0:dead_cell_size.t, ?tmp$14##0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 9:wybe.int)
-    dead_cell_size.diff_type<0>[410bae77d3](~tmp$14##0:dead_cell_size.t, ?tmp$4##0:dead_cell_size.t2) #7 @dead_cell_size:nn:nn
-    dead_cell_size.print_t2<0>(~tmp$4##0:dead_cell_size.t2, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #8 @dead_cell_size:nn:nn
+    foreign lpvm alloc(8:wybe.int, ?tmp#7##0:dead_cell_size.t)
+    foreign lpvm mutate(~tmp#7##0:dead_cell_size.t, ?tmp#8##0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 9:wybe.int)
+    dead_cell_size.foo<0>(~tmp#8##0:dead_cell_size.t, ?tmp#0##0:dead_cell_size.t) #1 @dead_cell_size:nn:nn
+    dead_cell_size.print_t<0>(~tmp#0##0:dead_cell_size.t, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @dead_cell_size:nn:nn
+    foreign lpvm alloc(8:wybe.int, ?tmp#10##0:dead_cell_size.t)
+    foreign lpvm mutate(~tmp#10##0:dead_cell_size.t, ?tmp#11##0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 9:wybe.int)
+    dead_cell_size.bar<0>[410bae77d3](~tmp#11##0:dead_cell_size.t, ?tmp#2##0:dead_cell_size.t) #4 @dead_cell_size:nn:nn
+    dead_cell_size.print_t<0>(~tmp#2##0:dead_cell_size.t, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #5 @dead_cell_size:nn:nn
+    foreign lpvm alloc(8:wybe.int, ?tmp#13##0:dead_cell_size.t)
+    foreign lpvm mutate(~tmp#13##0:dead_cell_size.t, ?tmp#14##0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 9:wybe.int)
+    dead_cell_size.diff_type<0>[410bae77d3](~tmp#14##0:dead_cell_size.t, ?tmp#4##0:dead_cell_size.t2) #7 @dead_cell_size:nn:nn
+    dead_cell_size.print_t2<0>(~tmp#4##0:dead_cell_size.t2, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #8 @dead_cell_size:nn:nn
 
 
 bar > public (1 calls)
@@ -69,35 +69,35 @@ bar > public (1 calls)
 bar(x##0:dead_cell_size.t, ?x##1:dead_cell_size.t):
  AliasPairs: [(x##0,x##1)]
  InterestingCallProperties: [InterestingUnaliased 0]
-    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.bool)
-    case ~tmp$3##0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.bool)
+    case ~tmp#3##0:wybe.bool of
     0:
         foreign llvm move(~x##0:dead_cell_size.t, ?x##1:dead_cell_size.t)
 
     1:
-        foreign llvm and(x##0:wybe.int, 3:wybe.int, ?tmp$4##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
-        case ~tmp$5##0:wybe.bool of
+        foreign llvm and(x##0:wybe.int, 3:wybe.int, ?tmp#4##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
+        case ~tmp#5##0:wybe.bool of
         0:
             foreign llvm move(~x##0:dead_cell_size.t, ?x##1:dead_cell_size.t)
 
         1:
             foreign lpvm access(~x##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int)
-            foreign lpvm alloc(8:wybe.int, ?tmp$7##0:dead_cell_size.t)
-            foreign lpvm mutate(~tmp$7##0:dead_cell_size.t, ?tmp$8##0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~a##0:wybe.int)
-            foreign llvm or(~tmp$8##0:dead_cell_size.t, 2:wybe.int, ?x##1:dead_cell_size.t)
+            foreign lpvm alloc(8:wybe.int, ?tmp#7##0:dead_cell_size.t)
+            foreign lpvm mutate(~tmp#7##0:dead_cell_size.t, ?tmp#8##0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~a##0:wybe.int)
+            foreign llvm or(~tmp#8##0:dead_cell_size.t, 2:wybe.int, ?x##1:dead_cell_size.t)
 
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.bool)
-    case ~tmp$3##0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.bool)
+    case ~tmp#3##0:wybe.bool of
     0:
         foreign llvm move(~x##0:dead_cell_size.t, ?x##1:dead_cell_size.t)
 
     1:
-        foreign llvm and(x##0:wybe.int, 3:wybe.int, ?tmp$4##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
-        case ~tmp$5##0:wybe.bool of
+        foreign llvm and(x##0:wybe.int, 3:wybe.int, ?tmp#4##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
+        case ~tmp#5##0:wybe.bool of
         0:
             foreign llvm move(~x##0:dead_cell_size.t, ?x##1:dead_cell_size.t)
 
@@ -112,40 +112,40 @@ diff_type > public (1 calls)
 diff_type(x##0:dead_cell_size.t, ?y##0:dead_cell_size.t2):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
-    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.bool)
-    case ~tmp$4##0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.bool)
+    case ~tmp#4##0:wybe.bool of
     0:
-        foreign lpvm alloc(8:wybe.int, ?tmp$8##0:dead_cell_size.t2)
-        foreign lpvm mutate(~tmp$8##0:dead_cell_size.t2, ?y##0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, -1:wybe.int)
+        foreign lpvm alloc(8:wybe.int, ?tmp#8##0:dead_cell_size.t2)
+        foreign lpvm mutate(~tmp#8##0:dead_cell_size.t2, ?y##0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, -1:wybe.int)
 
     1:
-        foreign llvm and(x##0:wybe.int, 3:wybe.int, ?tmp$5##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$5##0:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.bool)
-        case ~tmp$6##0:wybe.bool of
+        foreign llvm and(x##0:wybe.int, 3:wybe.int, ?tmp#5##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#5##0:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.bool)
+        case ~tmp#6##0:wybe.bool of
         0:
-            foreign lpvm alloc(8:wybe.int, ?tmp$8##0:dead_cell_size.t2)
-            foreign lpvm mutate(~tmp$8##0:dead_cell_size.t2, ?y##0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, -1:wybe.int)
+            foreign lpvm alloc(8:wybe.int, ?tmp#8##0:dead_cell_size.t2)
+            foreign lpvm mutate(~tmp#8##0:dead_cell_size.t2, ?y##0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, -1:wybe.int)
 
         1:
             foreign lpvm access(~x##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int)
-            foreign lpvm alloc(8:wybe.int, ?tmp$8##0:dead_cell_size.t2)
-            foreign lpvm mutate(~tmp$8##0:dead_cell_size.t2, ?y##0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~a##0:wybe.int)
+            foreign lpvm alloc(8:wybe.int, ?tmp#8##0:dead_cell_size.t2)
+            foreign lpvm mutate(~tmp#8##0:dead_cell_size.t2, ?y##0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~a##0:wybe.int)
 
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.bool)
-    case ~tmp$4##0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.bool)
+    case ~tmp#4##0:wybe.bool of
     0:
-        foreign lpvm alloc(8:wybe.int, ?tmp$8##0:dead_cell_size.t2)
-        foreign lpvm mutate(~tmp$8##0:dead_cell_size.t2, ?y##0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, -1:wybe.int)
+        foreign lpvm alloc(8:wybe.int, ?tmp#8##0:dead_cell_size.t2)
+        foreign lpvm mutate(~tmp#8##0:dead_cell_size.t2, ?y##0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, -1:wybe.int)
 
     1:
-        foreign llvm and(x##0:wybe.int, 3:wybe.int, ?tmp$5##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$5##0:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.bool)
-        case ~tmp$6##0:wybe.bool of
+        foreign llvm and(x##0:wybe.int, 3:wybe.int, ?tmp#5##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#5##0:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.bool)
+        case ~tmp#6##0:wybe.bool of
         0:
-            foreign lpvm alloc(8:wybe.int, ?tmp$8##0:dead_cell_size.t2)
-            foreign lpvm mutate(~tmp$8##0:dead_cell_size.t2, ?y##0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, -1:wybe.int)
+            foreign lpvm alloc(8:wybe.int, ?tmp#8##0:dead_cell_size.t2)
+            foreign lpvm mutate(~tmp#8##0:dead_cell_size.t2, ?y##0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, -1:wybe.int)
 
         1:
             foreign llvm move(~x##0:dead_cell_size.t, ?y##0:dead_cell_size.t2)
@@ -158,25 +158,25 @@ foo > public (1 calls)
 foo(x##0:dead_cell_size.t, ?x##1:dead_cell_size.t):
  AliasPairs: [(x##0,x##1)]
  InterestingCallProperties: []
-    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.bool)
-    case ~tmp$3##0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.bool)
+    case ~tmp#3##0:wybe.bool of
     0:
         foreign llvm move(~x##0:dead_cell_size.t, ?x##1:dead_cell_size.t)
 
     1:
-        foreign llvm and(x##0:wybe.int, 3:wybe.int, ?tmp$4##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
-        case ~tmp$5##0:wybe.bool of
+        foreign llvm and(x##0:wybe.int, 3:wybe.int, ?tmp#4##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
+        case ~tmp#5##0:wybe.bool of
         0:
             foreign llvm move(~x##0:dead_cell_size.t, ?x##1:dead_cell_size.t)
 
         1:
             foreign lpvm access(~x##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int)
-            foreign lpvm alloc(24:wybe.int, ?tmp$9##0:dead_cell_size.t)
-            foreign lpvm mutate(~tmp$9##0:dead_cell_size.t, ?tmp$10##0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~a##0:wybe.int)
-            foreign lpvm mutate(~tmp$10##0:dead_cell_size.t, ?tmp$11##0:dead_cell_size.t, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 2:wybe.int)
-            foreign lpvm mutate(~tmp$11##0:dead_cell_size.t, ?tmp$12##0:dead_cell_size.t, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 3:wybe.int)
-            foreign llvm or(~tmp$12##0:dead_cell_size.t, 1:wybe.int, ?x##1:dead_cell_size.t)
+            foreign lpvm alloc(24:wybe.int, ?tmp#9##0:dead_cell_size.t)
+            foreign lpvm mutate(~tmp#9##0:dead_cell_size.t, ?tmp#10##0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~a##0:wybe.int)
+            foreign lpvm mutate(~tmp#10##0:dead_cell_size.t, ?tmp#11##0:dead_cell_size.t, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 2:wybe.int)
+            foreign lpvm mutate(~tmp#11##0:dead_cell_size.t, ?tmp#12##0:dead_cell_size.t, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 3:wybe.int)
+            foreign llvm or(~tmp#12##0:dead_cell_size.t, 1:wybe.int, ?x##1:dead_cell_size.t)
 
 
 
@@ -186,24 +186,24 @@ print_t > public (2 calls)
 print_t(x##0:dead_cell_size.t, io##0:wybe.phantom, ?io##8:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    dead_cell_size.t.=<0>(0:dead_cell_size.t, x##0:dead_cell_size.t, ?tmp$4##0:wybe.bool) #1 @dead_cell_size:nn:nn
-    case ~tmp$4##0:wybe.bool of
+    dead_cell_size.t.=<0>(0:dead_cell_size.t, x##0:dead_cell_size.t, ?tmp#4##0:wybe.bool) #1 @dead_cell_size:nn:nn
+    case ~tmp#4##0:wybe.bool of
     0:
-        foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.bool)
-        case ~tmp$6##0:wybe.bool of
+        foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.bool)
+        case ~tmp#6##0:wybe.bool of
         0:
             foreign c putchar('\n':wybe.char, ~#io##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
 
         1:
-            foreign llvm and(x##0:wybe.int, 3:wybe.int, ?tmp$7##0:wybe.int)
-            foreign llvm icmp_eq(tmp$7##0:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.bool)
-            case ~tmp$8##0:wybe.bool of
+            foreign llvm and(x##0:wybe.int, 3:wybe.int, ?tmp#7##0:wybe.int)
+            foreign llvm icmp_eq(tmp#7##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool)
+            case ~tmp#8##0:wybe.bool of
             0:
-                foreign llvm icmp_eq(tmp$7##0:wybe.int, 1:wybe.int, ?tmp$12##0:wybe.bool)
-                case ~tmp$12##0:wybe.bool of
+                foreign llvm icmp_eq(tmp#7##0:wybe.int, 1:wybe.int, ?tmp#12##0:wybe.bool)
+                case ~tmp#12##0:wybe.bool of
                 0:
-                    foreign llvm icmp_eq(~tmp$7##0:wybe.int, 2:wybe.int, ?tmp$16##0:wybe.bool)
-                    case ~tmp$16##0:wybe.bool of
+                    foreign llvm icmp_eq(~tmp#7##0:wybe.int, 2:wybe.int, ?tmp#16##0:wybe.bool)
+                    case ~tmp#16##0:wybe.bool of
                     0:
                         foreign c putchar('\n':wybe.char, ~#io##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
 
@@ -249,11 +249,11 @@ print_t2 > public (1 calls)
 print_t2(x##0:dead_cell_size.t2, io##0:wybe.phantom, ?io##4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    dead_cell_size.t2.=<0>(0:dead_cell_size.t2, x##0:dead_cell_size.t2, ?tmp$2##0:wybe.bool) #1 @dead_cell_size:nn:nn
-    case ~tmp$2##0:wybe.bool of
+    dead_cell_size.t2.=<0>(0:dead_cell_size.t2, x##0:dead_cell_size.t2, ?tmp#2##0:wybe.bool) #1 @dead_cell_size:nn:nn
+    case ~tmp#2##0:wybe.bool of
     0:
-        foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.bool)
-        case ~tmp$4##0:wybe.bool of
+        foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.bool)
+        case ~tmp#4##0:wybe.bool of
         0:
             foreign c putchar('\n':wybe.char, ~#io##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
 
@@ -337,36 +337,36 @@ entry:
   %4 = inttoptr i64 %3 to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
   store  i64 9, i64* %5 
-  %"1$tmp$0##0" = tail call fastcc  i64  @"dead_cell_size.foo<0>"(i64  %3)  
-  tail call fastcc  void  @"dead_cell_size.print_t<0>"(i64  %"1$tmp$0##0")  
+  %"1#tmp#0##0" = tail call fastcc  i64  @"dead_cell_size.foo<0>"(i64  %3)  
+  tail call fastcc  void  @"dead_cell_size.print_t<0>"(i64  %"1#tmp#0##0")  
   %6 = trunc i64 8 to i32  
   %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
   %8 = ptrtoint i8* %7 to i64 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   store  i64 9, i64* %10 
-  %"1$tmp$2##0" = tail call fastcc  i64  @"dead_cell_size.bar<0>[410bae77d3]"(i64  %8)  
-  tail call fastcc  void  @"dead_cell_size.print_t<0>"(i64  %"1$tmp$2##0")  
+  %"1#tmp#2##0" = tail call fastcc  i64  @"dead_cell_size.bar<0>[410bae77d3]"(i64  %8)  
+  tail call fastcc  void  @"dead_cell_size.print_t<0>"(i64  %"1#tmp#2##0")  
   %11 = trunc i64 8 to i32  
   %12 = tail call ccc  i8*  @wybe_malloc(i32  %11)  
   %13 = ptrtoint i8* %12 to i64 
   %14 = inttoptr i64 %13 to i64* 
   %15 = getelementptr  i64, i64* %14, i64 0 
   store  i64 9, i64* %15 
-  %"1$tmp$4##0" = tail call fastcc  i64  @"dead_cell_size.diff_type<0>[410bae77d3]"(i64  %13)  
-  tail call fastcc  void  @"dead_cell_size.print_t2<0>"(i64  %"1$tmp$4##0")  
+  %"1#tmp#4##0" = tail call fastcc  i64  @"dead_cell_size.diff_type<0>[410bae77d3]"(i64  %13)  
+  tail call fastcc  void  @"dead_cell_size.print_t2<0>"(i64  %"1#tmp#4##0")  
   ret void 
 }
 
 
 define external fastcc  i64 @"dead_cell_size.bar<0>"(i64  %"x##0")    {
 entry:
-  %"1$tmp$3##0" = icmp ne i64 %"x##0", 0 
-  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
+  %"1#tmp#3##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$4##0" = and i64 %"x##0", 3 
-  %"2$tmp$5##0" = icmp eq i64 %"2$tmp$4##0", 0 
-  br i1 %"2$tmp$5##0", label %if.then1, label %if.else1 
+  %"2#tmp#4##0" = and i64 %"x##0", 3 
+  %"2#tmp#5##0" = icmp eq i64 %"2#tmp#4##0", 0 
+  br i1 %"2#tmp#5##0", label %if.then1, label %if.else1 
 if.else:
   ret i64 %"x##0" 
 if.then1:
@@ -379,8 +379,8 @@ if.then1:
   %22 = inttoptr i64 %21 to i64* 
   %23 = getelementptr  i64, i64* %22, i64 0 
   store  i64 %18, i64* %23 
-  %"4$x##1" = or i64 %21, 2 
-  ret i64 %"4$x##1" 
+  %"4#x##1" = or i64 %21, 2 
+  ret i64 %"4#x##1" 
 if.else1:
   ret i64 %"x##0" 
 }
@@ -388,17 +388,17 @@ if.else1:
 
 define external fastcc  i64 @"dead_cell_size.bar<0>[410bae77d3]"(i64  %"x##0")    {
 entry:
-  %"1$tmp$3##0" = icmp ne i64 %"x##0", 0 
-  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
+  %"1#tmp#3##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$4##0" = and i64 %"x##0", 3 
-  %"2$tmp$5##0" = icmp eq i64 %"2$tmp$4##0", 0 
-  br i1 %"2$tmp$5##0", label %if.then1, label %if.else1 
+  %"2#tmp#4##0" = and i64 %"x##0", 3 
+  %"2#tmp#5##0" = icmp eq i64 %"2#tmp#4##0", 0 
+  br i1 %"2#tmp#5##0", label %if.then1, label %if.else1 
 if.else:
   ret i64 %"x##0" 
 if.then1:
-  %"4$x##1" = or i64 %"x##0", 2 
-  ret i64 %"4$x##1" 
+  %"4#x##1" = or i64 %"x##0", 2 
+  ret i64 %"4#x##1" 
 if.else1:
   ret i64 %"x##0" 
 }
@@ -406,12 +406,12 @@ if.else1:
 
 define external fastcc  i64 @"dead_cell_size.diff_type<0>"(i64  %"x##0")    {
 entry:
-  %"1$tmp$4##0" = icmp ne i64 %"x##0", 0 
-  br i1 %"1$tmp$4##0", label %if.then, label %if.else 
+  %"1#tmp#4##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1#tmp#4##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$5##0" = and i64 %"x##0", 3 
-  %"2$tmp$6##0" = icmp eq i64 %"2$tmp$5##0", 0 
-  br i1 %"2$tmp$6##0", label %if.then1, label %if.else1 
+  %"2#tmp#5##0" = and i64 %"x##0", 3 
+  %"2#tmp#6##0" = icmp eq i64 %"2#tmp#5##0", 0 
+  br i1 %"2#tmp#6##0", label %if.then1, label %if.else1 
 if.else:
   %37 = trunc i64 8 to i32  
   %38 = tail call ccc  i8*  @wybe_malloc(i32  %37)  
@@ -444,12 +444,12 @@ if.else1:
 
 define external fastcc  i64 @"dead_cell_size.diff_type<0>[410bae77d3]"(i64  %"x##0")    {
 entry:
-  %"1$tmp$4##0" = icmp ne i64 %"x##0", 0 
-  br i1 %"1$tmp$4##0", label %if.then, label %if.else 
+  %"1#tmp#4##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1#tmp#4##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$5##0" = and i64 %"x##0", 3 
-  %"2$tmp$6##0" = icmp eq i64 %"2$tmp$5##0", 0 
-  br i1 %"2$tmp$6##0", label %if.then1, label %if.else1 
+  %"2#tmp#5##0" = and i64 %"x##0", 3 
+  %"2#tmp#6##0" = icmp eq i64 %"2#tmp#5##0", 0 
+  br i1 %"2#tmp#6##0", label %if.then1, label %if.else1 
 if.else:
   %47 = trunc i64 8 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
@@ -473,12 +473,12 @@ if.else1:
 
 define external fastcc  i64 @"dead_cell_size.foo<0>"(i64  %"x##0")    {
 entry:
-  %"1$tmp$3##0" = icmp ne i64 %"x##0", 0 
-  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
+  %"1#tmp#3##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$4##0" = and i64 %"x##0", 3 
-  %"2$tmp$5##0" = icmp eq i64 %"2$tmp$4##0", 0 
-  br i1 %"2$tmp$5##0", label %if.then1, label %if.else1 
+  %"2#tmp#4##0" = and i64 %"x##0", 3 
+  %"2#tmp#5##0" = icmp eq i64 %"2#tmp#4##0", 0 
+  br i1 %"2#tmp#5##0", label %if.then1, label %if.else1 
 if.else:
   ret i64 %"x##0" 
 if.then1:
@@ -499,8 +499,8 @@ if.then1:
   %64 = inttoptr i64 %63 to i64* 
   %65 = getelementptr  i64, i64* %64, i64 0 
   store  i64 3, i64* %65 
-  %"4$x##1" = or i64 %57, 1 
-  ret i64 %"4$x##1" 
+  %"4#x##1" = or i64 %57, 1 
+  ret i64 %"4#x##1" 
 if.else1:
   ret i64 %"x##0" 
 }
@@ -508,20 +508,20 @@ if.else1:
 
 define external fastcc  void @"dead_cell_size.print_t<0>"(i64  %"x##0")    {
 entry:
-  %"1$tmp$4##0" = tail call fastcc  i1  @"dead_cell_size.t.=<0>"(i64  0, i64  %"x##0")  
-  br i1 %"1$tmp$4##0", label %if.then, label %if.else 
+  %"1#tmp#4##0" = tail call fastcc  i1  @"dead_cell_size.t.=<0>"(i64  0, i64  %"x##0")  
+  br i1 %"1#tmp#4##0", label %if.then, label %if.else 
 if.then:
   %67 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @dead_cell_size.66, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %67)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else:
-  %"3$tmp$6##0" = icmp ne i64 %"x##0", 0 
-  br i1 %"3$tmp$6##0", label %if.then1, label %if.else1 
+  %"3#tmp#6##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"3#tmp#6##0", label %if.then1, label %if.else1 
 if.then1:
-  %"4$tmp$7##0" = and i64 %"x##0", 3 
-  %"4$tmp$8##0" = icmp eq i64 %"4$tmp$7##0", 0 
-  br i1 %"4$tmp$8##0", label %if.then2, label %if.else2 
+  %"4#tmp#7##0" = and i64 %"x##0", 3 
+  %"4#tmp#8##0" = icmp eq i64 %"4#tmp#7##0", 0 
+  br i1 %"4#tmp#8##0", label %if.then2, label %if.else2 
 if.else1:
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -537,8 +537,8 @@ if.then2:
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else2:
-  %"7$tmp$12##0" = icmp eq i64 %"4$tmp$7##0", 1 
-  br i1 %"7$tmp$12##0", label %if.then3, label %if.else3 
+  %"7#tmp#12##0" = icmp eq i64 %"4#tmp#7##0", 1 
+  br i1 %"7#tmp#12##0", label %if.then3, label %if.else3 
 if.then3:
   %75 = add   i64 %"x##0", -1 
   %76 = inttoptr i64 %75 to i64* 
@@ -566,8 +566,8 @@ if.then3:
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else3:
-  %"9$tmp$16##0" = icmp eq i64 %"4$tmp$7##0", 2 
-  br i1 %"9$tmp$16##0", label %if.then4, label %if.else4 
+  %"9#tmp#16##0" = icmp eq i64 %"4#tmp#7##0", 2 
+  br i1 %"9#tmp#16##0", label %if.then4, label %if.else4 
 if.then4:
   %95 = add   i64 %"x##0", -2 
   %96 = inttoptr i64 %95 to i64* 
@@ -588,16 +588,16 @@ if.else4:
 
 define external fastcc  void @"dead_cell_size.print_t2<0>"(i64  %"x##0")    {
 entry:
-  %"1$tmp$2##0" = tail call fastcc  i1  @"dead_cell_size.t2.=<0>"(i64  0, i64  %"x##0")  
-  br i1 %"1$tmp$2##0", label %if.then, label %if.else 
+  %"1#tmp#2##0" = tail call fastcc  i1  @"dead_cell_size.t2.=<0>"(i64  0, i64  %"x##0")  
+  br i1 %"1#tmp#2##0", label %if.then, label %if.else 
 if.then:
   %104 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @dead_cell_size.103, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %104)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else:
-  %"3$tmp$4##0" = icmp ne i64 %"x##0", 0 
-  br i1 %"3$tmp$4##0", label %if.then1, label %if.else1 
+  %"3#tmp#4##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"3#tmp#4##0", label %if.then1, label %if.else1 
 if.then1:
   %105 = inttoptr i64 %"x##0" to i64* 
   %106 = getelementptr  i64, i64* %105, i64 0 
@@ -644,81 +644,81 @@ if.else1:
 
 = > public (1 calls)
 0: dead_cell_size.t.=<0>
-=($left##0:dead_cell_size.t, $right##0:dead_cell_size.t, ?$$##0:wybe.bool):
+=(#left##0:dead_cell_size.t, #right##0:dead_cell_size.t, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left##0:dead_cell_size.t, ~$right##0:dead_cell_size.t, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:dead_cell_size.t, ~#right##0:dead_cell_size.t, ?####0:wybe.bool)
 
     1:
-        foreign llvm and($left##0:wybe.int, 3:wybe.int, ?tmp$15##0:wybe.int)
-        foreign llvm icmp_eq(tmp$15##0:wybe.int, 0:wybe.int, ?tmp$16##0:wybe.bool)
-        case ~tmp$16##0:wybe.bool of
+        foreign llvm and(#left##0:wybe.int, 3:wybe.int, ?tmp#15##0:wybe.int)
+        foreign llvm icmp_eq(tmp#15##0:wybe.int, 0:wybe.int, ?tmp#16##0:wybe.bool)
+        case ~tmp#16##0:wybe.bool of
         0:
-            foreign llvm icmp_eq(tmp$15##0:wybe.int, 1:wybe.int, ?tmp$20##0:wybe.bool)
-            case ~tmp$20##0:wybe.bool of
+            foreign llvm icmp_eq(tmp#15##0:wybe.int, 1:wybe.int, ?tmp#20##0:wybe.bool)
+            case ~tmp#20##0:wybe.bool of
             0:
-                foreign llvm icmp_eq(~tmp$15##0:wybe.int, 2:wybe.int, ?tmp$24##0:wybe.bool)
-                case ~tmp$24##0:wybe.bool of
+                foreign llvm icmp_eq(~tmp#15##0:wybe.int, 2:wybe.int, ?tmp#24##0:wybe.bool)
+                case ~tmp#24##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                 1:
-                    foreign lpvm access(~$left##0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$left$td1##0:wybe.int)
-                    foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$26##0:wybe.bool)
-                    case ~tmp$26##0:wybe.bool of
+                    foreign lpvm access(~#left##0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#left#td1##0:wybe.int)
+                    foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#26##0:wybe.bool)
+                    case ~tmp#26##0:wybe.bool of
                     0:
-                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                     1:
-                        foreign llvm and($right##0:wybe.int, 3:wybe.int, ?tmp$27##0:wybe.int)
-                        foreign llvm icmp_eq(~tmp$27##0:wybe.int, 2:wybe.int, ?tmp$28##0:wybe.bool)
-                        case ~tmp$28##0:wybe.bool of
+                        foreign llvm and(#right##0:wybe.int, 3:wybe.int, ?tmp#27##0:wybe.int)
+                        foreign llvm icmp_eq(~tmp#27##0:wybe.int, 2:wybe.int, ?tmp#28##0:wybe.bool)
+                        case ~tmp#28##0:wybe.bool of
                         0:
-                            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                         1:
-                            foreign lpvm access(~$right##0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$right$td1##0:wybe.int)
-                            foreign llvm icmp_eq(~$left$td1##0:wybe.int, ~$right$td1##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+                            foreign lpvm access(~#right##0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#right#td1##0:wybe.int)
+                            foreign llvm icmp_eq(~#left#td1##0:wybe.int, ~#right#td1##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 
             1:
-                foreign lpvm access($left##0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?$left$tc1##0:wybe.int)
-                foreign lpvm access($left##0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?$left$tc2##0:wybe.int)
-                foreign lpvm access(~$left##0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?$left$tc3##0:wybe.int)
-                foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$22##0:wybe.bool)
-                case ~tmp$22##0:wybe.bool of
+                foreign lpvm access(#left##0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?#left#tc1##0:wybe.int)
+                foreign lpvm access(#left##0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?#left#tc2##0:wybe.int)
+                foreign lpvm access(~#left##0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?#left#tc3##0:wybe.int)
+                foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#22##0:wybe.bool)
+                case ~tmp#22##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                 1:
-                    foreign llvm and($right##0:wybe.int, 3:wybe.int, ?tmp$23##0:wybe.int)
-                    foreign llvm icmp_eq(~tmp$23##0:wybe.int, 1:wybe.int, ?tmp$24##0:wybe.bool)
-                    case ~tmp$24##0:wybe.bool of
+                    foreign llvm and(#right##0:wybe.int, 3:wybe.int, ?tmp#23##0:wybe.int)
+                    foreign llvm icmp_eq(~tmp#23##0:wybe.int, 1:wybe.int, ?tmp#24##0:wybe.bool)
+                    case ~tmp#24##0:wybe.bool of
                     0:
-                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                     1:
-                        foreign lpvm access($right##0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?$right$tc1##0:wybe.int)
-                        foreign lpvm access($right##0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?$right$tc2##0:wybe.int)
-                        foreign lpvm access(~$right##0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?$right$tc3##0:wybe.int)
-                        foreign llvm icmp_eq(~$left$tc1##0:wybe.int, ~$right$tc1##0:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
-                        case ~tmp$5##0:wybe.bool of
+                        foreign lpvm access(#right##0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?#right#tc1##0:wybe.int)
+                        foreign lpvm access(#right##0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?#right#tc2##0:wybe.int)
+                        foreign lpvm access(~#right##0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?#right#tc3##0:wybe.int)
+                        foreign llvm icmp_eq(~#left#tc1##0:wybe.int, ~#right#tc1##0:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
+                        case ~tmp#5##0:wybe.bool of
                         0:
-                            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                         1:
-                            foreign llvm icmp_eq(~$left$tc2##0:wybe.int, ~$right$tc2##0:wybe.int, ?tmp$6##0:wybe.bool) @int:nn:nn
-                            case ~tmp$6##0:wybe.bool of
+                            foreign llvm icmp_eq(~#left#tc2##0:wybe.int, ~#right#tc2##0:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
+                            case ~tmp#6##0:wybe.bool of
                             0:
-                                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                             1:
-                                foreign llvm icmp_eq(~$left$tc3##0:wybe.int, ~$right$tc3##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+                                foreign llvm icmp_eq(~#left#tc3##0:wybe.int, ~#right#tc3##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
@@ -726,22 +726,22 @@ if.else1:
 
 
         1:
-            foreign lpvm access(~$left##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$left$tb1##0:wybe.int)
-            foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$18##0:wybe.bool)
-            case ~tmp$18##0:wybe.bool of
+            foreign lpvm access(~#left##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#left#tb1##0:wybe.int)
+            foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#18##0:wybe.bool)
+            case ~tmp#18##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
             1:
-                foreign llvm and($right##0:wybe.int, 3:wybe.int, ?tmp$19##0:wybe.int)
-                foreign llvm icmp_eq(~tmp$19##0:wybe.int, 0:wybe.int, ?tmp$20##0:wybe.bool)
-                case ~tmp$20##0:wybe.bool of
+                foreign llvm and(#right##0:wybe.int, 3:wybe.int, ?tmp#19##0:wybe.int)
+                foreign llvm icmp_eq(~tmp#19##0:wybe.int, 0:wybe.int, ?tmp#20##0:wybe.bool)
+                case ~tmp#20##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                 1:
-                    foreign lpvm access(~$right##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$right$tb1##0:wybe.int)
-                    foreign llvm icmp_eq(~$left$tb1##0:wybe.int, ~$right$tb1##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+                    foreign lpvm access(~#right##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#right#tb1##0:wybe.int)
+                    foreign llvm icmp_eq(~#left#tb1##0:wybe.int, ~#right#tb1##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
@@ -750,378 +750,378 @@ if.else1:
 
 ta > public {inline} (0 calls)
 0: dead_cell_size.t.ta<0>
-ta(?$##0:dead_cell_size.t):
+ta(?###0:dead_cell_size.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:dead_cell_size.t, ?$##0:dead_cell_size.t)
+    foreign llvm move(0:dead_cell_size.t, ?###0:dead_cell_size.t)
 
 
 tb > public {inline} (0 calls)
 0: dead_cell_size.t.tb<0>
-tb(tb1##0:wybe.int, ?$##0:dead_cell_size.t):
+tb(tb1##0:wybe.int, ?###0:dead_cell_size.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec##0:dead_cell_size.t)
-    foreign lpvm mutate(~$rec##0:dead_cell_size.t, ?$##0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~tb1##0:wybe.int)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:dead_cell_size.t)
+    foreign lpvm mutate(~#rec##0:dead_cell_size.t, ?###0:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~tb1##0:wybe.int)
 tb > public {inline} (14 calls)
 1: dead_cell_size.t.tb<1>
-tb(?tb1##0:wybe.int, $##0:dead_cell_size.t, ?$$##0:wybe.bool):
+tb(?tb1##0:wybe.int, ###0:dead_cell_size.t, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?tb1##0:wybe.int)
 
     1:
-        foreign llvm and($##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(###0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?tb1##0:wybe.int)
 
         1:
-            foreign lpvm access(~$##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?tb1##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm access(~###0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?tb1##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 tb1 > public {inline} (0 calls)
 0: dead_cell_size.t.tb1<0>
-tb1($rec##0:dead_cell_size.t, ?$##0:wybe.int, ?$$##0:wybe.bool):
+tb1(#rec##0:dead_cell_size.t, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
         1:
-            foreign lpvm access(~$rec##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm access(~#rec##0:dead_cell_size.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?###0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 tb1 > public {inline} (0 calls)
 1: dead_cell_size.t.tb1<1>
-tb1($rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t, $field##0:wybe.int, ?$$##0:wybe.bool):
+tb1(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(~$rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t)
 
         1:
-            foreign lpvm {noalias} mutate(~$rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm {noalias} mutate(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 tc > public {inline} (0 calls)
 0: dead_cell_size.t.tc<0>
-tc(tc1##0:wybe.int, tc2##0:wybe.int, tc3##0:wybe.int, ?$##0:dead_cell_size.t):
+tc(tc1##0:wybe.int, tc2##0:wybe.int, tc3##0:wybe.int, ?###0:dead_cell_size.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?$rec##0:dead_cell_size.t)
-    foreign lpvm mutate(~$rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tc1##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:dead_cell_size.t, ?$rec##2:dead_cell_size.t, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tc2##0:wybe.int)
-    foreign lpvm mutate(~$rec##2:dead_cell_size.t, ?$rec##3:dead_cell_size.t, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tc3##0:wybe.int)
-    foreign llvm or(~$rec##3:dead_cell_size.t, 1:wybe.int, ?$##0:dead_cell_size.t)
+    foreign lpvm alloc(24:wybe.int, ?#rec##0:dead_cell_size.t)
+    foreign lpvm mutate(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tc1##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:dead_cell_size.t, ?#rec##2:dead_cell_size.t, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tc2##0:wybe.int)
+    foreign lpvm mutate(~#rec##2:dead_cell_size.t, ?#rec##3:dead_cell_size.t, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tc3##0:wybe.int)
+    foreign llvm or(~#rec##3:dead_cell_size.t, 1:wybe.int, ?###0:dead_cell_size.t)
 tc > public {inline} (11 calls)
 1: dead_cell_size.t.tc<1>
-tc(?tc1##0:wybe.int, ?tc2##0:wybe.int, ?tc3##0:wybe.int, $##0:dead_cell_size.t, ?$$##0:wybe.bool):
+tc(?tc1##0:wybe.int, ?tc2##0:wybe.int, ?tc3##0:wybe.int, ###0:dead_cell_size.t, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?tc1##0:wybe.int)
         foreign llvm move(undef:wybe.int, ?tc2##0:wybe.int)
         foreign llvm move(undef:wybe.int, ?tc3##0:wybe.int)
 
     1:
-        foreign llvm and($##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(###0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?tc1##0:wybe.int)
             foreign llvm move(undef:wybe.int, ?tc2##0:wybe.int)
             foreign llvm move(undef:wybe.int, ?tc3##0:wybe.int)
 
         1:
-            foreign lpvm access($##0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?tc1##0:wybe.int)
-            foreign lpvm access($##0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?tc2##0:wybe.int)
-            foreign lpvm access(~$##0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?tc3##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm access(###0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?tc1##0:wybe.int)
+            foreign lpvm access(###0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?tc2##0:wybe.int)
+            foreign lpvm access(~###0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?tc3##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 tc1 > public {inline} (0 calls)
 0: dead_cell_size.t.tc1<0>
-tc1($rec##0:dead_cell_size.t, ?$##0:wybe.int, ?$$##0:wybe.bool):
+tc1(#rec##0:dead_cell_size.t, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
         1:
-            foreign lpvm access(~$rec##0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?$##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm access(~#rec##0:dead_cell_size.t, -1:wybe.int, 24:wybe.int, 1:wybe.int, ?###0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 tc1 > public {inline} (0 calls)
 1: dead_cell_size.t.tc1<1>
-tc1($rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t, $field##0:wybe.int, ?$$##0:wybe.bool):
+tc1(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(~$rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t)
 
         1:
-            foreign lpvm {noalias} mutate(~$rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t, -1:wybe.int, 0:wybe.int, 24:wybe.int, 1:wybe.int, ~$field##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm {noalias} mutate(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, -1:wybe.int, 0:wybe.int, 24:wybe.int, 1:wybe.int, ~#field##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 tc2 > public {inline} (0 calls)
 0: dead_cell_size.t.tc2<0>
-tc2($rec##0:dead_cell_size.t, ?$##0:wybe.int, ?$$##0:wybe.bool):
+tc2(#rec##0:dead_cell_size.t, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
         1:
-            foreign lpvm access(~$rec##0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?$##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm access(~#rec##0:dead_cell_size.t, 7:wybe.int, 24:wybe.int, 1:wybe.int, ?###0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 tc2 > public {inline} (0 calls)
 1: dead_cell_size.t.tc2<1>
-tc2($rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t, $field##0:wybe.int, ?$$##0:wybe.bool):
+tc2(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(~$rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t)
 
         1:
-            foreign lpvm {noalias} mutate(~$rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t, 7:wybe.int, 0:wybe.int, 24:wybe.int, 1:wybe.int, ~$field##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm {noalias} mutate(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, 7:wybe.int, 0:wybe.int, 24:wybe.int, 1:wybe.int, ~#field##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 tc3 > public {inline} (0 calls)
 0: dead_cell_size.t.tc3<0>
-tc3($rec##0:dead_cell_size.t, ?$##0:wybe.int, ?$$##0:wybe.bool):
+tc3(#rec##0:dead_cell_size.t, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
         1:
-            foreign lpvm access(~$rec##0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?$##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm access(~#rec##0:dead_cell_size.t, 15:wybe.int, 24:wybe.int, 1:wybe.int, ?###0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 tc3 > public {inline} (0 calls)
 1: dead_cell_size.t.tc3<1>
-tc3($rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t, $field##0:wybe.int, ?$$##0:wybe.bool):
+tc3(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(~$rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t)
 
         1:
-            foreign lpvm {noalias} mutate(~$rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t, 15:wybe.int, 0:wybe.int, 24:wybe.int, 1:wybe.int, ~$field##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm {noalias} mutate(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, 15:wybe.int, 0:wybe.int, 24:wybe.int, 1:wybe.int, ~#field##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 td > public {inline} (0 calls)
 0: dead_cell_size.t.td<0>
-td(td1##0:wybe.int, ?$##0:dead_cell_size.t):
+td(td1##0:wybe.int, ?###0:dead_cell_size.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec##0:dead_cell_size.t)
-    foreign lpvm mutate(~$rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~td1##0:wybe.int)
-    foreign llvm or(~$rec##1:dead_cell_size.t, 2:wybe.int, ?$##0:dead_cell_size.t)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:dead_cell_size.t)
+    foreign lpvm mutate(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~td1##0:wybe.int)
+    foreign llvm or(~#rec##1:dead_cell_size.t, 2:wybe.int, ?###0:dead_cell_size.t)
 td > public {inline} (5 calls)
 1: dead_cell_size.t.td<1>
-td(?td1##0:wybe.int, $##0:dead_cell_size.t, ?$$##0:wybe.bool):
+td(?td1##0:wybe.int, ###0:dead_cell_size.t, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?td1##0:wybe.int)
 
     1:
-        foreign llvm and($##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 2:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(###0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 2:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?td1##0:wybe.int)
 
         1:
-            foreign lpvm access(~$##0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?td1##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm access(~###0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?td1##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 td1 > public {inline} (0 calls)
 0: dead_cell_size.t.td1<0>
-td1($rec##0:dead_cell_size.t, ?$##0:wybe.int, ?$$##0:wybe.bool):
+td1(#rec##0:dead_cell_size.t, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 2:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 2:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
         1:
-            foreign lpvm access(~$rec##0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm access(~#rec##0:dead_cell_size.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?###0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 td1 > public {inline} (0 calls)
 1: dead_cell_size.t.td1<1>
-td1($rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t, $field##0:wybe.int, ?$$##0:wybe.bool):
+td1(#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 3:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 2:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 3:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 2:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(~$rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t)
 
         1:
-            foreign lpvm {noalias} mutate(~$rec##0:dead_cell_size.t, ?$rec##1:dead_cell_size.t, -2:wybe.int, 0:wybe.int, 8:wybe.int, 2:wybe.int, ~$field##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm {noalias} mutate(~#rec##0:dead_cell_size.t, ?#rec##1:dead_cell_size.t, -2:wybe.int, 0:wybe.int, 8:wybe.int, 2:wybe.int, ~#field##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 ~= > public {inline} (0 calls)
 0: dead_cell_size.t.~=<0>
-~=($left##0:dead_cell_size.t, $right##0:dead_cell_size.t, ?$$##0:wybe.bool):
+~=(#left##0:dead_cell_size.t, #right##0:dead_cell_size.t, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    dead_cell_size.t.=<0>(~$left##0:dead_cell_size.t, ~$right##0:dead_cell_size.t, ?tmp$0##0:wybe.bool) #0
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    dead_cell_size.t.=<0>(~#left##0:dead_cell_size.t, ~#right##0:dead_cell_size.t, ?tmp#0##0:wybe.bool) #0
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
   LLVM code       :
 
@@ -1137,113 +1137,113 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"dead_cell_size.t.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"dead_cell_size.t.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#left##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$15##0" = and i64 %"$left##0", 3 
-  %"2$tmp$16##0" = icmp eq i64 %"2$tmp$15##0", 0 
-  br i1 %"2$tmp$16##0", label %if.then1, label %if.else1 
+  %"2#tmp#15##0" = and i64 %"#left##0", 3 
+  %"2#tmp#16##0" = icmp eq i64 %"2#tmp#15##0", 0 
+  br i1 %"2#tmp#16##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3#####0" 
 if.then1:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %"4$tmp$18##0" = icmp ne i64 %"$right##0", 0 
-  br i1 %"4$tmp$18##0", label %if.then2, label %if.else2 
+  %"4#tmp#18##0" = icmp ne i64 %"#right##0", 0 
+  br i1 %"4#tmp#18##0", label %if.then2, label %if.else2 
 if.else1:
-  %"5$tmp$20##0" = icmp eq i64 %"2$tmp$15##0", 1 
-  br i1 %"5$tmp$20##0", label %if.then4, label %if.else4 
+  %"5#tmp#20##0" = icmp eq i64 %"2#tmp#15##0", 1 
+  br i1 %"5#tmp#20##0", label %if.then4, label %if.else4 
 if.then2:
-  %"6$tmp$19##0" = and i64 %"$right##0", 3 
-  %"6$tmp$20##0" = icmp eq i64 %"6$tmp$19##0", 0 
-  br i1 %"6$tmp$20##0", label %if.then3, label %if.else3 
+  %"6#tmp#19##0" = and i64 %"#right##0", 3 
+  %"6#tmp#20##0" = icmp eq i64 %"6#tmp#19##0", 0 
+  br i1 %"6#tmp#20##0", label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %4 = inttoptr i64 %"$right##0" to i64* 
+  %4 = inttoptr i64 %"#right##0" to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
   %6 = load  i64, i64* %5 
-  %"8$$$##0" = icmp eq i64 %3, %6 
-  ret i1 %"8$$$##0" 
+  %"8#####0" = icmp eq i64 %3, %6 
+  ret i1 %"8#####0" 
 if.else3:
   ret i1 0 
 if.then4:
-  %7 = add   i64 %"$left##0", -1 
+  %7 = add   i64 %"#left##0", -1 
   %8 = inttoptr i64 %7 to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$left##0", 7 
+  %11 = add   i64 %"#left##0", 7 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %15 = add   i64 %"$left##0", 15 
+  %15 = add   i64 %"#left##0", 15 
   %16 = inttoptr i64 %15 to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
-  %"10$tmp$22##0" = icmp ne i64 %"$right##0", 0 
-  br i1 %"10$tmp$22##0", label %if.then5, label %if.else5 
+  %"10#tmp#22##0" = icmp ne i64 %"#right##0", 0 
+  br i1 %"10#tmp#22##0", label %if.then5, label %if.else5 
 if.else4:
-  %"11$tmp$24##0" = icmp eq i64 %"2$tmp$15##0", 2 
-  br i1 %"11$tmp$24##0", label %if.then9, label %if.else9 
+  %"11#tmp#24##0" = icmp eq i64 %"2#tmp#15##0", 2 
+  br i1 %"11#tmp#24##0", label %if.then9, label %if.else9 
 if.then5:
-  %"12$tmp$23##0" = and i64 %"$right##0", 3 
-  %"12$tmp$24##0" = icmp eq i64 %"12$tmp$23##0", 1 
-  br i1 %"12$tmp$24##0", label %if.then6, label %if.else6 
+  %"12#tmp#23##0" = and i64 %"#right##0", 3 
+  %"12#tmp#24##0" = icmp eq i64 %"12#tmp#23##0", 1 
+  br i1 %"12#tmp#24##0", label %if.then6, label %if.else6 
 if.else5:
   ret i1 0 
 if.then6:
-  %19 = add   i64 %"$right##0", -1 
+  %19 = add   i64 %"#right##0", -1 
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %23 = add   i64 %"$right##0", 7 
+  %23 = add   i64 %"#right##0", 7 
   %24 = inttoptr i64 %23 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
   %26 = load  i64, i64* %25 
-  %27 = add   i64 %"$right##0", 15 
+  %27 = add   i64 %"#right##0", 15 
   %28 = inttoptr i64 %27 to i64* 
   %29 = getelementptr  i64, i64* %28, i64 0 
   %30 = load  i64, i64* %29 
-  %"14$tmp$5##0" = icmp eq i64 %10, %22 
-  br i1 %"14$tmp$5##0", label %if.then7, label %if.else7 
+  %"14#tmp#5##0" = icmp eq i64 %10, %22 
+  br i1 %"14#tmp#5##0", label %if.then7, label %if.else7 
 if.else6:
   ret i1 0 
 if.then7:
-  %"16$tmp$6##0" = icmp eq i64 %14, %26 
-  br i1 %"16$tmp$6##0", label %if.then8, label %if.else8 
+  %"16#tmp#6##0" = icmp eq i64 %14, %26 
+  br i1 %"16#tmp#6##0", label %if.then8, label %if.else8 
 if.else7:
   ret i1 0 
 if.then8:
-  %"18$$$##0" = icmp eq i64 %18, %30 
-  ret i1 %"18$$$##0" 
+  %"18#####0" = icmp eq i64 %18, %30 
+  ret i1 %"18#####0" 
 if.else8:
   ret i1 0 
 if.then9:
-  %31 = add   i64 %"$left##0", -2 
+  %31 = add   i64 %"#left##0", -2 
   %32 = inttoptr i64 %31 to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
-  %"20$tmp$26##0" = icmp ne i64 %"$right##0", 0 
-  br i1 %"20$tmp$26##0", label %if.then10, label %if.else10 
+  %"20#tmp#26##0" = icmp ne i64 %"#right##0", 0 
+  br i1 %"20#tmp#26##0", label %if.then10, label %if.else10 
 if.else9:
   ret i1 0 
 if.then10:
-  %"22$tmp$27##0" = and i64 %"$right##0", 3 
-  %"22$tmp$28##0" = icmp eq i64 %"22$tmp$27##0", 2 
-  br i1 %"22$tmp$28##0", label %if.then11, label %if.else11 
+  %"22#tmp#27##0" = and i64 %"#right##0", 3 
+  %"22#tmp#28##0" = icmp eq i64 %"22#tmp#27##0", 2 
+  br i1 %"22#tmp#28##0", label %if.then11, label %if.else11 
 if.else10:
   ret i1 0 
 if.then11:
-  %35 = add   i64 %"$right##0", -2 
+  %35 = add   i64 %"#right##0", -2 
   %36 = inttoptr i64 %35 to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
-  %"24$$$##0" = icmp eq i64 %34, %38 
-  ret i1 %"24$$$##0" 
+  %"24#####0" = icmp eq i64 %34, %38 
+  ret i1 %"24#####0" 
 if.else11:
   ret i1 0 
 }
@@ -1267,20 +1267,20 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.tb<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.tb<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$##0", 3 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 0 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"###0", 3 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 0 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %51 = insertvalue {i64, i1} undef, i64 undef, 0 
   %52 = insertvalue {i64, i1} %51, i1 0, 1 
   ret {i64, i1} %52 
 if.then1:
-  %44 = inttoptr i64 %"$##0" to i64* 
+  %44 = inttoptr i64 %"###0" to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
   %47 = insertvalue {i64, i1} undef, i64 %46, 0 
@@ -1293,20 +1293,20 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.tb1<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.tb1<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 3 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 0 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 3 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 0 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %60 = insertvalue {i64, i1} undef, i64 undef, 0 
   %61 = insertvalue {i64, i1} %60, i1 0, 1 
   ret {i64, i1} %61 
 if.then1:
-  %53 = inttoptr i64 %"$rec##0" to i64* 
+  %53 = inttoptr i64 %"#rec##0" to i64* 
   %54 = getelementptr  i64, i64* %53, i64 0 
   %55 = load  i64, i64* %54 
   %56 = insertvalue {i64, i1} undef, i64 %55, 0 
@@ -1319,16 +1319,16 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.tb1<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.tb1<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 3 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 0 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 3 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 0 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
-  %74 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %74 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %75 = insertvalue {i64, i1} %74, i1 0, 1 
   ret {i64, i1} %75 
 if.then1:
@@ -1336,17 +1336,17 @@ if.then1:
   %63 = tail call ccc  i8*  @wybe_malloc(i32  %62)  
   %64 = ptrtoint i8* %63 to i64 
   %65 = inttoptr i64 %64 to i8* 
-  %66 = inttoptr i64 %"$rec##0" to i8* 
+  %66 = inttoptr i64 %"#rec##0" to i8* 
   %67 = trunc i64 8 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %65, i8*  %66, i32  %67, i32  8, i1  0)  
   %68 = inttoptr i64 %64 to i64* 
   %69 = getelementptr  i64, i64* %68, i64 0 
-  store  i64 %"$field##0", i64* %69 
+  store  i64 %"#field##0", i64* %69 
   %70 = insertvalue {i64, i1} undef, i64 %64, 0 
   %71 = insertvalue {i64, i1} %70, i1 1, 1 
   ret {i64, i1} %71 
 if.else1:
-  %72 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %72 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %73 = insertvalue {i64, i1} %72, i1 0, 1 
   ret {i64, i1} %73 
 }
@@ -1368,19 +1368,19 @@ entry:
   %85 = inttoptr i64 %84 to i64* 
   %86 = getelementptr  i64, i64* %85, i64 0 
   store  i64 %"tc3##0", i64* %86 
-  %"1$$##0" = or i64 %78, 1 
-  ret i64 %"1$$##0" 
+  %"1####0" = or i64 %78, 1 
+  ret i64 %"1####0" 
 }
 
 
-define external fastcc  {i64, i64, i64, i1} @"dead_cell_size.t.tc<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64, i64, i1} @"dead_cell_size.t.tc<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$##0", 3 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 1 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"###0", 3 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 1 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %107 = insertvalue {i64, i64, i64, i1} undef, i64 undef, 0 
   %108 = insertvalue {i64, i64, i64, i1} %107, i64 undef, 1 
@@ -1388,15 +1388,15 @@ if.else:
   %110 = insertvalue {i64, i64, i64, i1} %109, i1 0, 3 
   ret {i64, i64, i64, i1} %110 
 if.then1:
-  %87 = add   i64 %"$##0", -1 
+  %87 = add   i64 %"###0", -1 
   %88 = inttoptr i64 %87 to i64* 
   %89 = getelementptr  i64, i64* %88, i64 0 
   %90 = load  i64, i64* %89 
-  %91 = add   i64 %"$##0", 7 
+  %91 = add   i64 %"###0", 7 
   %92 = inttoptr i64 %91 to i64* 
   %93 = getelementptr  i64, i64* %92, i64 0 
   %94 = load  i64, i64* %93 
-  %95 = add   i64 %"$##0", 15 
+  %95 = add   i64 %"###0", 15 
   %96 = inttoptr i64 %95 to i64* 
   %97 = getelementptr  i64, i64* %96, i64 0 
   %98 = load  i64, i64* %97 
@@ -1414,20 +1414,20 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.tc1<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.tc1<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 3 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 1 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 3 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 1 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %119 = insertvalue {i64, i1} undef, i64 undef, 0 
   %120 = insertvalue {i64, i1} %119, i1 0, 1 
   ret {i64, i1} %120 
 if.then1:
-  %111 = add   i64 %"$rec##0", -1 
+  %111 = add   i64 %"#rec##0", -1 
   %112 = inttoptr i64 %111 to i64* 
   %113 = getelementptr  i64, i64* %112, i64 0 
   %114 = load  i64, i64* %113 
@@ -1441,16 +1441,16 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.tc1<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.tc1<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 3 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 1 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 3 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 1 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
-  %136 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %136 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %137 = insertvalue {i64, i1} %136, i1 0, 1 
   ret {i64, i1} %137 
 if.then1:
@@ -1458,7 +1458,7 @@ if.then1:
   %122 = tail call ccc  i8*  @wybe_malloc(i32  %121)  
   %123 = ptrtoint i8* %122 to i64 
   %124 = add   i64 %123, 1 
-  %125 = sub   i64 %"$rec##0", 1 
+  %125 = sub   i64 %"#rec##0", 1 
   %126 = inttoptr i64 %123 to i8* 
   %127 = inttoptr i64 %125 to i8* 
   %128 = trunc i64 24 to i32  
@@ -1466,31 +1466,31 @@ if.then1:
   %129 = add   i64 %124, -1 
   %130 = inttoptr i64 %129 to i64* 
   %131 = getelementptr  i64, i64* %130, i64 0 
-  store  i64 %"$field##0", i64* %131 
+  store  i64 %"#field##0", i64* %131 
   %132 = insertvalue {i64, i1} undef, i64 %124, 0 
   %133 = insertvalue {i64, i1} %132, i1 1, 1 
   ret {i64, i1} %133 
 if.else1:
-  %134 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %134 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %135 = insertvalue {i64, i1} %134, i1 0, 1 
   ret {i64, i1} %135 
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.tc2<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.tc2<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 3 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 1 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 3 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 1 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %146 = insertvalue {i64, i1} undef, i64 undef, 0 
   %147 = insertvalue {i64, i1} %146, i1 0, 1 
   ret {i64, i1} %147 
 if.then1:
-  %138 = add   i64 %"$rec##0", 7 
+  %138 = add   i64 %"#rec##0", 7 
   %139 = inttoptr i64 %138 to i64* 
   %140 = getelementptr  i64, i64* %139, i64 0 
   %141 = load  i64, i64* %140 
@@ -1504,16 +1504,16 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.tc2<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.tc2<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 3 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 1 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 3 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 1 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
-  %163 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %163 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %164 = insertvalue {i64, i1} %163, i1 0, 1 
   ret {i64, i1} %164 
 if.then1:
@@ -1521,7 +1521,7 @@ if.then1:
   %149 = tail call ccc  i8*  @wybe_malloc(i32  %148)  
   %150 = ptrtoint i8* %149 to i64 
   %151 = add   i64 %150, 1 
-  %152 = sub   i64 %"$rec##0", 1 
+  %152 = sub   i64 %"#rec##0", 1 
   %153 = inttoptr i64 %150 to i8* 
   %154 = inttoptr i64 %152 to i8* 
   %155 = trunc i64 24 to i32  
@@ -1529,31 +1529,31 @@ if.then1:
   %156 = add   i64 %151, 7 
   %157 = inttoptr i64 %156 to i64* 
   %158 = getelementptr  i64, i64* %157, i64 0 
-  store  i64 %"$field##0", i64* %158 
+  store  i64 %"#field##0", i64* %158 
   %159 = insertvalue {i64, i1} undef, i64 %151, 0 
   %160 = insertvalue {i64, i1} %159, i1 1, 1 
   ret {i64, i1} %160 
 if.else1:
-  %161 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %161 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %162 = insertvalue {i64, i1} %161, i1 0, 1 
   ret {i64, i1} %162 
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.tc3<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.tc3<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 3 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 1 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 3 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 1 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %173 = insertvalue {i64, i1} undef, i64 undef, 0 
   %174 = insertvalue {i64, i1} %173, i1 0, 1 
   ret {i64, i1} %174 
 if.then1:
-  %165 = add   i64 %"$rec##0", 15 
+  %165 = add   i64 %"#rec##0", 15 
   %166 = inttoptr i64 %165 to i64* 
   %167 = getelementptr  i64, i64* %166, i64 0 
   %168 = load  i64, i64* %167 
@@ -1567,16 +1567,16 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.tc3<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.tc3<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 3 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 1 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 3 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 1 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
-  %190 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %190 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %191 = insertvalue {i64, i1} %190, i1 0, 1 
   ret {i64, i1} %191 
 if.then1:
@@ -1584,7 +1584,7 @@ if.then1:
   %176 = tail call ccc  i8*  @wybe_malloc(i32  %175)  
   %177 = ptrtoint i8* %176 to i64 
   %178 = add   i64 %177, 1 
-  %179 = sub   i64 %"$rec##0", 1 
+  %179 = sub   i64 %"#rec##0", 1 
   %180 = inttoptr i64 %177 to i8* 
   %181 = inttoptr i64 %179 to i8* 
   %182 = trunc i64 24 to i32  
@@ -1592,12 +1592,12 @@ if.then1:
   %183 = add   i64 %178, 15 
   %184 = inttoptr i64 %183 to i64* 
   %185 = getelementptr  i64, i64* %184, i64 0 
-  store  i64 %"$field##0", i64* %185 
+  store  i64 %"#field##0", i64* %185 
   %186 = insertvalue {i64, i1} undef, i64 %178, 0 
   %187 = insertvalue {i64, i1} %186, i1 1, 1 
   ret {i64, i1} %187 
 if.else1:
-  %188 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %188 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %189 = insertvalue {i64, i1} %188, i1 0, 1 
   ret {i64, i1} %189 
 }
@@ -1611,25 +1611,25 @@ entry:
   %195 = inttoptr i64 %194 to i64* 
   %196 = getelementptr  i64, i64* %195, i64 0 
   store  i64 %"td1##0", i64* %196 
-  %"1$$##0" = or i64 %194, 2 
-  ret i64 %"1$$##0" 
+  %"1####0" = or i64 %194, 2 
+  ret i64 %"1####0" 
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.td<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.td<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$##0", 3 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 2 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"###0", 3 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 2 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %205 = insertvalue {i64, i1} undef, i64 undef, 0 
   %206 = insertvalue {i64, i1} %205, i1 0, 1 
   ret {i64, i1} %206 
 if.then1:
-  %197 = add   i64 %"$##0", -2 
+  %197 = add   i64 %"###0", -2 
   %198 = inttoptr i64 %197 to i64* 
   %199 = getelementptr  i64, i64* %198, i64 0 
   %200 = load  i64, i64* %199 
@@ -1643,20 +1643,20 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.td1<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.td1<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 3 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 2 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 3 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 2 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %215 = insertvalue {i64, i1} undef, i64 undef, 0 
   %216 = insertvalue {i64, i1} %215, i1 0, 1 
   ret {i64, i1} %216 
 if.then1:
-  %207 = add   i64 %"$rec##0", -2 
+  %207 = add   i64 %"#rec##0", -2 
   %208 = inttoptr i64 %207 to i64* 
   %209 = getelementptr  i64, i64* %208, i64 0 
   %210 = load  i64, i64* %209 
@@ -1670,16 +1670,16 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t.td1<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t.td1<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 3 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 2 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 3 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 2 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
-  %232 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %232 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %233 = insertvalue {i64, i1} %232, i1 0, 1 
   ret {i64, i1} %233 
 if.then1:
@@ -1687,7 +1687,7 @@ if.then1:
   %218 = tail call ccc  i8*  @wybe_malloc(i32  %217)  
   %219 = ptrtoint i8* %218 to i64 
   %220 = add   i64 %219, 2 
-  %221 = sub   i64 %"$rec##0", 2 
+  %221 = sub   i64 %"#rec##0", 2 
   %222 = inttoptr i64 %219 to i8* 
   %223 = inttoptr i64 %221 to i8* 
   %224 = trunc i64 8 to i32  
@@ -1695,22 +1695,22 @@ if.then1:
   %225 = add   i64 %220, -2 
   %226 = inttoptr i64 %225 to i64* 
   %227 = getelementptr  i64, i64* %226, i64 0 
-  store  i64 %"$field##0", i64* %227 
+  store  i64 %"#field##0", i64* %227 
   %228 = insertvalue {i64, i1} undef, i64 %220, 0 
   %229 = insertvalue {i64, i1} %228, i1 1, 1 
   ret {i64, i1} %229 
 if.else1:
-  %230 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %230 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %231 = insertvalue {i64, i1} %230, i1 0, 1 
   ret {i64, i1} %231 
 }
 
 
-define external fastcc  i1 @"dead_cell_size.t.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"dead_cell_size.t.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = tail call fastcc  i1  @"dead_cell_size.t.=<0>"(i64  %"$left##0", i64  %"$right##0")  
-  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
-  ret i1 %"1$$$##0" 
+  %"1#tmp#0##0" = tail call fastcc  i1  @"dead_cell_size.t.=<0>"(i64  %"#left##0", i64  %"#right##0")  
+  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1#####0" 
 }
 --------------------------------------------------
  Module dead_cell_size.t2
@@ -1731,99 +1731,99 @@ entry:
 
 = > public (1 calls)
 0: dead_cell_size.t2.=<0>
-=($left##0:dead_cell_size.t2, $right##0:dead_cell_size.t2, ?$$##0:wybe.bool):
+=(#left##0:dead_cell_size.t2, #right##0:dead_cell_size.t2, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left##0:dead_cell_size.t2, ~$right##0:dead_cell_size.t2, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:dead_cell_size.t2, ~#right##0:dead_cell_size.t2, ?####0:wybe.bool)
 
     1:
-        foreign lpvm access(~$left##0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$left$a##0:wybe.int)
-        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.bool)
-        case ~tmp$8##0:wybe.bool of
+        foreign lpvm access(~#left##0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#left#a##0:wybe.int)
+        foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool)
+        case ~tmp#8##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign lpvm access(~$right##0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$right$a##0:wybe.int)
-            foreign llvm icmp_eq(~$left$a##0:wybe.int, ~$right$a##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+            foreign lpvm access(~#right##0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#right#a##0:wybe.int)
+            foreign llvm icmp_eq(~#left#a##0:wybe.int, ~#right#a##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 
 a > public {inline} (0 calls)
 0: dead_cell_size.t2.a<0>
-a($rec##0:dead_cell_size.t2, ?$##0:wybe.int, ?$$##0:wybe.bool):
+a(#rec##0:dead_cell_size.t2, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec##0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 a > public {inline} (0 calls)
 1: dead_cell_size.t2.a<1>
-a($rec##0:dead_cell_size.t2, ?$rec##1:dead_cell_size.t2, $field##0:wybe.int, ?$$##0:wybe.bool):
+a(#rec##0:dead_cell_size.t2, ?#rec##1:dead_cell_size.t2, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:dead_cell_size.t2, ?$rec##1:dead_cell_size.t2)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:dead_cell_size.t2, ?#rec##1:dead_cell_size.t2)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec##0:dead_cell_size.t2, ?$rec##1:dead_cell_size.t2, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm {noalias} mutate(~#rec##0:dead_cell_size.t2, ?#rec##1:dead_cell_size.t2, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 t2a > public {inline} (0 calls)
 0: dead_cell_size.t2.t2a<0>
-t2a(?$##0:dead_cell_size.t2):
+t2a(?###0:dead_cell_size.t2):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:dead_cell_size.t2, ?$##0:dead_cell_size.t2)
+    foreign llvm move(0:dead_cell_size.t2, ?###0:dead_cell_size.t2)
 
 
 t2b > public {inline} (0 calls)
 0: dead_cell_size.t2.t2b<0>
-t2b(a##0:wybe.int, ?$##0:dead_cell_size.t2):
+t2b(a##0:wybe.int, ?###0:dead_cell_size.t2):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec##0:dead_cell_size.t2)
-    foreign lpvm mutate(~$rec##0:dead_cell_size.t2, ?$##0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~a##0:wybe.int)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:dead_cell_size.t2)
+    foreign lpvm mutate(~#rec##0:dead_cell_size.t2, ?###0:dead_cell_size.t2, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~a##0:wybe.int)
 t2b > public {inline} (8 calls)
 1: dead_cell_size.t2.t2b<1>
-t2b(?a##0:wybe.int, $##0:dead_cell_size.t2, ?$$##0:wybe.bool):
+t2b(?a##0:wybe.int, ###0:dead_cell_size.t2, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?a##0:wybe.int)
 
     1:
-        foreign lpvm access(~$##0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~###0:dead_cell_size.t2, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: dead_cell_size.t2.~=<0>
-~=($left##0:dead_cell_size.t2, $right##0:dead_cell_size.t2, ?$$##0:wybe.bool):
+~=(#left##0:dead_cell_size.t2, #right##0:dead_cell_size.t2, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    dead_cell_size.t2.=<0>(~$left##0:dead_cell_size.t2, ~$right##0:dead_cell_size.t2, ?tmp$0##0:wybe.bool) #0
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    dead_cell_size.t2.=<0>(~#left##0:dead_cell_size.t2, ~#right##0:dead_cell_size.t2, ?tmp#0##0:wybe.bool) #0
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
   LLVM code       :
 
@@ -1839,36 +1839,36 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"dead_cell_size.t2.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"dead_cell_size.t2.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#left##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %"2$tmp$8##0" = icmp ne i64 %"$right##0", 0 
-  br i1 %"2$tmp$8##0", label %if.then1, label %if.else1 
+  %"2#tmp#8##0" = icmp ne i64 %"#right##0", 0 
+  br i1 %"2#tmp#8##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3#####0" 
 if.then1:
-  %4 = inttoptr i64 %"$right##0" to i64* 
+  %4 = inttoptr i64 %"#right##0" to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
   %6 = load  i64, i64* %5 
-  %"4$$$##0" = icmp eq i64 %3, %6 
-  ret i1 %"4$$$##0" 
+  %"4#####0" = icmp eq i64 %3, %6 
+  ret i1 %"4#####0" 
 if.else1:
   ret i1 0 
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t2.a<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t2.a<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %7 = inttoptr i64 %"$rec##0" to i64* 
+  %7 = inttoptr i64 %"#rec##0" to i64* 
   %8 = getelementptr  i64, i64* %7, i64 0 
   %9 = load  i64, i64* %8 
   %10 = insertvalue {i64, i1} undef, i64 %9, 0 
@@ -1881,26 +1881,26 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t2.a<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t2.a<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %14 = trunc i64 8 to i32  
   %15 = tail call ccc  i8*  @wybe_malloc(i32  %14)  
   %16 = ptrtoint i8* %15 to i64 
   %17 = inttoptr i64 %16 to i8* 
-  %18 = inttoptr i64 %"$rec##0" to i8* 
+  %18 = inttoptr i64 %"#rec##0" to i8* 
   %19 = trunc i64 8 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %17, i8*  %18, i32  %19, i32  8, i1  0)  
   %20 = inttoptr i64 %16 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
-  store  i64 %"$field##0", i64* %21 
+  store  i64 %"#field##0", i64* %21 
   %22 = insertvalue {i64, i1} undef, i64 %16, 0 
   %23 = insertvalue {i64, i1} %22, i1 1, 1 
   ret {i64, i1} %23 
 if.else:
-  %24 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %24 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %25 = insertvalue {i64, i1} %24, i1 0, 1 
   ret {i64, i1} %25 
 }
@@ -1924,12 +1924,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"dead_cell_size.t2.t2b<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"dead_cell_size.t2.t2b<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %31 = inttoptr i64 %"$##0" to i64* 
+  %31 = inttoptr i64 %"###0" to i64* 
   %32 = getelementptr  i64, i64* %31, i64 0 
   %33 = load  i64, i64* %32 
   %34 = insertvalue {i64, i1} undef, i64 %33, 0 
@@ -1942,9 +1942,9 @@ if.else:
 }
 
 
-define external fastcc  i1 @"dead_cell_size.t2.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"dead_cell_size.t2.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = tail call fastcc  i1  @"dead_cell_size.t2.=<0>"(i64  %"$left##0", i64  %"$right##0")  
-  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
-  ret i1 %"1$$$##0" 
+  %"1#tmp#0##0" = tail call fastcc  i1  @"dead_cell_size.t2.=<0>"(i64  %"#left##0", i64  %"#right##0")  
+  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1#####0" 
 }

--- a/test-cases/final-dump/decimal.exp
+++ b/test-cases/final-dump/decimal.exp
@@ -14,26 +14,26 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##10:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_float(1.0e-2:wybe.float, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign c print_int(255:wybe.int, ~#io##1:wybe.phantom, ?tmp$5##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$5##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    foreign c print_int(42:wybe.int, ~#io##2:wybe.phantom, ?tmp$8##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$8##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign c print_int(63:wybe.int, ~#io##3:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$11##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign c print_float(1.0e100:wybe.float, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
-    foreign c print_float(100.001:wybe.float, ~#io##5:wybe.phantom, ?tmp$17##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$17##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
-    foreign c print_float(50010.0:wybe.float, ~#io##6:wybe.phantom, ?tmp$20##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$20##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
-    foreign c print_int(1000000000:wybe.int, ~#io##7:wybe.phantom, ?tmp$23##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$23##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
-    foreign c print_float(5.0010000000000006e-14:wybe.float, ~#io##8:wybe.phantom, ?tmp$26##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$26##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
-    foreign c print_float(-10.0:wybe.float, ~#io##9:wybe.phantom, ?tmp$29##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$29##0:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
+    foreign c print_float(1.0e-2:wybe.float, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(255:wybe.int, ~#io##1:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_int(42:wybe.int, ~#io##2:wybe.phantom, ?tmp#8##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#8##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign c print_int(63:wybe.int, ~#io##3:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_float(1.0e100:wybe.float, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign c print_float(100.001:wybe.float, ~#io##5:wybe.phantom, ?tmp#17##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#17##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+    foreign c print_float(50010.0:wybe.float, ~#io##6:wybe.phantom, ?tmp#20##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#20##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
+    foreign c print_int(1000000000:wybe.int, ~#io##7:wybe.phantom, ?tmp#23##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#23##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
+    foreign c print_float(5.0010000000000006e-14:wybe.float, ~#io##8:wybe.phantom, ?tmp#26##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#26##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
+    foreign c print_float(-10.0:wybe.float, ~#io##9:wybe.phantom, ?tmp#29##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#29##0:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/decimal.exp
+++ b/test-cases/final-dump/decimal.exp
@@ -11,29 +11,29 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: decimal.<0>
-(io#0:wybe.phantom, ?io#10:wybe.phantom):
+(io##0:wybe.phantom, ?io##10:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_float(1.0e-2:wybe.float, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_int(255:wybe.int, ~#io#1:wybe.phantom, ?tmp$5#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$5#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_int(42:wybe.int, ~#io#2:wybe.phantom, ?tmp$8#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$8#0:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign c print_int(63:wybe.int, ~#io#3:wybe.phantom, ?tmp$11#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$11#0:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_float(1.0e100:wybe.float, ~#io#4:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-    foreign c print_float(100.001:wybe.float, ~#io#5:wybe.phantom, ?tmp$17#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$17#0:wybe.phantom, ?#io#6:wybe.phantom) @io:nn:nn
-    foreign c print_float(50010.0:wybe.float, ~#io#6:wybe.phantom, ?tmp$20#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$20#0:wybe.phantom, ?#io#7:wybe.phantom) @io:nn:nn
-    foreign c print_int(1000000000:wybe.int, ~#io#7:wybe.phantom, ?tmp$23#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$23#0:wybe.phantom, ?#io#8:wybe.phantom) @io:nn:nn
-    foreign c print_float(5.0010000000000006e-14:wybe.float, ~#io#8:wybe.phantom, ?tmp$26#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$26#0:wybe.phantom, ?#io#9:wybe.phantom) @io:nn:nn
-    foreign c print_float(-10.0:wybe.float, ~#io#9:wybe.phantom, ?tmp$29#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$29#0:wybe.phantom, ?#io#10:wybe.phantom) @io:nn:nn
+    foreign c print_float(1.0e-2:wybe.float, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(255:wybe.int, ~#io##1:wybe.phantom, ?tmp$5##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$5##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_int(42:wybe.int, ~#io##2:wybe.phantom, ?tmp$8##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$8##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign c print_int(63:wybe.int, ~#io##3:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$11##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_float(1.0e100:wybe.float, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign c print_float(100.001:wybe.float, ~#io##5:wybe.phantom, ?tmp$17##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$17##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+    foreign c print_float(50010.0:wybe.float, ~#io##6:wybe.phantom, ?tmp$20##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$20##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
+    foreign c print_int(1000000000:wybe.int, ~#io##7:wybe.phantom, ?tmp$23##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$23##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
+    foreign c print_float(5.0010000000000006e-14:wybe.float, ~#io##8:wybe.phantom, ?tmp$26##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$26##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
+    foreign c print_float(-10.0:wybe.float, ~#io##9:wybe.phantom, ?tmp$29##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$29##0:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/early_error.exp
+++ b/test-cases/final-dump/early_error.exp
@@ -11,21 +11,21 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: early_error.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("should print this":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_string("should print this":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     foreign c {impure} puts("should print this error message":wybe.string) @early_error:nn:nn
     foreign c {terminal,semipure} exit(1:wybe.int) @early_error:nn:nn
 
 
 my_error > {terminal,inline,semipure} (1 calls)
 0: early_error.my_error<0>
-my_error(msg#0:wybe.string):
+my_error(msg##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c {impure} puts(~msg#0:wybe.string) @early_error:nn:nn
+    foreign c {impure} puts(~msg##0:wybe.string) @early_error:nn:nn
     foreign c {terminal,semipure} exit(1:wybe.int) @early_error:nn:nn
 
   LLVM code       :
@@ -72,9 +72,9 @@ entry:
 }
 
 
-define external fastcc  void @"early_error.my_error<0>"(i64  %"msg#0")    {
+define external fastcc  void @"early_error.my_error<0>"(i64  %"msg##0")    {
 entry:
-  tail call ccc  void  @puts(i64  %"msg#0")  
+  tail call ccc  void  @puts(i64  %"msg##0")  
   tail call ccc  void  @exit(i64  1)  
   ret void 
 }

--- a/test-cases/final-dump/early_error.exp
+++ b/test-cases/final-dump/early_error.exp
@@ -14,8 +14,8 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("should print this":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("should print this":wybe.string, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     foreign c {impure} puts("should print this error message":wybe.string) @early_error:nn:nn
     foreign c {terminal,semipure} exit(1:wybe.int) @early_error:nn:nn
 

--- a/test-cases/final-dump/early_exit.exp
+++ b/test-cases/final-dump/early_exit.exp
@@ -14,8 +14,8 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("should print this":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("should print this":wybe.string, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     foreign c {terminal,semipure} exit(1:wybe.int) @control:nn:nn
 
   LLVM code       :

--- a/test-cases/final-dump/early_exit.exp
+++ b/test-cases/final-dump/early_exit.exp
@@ -11,11 +11,11 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: early_exit.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("should print this":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_string("should print this":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     foreign c {terminal,semipure} exit(1:wybe.int) @control:nn:nn
 
   LLVM code       :

--- a/test-cases/final-dump/early_exit2.exp
+++ b/test-cases/final-dump/early_exit2.exp
@@ -14,8 +14,8 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("should print this":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("should print this":wybe.string, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     foreign c {terminal,semipure} exit(1:wybe.int) @early_exit2:7:5
 
 

--- a/test-cases/final-dump/early_exit2.exp
+++ b/test-cases/final-dump/early_exit2.exp
@@ -11,20 +11,20 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: early_exit2.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("should print this":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_string("should print this":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     foreign c {terminal,semipure} exit(1:wybe.int) @early_exit2:7:5
 
 
 my_exit > {terminal,inline} (1 calls)
 0: early_exit2.my_exit<0>
-my_exit(code#0:wybe.int):
+my_exit(code##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c {terminal,semipure} exit(~code#0:wybe.int) @early_exit2:7:5
+    foreign c {terminal,semipure} exit(~code##0:wybe.int) @early_exit2:7:5
 
   LLVM code       :
 
@@ -62,8 +62,8 @@ entry:
 }
 
 
-define external fastcc  void @"early_exit2.my_exit<0>"(i64  %"code#0")    {
+define external fastcc  void @"early_exit2.my_exit<0>"(i64  %"code##0")    {
 entry:
-  tail call ccc  void  @exit(i64  %"code#0")  
+  tail call ccc  void  @exit(i64  %"code##0")  
   ret void 
 }

--- a/test-cases/final-dump/eof_comment.exp
+++ b/test-cases/final-dump/eof_comment.exp
@@ -11,11 +11,11 @@ AFTER EVERYTHING:
 
 *main* > public {inline} (0 calls)
 0: eof_comment.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("Wominjeka!":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_string("Wominjeka!":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/eof_comment.exp
+++ b/test-cases/final-dump/eof_comment.exp
@@ -14,8 +14,8 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("Wominjeka!":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("Wominjeka!":wybe.string, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/exp_if.exp
+++ b/test-cases/final-dump/exp_if.exp
@@ -16,22 +16,22 @@ AFTER EVERYTHING:
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("expect larger: ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    exp_if.if_test<0>(3:wybe.int, ?tmp$0##0:wybe.string) #1 @exp_if:nn:nn
-    foreign c print_string(~tmp$0##0:wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    exp_if.if_test<0>(3:wybe.int, ?tmp#0##0:wybe.string) #1 @exp_if:nn:nn
+    foreign c print_string(~tmp#0##0:wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
 
 if_test > public (1 calls)
 0: exp_if.if_test<0>
-if_test(x##0:wybe.int, ?$##0:wybe.string):
+if_test(x##0:wybe.int, ?###0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_sgt(~x##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign llvm icmp_sgt(~x##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move("smaller":wybe.string, ?$##0:wybe.string) @exp_if:nn:nn
+        foreign llvm move("smaller":wybe.string, ?###0:wybe.string) @exp_if:nn:nn
 
     1:
-        foreign llvm move("larger":wybe.string, ?$##0:wybe.string) @exp_if:nn:nn
+        foreign llvm move("larger":wybe.string, ?###0:wybe.string) @exp_if:nn:nn
 
 
   LLVM code       :
@@ -64,16 +64,16 @@ define external fastcc  void @"exp_if.<0>"()    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @exp_if.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
-  %"1$tmp$0##0" = tail call fastcc  i64  @"exp_if.if_test<0>"(i64  3)  
-  tail call ccc  void  @print_string(i64  %"1$tmp$0##0")  
+  %"1#tmp#0##0" = tail call fastcc  i64  @"exp_if.if_test<0>"(i64  3)  
+  tail call ccc  void  @print_string(i64  %"1#tmp#0##0")  
   ret void 
 }
 
 
 define external fastcc  i64 @"exp_if.if_test<0>"(i64  %"x##0")    {
 entry:
-  %"1$tmp$1##0" = icmp sgt i64 %"x##0", 0 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp sgt i64 %"x##0", 0 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
   %4 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @exp_if.3, i32 0, i32 0) to i64 
   ret i64 %4 

--- a/test-cases/final-dump/exp_if.exp
+++ b/test-cases/final-dump/exp_if.exp
@@ -12,26 +12,26 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: exp_if.<0>
-(io#0:wybe.phantom, ?io#2:wybe.phantom):
+(io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("expect larger: ":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    exp_if.if_test<0>(3:wybe.int, ?tmp$0#0:wybe.string) #1 @exp_if:nn:nn
-    foreign c print_string(~tmp$0#0:wybe.string, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
+    foreign c print_string("expect larger: ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    exp_if.if_test<0>(3:wybe.int, ?tmp$0##0:wybe.string) #1 @exp_if:nn:nn
+    foreign c print_string(~tmp$0##0:wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
 
 if_test > public (1 calls)
 0: exp_if.if_test<0>
-if_test(x#0:wybe.int, ?$#0:wybe.string):
+if_test(x##0:wybe.int, ?$##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_sgt(~x#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign llvm icmp_sgt(~x##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move("smaller":wybe.string, ?$#0:wybe.string) @exp_if:nn:nn
+        foreign llvm move("smaller":wybe.string, ?$##0:wybe.string) @exp_if:nn:nn
 
     1:
-        foreign llvm move("larger":wybe.string, ?$#0:wybe.string) @exp_if:nn:nn
+        foreign llvm move("larger":wybe.string, ?$##0:wybe.string) @exp_if:nn:nn
 
 
   LLVM code       :
@@ -64,16 +64,16 @@ define external fastcc  void @"exp_if.<0>"()    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @exp_if.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
-  %"1$tmp$0#0" = tail call fastcc  i64  @"exp_if.if_test<0>"(i64  3)  
-  tail call ccc  void  @print_string(i64  %"1$tmp$0#0")  
+  %"1$tmp$0##0" = tail call fastcc  i64  @"exp_if.if_test<0>"(i64  3)  
+  tail call ccc  void  @print_string(i64  %"1$tmp$0##0")  
   ret void 
 }
 
 
-define external fastcc  i64 @"exp_if.if_test<0>"(i64  %"x#0")    {
+define external fastcc  i64 @"exp_if.if_test<0>"(i64  %"x##0")    {
 entry:
-  %"1$tmp$1#0" = icmp sgt i64 %"x#0", 0 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp sgt i64 %"x##0", 0 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
   %4 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @exp_if.3, i32 0, i32 0) to i64 
   ret i64 %4 

--- a/test-cases/final-dump/exp_if.exp
+++ b/test-cases/final-dump/exp_if.exp
@@ -22,16 +22,16 @@ AFTER EVERYTHING:
 
 if_test > public (1 calls)
 0: exp_if.if_test<0>
-if_test(x##0:wybe.int, ?###0:wybe.string):
+if_test(x##0:wybe.int, ?#result##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_sgt(~x##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move("smaller":wybe.string, ?###0:wybe.string) @exp_if:nn:nn
+        foreign llvm move("smaller":wybe.string, ?#result##0:wybe.string) @exp_if:nn:nn
 
     1:
-        foreign llvm move("larger":wybe.string, ?###0:wybe.string) @exp_if:nn:nn
+        foreign llvm move("larger":wybe.string, ?#result##0:wybe.string) @exp_if:nn:nn
 
 
   LLVM code       :

--- a/test-cases/final-dump/exp_print.exp
+++ b/test-cases/final-dump/exp_print.exp
@@ -15,14 +15,14 @@ AFTER EVERYTHING:
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("print(x:string) creates a newline already":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign c print_string("println(x:string) generates an extra newline?":wybe.string, ~#io##1:wybe.phantom, ?tmp$4##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$4##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    foreign c print_string("println(x:string) generates an extra newline?":wybe.string, ~#io##2:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign c putchar('c':wybe.char, ~#io##3:wybe.phantom, ?tmp$10##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$10##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign c print_int(1:wybe.int, ~#io##4:wybe.phantom, ?tmp$13##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$13##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign c print_string("println(x:string) generates an extra newline?":wybe.string, ~#io##1:wybe.phantom, ?tmp#4##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#4##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string("println(x:string) generates an extra newline?":wybe.string, ~#io##2:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign c putchar('c':wybe.char, ~#io##3:wybe.phantom, ?tmp#10##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_int(1:wybe.int, ~#io##4:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
     foreign c print_int(1:wybe.int, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
 
   LLVM code       :

--- a/test-cases/final-dump/exp_print.exp
+++ b/test-cases/final-dump/exp_print.exp
@@ -11,19 +11,19 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: exp_print.<0>
-(io#0:wybe.phantom, ?io#6:wybe.phantom):
+(io##0:wybe.phantom, ?io##6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("print(x:string) creates a newline already":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_string("println(x:string) generates an extra newline?":wybe.string, ~#io#1:wybe.phantom, ?tmp$4#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$4#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string("println(x:string) generates an extra newline?":wybe.string, ~#io#2:wybe.phantom, ?tmp$7#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$7#0:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign c putchar('c':wybe.char, ~#io#3:wybe.phantom, ?tmp$10#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$10#0:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_int(1:wybe.int, ~#io#4:wybe.phantom, ?tmp$13#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$13#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-    foreign c print_int(1:wybe.int, ~#io#5:wybe.phantom, ?#io#6:wybe.phantom) @io:nn:nn
+    foreign c print_string("print(x:string) creates a newline already":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("println(x:string) generates an extra newline?":wybe.string, ~#io##1:wybe.phantom, ?tmp$4##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$4##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string("println(x:string) generates an extra newline?":wybe.string, ~#io##2:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign c putchar('c':wybe.char, ~#io##3:wybe.phantom, ?tmp$10##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$10##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_int(1:wybe.int, ~#io##4:wybe.phantom, ?tmp$13##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$13##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign c print_int(1:wybe.int, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/exp_simple.exp
+++ b/test-cases/final-dump/exp_simple.exp
@@ -30,10 +30,10 @@ AFTER EVERYTHING:
 
 foreign_add > {inline} (1 calls)
 0: exp_simple.foreign_add<0>
-foreign_add(?###0:wybe.int):
+foreign_add(?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(3:wybe.int, ?###0:wybe.int) @exp_simple:nn:nn
+    foreign llvm move(3:wybe.int, ?#result##0:wybe.int) @exp_simple:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/exp_simple.exp
+++ b/test-cases/final-dump/exp_simple.exp
@@ -14,26 +14,26 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##7:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(3:wybe.int, ~#io##0:wybe.phantom, ?tmp$8##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$8##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign c print_float(3.5999999999999996:wybe.float, ~#io##1:wybe.phantom, ?tmp$13##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$13##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    foreign c putchar('h':wybe.char, ~#io##2:wybe.phantom, ?tmp$16##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$16##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign c print_int(3:wybe.int, ~#io##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#8##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_float(3.5999999999999996:wybe.float, ~#io##1:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c putchar('h':wybe.char, ~#io##2:wybe.phantom, ?tmp#16##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
     foreign c print_string("hello":wybe.string, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign c print_int(3:wybe.int, ~#io##4:wybe.phantom, ?tmp$23##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$23##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
-    foreign c print_int(1001:wybe.int, ~#io##5:wybe.phantom, ?tmp$27##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$27##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+    foreign c print_int(3:wybe.int, ~#io##4:wybe.phantom, ?tmp#23##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#23##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign c print_int(1001:wybe.int, ~#io##5:wybe.phantom, ?tmp#27##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#27##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
     foreign c print_int(3:wybe.int, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
 
 
 foreign_add > {inline} (1 calls)
 0: exp_simple.foreign_add<0>
-foreign_add(?$##0:wybe.int):
+foreign_add(?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(3:wybe.int, ?$##0:wybe.int) @exp_simple:nn:nn
+    foreign llvm move(3:wybe.int, ?###0:wybe.int) @exp_simple:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/exp_simple.exp
+++ b/test-cases/final-dump/exp_simple.exp
@@ -11,29 +11,29 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: exp_simple.<0>
-(io#0:wybe.phantom, ?io#7:wybe.phantom):
+(io##0:wybe.phantom, ?io##7:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(3:wybe.int, ~#io#0:wybe.phantom, ?tmp$8#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$8#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_float(3.5999999999999996:wybe.float, ~#io#1:wybe.phantom, ?tmp$13#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$13#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c putchar('h':wybe.char, ~#io#2:wybe.phantom, ?tmp$16#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$16#0:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign c print_string("hello":wybe.string, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_int(3:wybe.int, ~#io#4:wybe.phantom, ?tmp$23#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$23#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-    foreign c print_int(1001:wybe.int, ~#io#5:wybe.phantom, ?tmp$27#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$27#0:wybe.phantom, ?#io#6:wybe.phantom) @io:nn:nn
-    foreign c print_int(3:wybe.int, ~#io#6:wybe.phantom, ?#io#7:wybe.phantom) @io:nn:nn
+    foreign c print_int(3:wybe.int, ~#io##0:wybe.phantom, ?tmp$8##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$8##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_float(3.5999999999999996:wybe.float, ~#io##1:wybe.phantom, ?tmp$13##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$13##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c putchar('h':wybe.char, ~#io##2:wybe.phantom, ?tmp$16##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$16##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign c print_string("hello":wybe.string, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_int(3:wybe.int, ~#io##4:wybe.phantom, ?tmp$23##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$23##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign c print_int(1001:wybe.int, ~#io##5:wybe.phantom, ?tmp$27##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$27##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+    foreign c print_int(3:wybe.int, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
 
 
 foreign_add > {inline} (1 calls)
 0: exp_simple.foreign_add<0>
-foreign_add(?$#0:wybe.int):
+foreign_add(?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(3:wybe.int, ?$#0:wybe.int) @exp_simple:nn:nn
+    foreign llvm move(3:wybe.int, ?$##0:wybe.int) @exp_simple:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/func_factorial.exp
+++ b/test-cases/final-dump/func_factorial.exp
@@ -12,28 +12,28 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: func_factorial.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    func_factorial.factorial<0>(5:wybe.int, ?tmp$0#0:wybe.int) #0 @func_factorial:nn:nn
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$3#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$3#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    func_factorial.factorial<0>(5:wybe.int, ?tmp$0##0:wybe.int) #0 @func_factorial:nn:nn
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$3##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$3##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 factorial > public (2 calls)
 0: func_factorial.factorial<0>
-factorial(n#0:wybe.int, ?$#0:wybe.int):
+factorial(n##0:wybe.int, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_sle(n#0:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.bool) @int:nn:nn
-    case ~tmp$4#0:wybe.bool of
+    foreign llvm icmp_sle(n##0:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
+    case ~tmp$4##0:wybe.bool of
     0:
-        foreign llvm sub(n#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.int) @int:nn:nn
-        func_factorial.factorial<0>(~tmp$3#0:wybe.int, ?tmp$2#0:wybe.int) #2 @func_factorial:nn:nn
-        foreign llvm mul(~n#0:wybe.int, ~tmp$2#0:wybe.int, ?$#0:wybe.int) @int:nn:nn
+        foreign llvm sub(n##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
+        func_factorial.factorial<0>(~tmp$3##0:wybe.int, ?tmp$2##0:wybe.int) #2 @func_factorial:nn:nn
+        foreign llvm mul(~n##0:wybe.int, ~tmp$2##0:wybe.int, ?$##0:wybe.int) @int:nn:nn
 
     1:
-        foreign llvm move(1:wybe.int, ?$#0:wybe.int) @func_factorial:nn:nn
+        foreign llvm move(1:wybe.int, ?$##0:wybe.int) @func_factorial:nn:nn
 
 
   LLVM code       :
@@ -58,22 +58,22 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"func_factorial.<0>"()    {
 entry:
-  %"1$tmp$0#0" = tail call fastcc  i64  @"func_factorial.factorial<0>"(i64  5)  
-  tail call ccc  void  @print_int(i64  %"1$tmp$0#0")  
+  %"1$tmp$0##0" = tail call fastcc  i64  @"func_factorial.factorial<0>"(i64  5)  
+  tail call ccc  void  @print_int(i64  %"1$tmp$0##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  i64 @"func_factorial.factorial<0>"(i64  %"n#0")    {
+define external fastcc  i64 @"func_factorial.factorial<0>"(i64  %"n##0")    {
 entry:
-  %"1$tmp$4#0" = icmp sle i64 %"n#0", 0 
-  br i1 %"1$tmp$4#0", label %if.then, label %if.else 
+  %"1$tmp$4##0" = icmp sle i64 %"n##0", 0 
+  br i1 %"1$tmp$4##0", label %if.then, label %if.else 
 if.then:
   ret i64 1 
 if.else:
-  %"3$tmp$3#0" = sub   i64 %"n#0", 1 
-  %"3$tmp$2#0" = tail call fastcc  i64  @"func_factorial.factorial<0>"(i64  %"3$tmp$3#0")  
-  %"3$$#0" = mul   i64 %"n#0", %"3$tmp$2#0" 
-  ret i64 %"3$$#0" 
+  %"3$tmp$3##0" = sub   i64 %"n##0", 1 
+  %"3$tmp$2##0" = tail call fastcc  i64  @"func_factorial.factorial<0>"(i64  %"3$tmp$3##0")  
+  %"3$$##0" = mul   i64 %"n##0", %"3$tmp$2##0" 
+  ret i64 %"3$$##0" 
 }

--- a/test-cases/final-dump/func_factorial.exp
+++ b/test-cases/final-dump/func_factorial.exp
@@ -15,25 +15,25 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    func_factorial.factorial<0>(5:wybe.int, ?tmp$0##0:wybe.int) #0 @func_factorial:nn:nn
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$3##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$3##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    func_factorial.factorial<0>(5:wybe.int, ?tmp#0##0:wybe.int) #0 @func_factorial:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#3##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#3##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 factorial > public (2 calls)
 0: func_factorial.factorial<0>
-factorial(n##0:wybe.int, ?$##0:wybe.int):
+factorial(n##0:wybe.int, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_sle(n##0:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
-    case ~tmp$4##0:wybe.bool of
+    foreign llvm icmp_sle(n##0:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
+    case ~tmp#4##0:wybe.bool of
     0:
-        foreign llvm sub(n##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
-        func_factorial.factorial<0>(~tmp$3##0:wybe.int, ?tmp$2##0:wybe.int) #2 @func_factorial:nn:nn
-        foreign llvm mul(~n##0:wybe.int, ~tmp$2##0:wybe.int, ?$##0:wybe.int) @int:nn:nn
+        foreign llvm sub(n##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
+        func_factorial.factorial<0>(~tmp#3##0:wybe.int, ?tmp#2##0:wybe.int) #2 @func_factorial:nn:nn
+        foreign llvm mul(~n##0:wybe.int, ~tmp#2##0:wybe.int, ?###0:wybe.int) @int:nn:nn
 
     1:
-        foreign llvm move(1:wybe.int, ?$##0:wybe.int) @func_factorial:nn:nn
+        foreign llvm move(1:wybe.int, ?###0:wybe.int) @func_factorial:nn:nn
 
 
   LLVM code       :
@@ -58,8 +58,8 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"func_factorial.<0>"()    {
 entry:
-  %"1$tmp$0##0" = tail call fastcc  i64  @"func_factorial.factorial<0>"(i64  5)  
-  tail call ccc  void  @print_int(i64  %"1$tmp$0##0")  
+  %"1#tmp#0##0" = tail call fastcc  i64  @"func_factorial.factorial<0>"(i64  5)  
+  tail call ccc  void  @print_int(i64  %"1#tmp#0##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -67,13 +67,13 @@ entry:
 
 define external fastcc  i64 @"func_factorial.factorial<0>"(i64  %"n##0")    {
 entry:
-  %"1$tmp$4##0" = icmp sle i64 %"n##0", 0 
-  br i1 %"1$tmp$4##0", label %if.then, label %if.else 
+  %"1#tmp#4##0" = icmp sle i64 %"n##0", 0 
+  br i1 %"1#tmp#4##0", label %if.then, label %if.else 
 if.then:
   ret i64 1 
 if.else:
-  %"3$tmp$3##0" = sub   i64 %"n##0", 1 
-  %"3$tmp$2##0" = tail call fastcc  i64  @"func_factorial.factorial<0>"(i64  %"3$tmp$3##0")  
-  %"3$$##0" = mul   i64 %"n##0", %"3$tmp$2##0" 
-  ret i64 %"3$$##0" 
+  %"3#tmp#3##0" = sub   i64 %"n##0", 1 
+  %"3#tmp#2##0" = tail call fastcc  i64  @"func_factorial.factorial<0>"(i64  %"3#tmp#3##0")  
+  %"3####0" = mul   i64 %"n##0", %"3#tmp#2##0" 
+  ret i64 %"3####0" 
 }

--- a/test-cases/final-dump/func_factorial.exp
+++ b/test-cases/final-dump/func_factorial.exp
@@ -22,7 +22,7 @@ AFTER EVERYTHING:
 
 factorial > public (2 calls)
 0: func_factorial.factorial<0>
-factorial(n##0:wybe.int, ?###0:wybe.int):
+factorial(n##0:wybe.int, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_sle(n##0:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
@@ -30,10 +30,10 @@ factorial(n##0:wybe.int, ?###0:wybe.int):
     0:
         foreign llvm sub(n##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
         func_factorial.factorial<0>(~tmp#3##0:wybe.int, ?tmp#2##0:wybe.int) #2 @func_factorial:nn:nn
-        foreign llvm mul(~n##0:wybe.int, ~tmp#2##0:wybe.int, ?###0:wybe.int) @int:nn:nn
+        foreign llvm mul(~n##0:wybe.int, ~tmp#2##0:wybe.int, ?#result##0:wybe.int) @int:nn:nn
 
     1:
-        foreign llvm move(1:wybe.int, ?###0:wybe.int) @func_factorial:nn:nn
+        foreign llvm move(1:wybe.int, ?#result##0:wybe.int) @func_factorial:nn:nn
 
 
   LLVM code       :
@@ -74,6 +74,6 @@ if.then:
 if.else:
   %"3#tmp#3##0" = sub   i64 %"n##0", 1 
   %"3#tmp#2##0" = tail call fastcc  i64  @"func_factorial.factorial<0>"(i64  %"3#tmp#3##0")  
-  %"3####0" = mul   i64 %"n##0", %"3#tmp#2##0" 
-  ret i64 %"3####0" 
+  %"3##result##0" = mul   i64 %"n##0", %"3#tmp#2##0" 
+  ret i64 %"3##result##0" 
 }

--- a/test-cases/final-dump/func_let.exp
+++ b/test-cases/final-dump/func_let.exp
@@ -20,11 +20,11 @@ AFTER EVERYTHING:
 
 quad > public {inline} (1 calls)
 0: func_let.quad<0>
-quad(x##0:wybe.int, ?$##0:wybe.int):
+quad(x##0:wybe.int, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~x##0:wybe.int, ~x##0:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
-    foreign llvm add(~tmp$0##0:wybe.int, ~tmp$0##0:wybe.int, ?$##0:wybe.int) @int:nn:nn
+    foreign llvm add(~x##0:wybe.int, ~x##0:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
+    foreign llvm add(~tmp#0##0:wybe.int, ~tmp#0##0:wybe.int, ?###0:wybe.int) @int:nn:nn
 
   LLVM code       :
 
@@ -52,7 +52,7 @@ entry:
 
 define external fastcc  i64 @"func_let.quad<0>"(i64  %"x##0")    {
 entry:
-  %"1$tmp$0##0" = add   i64 %"x##0", %"x##0" 
-  %"1$$##0" = add   i64 %"1$tmp$0##0", %"1$tmp$0##0" 
-  ret i64 %"1$$##0" 
+  %"1#tmp#0##0" = add   i64 %"x##0", %"x##0" 
+  %"1####0" = add   i64 %"1#tmp#0##0", %"1#tmp#0##0" 
+  ret i64 %"1####0" 
 }

--- a/test-cases/final-dump/func_let.exp
+++ b/test-cases/final-dump/func_let.exp
@@ -20,11 +20,11 @@ AFTER EVERYTHING:
 
 quad > public {inline} (1 calls)
 0: func_let.quad<0>
-quad(x##0:wybe.int, ?###0:wybe.int):
+quad(x##0:wybe.int, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm add(~x##0:wybe.int, ~x##0:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
-    foreign llvm add(~tmp#0##0:wybe.int, ~tmp#0##0:wybe.int, ?###0:wybe.int) @int:nn:nn
+    foreign llvm add(~tmp#0##0:wybe.int, ~tmp#0##0:wybe.int, ?#result##0:wybe.int) @int:nn:nn
 
   LLVM code       :
 
@@ -53,6 +53,6 @@ entry:
 define external fastcc  i64 @"func_let.quad<0>"(i64  %"x##0")    {
 entry:
   %"1#tmp#0##0" = add   i64 %"x##0", %"x##0" 
-  %"1####0" = add   i64 %"1#tmp#0##0", %"1#tmp#0##0" 
-  ret i64 %"1####0" 
+  %"1##result##0" = add   i64 %"1#tmp#0##0", %"1#tmp#0##0" 
+  ret i64 %"1##result##0" 
 }

--- a/test-cases/final-dump/func_let.exp
+++ b/test-cases/final-dump/func_let.exp
@@ -12,19 +12,19 @@ AFTER EVERYTHING:
 
 *main* > public {inline} (0 calls)
 0: func_let.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(40:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_int(40:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 quad > public {inline} (1 calls)
 0: func_let.quad<0>
-quad(x#0:wybe.int, ?$#0:wybe.int):
+quad(x##0:wybe.int, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~x#0:wybe.int, ~x#0:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn
-    foreign llvm add(~tmp$0#0:wybe.int, ~tmp$0#0:wybe.int, ?$#0:wybe.int) @int:nn:nn
+    foreign llvm add(~x##0:wybe.int, ~x##0:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
+    foreign llvm add(~tmp$0##0:wybe.int, ~tmp$0##0:wybe.int, ?$##0:wybe.int) @int:nn:nn
 
   LLVM code       :
 
@@ -50,9 +50,9 @@ entry:
 }
 
 
-define external fastcc  i64 @"func_let.quad<0>"(i64  %"x#0")    {
+define external fastcc  i64 @"func_let.quad<0>"(i64  %"x##0")    {
 entry:
-  %"1$tmp$0#0" = add   i64 %"x#0", %"x#0" 
-  %"1$$#0" = add   i64 %"1$tmp$0#0", %"1$tmp$0#0" 
-  ret i64 %"1$$#0" 
+  %"1$tmp$0##0" = add   i64 %"x##0", %"x##0" 
+  %"1$$##0" = add   i64 %"1$tmp$0##0", %"1$tmp$0##0" 
+  ret i64 %"1$$##0" 
 }

--- a/test-cases/final-dump/func_quadruple.exp
+++ b/test-cases/final-dump/func_quadruple.exp
@@ -12,19 +12,19 @@ AFTER EVERYTHING:
 
 double > public {inline} (2 calls)
 0: func_quadruple.double<0>
-double(a##0:wybe.int, ?###0:wybe.int):
+double(a##0:wybe.int, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~a##0:wybe.int, ~a##0:wybe.int, ?###0:wybe.int) @int:nn:nn
+    foreign llvm add(~a##0:wybe.int, ~a##0:wybe.int, ?#result##0:wybe.int) @int:nn:nn
 
 
 quadruple > public {inline} (0 calls)
 0: func_quadruple.quadruple<0>
-quadruple(a##0:wybe.int, ?###0:wybe.int):
+quadruple(a##0:wybe.int, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm add(~a##0:wybe.int, ~a##0:wybe.int, ?tmp#1##0:wybe.int) @int:nn:nn
-    foreign llvm add(~tmp#1##0:wybe.int, ~tmp#1##0:wybe.int, ?###0:wybe.int) @int:nn:nn
+    foreign llvm add(~tmp#1##0:wybe.int, ~tmp#1##0:wybe.int, ?#result##0:wybe.int) @int:nn:nn
 
   LLVM code       :
 
@@ -42,14 +42,14 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  i64 @"func_quadruple.double<0>"(i64  %"a##0")    {
 entry:
-  %"1####0" = add   i64 %"a##0", %"a##0" 
-  ret i64 %"1####0" 
+  %"1##result##0" = add   i64 %"a##0", %"a##0" 
+  ret i64 %"1##result##0" 
 }
 
 
 define external fastcc  i64 @"func_quadruple.quadruple<0>"(i64  %"a##0")    {
 entry:
   %"1#tmp#1##0" = add   i64 %"a##0", %"a##0" 
-  %"1####0" = add   i64 %"1#tmp#1##0", %"1#tmp#1##0" 
-  ret i64 %"1####0" 
+  %"1##result##0" = add   i64 %"1#tmp#1##0", %"1#tmp#1##0" 
+  ret i64 %"1##result##0" 
 }

--- a/test-cases/final-dump/func_quadruple.exp
+++ b/test-cases/final-dump/func_quadruple.exp
@@ -12,19 +12,19 @@ AFTER EVERYTHING:
 
 double > public {inline} (2 calls)
 0: func_quadruple.double<0>
-double(a##0:wybe.int, ?$##0:wybe.int):
+double(a##0:wybe.int, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~a##0:wybe.int, ~a##0:wybe.int, ?$##0:wybe.int) @int:nn:nn
+    foreign llvm add(~a##0:wybe.int, ~a##0:wybe.int, ?###0:wybe.int) @int:nn:nn
 
 
 quadruple > public {inline} (0 calls)
 0: func_quadruple.quadruple<0>
-quadruple(a##0:wybe.int, ?$##0:wybe.int):
+quadruple(a##0:wybe.int, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~a##0:wybe.int, ~a##0:wybe.int, ?tmp$1##0:wybe.int) @int:nn:nn
-    foreign llvm add(~tmp$1##0:wybe.int, ~tmp$1##0:wybe.int, ?$##0:wybe.int) @int:nn:nn
+    foreign llvm add(~a##0:wybe.int, ~a##0:wybe.int, ?tmp#1##0:wybe.int) @int:nn:nn
+    foreign llvm add(~tmp#1##0:wybe.int, ~tmp#1##0:wybe.int, ?###0:wybe.int) @int:nn:nn
 
   LLVM code       :
 
@@ -42,14 +42,14 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  i64 @"func_quadruple.double<0>"(i64  %"a##0")    {
 entry:
-  %"1$$##0" = add   i64 %"a##0", %"a##0" 
-  ret i64 %"1$$##0" 
+  %"1####0" = add   i64 %"a##0", %"a##0" 
+  ret i64 %"1####0" 
 }
 
 
 define external fastcc  i64 @"func_quadruple.quadruple<0>"(i64  %"a##0")    {
 entry:
-  %"1$tmp$1##0" = add   i64 %"a##0", %"a##0" 
-  %"1$$##0" = add   i64 %"1$tmp$1##0", %"1$tmp$1##0" 
-  ret i64 %"1$$##0" 
+  %"1#tmp#1##0" = add   i64 %"a##0", %"a##0" 
+  %"1####0" = add   i64 %"1#tmp#1##0", %"1#tmp#1##0" 
+  ret i64 %"1####0" 
 }

--- a/test-cases/final-dump/func_quadruple.exp
+++ b/test-cases/final-dump/func_quadruple.exp
@@ -12,19 +12,19 @@ AFTER EVERYTHING:
 
 double > public {inline} (2 calls)
 0: func_quadruple.double<0>
-double(a#0:wybe.int, ?$#0:wybe.int):
+double(a##0:wybe.int, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~a#0:wybe.int, ~a#0:wybe.int, ?$#0:wybe.int) @int:nn:nn
+    foreign llvm add(~a##0:wybe.int, ~a##0:wybe.int, ?$##0:wybe.int) @int:nn:nn
 
 
 quadruple > public {inline} (0 calls)
 0: func_quadruple.quadruple<0>
-quadruple(a#0:wybe.int, ?$#0:wybe.int):
+quadruple(a##0:wybe.int, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~a#0:wybe.int, ~a#0:wybe.int, ?tmp$1#0:wybe.int) @int:nn:nn
-    foreign llvm add(~tmp$1#0:wybe.int, ~tmp$1#0:wybe.int, ?$#0:wybe.int) @int:nn:nn
+    foreign llvm add(~a##0:wybe.int, ~a##0:wybe.int, ?tmp$1##0:wybe.int) @int:nn:nn
+    foreign llvm add(~tmp$1##0:wybe.int, ~tmp$1##0:wybe.int, ?$##0:wybe.int) @int:nn:nn
 
   LLVM code       :
 
@@ -40,16 +40,16 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i64 @"func_quadruple.double<0>"(i64  %"a#0")    {
+define external fastcc  i64 @"func_quadruple.double<0>"(i64  %"a##0")    {
 entry:
-  %"1$$#0" = add   i64 %"a#0", %"a#0" 
-  ret i64 %"1$$#0" 
+  %"1$$##0" = add   i64 %"a##0", %"a##0" 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  i64 @"func_quadruple.quadruple<0>"(i64  %"a#0")    {
+define external fastcc  i64 @"func_quadruple.quadruple<0>"(i64  %"a##0")    {
 entry:
-  %"1$tmp$1#0" = add   i64 %"a#0", %"a#0" 
-  %"1$$#0" = add   i64 %"1$tmp$1#0", %"1$tmp$1#0" 
-  ret i64 %"1$$#0" 
+  %"1$tmp$1##0" = add   i64 %"a##0", %"a##0" 
+  %"1$$##0" = add   i64 %"1$tmp$1##0", %"1$tmp$1##0" 
+  ret i64 %"1$$##0" 
 }

--- a/test-cases/final-dump/func_typed.exp
+++ b/test-cases/final-dump/func_typed.exp
@@ -11,10 +11,10 @@ AFTER EVERYTHING:
 
 plus > public {inline} (0 calls)
 0: func_typed.plus<0>
-plus(a##0:wybe.int, b##0:wybe.int, ?$##0:wybe.int):
+plus(a##0:wybe.int, b##0:wybe.int, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~a##0:wybe.int, ~b##0:wybe.int, ?$##0:wybe.int) @int:nn:nn
+    foreign llvm add(~a##0:wybe.int, ~b##0:wybe.int, ?###0:wybe.int) @int:nn:nn
 
   LLVM code       :
 
@@ -32,6 +32,6 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  i64 @"func_typed.plus<0>"(i64  %"a##0", i64  %"b##0")    {
 entry:
-  %"1$$##0" = add   i64 %"a##0", %"b##0" 
-  ret i64 %"1$$##0" 
+  %"1####0" = add   i64 %"a##0", %"b##0" 
+  ret i64 %"1####0" 
 }

--- a/test-cases/final-dump/func_typed.exp
+++ b/test-cases/final-dump/func_typed.exp
@@ -11,10 +11,10 @@ AFTER EVERYTHING:
 
 plus > public {inline} (0 calls)
 0: func_typed.plus<0>
-plus(a#0:wybe.int, b#0:wybe.int, ?$#0:wybe.int):
+plus(a##0:wybe.int, b##0:wybe.int, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~a#0:wybe.int, ~b#0:wybe.int, ?$#0:wybe.int) @int:nn:nn
+    foreign llvm add(~a##0:wybe.int, ~b##0:wybe.int, ?$##0:wybe.int) @int:nn:nn
 
   LLVM code       :
 
@@ -30,8 +30,8 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i64 @"func_typed.plus<0>"(i64  %"a#0", i64  %"b#0")    {
+define external fastcc  i64 @"func_typed.plus<0>"(i64  %"a##0", i64  %"b##0")    {
 entry:
-  %"1$$#0" = add   i64 %"a#0", %"b#0" 
-  ret i64 %"1$$#0" 
+  %"1$$##0" = add   i64 %"a##0", %"b##0" 
+  ret i64 %"1$$##0" 
 }

--- a/test-cases/final-dump/func_typed.exp
+++ b/test-cases/final-dump/func_typed.exp
@@ -11,10 +11,10 @@ AFTER EVERYTHING:
 
 plus > public {inline} (0 calls)
 0: func_typed.plus<0>
-plus(a##0:wybe.int, b##0:wybe.int, ?###0:wybe.int):
+plus(a##0:wybe.int, b##0:wybe.int, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~a##0:wybe.int, ~b##0:wybe.int, ?###0:wybe.int) @int:nn:nn
+    foreign llvm add(~a##0:wybe.int, ~b##0:wybe.int, ?#result##0:wybe.int) @int:nn:nn
 
   LLVM code       :
 
@@ -32,6 +32,6 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  i64 @"func_typed.plus<0>"(i64  %"a##0", i64  %"b##0")    {
 entry:
-  %"1####0" = add   i64 %"a##0", %"b##0" 
-  ret i64 %"1####0" 
+  %"1##result##0" = add   i64 %"a##0", %"b##0" 
+  ret i64 %"1##result##0" 
 }

--- a/test-cases/final-dump/func_untyped.exp
+++ b/test-cases/final-dump/func_untyped.exp
@@ -11,10 +11,10 @@ AFTER EVERYTHING:
 
 incr > {inline} (0 calls)
 0: func_untyped.incr<0>
-incr(a#0:wybe.int, ?$#0:wybe.int):
+incr(a##0:wybe.int, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~a#0:wybe.int, 1:wybe.int, ?$#0:wybe.int) @int:nn:nn
+    foreign llvm add(~a##0:wybe.int, 1:wybe.int, ?$##0:wybe.int) @int:nn:nn
 
   LLVM code       :
 
@@ -30,8 +30,8 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i64 @"func_untyped.incr<0>"(i64  %"a#0")    {
+define external fastcc  i64 @"func_untyped.incr<0>"(i64  %"a##0")    {
 entry:
-  %"1$$#0" = add   i64 %"a#0", 1 
-  ret i64 %"1$$#0" 
+  %"1$$##0" = add   i64 %"a##0", 1 
+  ret i64 %"1$$##0" 
 }

--- a/test-cases/final-dump/func_untyped.exp
+++ b/test-cases/final-dump/func_untyped.exp
@@ -11,10 +11,10 @@ AFTER EVERYTHING:
 
 incr > {inline} (0 calls)
 0: func_untyped.incr<0>
-incr(a##0:wybe.int, ?$##0:wybe.int):
+incr(a##0:wybe.int, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~a##0:wybe.int, 1:wybe.int, ?$##0:wybe.int) @int:nn:nn
+    foreign llvm add(~a##0:wybe.int, 1:wybe.int, ?###0:wybe.int) @int:nn:nn
 
   LLVM code       :
 
@@ -32,6 +32,6 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  i64 @"func_untyped.incr<0>"(i64  %"a##0")    {
 entry:
-  %"1$$##0" = add   i64 %"a##0", 1 
-  ret i64 %"1$$##0" 
+  %"1####0" = add   i64 %"a##0", 1 
+  ret i64 %"1####0" 
 }

--- a/test-cases/final-dump/func_untyped.exp
+++ b/test-cases/final-dump/func_untyped.exp
@@ -11,10 +11,10 @@ AFTER EVERYTHING:
 
 incr > {inline} (0 calls)
 0: func_untyped.incr<0>
-incr(a##0:wybe.int, ?###0:wybe.int):
+incr(a##0:wybe.int, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~a##0:wybe.int, 1:wybe.int, ?###0:wybe.int) @int:nn:nn
+    foreign llvm add(~a##0:wybe.int, 1:wybe.int, ?#result##0:wybe.int) @int:nn:nn
 
   LLVM code       :
 
@@ -32,6 +32,6 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  i64 @"func_untyped.incr<0>"(i64  %"a##0")    {
 entry:
-  %"1####0" = add   i64 %"a##0", 1 
-  ret i64 %"1####0" 
+  %"1##result##0" = add   i64 %"a##0", 1 
+  ret i64 %"1##result##0" 
 }

--- a/test-cases/final-dump/func_where.exp
+++ b/test-cases/final-dump/func_where.exp
@@ -11,11 +11,11 @@ AFTER EVERYTHING:
 
 quad > public {inline} (0 calls)
 0: func_where.quad<0>
-quad(x##0:wybe.int, ?$##0:wybe.int):
+quad(x##0:wybe.int, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~x##0:wybe.int, ~x##0:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
-    foreign llvm add(~tmp$0##0:wybe.int, ~tmp$0##0:wybe.int, ?$##0:wybe.int) @int:nn:nn
+    foreign llvm add(~x##0:wybe.int, ~x##0:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
+    foreign llvm add(~tmp#0##0:wybe.int, ~tmp#0##0:wybe.int, ?###0:wybe.int) @int:nn:nn
 
   LLVM code       :
 
@@ -33,7 +33,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  i64 @"func_where.quad<0>"(i64  %"x##0")    {
 entry:
-  %"1$tmp$0##0" = add   i64 %"x##0", %"x##0" 
-  %"1$$##0" = add   i64 %"1$tmp$0##0", %"1$tmp$0##0" 
-  ret i64 %"1$$##0" 
+  %"1#tmp#0##0" = add   i64 %"x##0", %"x##0" 
+  %"1####0" = add   i64 %"1#tmp#0##0", %"1#tmp#0##0" 
+  ret i64 %"1####0" 
 }

--- a/test-cases/final-dump/func_where.exp
+++ b/test-cases/final-dump/func_where.exp
@@ -11,11 +11,11 @@ AFTER EVERYTHING:
 
 quad > public {inline} (0 calls)
 0: func_where.quad<0>
-quad(x#0:wybe.int, ?$#0:wybe.int):
+quad(x##0:wybe.int, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~x#0:wybe.int, ~x#0:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn
-    foreign llvm add(~tmp$0#0:wybe.int, ~tmp$0#0:wybe.int, ?$#0:wybe.int) @int:nn:nn
+    foreign llvm add(~x##0:wybe.int, ~x##0:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
+    foreign llvm add(~tmp$0##0:wybe.int, ~tmp$0##0:wybe.int, ?$##0:wybe.int) @int:nn:nn
 
   LLVM code       :
 
@@ -31,9 +31,9 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i64 @"func_where.quad<0>"(i64  %"x#0")    {
+define external fastcc  i64 @"func_where.quad<0>"(i64  %"x##0")    {
 entry:
-  %"1$tmp$0#0" = add   i64 %"x#0", %"x#0" 
-  %"1$$#0" = add   i64 %"1$tmp$0#0", %"1$tmp$0#0" 
-  ret i64 %"1$$#0" 
+  %"1$tmp$0##0" = add   i64 %"x##0", %"x##0" 
+  %"1$$##0" = add   i64 %"1$tmp$0##0", %"1$tmp$0##0" 
+  ret i64 %"1$$##0" 
 }

--- a/test-cases/final-dump/func_where.exp
+++ b/test-cases/final-dump/func_where.exp
@@ -11,11 +11,11 @@ AFTER EVERYTHING:
 
 quad > public {inline} (0 calls)
 0: func_where.quad<0>
-quad(x##0:wybe.int, ?###0:wybe.int):
+quad(x##0:wybe.int, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm add(~x##0:wybe.int, ~x##0:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
-    foreign llvm add(~tmp#0##0:wybe.int, ~tmp#0##0:wybe.int, ?###0:wybe.int) @int:nn:nn
+    foreign llvm add(~tmp#0##0:wybe.int, ~tmp#0##0:wybe.int, ?#result##0:wybe.int) @int:nn:nn
 
   LLVM code       :
 
@@ -34,6 +34,6 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 define external fastcc  i64 @"func_where.quad<0>"(i64  %"x##0")    {
 entry:
   %"1#tmp#0##0" = add   i64 %"x##0", %"x##0" 
-  %"1####0" = add   i64 %"1#tmp#0##0", %"1#tmp#0##0" 
-  ret i64 %"1####0" 
+  %"1##result##0" = add   i64 %"1#tmp#0##0", %"1#tmp#0##0" 
+  ret i64 %"1##result##0" 
 }

--- a/test-cases/final-dump/generic_list.exp
+++ b/test-cases/final-dump/generic_list.exp
@@ -19,14 +19,14 @@ AFTER EVERYTHING:
 
 append > public (1 calls)
 0: generic_list.append<0>
-append(x##0:generic_list(?T), y##0:generic_list(?T), ?###0:generic_list(?T)):
- AliasPairs: [(###0,y##0)]
+append(x##0:generic_list(?T), y##0:generic_list(?T), ?#result##0:generic_list(?T)):
+ AliasPairs: [(#result##0,y##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(generic_list.append<0>,fromList [NonAliasedParamCond 0 [0]]))]
     foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
     case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~y##0:generic_list(?T), ?###0:generic_list(?T)) @generic_list:nn:nn
+        foreign llvm move(~y##0:generic_list(?T), ?#result##0:generic_list(?T)) @generic_list:nn:nn
 
     1:
         foreign lpvm access(x##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:?T)
@@ -34,23 +34,23 @@ append(x##0:generic_list(?T), y##0:generic_list(?T), ?###0:generic_list(?T)):
         generic_list.append<0>(~t##0:generic_list(?T), ~y##0:generic_list(?T), ?tmp#2##0:generic_list(?T)) #1 @generic_list:nn:nn
         foreign lpvm alloc(16:wybe.int, ?tmp#8##0:generic_list(?T))
         foreign lpvm mutate(~tmp#8##0:generic_list(?T), ?tmp#9##0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:?T)
-        foreign lpvm mutate(~tmp#9##0:generic_list(?T), ?###0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:generic_list(?T))
+        foreign lpvm mutate(~tmp#9##0:generic_list(?T), ?#result##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:generic_list(?T))
 
 
 
 car > public {inline} (0 calls)
 0: generic_list.car<0>
-car(#rec##0:generic_list(?T), ?###0:?T, ?####0:wybe.bool):
+car(#rec##0:generic_list(?T), ?#result##0:?T, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:?T, ?###0:?T)
+        foreign llvm move(undef:?T, ?#result##0:?T)
 
     1:
-        foreign lpvm access(~#rec##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:?T)
+        foreign lpvm access(~#rec##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:?T)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 car > public {inline} (0 calls)
@@ -72,17 +72,17 @@ car(#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), #field##0:?T, ?####0:wy
 
 cdr > public {inline} (0 calls)
 0: generic_list.cdr<0>
-cdr(#rec##0:generic_list(?T), ?###0:generic_list(?T), ?####0:wybe.bool):
+cdr(#rec##0:generic_list(?T), ?#result##0:generic_list(?T), ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:generic_list(?T), ?###0:generic_list(?T))
+        foreign llvm move(undef:generic_list(?T), ?#result##0:generic_list(?T))
 
     1:
-        foreign lpvm access(~#rec##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:generic_list(?T))
+        foreign lpvm access(~#rec##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:generic_list(?T))
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 cdr > public {inline} (0 calls)
@@ -104,18 +104,18 @@ cdr(#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), #field##0:generic_list(
 
 cons > public {inline} (1 calls)
 0: generic_list.cons<0>
-cons(car##0:?T, cdr##0:generic_list(?T), ?###0:generic_list(?T)):
+cons(car##0:?T, cdr##0:generic_list(?T), ?#result##0:generic_list(?T)):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:generic_list(?T))
     foreign lpvm mutate(~#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~car##0:?T)
-    foreign lpvm mutate(~#rec##1:generic_list(?T), ?###0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr##0:generic_list(?T))
+    foreign lpvm mutate(~#rec##1:generic_list(?T), ?#result##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr##0:generic_list(?T))
 cons > public {inline} (6 calls)
 1: generic_list.cons<1>
-cons(?car##0:?T, ?cdr##0:generic_list(?T), ###0:generic_list(?T), ?####0:wybe.bool):
+cons(?car##0:?T, ?cdr##0:generic_list(?T), #result##0:generic_list(?T), ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
@@ -123,43 +123,43 @@ cons(?car##0:?T, ?cdr##0:generic_list(?T), ###0:generic_list(?T), ?####0:wybe.bo
         foreign llvm move(undef:generic_list(?T), ?cdr##0:generic_list(?T))
 
     1:
-        foreign lpvm access(###0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?car##0:?T)
-        foreign lpvm access(~###0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?cdr##0:generic_list(?T))
+        foreign lpvm access(#result##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?car##0:?T)
+        foreign lpvm access(~#result##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?cdr##0:generic_list(?T))
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 length > public {inline} (0 calls)
 0: generic_list.length<0>
-length(x##0:generic_list(?T), ?###0:wybe.int):
+length(x##0:generic_list(?T), ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    generic_list.length1<0>(~x##0:generic_list(?T), 0:wybe.int, ?###0:wybe.int) #0 @generic_list:nn:nn
+    generic_list.length1<0>(~x##0:generic_list(?T), 0:wybe.int, ?#result##0:wybe.int) #0 @generic_list:nn:nn
 
 
 length1 > (2 calls)
 0: generic_list.length1<0>
-length1(x##0:generic_list(?T), acc##0:wybe.int, ?###0:wybe.int):
+length1(x##0:generic_list(?T), acc##0:wybe.int, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
     case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~acc##0:wybe.int, ?###0:wybe.int) @generic_list:nn:nn
+        foreign llvm move(~acc##0:wybe.int, ?#result##0:wybe.int) @generic_list:nn:nn
 
     1:
         foreign lpvm access(~x##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
         foreign llvm add(~acc##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
-        generic_list.length1<0>(~t##0:generic_list(?T), ~tmp#2##0:wybe.int, ?###0:wybe.int) #2 @generic_list:nn:nn
+        generic_list.length1<0>(~t##0:generic_list(?T), ~tmp#2##0:wybe.int, ?#result##0:wybe.int) #2 @generic_list:nn:nn
 
 
 
 nil > public {inline} (0 calls)
 0: generic_list.nil<0>
-nil(?###0:generic_list(?T)):
+nil(?#result##0:generic_list(?T)):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:generic_list(?T), ?###0:generic_list(?T))
+    foreign llvm move(0:generic_list(?T), ?#result##0:generic_list(?T))
 
   LLVM code       :
 
@@ -308,15 +308,15 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"generic_list.cons<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64, i1} @"generic_list.cons<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  %"1#tmp#0##0" = icmp ne i64 %"#result##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %64 = inttoptr i64 %"###0" to i64* 
+  %64 = inttoptr i64 %"#result##0" to i64* 
   %65 = getelementptr  i64, i64* %64, i64 0 
   %66 = load  i64, i64* %65 
-  %67 = add   i64 %"###0", 8 
+  %67 = add   i64 %"#result##0", 8 
   %68 = inttoptr i64 %67 to i64* 
   %69 = getelementptr  i64, i64* %68, i64 0 
   %70 = load  i64, i64* %69 
@@ -334,8 +334,8 @@ if.else:
 
 define external fastcc  i64 @"generic_list.length<0>"(i64  %"x##0")    {
 entry:
-  %"1####0" = tail call fastcc  i64  @"generic_list.length1<0>"(i64  %"x##0", i64  0)  
-  ret i64 %"1####0" 
+  %"1##result##0" = tail call fastcc  i64  @"generic_list.length1<0>"(i64  %"x##0", i64  0)  
+  ret i64 %"1##result##0" 
 }
 
 
@@ -349,8 +349,8 @@ if.then:
   %79 = getelementptr  i64, i64* %78, i64 0 
   %80 = load  i64, i64* %79 
   %"2#tmp#2##0" = add   i64 %"acc##0", 1 
-  %"2####0" = tail call fastcc  i64  @"generic_list.length1<0>"(i64  %80, i64  %"2#tmp#2##0")  
-  ret i64 %"2####0" 
+  %"2##result##0" = tail call fastcc  i64  @"generic_list.length1<0>"(i64  %80, i64  %"2#tmp#2##0")  
+  ret i64 %"2##result##0" 
 if.else:
   ret i64 %"acc##0" 
 }

--- a/test-cases/final-dump/generic_list.exp
+++ b/test-cases/final-dump/generic_list.exp
@@ -40,65 +40,65 @@ append(x##0:generic_list(?T), y##0:generic_list(?T), ?#result##0:generic_list(?T
 
 car > public {inline} (0 calls)
 0: generic_list.car<0>
-car(#rec##0:generic_list(?T), ?#result##0:?T, ?####0:wybe.bool):
+car(#rec##0:generic_list(?T), ?#result##0:?T, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:?T, ?#result##0:?T)
 
     1:
         foreign lpvm access(~#rec##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:?T)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 car > public {inline} (0 calls)
 1: generic_list.car<1>
-car(#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), #field##0:?T, ?####0:wybe.bool):
+car(#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), #field##0:?T, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:generic_list(?T), ?#rec##1:generic_list(?T))
 
     1:
         foreign lpvm mutate(~#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:?T)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 cdr > public {inline} (0 calls)
 0: generic_list.cdr<0>
-cdr(#rec##0:generic_list(?T), ?#result##0:generic_list(?T), ?####0:wybe.bool):
+cdr(#rec##0:generic_list(?T), ?#result##0:generic_list(?T), ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:generic_list(?T), ?#result##0:generic_list(?T))
 
     1:
         foreign lpvm access(~#rec##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:generic_list(?T))
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 cdr > public {inline} (0 calls)
 1: generic_list.cdr<1>
-cdr(#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), #field##0:generic_list(?T), ?####0:wybe.bool):
+cdr(#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), #field##0:generic_list(?T), ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:generic_list(?T), ?#rec##1:generic_list(?T))
 
     1:
         foreign lpvm {noalias} mutate(~#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:generic_list(?T))
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -112,20 +112,20 @@ cons(car##0:?T, cdr##0:generic_list(?T), ?#result##0:generic_list(?T)):
     foreign lpvm mutate(~#rec##1:generic_list(?T), ?#result##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr##0:generic_list(?T))
 cons > public {inline} (6 calls)
 1: generic_list.cons<1>
-cons(?car##0:?T, ?cdr##0:generic_list(?T), #result##0:generic_list(?T), ?####0:wybe.bool):
+cons(?car##0:?T, ?cdr##0:generic_list(?T), #result##0:generic_list(?T), ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:?T, ?car##0:?T)
         foreign llvm move(undef:generic_list(?T), ?cdr##0:generic_list(?T))
 
     1:
         foreign lpvm access(#result##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?car##0:?T)
         foreign lpvm access(~#result##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?cdr##0:generic_list(?T))
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 

--- a/test-cases/final-dump/generic_list.exp
+++ b/test-cases/final-dump/generic_list.exp
@@ -19,147 +19,147 @@ AFTER EVERYTHING:
 
 append > public (1 calls)
 0: generic_list.append<0>
-append(x##0:generic_list(?T), y##0:generic_list(?T), ?$##0:generic_list(?T)):
- AliasPairs: [($##0,y##0)]
+append(x##0:generic_list(?T), y##0:generic_list(?T), ?###0:generic_list(?T)):
+ AliasPairs: [(###0,y##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(generic_list.append<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
-    case ~tmp$5##0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
+    case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~y##0:generic_list(?T), ?$##0:generic_list(?T)) @generic_list:nn:nn
+        foreign llvm move(~y##0:generic_list(?T), ?###0:generic_list(?T)) @generic_list:nn:nn
 
     1:
         foreign lpvm access(x##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:?T)
         foreign lpvm access(~x##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
-        generic_list.append<0>(~t##0:generic_list(?T), ~y##0:generic_list(?T), ?tmp$2##0:generic_list(?T)) #1 @generic_list:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$8##0:generic_list(?T))
-        foreign lpvm mutate(~tmp$8##0:generic_list(?T), ?tmp$9##0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:?T)
-        foreign lpvm mutate(~tmp$9##0:generic_list(?T), ?$##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:generic_list(?T))
+        generic_list.append<0>(~t##0:generic_list(?T), ~y##0:generic_list(?T), ?tmp#2##0:generic_list(?T)) #1 @generic_list:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:generic_list(?T))
+        foreign lpvm mutate(~tmp#8##0:generic_list(?T), ?tmp#9##0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:?T)
+        foreign lpvm mutate(~tmp#9##0:generic_list(?T), ?###0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:generic_list(?T))
 
 
 
 car > public {inline} (0 calls)
 0: generic_list.car<0>
-car($rec##0:generic_list(?T), ?$##0:?T, ?$$##0:wybe.bool):
+car(#rec##0:generic_list(?T), ?###0:?T, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:?T, ?$##0:?T)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:?T, ?###0:?T)
 
     1:
-        foreign lpvm access(~$rec##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:?T)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:?T)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 car > public {inline} (0 calls)
 1: generic_list.car<1>
-car($rec##0:generic_list(?T), ?$rec##1:generic_list(?T), $field##0:?T, ?$$##0:wybe.bool):
+car(#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), #field##0:?T, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:generic_list(?T), ?$rec##1:generic_list(?T))
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:generic_list(?T), ?#rec##1:generic_list(?T))
 
     1:
-        foreign lpvm mutate(~$rec##0:generic_list(?T), ?$rec##1:generic_list(?T), 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:?T)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:?T)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 cdr > public {inline} (0 calls)
 0: generic_list.cdr<0>
-cdr($rec##0:generic_list(?T), ?$##0:generic_list(?T), ?$$##0:wybe.bool):
+cdr(#rec##0:generic_list(?T), ?###0:generic_list(?T), ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:generic_list(?T), ?$##0:generic_list(?T))
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:generic_list(?T), ?###0:generic_list(?T))
 
     1:
-        foreign lpvm access(~$rec##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:generic_list(?T))
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:generic_list(?T))
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 cdr > public {inline} (0 calls)
 1: generic_list.cdr<1>
-cdr($rec##0:generic_list(?T), ?$rec##1:generic_list(?T), $field##0:generic_list(?T), ?$$##0:wybe.bool):
+cdr(#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), #field##0:generic_list(?T), ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:generic_list(?T), ?$rec##1:generic_list(?T))
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:generic_list(?T), ?#rec##1:generic_list(?T))
 
     1:
-        foreign lpvm {noalias} mutate(~$rec##0:generic_list(?T), ?$rec##1:generic_list(?T), 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:generic_list(?T))
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm {noalias} mutate(~#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:generic_list(?T))
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 cons > public {inline} (1 calls)
 0: generic_list.cons<0>
-cons(car##0:?T, cdr##0:generic_list(?T), ?$##0:generic_list(?T)):
+cons(car##0:?T, cdr##0:generic_list(?T), ?###0:generic_list(?T)):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:generic_list(?T))
-    foreign lpvm mutate(~$rec##0:generic_list(?T), ?$rec##1:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~car##0:?T)
-    foreign lpvm mutate(~$rec##1:generic_list(?T), ?$##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr##0:generic_list(?T))
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:generic_list(?T))
+    foreign lpvm mutate(~#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~car##0:?T)
+    foreign lpvm mutate(~#rec##1:generic_list(?T), ?###0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr##0:generic_list(?T))
 cons > public {inline} (6 calls)
 1: generic_list.cons<1>
-cons(?car##0:?T, ?cdr##0:generic_list(?T), $##0:generic_list(?T), ?$$##0:wybe.bool):
+cons(?car##0:?T, ?cdr##0:generic_list(?T), ###0:generic_list(?T), ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:?T, ?car##0:?T)
         foreign llvm move(undef:generic_list(?T), ?cdr##0:generic_list(?T))
 
     1:
-        foreign lpvm access($##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?car##0:?T)
-        foreign lpvm access(~$##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?cdr##0:generic_list(?T))
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(###0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?car##0:?T)
+        foreign lpvm access(~###0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?cdr##0:generic_list(?T))
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 length > public {inline} (0 calls)
 0: generic_list.length<0>
-length(x##0:generic_list(?T), ?$##0:wybe.int):
+length(x##0:generic_list(?T), ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    generic_list.length1<0>(~x##0:generic_list(?T), 0:wybe.int, ?$##0:wybe.int) #0 @generic_list:nn:nn
+    generic_list.length1<0>(~x##0:generic_list(?T), 0:wybe.int, ?###0:wybe.int) #0 @generic_list:nn:nn
 
 
 length1 > (2 calls)
 0: generic_list.length1<0>
-length1(x##0:generic_list(?T), acc##0:wybe.int, ?$##0:wybe.int):
+length1(x##0:generic_list(?T), acc##0:wybe.int, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
-    case ~tmp$5##0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
+    case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~acc##0:wybe.int, ?$##0:wybe.int) @generic_list:nn:nn
+        foreign llvm move(~acc##0:wybe.int, ?###0:wybe.int) @generic_list:nn:nn
 
     1:
         foreign lpvm access(~x##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
-        foreign llvm add(~acc##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
-        generic_list.length1<0>(~t##0:generic_list(?T), ~tmp$2##0:wybe.int, ?$##0:wybe.int) #2 @generic_list:nn:nn
+        foreign llvm add(~acc##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
+        generic_list.length1<0>(~t##0:generic_list(?T), ~tmp#2##0:wybe.int, ?###0:wybe.int) #2 @generic_list:nn:nn
 
 
 
 nil > public {inline} (0 calls)
 0: generic_list.nil<0>
-nil(?$##0:generic_list(?T)):
+nil(?###0:generic_list(?T)):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:generic_list(?T), ?$##0:generic_list(?T))
+    foreign llvm move(0:generic_list(?T), ?###0:generic_list(?T))
 
   LLVM code       :
 
@@ -177,8 +177,8 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  i64 @"generic_list.append<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$tmp$5##0" = icmp ne i64 %"x##0", 0 
-  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
+  %"1#tmp#5##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"x##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
@@ -187,7 +187,7 @@ if.then:
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %"2$tmp$2##0" = tail call fastcc  i64  @"generic_list.append<0>"(i64  %7, i64  %"y##0")  
+  %"2#tmp#2##0" = tail call fastcc  i64  @"generic_list.append<0>"(i64  %7, i64  %"y##0")  
   %8 = trunc i64 16 to i32  
   %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
   %10 = ptrtoint i8* %9 to i64 
@@ -197,19 +197,19 @@ if.then:
   %13 = add   i64 %10, 8 
   %14 = inttoptr i64 %13 to i64* 
   %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 %"2$tmp$2##0", i64* %15 
+  store  i64 %"2#tmp#2##0", i64* %15 
   ret i64 %10 
 if.else:
   ret i64 %"y##0" 
 }
 
 
-define external fastcc  {i64, i1} @"generic_list.car<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"generic_list.car<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %16 = inttoptr i64 %"$rec##0" to i64* 
+  %16 = inttoptr i64 %"#rec##0" to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
   %19 = insertvalue {i64, i1} undef, i64 %18, 0 
@@ -222,37 +222,37 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"generic_list.car<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"generic_list.car<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %23 = trunc i64 16 to i32  
   %24 = tail call ccc  i8*  @wybe_malloc(i32  %23)  
   %25 = ptrtoint i8* %24 to i64 
   %26 = inttoptr i64 %25 to i8* 
-  %27 = inttoptr i64 %"$rec##0" to i8* 
+  %27 = inttoptr i64 %"#rec##0" to i8* 
   %28 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %26, i8*  %27, i32  %28, i32  8, i1  0)  
   %29 = inttoptr i64 %25 to i64* 
   %30 = getelementptr  i64, i64* %29, i64 0 
-  store  i64 %"$field##0", i64* %30 
+  store  i64 %"#field##0", i64* %30 
   %31 = insertvalue {i64, i1} undef, i64 %25, 0 
   %32 = insertvalue {i64, i1} %31, i1 1, 1 
   ret {i64, i1} %32 
 if.else:
-  %33 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %33 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %34 = insertvalue {i64, i1} %33, i1 0, 1 
   ret {i64, i1} %34 
 }
 
 
-define external fastcc  {i64, i1} @"generic_list.cdr<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"generic_list.cdr<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %35 = add   i64 %"$rec##0", 8 
+  %35 = add   i64 %"#rec##0", 8 
   %36 = inttoptr i64 %35 to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
@@ -266,27 +266,27 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"generic_list.cdr<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"generic_list.cdr<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %43 = trunc i64 16 to i32  
   %44 = tail call ccc  i8*  @wybe_malloc(i32  %43)  
   %45 = ptrtoint i8* %44 to i64 
   %46 = inttoptr i64 %45 to i8* 
-  %47 = inttoptr i64 %"$rec##0" to i8* 
+  %47 = inttoptr i64 %"#rec##0" to i8* 
   %48 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %46, i8*  %47, i32  %48, i32  8, i1  0)  
   %49 = add   i64 %45, 8 
   %50 = inttoptr i64 %49 to i64* 
   %51 = getelementptr  i64, i64* %50, i64 0 
-  store  i64 %"$field##0", i64* %51 
+  store  i64 %"#field##0", i64* %51 
   %52 = insertvalue {i64, i1} undef, i64 %45, 0 
   %53 = insertvalue {i64, i1} %52, i1 1, 1 
   ret {i64, i1} %53 
 if.else:
-  %54 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %54 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %55 = insertvalue {i64, i1} %54, i1 0, 1 
   ret {i64, i1} %55 
 }
@@ -308,15 +308,15 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"generic_list.cons<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64, i1} @"generic_list.cons<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %64 = inttoptr i64 %"$##0" to i64* 
+  %64 = inttoptr i64 %"###0" to i64* 
   %65 = getelementptr  i64, i64* %64, i64 0 
   %66 = load  i64, i64* %65 
-  %67 = add   i64 %"$##0", 8 
+  %67 = add   i64 %"###0", 8 
   %68 = inttoptr i64 %67 to i64* 
   %69 = getelementptr  i64, i64* %68, i64 0 
   %70 = load  i64, i64* %69 
@@ -334,23 +334,23 @@ if.else:
 
 define external fastcc  i64 @"generic_list.length<0>"(i64  %"x##0")    {
 entry:
-  %"1$$##0" = tail call fastcc  i64  @"generic_list.length1<0>"(i64  %"x##0", i64  0)  
-  ret i64 %"1$$##0" 
+  %"1####0" = tail call fastcc  i64  @"generic_list.length1<0>"(i64  %"x##0", i64  0)  
+  ret i64 %"1####0" 
 }
 
 
 define external fastcc  i64 @"generic_list.length1<0>"(i64  %"x##0", i64  %"acc##0")    {
 entry:
-  %"1$tmp$5##0" = icmp ne i64 %"x##0", 0 
-  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
+  %"1#tmp#5##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
   %77 = add   i64 %"x##0", 8 
   %78 = inttoptr i64 %77 to i64* 
   %79 = getelementptr  i64, i64* %78, i64 0 
   %80 = load  i64, i64* %79 
-  %"2$tmp$2##0" = add   i64 %"acc##0", 1 
-  %"2$$##0" = tail call fastcc  i64  @"generic_list.length1<0>"(i64  %80, i64  %"2$tmp$2##0")  
-  ret i64 %"2$$##0" 
+  %"2#tmp#2##0" = add   i64 %"acc##0", 1 
+  %"2####0" = tail call fastcc  i64  @"generic_list.length1<0>"(i64  %80, i64  %"2#tmp#2##0")  
+  ret i64 %"2####0" 
 if.else:
   ret i64 %"acc##0" 
 }

--- a/test-cases/final-dump/generic_list.exp
+++ b/test-cases/final-dump/generic_list.exp
@@ -19,147 +19,147 @@ AFTER EVERYTHING:
 
 append > public (1 calls)
 0: generic_list.append<0>
-append(x#0:generic_list(?T), y#0:generic_list(?T), ?$#0:generic_list(?T)):
- AliasPairs: [($#0,y#0)]
+append(x##0:generic_list(?T), y##0:generic_list(?T), ?$##0:generic_list(?T)):
+ AliasPairs: [($##0,y##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(generic_list.append<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(x#0:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.bool)
-    case ~tmp$5#0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
+    case ~tmp$5##0:wybe.bool of
     0:
-        foreign llvm move(~y#0:generic_list(?T), ?$#0:generic_list(?T)) @generic_list:nn:nn
+        foreign llvm move(~y##0:generic_list(?T), ?$##0:generic_list(?T)) @generic_list:nn:nn
 
     1:
-        foreign lpvm access(x#0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:?T)
-        foreign lpvm access(~x#0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:generic_list(?T))
-        generic_list.append<0>(~t#0:generic_list(?T), ~y#0:generic_list(?T), ?tmp$2#0:generic_list(?T)) #1 @generic_list:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$8#0:generic_list(?T))
-        foreign lpvm mutate(~tmp$8#0:generic_list(?T), ?tmp$9#0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h#0:?T)
-        foreign lpvm mutate(~tmp$9#0:generic_list(?T), ?$#0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:generic_list(?T))
+        foreign lpvm access(x##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:?T)
+        foreign lpvm access(~x##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
+        generic_list.append<0>(~t##0:generic_list(?T), ~y##0:generic_list(?T), ?tmp$2##0:generic_list(?T)) #1 @generic_list:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp$8##0:generic_list(?T))
+        foreign lpvm mutate(~tmp$8##0:generic_list(?T), ?tmp$9##0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:?T)
+        foreign lpvm mutate(~tmp$9##0:generic_list(?T), ?$##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:generic_list(?T))
 
 
 
 car > public {inline} (0 calls)
 0: generic_list.car<0>
-car($rec#0:generic_list(?T), ?$#0:?T, ?$$#0:wybe.bool):
+car($rec##0:generic_list(?T), ?$##0:?T, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:?T, ?$#0:?T)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:?T, ?$##0:?T)
 
     1:
-        foreign lpvm access(~$rec#0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:?T)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:?T)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 car > public {inline} (0 calls)
 1: generic_list.car<1>
-car($rec#0:generic_list(?T), ?$rec#1:generic_list(?T), $field#0:?T, ?$$#0:wybe.bool):
+car($rec##0:generic_list(?T), ?$rec##1:generic_list(?T), $field##0:?T, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:generic_list(?T), ?$rec#1:generic_list(?T))
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:generic_list(?T), ?$rec##1:generic_list(?T))
 
     1:
-        foreign lpvm mutate(~$rec#0:generic_list(?T), ?$rec#1:generic_list(?T), 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:?T)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~$rec##0:generic_list(?T), ?$rec##1:generic_list(?T), 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:?T)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 cdr > public {inline} (0 calls)
 0: generic_list.cdr<0>
-cdr($rec#0:generic_list(?T), ?$#0:generic_list(?T), ?$$#0:wybe.bool):
+cdr($rec##0:generic_list(?T), ?$##0:generic_list(?T), ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:generic_list(?T), ?$#0:generic_list(?T))
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:generic_list(?T), ?$##0:generic_list(?T))
 
     1:
-        foreign lpvm access(~$rec#0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:generic_list(?T))
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:generic_list(?T))
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 cdr > public {inline} (0 calls)
 1: generic_list.cdr<1>
-cdr($rec#0:generic_list(?T), ?$rec#1:generic_list(?T), $field#0:generic_list(?T), ?$$#0:wybe.bool):
+cdr($rec##0:generic_list(?T), ?$rec##1:generic_list(?T), $field##0:generic_list(?T), ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:generic_list(?T), ?$rec#1:generic_list(?T))
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:generic_list(?T), ?$rec##1:generic_list(?T))
 
     1:
-        foreign lpvm {noalias} mutate(~$rec#0:generic_list(?T), ?$rec#1:generic_list(?T), 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:generic_list(?T))
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm {noalias} mutate(~$rec##0:generic_list(?T), ?$rec##1:generic_list(?T), 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:generic_list(?T))
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 cons > public {inline} (1 calls)
 0: generic_list.cons<0>
-cons(car#0:?T, cdr#0:generic_list(?T), ?$#0:generic_list(?T)):
+cons(car##0:?T, cdr##0:generic_list(?T), ?$##0:generic_list(?T)):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:generic_list(?T))
-    foreign lpvm mutate(~$rec#0:generic_list(?T), ?$rec#1:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~car#0:?T)
-    foreign lpvm mutate(~$rec#1:generic_list(?T), ?$#0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr#0:generic_list(?T))
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:generic_list(?T))
+    foreign lpvm mutate(~$rec##0:generic_list(?T), ?$rec##1:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~car##0:?T)
+    foreign lpvm mutate(~$rec##1:generic_list(?T), ?$##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr##0:generic_list(?T))
 cons > public {inline} (6 calls)
 1: generic_list.cons<1>
-cons(?car#0:?T, ?cdr#0:generic_list(?T), $#0:generic_list(?T), ?$$#0:wybe.bool):
+cons(?car##0:?T, ?cdr##0:generic_list(?T), $##0:generic_list(?T), ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:?T, ?car#0:?T)
-        foreign llvm move(undef:generic_list(?T), ?cdr#0:generic_list(?T))
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:?T, ?car##0:?T)
+        foreign llvm move(undef:generic_list(?T), ?cdr##0:generic_list(?T))
 
     1:
-        foreign lpvm access($#0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?car#0:?T)
-        foreign lpvm access(~$#0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?cdr#0:generic_list(?T))
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access($##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?car##0:?T)
+        foreign lpvm access(~$##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?cdr##0:generic_list(?T))
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 length > public {inline} (0 calls)
 0: generic_list.length<0>
-length(x#0:generic_list(?T), ?$#0:wybe.int):
+length(x##0:generic_list(?T), ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    generic_list.length1<0>(~x#0:generic_list(?T), 0:wybe.int, ?$#0:wybe.int) #0 @generic_list:nn:nn
+    generic_list.length1<0>(~x##0:generic_list(?T), 0:wybe.int, ?$##0:wybe.int) #0 @generic_list:nn:nn
 
 
 length1 > (2 calls)
 0: generic_list.length1<0>
-length1(x#0:generic_list(?T), acc#0:wybe.int, ?$#0:wybe.int):
+length1(x##0:generic_list(?T), acc##0:wybe.int, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(x#0:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.bool)
-    case ~tmp$5#0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
+    case ~tmp$5##0:wybe.bool of
     0:
-        foreign llvm move(~acc#0:wybe.int, ?$#0:wybe.int) @generic_list:nn:nn
+        foreign llvm move(~acc##0:wybe.int, ?$##0:wybe.int) @generic_list:nn:nn
 
     1:
-        foreign lpvm access(~x#0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:generic_list(?T))
-        foreign llvm add(~acc#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int) @int:nn:nn
-        generic_list.length1<0>(~t#0:generic_list(?T), ~tmp$2#0:wybe.int, ?$#0:wybe.int) #2 @generic_list:nn:nn
+        foreign lpvm access(~x##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
+        foreign llvm add(~acc##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
+        generic_list.length1<0>(~t##0:generic_list(?T), ~tmp$2##0:wybe.int, ?$##0:wybe.int) #2 @generic_list:nn:nn
 
 
 
 nil > public {inline} (0 calls)
 0: generic_list.nil<0>
-nil(?$#0:generic_list(?T)):
+nil(?$##0:generic_list(?T)):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:generic_list(?T), ?$#0:generic_list(?T))
+    foreign llvm move(0:generic_list(?T), ?$##0:generic_list(?T))
 
   LLVM code       :
 
@@ -175,19 +175,19 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i64 @"generic_list.append<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"generic_list.append<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$tmp$5#0" = icmp ne i64 %"x#0", 0 
-  br i1 %"1$tmp$5#0", label %if.then, label %if.else 
+  %"1$tmp$5##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"x#0" to i64* 
+  %1 = inttoptr i64 %"x##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"x#0", 8 
+  %4 = add   i64 %"x##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %"2$tmp$2#0" = tail call fastcc  i64  @"generic_list.append<0>"(i64  %7, i64  %"y#0")  
+  %"2$tmp$2##0" = tail call fastcc  i64  @"generic_list.append<0>"(i64  %7, i64  %"y##0")  
   %8 = trunc i64 16 to i32  
   %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
   %10 = ptrtoint i8* %9 to i64 
@@ -197,19 +197,19 @@ if.then:
   %13 = add   i64 %10, 8 
   %14 = inttoptr i64 %13 to i64* 
   %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 %"2$tmp$2#0", i64* %15 
+  store  i64 %"2$tmp$2##0", i64* %15 
   ret i64 %10 
 if.else:
-  ret i64 %"y#0" 
+  ret i64 %"y##0" 
 }
 
 
-define external fastcc  {i64, i1} @"generic_list.car<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"generic_list.car<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %16 = inttoptr i64 %"$rec#0" to i64* 
+  %16 = inttoptr i64 %"$rec##0" to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
   %19 = insertvalue {i64, i1} undef, i64 %18, 0 
@@ -222,37 +222,37 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"generic_list.car<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"generic_list.car<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %23 = trunc i64 16 to i32  
   %24 = tail call ccc  i8*  @wybe_malloc(i32  %23)  
   %25 = ptrtoint i8* %24 to i64 
   %26 = inttoptr i64 %25 to i8* 
-  %27 = inttoptr i64 %"$rec#0" to i8* 
+  %27 = inttoptr i64 %"$rec##0" to i8* 
   %28 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %26, i8*  %27, i32  %28, i32  8, i1  0)  
   %29 = inttoptr i64 %25 to i64* 
   %30 = getelementptr  i64, i64* %29, i64 0 
-  store  i64 %"$field#0", i64* %30 
+  store  i64 %"$field##0", i64* %30 
   %31 = insertvalue {i64, i1} undef, i64 %25, 0 
   %32 = insertvalue {i64, i1} %31, i1 1, 1 
   ret {i64, i1} %32 
 if.else:
-  %33 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %33 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %34 = insertvalue {i64, i1} %33, i1 0, 1 
   ret {i64, i1} %34 
 }
 
 
-define external fastcc  {i64, i1} @"generic_list.cdr<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"generic_list.cdr<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %35 = add   i64 %"$rec#0", 8 
+  %35 = add   i64 %"$rec##0", 8 
   %36 = inttoptr i64 %35 to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
@@ -266,57 +266,57 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"generic_list.cdr<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"generic_list.cdr<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %43 = trunc i64 16 to i32  
   %44 = tail call ccc  i8*  @wybe_malloc(i32  %43)  
   %45 = ptrtoint i8* %44 to i64 
   %46 = inttoptr i64 %45 to i8* 
-  %47 = inttoptr i64 %"$rec#0" to i8* 
+  %47 = inttoptr i64 %"$rec##0" to i8* 
   %48 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %46, i8*  %47, i32  %48, i32  8, i1  0)  
   %49 = add   i64 %45, 8 
   %50 = inttoptr i64 %49 to i64* 
   %51 = getelementptr  i64, i64* %50, i64 0 
-  store  i64 %"$field#0", i64* %51 
+  store  i64 %"$field##0", i64* %51 
   %52 = insertvalue {i64, i1} undef, i64 %45, 0 
   %53 = insertvalue {i64, i1} %52, i1 1, 1 
   ret {i64, i1} %53 
 if.else:
-  %54 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %54 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %55 = insertvalue {i64, i1} %54, i1 0, 1 
   ret {i64, i1} %55 
 }
 
 
-define external fastcc  i64 @"generic_list.cons<0>"(i64  %"car#0", i64  %"cdr#0")    {
+define external fastcc  i64 @"generic_list.cons<0>"(i64  %"car##0", i64  %"cdr##0")    {
 entry:
   %56 = trunc i64 16 to i32  
   %57 = tail call ccc  i8*  @wybe_malloc(i32  %56)  
   %58 = ptrtoint i8* %57 to i64 
   %59 = inttoptr i64 %58 to i64* 
   %60 = getelementptr  i64, i64* %59, i64 0 
-  store  i64 %"car#0", i64* %60 
+  store  i64 %"car##0", i64* %60 
   %61 = add   i64 %58, 8 
   %62 = inttoptr i64 %61 to i64* 
   %63 = getelementptr  i64, i64* %62, i64 0 
-  store  i64 %"cdr#0", i64* %63 
+  store  i64 %"cdr##0", i64* %63 
   ret i64 %58 
 }
 
 
-define external fastcc  {i64, i64, i1} @"generic_list.cons<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64, i1} @"generic_list.cons<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %64 = inttoptr i64 %"$#0" to i64* 
+  %64 = inttoptr i64 %"$##0" to i64* 
   %65 = getelementptr  i64, i64* %64, i64 0 
   %66 = load  i64, i64* %65 
-  %67 = add   i64 %"$#0", 8 
+  %67 = add   i64 %"$##0", 8 
   %68 = inttoptr i64 %67 to i64* 
   %69 = getelementptr  i64, i64* %68, i64 0 
   %70 = load  i64, i64* %69 
@@ -332,27 +332,27 @@ if.else:
 }
 
 
-define external fastcc  i64 @"generic_list.length<0>"(i64  %"x#0")    {
+define external fastcc  i64 @"generic_list.length<0>"(i64  %"x##0")    {
 entry:
-  %"1$$#0" = tail call fastcc  i64  @"generic_list.length1<0>"(i64  %"x#0", i64  0)  
-  ret i64 %"1$$#0" 
+  %"1$$##0" = tail call fastcc  i64  @"generic_list.length1<0>"(i64  %"x##0", i64  0)  
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  i64 @"generic_list.length1<0>"(i64  %"x#0", i64  %"acc#0")    {
+define external fastcc  i64 @"generic_list.length1<0>"(i64  %"x##0", i64  %"acc##0")    {
 entry:
-  %"1$tmp$5#0" = icmp ne i64 %"x#0", 0 
-  br i1 %"1$tmp$5#0", label %if.then, label %if.else 
+  %"1$tmp$5##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
 if.then:
-  %77 = add   i64 %"x#0", 8 
+  %77 = add   i64 %"x##0", 8 
   %78 = inttoptr i64 %77 to i64* 
   %79 = getelementptr  i64, i64* %78, i64 0 
   %80 = load  i64, i64* %79 
-  %"2$tmp$2#0" = add   i64 %"acc#0", 1 
-  %"2$$#0" = tail call fastcc  i64  @"generic_list.length1<0>"(i64  %80, i64  %"2$tmp$2#0")  
-  ret i64 %"2$$#0" 
+  %"2$tmp$2##0" = add   i64 %"acc##0", 1 
+  %"2$$##0" = tail call fastcc  i64  @"generic_list.length1<0>"(i64  %80, i64  %"2$tmp$2##0")  
+  ret i64 %"2$$##0" 
 if.else:
-  ret i64 %"acc#0" 
+  ret i64 %"acc##0" 
 }
 
 

--- a/test-cases/final-dump/generic_use.exp
+++ b/test-cases/final-dump/generic_use.exp
@@ -19,147 +19,147 @@ AFTER EVERYTHING:
 
 append > public (1 calls)
 0: generic_list.append<0>
-append(x#0:generic_list(?T), y#0:generic_list(?T), ?$#0:generic_list(?T)):
- AliasPairs: [($#0,y#0)]
+append(x##0:generic_list(?T), y##0:generic_list(?T), ?$##0:generic_list(?T)):
+ AliasPairs: [($##0,y##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(generic_list.append<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(x#0:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.bool)
-    case ~tmp$5#0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
+    case ~tmp$5##0:wybe.bool of
     0:
-        foreign llvm move(~y#0:generic_list(?T), ?$#0:generic_list(?T)) @generic_list:nn:nn
+        foreign llvm move(~y##0:generic_list(?T), ?$##0:generic_list(?T)) @generic_list:nn:nn
 
     1:
-        foreign lpvm access(x#0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:?T)
-        foreign lpvm access(~x#0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:generic_list(?T))
-        generic_list.append<0>(~t#0:generic_list(?T), ~y#0:generic_list(?T), ?tmp$2#0:generic_list(?T)) #1 @generic_list:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$8#0:generic_list(?T))
-        foreign lpvm mutate(~tmp$8#0:generic_list(?T), ?tmp$9#0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h#0:?T)
-        foreign lpvm mutate(~tmp$9#0:generic_list(?T), ?$#0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:generic_list(?T))
+        foreign lpvm access(x##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:?T)
+        foreign lpvm access(~x##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
+        generic_list.append<0>(~t##0:generic_list(?T), ~y##0:generic_list(?T), ?tmp$2##0:generic_list(?T)) #1 @generic_list:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp$8##0:generic_list(?T))
+        foreign lpvm mutate(~tmp$8##0:generic_list(?T), ?tmp$9##0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:?T)
+        foreign lpvm mutate(~tmp$9##0:generic_list(?T), ?$##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:generic_list(?T))
 
 
 
 car > public {inline} (0 calls)
 0: generic_list.car<0>
-car($rec#0:generic_list(?T), ?$#0:?T, ?$$#0:wybe.bool):
+car($rec##0:generic_list(?T), ?$##0:?T, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:?T, ?$#0:?T)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:?T, ?$##0:?T)
 
     1:
-        foreign lpvm access(~$rec#0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:?T)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:?T)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 car > public {inline} (0 calls)
 1: generic_list.car<1>
-car($rec#0:generic_list(?T), ?$rec#1:generic_list(?T), $field#0:?T, ?$$#0:wybe.bool):
+car($rec##0:generic_list(?T), ?$rec##1:generic_list(?T), $field##0:?T, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:generic_list(?T), ?$rec#1:generic_list(?T))
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:generic_list(?T), ?$rec##1:generic_list(?T))
 
     1:
-        foreign lpvm mutate(~$rec#0:generic_list(?T), ?$rec#1:generic_list(?T), 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:?T)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~$rec##0:generic_list(?T), ?$rec##1:generic_list(?T), 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:?T)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 cdr > public {inline} (0 calls)
 0: generic_list.cdr<0>
-cdr($rec#0:generic_list(?T), ?$#0:generic_list(?T), ?$$#0:wybe.bool):
+cdr($rec##0:generic_list(?T), ?$##0:generic_list(?T), ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:generic_list(?T), ?$#0:generic_list(?T))
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:generic_list(?T), ?$##0:generic_list(?T))
 
     1:
-        foreign lpvm access(~$rec#0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:generic_list(?T))
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:generic_list(?T))
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 cdr > public {inline} (0 calls)
 1: generic_list.cdr<1>
-cdr($rec#0:generic_list(?T), ?$rec#1:generic_list(?T), $field#0:generic_list(?T), ?$$#0:wybe.bool):
+cdr($rec##0:generic_list(?T), ?$rec##1:generic_list(?T), $field##0:generic_list(?T), ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:generic_list(?T), ?$rec#1:generic_list(?T))
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:generic_list(?T), ?$rec##1:generic_list(?T))
 
     1:
-        foreign lpvm {noalias} mutate(~$rec#0:generic_list(?T), ?$rec#1:generic_list(?T), 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:generic_list(?T))
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm {noalias} mutate(~$rec##0:generic_list(?T), ?$rec##1:generic_list(?T), 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:generic_list(?T))
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 cons > public {inline} (1 calls)
 0: generic_list.cons<0>
-cons(car#0:?T, cdr#0:generic_list(?T), ?$#0:generic_list(?T)):
+cons(car##0:?T, cdr##0:generic_list(?T), ?$##0:generic_list(?T)):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:generic_list(?T))
-    foreign lpvm mutate(~$rec#0:generic_list(?T), ?$rec#1:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~car#0:?T)
-    foreign lpvm mutate(~$rec#1:generic_list(?T), ?$#0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr#0:generic_list(?T))
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:generic_list(?T))
+    foreign lpvm mutate(~$rec##0:generic_list(?T), ?$rec##1:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~car##0:?T)
+    foreign lpvm mutate(~$rec##1:generic_list(?T), ?$##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr##0:generic_list(?T))
 cons > public {inline} (6 calls)
 1: generic_list.cons<1>
-cons(?car#0:?T, ?cdr#0:generic_list(?T), $#0:generic_list(?T), ?$$#0:wybe.bool):
+cons(?car##0:?T, ?cdr##0:generic_list(?T), $##0:generic_list(?T), ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:?T, ?car#0:?T)
-        foreign llvm move(undef:generic_list(?T), ?cdr#0:generic_list(?T))
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:?T, ?car##0:?T)
+        foreign llvm move(undef:generic_list(?T), ?cdr##0:generic_list(?T))
 
     1:
-        foreign lpvm access($#0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?car#0:?T)
-        foreign lpvm access(~$#0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?cdr#0:generic_list(?T))
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access($##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?car##0:?T)
+        foreign lpvm access(~$##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?cdr##0:generic_list(?T))
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 length > public {inline} (0 calls)
 0: generic_list.length<0>
-length(x#0:generic_list(?T), ?$#0:wybe.int):
+length(x##0:generic_list(?T), ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    generic_list.length1<0>(~x#0:generic_list(?T), 0:wybe.int, ?$#0:wybe.int) #0 @generic_list:nn:nn
+    generic_list.length1<0>(~x##0:generic_list(?T), 0:wybe.int, ?$##0:wybe.int) #0 @generic_list:nn:nn
 
 
 length1 > (2 calls)
 0: generic_list.length1<0>
-length1(x#0:generic_list(?T), acc#0:wybe.int, ?$#0:wybe.int):
+length1(x##0:generic_list(?T), acc##0:wybe.int, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(x#0:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.bool)
-    case ~tmp$5#0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
+    case ~tmp$5##0:wybe.bool of
     0:
-        foreign llvm move(~acc#0:wybe.int, ?$#0:wybe.int) @generic_list:nn:nn
+        foreign llvm move(~acc##0:wybe.int, ?$##0:wybe.int) @generic_list:nn:nn
 
     1:
-        foreign lpvm access(~x#0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:generic_list(?T))
-        foreign llvm add(~acc#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int) @int:nn:nn
-        generic_list.length1<0>(~t#0:generic_list(?T), ~tmp$2#0:wybe.int, ?$#0:wybe.int) #2 @generic_list:nn:nn
+        foreign lpvm access(~x##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
+        foreign llvm add(~acc##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
+        generic_list.length1<0>(~t##0:generic_list(?T), ~tmp$2##0:wybe.int, ?$##0:wybe.int) #2 @generic_list:nn:nn
 
 
 
 nil > public {inline} (0 calls)
 0: generic_list.nil<0>
-nil(?$#0:generic_list(?T)):
+nil(?$##0:generic_list(?T)):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:generic_list(?T), ?$#0:generic_list(?T))
+    foreign llvm move(0:generic_list(?T), ?$##0:generic_list(?T))
 
   LLVM code       :
 
@@ -175,19 +175,19 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i64 @"generic_list.append<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"generic_list.append<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$tmp$5#0" = icmp ne i64 %"x#0", 0 
-  br i1 %"1$tmp$5#0", label %if.then, label %if.else 
+  %"1$tmp$5##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"x#0" to i64* 
+  %1 = inttoptr i64 %"x##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"x#0", 8 
+  %4 = add   i64 %"x##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %"2$tmp$2#0" = tail call fastcc  i64  @"generic_list.append<0>"(i64  %7, i64  %"y#0")  
+  %"2$tmp$2##0" = tail call fastcc  i64  @"generic_list.append<0>"(i64  %7, i64  %"y##0")  
   %8 = trunc i64 16 to i32  
   %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
   %10 = ptrtoint i8* %9 to i64 
@@ -197,19 +197,19 @@ if.then:
   %13 = add   i64 %10, 8 
   %14 = inttoptr i64 %13 to i64* 
   %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 %"2$tmp$2#0", i64* %15 
+  store  i64 %"2$tmp$2##0", i64* %15 
   ret i64 %10 
 if.else:
-  ret i64 %"y#0" 
+  ret i64 %"y##0" 
 }
 
 
-define external fastcc  {i64, i1} @"generic_list.car<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"generic_list.car<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %16 = inttoptr i64 %"$rec#0" to i64* 
+  %16 = inttoptr i64 %"$rec##0" to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
   %19 = insertvalue {i64, i1} undef, i64 %18, 0 
@@ -222,37 +222,37 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"generic_list.car<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"generic_list.car<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %23 = trunc i64 16 to i32  
   %24 = tail call ccc  i8*  @wybe_malloc(i32  %23)  
   %25 = ptrtoint i8* %24 to i64 
   %26 = inttoptr i64 %25 to i8* 
-  %27 = inttoptr i64 %"$rec#0" to i8* 
+  %27 = inttoptr i64 %"$rec##0" to i8* 
   %28 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %26, i8*  %27, i32  %28, i32  8, i1  0)  
   %29 = inttoptr i64 %25 to i64* 
   %30 = getelementptr  i64, i64* %29, i64 0 
-  store  i64 %"$field#0", i64* %30 
+  store  i64 %"$field##0", i64* %30 
   %31 = insertvalue {i64, i1} undef, i64 %25, 0 
   %32 = insertvalue {i64, i1} %31, i1 1, 1 
   ret {i64, i1} %32 
 if.else:
-  %33 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %33 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %34 = insertvalue {i64, i1} %33, i1 0, 1 
   ret {i64, i1} %34 
 }
 
 
-define external fastcc  {i64, i1} @"generic_list.cdr<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"generic_list.cdr<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %35 = add   i64 %"$rec#0", 8 
+  %35 = add   i64 %"$rec##0", 8 
   %36 = inttoptr i64 %35 to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
@@ -266,57 +266,57 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"generic_list.cdr<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"generic_list.cdr<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %43 = trunc i64 16 to i32  
   %44 = tail call ccc  i8*  @wybe_malloc(i32  %43)  
   %45 = ptrtoint i8* %44 to i64 
   %46 = inttoptr i64 %45 to i8* 
-  %47 = inttoptr i64 %"$rec#0" to i8* 
+  %47 = inttoptr i64 %"$rec##0" to i8* 
   %48 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %46, i8*  %47, i32  %48, i32  8, i1  0)  
   %49 = add   i64 %45, 8 
   %50 = inttoptr i64 %49 to i64* 
   %51 = getelementptr  i64, i64* %50, i64 0 
-  store  i64 %"$field#0", i64* %51 
+  store  i64 %"$field##0", i64* %51 
   %52 = insertvalue {i64, i1} undef, i64 %45, 0 
   %53 = insertvalue {i64, i1} %52, i1 1, 1 
   ret {i64, i1} %53 
 if.else:
-  %54 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %54 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %55 = insertvalue {i64, i1} %54, i1 0, 1 
   ret {i64, i1} %55 
 }
 
 
-define external fastcc  i64 @"generic_list.cons<0>"(i64  %"car#0", i64  %"cdr#0")    {
+define external fastcc  i64 @"generic_list.cons<0>"(i64  %"car##0", i64  %"cdr##0")    {
 entry:
   %56 = trunc i64 16 to i32  
   %57 = tail call ccc  i8*  @wybe_malloc(i32  %56)  
   %58 = ptrtoint i8* %57 to i64 
   %59 = inttoptr i64 %58 to i64* 
   %60 = getelementptr  i64, i64* %59, i64 0 
-  store  i64 %"car#0", i64* %60 
+  store  i64 %"car##0", i64* %60 
   %61 = add   i64 %58, 8 
   %62 = inttoptr i64 %61 to i64* 
   %63 = getelementptr  i64, i64* %62, i64 0 
-  store  i64 %"cdr#0", i64* %63 
+  store  i64 %"cdr##0", i64* %63 
   ret i64 %58 
 }
 
 
-define external fastcc  {i64, i64, i1} @"generic_list.cons<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64, i1} @"generic_list.cons<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %64 = inttoptr i64 %"$#0" to i64* 
+  %64 = inttoptr i64 %"$##0" to i64* 
   %65 = getelementptr  i64, i64* %64, i64 0 
   %66 = load  i64, i64* %65 
-  %67 = add   i64 %"$#0", 8 
+  %67 = add   i64 %"$##0", 8 
   %68 = inttoptr i64 %67 to i64* 
   %69 = getelementptr  i64, i64* %68, i64 0 
   %70 = load  i64, i64* %69 
@@ -332,27 +332,27 @@ if.else:
 }
 
 
-define external fastcc  i64 @"generic_list.length<0>"(i64  %"x#0")    {
+define external fastcc  i64 @"generic_list.length<0>"(i64  %"x##0")    {
 entry:
-  %"1$$#0" = tail call fastcc  i64  @"generic_list.length1<0>"(i64  %"x#0", i64  0)  
-  ret i64 %"1$$#0" 
+  %"1$$##0" = tail call fastcc  i64  @"generic_list.length1<0>"(i64  %"x##0", i64  0)  
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  i64 @"generic_list.length1<0>"(i64  %"x#0", i64  %"acc#0")    {
+define external fastcc  i64 @"generic_list.length1<0>"(i64  %"x##0", i64  %"acc##0")    {
 entry:
-  %"1$tmp$5#0" = icmp ne i64 %"x#0", 0 
-  br i1 %"1$tmp$5#0", label %if.then, label %if.else 
+  %"1$tmp$5##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
 if.then:
-  %77 = add   i64 %"x#0", 8 
+  %77 = add   i64 %"x##0", 8 
   %78 = inttoptr i64 %77 to i64* 
   %79 = getelementptr  i64, i64* %78, i64 0 
   %80 = load  i64, i64* %79 
-  %"2$tmp$2#0" = add   i64 %"acc#0", 1 
-  %"2$$#0" = tail call fastcc  i64  @"generic_list.length1<0>"(i64  %80, i64  %"2$tmp$2#0")  
-  ret i64 %"2$$#0" 
+  %"2$tmp$2##0" = add   i64 %"acc##0", 1 
+  %"2$$##0" = tail call fastcc  i64  @"generic_list.length1<0>"(i64  %80, i64  %"2$tmp$2##0")  
+  ret i64 %"2$$##0" 
 if.else:
-  ret i64 %"acc#0" 
+  ret i64 %"acc##0" 
 }
 
 
@@ -379,213 +379,213 @@ entry:
 
 *main* > public (0 calls)
 0: generic_use.<0>
-(io#0:wybe.phantom, ?io#5:wybe.phantom):
+(io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(8,(generic_use.nrev<0>,fromList [NonAliasedParamCond 0 []])),(15,(generic_use.reverse1<0>,fromList [NonAliasedParamCond 0 []]))]
-    generic_use.fromto1<0>(1:wybe.int, 5:wybe.int, 0:generic_list(wybe.int), ?tmp$0#0:generic_list(wybe.int)) #10 @generic_use:nn:nn
-    generic_use.fromto1<0>(6:wybe.int, 10:wybe.int, 0:generic_list(wybe.int), ?tmp$1#0:generic_list(wybe.int)) #11 @generic_use:nn:nn
-    generic_use.print<0>(tmp$0#0:generic_list(wybe.int), ~#io#0:wybe.phantom, ?tmp$10#0:wybe.phantom) #12 @generic_use:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$10#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    generic_use.print<0>(tmp$1#0:generic_list(wybe.int), ~#io#1:wybe.phantom, ?tmp$13#0:wybe.phantom) #13 @generic_use:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$13#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    generic_use.concat<0>(tmp$0#0:generic_list(?t), tmp$1#0:generic_list(?t), ?tmp$2#0:generic_list(?t)) #4 @generic_use:nn:nn
-    generic_use.print<0>(~tmp$2#0:generic_list(wybe.int), ~#io#2:wybe.phantom, ?tmp$16#0:wybe.phantom) #14 @generic_use:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$16#0:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    generic_use.reverse1<0>[410bae77d3](~tmp$0#0:generic_list(?t), 0:generic_list(?t), ?tmp$3#0:generic_list(?t)) #15 @generic_use:nn:nn
-    generic_use.print<0>(~tmp$3#0:generic_list(wybe.int), ~#io#3:wybe.phantom, ?tmp$20#0:wybe.phantom) #16 @generic_use:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$20#0:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    generic_use.nrev<0>[410bae77d3](~tmp$1#0:generic_list(?t), ?tmp$4#0:generic_list(?t)) #8 @generic_use:nn:nn
-    generic_use.print<0>(~tmp$4#0:generic_list(wybe.int), ~#io#4:wybe.phantom, ?tmp$23#0:wybe.phantom) #17 @generic_use:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$23#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
+    generic_use.fromto1<0>(1:wybe.int, 5:wybe.int, 0:generic_list(wybe.int), ?tmp$0##0:generic_list(wybe.int)) #10 @generic_use:nn:nn
+    generic_use.fromto1<0>(6:wybe.int, 10:wybe.int, 0:generic_list(wybe.int), ?tmp$1##0:generic_list(wybe.int)) #11 @generic_use:nn:nn
+    generic_use.print<0>(tmp$0##0:generic_list(wybe.int), ~#io##0:wybe.phantom, ?tmp$10##0:wybe.phantom) #12 @generic_use:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    generic_use.print<0>(tmp$1##0:generic_list(wybe.int), ~#io##1:wybe.phantom, ?tmp$13##0:wybe.phantom) #13 @generic_use:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$13##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    generic_use.concat<0>(tmp$0##0:generic_list(?t), tmp$1##0:generic_list(?t), ?tmp$2##0:generic_list(?t)) #4 @generic_use:nn:nn
+    generic_use.print<0>(~tmp$2##0:generic_list(wybe.int), ~#io##2:wybe.phantom, ?tmp$16##0:wybe.phantom) #14 @generic_use:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$16##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    generic_use.reverse1<0>[410bae77d3](~tmp$0##0:generic_list(?t), 0:generic_list(?t), ?tmp$3##0:generic_list(?t)) #15 @generic_use:nn:nn
+    generic_use.print<0>(~tmp$3##0:generic_list(wybe.int), ~#io##3:wybe.phantom, ?tmp$20##0:wybe.phantom) #16 @generic_use:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$20##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    generic_use.nrev<0>[410bae77d3](~tmp$1##0:generic_list(?t), ?tmp$4##0:generic_list(?t)) #8 @generic_use:nn:nn
+    generic_use.print<0>(~tmp$4##0:generic_list(wybe.int), ~#io##4:wybe.phantom, ?tmp$23##0:wybe.phantom) #17 @generic_use:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$23##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
 
 concat > public (3 calls)
 0: generic_use.concat<0>[410bae77d3]
-concat(l1#0:generic_list(?t), l2#0:generic_list(?t), ?$#0:generic_list(?t)):
- AliasPairs: [($#0,l2#0)]
+concat(l1##0:generic_list(?t), l2##0:generic_list(?t), ?$##0:generic_list(?t)):
+ AliasPairs: [($##0,l2##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(generic_use.concat<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(l1#0:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.bool)
-    case ~tmp$5#0:wybe.bool of
+    foreign llvm icmp_ne(l1##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
+    case ~tmp$5##0:wybe.bool of
     0:
-        foreign llvm move(~l2#0:generic_list(?t), ?$#0:generic_list(?t)) @generic_use:nn:nn
+        foreign llvm move(~l2##0:generic_list(?t), ?$##0:generic_list(?t)) @generic_use:nn:nn
 
     1:
-        foreign lpvm access(l1#0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:?T)
-        foreign lpvm access(~l1#0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:generic_list(?T))
-        generic_use.concat<0>(~t#0:generic_list(?t), ~l2#0:generic_list(?t), ?tmp$2#0:generic_list(?t)) #1 @generic_use:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$8#0:generic_list(?T))
-        foreign lpvm mutate(~tmp$8#0:generic_list(?T), ?tmp$9#0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h#0:?T)
-        foreign lpvm mutate(~tmp$9#0:generic_list(?T), ?$#0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:generic_list(?T))
+        foreign lpvm access(l1##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:?T)
+        foreign lpvm access(~l1##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
+        generic_use.concat<0>(~t##0:generic_list(?t), ~l2##0:generic_list(?t), ?tmp$2##0:generic_list(?t)) #1 @generic_use:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp$8##0:generic_list(?T))
+        foreign lpvm mutate(~tmp$8##0:generic_list(?T), ?tmp$9##0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:?T)
+        foreign lpvm mutate(~tmp$9##0:generic_list(?T), ?$##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:generic_list(?T))
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_ne(l1#0:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.bool)
-    case ~tmp$5#0:wybe.bool of
+    foreign llvm icmp_ne(l1##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
+    case ~tmp$5##0:wybe.bool of
     0:
-        foreign llvm move(~l2#0:generic_list(?t), ?$#0:generic_list(?t)) @generic_use:nn:nn
+        foreign llvm move(~l2##0:generic_list(?t), ?$##0:generic_list(?t)) @generic_use:nn:nn
 
     1:
-        foreign lpvm access(l1#0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:generic_list(?T))
-        generic_use.concat<0>[410bae77d3](~t#0:generic_list(?t), ~l2#0:generic_list(?t), ?tmp$2#0:generic_list(?t)) #1 @generic_use:nn:nn
-        foreign lpvm mutate(~l1#0:generic_list(?T), ?$#0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:generic_list(?T))
+        foreign lpvm access(l1##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
+        generic_use.concat<0>[410bae77d3](~t##0:generic_list(?t), ~l2##0:generic_list(?t), ?tmp$2##0:generic_list(?t)) #1 @generic_use:nn:nn
+        foreign lpvm mutate(~l1##0:generic_list(?T), ?$##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:generic_list(?T))
 
 
 
 fromto > public {inline} (2 calls)
 0: generic_use.fromto<0>
-fromto(lo#0:wybe.int, hi#0:wybe.int, ?$#0:generic_list(wybe.int)):
+fromto(lo##0:wybe.int, hi##0:wybe.int, ?$##0:generic_list(wybe.int)):
  AliasPairs: []
  InterestingCallProperties: []
-    generic_use.fromto1<0>(~lo#0:wybe.int, ~hi#0:wybe.int, 0:generic_list(wybe.int), ?$#0:generic_list(wybe.int)) #1 @generic_use:nn:nn
+    generic_use.fromto1<0>(~lo##0:wybe.int, ~hi##0:wybe.int, 0:generic_list(wybe.int), ?$##0:generic_list(wybe.int)) #1 @generic_use:nn:nn
 
 
 fromto1 > (2 calls)
 0: generic_use.fromto1<0>
-fromto1(lo#0:wybe.int, hi#0:wybe.int, sofar#0:generic_list(wybe.int), ?$#0:generic_list(wybe.int)):
- AliasPairs: [($#0,sofar#0)]
+fromto1(lo##0:wybe.int, hi##0:wybe.int, sofar##0:generic_list(wybe.int), ?$##0:generic_list(wybe.int)):
+ AliasPairs: [($##0,sofar##0)]
  InterestingCallProperties: []
-    foreign llvm icmp_sge(hi#0:wybe.int, lo#0:wybe.int, ?tmp$4#0:wybe.bool) @int:nn:nn
-    case ~tmp$4#0:wybe.bool of
+    foreign llvm icmp_sge(hi##0:wybe.int, lo##0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
+    case ~tmp$4##0:wybe.bool of
     0:
-        foreign llvm move(~sofar#0:generic_list(wybe.int), ?$#0:generic_list(wybe.int)) @generic_use:nn:nn
+        foreign llvm move(~sofar##0:generic_list(wybe.int), ?$##0:generic_list(wybe.int)) @generic_use:nn:nn
 
     1:
-        foreign llvm sub(hi#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int) @int:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$11#0:generic_list(?T))
-        foreign lpvm mutate(~tmp$11#0:generic_list(?T), ?tmp$12#0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~hi#0:?T)
-        foreign lpvm mutate(~tmp$12#0:generic_list(?T), ?tmp$3#0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~sofar#0:generic_list(?T))
-        generic_use.fromto1<0>(~lo#0:wybe.int, ~tmp$2#0:wybe.int, ~tmp$3#0:generic_list(wybe.int), ?$#0:generic_list(wybe.int)) #3 @generic_use:nn:nn
+        foreign llvm sub(hi##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp$11##0:generic_list(?T))
+        foreign lpvm mutate(~tmp$11##0:generic_list(?T), ?tmp$12##0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~hi##0:?T)
+        foreign lpvm mutate(~tmp$12##0:generic_list(?T), ?tmp$3##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~sofar##0:generic_list(?T))
+        generic_use.fromto1<0>(~lo##0:wybe.int, ~tmp$2##0:wybe.int, ~tmp$3##0:generic_list(wybe.int), ?$##0:generic_list(wybe.int)) #3 @generic_use:nn:nn
 
 
 
 iota > public {inline} (1 calls)
 0: generic_use.iota<0>
-iota(n#0:wybe.int, ?$#0:generic_list(wybe.int)):
+iota(n##0:wybe.int, ?$##0:generic_list(wybe.int)):
  AliasPairs: []
  InterestingCallProperties: []
-    generic_use.fromto1<0>(1:wybe.int, ~n#0:wybe.int, 0:generic_list(wybe.int), ?$#0:generic_list(wybe.int)) #1 @generic_use:nn:nn
+    generic_use.fromto1<0>(1:wybe.int, ~n##0:wybe.int, 0:generic_list(wybe.int), ?$##0:generic_list(wybe.int)) #1 @generic_use:nn:nn
 
 
 nrev > public (2 calls)
 0: generic_use.nrev<0>[410bae77d3]
-nrev(lst#0:generic_list(?t), ?$#0:generic_list(?t)):
+nrev(lst##0:generic_list(?t), ?$##0:generic_list(?t)):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(generic_use.nrev<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(generic_use.concat<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign llvm icmp_ne(lst#0:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.bool)
-    case ~tmp$8#0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.bool)
+    case ~tmp$8##0:wybe.bool of
     0:
-        foreign llvm move(0:generic_list(?t), ?$#0:generic_list(?t)) @generic_use:nn:nn
+        foreign llvm move(0:generic_list(?t), ?$##0:generic_list(?t)) @generic_use:nn:nn
 
     1:
-        foreign lpvm access(lst#0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:?T)
-        foreign lpvm access(~lst#0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:generic_list(?T))
-        generic_use.nrev<0>(~t#0:generic_list(?t), ?tmp$2#0:generic_list(?t)) #1 @generic_use:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$11#0:generic_list(?T))
-        foreign lpvm mutate(~tmp$11#0:generic_list(?T), ?tmp$12#0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h#0:?T)
-        foreign lpvm mutate(~tmp$12#0:generic_list(?T), ?tmp$3#0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:generic_list(?T))
-        generic_use.concat<0>[410bae77d3](~tmp$2#0:generic_list(?t), ~tmp$3#0:generic_list(?t), ?$#0:generic_list(?t)) #4 @generic_use:nn:nn
+        foreign lpvm access(lst##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:?T)
+        foreign lpvm access(~lst##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
+        generic_use.nrev<0>(~t##0:generic_list(?t), ?tmp$2##0:generic_list(?t)) #1 @generic_use:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp$11##0:generic_list(?T))
+        foreign lpvm mutate(~tmp$11##0:generic_list(?T), ?tmp$12##0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:?T)
+        foreign lpvm mutate(~tmp$12##0:generic_list(?T), ?tmp$3##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:generic_list(?T))
+        generic_use.concat<0>[410bae77d3](~tmp$2##0:generic_list(?t), ~tmp$3##0:generic_list(?t), ?$##0:generic_list(?t)) #4 @generic_use:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_ne(lst#0:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.bool)
-    case ~tmp$8#0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.bool)
+    case ~tmp$8##0:wybe.bool of
     0:
-        foreign llvm move(0:generic_list(?t), ?$#0:generic_list(?t)) @generic_use:nn:nn
+        foreign llvm move(0:generic_list(?t), ?$##0:generic_list(?t)) @generic_use:nn:nn
 
     1:
-        foreign lpvm access(lst#0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:generic_list(?T))
-        generic_use.nrev<0>[410bae77d3](~t#0:generic_list(?t), ?tmp$2#0:generic_list(?t)) #1 @generic_use:nn:nn
-        foreign lpvm mutate(~lst#0:generic_list(?T), ?tmp$3#0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:generic_list(?T))
-        generic_use.concat<0>[410bae77d3](~tmp$2#0:generic_list(?t), ~tmp$3#0:generic_list(?t), ?$#0:generic_list(?t)) #4 @generic_use:nn:nn
+        foreign lpvm access(lst##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
+        generic_use.nrev<0>[410bae77d3](~t##0:generic_list(?t), ?tmp$2##0:generic_list(?t)) #1 @generic_use:nn:nn
+        foreign lpvm mutate(~lst##0:generic_list(?T), ?tmp$3##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:generic_list(?T))
+        generic_use.concat<0>[410bae77d3](~tmp$2##0:generic_list(?t), ~tmp$3##0:generic_list(?t), ?$##0:generic_list(?t)) #4 @generic_use:nn:nn
 
 
 
 print > (1 calls)
 0: generic_use.print<0>
-print(lst#0:generic_list(wybe.int), io#0:wybe.phantom, ?io#4:wybe.phantom):
+print(lst##0:generic_list(wybe.int), io##0:wybe.phantom, ?io##4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c putchar('[':wybe.char, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign llvm icmp_ne(lst#0:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.bool)
-    case ~tmp$4#0:wybe.bool of
+    foreign c putchar('[':wybe.char, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.bool)
+    case ~tmp$4##0:wybe.bool of
     0:
-        foreign c putchar(']':wybe.char, ~#io#1:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
+        foreign c putchar(']':wybe.char, ~#io##1:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
 
     1:
-        foreign lpvm access(lst#0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:?T)
-        foreign lpvm access(~lst#0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:generic_list(?T))
-        foreign c print_int(~h#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-        generic_use.print_tail<0>(~t#0:generic_list(wybe.int), ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) #3 @generic_use:nn:nn
-        foreign c putchar(']':wybe.char, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
+        foreign lpvm access(lst##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:?T)
+        foreign lpvm access(~lst##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
+        foreign c print_int(~h##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+        generic_use.print_tail<0>(~t##0:generic_list(wybe.int), ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @generic_use:nn:nn
+        foreign c putchar(']':wybe.char, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
 
 
 
 print_tail > (2 calls)
 0: generic_use.print_tail<0>
-print_tail(lst#0:generic_list(wybe.int), io#0:wybe.phantom, ?io#3:wybe.phantom):
+print_tail(lst##0:generic_list(wybe.int), io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(lst#0:wybe.int, 0:wybe.int, ?tmp$2#0:wybe.bool)
-    case ~tmp$2#0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.bool)
+    case ~tmp$2##0:wybe.bool of
     0:
-        foreign llvm move(~io#0:wybe.phantom, ?io#3:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##3:wybe.phantom)
 
     1:
-        foreign lpvm access(lst#0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:?T)
-        foreign lpvm access(~lst#0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:generic_list(?T))
-        foreign c print_string(", ":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        foreign c print_int(~h#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-        generic_use.print_tail<0>(~t#0:generic_list(wybe.int), ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) #3 @generic_use:nn:nn
+        foreign lpvm access(lst##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:?T)
+        foreign lpvm access(~lst##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
+        foreign c print_string(", ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        foreign c print_int(~h##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+        generic_use.print_tail<0>(~t##0:generic_list(wybe.int), ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @generic_use:nn:nn
 
 
 
 println > {inline} (5 calls)
 0: generic_use.println<0>
-println(lst#0:generic_list(wybe.int), io#0:wybe.phantom, ?io#2:wybe.phantom):
+println(lst##0:generic_list(wybe.int), io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    generic_use.print<0>(~lst#0:generic_list(wybe.int), ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @generic_use:nn:nn
-    foreign c putchar('\n':wybe.char, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
+    generic_use.print<0>(~lst##0:generic_list(wybe.int), ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @generic_use:nn:nn
+    foreign c putchar('\n':wybe.char, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
 
 reverse > public {inline} (1 calls)
 0: generic_use.reverse<0>
-reverse(lst#0:generic_list(?t), ?$#0:generic_list(?t)):
+reverse(lst##0:generic_list(?t), ?$##0:generic_list(?t)):
  AliasPairs: []
  InterestingCallProperties: []
-    generic_use.reverse1<0>(~lst#0:generic_list(?t), 0:generic_list(?t), ?$#0:generic_list(?t)) #1 @generic_use:nn:nn
+    generic_use.reverse1<0>(~lst##0:generic_list(?t), 0:generic_list(?t), ?$##0:generic_list(?t)) #1 @generic_use:nn:nn
 
 
 reverse1 > public (2 calls)
 0: generic_use.reverse1<0>[410bae77d3]
-reverse1(lst#0:generic_list(?t), suffix#0:generic_list(?t), ?$#0:generic_list(?t)):
- AliasPairs: [($#0,suffix#0)]
+reverse1(lst##0:generic_list(?t), suffix##0:generic_list(?t), ?$##0:generic_list(?t)):
+ AliasPairs: [($##0,suffix##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(generic_use.reverse1<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(lst#0:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.bool)
-    case ~tmp$5#0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
+    case ~tmp$5##0:wybe.bool of
     0:
-        foreign llvm move(~suffix#0:generic_list(?t), ?$#0:generic_list(?t)) @generic_use:nn:nn
+        foreign llvm move(~suffix##0:generic_list(?t), ?$##0:generic_list(?t)) @generic_use:nn:nn
 
     1:
-        foreign lpvm access(lst#0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:?T)
-        foreign lpvm access(~lst#0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:generic_list(?T))
-        foreign lpvm alloc(16:wybe.int, ?tmp$8#0:generic_list(?T))
-        foreign lpvm mutate(~tmp$8#0:generic_list(?T), ?tmp$9#0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h#0:?T)
-        foreign lpvm mutate(~tmp$9#0:generic_list(?T), ?tmp$2#0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~suffix#0:generic_list(?T))
-        generic_use.reverse1<0>(~t#0:generic_list(?t), ~tmp$2#0:generic_list(?t), ?$#0:generic_list(?t)) #2 @generic_use:nn:nn
+        foreign lpvm access(lst##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:?T)
+        foreign lpvm access(~lst##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
+        foreign lpvm alloc(16:wybe.int, ?tmp$8##0:generic_list(?T))
+        foreign lpvm mutate(~tmp$8##0:generic_list(?T), ?tmp$9##0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:?T)
+        foreign lpvm mutate(~tmp$9##0:generic_list(?T), ?tmp$2##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~suffix##0:generic_list(?T))
+        generic_use.reverse1<0>(~t##0:generic_list(?t), ~tmp$2##0:generic_list(?t), ?$##0:generic_list(?t)) #2 @generic_use:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_ne(lst#0:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.bool)
-    case ~tmp$5#0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
+    case ~tmp$5##0:wybe.bool of
     0:
-        foreign llvm move(~suffix#0:generic_list(?t), ?$#0:generic_list(?t)) @generic_use:nn:nn
+        foreign llvm move(~suffix##0:generic_list(?t), ?$##0:generic_list(?t)) @generic_use:nn:nn
 
     1:
-        foreign lpvm access(lst#0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:generic_list(?T))
-        foreign lpvm mutate(~lst#0:generic_list(?T), ?tmp$2#0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~suffix#0:generic_list(?T))
-        generic_use.reverse1<0>[410bae77d3](~t#0:generic_list(?t), ~tmp$2#0:generic_list(?t), ?$#0:generic_list(?t)) #2 @generic_use:nn:nn
+        foreign lpvm access(lst##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
+        foreign lpvm mutate(~lst##0:generic_list(?T), ?tmp$2##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~suffix##0:generic_list(?T))
+        generic_use.reverse1<0>[410bae77d3](~t##0:generic_list(?t), ~tmp$2##0:generic_list(?t), ?$##0:generic_list(?t)) #2 @generic_use:nn:nn
 
 
   LLVM code       :
@@ -616,38 +616,38 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"generic_use.<0>"()    {
 entry:
-  %"1$tmp$0#0" = tail call fastcc  i64  @"generic_use.fromto1<0>"(i64  1, i64  5, i64  0)  
-  %"1$tmp$1#0" = tail call fastcc  i64  @"generic_use.fromto1<0>"(i64  6, i64  10, i64  0)  
-  tail call fastcc  void  @"generic_use.print<0>"(i64  %"1$tmp$0#0")  
+  %"1$tmp$0##0" = tail call fastcc  i64  @"generic_use.fromto1<0>"(i64  1, i64  5, i64  0)  
+  %"1$tmp$1##0" = tail call fastcc  i64  @"generic_use.fromto1<0>"(i64  6, i64  10, i64  0)  
+  tail call fastcc  void  @"generic_use.print<0>"(i64  %"1$tmp$0##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"generic_use.print<0>"(i64  %"1$tmp$1#0")  
+  tail call fastcc  void  @"generic_use.print<0>"(i64  %"1$tmp$1##0")  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$tmp$2#0" = tail call fastcc  i64  @"generic_use.concat<0>"(i64  %"1$tmp$0#0", i64  %"1$tmp$1#0")  
-  tail call fastcc  void  @"generic_use.print<0>"(i64  %"1$tmp$2#0")  
+  %"1$tmp$2##0" = tail call fastcc  i64  @"generic_use.concat<0>"(i64  %"1$tmp$0##0", i64  %"1$tmp$1##0")  
+  tail call fastcc  void  @"generic_use.print<0>"(i64  %"1$tmp$2##0")  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$tmp$3#0" = tail call fastcc  i64  @"generic_use.reverse1<0>[410bae77d3]"(i64  %"1$tmp$0#0", i64  0)  
-  tail call fastcc  void  @"generic_use.print<0>"(i64  %"1$tmp$3#0")  
+  %"1$tmp$3##0" = tail call fastcc  i64  @"generic_use.reverse1<0>[410bae77d3]"(i64  %"1$tmp$0##0", i64  0)  
+  tail call fastcc  void  @"generic_use.print<0>"(i64  %"1$tmp$3##0")  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$tmp$4#0" = tail call fastcc  i64  @"generic_use.nrev<0>[410bae77d3]"(i64  %"1$tmp$1#0")  
-  tail call fastcc  void  @"generic_use.print<0>"(i64  %"1$tmp$4#0")  
+  %"1$tmp$4##0" = tail call fastcc  i64  @"generic_use.nrev<0>[410bae77d3]"(i64  %"1$tmp$1##0")  
+  tail call fastcc  void  @"generic_use.print<0>"(i64  %"1$tmp$4##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  i64 @"generic_use.concat<0>"(i64  %"l1#0", i64  %"l2#0")    {
+define external fastcc  i64 @"generic_use.concat<0>"(i64  %"l1##0", i64  %"l2##0")    {
 entry:
-  %"1$tmp$5#0" = icmp ne i64 %"l1#0", 0 
-  br i1 %"1$tmp$5#0", label %if.then, label %if.else 
+  %"1$tmp$5##0" = icmp ne i64 %"l1##0", 0 
+  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"l1#0" to i64* 
+  %1 = inttoptr i64 %"l1##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"l1#0", 8 
+  %4 = add   i64 %"l1##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %"2$tmp$2#0" = tail call fastcc  i64  @"generic_use.concat<0>"(i64  %7, i64  %"l2#0")  
+  %"2$tmp$2##0" = tail call fastcc  i64  @"generic_use.concat<0>"(i64  %7, i64  %"l2##0")  
   %8 = trunc i64 16 to i32  
   %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
   %10 = ptrtoint i8* %9 to i64 
@@ -657,83 +657,83 @@ if.then:
   %13 = add   i64 %10, 8 
   %14 = inttoptr i64 %13 to i64* 
   %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 %"2$tmp$2#0", i64* %15 
+  store  i64 %"2$tmp$2##0", i64* %15 
   ret i64 %10 
 if.else:
-  ret i64 %"l2#0" 
+  ret i64 %"l2##0" 
 }
 
 
-define external fastcc  i64 @"generic_use.concat<0>[410bae77d3]"(i64  %"l1#0", i64  %"l2#0")    {
+define external fastcc  i64 @"generic_use.concat<0>[410bae77d3]"(i64  %"l1##0", i64  %"l2##0")    {
 entry:
-  %"1$tmp$5#0" = icmp ne i64 %"l1#0", 0 
-  br i1 %"1$tmp$5#0", label %if.then, label %if.else 
+  %"1$tmp$5##0" = icmp ne i64 %"l1##0", 0 
+  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
 if.then:
-  %16 = add   i64 %"l1#0", 8 
+  %16 = add   i64 %"l1##0", 8 
   %17 = inttoptr i64 %16 to i64* 
   %18 = getelementptr  i64, i64* %17, i64 0 
   %19 = load  i64, i64* %18 
-  %"2$tmp$2#0" = tail call fastcc  i64  @"generic_use.concat<0>[410bae77d3]"(i64  %19, i64  %"l2#0")  
-  %20 = add   i64 %"l1#0", 8 
+  %"2$tmp$2##0" = tail call fastcc  i64  @"generic_use.concat<0>[410bae77d3]"(i64  %19, i64  %"l2##0")  
+  %20 = add   i64 %"l1##0", 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"2$tmp$2#0", i64* %22 
-  ret i64 %"l1#0" 
+  store  i64 %"2$tmp$2##0", i64* %22 
+  ret i64 %"l1##0" 
 if.else:
-  ret i64 %"l2#0" 
+  ret i64 %"l2##0" 
 }
 
 
-define external fastcc  i64 @"generic_use.fromto<0>"(i64  %"lo#0", i64  %"hi#0")    {
+define external fastcc  i64 @"generic_use.fromto<0>"(i64  %"lo##0", i64  %"hi##0")    {
 entry:
-  %"1$$#0" = tail call fastcc  i64  @"generic_use.fromto1<0>"(i64  %"lo#0", i64  %"hi#0", i64  0)  
-  ret i64 %"1$$#0" 
+  %"1$$##0" = tail call fastcc  i64  @"generic_use.fromto1<0>"(i64  %"lo##0", i64  %"hi##0", i64  0)  
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  i64 @"generic_use.fromto1<0>"(i64  %"lo#0", i64  %"hi#0", i64  %"sofar#0")    {
+define external fastcc  i64 @"generic_use.fromto1<0>"(i64  %"lo##0", i64  %"hi##0", i64  %"sofar##0")    {
 entry:
-  %"1$tmp$4#0" = icmp sge i64 %"hi#0", %"lo#0" 
-  br i1 %"1$tmp$4#0", label %if.then, label %if.else 
+  %"1$tmp$4##0" = icmp sge i64 %"hi##0", %"lo##0" 
+  br i1 %"1$tmp$4##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = sub   i64 %"hi#0", 1 
+  %"2$tmp$2##0" = sub   i64 %"hi##0", 1 
   %23 = trunc i64 16 to i32  
   %24 = tail call ccc  i8*  @wybe_malloc(i32  %23)  
   %25 = ptrtoint i8* %24 to i64 
   %26 = inttoptr i64 %25 to i64* 
   %27 = getelementptr  i64, i64* %26, i64 0 
-  store  i64 %"hi#0", i64* %27 
+  store  i64 %"hi##0", i64* %27 
   %28 = add   i64 %25, 8 
   %29 = inttoptr i64 %28 to i64* 
   %30 = getelementptr  i64, i64* %29, i64 0 
-  store  i64 %"sofar#0", i64* %30 
-  %"2$$#0" = tail call fastcc  i64  @"generic_use.fromto1<0>"(i64  %"lo#0", i64  %"2$tmp$2#0", i64  %25)  
-  ret i64 %"2$$#0" 
+  store  i64 %"sofar##0", i64* %30 
+  %"2$$##0" = tail call fastcc  i64  @"generic_use.fromto1<0>"(i64  %"lo##0", i64  %"2$tmp$2##0", i64  %25)  
+  ret i64 %"2$$##0" 
 if.else:
-  ret i64 %"sofar#0" 
+  ret i64 %"sofar##0" 
 }
 
 
-define external fastcc  i64 @"generic_use.iota<0>"(i64  %"n#0")    {
+define external fastcc  i64 @"generic_use.iota<0>"(i64  %"n##0")    {
 entry:
-  %"1$$#0" = tail call fastcc  i64  @"generic_use.fromto1<0>"(i64  1, i64  %"n#0", i64  0)  
-  ret i64 %"1$$#0" 
+  %"1$$##0" = tail call fastcc  i64  @"generic_use.fromto1<0>"(i64  1, i64  %"n##0", i64  0)  
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  i64 @"generic_use.nrev<0>"(i64  %"lst#0")    {
+define external fastcc  i64 @"generic_use.nrev<0>"(i64  %"lst##0")    {
 entry:
-  %"1$tmp$8#0" = icmp ne i64 %"lst#0", 0 
-  br i1 %"1$tmp$8#0", label %if.then, label %if.else 
+  %"1$tmp$8##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1$tmp$8##0", label %if.then, label %if.else 
 if.then:
-  %31 = inttoptr i64 %"lst#0" to i64* 
+  %31 = inttoptr i64 %"lst##0" to i64* 
   %32 = getelementptr  i64, i64* %31, i64 0 
   %33 = load  i64, i64* %32 
-  %34 = add   i64 %"lst#0", 8 
+  %34 = add   i64 %"lst##0", 8 
   %35 = inttoptr i64 %34 to i64* 
   %36 = getelementptr  i64, i64* %35, i64 0 
   %37 = load  i64, i64* %36 
-  %"2$tmp$2#0" = tail call fastcc  i64  @"generic_use.nrev<0>"(i64  %37)  
+  %"2$tmp$2##0" = tail call fastcc  i64  @"generic_use.nrev<0>"(i64  %37)  
   %38 = trunc i64 16 to i32  
   %39 = tail call ccc  i8*  @wybe_malloc(i32  %38)  
   %40 = ptrtoint i8* %39 to i64 
@@ -744,44 +744,44 @@ if.then:
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   store  i64 0, i64* %45 
-  %"2$$#0" = tail call fastcc  i64  @"generic_use.concat<0>[410bae77d3]"(i64  %"2$tmp$2#0", i64  %40)  
-  ret i64 %"2$$#0" 
+  %"2$$##0" = tail call fastcc  i64  @"generic_use.concat<0>[410bae77d3]"(i64  %"2$tmp$2##0", i64  %40)  
+  ret i64 %"2$$##0" 
 if.else:
   ret i64 0 
 }
 
 
-define external fastcc  i64 @"generic_use.nrev<0>[410bae77d3]"(i64  %"lst#0")    {
+define external fastcc  i64 @"generic_use.nrev<0>[410bae77d3]"(i64  %"lst##0")    {
 entry:
-  %"1$tmp$8#0" = icmp ne i64 %"lst#0", 0 
-  br i1 %"1$tmp$8#0", label %if.then, label %if.else 
+  %"1$tmp$8##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1$tmp$8##0", label %if.then, label %if.else 
 if.then:
-  %46 = add   i64 %"lst#0", 8 
+  %46 = add   i64 %"lst##0", 8 
   %47 = inttoptr i64 %46 to i64* 
   %48 = getelementptr  i64, i64* %47, i64 0 
   %49 = load  i64, i64* %48 
-  %"2$tmp$2#0" = tail call fastcc  i64  @"generic_use.nrev<0>[410bae77d3]"(i64  %49)  
-  %50 = add   i64 %"lst#0", 8 
+  %"2$tmp$2##0" = tail call fastcc  i64  @"generic_use.nrev<0>[410bae77d3]"(i64  %49)  
+  %50 = add   i64 %"lst##0", 8 
   %51 = inttoptr i64 %50 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
   store  i64 0, i64* %52 
-  %"2$$#0" = tail call fastcc  i64  @"generic_use.concat<0>[410bae77d3]"(i64  %"2$tmp$2#0", i64  %"lst#0")  
-  ret i64 %"2$$#0" 
+  %"2$$##0" = tail call fastcc  i64  @"generic_use.concat<0>[410bae77d3]"(i64  %"2$tmp$2##0", i64  %"lst##0")  
+  ret i64 %"2$$##0" 
 if.else:
   ret i64 0 
 }
 
 
-define external fastcc  void @"generic_use.print<0>"(i64  %"lst#0")    {
+define external fastcc  void @"generic_use.print<0>"(i64  %"lst##0")    {
 entry:
   tail call ccc  void  @putchar(i8  91)  
-  %"1$tmp$4#0" = icmp ne i64 %"lst#0", 0 
-  br i1 %"1$tmp$4#0", label %if.then, label %if.else 
+  %"1$tmp$4##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1$tmp$4##0", label %if.then, label %if.else 
 if.then:
-  %53 = inttoptr i64 %"lst#0" to i64* 
+  %53 = inttoptr i64 %"lst##0" to i64* 
   %54 = getelementptr  i64, i64* %53, i64 0 
   %55 = load  i64, i64* %54 
-  %56 = add   i64 %"lst#0", 8 
+  %56 = add   i64 %"lst##0", 8 
   %57 = inttoptr i64 %56 to i64* 
   %58 = getelementptr  i64, i64* %57, i64 0 
   %59 = load  i64, i64* %58 
@@ -795,15 +795,15 @@ if.else:
 }
 
 
-define external fastcc  void @"generic_use.print_tail<0>"(i64  %"lst#0")    {
+define external fastcc  void @"generic_use.print_tail<0>"(i64  %"lst##0")    {
 entry:
-  %"1$tmp$2#0" = icmp ne i64 %"lst#0", 0 
-  br i1 %"1$tmp$2#0", label %if.then, label %if.else 
+  %"1$tmp$2##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1$tmp$2##0", label %if.then, label %if.else 
 if.then:
-  %60 = inttoptr i64 %"lst#0" to i64* 
+  %60 = inttoptr i64 %"lst##0" to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = add   i64 %"lst#0", 8 
+  %63 = add   i64 %"lst##0", 8 
   %64 = inttoptr i64 %63 to i64* 
   %65 = getelementptr  i64, i64* %64, i64 0 
   %66 = load  i64, i64* %65 
@@ -817,30 +817,30 @@ if.else:
 }
 
 
-define external fastcc  void @"generic_use.println<0>"(i64  %"lst#0")    {
+define external fastcc  void @"generic_use.println<0>"(i64  %"lst##0")    {
 entry:
-  tail call fastcc  void  @"generic_use.print<0>"(i64  %"lst#0")  
+  tail call fastcc  void  @"generic_use.print<0>"(i64  %"lst##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  i64 @"generic_use.reverse<0>"(i64  %"lst#0")    {
+define external fastcc  i64 @"generic_use.reverse<0>"(i64  %"lst##0")    {
 entry:
-  %"1$$#0" = tail call fastcc  i64  @"generic_use.reverse1<0>"(i64  %"lst#0", i64  0)  
-  ret i64 %"1$$#0" 
+  %"1$$##0" = tail call fastcc  i64  @"generic_use.reverse1<0>"(i64  %"lst##0", i64  0)  
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  i64 @"generic_use.reverse1<0>"(i64  %"lst#0", i64  %"suffix#0")    {
+define external fastcc  i64 @"generic_use.reverse1<0>"(i64  %"lst##0", i64  %"suffix##0")    {
 entry:
-  %"1$tmp$5#0" = icmp ne i64 %"lst#0", 0 
-  br i1 %"1$tmp$5#0", label %if.then, label %if.else 
+  %"1$tmp$5##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
 if.then:
-  %69 = inttoptr i64 %"lst#0" to i64* 
+  %69 = inttoptr i64 %"lst##0" to i64* 
   %70 = getelementptr  i64, i64* %69, i64 0 
   %71 = load  i64, i64* %70 
-  %72 = add   i64 %"lst#0", 8 
+  %72 = add   i64 %"lst##0", 8 
   %73 = inttoptr i64 %72 to i64* 
   %74 = getelementptr  i64, i64* %73, i64 0 
   %75 = load  i64, i64* %74 
@@ -853,29 +853,29 @@ if.then:
   %81 = add   i64 %78, 8 
   %82 = inttoptr i64 %81 to i64* 
   %83 = getelementptr  i64, i64* %82, i64 0 
-  store  i64 %"suffix#0", i64* %83 
-  %"2$$#0" = tail call fastcc  i64  @"generic_use.reverse1<0>"(i64  %75, i64  %78)  
-  ret i64 %"2$$#0" 
+  store  i64 %"suffix##0", i64* %83 
+  %"2$$##0" = tail call fastcc  i64  @"generic_use.reverse1<0>"(i64  %75, i64  %78)  
+  ret i64 %"2$$##0" 
 if.else:
-  ret i64 %"suffix#0" 
+  ret i64 %"suffix##0" 
 }
 
 
-define external fastcc  i64 @"generic_use.reverse1<0>[410bae77d3]"(i64  %"lst#0", i64  %"suffix#0")    {
+define external fastcc  i64 @"generic_use.reverse1<0>[410bae77d3]"(i64  %"lst##0", i64  %"suffix##0")    {
 entry:
-  %"1$tmp$5#0" = icmp ne i64 %"lst#0", 0 
-  br i1 %"1$tmp$5#0", label %if.then, label %if.else 
+  %"1$tmp$5##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
 if.then:
-  %84 = add   i64 %"lst#0", 8 
+  %84 = add   i64 %"lst##0", 8 
   %85 = inttoptr i64 %84 to i64* 
   %86 = getelementptr  i64, i64* %85, i64 0 
   %87 = load  i64, i64* %86 
-  %88 = add   i64 %"lst#0", 8 
+  %88 = add   i64 %"lst##0", 8 
   %89 = inttoptr i64 %88 to i64* 
   %90 = getelementptr  i64, i64* %89, i64 0 
-  store  i64 %"suffix#0", i64* %90 
-  %"2$$#0" = tail call fastcc  i64  @"generic_use.reverse1<0>[410bae77d3]"(i64  %87, i64  %"lst#0")  
-  ret i64 %"2$$#0" 
+  store  i64 %"suffix##0", i64* %90 
+  %"2$$##0" = tail call fastcc  i64  @"generic_use.reverse1<0>[410bae77d3]"(i64  %87, i64  %"lst##0")  
+  ret i64 %"2$$##0" 
 if.else:
-  ret i64 %"suffix#0" 
+  ret i64 %"suffix##0" 
 }

--- a/test-cases/final-dump/generic_use.exp
+++ b/test-cases/final-dump/generic_use.exp
@@ -40,65 +40,65 @@ append(x##0:generic_list(?T), y##0:generic_list(?T), ?#result##0:generic_list(?T
 
 car > public {inline} (0 calls)
 0: generic_list.car<0>
-car(#rec##0:generic_list(?T), ?#result##0:?T, ?####0:wybe.bool):
+car(#rec##0:generic_list(?T), ?#result##0:?T, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:?T, ?#result##0:?T)
 
     1:
         foreign lpvm access(~#rec##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:?T)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 car > public {inline} (0 calls)
 1: generic_list.car<1>
-car(#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), #field##0:?T, ?####0:wybe.bool):
+car(#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), #field##0:?T, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:generic_list(?T), ?#rec##1:generic_list(?T))
 
     1:
         foreign lpvm mutate(~#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:?T)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 cdr > public {inline} (0 calls)
 0: generic_list.cdr<0>
-cdr(#rec##0:generic_list(?T), ?#result##0:generic_list(?T), ?####0:wybe.bool):
+cdr(#rec##0:generic_list(?T), ?#result##0:generic_list(?T), ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:generic_list(?T), ?#result##0:generic_list(?T))
 
     1:
         foreign lpvm access(~#rec##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:generic_list(?T))
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 cdr > public {inline} (0 calls)
 1: generic_list.cdr<1>
-cdr(#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), #field##0:generic_list(?T), ?####0:wybe.bool):
+cdr(#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), #field##0:generic_list(?T), ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:generic_list(?T), ?#rec##1:generic_list(?T))
 
     1:
         foreign lpvm {noalias} mutate(~#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:generic_list(?T))
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -112,20 +112,20 @@ cons(car##0:?T, cdr##0:generic_list(?T), ?#result##0:generic_list(?T)):
     foreign lpvm mutate(~#rec##1:generic_list(?T), ?#result##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr##0:generic_list(?T))
 cons > public {inline} (6 calls)
 1: generic_list.cons<1>
-cons(?car##0:?T, ?cdr##0:generic_list(?T), #result##0:generic_list(?T), ?####0:wybe.bool):
+cons(?car##0:?T, ?cdr##0:generic_list(?T), #result##0:generic_list(?T), ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:?T, ?car##0:?T)
         foreign llvm move(undef:generic_list(?T), ?cdr##0:generic_list(?T))
 
     1:
         foreign lpvm access(#result##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?car##0:?T)
         foreign lpvm access(~#result##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?cdr##0:generic_list(?T))
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 

--- a/test-cases/final-dump/generic_use.exp
+++ b/test-cases/final-dump/generic_use.exp
@@ -19,14 +19,14 @@ AFTER EVERYTHING:
 
 append > public (1 calls)
 0: generic_list.append<0>
-append(x##0:generic_list(?T), y##0:generic_list(?T), ?###0:generic_list(?T)):
- AliasPairs: [(###0,y##0)]
+append(x##0:generic_list(?T), y##0:generic_list(?T), ?#result##0:generic_list(?T)):
+ AliasPairs: [(#result##0,y##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(generic_list.append<0>,fromList [NonAliasedParamCond 0 [0]]))]
     foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
     case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~y##0:generic_list(?T), ?###0:generic_list(?T)) @generic_list:nn:nn
+        foreign llvm move(~y##0:generic_list(?T), ?#result##0:generic_list(?T)) @generic_list:nn:nn
 
     1:
         foreign lpvm access(x##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:?T)
@@ -34,23 +34,23 @@ append(x##0:generic_list(?T), y##0:generic_list(?T), ?###0:generic_list(?T)):
         generic_list.append<0>(~t##0:generic_list(?T), ~y##0:generic_list(?T), ?tmp#2##0:generic_list(?T)) #1 @generic_list:nn:nn
         foreign lpvm alloc(16:wybe.int, ?tmp#8##0:generic_list(?T))
         foreign lpvm mutate(~tmp#8##0:generic_list(?T), ?tmp#9##0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:?T)
-        foreign lpvm mutate(~tmp#9##0:generic_list(?T), ?###0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:generic_list(?T))
+        foreign lpvm mutate(~tmp#9##0:generic_list(?T), ?#result##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:generic_list(?T))
 
 
 
 car > public {inline} (0 calls)
 0: generic_list.car<0>
-car(#rec##0:generic_list(?T), ?###0:?T, ?####0:wybe.bool):
+car(#rec##0:generic_list(?T), ?#result##0:?T, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:?T, ?###0:?T)
+        foreign llvm move(undef:?T, ?#result##0:?T)
 
     1:
-        foreign lpvm access(~#rec##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:?T)
+        foreign lpvm access(~#rec##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:?T)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 car > public {inline} (0 calls)
@@ -72,17 +72,17 @@ car(#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), #field##0:?T, ?####0:wy
 
 cdr > public {inline} (0 calls)
 0: generic_list.cdr<0>
-cdr(#rec##0:generic_list(?T), ?###0:generic_list(?T), ?####0:wybe.bool):
+cdr(#rec##0:generic_list(?T), ?#result##0:generic_list(?T), ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:generic_list(?T), ?###0:generic_list(?T))
+        foreign llvm move(undef:generic_list(?T), ?#result##0:generic_list(?T))
 
     1:
-        foreign lpvm access(~#rec##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:generic_list(?T))
+        foreign lpvm access(~#rec##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:generic_list(?T))
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 cdr > public {inline} (0 calls)
@@ -104,18 +104,18 @@ cdr(#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), #field##0:generic_list(
 
 cons > public {inline} (1 calls)
 0: generic_list.cons<0>
-cons(car##0:?T, cdr##0:generic_list(?T), ?###0:generic_list(?T)):
+cons(car##0:?T, cdr##0:generic_list(?T), ?#result##0:generic_list(?T)):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:generic_list(?T))
     foreign lpvm mutate(~#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~car##0:?T)
-    foreign lpvm mutate(~#rec##1:generic_list(?T), ?###0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr##0:generic_list(?T))
+    foreign lpvm mutate(~#rec##1:generic_list(?T), ?#result##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr##0:generic_list(?T))
 cons > public {inline} (6 calls)
 1: generic_list.cons<1>
-cons(?car##0:?T, ?cdr##0:generic_list(?T), ###0:generic_list(?T), ?####0:wybe.bool):
+cons(?car##0:?T, ?cdr##0:generic_list(?T), #result##0:generic_list(?T), ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
@@ -123,43 +123,43 @@ cons(?car##0:?T, ?cdr##0:generic_list(?T), ###0:generic_list(?T), ?####0:wybe.bo
         foreign llvm move(undef:generic_list(?T), ?cdr##0:generic_list(?T))
 
     1:
-        foreign lpvm access(###0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?car##0:?T)
-        foreign lpvm access(~###0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?cdr##0:generic_list(?T))
+        foreign lpvm access(#result##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?car##0:?T)
+        foreign lpvm access(~#result##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?cdr##0:generic_list(?T))
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 length > public {inline} (0 calls)
 0: generic_list.length<0>
-length(x##0:generic_list(?T), ?###0:wybe.int):
+length(x##0:generic_list(?T), ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    generic_list.length1<0>(~x##0:generic_list(?T), 0:wybe.int, ?###0:wybe.int) #0 @generic_list:nn:nn
+    generic_list.length1<0>(~x##0:generic_list(?T), 0:wybe.int, ?#result##0:wybe.int) #0 @generic_list:nn:nn
 
 
 length1 > (2 calls)
 0: generic_list.length1<0>
-length1(x##0:generic_list(?T), acc##0:wybe.int, ?###0:wybe.int):
+length1(x##0:generic_list(?T), acc##0:wybe.int, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
     case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~acc##0:wybe.int, ?###0:wybe.int) @generic_list:nn:nn
+        foreign llvm move(~acc##0:wybe.int, ?#result##0:wybe.int) @generic_list:nn:nn
 
     1:
         foreign lpvm access(~x##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
         foreign llvm add(~acc##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
-        generic_list.length1<0>(~t##0:generic_list(?T), ~tmp#2##0:wybe.int, ?###0:wybe.int) #2 @generic_list:nn:nn
+        generic_list.length1<0>(~t##0:generic_list(?T), ~tmp#2##0:wybe.int, ?#result##0:wybe.int) #2 @generic_list:nn:nn
 
 
 
 nil > public {inline} (0 calls)
 0: generic_list.nil<0>
-nil(?###0:generic_list(?T)):
+nil(?#result##0:generic_list(?T)):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:generic_list(?T), ?###0:generic_list(?T))
+    foreign llvm move(0:generic_list(?T), ?#result##0:generic_list(?T))
 
   LLVM code       :
 
@@ -308,15 +308,15 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"generic_list.cons<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64, i1} @"generic_list.cons<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  %"1#tmp#0##0" = icmp ne i64 %"#result##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %64 = inttoptr i64 %"###0" to i64* 
+  %64 = inttoptr i64 %"#result##0" to i64* 
   %65 = getelementptr  i64, i64* %64, i64 0 
   %66 = load  i64, i64* %65 
-  %67 = add   i64 %"###0", 8 
+  %67 = add   i64 %"#result##0", 8 
   %68 = inttoptr i64 %67 to i64* 
   %69 = getelementptr  i64, i64* %68, i64 0 
   %70 = load  i64, i64* %69 
@@ -334,8 +334,8 @@ if.else:
 
 define external fastcc  i64 @"generic_list.length<0>"(i64  %"x##0")    {
 entry:
-  %"1####0" = tail call fastcc  i64  @"generic_list.length1<0>"(i64  %"x##0", i64  0)  
-  ret i64 %"1####0" 
+  %"1##result##0" = tail call fastcc  i64  @"generic_list.length1<0>"(i64  %"x##0", i64  0)  
+  ret i64 %"1##result##0" 
 }
 
 
@@ -349,8 +349,8 @@ if.then:
   %79 = getelementptr  i64, i64* %78, i64 0 
   %80 = load  i64, i64* %79 
   %"2#tmp#2##0" = add   i64 %"acc##0", 1 
-  %"2####0" = tail call fastcc  i64  @"generic_list.length1<0>"(i64  %80, i64  %"2#tmp#2##0")  
-  ret i64 %"2####0" 
+  %"2##result##0" = tail call fastcc  i64  @"generic_list.length1<0>"(i64  %80, i64  %"2#tmp#2##0")  
+  ret i64 %"2##result##0" 
 if.else:
   ret i64 %"acc##0" 
 }
@@ -402,14 +402,14 @@ entry:
 
 concat > public (3 calls)
 0: generic_use.concat<0>[410bae77d3]
-concat(l1##0:generic_list(?t), l2##0:generic_list(?t), ?###0:generic_list(?t)):
- AliasPairs: [(###0,l2##0)]
+concat(l1##0:generic_list(?t), l2##0:generic_list(?t), ?#result##0:generic_list(?t)):
+ AliasPairs: [(#result##0,l2##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(generic_use.concat<0>,fromList [NonAliasedParamCond 0 [0]]))]
     foreign llvm icmp_ne(l1##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
     case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~l2##0:generic_list(?t), ?###0:generic_list(?t)) @generic_use:nn:nn
+        foreign llvm move(~l2##0:generic_list(?t), ?#result##0:generic_list(?t)) @generic_use:nn:nn
 
     1:
         foreign lpvm access(l1##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:?T)
@@ -417,66 +417,66 @@ concat(l1##0:generic_list(?t), l2##0:generic_list(?t), ?###0:generic_list(?t)):
         generic_use.concat<0>(~t##0:generic_list(?t), ~l2##0:generic_list(?t), ?tmp#2##0:generic_list(?t)) #1 @generic_use:nn:nn
         foreign lpvm alloc(16:wybe.int, ?tmp#8##0:generic_list(?T))
         foreign lpvm mutate(~tmp#8##0:generic_list(?T), ?tmp#9##0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:?T)
-        foreign lpvm mutate(~tmp#9##0:generic_list(?T), ?###0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:generic_list(?T))
+        foreign lpvm mutate(~tmp#9##0:generic_list(?T), ?#result##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:generic_list(?T))
 
  [410bae77d3] [NonAliasedParam 0] :
     foreign llvm icmp_ne(l1##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
     case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~l2##0:generic_list(?t), ?###0:generic_list(?t)) @generic_use:nn:nn
+        foreign llvm move(~l2##0:generic_list(?t), ?#result##0:generic_list(?t)) @generic_use:nn:nn
 
     1:
         foreign lpvm access(l1##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
         generic_use.concat<0>[410bae77d3](~t##0:generic_list(?t), ~l2##0:generic_list(?t), ?tmp#2##0:generic_list(?t)) #1 @generic_use:nn:nn
-        foreign lpvm mutate(~l1##0:generic_list(?T), ?###0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:generic_list(?T))
+        foreign lpvm mutate(~l1##0:generic_list(?T), ?#result##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:generic_list(?T))
 
 
 
 fromto > public {inline} (2 calls)
 0: generic_use.fromto<0>
-fromto(lo##0:wybe.int, hi##0:wybe.int, ?###0:generic_list(wybe.int)):
+fromto(lo##0:wybe.int, hi##0:wybe.int, ?#result##0:generic_list(wybe.int)):
  AliasPairs: []
  InterestingCallProperties: []
-    generic_use.fromto1<0>(~lo##0:wybe.int, ~hi##0:wybe.int, 0:generic_list(wybe.int), ?###0:generic_list(wybe.int)) #1 @generic_use:nn:nn
+    generic_use.fromto1<0>(~lo##0:wybe.int, ~hi##0:wybe.int, 0:generic_list(wybe.int), ?#result##0:generic_list(wybe.int)) #1 @generic_use:nn:nn
 
 
 fromto1 > (2 calls)
 0: generic_use.fromto1<0>
-fromto1(lo##0:wybe.int, hi##0:wybe.int, sofar##0:generic_list(wybe.int), ?###0:generic_list(wybe.int)):
- AliasPairs: [(###0,sofar##0)]
+fromto1(lo##0:wybe.int, hi##0:wybe.int, sofar##0:generic_list(wybe.int), ?#result##0:generic_list(wybe.int)):
+ AliasPairs: [(#result##0,sofar##0)]
  InterestingCallProperties: []
     foreign llvm icmp_sge(hi##0:wybe.int, lo##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
     case ~tmp#4##0:wybe.bool of
     0:
-        foreign llvm move(~sofar##0:generic_list(wybe.int), ?###0:generic_list(wybe.int)) @generic_use:nn:nn
+        foreign llvm move(~sofar##0:generic_list(wybe.int), ?#result##0:generic_list(wybe.int)) @generic_use:nn:nn
 
     1:
         foreign llvm sub(hi##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
         foreign lpvm alloc(16:wybe.int, ?tmp#11##0:generic_list(?T))
         foreign lpvm mutate(~tmp#11##0:generic_list(?T), ?tmp#12##0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~hi##0:?T)
         foreign lpvm mutate(~tmp#12##0:generic_list(?T), ?tmp#3##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~sofar##0:generic_list(?T))
-        generic_use.fromto1<0>(~lo##0:wybe.int, ~tmp#2##0:wybe.int, ~tmp#3##0:generic_list(wybe.int), ?###0:generic_list(wybe.int)) #3 @generic_use:nn:nn
+        generic_use.fromto1<0>(~lo##0:wybe.int, ~tmp#2##0:wybe.int, ~tmp#3##0:generic_list(wybe.int), ?#result##0:generic_list(wybe.int)) #3 @generic_use:nn:nn
 
 
 
 iota > public {inline} (1 calls)
 0: generic_use.iota<0>
-iota(n##0:wybe.int, ?###0:generic_list(wybe.int)):
+iota(n##0:wybe.int, ?#result##0:generic_list(wybe.int)):
  AliasPairs: []
  InterestingCallProperties: []
-    generic_use.fromto1<0>(1:wybe.int, ~n##0:wybe.int, 0:generic_list(wybe.int), ?###0:generic_list(wybe.int)) #1 @generic_use:nn:nn
+    generic_use.fromto1<0>(1:wybe.int, ~n##0:wybe.int, 0:generic_list(wybe.int), ?#result##0:generic_list(wybe.int)) #1 @generic_use:nn:nn
 
 
 nrev > public (2 calls)
 0: generic_use.nrev<0>[410bae77d3]
-nrev(lst##0:generic_list(?t), ?###0:generic_list(?t)):
+nrev(lst##0:generic_list(?t), ?#result##0:generic_list(?t)):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(generic_use.nrev<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(generic_use.concat<0>,fromList [NonAliasedParamCond 0 []]))]
     foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool)
     case ~tmp#8##0:wybe.bool of
     0:
-        foreign llvm move(0:generic_list(?t), ?###0:generic_list(?t)) @generic_use:nn:nn
+        foreign llvm move(0:generic_list(?t), ?#result##0:generic_list(?t)) @generic_use:nn:nn
 
     1:
         foreign lpvm access(lst##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:?T)
@@ -485,19 +485,19 @@ nrev(lst##0:generic_list(?t), ?###0:generic_list(?t)):
         foreign lpvm alloc(16:wybe.int, ?tmp#11##0:generic_list(?T))
         foreign lpvm mutate(~tmp#11##0:generic_list(?T), ?tmp#12##0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:?T)
         foreign lpvm mutate(~tmp#12##0:generic_list(?T), ?tmp#3##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:generic_list(?T))
-        generic_use.concat<0>[410bae77d3](~tmp#2##0:generic_list(?t), ~tmp#3##0:generic_list(?t), ?###0:generic_list(?t)) #4 @generic_use:nn:nn
+        generic_use.concat<0>[410bae77d3](~tmp#2##0:generic_list(?t), ~tmp#3##0:generic_list(?t), ?#result##0:generic_list(?t)) #4 @generic_use:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
     foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool)
     case ~tmp#8##0:wybe.bool of
     0:
-        foreign llvm move(0:generic_list(?t), ?###0:generic_list(?t)) @generic_use:nn:nn
+        foreign llvm move(0:generic_list(?t), ?#result##0:generic_list(?t)) @generic_use:nn:nn
 
     1:
         foreign lpvm access(lst##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
         generic_use.nrev<0>[410bae77d3](~t##0:generic_list(?t), ?tmp#2##0:generic_list(?t)) #1 @generic_use:nn:nn
         foreign lpvm mutate(~lst##0:generic_list(?T), ?tmp#3##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:generic_list(?T))
-        generic_use.concat<0>[410bae77d3](~tmp#2##0:generic_list(?t), ~tmp#3##0:generic_list(?t), ?###0:generic_list(?t)) #4 @generic_use:nn:nn
+        generic_use.concat<0>[410bae77d3](~tmp#2##0:generic_list(?t), ~tmp#3##0:generic_list(?t), ?#result##0:generic_list(?t)) #4 @generic_use:nn:nn
 
 
 
@@ -551,22 +551,22 @@ println(lst##0:generic_list(wybe.int), io##0:wybe.phantom, ?io##2:wybe.phantom):
 
 reverse > public {inline} (1 calls)
 0: generic_use.reverse<0>
-reverse(lst##0:generic_list(?t), ?###0:generic_list(?t)):
+reverse(lst##0:generic_list(?t), ?#result##0:generic_list(?t)):
  AliasPairs: []
  InterestingCallProperties: []
-    generic_use.reverse1<0>(~lst##0:generic_list(?t), 0:generic_list(?t), ?###0:generic_list(?t)) #1 @generic_use:nn:nn
+    generic_use.reverse1<0>(~lst##0:generic_list(?t), 0:generic_list(?t), ?#result##0:generic_list(?t)) #1 @generic_use:nn:nn
 
 
 reverse1 > public (2 calls)
 0: generic_use.reverse1<0>[410bae77d3]
-reverse1(lst##0:generic_list(?t), suffix##0:generic_list(?t), ?###0:generic_list(?t)):
- AliasPairs: [(###0,suffix##0)]
+reverse1(lst##0:generic_list(?t), suffix##0:generic_list(?t), ?#result##0:generic_list(?t)):
+ AliasPairs: [(#result##0,suffix##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(generic_use.reverse1<0>,fromList [NonAliasedParamCond 0 [0]]))]
     foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
     case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~suffix##0:generic_list(?t), ?###0:generic_list(?t)) @generic_use:nn:nn
+        foreign llvm move(~suffix##0:generic_list(?t), ?#result##0:generic_list(?t)) @generic_use:nn:nn
 
     1:
         foreign lpvm access(lst##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:?T)
@@ -574,18 +574,18 @@ reverse1(lst##0:generic_list(?t), suffix##0:generic_list(?t), ?###0:generic_list
         foreign lpvm alloc(16:wybe.int, ?tmp#8##0:generic_list(?T))
         foreign lpvm mutate(~tmp#8##0:generic_list(?T), ?tmp#9##0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:?T)
         foreign lpvm mutate(~tmp#9##0:generic_list(?T), ?tmp#2##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~suffix##0:generic_list(?T))
-        generic_use.reverse1<0>(~t##0:generic_list(?t), ~tmp#2##0:generic_list(?t), ?###0:generic_list(?t)) #2 @generic_use:nn:nn
+        generic_use.reverse1<0>(~t##0:generic_list(?t), ~tmp#2##0:generic_list(?t), ?#result##0:generic_list(?t)) #2 @generic_use:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
     foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
     case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~suffix##0:generic_list(?t), ?###0:generic_list(?t)) @generic_use:nn:nn
+        foreign llvm move(~suffix##0:generic_list(?t), ?#result##0:generic_list(?t)) @generic_use:nn:nn
 
     1:
         foreign lpvm access(lst##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
         foreign lpvm mutate(~lst##0:generic_list(?T), ?tmp#2##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~suffix##0:generic_list(?T))
-        generic_use.reverse1<0>[410bae77d3](~t##0:generic_list(?t), ~tmp#2##0:generic_list(?t), ?###0:generic_list(?t)) #2 @generic_use:nn:nn
+        generic_use.reverse1<0>[410bae77d3](~t##0:generic_list(?t), ~tmp#2##0:generic_list(?t), ?#result##0:generic_list(?t)) #2 @generic_use:nn:nn
 
 
   LLVM code       :
@@ -686,8 +686,8 @@ if.else:
 
 define external fastcc  i64 @"generic_use.fromto<0>"(i64  %"lo##0", i64  %"hi##0")    {
 entry:
-  %"1####0" = tail call fastcc  i64  @"generic_use.fromto1<0>"(i64  %"lo##0", i64  %"hi##0", i64  0)  
-  ret i64 %"1####0" 
+  %"1##result##0" = tail call fastcc  i64  @"generic_use.fromto1<0>"(i64  %"lo##0", i64  %"hi##0", i64  0)  
+  ret i64 %"1##result##0" 
 }
 
 
@@ -707,8 +707,8 @@ if.then:
   %29 = inttoptr i64 %28 to i64* 
   %30 = getelementptr  i64, i64* %29, i64 0 
   store  i64 %"sofar##0", i64* %30 
-  %"2####0" = tail call fastcc  i64  @"generic_use.fromto1<0>"(i64  %"lo##0", i64  %"2#tmp#2##0", i64  %25)  
-  ret i64 %"2####0" 
+  %"2##result##0" = tail call fastcc  i64  @"generic_use.fromto1<0>"(i64  %"lo##0", i64  %"2#tmp#2##0", i64  %25)  
+  ret i64 %"2##result##0" 
 if.else:
   ret i64 %"sofar##0" 
 }
@@ -716,8 +716,8 @@ if.else:
 
 define external fastcc  i64 @"generic_use.iota<0>"(i64  %"n##0")    {
 entry:
-  %"1####0" = tail call fastcc  i64  @"generic_use.fromto1<0>"(i64  1, i64  %"n##0", i64  0)  
-  ret i64 %"1####0" 
+  %"1##result##0" = tail call fastcc  i64  @"generic_use.fromto1<0>"(i64  1, i64  %"n##0", i64  0)  
+  ret i64 %"1##result##0" 
 }
 
 
@@ -744,8 +744,8 @@ if.then:
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   store  i64 0, i64* %45 
-  %"2####0" = tail call fastcc  i64  @"generic_use.concat<0>[410bae77d3]"(i64  %"2#tmp#2##0", i64  %40)  
-  ret i64 %"2####0" 
+  %"2##result##0" = tail call fastcc  i64  @"generic_use.concat<0>[410bae77d3]"(i64  %"2#tmp#2##0", i64  %40)  
+  ret i64 %"2##result##0" 
 if.else:
   ret i64 0 
 }
@@ -765,8 +765,8 @@ if.then:
   %51 = inttoptr i64 %50 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
   store  i64 0, i64* %52 
-  %"2####0" = tail call fastcc  i64  @"generic_use.concat<0>[410bae77d3]"(i64  %"2#tmp#2##0", i64  %"lst##0")  
-  ret i64 %"2####0" 
+  %"2##result##0" = tail call fastcc  i64  @"generic_use.concat<0>[410bae77d3]"(i64  %"2#tmp#2##0", i64  %"lst##0")  
+  ret i64 %"2##result##0" 
 if.else:
   ret i64 0 
 }
@@ -827,8 +827,8 @@ entry:
 
 define external fastcc  i64 @"generic_use.reverse<0>"(i64  %"lst##0")    {
 entry:
-  %"1####0" = tail call fastcc  i64  @"generic_use.reverse1<0>"(i64  %"lst##0", i64  0)  
-  ret i64 %"1####0" 
+  %"1##result##0" = tail call fastcc  i64  @"generic_use.reverse1<0>"(i64  %"lst##0", i64  0)  
+  ret i64 %"1##result##0" 
 }
 
 
@@ -854,8 +854,8 @@ if.then:
   %82 = inttoptr i64 %81 to i64* 
   %83 = getelementptr  i64, i64* %82, i64 0 
   store  i64 %"suffix##0", i64* %83 
-  %"2####0" = tail call fastcc  i64  @"generic_use.reverse1<0>"(i64  %75, i64  %78)  
-  ret i64 %"2####0" 
+  %"2##result##0" = tail call fastcc  i64  @"generic_use.reverse1<0>"(i64  %75, i64  %78)  
+  ret i64 %"2##result##0" 
 if.else:
   ret i64 %"suffix##0" 
 }
@@ -874,8 +874,8 @@ if.then:
   %89 = inttoptr i64 %88 to i64* 
   %90 = getelementptr  i64, i64* %89, i64 0 
   store  i64 %"suffix##0", i64* %90 
-  %"2####0" = tail call fastcc  i64  @"generic_use.reverse1<0>[410bae77d3]"(i64  %87, i64  %"lst##0")  
-  ret i64 %"2####0" 
+  %"2##result##0" = tail call fastcc  i64  @"generic_use.reverse1<0>[410bae77d3]"(i64  %87, i64  %"lst##0")  
+  ret i64 %"2##result##0" 
 if.else:
   ret i64 %"suffix##0" 
 }

--- a/test-cases/final-dump/generic_use.exp
+++ b/test-cases/final-dump/generic_use.exp
@@ -19,147 +19,147 @@ AFTER EVERYTHING:
 
 append > public (1 calls)
 0: generic_list.append<0>
-append(x##0:generic_list(?T), y##0:generic_list(?T), ?$##0:generic_list(?T)):
- AliasPairs: [($##0,y##0)]
+append(x##0:generic_list(?T), y##0:generic_list(?T), ?###0:generic_list(?T)):
+ AliasPairs: [(###0,y##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(generic_list.append<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
-    case ~tmp$5##0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
+    case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~y##0:generic_list(?T), ?$##0:generic_list(?T)) @generic_list:nn:nn
+        foreign llvm move(~y##0:generic_list(?T), ?###0:generic_list(?T)) @generic_list:nn:nn
 
     1:
         foreign lpvm access(x##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:?T)
         foreign lpvm access(~x##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
-        generic_list.append<0>(~t##0:generic_list(?T), ~y##0:generic_list(?T), ?tmp$2##0:generic_list(?T)) #1 @generic_list:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$8##0:generic_list(?T))
-        foreign lpvm mutate(~tmp$8##0:generic_list(?T), ?tmp$9##0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:?T)
-        foreign lpvm mutate(~tmp$9##0:generic_list(?T), ?$##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:generic_list(?T))
+        generic_list.append<0>(~t##0:generic_list(?T), ~y##0:generic_list(?T), ?tmp#2##0:generic_list(?T)) #1 @generic_list:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:generic_list(?T))
+        foreign lpvm mutate(~tmp#8##0:generic_list(?T), ?tmp#9##0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:?T)
+        foreign lpvm mutate(~tmp#9##0:generic_list(?T), ?###0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:generic_list(?T))
 
 
 
 car > public {inline} (0 calls)
 0: generic_list.car<0>
-car($rec##0:generic_list(?T), ?$##0:?T, ?$$##0:wybe.bool):
+car(#rec##0:generic_list(?T), ?###0:?T, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:?T, ?$##0:?T)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:?T, ?###0:?T)
 
     1:
-        foreign lpvm access(~$rec##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:?T)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:?T)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 car > public {inline} (0 calls)
 1: generic_list.car<1>
-car($rec##0:generic_list(?T), ?$rec##1:generic_list(?T), $field##0:?T, ?$$##0:wybe.bool):
+car(#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), #field##0:?T, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:generic_list(?T), ?$rec##1:generic_list(?T))
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:generic_list(?T), ?#rec##1:generic_list(?T))
 
     1:
-        foreign lpvm mutate(~$rec##0:generic_list(?T), ?$rec##1:generic_list(?T), 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:?T)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:?T)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 cdr > public {inline} (0 calls)
 0: generic_list.cdr<0>
-cdr($rec##0:generic_list(?T), ?$##0:generic_list(?T), ?$$##0:wybe.bool):
+cdr(#rec##0:generic_list(?T), ?###0:generic_list(?T), ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:generic_list(?T), ?$##0:generic_list(?T))
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:generic_list(?T), ?###0:generic_list(?T))
 
     1:
-        foreign lpvm access(~$rec##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:generic_list(?T))
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:generic_list(?T))
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 cdr > public {inline} (0 calls)
 1: generic_list.cdr<1>
-cdr($rec##0:generic_list(?T), ?$rec##1:generic_list(?T), $field##0:generic_list(?T), ?$$##0:wybe.bool):
+cdr(#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), #field##0:generic_list(?T), ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:generic_list(?T), ?$rec##1:generic_list(?T))
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:generic_list(?T), ?#rec##1:generic_list(?T))
 
     1:
-        foreign lpvm {noalias} mutate(~$rec##0:generic_list(?T), ?$rec##1:generic_list(?T), 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:generic_list(?T))
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm {noalias} mutate(~#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:generic_list(?T))
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 cons > public {inline} (1 calls)
 0: generic_list.cons<0>
-cons(car##0:?T, cdr##0:generic_list(?T), ?$##0:generic_list(?T)):
+cons(car##0:?T, cdr##0:generic_list(?T), ?###0:generic_list(?T)):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:generic_list(?T))
-    foreign lpvm mutate(~$rec##0:generic_list(?T), ?$rec##1:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~car##0:?T)
-    foreign lpvm mutate(~$rec##1:generic_list(?T), ?$##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr##0:generic_list(?T))
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:generic_list(?T))
+    foreign lpvm mutate(~#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~car##0:?T)
+    foreign lpvm mutate(~#rec##1:generic_list(?T), ?###0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr##0:generic_list(?T))
 cons > public {inline} (6 calls)
 1: generic_list.cons<1>
-cons(?car##0:?T, ?cdr##0:generic_list(?T), $##0:generic_list(?T), ?$$##0:wybe.bool):
+cons(?car##0:?T, ?cdr##0:generic_list(?T), ###0:generic_list(?T), ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:?T, ?car##0:?T)
         foreign llvm move(undef:generic_list(?T), ?cdr##0:generic_list(?T))
 
     1:
-        foreign lpvm access($##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?car##0:?T)
-        foreign lpvm access(~$##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?cdr##0:generic_list(?T))
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(###0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?car##0:?T)
+        foreign lpvm access(~###0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?cdr##0:generic_list(?T))
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 length > public {inline} (0 calls)
 0: generic_list.length<0>
-length(x##0:generic_list(?T), ?$##0:wybe.int):
+length(x##0:generic_list(?T), ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    generic_list.length1<0>(~x##0:generic_list(?T), 0:wybe.int, ?$##0:wybe.int) #0 @generic_list:nn:nn
+    generic_list.length1<0>(~x##0:generic_list(?T), 0:wybe.int, ?###0:wybe.int) #0 @generic_list:nn:nn
 
 
 length1 > (2 calls)
 0: generic_list.length1<0>
-length1(x##0:generic_list(?T), acc##0:wybe.int, ?$##0:wybe.int):
+length1(x##0:generic_list(?T), acc##0:wybe.int, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
-    case ~tmp$5##0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
+    case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~acc##0:wybe.int, ?$##0:wybe.int) @generic_list:nn:nn
+        foreign llvm move(~acc##0:wybe.int, ?###0:wybe.int) @generic_list:nn:nn
 
     1:
         foreign lpvm access(~x##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
-        foreign llvm add(~acc##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
-        generic_list.length1<0>(~t##0:generic_list(?T), ~tmp$2##0:wybe.int, ?$##0:wybe.int) #2 @generic_list:nn:nn
+        foreign llvm add(~acc##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
+        generic_list.length1<0>(~t##0:generic_list(?T), ~tmp#2##0:wybe.int, ?###0:wybe.int) #2 @generic_list:nn:nn
 
 
 
 nil > public {inline} (0 calls)
 0: generic_list.nil<0>
-nil(?$##0:generic_list(?T)):
+nil(?###0:generic_list(?T)):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:generic_list(?T), ?$##0:generic_list(?T))
+    foreign llvm move(0:generic_list(?T), ?###0:generic_list(?T))
 
   LLVM code       :
 
@@ -177,8 +177,8 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  i64 @"generic_list.append<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$tmp$5##0" = icmp ne i64 %"x##0", 0 
-  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
+  %"1#tmp#5##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"x##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
@@ -187,7 +187,7 @@ if.then:
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %"2$tmp$2##0" = tail call fastcc  i64  @"generic_list.append<0>"(i64  %7, i64  %"y##0")  
+  %"2#tmp#2##0" = tail call fastcc  i64  @"generic_list.append<0>"(i64  %7, i64  %"y##0")  
   %8 = trunc i64 16 to i32  
   %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
   %10 = ptrtoint i8* %9 to i64 
@@ -197,19 +197,19 @@ if.then:
   %13 = add   i64 %10, 8 
   %14 = inttoptr i64 %13 to i64* 
   %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 %"2$tmp$2##0", i64* %15 
+  store  i64 %"2#tmp#2##0", i64* %15 
   ret i64 %10 
 if.else:
   ret i64 %"y##0" 
 }
 
 
-define external fastcc  {i64, i1} @"generic_list.car<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"generic_list.car<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %16 = inttoptr i64 %"$rec##0" to i64* 
+  %16 = inttoptr i64 %"#rec##0" to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
   %19 = insertvalue {i64, i1} undef, i64 %18, 0 
@@ -222,37 +222,37 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"generic_list.car<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"generic_list.car<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %23 = trunc i64 16 to i32  
   %24 = tail call ccc  i8*  @wybe_malloc(i32  %23)  
   %25 = ptrtoint i8* %24 to i64 
   %26 = inttoptr i64 %25 to i8* 
-  %27 = inttoptr i64 %"$rec##0" to i8* 
+  %27 = inttoptr i64 %"#rec##0" to i8* 
   %28 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %26, i8*  %27, i32  %28, i32  8, i1  0)  
   %29 = inttoptr i64 %25 to i64* 
   %30 = getelementptr  i64, i64* %29, i64 0 
-  store  i64 %"$field##0", i64* %30 
+  store  i64 %"#field##0", i64* %30 
   %31 = insertvalue {i64, i1} undef, i64 %25, 0 
   %32 = insertvalue {i64, i1} %31, i1 1, 1 
   ret {i64, i1} %32 
 if.else:
-  %33 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %33 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %34 = insertvalue {i64, i1} %33, i1 0, 1 
   ret {i64, i1} %34 
 }
 
 
-define external fastcc  {i64, i1} @"generic_list.cdr<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"generic_list.cdr<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %35 = add   i64 %"$rec##0", 8 
+  %35 = add   i64 %"#rec##0", 8 
   %36 = inttoptr i64 %35 to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
@@ -266,27 +266,27 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"generic_list.cdr<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"generic_list.cdr<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %43 = trunc i64 16 to i32  
   %44 = tail call ccc  i8*  @wybe_malloc(i32  %43)  
   %45 = ptrtoint i8* %44 to i64 
   %46 = inttoptr i64 %45 to i8* 
-  %47 = inttoptr i64 %"$rec##0" to i8* 
+  %47 = inttoptr i64 %"#rec##0" to i8* 
   %48 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %46, i8*  %47, i32  %48, i32  8, i1  0)  
   %49 = add   i64 %45, 8 
   %50 = inttoptr i64 %49 to i64* 
   %51 = getelementptr  i64, i64* %50, i64 0 
-  store  i64 %"$field##0", i64* %51 
+  store  i64 %"#field##0", i64* %51 
   %52 = insertvalue {i64, i1} undef, i64 %45, 0 
   %53 = insertvalue {i64, i1} %52, i1 1, 1 
   ret {i64, i1} %53 
 if.else:
-  %54 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %54 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %55 = insertvalue {i64, i1} %54, i1 0, 1 
   ret {i64, i1} %55 
 }
@@ -308,15 +308,15 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"generic_list.cons<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64, i1} @"generic_list.cons<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %64 = inttoptr i64 %"$##0" to i64* 
+  %64 = inttoptr i64 %"###0" to i64* 
   %65 = getelementptr  i64, i64* %64, i64 0 
   %66 = load  i64, i64* %65 
-  %67 = add   i64 %"$##0", 8 
+  %67 = add   i64 %"###0", 8 
   %68 = inttoptr i64 %67 to i64* 
   %69 = getelementptr  i64, i64* %68, i64 0 
   %70 = load  i64, i64* %69 
@@ -334,23 +334,23 @@ if.else:
 
 define external fastcc  i64 @"generic_list.length<0>"(i64  %"x##0")    {
 entry:
-  %"1$$##0" = tail call fastcc  i64  @"generic_list.length1<0>"(i64  %"x##0", i64  0)  
-  ret i64 %"1$$##0" 
+  %"1####0" = tail call fastcc  i64  @"generic_list.length1<0>"(i64  %"x##0", i64  0)  
+  ret i64 %"1####0" 
 }
 
 
 define external fastcc  i64 @"generic_list.length1<0>"(i64  %"x##0", i64  %"acc##0")    {
 entry:
-  %"1$tmp$5##0" = icmp ne i64 %"x##0", 0 
-  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
+  %"1#tmp#5##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
   %77 = add   i64 %"x##0", 8 
   %78 = inttoptr i64 %77 to i64* 
   %79 = getelementptr  i64, i64* %78, i64 0 
   %80 = load  i64, i64* %79 
-  %"2$tmp$2##0" = add   i64 %"acc##0", 1 
-  %"2$$##0" = tail call fastcc  i64  @"generic_list.length1<0>"(i64  %80, i64  %"2$tmp$2##0")  
-  ret i64 %"2$$##0" 
+  %"2#tmp#2##0" = add   i64 %"acc##0", 1 
+  %"2####0" = tail call fastcc  i64  @"generic_list.length1<0>"(i64  %80, i64  %"2#tmp#2##0")  
+  ret i64 %"2####0" 
 if.else:
   ret i64 %"acc##0" 
 }
@@ -383,121 +383,121 @@ entry:
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(8,(generic_use.nrev<0>,fromList [NonAliasedParamCond 0 []])),(15,(generic_use.reverse1<0>,fromList [NonAliasedParamCond 0 []]))]
-    generic_use.fromto1<0>(1:wybe.int, 5:wybe.int, 0:generic_list(wybe.int), ?tmp$0##0:generic_list(wybe.int)) #10 @generic_use:nn:nn
-    generic_use.fromto1<0>(6:wybe.int, 10:wybe.int, 0:generic_list(wybe.int), ?tmp$1##0:generic_list(wybe.int)) #11 @generic_use:nn:nn
-    generic_use.print<0>(tmp$0##0:generic_list(wybe.int), ~#io##0:wybe.phantom, ?tmp$10##0:wybe.phantom) #12 @generic_use:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    generic_use.print<0>(tmp$1##0:generic_list(wybe.int), ~#io##1:wybe.phantom, ?tmp$13##0:wybe.phantom) #13 @generic_use:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$13##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    generic_use.concat<0>(tmp$0##0:generic_list(?t), tmp$1##0:generic_list(?t), ?tmp$2##0:generic_list(?t)) #4 @generic_use:nn:nn
-    generic_use.print<0>(~tmp$2##0:generic_list(wybe.int), ~#io##2:wybe.phantom, ?tmp$16##0:wybe.phantom) #14 @generic_use:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$16##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    generic_use.reverse1<0>[410bae77d3](~tmp$0##0:generic_list(?t), 0:generic_list(?t), ?tmp$3##0:generic_list(?t)) #15 @generic_use:nn:nn
-    generic_use.print<0>(~tmp$3##0:generic_list(wybe.int), ~#io##3:wybe.phantom, ?tmp$20##0:wybe.phantom) #16 @generic_use:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$20##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    generic_use.nrev<0>[410bae77d3](~tmp$1##0:generic_list(?t), ?tmp$4##0:generic_list(?t)) #8 @generic_use:nn:nn
-    generic_use.print<0>(~tmp$4##0:generic_list(wybe.int), ~#io##4:wybe.phantom, ?tmp$23##0:wybe.phantom) #17 @generic_use:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$23##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    generic_use.fromto1<0>(1:wybe.int, 5:wybe.int, 0:generic_list(wybe.int), ?tmp#0##0:generic_list(wybe.int)) #10 @generic_use:nn:nn
+    generic_use.fromto1<0>(6:wybe.int, 10:wybe.int, 0:generic_list(wybe.int), ?tmp#1##0:generic_list(wybe.int)) #11 @generic_use:nn:nn
+    generic_use.print<0>(tmp#0##0:generic_list(wybe.int), ~#io##0:wybe.phantom, ?tmp#10##0:wybe.phantom) #12 @generic_use:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    generic_use.print<0>(tmp#1##0:generic_list(wybe.int), ~#io##1:wybe.phantom, ?tmp#13##0:wybe.phantom) #13 @generic_use:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    generic_use.concat<0>(tmp#0##0:generic_list(?t), tmp#1##0:generic_list(?t), ?tmp#2##0:generic_list(?t)) #4 @generic_use:nn:nn
+    generic_use.print<0>(~tmp#2##0:generic_list(wybe.int), ~#io##2:wybe.phantom, ?tmp#16##0:wybe.phantom) #14 @generic_use:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    generic_use.reverse1<0>[410bae77d3](~tmp#0##0:generic_list(?t), 0:generic_list(?t), ?tmp#3##0:generic_list(?t)) #15 @generic_use:nn:nn
+    generic_use.print<0>(~tmp#3##0:generic_list(wybe.int), ~#io##3:wybe.phantom, ?tmp#20##0:wybe.phantom) #16 @generic_use:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#20##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    generic_use.nrev<0>[410bae77d3](~tmp#1##0:generic_list(?t), ?tmp#4##0:generic_list(?t)) #8 @generic_use:nn:nn
+    generic_use.print<0>(~tmp#4##0:generic_list(wybe.int), ~#io##4:wybe.phantom, ?tmp#23##0:wybe.phantom) #17 @generic_use:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#23##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
 
 concat > public (3 calls)
 0: generic_use.concat<0>[410bae77d3]
-concat(l1##0:generic_list(?t), l2##0:generic_list(?t), ?$##0:generic_list(?t)):
- AliasPairs: [($##0,l2##0)]
+concat(l1##0:generic_list(?t), l2##0:generic_list(?t), ?###0:generic_list(?t)):
+ AliasPairs: [(###0,l2##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(generic_use.concat<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(l1##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
-    case ~tmp$5##0:wybe.bool of
+    foreign llvm icmp_ne(l1##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
+    case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~l2##0:generic_list(?t), ?$##0:generic_list(?t)) @generic_use:nn:nn
+        foreign llvm move(~l2##0:generic_list(?t), ?###0:generic_list(?t)) @generic_use:nn:nn
 
     1:
         foreign lpvm access(l1##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:?T)
         foreign lpvm access(~l1##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
-        generic_use.concat<0>(~t##0:generic_list(?t), ~l2##0:generic_list(?t), ?tmp$2##0:generic_list(?t)) #1 @generic_use:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$8##0:generic_list(?T))
-        foreign lpvm mutate(~tmp$8##0:generic_list(?T), ?tmp$9##0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:?T)
-        foreign lpvm mutate(~tmp$9##0:generic_list(?T), ?$##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:generic_list(?T))
+        generic_use.concat<0>(~t##0:generic_list(?t), ~l2##0:generic_list(?t), ?tmp#2##0:generic_list(?t)) #1 @generic_use:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:generic_list(?T))
+        foreign lpvm mutate(~tmp#8##0:generic_list(?T), ?tmp#9##0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:?T)
+        foreign lpvm mutate(~tmp#9##0:generic_list(?T), ?###0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:generic_list(?T))
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_ne(l1##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
-    case ~tmp$5##0:wybe.bool of
+    foreign llvm icmp_ne(l1##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
+    case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~l2##0:generic_list(?t), ?$##0:generic_list(?t)) @generic_use:nn:nn
+        foreign llvm move(~l2##0:generic_list(?t), ?###0:generic_list(?t)) @generic_use:nn:nn
 
     1:
         foreign lpvm access(l1##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
-        generic_use.concat<0>[410bae77d3](~t##0:generic_list(?t), ~l2##0:generic_list(?t), ?tmp$2##0:generic_list(?t)) #1 @generic_use:nn:nn
-        foreign lpvm mutate(~l1##0:generic_list(?T), ?$##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:generic_list(?T))
+        generic_use.concat<0>[410bae77d3](~t##0:generic_list(?t), ~l2##0:generic_list(?t), ?tmp#2##0:generic_list(?t)) #1 @generic_use:nn:nn
+        foreign lpvm mutate(~l1##0:generic_list(?T), ?###0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:generic_list(?T))
 
 
 
 fromto > public {inline} (2 calls)
 0: generic_use.fromto<0>
-fromto(lo##0:wybe.int, hi##0:wybe.int, ?$##0:generic_list(wybe.int)):
+fromto(lo##0:wybe.int, hi##0:wybe.int, ?###0:generic_list(wybe.int)):
  AliasPairs: []
  InterestingCallProperties: []
-    generic_use.fromto1<0>(~lo##0:wybe.int, ~hi##0:wybe.int, 0:generic_list(wybe.int), ?$##0:generic_list(wybe.int)) #1 @generic_use:nn:nn
+    generic_use.fromto1<0>(~lo##0:wybe.int, ~hi##0:wybe.int, 0:generic_list(wybe.int), ?###0:generic_list(wybe.int)) #1 @generic_use:nn:nn
 
 
 fromto1 > (2 calls)
 0: generic_use.fromto1<0>
-fromto1(lo##0:wybe.int, hi##0:wybe.int, sofar##0:generic_list(wybe.int), ?$##0:generic_list(wybe.int)):
- AliasPairs: [($##0,sofar##0)]
+fromto1(lo##0:wybe.int, hi##0:wybe.int, sofar##0:generic_list(wybe.int), ?###0:generic_list(wybe.int)):
+ AliasPairs: [(###0,sofar##0)]
  InterestingCallProperties: []
-    foreign llvm icmp_sge(hi##0:wybe.int, lo##0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
-    case ~tmp$4##0:wybe.bool of
+    foreign llvm icmp_sge(hi##0:wybe.int, lo##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
+    case ~tmp#4##0:wybe.bool of
     0:
-        foreign llvm move(~sofar##0:generic_list(wybe.int), ?$##0:generic_list(wybe.int)) @generic_use:nn:nn
+        foreign llvm move(~sofar##0:generic_list(wybe.int), ?###0:generic_list(wybe.int)) @generic_use:nn:nn
 
     1:
-        foreign llvm sub(hi##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$11##0:generic_list(?T))
-        foreign lpvm mutate(~tmp$11##0:generic_list(?T), ?tmp$12##0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~hi##0:?T)
-        foreign lpvm mutate(~tmp$12##0:generic_list(?T), ?tmp$3##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~sofar##0:generic_list(?T))
-        generic_use.fromto1<0>(~lo##0:wybe.int, ~tmp$2##0:wybe.int, ~tmp$3##0:generic_list(wybe.int), ?$##0:generic_list(wybe.int)) #3 @generic_use:nn:nn
+        foreign llvm sub(hi##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:generic_list(?T))
+        foreign lpvm mutate(~tmp#11##0:generic_list(?T), ?tmp#12##0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~hi##0:?T)
+        foreign lpvm mutate(~tmp#12##0:generic_list(?T), ?tmp#3##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~sofar##0:generic_list(?T))
+        generic_use.fromto1<0>(~lo##0:wybe.int, ~tmp#2##0:wybe.int, ~tmp#3##0:generic_list(wybe.int), ?###0:generic_list(wybe.int)) #3 @generic_use:nn:nn
 
 
 
 iota > public {inline} (1 calls)
 0: generic_use.iota<0>
-iota(n##0:wybe.int, ?$##0:generic_list(wybe.int)):
+iota(n##0:wybe.int, ?###0:generic_list(wybe.int)):
  AliasPairs: []
  InterestingCallProperties: []
-    generic_use.fromto1<0>(1:wybe.int, ~n##0:wybe.int, 0:generic_list(wybe.int), ?$##0:generic_list(wybe.int)) #1 @generic_use:nn:nn
+    generic_use.fromto1<0>(1:wybe.int, ~n##0:wybe.int, 0:generic_list(wybe.int), ?###0:generic_list(wybe.int)) #1 @generic_use:nn:nn
 
 
 nrev > public (2 calls)
 0: generic_use.nrev<0>[410bae77d3]
-nrev(lst##0:generic_list(?t), ?$##0:generic_list(?t)):
+nrev(lst##0:generic_list(?t), ?###0:generic_list(?t)):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(generic_use.nrev<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(generic_use.concat<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.bool)
-    case ~tmp$8##0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool)
+    case ~tmp#8##0:wybe.bool of
     0:
-        foreign llvm move(0:generic_list(?t), ?$##0:generic_list(?t)) @generic_use:nn:nn
+        foreign llvm move(0:generic_list(?t), ?###0:generic_list(?t)) @generic_use:nn:nn
 
     1:
         foreign lpvm access(lst##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:?T)
         foreign lpvm access(~lst##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
-        generic_use.nrev<0>(~t##0:generic_list(?t), ?tmp$2##0:generic_list(?t)) #1 @generic_use:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$11##0:generic_list(?T))
-        foreign lpvm mutate(~tmp$11##0:generic_list(?T), ?tmp$12##0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:?T)
-        foreign lpvm mutate(~tmp$12##0:generic_list(?T), ?tmp$3##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:generic_list(?T))
-        generic_use.concat<0>[410bae77d3](~tmp$2##0:generic_list(?t), ~tmp$3##0:generic_list(?t), ?$##0:generic_list(?t)) #4 @generic_use:nn:nn
+        generic_use.nrev<0>(~t##0:generic_list(?t), ?tmp#2##0:generic_list(?t)) #1 @generic_use:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:generic_list(?T))
+        foreign lpvm mutate(~tmp#11##0:generic_list(?T), ?tmp#12##0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:?T)
+        foreign lpvm mutate(~tmp#12##0:generic_list(?T), ?tmp#3##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:generic_list(?T))
+        generic_use.concat<0>[410bae77d3](~tmp#2##0:generic_list(?t), ~tmp#3##0:generic_list(?t), ?###0:generic_list(?t)) #4 @generic_use:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.bool)
-    case ~tmp$8##0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool)
+    case ~tmp#8##0:wybe.bool of
     0:
-        foreign llvm move(0:generic_list(?t), ?$##0:generic_list(?t)) @generic_use:nn:nn
+        foreign llvm move(0:generic_list(?t), ?###0:generic_list(?t)) @generic_use:nn:nn
 
     1:
         foreign lpvm access(lst##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
-        generic_use.nrev<0>[410bae77d3](~t##0:generic_list(?t), ?tmp$2##0:generic_list(?t)) #1 @generic_use:nn:nn
-        foreign lpvm mutate(~lst##0:generic_list(?T), ?tmp$3##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:generic_list(?T))
-        generic_use.concat<0>[410bae77d3](~tmp$2##0:generic_list(?t), ~tmp$3##0:generic_list(?t), ?$##0:generic_list(?t)) #4 @generic_use:nn:nn
+        generic_use.nrev<0>[410bae77d3](~t##0:generic_list(?t), ?tmp#2##0:generic_list(?t)) #1 @generic_use:nn:nn
+        foreign lpvm mutate(~lst##0:generic_list(?T), ?tmp#3##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:generic_list(?T))
+        generic_use.concat<0>[410bae77d3](~tmp#2##0:generic_list(?t), ~tmp#3##0:generic_list(?t), ?###0:generic_list(?t)) #4 @generic_use:nn:nn
 
 
 
@@ -507,8 +507,8 @@ print(lst##0:generic_list(wybe.int), io##0:wybe.phantom, ?io##4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c putchar('[':wybe.char, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.bool)
-    case ~tmp$4##0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.bool)
+    case ~tmp#4##0:wybe.bool of
     0:
         foreign c putchar(']':wybe.char, ~#io##1:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
 
@@ -526,8 +526,8 @@ print_tail > (2 calls)
 print_tail(lst##0:generic_list(wybe.int), io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.bool)
-    case ~tmp$2##0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.bool)
+    case ~tmp#2##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##3:wybe.phantom)
 
@@ -551,41 +551,41 @@ println(lst##0:generic_list(wybe.int), io##0:wybe.phantom, ?io##2:wybe.phantom):
 
 reverse > public {inline} (1 calls)
 0: generic_use.reverse<0>
-reverse(lst##0:generic_list(?t), ?$##0:generic_list(?t)):
+reverse(lst##0:generic_list(?t), ?###0:generic_list(?t)):
  AliasPairs: []
  InterestingCallProperties: []
-    generic_use.reverse1<0>(~lst##0:generic_list(?t), 0:generic_list(?t), ?$##0:generic_list(?t)) #1 @generic_use:nn:nn
+    generic_use.reverse1<0>(~lst##0:generic_list(?t), 0:generic_list(?t), ?###0:generic_list(?t)) #1 @generic_use:nn:nn
 
 
 reverse1 > public (2 calls)
 0: generic_use.reverse1<0>[410bae77d3]
-reverse1(lst##0:generic_list(?t), suffix##0:generic_list(?t), ?$##0:generic_list(?t)):
- AliasPairs: [($##0,suffix##0)]
+reverse1(lst##0:generic_list(?t), suffix##0:generic_list(?t), ?###0:generic_list(?t)):
+ AliasPairs: [(###0,suffix##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(generic_use.reverse1<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
-    case ~tmp$5##0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
+    case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~suffix##0:generic_list(?t), ?$##0:generic_list(?t)) @generic_use:nn:nn
+        foreign llvm move(~suffix##0:generic_list(?t), ?###0:generic_list(?t)) @generic_use:nn:nn
 
     1:
         foreign lpvm access(lst##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:?T)
         foreign lpvm access(~lst##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
-        foreign lpvm alloc(16:wybe.int, ?tmp$8##0:generic_list(?T))
-        foreign lpvm mutate(~tmp$8##0:generic_list(?T), ?tmp$9##0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:?T)
-        foreign lpvm mutate(~tmp$9##0:generic_list(?T), ?tmp$2##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~suffix##0:generic_list(?T))
-        generic_use.reverse1<0>(~t##0:generic_list(?t), ~tmp$2##0:generic_list(?t), ?$##0:generic_list(?t)) #2 @generic_use:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:generic_list(?T))
+        foreign lpvm mutate(~tmp#8##0:generic_list(?T), ?tmp#9##0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:?T)
+        foreign lpvm mutate(~tmp#9##0:generic_list(?T), ?tmp#2##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~suffix##0:generic_list(?T))
+        generic_use.reverse1<0>(~t##0:generic_list(?t), ~tmp#2##0:generic_list(?t), ?###0:generic_list(?t)) #2 @generic_use:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
-    case ~tmp$5##0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
+    case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~suffix##0:generic_list(?t), ?$##0:generic_list(?t)) @generic_use:nn:nn
+        foreign llvm move(~suffix##0:generic_list(?t), ?###0:generic_list(?t)) @generic_use:nn:nn
 
     1:
         foreign lpvm access(lst##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
-        foreign lpvm mutate(~lst##0:generic_list(?T), ?tmp$2##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~suffix##0:generic_list(?T))
-        generic_use.reverse1<0>[410bae77d3](~t##0:generic_list(?t), ~tmp$2##0:generic_list(?t), ?$##0:generic_list(?t)) #2 @generic_use:nn:nn
+        foreign lpvm mutate(~lst##0:generic_list(?T), ?tmp#2##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~suffix##0:generic_list(?T))
+        generic_use.reverse1<0>[410bae77d3](~t##0:generic_list(?t), ~tmp#2##0:generic_list(?t), ?###0:generic_list(?t)) #2 @generic_use:nn:nn
 
 
   LLVM code       :
@@ -616,20 +616,20 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"generic_use.<0>"()    {
 entry:
-  %"1$tmp$0##0" = tail call fastcc  i64  @"generic_use.fromto1<0>"(i64  1, i64  5, i64  0)  
-  %"1$tmp$1##0" = tail call fastcc  i64  @"generic_use.fromto1<0>"(i64  6, i64  10, i64  0)  
-  tail call fastcc  void  @"generic_use.print<0>"(i64  %"1$tmp$0##0")  
+  %"1#tmp#0##0" = tail call fastcc  i64  @"generic_use.fromto1<0>"(i64  1, i64  5, i64  0)  
+  %"1#tmp#1##0" = tail call fastcc  i64  @"generic_use.fromto1<0>"(i64  6, i64  10, i64  0)  
+  tail call fastcc  void  @"generic_use.print<0>"(i64  %"1#tmp#0##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"generic_use.print<0>"(i64  %"1$tmp$1##0")  
+  tail call fastcc  void  @"generic_use.print<0>"(i64  %"1#tmp#1##0")  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$tmp$2##0" = tail call fastcc  i64  @"generic_use.concat<0>"(i64  %"1$tmp$0##0", i64  %"1$tmp$1##0")  
-  tail call fastcc  void  @"generic_use.print<0>"(i64  %"1$tmp$2##0")  
+  %"1#tmp#2##0" = tail call fastcc  i64  @"generic_use.concat<0>"(i64  %"1#tmp#0##0", i64  %"1#tmp#1##0")  
+  tail call fastcc  void  @"generic_use.print<0>"(i64  %"1#tmp#2##0")  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$tmp$3##0" = tail call fastcc  i64  @"generic_use.reverse1<0>[410bae77d3]"(i64  %"1$tmp$0##0", i64  0)  
-  tail call fastcc  void  @"generic_use.print<0>"(i64  %"1$tmp$3##0")  
+  %"1#tmp#3##0" = tail call fastcc  i64  @"generic_use.reverse1<0>[410bae77d3]"(i64  %"1#tmp#0##0", i64  0)  
+  tail call fastcc  void  @"generic_use.print<0>"(i64  %"1#tmp#3##0")  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$tmp$4##0" = tail call fastcc  i64  @"generic_use.nrev<0>[410bae77d3]"(i64  %"1$tmp$1##0")  
-  tail call fastcc  void  @"generic_use.print<0>"(i64  %"1$tmp$4##0")  
+  %"1#tmp#4##0" = tail call fastcc  i64  @"generic_use.nrev<0>[410bae77d3]"(i64  %"1#tmp#1##0")  
+  tail call fastcc  void  @"generic_use.print<0>"(i64  %"1#tmp#4##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -637,8 +637,8 @@ entry:
 
 define external fastcc  i64 @"generic_use.concat<0>"(i64  %"l1##0", i64  %"l2##0")    {
 entry:
-  %"1$tmp$5##0" = icmp ne i64 %"l1##0", 0 
-  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
+  %"1#tmp#5##0" = icmp ne i64 %"l1##0", 0 
+  br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"l1##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
@@ -647,7 +647,7 @@ if.then:
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %"2$tmp$2##0" = tail call fastcc  i64  @"generic_use.concat<0>"(i64  %7, i64  %"l2##0")  
+  %"2#tmp#2##0" = tail call fastcc  i64  @"generic_use.concat<0>"(i64  %7, i64  %"l2##0")  
   %8 = trunc i64 16 to i32  
   %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
   %10 = ptrtoint i8* %9 to i64 
@@ -657,7 +657,7 @@ if.then:
   %13 = add   i64 %10, 8 
   %14 = inttoptr i64 %13 to i64* 
   %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 %"2$tmp$2##0", i64* %15 
+  store  i64 %"2#tmp#2##0", i64* %15 
   ret i64 %10 
 if.else:
   ret i64 %"l2##0" 
@@ -666,18 +666,18 @@ if.else:
 
 define external fastcc  i64 @"generic_use.concat<0>[410bae77d3]"(i64  %"l1##0", i64  %"l2##0")    {
 entry:
-  %"1$tmp$5##0" = icmp ne i64 %"l1##0", 0 
-  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
+  %"1#tmp#5##0" = icmp ne i64 %"l1##0", 0 
+  br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
   %16 = add   i64 %"l1##0", 8 
   %17 = inttoptr i64 %16 to i64* 
   %18 = getelementptr  i64, i64* %17, i64 0 
   %19 = load  i64, i64* %18 
-  %"2$tmp$2##0" = tail call fastcc  i64  @"generic_use.concat<0>[410bae77d3]"(i64  %19, i64  %"l2##0")  
+  %"2#tmp#2##0" = tail call fastcc  i64  @"generic_use.concat<0>[410bae77d3]"(i64  %19, i64  %"l2##0")  
   %20 = add   i64 %"l1##0", 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"2$tmp$2##0", i64* %22 
+  store  i64 %"2#tmp#2##0", i64* %22 
   ret i64 %"l1##0" 
 if.else:
   ret i64 %"l2##0" 
@@ -686,17 +686,17 @@ if.else:
 
 define external fastcc  i64 @"generic_use.fromto<0>"(i64  %"lo##0", i64  %"hi##0")    {
 entry:
-  %"1$$##0" = tail call fastcc  i64  @"generic_use.fromto1<0>"(i64  %"lo##0", i64  %"hi##0", i64  0)  
-  ret i64 %"1$$##0" 
+  %"1####0" = tail call fastcc  i64  @"generic_use.fromto1<0>"(i64  %"lo##0", i64  %"hi##0", i64  0)  
+  ret i64 %"1####0" 
 }
 
 
 define external fastcc  i64 @"generic_use.fromto1<0>"(i64  %"lo##0", i64  %"hi##0", i64  %"sofar##0")    {
 entry:
-  %"1$tmp$4##0" = icmp sge i64 %"hi##0", %"lo##0" 
-  br i1 %"1$tmp$4##0", label %if.then, label %if.else 
+  %"1#tmp#4##0" = icmp sge i64 %"hi##0", %"lo##0" 
+  br i1 %"1#tmp#4##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = sub   i64 %"hi##0", 1 
+  %"2#tmp#2##0" = sub   i64 %"hi##0", 1 
   %23 = trunc i64 16 to i32  
   %24 = tail call ccc  i8*  @wybe_malloc(i32  %23)  
   %25 = ptrtoint i8* %24 to i64 
@@ -707,8 +707,8 @@ if.then:
   %29 = inttoptr i64 %28 to i64* 
   %30 = getelementptr  i64, i64* %29, i64 0 
   store  i64 %"sofar##0", i64* %30 
-  %"2$$##0" = tail call fastcc  i64  @"generic_use.fromto1<0>"(i64  %"lo##0", i64  %"2$tmp$2##0", i64  %25)  
-  ret i64 %"2$$##0" 
+  %"2####0" = tail call fastcc  i64  @"generic_use.fromto1<0>"(i64  %"lo##0", i64  %"2#tmp#2##0", i64  %25)  
+  ret i64 %"2####0" 
 if.else:
   ret i64 %"sofar##0" 
 }
@@ -716,15 +716,15 @@ if.else:
 
 define external fastcc  i64 @"generic_use.iota<0>"(i64  %"n##0")    {
 entry:
-  %"1$$##0" = tail call fastcc  i64  @"generic_use.fromto1<0>"(i64  1, i64  %"n##0", i64  0)  
-  ret i64 %"1$$##0" 
+  %"1####0" = tail call fastcc  i64  @"generic_use.fromto1<0>"(i64  1, i64  %"n##0", i64  0)  
+  ret i64 %"1####0" 
 }
 
 
 define external fastcc  i64 @"generic_use.nrev<0>"(i64  %"lst##0")    {
 entry:
-  %"1$tmp$8##0" = icmp ne i64 %"lst##0", 0 
-  br i1 %"1$tmp$8##0", label %if.then, label %if.else 
+  %"1#tmp#8##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1#tmp#8##0", label %if.then, label %if.else 
 if.then:
   %31 = inttoptr i64 %"lst##0" to i64* 
   %32 = getelementptr  i64, i64* %31, i64 0 
@@ -733,7 +733,7 @@ if.then:
   %35 = inttoptr i64 %34 to i64* 
   %36 = getelementptr  i64, i64* %35, i64 0 
   %37 = load  i64, i64* %36 
-  %"2$tmp$2##0" = tail call fastcc  i64  @"generic_use.nrev<0>"(i64  %37)  
+  %"2#tmp#2##0" = tail call fastcc  i64  @"generic_use.nrev<0>"(i64  %37)  
   %38 = trunc i64 16 to i32  
   %39 = tail call ccc  i8*  @wybe_malloc(i32  %38)  
   %40 = ptrtoint i8* %39 to i64 
@@ -744,8 +744,8 @@ if.then:
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   store  i64 0, i64* %45 
-  %"2$$##0" = tail call fastcc  i64  @"generic_use.concat<0>[410bae77d3]"(i64  %"2$tmp$2##0", i64  %40)  
-  ret i64 %"2$$##0" 
+  %"2####0" = tail call fastcc  i64  @"generic_use.concat<0>[410bae77d3]"(i64  %"2#tmp#2##0", i64  %40)  
+  ret i64 %"2####0" 
 if.else:
   ret i64 0 
 }
@@ -753,20 +753,20 @@ if.else:
 
 define external fastcc  i64 @"generic_use.nrev<0>[410bae77d3]"(i64  %"lst##0")    {
 entry:
-  %"1$tmp$8##0" = icmp ne i64 %"lst##0", 0 
-  br i1 %"1$tmp$8##0", label %if.then, label %if.else 
+  %"1#tmp#8##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1#tmp#8##0", label %if.then, label %if.else 
 if.then:
   %46 = add   i64 %"lst##0", 8 
   %47 = inttoptr i64 %46 to i64* 
   %48 = getelementptr  i64, i64* %47, i64 0 
   %49 = load  i64, i64* %48 
-  %"2$tmp$2##0" = tail call fastcc  i64  @"generic_use.nrev<0>[410bae77d3]"(i64  %49)  
+  %"2#tmp#2##0" = tail call fastcc  i64  @"generic_use.nrev<0>[410bae77d3]"(i64  %49)  
   %50 = add   i64 %"lst##0", 8 
   %51 = inttoptr i64 %50 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
   store  i64 0, i64* %52 
-  %"2$$##0" = tail call fastcc  i64  @"generic_use.concat<0>[410bae77d3]"(i64  %"2$tmp$2##0", i64  %"lst##0")  
-  ret i64 %"2$$##0" 
+  %"2####0" = tail call fastcc  i64  @"generic_use.concat<0>[410bae77d3]"(i64  %"2#tmp#2##0", i64  %"lst##0")  
+  ret i64 %"2####0" 
 if.else:
   ret i64 0 
 }
@@ -775,8 +775,8 @@ if.else:
 define external fastcc  void @"generic_use.print<0>"(i64  %"lst##0")    {
 entry:
   tail call ccc  void  @putchar(i8  91)  
-  %"1$tmp$4##0" = icmp ne i64 %"lst##0", 0 
-  br i1 %"1$tmp$4##0", label %if.then, label %if.else 
+  %"1#tmp#4##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1#tmp#4##0", label %if.then, label %if.else 
 if.then:
   %53 = inttoptr i64 %"lst##0" to i64* 
   %54 = getelementptr  i64, i64* %53, i64 0 
@@ -797,8 +797,8 @@ if.else:
 
 define external fastcc  void @"generic_use.print_tail<0>"(i64  %"lst##0")    {
 entry:
-  %"1$tmp$2##0" = icmp ne i64 %"lst##0", 0 
-  br i1 %"1$tmp$2##0", label %if.then, label %if.else 
+  %"1#tmp#2##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1#tmp#2##0", label %if.then, label %if.else 
 if.then:
   %60 = inttoptr i64 %"lst##0" to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
@@ -827,15 +827,15 @@ entry:
 
 define external fastcc  i64 @"generic_use.reverse<0>"(i64  %"lst##0")    {
 entry:
-  %"1$$##0" = tail call fastcc  i64  @"generic_use.reverse1<0>"(i64  %"lst##0", i64  0)  
-  ret i64 %"1$$##0" 
+  %"1####0" = tail call fastcc  i64  @"generic_use.reverse1<0>"(i64  %"lst##0", i64  0)  
+  ret i64 %"1####0" 
 }
 
 
 define external fastcc  i64 @"generic_use.reverse1<0>"(i64  %"lst##0", i64  %"suffix##0")    {
 entry:
-  %"1$tmp$5##0" = icmp ne i64 %"lst##0", 0 
-  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
+  %"1#tmp#5##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
   %69 = inttoptr i64 %"lst##0" to i64* 
   %70 = getelementptr  i64, i64* %69, i64 0 
@@ -854,8 +854,8 @@ if.then:
   %82 = inttoptr i64 %81 to i64* 
   %83 = getelementptr  i64, i64* %82, i64 0 
   store  i64 %"suffix##0", i64* %83 
-  %"2$$##0" = tail call fastcc  i64  @"generic_use.reverse1<0>"(i64  %75, i64  %78)  
-  ret i64 %"2$$##0" 
+  %"2####0" = tail call fastcc  i64  @"generic_use.reverse1<0>"(i64  %75, i64  %78)  
+  ret i64 %"2####0" 
 if.else:
   ret i64 %"suffix##0" 
 }
@@ -863,8 +863,8 @@ if.else:
 
 define external fastcc  i64 @"generic_use.reverse1<0>[410bae77d3]"(i64  %"lst##0", i64  %"suffix##0")    {
 entry:
-  %"1$tmp$5##0" = icmp ne i64 %"lst##0", 0 
-  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
+  %"1#tmp#5##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
   %84 = add   i64 %"lst##0", 8 
   %85 = inttoptr i64 %84 to i64* 
@@ -874,8 +874,8 @@ if.then:
   %89 = inttoptr i64 %88 to i64* 
   %90 = getelementptr  i64, i64* %89, i64 0 
   store  i64 %"suffix##0", i64* %90 
-  %"2$$##0" = tail call fastcc  i64  @"generic_use.reverse1<0>[410bae77d3]"(i64  %87, i64  %"lst##0")  
-  ret i64 %"2$$##0" 
+  %"2####0" = tail call fastcc  i64  @"generic_use.reverse1<0>[410bae77d3]"(i64  %87, i64  %"lst##0")  
+  ret i64 %"2####0" 
 if.else:
   ret i64 %"suffix##0" 
 }

--- a/test-cases/final-dump/import.exp
+++ b/test-cases/final-dump/import.exp
@@ -13,35 +13,35 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: import.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$5#0:position.position)
-    foreign lpvm mutate(~tmp$5#0:position.position, ?tmp$6#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$6#0:position.position, ?tmp$1#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 20:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$9#0:position.position)
-    foreign lpvm mutate(~tmp$9#0:position.position, ?tmp$10#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$10#0:position.position, ?tmp$2#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    import.distance<0>(~tmp$1#0:position.position, ~tmp$2#0:position.position, ?tmp$0#0:wybe.int) #2 @import:nn:nn
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$13#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$13#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$5##0:position.position)
+    foreign lpvm mutate(~tmp$5##0:position.position, ?tmp$6##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp$6##0:position.position, ?tmp$1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 20:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp$9##0:position.position)
+    foreign lpvm mutate(~tmp$9##0:position.position, ?tmp$10##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp$10##0:position.position, ?tmp$2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    import.distance<0>(~tmp$1##0:position.position, ~tmp$2##0:position.position, ?tmp$0##0:wybe.int) #2 @import:nn:nn
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$13##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$13##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 distance > public (1 calls)
 0: import.distance<0>
-distance(p1#0:position.position, p2#0:position.position, ?$#0:wybe.int):
+distance(p1##0:position.position, p2##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(p2#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access(p1#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign llvm sub(~tmp$4#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$3#0:wybe.int) @int:nn:nn
-    foreign c ipow(~tmp$3#0:wybe.int, 2:wybe.int, ?tmp$2#0:wybe.int) @int:nn:nn
-    foreign lpvm access(~p2#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.int)
-    foreign lpvm access(~p1#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.int)
-    foreign llvm sub(~tmp$8#0:wybe.int, ~tmp$9#0:wybe.int, ?tmp$7#0:wybe.int) @int:nn:nn
-    foreign c ipow(~tmp$7#0:wybe.int, 2:wybe.int, ?tmp$6#0:wybe.int) @int:nn:nn
-    foreign llvm add(~tmp$2#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$1#0:wybe.int) @int:nn:nn
-    foreign c isqrt(~tmp$1#0:wybe.int, ?$#0:wybe.int) @int:nn:nn
+    foreign lpvm access(p2##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign llvm sub(~tmp$4##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
+    foreign c ipow(~tmp$3##0:wybe.int, 2:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
+    foreign lpvm access(~p2##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
+    foreign lpvm access(~p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.int)
+    foreign llvm sub(~tmp$8##0:wybe.int, ~tmp$9##0:wybe.int, ?tmp$7##0:wybe.int) @int:nn:nn
+    foreign c ipow(~tmp$7##0:wybe.int, 2:wybe.int, ?tmp$6##0:wybe.int) @int:nn:nn
+    foreign llvm add(~tmp$2##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$1##0:wybe.int) @int:nn:nn
+    foreign c isqrt(~tmp$1##0:wybe.int, ?$##0:wybe.int) @int:nn:nn
 
   LLVM code       :
 
@@ -91,36 +91,36 @@ entry:
   %15 = inttoptr i64 %14 to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
   store  i64 0, i64* %16 
-  %"1$tmp$0#0" = tail call fastcc  i64  @"import.distance<0>"(i64  %3, i64  %11)  
-  tail call ccc  void  @print_int(i64  %"1$tmp$0#0")  
+  %"1$tmp$0##0" = tail call fastcc  i64  @"import.distance<0>"(i64  %3, i64  %11)  
+  tail call ccc  void  @print_int(i64  %"1$tmp$0##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  i64 @"import.distance<0>"(i64  %"p1#0", i64  %"p2#0")    {
+define external fastcc  i64 @"import.distance<0>"(i64  %"p1##0", i64  %"p2##0")    {
 entry:
-  %17 = inttoptr i64 %"p2#0" to i64* 
+  %17 = inttoptr i64 %"p2##0" to i64* 
   %18 = getelementptr  i64, i64* %17, i64 0 
   %19 = load  i64, i64* %18 
-  %20 = inttoptr i64 %"p1#0" to i64* 
+  %20 = inttoptr i64 %"p1##0" to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %"1$tmp$3#0" = sub   i64 %19, %22 
-  %"1$tmp$2#0" = tail call ccc  i64  @ipow(i64  %"1$tmp$3#0", i64  2)  
-  %23 = add   i64 %"p2#0", 8 
+  %"1$tmp$3##0" = sub   i64 %19, %22 
+  %"1$tmp$2##0" = tail call ccc  i64  @ipow(i64  %"1$tmp$3##0", i64  2)  
+  %23 = add   i64 %"p2##0", 8 
   %24 = inttoptr i64 %23 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
   %26 = load  i64, i64* %25 
-  %27 = add   i64 %"p1#0", 8 
+  %27 = add   i64 %"p1##0", 8 
   %28 = inttoptr i64 %27 to i64* 
   %29 = getelementptr  i64, i64* %28, i64 0 
   %30 = load  i64, i64* %29 
-  %"1$tmp$7#0" = sub   i64 %26, %30 
-  %"1$tmp$6#0" = tail call ccc  i64  @ipow(i64  %"1$tmp$7#0", i64  2)  
-  %"1$tmp$1#0" = add   i64 %"1$tmp$2#0", %"1$tmp$6#0" 
-  %"1$$#0" = tail call ccc  i64  @isqrt(i64  %"1$tmp$1#0")  
-  ret i64 %"1$$#0" 
+  %"1$tmp$7##0" = sub   i64 %26, %30 
+  %"1$tmp$6##0" = tail call ccc  i64  @ipow(i64  %"1$tmp$7##0", i64  2)  
+  %"1$tmp$1##0" = add   i64 %"1$tmp$2##0", %"1$tmp$6##0" 
+  %"1$$##0" = tail call ccc  i64  @isqrt(i64  %"1$tmp$1##0")  
+  ret i64 %"1$$##0" 
 }
 --------------------------------------------------
  Module position
@@ -144,17 +144,17 @@ entry:
 
 printPosition > public (0 calls)
 0: position.printPosition<0>
-printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string(",":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io#4:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -188,17 +188,17 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"position.printPosition<0>"(i64  %"pos#0")    {
+define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
-  %3 = inttoptr i64 %"pos#0" to i64* 
+  %3 = inttoptr i64 %"pos##0" to i64* 
   %4 = getelementptr  i64, i64* %3, i64 0 
   %5 = load  i64, i64* %4 
   tail call ccc  void  @print_int(i64  %5)  
   %7 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.6, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %7)  
-  %8 = add   i64 %"pos#0", 8 
+  %8 = add   i64 %"pos##0", 8 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
@@ -228,86 +228,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y#0:wybe.int)
-    foreign llvm icmp_eq(~$left$x#0:wybe.int, ~$right$x#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
+    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y#0:wybe.int, ~$right$y#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
-    foreign lpvm mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:position.position, ?$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
+    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
-    foreign lpvm access(~$#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y#0:wybe.int)
+    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec#0:position.position, ?$#0:wybe.int):
+x($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec#0:position.position, ?$#0:wybe.int):
+y($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -324,54 +324,54 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$#0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = icmp eq i64 %7, %14 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"x#0", i64* %19 
+  store  i64 %"x##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"y#0", i64* %22 
+  store  i64 %"y##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
 entry:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -381,34 +381,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec#0" to i64* 
+  %32 = inttoptr i64 %"$rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec#0" to i8* 
+  %39 = inttoptr i64 %"$rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field#0", i64* %42 
+  store  i64 %"$field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = add   i64 %"$rec#0", 8 
+  %43 = add   i64 %"$rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -416,46 +416,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec#0" to i8* 
+  %51 = inttoptr i64 %"$rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field#0", i64* %55 
+  store  i64 %"$field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %58, %65 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = icmp eq i64 %62, %69 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$0##0" = icmp eq i64 %62, %69 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }

--- a/test-cases/final-dump/import.exp
+++ b/test-cases/final-dump/import.exp
@@ -29,7 +29,7 @@ AFTER EVERYTHING:
 
 distance > public (1 calls)
 0: import.distance<0>
-distance(p1##0:position.position, p2##0:position.position, ?###0:wybe.int):
+distance(p1##0:position.position, p2##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(p2##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
@@ -41,7 +41,7 @@ distance(p1##0:position.position, p2##0:position.position, ?###0:wybe.int):
     foreign llvm sub(~tmp#8##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#7##0:wybe.int) @int:nn:nn
     foreign c ipow(~tmp#7##0:wybe.int, 2:wybe.int, ?tmp#6##0:wybe.int) @int:nn:nn
     foreign llvm add(~tmp#2##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#1##0:wybe.int) @int:nn:nn
-    foreign c isqrt(~tmp#1##0:wybe.int, ?###0:wybe.int) @int:nn:nn
+    foreign c isqrt(~tmp#1##0:wybe.int, ?#result##0:wybe.int) @int:nn:nn
 
   LLVM code       :
 
@@ -119,8 +119,8 @@ entry:
   %"1#tmp#7##0" = sub   i64 %26, %30 
   %"1#tmp#6##0" = tail call ccc  i64  @ipow(i64  %"1#tmp#7##0", i64  2)  
   %"1#tmp#1##0" = add   i64 %"1#tmp#2##0", %"1#tmp#6##0" 
-  %"1####0" = tail call ccc  i64  @isqrt(i64  %"1#tmp#1##0")  
-  ret i64 %"1####0" 
+  %"1##result##0" = tail call ccc  i64  @isqrt(i64  %"1#tmp#1##0")  
+  ret i64 %"1##result##0" 
 }
 --------------------------------------------------
  Module position
@@ -247,27 +247,27 @@ entry:
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x(#rec##0:position.position, ?###0:wybe.int):
+x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -278,10 +278,10 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y(#rec##0:position.position, ?###0:wybe.int):
+y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -366,12 +366,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 

--- a/test-cases/final-dump/import.exp
+++ b/test-cases/final-dump/import.exp
@@ -16,32 +16,32 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$5##0:position.position)
-    foreign lpvm mutate(~tmp$5##0:position.position, ?tmp$6##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$6##0:position.position, ?tmp$1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 20:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$9##0:position.position)
-    foreign lpvm mutate(~tmp$9##0:position.position, ?tmp$10##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$10##0:position.position, ?tmp$2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    import.distance<0>(~tmp$1##0:position.position, ~tmp$2##0:position.position, ?tmp$0##0:wybe.int) #2 @import:nn:nn
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$13##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$13##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:position.position)
+    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#6##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp#6##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 20:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#9##0:position.position)
+    foreign lpvm mutate(~tmp#9##0:position.position, ?tmp#10##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp#10##0:position.position, ?tmp#2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    import.distance<0>(~tmp#1##0:position.position, ~tmp#2##0:position.position, ?tmp#0##0:wybe.int) #2 @import:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 distance > public (1 calls)
 0: import.distance<0>
-distance(p1##0:position.position, p2##0:position.position, ?$##0:wybe.int):
+distance(p1##0:position.position, p2##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(p2##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign llvm sub(~tmp$4##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
-    foreign c ipow(~tmp$3##0:wybe.int, 2:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
-    foreign lpvm access(~p2##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
-    foreign lpvm access(~p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.int)
-    foreign llvm sub(~tmp$8##0:wybe.int, ~tmp$9##0:wybe.int, ?tmp$7##0:wybe.int) @int:nn:nn
-    foreign c ipow(~tmp$7##0:wybe.int, 2:wybe.int, ?tmp$6##0:wybe.int) @int:nn:nn
-    foreign llvm add(~tmp$2##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$1##0:wybe.int) @int:nn:nn
-    foreign c isqrt(~tmp$1##0:wybe.int, ?$##0:wybe.int) @int:nn:nn
+    foreign lpvm access(p2##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(p1##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign llvm sub(~tmp#4##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
+    foreign c ipow(~tmp#3##0:wybe.int, 2:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
+    foreign lpvm access(~p2##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
+    foreign lpvm access(~p1##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
+    foreign llvm sub(~tmp#8##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#7##0:wybe.int) @int:nn:nn
+    foreign c ipow(~tmp#7##0:wybe.int, 2:wybe.int, ?tmp#6##0:wybe.int) @int:nn:nn
+    foreign llvm add(~tmp#2##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#1##0:wybe.int) @int:nn:nn
+    foreign c isqrt(~tmp#1##0:wybe.int, ?###0:wybe.int) @int:nn:nn
 
   LLVM code       :
 
@@ -91,8 +91,8 @@ entry:
   %15 = inttoptr i64 %14 to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
   store  i64 0, i64* %16 
-  %"1$tmp$0##0" = tail call fastcc  i64  @"import.distance<0>"(i64  %3, i64  %11)  
-  tail call ccc  void  @print_int(i64  %"1$tmp$0##0")  
+  %"1#tmp#0##0" = tail call fastcc  i64  @"import.distance<0>"(i64  %3, i64  %11)  
+  tail call ccc  void  @print_int(i64  %"1#tmp#0##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -106,8 +106,8 @@ entry:
   %20 = inttoptr i64 %"p1##0" to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %"1$tmp$3##0" = sub   i64 %19, %22 
-  %"1$tmp$2##0" = tail call ccc  i64  @ipow(i64  %"1$tmp$3##0", i64  2)  
+  %"1#tmp#3##0" = sub   i64 %19, %22 
+  %"1#tmp#2##0" = tail call ccc  i64  @ipow(i64  %"1#tmp#3##0", i64  2)  
   %23 = add   i64 %"p2##0", 8 
   %24 = inttoptr i64 %23 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
@@ -116,11 +116,11 @@ entry:
   %28 = inttoptr i64 %27 to i64* 
   %29 = getelementptr  i64, i64* %28, i64 0 
   %30 = load  i64, i64* %29 
-  %"1$tmp$7##0" = sub   i64 %26, %30 
-  %"1$tmp$6##0" = tail call ccc  i64  @ipow(i64  %"1$tmp$7##0", i64  2)  
-  %"1$tmp$1##0" = add   i64 %"1$tmp$2##0", %"1$tmp$6##0" 
-  %"1$$##0" = tail call ccc  i64  @isqrt(i64  %"1$tmp$1##0")  
-  ret i64 %"1$$##0" 
+  %"1#tmp#7##0" = sub   i64 %26, %30 
+  %"1#tmp#6##0" = tail call ccc  i64  @ipow(i64  %"1#tmp#7##0", i64  2)  
+  %"1#tmp#1##0" = add   i64 %"1#tmp#2##0", %"1#tmp#6##0" 
+  %"1####0" = tail call ccc  i64  @isqrt(i64  %"1#tmp#1##0")  
+  ret i64 %"1####0" 
 }
 --------------------------------------------------
  Module position
@@ -148,13 +148,13 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -228,86 +228,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
-    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
-    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec##0:position.position, ?$##0:wybe.int):
+x(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec##0:position.position, ?$##0:wybe.int):
+y(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -324,27 +324,27 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$##0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$##0" 
+  %"2#####0" = icmp eq i64 %7, %14 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
@@ -366,12 +366,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
 entry:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -381,34 +381,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec##0" to i64* 
+  %32 = inttoptr i64 %"#rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec##0" to i8* 
+  %39 = inttoptr i64 %"#rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field##0", i64* %42 
+  store  i64 %"#field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = add   i64 %"$rec##0", 8 
+  %43 = add   i64 %"#rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -416,46 +416,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec##0" to i8* 
+  %51 = inttoptr i64 %"#rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field##0", i64* %55 
+  store  i64 %"#field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %58, %65 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = icmp eq i64 %62, %69 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#0##0" = icmp eq i64 %62, %69 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }

--- a/test-cases/final-dump/import.exp
+++ b/test-cases/final-dump/import.exp
@@ -228,7 +228,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
@@ -238,10 +238,10 @@ entry:
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -292,7 +292,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -303,11 +303,11 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -343,8 +343,8 @@ entry:
   %"1#tmp#1##0" = icmp eq i64 %3, %10 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2#####0" = icmp eq i64 %7, %14 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %7, %14 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -453,9 +453,9 @@ entry:
   br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#0##0" = icmp eq i64 %62, %69 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }

--- a/test-cases/final-dump/import_in_sub_mod_lib.exp
+++ b/test-cases/final-dump/import_in_sub_mod_lib.exp
@@ -14,8 +14,8 @@ foo > public {inline} (0 calls)
 foo(v##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(~v##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~v##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/import_in_sub_mod_lib.exp
+++ b/test-cases/final-dump/import_in_sub_mod_lib.exp
@@ -11,11 +11,11 @@ AFTER EVERYTHING:
 
 foo > public {inline} (0 calls)
 0: import_in_sub_mod_lib.foo<0>
-foo(v#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+foo(v##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(~v#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~v##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -37,9 +37,9 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"import_in_sub_mod_lib.foo<0>"(i64  %"v#0")    {
+define external fastcc  void @"import_in_sub_mod_lib.foo<0>"(i64  %"v##0")    {
 entry:
-  tail call ccc  void  @print_int(i64  %"v#0")  
+  tail call ccc  void  @print_int(i64  %"v##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/import_in_sub_mod_main.exp
+++ b/test-cases/final-dump/import_in_sub_mod_main.exp
@@ -14,8 +14,8 @@ foo > public {inline} (0 calls)
 foo(v##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(~v##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~v##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -60,8 +60,8 @@ entry:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(10:wybe.int, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(10:wybe.int, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -106,8 +106,8 @@ bar > public {inline} (0 calls)
 bar(v##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(~v##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~v##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/import_in_sub_mod_main.exp
+++ b/test-cases/final-dump/import_in_sub_mod_main.exp
@@ -11,11 +11,11 @@ AFTER EVERYTHING:
 
 foo > public {inline} (0 calls)
 0: import_in_sub_mod_lib.foo<0>
-foo(v#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+foo(v##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(~v#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~v##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -37,9 +37,9 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"import_in_sub_mod_lib.foo<0>"(i64  %"v#0")    {
+define external fastcc  void @"import_in_sub_mod_lib.foo<0>"(i64  %"v##0")    {
 entry:
-  tail call ccc  void  @print_int(i64  %"v#0")  
+  tail call ccc  void  @print_int(i64  %"v##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -57,11 +57,11 @@ entry:
 
 *main* > public {inline} (0 calls)
 0: import_in_sub_mod_main.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(10:wybe.int, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_int(10:wybe.int, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -103,11 +103,11 @@ entry:
 
 bar > public {inline} (0 calls)
 0: import_in_sub_mod_main.sub.bar<0>
-bar(v#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+bar(v##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(~v#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~v##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -129,9 +129,9 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"import_in_sub_mod_main.sub.bar<0>"(i64  %"v#0")    {
+define external fastcc  void @"import_in_sub_mod_main.sub.bar<0>"(i64  %"v##0")    {
 entry:
-  tail call ccc  void  @print_int(i64  %"v#0")  
+  tail call ccc  void  @print_int(i64  %"v##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/inequality.exp
+++ b/test-cases/final-dump/inequality.exp
@@ -11,13 +11,13 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: inequality.<0>
-(io#0:wybe.phantom, ?io#2:wybe.phantom):
+(io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    wybe.io.print<5>(1:wybe.bool, ~#io#0:wybe.phantom, ?tmp$6#0:wybe.phantom) #4 @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$6#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    wybe.io.print<5>(0:wybe.bool, ~#io#1:wybe.phantom, ?tmp$11#0:wybe.phantom) #5 @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$11#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
+    wybe.io.print<5>(1:wybe.bool, ~#io##0:wybe.phantom, ?tmp$6##0:wybe.phantom) #4 @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    wybe.io.print<5>(0:wybe.bool, ~#io##1:wybe.phantom, ?tmp$11##0:wybe.phantom) #5 @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$11##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/inequality.exp
+++ b/test-cases/final-dump/inequality.exp
@@ -14,10 +14,10 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    wybe.io.print<5>(1:wybe.bool, ~#io##0:wybe.phantom, ?tmp$6##0:wybe.phantom) #4 @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    wybe.io.print<5>(0:wybe.bool, ~#io##1:wybe.phantom, ?tmp$11##0:wybe.phantom) #5 @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$11##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    wybe.io.print<5>(1:wybe.bool, ~#io##0:wybe.phantom, ?tmp#6##0:wybe.phantom) #4 @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    wybe.io.print<5>(0:wybe.bool, ~#io##1:wybe.phantom, ?tmp#11##0:wybe.phantom) #5 @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/inline_decl.exp
+++ b/test-cases/final-dump/inline_decl.exp
@@ -16,19 +16,19 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c putchar('h':wybe.char, ~#io##0:wybe.phantom, ?tmp$1##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('e':wybe.char, ~tmp$1##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('l':wybe.char, ~tmp$2##0:wybe.phantom, ?tmp$3##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('l':wybe.char, ~tmp$3##0:wybe.phantom, ?tmp$4##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('o':wybe.char, ~tmp$4##0:wybe.phantom, ?tmp$5##0:wybe.phantom) @io:nn:nn
-    foreign c putchar(' ':wybe.char, ~tmp$5##0:wybe.phantom, ?tmp$6##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('w':wybe.char, ~tmp$6##0:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('o':wybe.char, ~tmp$7##0:wybe.phantom, ?tmp$8##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('r':wybe.char, ~tmp$8##0:wybe.phantom, ?tmp$9##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('l':wybe.char, ~tmp$9##0:wybe.phantom, ?tmp$10##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('d':wybe.char, ~tmp$10##0:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('!':wybe.char, ~tmp$11##0:wybe.phantom, ?tmp$12##0:wybe.phantom) @io:nn:nn
-    inline_decl.finish<0>(~tmp$12##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @inline_decl:nn:nn
+    foreign c putchar('h':wybe.char, ~#io##0:wybe.phantom, ?tmp#1##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('e':wybe.char, ~tmp#1##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('l':wybe.char, ~tmp#2##0:wybe.phantom, ?tmp#3##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('l':wybe.char, ~tmp#3##0:wybe.phantom, ?tmp#4##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('o':wybe.char, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
+    foreign c putchar(' ':wybe.char, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('w':wybe.char, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('o':wybe.char, ~tmp#7##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('r':wybe.char, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('l':wybe.char, ~tmp#9##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('d':wybe.char, ~tmp#10##0:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('!':wybe.char, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @io:nn:nn
+    inline_decl.finish<0>(~tmp#12##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @inline_decl:nn:nn
 
 
 finish > public {noinline} (1 calls)

--- a/test-cases/final-dump/inline_decl.exp
+++ b/test-cases/final-dump/inline_decl.exp
@@ -13,50 +13,50 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: inline_decl.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c putchar('h':wybe.char, ~#io#0:wybe.phantom, ?tmp$1#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('e':wybe.char, ~tmp$1#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('l':wybe.char, ~tmp$2#0:wybe.phantom, ?tmp$3#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('l':wybe.char, ~tmp$3#0:wybe.phantom, ?tmp$4#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('o':wybe.char, ~tmp$4#0:wybe.phantom, ?tmp$5#0:wybe.phantom) @io:nn:nn
-    foreign c putchar(' ':wybe.char, ~tmp$5#0:wybe.phantom, ?tmp$6#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('w':wybe.char, ~tmp$6#0:wybe.phantom, ?tmp$7#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('o':wybe.char, ~tmp$7#0:wybe.phantom, ?tmp$8#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('r':wybe.char, ~tmp$8#0:wybe.phantom, ?tmp$9#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('l':wybe.char, ~tmp$9#0:wybe.phantom, ?tmp$10#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('d':wybe.char, ~tmp$10#0:wybe.phantom, ?tmp$11#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('!':wybe.char, ~tmp$11#0:wybe.phantom, ?tmp$12#0:wybe.phantom) @io:nn:nn
-    inline_decl.finish<0>(~tmp$12#0:wybe.phantom, ?#io#1:wybe.phantom) #1 @inline_decl:nn:nn
+    foreign c putchar('h':wybe.char, ~#io##0:wybe.phantom, ?tmp$1##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('e':wybe.char, ~tmp$1##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('l':wybe.char, ~tmp$2##0:wybe.phantom, ?tmp$3##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('l':wybe.char, ~tmp$3##0:wybe.phantom, ?tmp$4##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('o':wybe.char, ~tmp$4##0:wybe.phantom, ?tmp$5##0:wybe.phantom) @io:nn:nn
+    foreign c putchar(' ':wybe.char, ~tmp$5##0:wybe.phantom, ?tmp$6##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('w':wybe.char, ~tmp$6##0:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('o':wybe.char, ~tmp$7##0:wybe.phantom, ?tmp$8##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('r':wybe.char, ~tmp$8##0:wybe.phantom, ?tmp$9##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('l':wybe.char, ~tmp$9##0:wybe.phantom, ?tmp$10##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('d':wybe.char, ~tmp$10##0:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('!':wybe.char, ~tmp$11##0:wybe.phantom, ?tmp$12##0:wybe.phantom) @io:nn:nn
+    inline_decl.finish<0>(~tmp$12##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @inline_decl:nn:nn
 
 
 finish > public {noinline} (1 calls)
 0: inline_decl.finish<0>
-finish(io#0:wybe.phantom, ?io#1:wybe.phantom):
+finish(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c putchar('\n':wybe.char, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 long > public {inline} (1 calls)
 0: inline_decl.long<0>
-long(io#0:wybe.phantom, ?io#13:wybe.phantom):
+long(io##0:wybe.phantom, ?io##13:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c putchar('h':wybe.char, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c putchar('e':wybe.char, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c putchar('l':wybe.char, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign c putchar('l':wybe.char, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c putchar('o':wybe.char, ~#io#4:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-    foreign c putchar(' ':wybe.char, ~#io#5:wybe.phantom, ?#io#6:wybe.phantom) @io:nn:nn
-    foreign c putchar('w':wybe.char, ~#io#6:wybe.phantom, ?#io#7:wybe.phantom) @io:nn:nn
-    foreign c putchar('o':wybe.char, ~#io#7:wybe.phantom, ?#io#8:wybe.phantom) @io:nn:nn
-    foreign c putchar('r':wybe.char, ~#io#8:wybe.phantom, ?#io#9:wybe.phantom) @io:nn:nn
-    foreign c putchar('l':wybe.char, ~#io#9:wybe.phantom, ?#io#10:wybe.phantom) @io:nn:nn
-    foreign c putchar('d':wybe.char, ~#io#10:wybe.phantom, ?#io#11:wybe.phantom) @io:nn:nn
-    foreign c putchar('!':wybe.char, ~#io#11:wybe.phantom, ?#io#12:wybe.phantom) @io:nn:nn
-    inline_decl.finish<0>(~#io#12:wybe.phantom, ?#io#13:wybe.phantom) #12 @inline_decl:nn:nn
+    foreign c putchar('h':wybe.char, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c putchar('e':wybe.char, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c putchar('l':wybe.char, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign c putchar('l':wybe.char, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c putchar('o':wybe.char, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign c putchar(' ':wybe.char, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+    foreign c putchar('w':wybe.char, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
+    foreign c putchar('o':wybe.char, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
+    foreign c putchar('r':wybe.char, ~#io##8:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
+    foreign c putchar('l':wybe.char, ~#io##9:wybe.phantom, ?#io##10:wybe.phantom) @io:nn:nn
+    foreign c putchar('d':wybe.char, ~#io##10:wybe.phantom, ?#io##11:wybe.phantom) @io:nn:nn
+    foreign c putchar('!':wybe.char, ~#io##11:wybe.phantom, ?#io##12:wybe.phantom) @io:nn:nn
+    inline_decl.finish<0>(~#io##12:wybe.phantom, ?#io##13:wybe.phantom) #12 @inline_decl:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/int_list.exp
+++ b/test-cases/final-dump/int_list.exp
@@ -27,17 +27,17 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$6##0:int_list.int_list)
-    foreign lpvm mutate(~tmp$6##0:int_list.int_list, ?tmp$7##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-    foreign lpvm mutate(~tmp$7##0:int_list.int_list, ?tmp$8##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:int_list.int_list)
-    foreign lpvm alloc(16:wybe.int, ?tmp$11##0:int_list.int_list)
-    foreign lpvm mutate(~tmp$11##0:int_list.int_list, ?tmp$12##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm mutate(~tmp$12##0:int_list.int_list, ?tmp$13##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$8##0:int_list.int_list)
-    foreign lpvm alloc(16:wybe.int, ?tmp$16##0:int_list.int_list)
-    foreign lpvm mutate(~tmp$16##0:int_list.int_list, ?tmp$17##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp$17##0:int_list.int_list, ?tmp$18##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$13##0:int_list.int_list)
-    int_list.print<0>(~tmp$18##0:int_list.int_list, ~#io##0:wybe.phantom, ?tmp$21##0:wybe.phantom) #5 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$21##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#6##0:int_list.int_list)
+    foreign lpvm mutate(~tmp#6##0:int_list.int_list, ?tmp#7##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+    foreign lpvm mutate(~tmp#7##0:int_list.int_list, ?tmp#8##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:int_list.int_list)
+    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:int_list.int_list)
+    foreign lpvm mutate(~tmp#11##0:int_list.int_list, ?tmp#12##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+    foreign lpvm mutate(~tmp#12##0:int_list.int_list, ?tmp#13##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#8##0:int_list.int_list)
+    foreign lpvm alloc(16:wybe.int, ?tmp#16##0:int_list.int_list)
+    foreign lpvm mutate(~tmp#16##0:int_list.int_list, ?tmp#17##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp#17##0:int_list.int_list, ?tmp#18##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#13##0:int_list.int_list)
+    int_list.print<0>(~tmp#18##0:int_list.int_list, ~#io##0:wybe.phantom, ?tmp#21##0:wybe.phantom) #5 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 print > public (2 calls)
@@ -45,8 +45,8 @@ print > public (2 calls)
 print(x##0:int_list.int_list, io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.bool)
-    case ~tmp$2##0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.bool)
+    case ~tmp#2##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##3:wybe.phantom)
 
@@ -127,8 +127,8 @@ entry:
 
 define external fastcc  void @"int_list.print<0>"(i64  %"x##0")    {
 entry:
-  %"1$tmp$2##0" = icmp ne i64 %"x##0", 0 
-  br i1 %"1$tmp$2##0", label %if.then, label %if.else 
+  %"1#tmp#2##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1#tmp#2##0", label %if.then, label %if.else 
 if.then:
   %25 = inttoptr i64 %"x##0" to i64* 
   %26 = getelementptr  i64, i64* %25, i64 0 
@@ -173,32 +173,32 @@ entry:
 
 = > public (2 calls)
 0: int_list.int_list.=<0>
-=($left##0:int_list.int_list, $right##0:int_list.int_list, ?$$##0:wybe.bool):
+=(#left##0:int_list.int_list, #right##0:int_list.int_list, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left##0:int_list.int_list, ~$right##0:int_list.int_list, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:int_list.int_list, ~#right##0:int_list.int_list, ?####0:wybe.bool)
 
     1:
-        foreign lpvm access($left##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$head##0:wybe.int)
-        foreign lpvm access(~$left##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$tail##0:int_list.int_list)
-        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
-        case ~tmp$9##0:wybe.bool of
+        foreign lpvm access(#left##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#head##0:wybe.int)
+        foreign lpvm access(~#left##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#tail##0:int_list.int_list)
+        foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
+        case ~tmp#9##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign lpvm access($right##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$head##0:wybe.int)
-            foreign lpvm access(~$right##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$tail##0:int_list.int_list)
-            foreign llvm icmp_eq(~$left$head##0:wybe.int, ~$right$head##0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
-            case ~tmp$4##0:wybe.bool of
+            foreign lpvm access(#right##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#head##0:wybe.int)
+            foreign lpvm access(~#right##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#tail##0:int_list.int_list)
+            foreign llvm icmp_eq(~#left#head##0:wybe.int, ~#right#head##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
+            case ~tmp#4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
             1:
-                int_list.int_list.=<0>(~$left$tail##0:int_list.int_list, ~$right$tail##0:int_list.int_list, ?$$##0:wybe.bool) #3
+                int_list.int_list.=<0>(~#left#tail##0:int_list.int_list, ~#right#tail##0:int_list.int_list, ?####0:wybe.bool) #3
 
 
 
@@ -206,110 +206,110 @@ entry:
 
 cons > public {inline} (0 calls)
 0: int_list.int_list.cons<0>
-cons(head##0:wybe.int, tail##0:int_list.int_list, ?$##0:int_list.int_list):
+cons(head##0:wybe.int, tail##0:int_list.int_list, ?###0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:int_list.int_list)
-    foreign lpvm mutate(~$rec##0:int_list.int_list, ?$rec##1:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:int_list.int_list)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:int_list.int_list)
+    foreign lpvm mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:int_list.int_list)
 cons > public {inline} (12 calls)
 1: int_list.int_list.cons<1>
-cons(?head##0:wybe.int, ?tail##0:int_list.int_list, $##0:int_list.int_list, ?$$##0:wybe.bool):
+cons(?head##0:wybe.int, ?tail##0:int_list.int_list, ###0:int_list.int_list, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?head##0:wybe.int)
         foreign llvm move(undef:int_list.int_list, ?tail##0:int_list.int_list)
 
     1:
-        foreign lpvm access($##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
-        foreign lpvm access(~$##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:int_list.int_list)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(###0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
+        foreign lpvm access(~###0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:int_list.int_list)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 head > public {inline} (0 calls)
 0: int_list.int_list.head<0>
-head($rec##0:int_list.int_list, ?$##0:wybe.int, ?$$##0:wybe.bool):
+head(#rec##0:int_list.int_list, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 head > public {inline} (0 calls)
 1: int_list.int_list.head<1>
-head($rec##0:int_list.int_list, ?$rec##1:int_list.int_list, $field##0:wybe.int, ?$$##0:wybe.bool):
+head(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:int_list.int_list, ?$rec##1:int_list.int_list)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list)
 
     1:
-        foreign lpvm mutate(~$rec##0:int_list.int_list, ?$rec##1:int_list.int_list, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 nil > public {inline} (0 calls)
 0: int_list.int_list.nil<0>
-nil(?$##0:int_list.int_list):
+nil(?###0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:int_list.int_list, ?$##0:int_list.int_list)
+    foreign llvm move(0:int_list.int_list, ?###0:int_list.int_list)
 
 
 tail > public {inline} (0 calls)
 0: int_list.int_list.tail<0>
-tail($rec##0:int_list.int_list, ?$##0:int_list.int_list, ?$$##0:wybe.bool):
+tail(#rec##0:int_list.int_list, ?###0:int_list.int_list, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:int_list.int_list, ?$##0:int_list.int_list)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:int_list.int_list, ?###0:int_list.int_list)
 
     1:
-        foreign lpvm access(~$rec##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:int_list.int_list)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:int_list.int_list)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 tail > public {inline} (0 calls)
 1: int_list.int_list.tail<1>
-tail($rec##0:int_list.int_list, ?$rec##1:int_list.int_list, $field##0:int_list.int_list, ?$$##0:wybe.bool):
+tail(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:int_list.int_list, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:int_list.int_list, ?$rec##1:int_list.int_list)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec##0:int_list.int_list, ?$rec##1:int_list.int_list, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:int_list.int_list)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm {noalias} mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:int_list.int_list)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: int_list.int_list.~=<0>
-~=($left##0:int_list.int_list, $right##0:int_list.int_list, ?$$##0:wybe.bool):
+~=(#left##0:int_list.int_list, #right##0:int_list.int_list, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    int_list.int_list.=<0>(~$left##0:int_list.int_list, ~$right##0:int_list.int_list, ?tmp$0##0:wybe.bool) #0
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    int_list.int_list.=<0>(~#left##0:int_list.int_list, ~#right##0:int_list.int_list, ?tmp#0##0:wybe.bool) #0
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
   LLVM code       :
 
@@ -325,38 +325,38 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"int_list.int_list.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"int_list.int_list.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#left##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %"2$tmp$9##0" = icmp ne i64 %"$right##0", 0 
-  br i1 %"2$tmp$9##0", label %if.then1, label %if.else1 
+  %"2#tmp#9##0" = icmp ne i64 %"#right##0", 0 
+  br i1 %"2#tmp#9##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3#####0" 
 if.then1:
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"4$tmp$4##0" = icmp eq i64 %3, %10 
-  br i1 %"4$tmp$4##0", label %if.then2, label %if.else2 
+  %"4#tmp#4##0" = icmp eq i64 %3, %10 
+  br i1 %"4#tmp#4##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$$$##0" = tail call fastcc  i1  @"int_list.int_list.=<0>"(i64  %7, i64  %14)  
-  ret i1 %"6$$$##0" 
+  %"6#####0" = tail call fastcc  i1  @"int_list.int_list.=<0>"(i64  %7, i64  %14)  
+  ret i1 %"6#####0" 
 if.else2:
   ret i1 0 
 }
@@ -378,15 +378,15 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"int_list.int_list.cons<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64, i1} @"int_list.int_list.cons<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -402,12 +402,12 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"int_list.int_list.head<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"int_list.int_list.head<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %36 = inttoptr i64 %"$rec##0" to i64* 
+  %36 = inttoptr i64 %"#rec##0" to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
   %39 = insertvalue {i64, i1} undef, i64 %38, 0 
@@ -420,26 +420,26 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"int_list.int_list.head<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"int_list.int_list.head<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %43 = trunc i64 16 to i32  
   %44 = tail call ccc  i8*  @wybe_malloc(i32  %43)  
   %45 = ptrtoint i8* %44 to i64 
   %46 = inttoptr i64 %45 to i8* 
-  %47 = inttoptr i64 %"$rec##0" to i8* 
+  %47 = inttoptr i64 %"#rec##0" to i8* 
   %48 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %46, i8*  %47, i32  %48, i32  8, i1  0)  
   %49 = inttoptr i64 %45 to i64* 
   %50 = getelementptr  i64, i64* %49, i64 0 
-  store  i64 %"$field##0", i64* %50 
+  store  i64 %"#field##0", i64* %50 
   %51 = insertvalue {i64, i1} undef, i64 %45, 0 
   %52 = insertvalue {i64, i1} %51, i1 1, 1 
   ret {i64, i1} %52 
 if.else:
-  %53 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %53 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %54 = insertvalue {i64, i1} %53, i1 0, 1 
   ret {i64, i1} %54 
 }
@@ -451,12 +451,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"int_list.int_list.tail<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"int_list.int_list.tail<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %55 = add   i64 %"$rec##0", 8 
+  %55 = add   i64 %"#rec##0", 8 
   %56 = inttoptr i64 %55 to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
@@ -470,35 +470,35 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"int_list.int_list.tail<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"int_list.int_list.tail<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %63 = trunc i64 16 to i32  
   %64 = tail call ccc  i8*  @wybe_malloc(i32  %63)  
   %65 = ptrtoint i8* %64 to i64 
   %66 = inttoptr i64 %65 to i8* 
-  %67 = inttoptr i64 %"$rec##0" to i8* 
+  %67 = inttoptr i64 %"#rec##0" to i8* 
   %68 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %66, i8*  %67, i32  %68, i32  8, i1  0)  
   %69 = add   i64 %65, 8 
   %70 = inttoptr i64 %69 to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
-  store  i64 %"$field##0", i64* %71 
+  store  i64 %"#field##0", i64* %71 
   %72 = insertvalue {i64, i1} undef, i64 %65, 0 
   %73 = insertvalue {i64, i1} %72, i1 1, 1 
   ret {i64, i1} %73 
 if.else:
-  %74 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %74 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %75 = insertvalue {i64, i1} %74, i1 0, 1 
   ret {i64, i1} %75 
 }
 
 
-define external fastcc  i1 @"int_list.int_list.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"int_list.int_list.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = tail call fastcc  i1  @"int_list.int_list.=<0>"(i64  %"$left##0", i64  %"$right##0")  
-  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
-  ret i1 %"1$$$##0" 
+  %"1#tmp#0##0" = tail call fastcc  i1  @"int_list.int_list.=<0>"(i64  %"#left##0", i64  %"#right##0")  
+  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1#####0" 
 }

--- a/test-cases/final-dump/int_list.exp
+++ b/test-cases/final-dump/int_list.exp
@@ -173,13 +173,13 @@ entry:
 
 = > public (2 calls)
 0: int_list.int_list.=<0>
-=(#left##0:int_list.int_list, #right##0:int_list.int_list, ?####0:wybe.bool):
+=(#left##0:int_list.int_list, #right##0:int_list.int_list, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~#left##0:int_list.int_list, ~#right##0:int_list.int_list, ?####0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:int_list.int_list, ~#right##0:int_list.int_list, ?#success##0:wybe.bool)
 
     1:
         foreign lpvm access(#left##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#head##0:wybe.int)
@@ -187,7 +187,7 @@ entry:
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
         case ~tmp#9##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign lpvm access(#right##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#head##0:wybe.int)
@@ -195,10 +195,10 @@ entry:
             foreign llvm icmp_eq(~#left#head##0:wybe.int, ~#right#head##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
             case ~tmp#4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
-                int_list.int_list.=<0>(~#left#tail##0:int_list.int_list, ~#right#tail##0:int_list.int_list, ?####0:wybe.bool) #3
+                int_list.int_list.=<0>(~#left#tail##0:int_list.int_list, ~#right#tail##0:int_list.int_list, ?#success##0:wybe.bool) #3
 
 
 
@@ -214,52 +214,52 @@ cons(head##0:wybe.int, tail##0:int_list.int_list, ?#result##0:int_list.int_list)
     foreign lpvm mutate(~#rec##1:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:int_list.int_list)
 cons > public {inline} (12 calls)
 1: int_list.int_list.cons<1>
-cons(?head##0:wybe.int, ?tail##0:int_list.int_list, #result##0:int_list.int_list, ?####0:wybe.bool):
+cons(?head##0:wybe.int, ?tail##0:int_list.int_list, #result##0:int_list.int_list, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?head##0:wybe.int)
         foreign llvm move(undef:int_list.int_list, ?tail##0:int_list.int_list)
 
     1:
         foreign lpvm access(#result##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
         foreign lpvm access(~#result##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:int_list.int_list)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 head > public {inline} (0 calls)
 0: int_list.int_list.head<0>
-head(#rec##0:int_list.int_list, ?#result##0:wybe.int, ?####0:wybe.bool):
+head(#rec##0:int_list.int_list, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign lpvm access(~#rec##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 head > public {inline} (0 calls)
 1: int_list.int_list.head<1>
-head(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:wybe.int, ?####0:wybe.bool):
+head(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list)
 
     1:
         foreign lpvm mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -273,43 +273,43 @@ nil(?#result##0:int_list.int_list):
 
 tail > public {inline} (0 calls)
 0: int_list.int_list.tail<0>
-tail(#rec##0:int_list.int_list, ?#result##0:int_list.int_list, ?####0:wybe.bool):
+tail(#rec##0:int_list.int_list, ?#result##0:int_list.int_list, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:int_list.int_list, ?#result##0:int_list.int_list)
 
     1:
         foreign lpvm access(~#rec##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:int_list.int_list)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 tail > public {inline} (0 calls)
 1: int_list.int_list.tail<1>
-tail(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:int_list.int_list, ?####0:wybe.bool):
+tail(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:int_list.int_list, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list)
 
     1:
         foreign lpvm {noalias} mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:int_list.int_list)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: int_list.int_list.~=<0>
-~=(#left##0:int_list.int_list, #right##0:int_list.int_list, ?####0:wybe.bool):
+~=(#left##0:int_list.int_list, #right##0:int_list.int_list, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     int_list.int_list.=<0>(~#left##0:int_list.int_list, ~#right##0:int_list.int_list, ?tmp#0##0:wybe.bool) #0
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 
@@ -340,8 +340,8 @@ if.then:
   %"2#tmp#9##0" = icmp ne i64 %"#right##0", 0 
   br i1 %"2#tmp#9##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %"3#####0" 
+  %"3##success##0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3##success##0" 
 if.then1:
   %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
@@ -355,8 +355,8 @@ if.then1:
 if.else1:
   ret i1 0 
 if.then2:
-  %"6#####0" = tail call fastcc  i1  @"int_list.int_list.=<0>"(i64  %7, i64  %14)  
-  ret i1 %"6#####0" 
+  %"6##success##0" = tail call fastcc  i1  @"int_list.int_list.=<0>"(i64  %7, i64  %14)  
+  ret i1 %"6##success##0" 
 if.else2:
   ret i1 0 
 }
@@ -499,6 +499,6 @@ if.else:
 define external fastcc  i1 @"int_list.int_list.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %"1#tmp#0##0" = tail call fastcc  i1  @"int_list.int_list.=<0>"(i64  %"#left##0", i64  %"#right##0")  
-  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
-  ret i1 %"1#####0" 
+  %"1##success##0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1##success##0" 
 }

--- a/test-cases/final-dump/int_list.exp
+++ b/test-cases/final-dump/int_list.exp
@@ -206,18 +206,18 @@ entry:
 
 cons > public {inline} (0 calls)
 0: int_list.int_list.cons<0>
-cons(head##0:wybe.int, tail##0:int_list.int_list, ?###0:int_list.int_list):
+cons(head##0:wybe.int, tail##0:int_list.int_list, ?#result##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:int_list.int_list)
     foreign lpvm mutate(~#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:int_list.int_list, ?###0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:int_list.int_list)
+    foreign lpvm mutate(~#rec##1:int_list.int_list, ?#result##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:int_list.int_list)
 cons > public {inline} (12 calls)
 1: int_list.int_list.cons<1>
-cons(?head##0:wybe.int, ?tail##0:int_list.int_list, ###0:int_list.int_list, ?####0:wybe.bool):
+cons(?head##0:wybe.int, ?tail##0:int_list.int_list, #result##0:int_list.int_list, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
@@ -225,25 +225,25 @@ cons(?head##0:wybe.int, ?tail##0:int_list.int_list, ###0:int_list.int_list, ?###
         foreign llvm move(undef:int_list.int_list, ?tail##0:int_list.int_list)
 
     1:
-        foreign lpvm access(###0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
-        foreign lpvm access(~###0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:int_list.int_list)
+        foreign lpvm access(#result##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
+        foreign lpvm access(~#result##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:int_list.int_list)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 head > public {inline} (0 calls)
 0: int_list.int_list.head<0>
-head(#rec##0:int_list.int_list, ?###0:wybe.int, ?####0:wybe.bool):
+head(#rec##0:int_list.int_list, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign lpvm access(~#rec##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 head > public {inline} (0 calls)
@@ -265,25 +265,25 @@ head(#rec##0:int_list.int_list, ?#rec##1:int_list.int_list, #field##0:wybe.int, 
 
 nil > public {inline} (0 calls)
 0: int_list.int_list.nil<0>
-nil(?###0:int_list.int_list):
+nil(?#result##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:int_list.int_list, ?###0:int_list.int_list)
+    foreign llvm move(0:int_list.int_list, ?#result##0:int_list.int_list)
 
 
 tail > public {inline} (0 calls)
 0: int_list.int_list.tail<0>
-tail(#rec##0:int_list.int_list, ?###0:int_list.int_list, ?####0:wybe.bool):
+tail(#rec##0:int_list.int_list, ?#result##0:int_list.int_list, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:int_list.int_list, ?###0:int_list.int_list)
+        foreign llvm move(undef:int_list.int_list, ?#result##0:int_list.int_list)
 
     1:
-        foreign lpvm access(~#rec##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:int_list.int_list)
+        foreign lpvm access(~#rec##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:int_list.int_list)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 tail > public {inline} (0 calls)
@@ -378,15 +378,15 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"int_list.int_list.cons<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64, i1} @"int_list.int_list.cons<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  %"1#tmp#0##0" = icmp ne i64 %"#result##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 

--- a/test-cases/final-dump/int_list.exp
+++ b/test-cases/final-dump/int_list.exp
@@ -24,48 +24,48 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: int_list.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$6#0:int_list.int_list)
-    foreign lpvm mutate(~tmp$6#0:int_list.int_list, ?tmp$7#0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-    foreign lpvm mutate(~tmp$7#0:int_list.int_list, ?tmp$8#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:int_list.int_list)
-    foreign lpvm alloc(16:wybe.int, ?tmp$11#0:int_list.int_list)
-    foreign lpvm mutate(~tmp$11#0:int_list.int_list, ?tmp$12#0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm mutate(~tmp$12#0:int_list.int_list, ?tmp$13#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$8#0:int_list.int_list)
-    foreign lpvm alloc(16:wybe.int, ?tmp$16#0:int_list.int_list)
-    foreign lpvm mutate(~tmp$16#0:int_list.int_list, ?tmp$17#0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp$17#0:int_list.int_list, ?tmp$18#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$13#0:int_list.int_list)
-    int_list.print<0>(~tmp$18#0:int_list.int_list, ~#io#0:wybe.phantom, ?tmp$21#0:wybe.phantom) #5 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$21#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$6##0:int_list.int_list)
+    foreign lpvm mutate(~tmp$6##0:int_list.int_list, ?tmp$7##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+    foreign lpvm mutate(~tmp$7##0:int_list.int_list, ?tmp$8##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:int_list.int_list)
+    foreign lpvm alloc(16:wybe.int, ?tmp$11##0:int_list.int_list)
+    foreign lpvm mutate(~tmp$11##0:int_list.int_list, ?tmp$12##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+    foreign lpvm mutate(~tmp$12##0:int_list.int_list, ?tmp$13##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$8##0:int_list.int_list)
+    foreign lpvm alloc(16:wybe.int, ?tmp$16##0:int_list.int_list)
+    foreign lpvm mutate(~tmp$16##0:int_list.int_list, ?tmp$17##0:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp$17##0:int_list.int_list, ?tmp$18##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$13##0:int_list.int_list)
+    int_list.print<0>(~tmp$18##0:int_list.int_list, ~#io##0:wybe.phantom, ?tmp$21##0:wybe.phantom) #5 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$21##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 print > public (2 calls)
 0: int_list.print<0>
-print(x#0:int_list.int_list, io#0:wybe.phantom, ?io#3:wybe.phantom):
+print(x##0:int_list.int_list, io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(x#0:wybe.int, 0:wybe.int, ?tmp$2#0:wybe.bool)
-    case ~tmp$2#0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.bool)
+    case ~tmp$2##0:wybe.bool of
     0:
-        foreign llvm move(~io#0:wybe.phantom, ?io#3:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##3:wybe.phantom)
 
     1:
-        foreign lpvm access(x#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:wybe.int)
-        foreign lpvm access(~x#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:int_list.int_list)
-        foreign c print_int(~h#0:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        foreign c putchar(' ':wybe.char, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-        int_list.print<0>(~t#0:int_list.int_list, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) #3 @int_list:nn:nn
+        foreign lpvm access(x##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+        foreign lpvm access(~x##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:int_list.int_list)
+        foreign c print_int(~h##0:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        foreign c putchar(' ':wybe.char, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+        int_list.print<0>(~t##0:int_list.int_list, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @int_list:nn:nn
 
 
 
 println > public {inline} (1 calls)
 0: int_list.println<0>
-println(x#0:int_list.int_list, io#0:wybe.phantom, ?io#2:wybe.phantom):
+println(x##0:int_list.int_list, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    int_list.print<0>(~x#0:int_list.int_list, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @int_list:nn:nn
-    foreign c putchar('\n':wybe.char, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
+    int_list.print<0>(~x##0:int_list.int_list, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @int_list:nn:nn
+    foreign c putchar('\n':wybe.char, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -125,15 +125,15 @@ entry:
 }
 
 
-define external fastcc  void @"int_list.print<0>"(i64  %"x#0")    {
+define external fastcc  void @"int_list.print<0>"(i64  %"x##0")    {
 entry:
-  %"1$tmp$2#0" = icmp ne i64 %"x#0", 0 
-  br i1 %"1$tmp$2#0", label %if.then, label %if.else 
+  %"1$tmp$2##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1$tmp$2##0", label %if.then, label %if.else 
 if.then:
-  %25 = inttoptr i64 %"x#0" to i64* 
+  %25 = inttoptr i64 %"x##0" to i64* 
   %26 = getelementptr  i64, i64* %25, i64 0 
   %27 = load  i64, i64* %26 
-  %28 = add   i64 %"x#0", 8 
+  %28 = add   i64 %"x##0", 8 
   %29 = inttoptr i64 %28 to i64* 
   %30 = getelementptr  i64, i64* %29, i64 0 
   %31 = load  i64, i64* %30 
@@ -146,9 +146,9 @@ if.else:
 }
 
 
-define external fastcc  void @"int_list.println<0>"(i64  %"x#0")    {
+define external fastcc  void @"int_list.println<0>"(i64  %"x##0")    {
 entry:
-  tail call fastcc  void  @"int_list.print<0>"(i64  %"x#0")  
+  tail call fastcc  void  @"int_list.print<0>"(i64  %"x##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -173,32 +173,32 @@ entry:
 
 = > public (2 calls)
 0: int_list.int_list.=<0>
-=($left#0:int_list.int_list, $right#0:int_list.int_list, ?$$#0:wybe.bool):
+=($left##0:int_list.int_list, $right##0:int_list.int_list, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left#0:int_list.int_list, ~$right#0:int_list.int_list, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~$left##0:int_list.int_list, ~$right##0:int_list.int_list, ?$$##0:wybe.bool)
 
     1:
-        foreign lpvm access($left#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$head#0:wybe.int)
-        foreign lpvm access(~$left#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$tail#0:int_list.int_list)
-        foreign llvm icmp_ne($right#0:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.bool)
-        case ~tmp$9#0:wybe.bool of
+        foreign lpvm access($left##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$head##0:wybe.int)
+        foreign lpvm access(~$left##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$tail##0:int_list.int_list)
+        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
+        case ~tmp$9##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign lpvm access($right#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$head#0:wybe.int)
-            foreign lpvm access(~$right#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$tail#0:int_list.int_list)
-            foreign llvm icmp_eq(~$left$head#0:wybe.int, ~$right$head#0:wybe.int, ?tmp$4#0:wybe.bool) @int:nn:nn
-            case ~tmp$4#0:wybe.bool of
+            foreign lpvm access($right##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$head##0:wybe.int)
+            foreign lpvm access(~$right##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$tail##0:int_list.int_list)
+            foreign llvm icmp_eq(~$left$head##0:wybe.int, ~$right$head##0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
+            case ~tmp$4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                int_list.int_list.=<0>(~$left$tail#0:int_list.int_list, ~$right$tail#0:int_list.int_list, ?$$#0:wybe.bool) #3
+                int_list.int_list.=<0>(~$left$tail##0:int_list.int_list, ~$right$tail##0:int_list.int_list, ?$$##0:wybe.bool) #3
 
 
 
@@ -206,110 +206,110 @@ entry:
 
 cons > public {inline} (0 calls)
 0: int_list.int_list.cons<0>
-cons(head#0:wybe.int, tail#0:int_list.int_list, ?$#0:int_list.int_list):
+cons(head##0:wybe.int, tail##0:int_list.int_list, ?$##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:int_list.int_list)
-    foreign lpvm mutate(~$rec#0:int_list.int_list, ?$rec#1:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:int_list.int_list, ?$#0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail#0:int_list.int_list)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:int_list.int_list)
+    foreign lpvm mutate(~$rec##0:int_list.int_list, ?$rec##1:int_list.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:int_list.int_list, ?$##0:int_list.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:int_list.int_list)
 cons > public {inline} (12 calls)
 1: int_list.int_list.cons<1>
-cons(?head#0:wybe.int, ?tail#0:int_list.int_list, $#0:int_list.int_list, ?$$#0:wybe.bool):
+cons(?head##0:wybe.int, ?tail##0:int_list.int_list, $##0:int_list.int_list, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?head#0:wybe.int)
-        foreign llvm move(undef:int_list.int_list, ?tail#0:int_list.int_list)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?head##0:wybe.int)
+        foreign llvm move(undef:int_list.int_list, ?tail##0:int_list.int_list)
 
     1:
-        foreign lpvm access($#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head#0:wybe.int)
-        foreign lpvm access(~$#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail#0:int_list.int_list)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access($##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
+        foreign lpvm access(~$##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:int_list.int_list)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 head > public {inline} (0 calls)
 0: int_list.int_list.head<0>
-head($rec#0:int_list.int_list, ?$#0:wybe.int, ?$$#0:wybe.bool):
+head($rec##0:int_list.int_list, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec#0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:int_list.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 head > public {inline} (0 calls)
 1: int_list.int_list.head<1>
-head($rec#0:int_list.int_list, ?$rec#1:int_list.int_list, $field#0:wybe.int, ?$$#0:wybe.bool):
+head($rec##0:int_list.int_list, ?$rec##1:int_list.int_list, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:int_list.int_list, ?$rec#1:int_list.int_list)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:int_list.int_list, ?$rec##1:int_list.int_list)
 
     1:
-        foreign lpvm mutate(~$rec#0:int_list.int_list, ?$rec#1:int_list.int_list, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~$rec##0:int_list.int_list, ?$rec##1:int_list.int_list, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 nil > public {inline} (0 calls)
 0: int_list.int_list.nil<0>
-nil(?$#0:int_list.int_list):
+nil(?$##0:int_list.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:int_list.int_list, ?$#0:int_list.int_list)
+    foreign llvm move(0:int_list.int_list, ?$##0:int_list.int_list)
 
 
 tail > public {inline} (0 calls)
 0: int_list.int_list.tail<0>
-tail($rec#0:int_list.int_list, ?$#0:int_list.int_list, ?$$#0:wybe.bool):
+tail($rec##0:int_list.int_list, ?$##0:int_list.int_list, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:int_list.int_list, ?$#0:int_list.int_list)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:int_list.int_list, ?$##0:int_list.int_list)
 
     1:
-        foreign lpvm access(~$rec#0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:int_list.int_list)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:int_list.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:int_list.int_list)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 tail > public {inline} (0 calls)
 1: int_list.int_list.tail<1>
-tail($rec#0:int_list.int_list, ?$rec#1:int_list.int_list, $field#0:int_list.int_list, ?$$#0:wybe.bool):
+tail($rec##0:int_list.int_list, ?$rec##1:int_list.int_list, $field##0:int_list.int_list, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:int_list.int_list, ?$rec#1:int_list.int_list)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:int_list.int_list, ?$rec##1:int_list.int_list)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec#0:int_list.int_list, ?$rec#1:int_list.int_list, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:int_list.int_list)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm {noalias} mutate(~$rec##0:int_list.int_list, ?$rec##1:int_list.int_list, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:int_list.int_list)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: int_list.int_list.~=<0>
-~=($left#0:int_list.int_list, $right#0:int_list.int_list, ?$$#0:wybe.bool):
+~=($left##0:int_list.int_list, $right##0:int_list.int_list, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    int_list.int_list.=<0>(~$left#0:int_list.int_list, ~$right#0:int_list.int_list, ?tmp$0#0:wybe.bool) #0
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    int_list.int_list.=<0>(~$left##0:int_list.int_list, ~$right##0:int_list.int_list, ?tmp$0##0:wybe.bool) #0
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
   LLVM code       :
 
@@ -325,68 +325,68 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"int_list.int_list.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"int_list.int_list.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$left#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %"2$tmp$9#0" = icmp ne i64 %"$right#0", 0 
-  br i1 %"2$tmp$9#0", label %if.then1, label %if.else1 
+  %"2$tmp$9##0" = icmp ne i64 %"$right##0", 0 
+  br i1 %"2$tmp$9##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = icmp eq i64 %"$left#0", %"$right#0" 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
+  ret i1 %"3$$$##0" 
 if.then1:
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"4$tmp$4#0" = icmp eq i64 %3, %10 
-  br i1 %"4$tmp$4#0", label %if.then2, label %if.else2 
+  %"4$tmp$4##0" = icmp eq i64 %3, %10 
+  br i1 %"4$tmp$4##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$$$#0" = tail call fastcc  i1  @"int_list.int_list.=<0>"(i64  %7, i64  %14)  
-  ret i1 %"6$$$#0" 
+  %"6$$$##0" = tail call fastcc  i1  @"int_list.int_list.=<0>"(i64  %7, i64  %14)  
+  ret i1 %"6$$$##0" 
 if.else2:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"int_list.int_list.cons<0>"(i64  %"head#0", i64  %"tail#0")    {
+define external fastcc  i64 @"int_list.int_list.cons<0>"(i64  %"head##0", i64  %"tail##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"head#0", i64* %19 
+  store  i64 %"head##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"tail#0", i64* %22 
+  store  i64 %"tail##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64, i1} @"int_list.int_list.cons<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64, i1} @"int_list.int_list.cons<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -402,12 +402,12 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"int_list.int_list.head<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"int_list.int_list.head<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %36 = inttoptr i64 %"$rec#0" to i64* 
+  %36 = inttoptr i64 %"$rec##0" to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
   %39 = insertvalue {i64, i1} undef, i64 %38, 0 
@@ -420,26 +420,26 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"int_list.int_list.head<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"int_list.int_list.head<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %43 = trunc i64 16 to i32  
   %44 = tail call ccc  i8*  @wybe_malloc(i32  %43)  
   %45 = ptrtoint i8* %44 to i64 
   %46 = inttoptr i64 %45 to i8* 
-  %47 = inttoptr i64 %"$rec#0" to i8* 
+  %47 = inttoptr i64 %"$rec##0" to i8* 
   %48 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %46, i8*  %47, i32  %48, i32  8, i1  0)  
   %49 = inttoptr i64 %45 to i64* 
   %50 = getelementptr  i64, i64* %49, i64 0 
-  store  i64 %"$field#0", i64* %50 
+  store  i64 %"$field##0", i64* %50 
   %51 = insertvalue {i64, i1} undef, i64 %45, 0 
   %52 = insertvalue {i64, i1} %51, i1 1, 1 
   ret {i64, i1} %52 
 if.else:
-  %53 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %53 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %54 = insertvalue {i64, i1} %53, i1 0, 1 
   ret {i64, i1} %54 
 }
@@ -451,12 +451,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"int_list.int_list.tail<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"int_list.int_list.tail<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %55 = add   i64 %"$rec#0", 8 
+  %55 = add   i64 %"$rec##0", 8 
   %56 = inttoptr i64 %55 to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
@@ -470,35 +470,35 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"int_list.int_list.tail<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"int_list.int_list.tail<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %63 = trunc i64 16 to i32  
   %64 = tail call ccc  i8*  @wybe_malloc(i32  %63)  
   %65 = ptrtoint i8* %64 to i64 
   %66 = inttoptr i64 %65 to i8* 
-  %67 = inttoptr i64 %"$rec#0" to i8* 
+  %67 = inttoptr i64 %"$rec##0" to i8* 
   %68 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %66, i8*  %67, i32  %68, i32  8, i1  0)  
   %69 = add   i64 %65, 8 
   %70 = inttoptr i64 %69 to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
-  store  i64 %"$field#0", i64* %71 
+  store  i64 %"$field##0", i64* %71 
   %72 = insertvalue {i64, i1} undef, i64 %65, 0 
   %73 = insertvalue {i64, i1} %72, i1 1, 1 
   ret {i64, i1} %73 
 if.else:
-  %74 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %74 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %75 = insertvalue {i64, i1} %74, i1 0, 1 
   ret {i64, i1} %75 
 }
 
 
-define external fastcc  i1 @"int_list.int_list.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"int_list.int_list.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = tail call fastcc  i1  @"int_list.int_list.=<0>"(i64  %"$left#0", i64  %"$right#0")  
-  %"1$$$#0" = xor i1 %"1$tmp$0#0", 1 
-  ret i1 %"1$$$#0" 
+  %"1$tmp$0##0" = tail call fastcc  i1  @"int_list.int_list.=<0>"(i64  %"$left##0", i64  %"$right##0")  
+  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
+  ret i1 %"1$$$##0" 
 }

--- a/test-cases/final-dump/int_sequence.exp
+++ b/test-cases/final-dump/int_sequence.exp
@@ -31,19 +31,19 @@ AFTER EVERYTHING:
 
 .. > public {inline} (2 calls)
 0: int_sequence...<0>
-..(lower##0:wybe.int, upper##0:wybe.int, ?###0:int_sequence):
+..(lower##0:wybe.int, upper##0:wybe.int, ?#result##0:int_sequence):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:int_sequence)
     foreign lpvm mutate(~#rec##0:int_sequence, ?#rec##1:int_sequence, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lower##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:int_sequence, ?###0:int_sequence, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~upper##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:int_sequence, ?#result##0:int_sequence, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~upper##0:wybe.int)
 .. > public {inline} (6 calls)
 1: int_sequence...<1>
-..(?lower##0:wybe.int, ?upper##0:wybe.int, ###0:int_sequence):
+..(?lower##0:wybe.int, ?upper##0:wybe.int, #result##0:int_sequence):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?lower##0:wybe.int)
-    foreign lpvm access(~###0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?upper##0:wybe.int)
+    foreign lpvm access(#result##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?lower##0:wybe.int)
+    foreign lpvm access(~#result##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?upper##0:wybe.int)
 
 
 = > public {inline} (1 calls)
@@ -137,10 +137,10 @@ gen#1(io##0:wybe.phantom, tmp#0##0:int_sequence, tmp#3##0:int_sequence, ?io##2:w
 
 lower > public {inline} (5 calls)
 0: int_sequence.lower<0>
-lower(#rec##0:int_sequence, ?###0:wybe.int):
+lower(#rec##0:int_sequence, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 lower > public {inline} (0 calls)
 1: int_sequence.lower<1>
 lower(#rec##0:int_sequence, ?#rec##1:int_sequence, #field##0:wybe.int):
@@ -151,10 +151,10 @@ lower(#rec##0:int_sequence, ?#rec##1:int_sequence, #field##0:wybe.int):
 
 upper > public {inline} (4 calls)
 0: int_sequence.upper<0>
-upper(#rec##0:int_sequence, ?###0:wybe.int):
+upper(#rec##0:int_sequence, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 upper > public {inline} (0 calls)
 1: int_sequence.upper<1>
 upper(#rec##0:int_sequence, ?#rec##1:int_sequence, #field##0:wybe.int):
@@ -236,12 +236,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"int_sequence...<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"int_sequence...<1>"(i64  %"#result##0")    {
 entry:
-  %17 = inttoptr i64 %"###0" to i64* 
+  %17 = inttoptr i64 %"#result##0" to i64* 
   %18 = getelementptr  i64, i64* %17, i64 0 
   %19 = load  i64, i64* %18 
-  %20 = add   i64 %"###0", 8 
+  %20 = add   i64 %"#result##0", 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
   %23 = load  i64, i64* %22 

--- a/test-cases/final-dump/int_sequence.exp
+++ b/test-cases/final-dump/int_sequence.exp
@@ -20,167 +20,167 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: int_sequence.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$6#0:int_sequence)
-    foreign lpvm mutate(~tmp$6#0:int_sequence, ?tmp$7#0:int_sequence, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp$7#0:int_sequence, ?tmp$3#0:int_sequence, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    int_sequence.gen$1<0>(~io#0:wybe.phantom, ~tmp$3#0:int_sequence, ~tmp$3#0:int_sequence, ?io#1:wybe.phantom) #1 @int_sequence:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$6##0:int_sequence)
+    foreign lpvm mutate(~tmp$6##0:int_sequence, ?tmp$7##0:int_sequence, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp$7##0:int_sequence, ?tmp$3##0:int_sequence, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    int_sequence.gen$1<0>(~io##0:wybe.phantom, ~tmp$3##0:int_sequence, ~tmp$3##0:int_sequence, ?io##1:wybe.phantom) #1 @int_sequence:nn:nn
 
 
 .. > public {inline} (2 calls)
 0: int_sequence...<0>
-..(lower#0:wybe.int, upper#0:wybe.int, ?$#0:int_sequence):
+..(lower##0:wybe.int, upper##0:wybe.int, ?$##0:int_sequence):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:int_sequence)
-    foreign lpvm mutate(~$rec#0:int_sequence, ?$rec#1:int_sequence, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lower#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:int_sequence, ?$#0:int_sequence, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~upper#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:int_sequence)
+    foreign lpvm mutate(~$rec##0:int_sequence, ?$rec##1:int_sequence, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lower##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:int_sequence, ?$##0:int_sequence, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~upper##0:wybe.int)
 .. > public {inline} (6 calls)
 1: int_sequence...<1>
-..(?lower#0:wybe.int, ?upper#0:wybe.int, $#0:int_sequence):
+..(?lower##0:wybe.int, ?upper##0:wybe.int, $##0:int_sequence):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?lower#0:wybe.int)
-    foreign lpvm access(~$#0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?upper#0:wybe.int)
+    foreign lpvm access($##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?lower##0:wybe.int)
+    foreign lpvm access(~$##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?upper##0:wybe.int)
 
 
 = > public {inline} (1 calls)
 0: int_sequence.=<0>
-=($left#0:int_sequence, $right#0:int_sequence, ?$$#0:wybe.bool):
+=($left##0:int_sequence, $right##0:int_sequence, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$lower#0:wybe.int)
-    foreign lpvm access(~$left#0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$upper#0:wybe.int)
-    foreign lpvm access($right#0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$lower#0:wybe.int)
-    foreign lpvm access(~$right#0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$upper#0:wybe.int)
-    foreign llvm icmp_eq(~$left$lower#0:wybe.int, ~$right$lower#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$lower##0:wybe.int)
+    foreign lpvm access(~$left##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$upper##0:wybe.int)
+    foreign lpvm access($right##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$lower##0:wybe.int)
+    foreign lpvm access(~$right##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$upper##0:wybe.int)
+    foreign llvm icmp_eq(~$left$lower##0:wybe.int, ~$right$lower##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$upper#0:wybe.int, ~$right$upper#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~$left$upper##0:wybe.int, ~$right$upper##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 [|] > public (3 calls)
 0: int_sequence.[|]<0>[785a827a1b]
-[|](?head#0:wybe.int, ?tail#0:int_sequence, seq#0:int_sequence, ?$$#0:wybe.bool):
+[|](?head##0:wybe.int, ?tail##0:int_sequence, seq##0:int_sequence, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 2]
-    foreign lpvm access(seq#0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign lpvm access(~seq#0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_sle(tmp$0#0:wybe.int, tmp$1#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access(seq##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign lpvm access(~seq##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_sle(tmp$0##0:wybe.int, tmp$1##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?head#0:wybe.int)
-        foreign llvm move(undef:int_sequence, ?tail#0:int_sequence)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?head##0:wybe.int)
+        foreign llvm move(undef:int_sequence, ?tail##0:int_sequence)
 
     1:
-        foreign llvm move(tmp$0#0:wybe.int, ?head#0:wybe.int) @int_sequence:nn:nn
-        foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$4#0:wybe.int) @int:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$19#0:int_sequence)
-        foreign lpvm mutate(~tmp$19#0:int_sequence, ?tmp$20#0:int_sequence, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$4#0:wybe.int)
-        foreign lpvm mutate(~tmp$20#0:int_sequence, ?tail#0:int_sequence, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$1#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(tmp$0##0:wybe.int, ?head##0:wybe.int) @int_sequence:nn:nn
+        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$4##0:wybe.int) @int:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp$19##0:int_sequence)
+        foreign lpvm mutate(~tmp$19##0:int_sequence, ?tmp$20##0:int_sequence, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$4##0:wybe.int)
+        foreign lpvm mutate(~tmp$20##0:int_sequence, ?tail##0:int_sequence, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$1##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
  [785a827a1b] [NonAliasedParam 2] :
-    foreign lpvm access(seq#0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign lpvm access(seq#0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_sle(tmp$0#0:wybe.int, tmp$1#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access(seq##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign lpvm access(seq##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_sle(tmp$0##0:wybe.int, tmp$1##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?head#0:wybe.int)
-        foreign llvm move(undef:int_sequence, ?tail#0:int_sequence)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?head##0:wybe.int)
+        foreign llvm move(undef:int_sequence, ?tail##0:int_sequence)
 
     1:
-        foreign llvm move(tmp$0#0:wybe.int, ?head#0:wybe.int) @int_sequence:nn:nn
-        foreign llvm add(~tmp$0#0:wybe.int, 1:wybe.int, ?tmp$4#0:wybe.int) @int:nn:nn
-        foreign lpvm mutate(~seq#0:int_sequence, ?tmp$20#0:int_sequence, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$4#0:wybe.int)
-        foreign lpvm mutate(~tmp$20#0:int_sequence, ?tail#0:int_sequence, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$1#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(tmp$0##0:wybe.int, ?head##0:wybe.int) @int_sequence:nn:nn
+        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$4##0:wybe.int) @int:nn:nn
+        foreign lpvm mutate(~seq##0:int_sequence, ?tmp$20##0:int_sequence, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$4##0:wybe.int)
+        foreign lpvm mutate(~tmp$20##0:int_sequence, ?tail##0:int_sequence, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$1##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 gen$1 > (2 calls)
 0: int_sequence.gen$1<0>[6dacb8fd25]
-gen$1(io#0:wybe.phantom, tmp$0#0:int_sequence, tmp$3#0:int_sequence, ?io#2:wybe.phantom):
+gen$1(io##0:wybe.phantom, tmp$0##0:int_sequence, tmp$3##0:int_sequence, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 1]
  MultiSpeczDepInfo: [(0,(int_sequence.[|]<0>,fromList [NonAliasedParamCond 2 [1]])),(2,(int_sequence.gen$1<0>,fromList [NonAliasedParamCond 1 []]))]
-    int_sequence.[|]<0>(?i#0:wybe.int, ?tmp$1#0:int_sequence, ~tmp$0#0:int_sequence, ?tmp$2#0:wybe.bool) #0
-    case ~tmp$2#0:wybe.bool of
+    int_sequence.[|]<0>(?i##0:wybe.int, ?tmp$1##0:int_sequence, ~tmp$0##0:int_sequence, ?tmp$2##0:wybe.bool) #0
+    case ~tmp$2##0:wybe.bool of
     0:
-        foreign llvm move(~io#0:wybe.phantom, ?io#2:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign c print_int(~i#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$6#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$6#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        int_sequence.gen$1<0>[6dacb8fd25](~io#1:wybe.phantom, ~tmp$1#0:int_sequence, ~tmp$3#0:int_sequence, ?io#2:wybe.phantom) #2 @int_sequence:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$6##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        int_sequence.gen$1<0>[6dacb8fd25](~io##1:wybe.phantom, ~tmp$1##0:int_sequence, ~tmp$3##0:int_sequence, ?io##2:wybe.phantom) #2 @int_sequence:nn:nn
 
  [6dacb8fd25] [NonAliasedParam 1] :
-    int_sequence.[|]<0>[785a827a1b](?i#0:wybe.int, ?tmp$1#0:int_sequence, ~tmp$0#0:int_sequence, ?tmp$2#0:wybe.bool) #0
-    case ~tmp$2#0:wybe.bool of
+    int_sequence.[|]<0>[785a827a1b](?i##0:wybe.int, ?tmp$1##0:int_sequence, ~tmp$0##0:int_sequence, ?tmp$2##0:wybe.bool) #0
+    case ~tmp$2##0:wybe.bool of
     0:
-        foreign llvm move(~io#0:wybe.phantom, ?io#2:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign c print_int(~i#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$6#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$6#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        int_sequence.gen$1<0>[6dacb8fd25](~io#1:wybe.phantom, ~tmp$1#0:int_sequence, ~tmp$3#0:int_sequence, ?io#2:wybe.phantom) #2 @int_sequence:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$6##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        int_sequence.gen$1<0>[6dacb8fd25](~io##1:wybe.phantom, ~tmp$1##0:int_sequence, ~tmp$3##0:int_sequence, ?io##2:wybe.phantom) #2 @int_sequence:nn:nn
 
 
 
 lower > public {inline} (5 calls)
 0: int_sequence.lower<0>
-lower($rec#0:int_sequence, ?$#0:wybe.int):
+lower($rec##0:int_sequence, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 lower > public {inline} (0 calls)
 1: int_sequence.lower<1>
-lower($rec#0:int_sequence, ?$rec#1:int_sequence, $field#0:wybe.int):
+lower($rec##0:int_sequence, ?$rec##1:int_sequence, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:int_sequence, ?$rec#1:int_sequence, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:int_sequence, ?$rec##1:int_sequence, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 upper > public {inline} (4 calls)
 0: int_sequence.upper<0>
-upper($rec#0:int_sequence, ?$#0:wybe.int):
+upper($rec##0:int_sequence, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 upper > public {inline} (0 calls)
 1: int_sequence.upper<1>
-upper($rec#0:int_sequence, ?$rec#1:int_sequence, $field#0:wybe.int):
+upper($rec##0:int_sequence, ?$rec##1:int_sequence, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:int_sequence, ?$rec#1:int_sequence, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:int_sequence, ?$rec##1:int_sequence, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: int_sequence.~=<0>
-~=($left#0:int_sequence, $right#0:int_sequence, ?$$#0:wybe.bool):
+~=($left##0:int_sequence, $right##0:int_sequence, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -220,28 +220,28 @@ entry:
 }
 
 
-define external fastcc  i64 @"int_sequence...<0>"(i64  %"lower#0", i64  %"upper#0")    {
+define external fastcc  i64 @"int_sequence...<0>"(i64  %"lower##0", i64  %"upper##0")    {
 entry:
   %9 = trunc i64 16 to i32  
   %10 = tail call ccc  i8*  @wybe_malloc(i32  %9)  
   %11 = ptrtoint i8* %10 to i64 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 %"lower#0", i64* %13 
+  store  i64 %"lower##0", i64* %13 
   %14 = add   i64 %11, 8 
   %15 = inttoptr i64 %14 to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
-  store  i64 %"upper#0", i64* %16 
+  store  i64 %"upper##0", i64* %16 
   ret i64 %11 
 }
 
 
-define external fastcc  {i64, i64} @"int_sequence...<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"int_sequence...<1>"(i64  %"$##0")    {
 entry:
-  %17 = inttoptr i64 %"$#0" to i64* 
+  %17 = inttoptr i64 %"$##0" to i64* 
   %18 = getelementptr  i64, i64* %17, i64 0 
   %19 = load  i64, i64* %18 
-  %20 = add   i64 %"$#0", 8 
+  %20 = add   i64 %"$##0", 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
   %23 = load  i64, i64* %22 
@@ -251,51 +251,51 @@ entry:
 }
 
 
-define external fastcc  i1 @"int_sequence.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"int_sequence.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %26 = inttoptr i64 %"$left#0" to i64* 
+  %26 = inttoptr i64 %"$left##0" to i64* 
   %27 = getelementptr  i64, i64* %26, i64 0 
   %28 = load  i64, i64* %27 
-  %29 = add   i64 %"$left#0", 8 
+  %29 = add   i64 %"$left##0", 8 
   %30 = inttoptr i64 %29 to i64* 
   %31 = getelementptr  i64, i64* %30, i64 0 
   %32 = load  i64, i64* %31 
-  %33 = inttoptr i64 %"$right#0" to i64* 
+  %33 = inttoptr i64 %"$right##0" to i64* 
   %34 = getelementptr  i64, i64* %33, i64 0 
   %35 = load  i64, i64* %34 
-  %36 = add   i64 %"$right#0", 8 
+  %36 = add   i64 %"$right##0", 8 
   %37 = inttoptr i64 %36 to i64* 
   %38 = getelementptr  i64, i64* %37, i64 0 
   %39 = load  i64, i64* %38 
-  %"1$tmp$1#0" = icmp eq i64 %28, %35 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %28, %35 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$#0" = icmp eq i64 %32, %39 
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = icmp eq i64 %32, %39 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  {i64, i64, i1} @"int_sequence.[|]<0>"(i64  %"seq#0")    {
+define external fastcc  {i64, i64, i1} @"int_sequence.[|]<0>"(i64  %"seq##0")    {
 entry:
-  %40 = inttoptr i64 %"seq#0" to i64* 
+  %40 = inttoptr i64 %"seq##0" to i64* 
   %41 = getelementptr  i64, i64* %40, i64 0 
   %42 = load  i64, i64* %41 
-  %43 = add   i64 %"seq#0", 8 
+  %43 = add   i64 %"seq##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
-  %"1$tmp$7#0" = icmp sle i64 %42, %46 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp sle i64 %42, %46 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$4#0" = add   i64 %42, 1 
+  %"2$tmp$4##0" = add   i64 %42, 1 
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i64* 
   %51 = getelementptr  i64, i64* %50, i64 0 
-  store  i64 %"2$tmp$4#0", i64* %51 
+  store  i64 %"2$tmp$4##0", i64* %51 
   %52 = add   i64 %49, 8 
   %53 = inttoptr i64 %52 to i64* 
   %54 = getelementptr  i64, i64* %53, i64 0 
@@ -312,28 +312,28 @@ if.else:
 }
 
 
-define external fastcc  {i64, i64, i1} @"int_sequence.[|]<0>[785a827a1b]"(i64  %"seq#0")    {
+define external fastcc  {i64, i64, i1} @"int_sequence.[|]<0>[785a827a1b]"(i64  %"seq##0")    {
 entry:
-  %61 = inttoptr i64 %"seq#0" to i64* 
+  %61 = inttoptr i64 %"seq##0" to i64* 
   %62 = getelementptr  i64, i64* %61, i64 0 
   %63 = load  i64, i64* %62 
-  %64 = add   i64 %"seq#0", 8 
+  %64 = add   i64 %"seq##0", 8 
   %65 = inttoptr i64 %64 to i64* 
   %66 = getelementptr  i64, i64* %65, i64 0 
   %67 = load  i64, i64* %66 
-  %"1$tmp$7#0" = icmp sle i64 %63, %67 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp sle i64 %63, %67 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$4#0" = add   i64 %63, 1 
-  %68 = inttoptr i64 %"seq#0" to i64* 
+  %"2$tmp$4##0" = add   i64 %63, 1 
+  %68 = inttoptr i64 %"seq##0" to i64* 
   %69 = getelementptr  i64, i64* %68, i64 0 
-  store  i64 %"2$tmp$4#0", i64* %69 
-  %70 = add   i64 %"seq#0", 8 
+  store  i64 %"2$tmp$4##0", i64* %69 
+  %70 = add   i64 %"seq##0", 8 
   %71 = inttoptr i64 %70 to i64* 
   %72 = getelementptr  i64, i64* %71, i64 0 
   store  i64 %67, i64* %72 
   %73 = insertvalue {i64, i64, i1} undef, i64 %63, 0 
-  %74 = insertvalue {i64, i64, i1} %73, i64 %"seq#0", 1 
+  %74 = insertvalue {i64, i64, i1} %73, i64 %"seq##0", 1 
   %75 = insertvalue {i64, i64, i1} %74, i1 1, 2 
   ret {i64, i64, i1} %75 
 if.else:
@@ -344,9 +344,9 @@ if.else:
 }
 
 
-define external fastcc  void @"int_sequence.gen$1<0>"(i64  %"tmp$0#0", i64  %"tmp$3#0")    {
+define external fastcc  void @"int_sequence.gen$1<0>"(i64  %"tmp$0##0", i64  %"tmp$3##0")    {
 entry:
-  %79 = tail call fastcc  {i64, i64, i1}  @"int_sequence.[|]<0>"(i64  %"tmp$0#0")  
+  %79 = tail call fastcc  {i64, i64, i1}  @"int_sequence.[|]<0>"(i64  %"tmp$0##0")  
   %80 = extractvalue {i64, i64, i1} %79, 0 
   %81 = extractvalue {i64, i64, i1} %79, 1 
   %82 = extractvalue {i64, i64, i1} %79, 2 
@@ -354,16 +354,16 @@ entry:
 if.then:
   tail call ccc  void  @print_int(i64  %80)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_sequence.gen$1<0>[6dacb8fd25]"(i64  %81, i64  %"tmp$3#0")  
+  tail call fastcc  void  @"int_sequence.gen$1<0>[6dacb8fd25]"(i64  %81, i64  %"tmp$3##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"int_sequence.gen$1<0>[6dacb8fd25]"(i64  %"tmp$0#0", i64  %"tmp$3#0")    {
+define external fastcc  void @"int_sequence.gen$1<0>[6dacb8fd25]"(i64  %"tmp$0##0", i64  %"tmp$3##0")    {
 entry:
-  %83 = tail call fastcc  {i64, i64, i1}  @"int_sequence.[|]<0>[785a827a1b]"(i64  %"tmp$0#0")  
+  %83 = tail call fastcc  {i64, i64, i1}  @"int_sequence.[|]<0>[785a827a1b]"(i64  %"tmp$0##0")  
   %84 = extractvalue {i64, i64, i1} %83, 0 
   %85 = extractvalue {i64, i64, i1} %83, 1 
   %86 = extractvalue {i64, i64, i1} %83, 2 
@@ -371,41 +371,41 @@ entry:
 if.then:
   tail call ccc  void  @print_int(i64  %84)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_sequence.gen$1<0>[6dacb8fd25]"(i64  %85, i64  %"tmp$3#0")  
+  tail call fastcc  void  @"int_sequence.gen$1<0>[6dacb8fd25]"(i64  %85, i64  %"tmp$3##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  i64 @"int_sequence.lower<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"int_sequence.lower<0>"(i64  %"$rec##0")    {
 entry:
-  %87 = inttoptr i64 %"$rec#0" to i64* 
+  %87 = inttoptr i64 %"$rec##0" to i64* 
   %88 = getelementptr  i64, i64* %87, i64 0 
   %89 = load  i64, i64* %88 
   ret i64 %89 
 }
 
 
-define external fastcc  i64 @"int_sequence.lower<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"int_sequence.lower<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %90 = trunc i64 16 to i32  
   %91 = tail call ccc  i8*  @wybe_malloc(i32  %90)  
   %92 = ptrtoint i8* %91 to i64 
   %93 = inttoptr i64 %92 to i8* 
-  %94 = inttoptr i64 %"$rec#0" to i8* 
+  %94 = inttoptr i64 %"$rec##0" to i8* 
   %95 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %93, i8*  %94, i32  %95, i32  8, i1  0)  
   %96 = inttoptr i64 %92 to i64* 
   %97 = getelementptr  i64, i64* %96, i64 0 
-  store  i64 %"$field#0", i64* %97 
+  store  i64 %"$field##0", i64* %97 
   ret i64 %92 
 }
 
 
-define external fastcc  i64 @"int_sequence.upper<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"int_sequence.upper<0>"(i64  %"$rec##0")    {
 entry:
-  %98 = add   i64 %"$rec#0", 8 
+  %98 = add   i64 %"$rec##0", 8 
   %99 = inttoptr i64 %98 to i64* 
   %100 = getelementptr  i64, i64* %99, i64 0 
   %101 = load  i64, i64* %100 
@@ -413,46 +413,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"int_sequence.upper<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"int_sequence.upper<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %102 = trunc i64 16 to i32  
   %103 = tail call ccc  i8*  @wybe_malloc(i32  %102)  
   %104 = ptrtoint i8* %103 to i64 
   %105 = inttoptr i64 %104 to i8* 
-  %106 = inttoptr i64 %"$rec#0" to i8* 
+  %106 = inttoptr i64 %"$rec##0" to i8* 
   %107 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %105, i8*  %106, i32  %107, i32  8, i1  0)  
   %108 = add   i64 %104, 8 
   %109 = inttoptr i64 %108 to i64* 
   %110 = getelementptr  i64, i64* %109, i64 0 
-  store  i64 %"$field#0", i64* %110 
+  store  i64 %"$field##0", i64* %110 
   ret i64 %104 
 }
 
 
-define external fastcc  i1 @"int_sequence.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"int_sequence.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %111 = inttoptr i64 %"$left#0" to i64* 
+  %111 = inttoptr i64 %"$left##0" to i64* 
   %112 = getelementptr  i64, i64* %111, i64 0 
   %113 = load  i64, i64* %112 
-  %114 = add   i64 %"$left#0", 8 
+  %114 = add   i64 %"$left##0", 8 
   %115 = inttoptr i64 %114 to i64* 
   %116 = getelementptr  i64, i64* %115, i64 0 
   %117 = load  i64, i64* %116 
-  %118 = inttoptr i64 %"$right#0" to i64* 
+  %118 = inttoptr i64 %"$right##0" to i64* 
   %119 = getelementptr  i64, i64* %118, i64 0 
   %120 = load  i64, i64* %119 
-  %121 = add   i64 %"$right#0", 8 
+  %121 = add   i64 %"$right##0", 8 
   %122 = inttoptr i64 %121 to i64* 
   %123 = getelementptr  i64, i64* %122, i64 0 
   %124 = load  i64, i64* %123 
-  %"1$tmp$7#0" = icmp eq i64 %113, %120 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %113, %120 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = icmp eq i64 %117, %124 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$0##0" = icmp eq i64 %117, %124 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }

--- a/test-cases/final-dump/int_sequence.exp
+++ b/test-cases/final-dump/int_sequence.exp
@@ -48,7 +48,7 @@ AFTER EVERYTHING:
 
 = > public {inline} (1 calls)
 0: int_sequence.=<0>
-=(#left##0:int_sequence, #right##0:int_sequence, ?####0:wybe.bool):
+=(#left##0:int_sequence, #right##0:int_sequence, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#lower##0:wybe.int)
@@ -58,16 +58,16 @@ AFTER EVERYTHING:
     foreign llvm icmp_eq(~#left#lower##0:wybe.int, ~#right#lower##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~#left#upper##0:wybe.int, ~#right#upper##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#upper##0:wybe.int, ~#right#upper##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
 [|] > public (3 calls)
 0: int_sequence.[|]<0>[785a827a1b]
-[|](?head##0:wybe.int, ?tail##0:int_sequence, seq##0:int_sequence, ?####0:wybe.bool):
+[|](?head##0:wybe.int, ?tail##0:int_sequence, seq##0:int_sequence, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 2]
     foreign lpvm access(seq##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
@@ -75,7 +75,7 @@ AFTER EVERYTHING:
     foreign llvm icmp_sle(tmp#0##0:wybe.int, tmp#1##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?head##0:wybe.int)
         foreign llvm move(undef:int_sequence, ?tail##0:int_sequence)
 
@@ -85,7 +85,7 @@ AFTER EVERYTHING:
         foreign lpvm alloc(16:wybe.int, ?tmp#19##0:int_sequence)
         foreign lpvm mutate(~tmp#19##0:int_sequence, ?tmp#20##0:int_sequence, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#4##0:wybe.int)
         foreign lpvm mutate(~tmp#20##0:int_sequence, ?tail##0:int_sequence, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
  [785a827a1b] [NonAliasedParam 2] :
     foreign lpvm access(seq##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
@@ -93,7 +93,7 @@ AFTER EVERYTHING:
     foreign llvm icmp_sle(tmp#0##0:wybe.int, tmp#1##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?head##0:wybe.int)
         foreign llvm move(undef:int_sequence, ?tail##0:int_sequence)
 
@@ -102,7 +102,7 @@ AFTER EVERYTHING:
         foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#4##0:wybe.int) @int:nn:nn
         foreign lpvm mutate(~seq##0:int_sequence, ?tmp#20##0:int_sequence, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#4##0:wybe.int)
         foreign lpvm mutate(~tmp#20##0:int_sequence, ?tail##0:int_sequence, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -165,7 +165,7 @@ upper(#rec##0:int_sequence, ?#rec##1:int_sequence, #field##0:wybe.int):
 
 ~= > public {inline} (0 calls)
 0: int_sequence.~=<0>
-~=(#left##0:int_sequence, #right##0:int_sequence, ?####0:wybe.bool):
+~=(#left##0:int_sequence, #right##0:int_sequence, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -176,11 +176,11 @@ upper(#rec##0:int_sequence, ?#rec##1:int_sequence, #field##0:wybe.int):
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -270,8 +270,8 @@ entry:
   %"1#tmp#1##0" = icmp eq i64 %28, %35 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2#####0" = icmp eq i64 %32, %39 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %32, %39 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -450,9 +450,9 @@ entry:
   br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#0##0" = icmp eq i64 %117, %124 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }

--- a/test-cases/final-dump/int_sequence.exp
+++ b/test-cases/final-dump/int_sequence.exp
@@ -23,164 +23,164 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$6##0:int_sequence)
-    foreign lpvm mutate(~tmp$6##0:int_sequence, ?tmp$7##0:int_sequence, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp$7##0:int_sequence, ?tmp$3##0:int_sequence, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    int_sequence.gen$1<0>(~io##0:wybe.phantom, ~tmp$3##0:int_sequence, ~tmp$3##0:int_sequence, ?io##1:wybe.phantom) #1 @int_sequence:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#6##0:int_sequence)
+    foreign lpvm mutate(~tmp#6##0:int_sequence, ?tmp#7##0:int_sequence, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp#7##0:int_sequence, ?tmp#3##0:int_sequence, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    int_sequence.gen#1<0>(~io##0:wybe.phantom, ~tmp#3##0:int_sequence, ~tmp#3##0:int_sequence, ?io##1:wybe.phantom) #1 @int_sequence:nn:nn
 
 
 .. > public {inline} (2 calls)
 0: int_sequence...<0>
-..(lower##0:wybe.int, upper##0:wybe.int, ?$##0:int_sequence):
+..(lower##0:wybe.int, upper##0:wybe.int, ?###0:int_sequence):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:int_sequence)
-    foreign lpvm mutate(~$rec##0:int_sequence, ?$rec##1:int_sequence, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lower##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:int_sequence, ?$##0:int_sequence, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~upper##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:int_sequence)
+    foreign lpvm mutate(~#rec##0:int_sequence, ?#rec##1:int_sequence, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lower##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:int_sequence, ?###0:int_sequence, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~upper##0:wybe.int)
 .. > public {inline} (6 calls)
 1: int_sequence...<1>
-..(?lower##0:wybe.int, ?upper##0:wybe.int, $##0:int_sequence):
+..(?lower##0:wybe.int, ?upper##0:wybe.int, ###0:int_sequence):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?lower##0:wybe.int)
-    foreign lpvm access(~$##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?upper##0:wybe.int)
+    foreign lpvm access(###0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?lower##0:wybe.int)
+    foreign lpvm access(~###0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?upper##0:wybe.int)
 
 
 = > public {inline} (1 calls)
 0: int_sequence.=<0>
-=($left##0:int_sequence, $right##0:int_sequence, ?$$##0:wybe.bool):
+=(#left##0:int_sequence, #right##0:int_sequence, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$lower##0:wybe.int)
-    foreign lpvm access(~$left##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$upper##0:wybe.int)
-    foreign lpvm access($right##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$lower##0:wybe.int)
-    foreign lpvm access(~$right##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$upper##0:wybe.int)
-    foreign llvm icmp_eq(~$left$lower##0:wybe.int, ~$right$lower##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#lower##0:wybe.int)
+    foreign lpvm access(~#left##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#upper##0:wybe.int)
+    foreign lpvm access(#right##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#lower##0:wybe.int)
+    foreign lpvm access(~#right##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#upper##0:wybe.int)
+    foreign llvm icmp_eq(~#left#lower##0:wybe.int, ~#right#lower##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$upper##0:wybe.int, ~$right$upper##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#upper##0:wybe.int, ~#right#upper##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 [|] > public (3 calls)
 0: int_sequence.[|]<0>[785a827a1b]
-[|](?head##0:wybe.int, ?tail##0:int_sequence, seq##0:int_sequence, ?$$##0:wybe.bool):
+[|](?head##0:wybe.int, ?tail##0:int_sequence, seq##0:int_sequence, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 2]
-    foreign lpvm access(seq##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign lpvm access(~seq##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_sle(tmp$0##0:wybe.int, tmp$1##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(seq##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(~seq##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_sle(tmp#0##0:wybe.int, tmp#1##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?head##0:wybe.int)
         foreign llvm move(undef:int_sequence, ?tail##0:int_sequence)
 
     1:
-        foreign llvm move(tmp$0##0:wybe.int, ?head##0:wybe.int) @int_sequence:nn:nn
-        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$4##0:wybe.int) @int:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$19##0:int_sequence)
-        foreign lpvm mutate(~tmp$19##0:int_sequence, ?tmp$20##0:int_sequence, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$4##0:wybe.int)
-        foreign lpvm mutate(~tmp$20##0:int_sequence, ?tail##0:int_sequence, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$1##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(tmp#0##0:wybe.int, ?head##0:wybe.int) @int_sequence:nn:nn
+        foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#4##0:wybe.int) @int:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#19##0:int_sequence)
+        foreign lpvm mutate(~tmp#19##0:int_sequence, ?tmp#20##0:int_sequence, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#4##0:wybe.int)
+        foreign lpvm mutate(~tmp#20##0:int_sequence, ?tail##0:int_sequence, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
  [785a827a1b] [NonAliasedParam 2] :
-    foreign lpvm access(seq##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign lpvm access(seq##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_sle(tmp$0##0:wybe.int, tmp$1##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(seq##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(seq##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_sle(tmp#0##0:wybe.int, tmp#1##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?head##0:wybe.int)
         foreign llvm move(undef:int_sequence, ?tail##0:int_sequence)
 
     1:
-        foreign llvm move(tmp$0##0:wybe.int, ?head##0:wybe.int) @int_sequence:nn:nn
-        foreign llvm add(~tmp$0##0:wybe.int, 1:wybe.int, ?tmp$4##0:wybe.int) @int:nn:nn
-        foreign lpvm mutate(~seq##0:int_sequence, ?tmp$20##0:int_sequence, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$4##0:wybe.int)
-        foreign lpvm mutate(~tmp$20##0:int_sequence, ?tail##0:int_sequence, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$1##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(tmp#0##0:wybe.int, ?head##0:wybe.int) @int_sequence:nn:nn
+        foreign llvm add(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#4##0:wybe.int) @int:nn:nn
+        foreign lpvm mutate(~seq##0:int_sequence, ?tmp#20##0:int_sequence, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#4##0:wybe.int)
+        foreign lpvm mutate(~tmp#20##0:int_sequence, ?tail##0:int_sequence, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
-gen$1 > (2 calls)
-0: int_sequence.gen$1<0>[6dacb8fd25]
-gen$1(io##0:wybe.phantom, tmp$0##0:int_sequence, tmp$3##0:int_sequence, ?io##2:wybe.phantom):
+gen#1 > (2 calls)
+0: int_sequence.gen#1<0>[6dacb8fd25]
+gen#1(io##0:wybe.phantom, tmp#0##0:int_sequence, tmp#3##0:int_sequence, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 1]
- MultiSpeczDepInfo: [(0,(int_sequence.[|]<0>,fromList [NonAliasedParamCond 2 [1]])),(2,(int_sequence.gen$1<0>,fromList [NonAliasedParamCond 1 []]))]
-    int_sequence.[|]<0>(?i##0:wybe.int, ?tmp$1##0:int_sequence, ~tmp$0##0:int_sequence, ?tmp$2##0:wybe.bool) #0
-    case ~tmp$2##0:wybe.bool of
+ MultiSpeczDepInfo: [(0,(int_sequence.[|]<0>,fromList [NonAliasedParamCond 2 [1]])),(2,(int_sequence.gen#1<0>,fromList [NonAliasedParamCond 1 []]))]
+    int_sequence.[|]<0>(?i##0:wybe.int, ?tmp#1##0:int_sequence, ~tmp#0##0:int_sequence, ?tmp#2##0:wybe.bool) #0
+    case ~tmp#2##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$6##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        int_sequence.gen$1<0>[6dacb8fd25](~io##1:wybe.phantom, ~tmp$1##0:int_sequence, ~tmp$3##0:int_sequence, ?io##2:wybe.phantom) #2 @int_sequence:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        int_sequence.gen#1<0>[6dacb8fd25](~io##1:wybe.phantom, ~tmp#1##0:int_sequence, ~tmp#3##0:int_sequence, ?io##2:wybe.phantom) #2 @int_sequence:nn:nn
 
  [6dacb8fd25] [NonAliasedParam 1] :
-    int_sequence.[|]<0>[785a827a1b](?i##0:wybe.int, ?tmp$1##0:int_sequence, ~tmp$0##0:int_sequence, ?tmp$2##0:wybe.bool) #0
-    case ~tmp$2##0:wybe.bool of
+    int_sequence.[|]<0>[785a827a1b](?i##0:wybe.int, ?tmp#1##0:int_sequence, ~tmp#0##0:int_sequence, ?tmp#2##0:wybe.bool) #0
+    case ~tmp#2##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$6##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        int_sequence.gen$1<0>[6dacb8fd25](~io##1:wybe.phantom, ~tmp$1##0:int_sequence, ~tmp$3##0:int_sequence, ?io##2:wybe.phantom) #2 @int_sequence:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        int_sequence.gen#1<0>[6dacb8fd25](~io##1:wybe.phantom, ~tmp#1##0:int_sequence, ~tmp#3##0:int_sequence, ?io##2:wybe.phantom) #2 @int_sequence:nn:nn
 
 
 
 lower > public {inline} (5 calls)
 0: int_sequence.lower<0>
-lower($rec##0:int_sequence, ?$##0:wybe.int):
+lower(#rec##0:int_sequence, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 lower > public {inline} (0 calls)
 1: int_sequence.lower<1>
-lower($rec##0:int_sequence, ?$rec##1:int_sequence, $field##0:wybe.int):
+lower(#rec##0:int_sequence, ?#rec##1:int_sequence, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:int_sequence, ?$rec##1:int_sequence, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:int_sequence, ?#rec##1:int_sequence, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 upper > public {inline} (4 calls)
 0: int_sequence.upper<0>
-upper($rec##0:int_sequence, ?$##0:wybe.int):
+upper(#rec##0:int_sequence, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 upper > public {inline} (0 calls)
 1: int_sequence.upper<1>
-upper($rec##0:int_sequence, ?$rec##1:int_sequence, $field##0:wybe.int):
+upper(#rec##0:int_sequence, ?#rec##1:int_sequence, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:int_sequence, ?$rec##1:int_sequence, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:int_sequence, ?#rec##1:int_sequence, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: int_sequence.~=<0>
-~=($left##0:int_sequence, $right##0:int_sequence, ?$$##0:wybe.bool):
+~=(#left##0:int_sequence, #right##0:int_sequence, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:int_sequence, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:int_sequence, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -215,7 +215,7 @@ entry:
   %7 = inttoptr i64 %6 to i64* 
   %8 = getelementptr  i64, i64* %7, i64 0 
   store  i64 10, i64* %8 
-  tail call fastcc  void  @"int_sequence.gen$1<0>"(i64  %3, i64  %3)  
+  tail call fastcc  void  @"int_sequence.gen#1<0>"(i64  %3, i64  %3)  
   ret void 
 }
 
@@ -236,12 +236,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"int_sequence...<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"int_sequence...<1>"(i64  %"###0")    {
 entry:
-  %17 = inttoptr i64 %"$##0" to i64* 
+  %17 = inttoptr i64 %"###0" to i64* 
   %18 = getelementptr  i64, i64* %17, i64 0 
   %19 = load  i64, i64* %18 
-  %20 = add   i64 %"$##0", 8 
+  %20 = add   i64 %"###0", 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
   %23 = load  i64, i64* %22 
@@ -251,27 +251,27 @@ entry:
 }
 
 
-define external fastcc  i1 @"int_sequence.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"int_sequence.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %26 = inttoptr i64 %"$left##0" to i64* 
+  %26 = inttoptr i64 %"#left##0" to i64* 
   %27 = getelementptr  i64, i64* %26, i64 0 
   %28 = load  i64, i64* %27 
-  %29 = add   i64 %"$left##0", 8 
+  %29 = add   i64 %"#left##0", 8 
   %30 = inttoptr i64 %29 to i64* 
   %31 = getelementptr  i64, i64* %30, i64 0 
   %32 = load  i64, i64* %31 
-  %33 = inttoptr i64 %"$right##0" to i64* 
+  %33 = inttoptr i64 %"#right##0" to i64* 
   %34 = getelementptr  i64, i64* %33, i64 0 
   %35 = load  i64, i64* %34 
-  %36 = add   i64 %"$right##0", 8 
+  %36 = add   i64 %"#right##0", 8 
   %37 = inttoptr i64 %36 to i64* 
   %38 = getelementptr  i64, i64* %37, i64 0 
   %39 = load  i64, i64* %38 
-  %"1$tmp$1##0" = icmp eq i64 %28, %35 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %28, %35 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$##0" = icmp eq i64 %32, %39 
-  ret i1 %"2$$$##0" 
+  %"2#####0" = icmp eq i64 %32, %39 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
@@ -286,16 +286,16 @@ entry:
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
-  %"1$tmp$7##0" = icmp sle i64 %42, %46 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp sle i64 %42, %46 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$4##0" = add   i64 %42, 1 
+  %"2#tmp#4##0" = add   i64 %42, 1 
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i64* 
   %51 = getelementptr  i64, i64* %50, i64 0 
-  store  i64 %"2$tmp$4##0", i64* %51 
+  store  i64 %"2#tmp#4##0", i64* %51 
   %52 = add   i64 %49, 8 
   %53 = inttoptr i64 %52 to i64* 
   %54 = getelementptr  i64, i64* %53, i64 0 
@@ -321,13 +321,13 @@ entry:
   %65 = inttoptr i64 %64 to i64* 
   %66 = getelementptr  i64, i64* %65, i64 0 
   %67 = load  i64, i64* %66 
-  %"1$tmp$7##0" = icmp sle i64 %63, %67 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp sle i64 %63, %67 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$4##0" = add   i64 %63, 1 
+  %"2#tmp#4##0" = add   i64 %63, 1 
   %68 = inttoptr i64 %"seq##0" to i64* 
   %69 = getelementptr  i64, i64* %68, i64 0 
-  store  i64 %"2$tmp$4##0", i64* %69 
+  store  i64 %"2#tmp#4##0", i64* %69 
   %70 = add   i64 %"seq##0", 8 
   %71 = inttoptr i64 %70 to i64* 
   %72 = getelementptr  i64, i64* %71, i64 0 
@@ -344,9 +344,9 @@ if.else:
 }
 
 
-define external fastcc  void @"int_sequence.gen$1<0>"(i64  %"tmp$0##0", i64  %"tmp$3##0")    {
+define external fastcc  void @"int_sequence.gen#1<0>"(i64  %"tmp#0##0", i64  %"tmp#3##0")    {
 entry:
-  %79 = tail call fastcc  {i64, i64, i1}  @"int_sequence.[|]<0>"(i64  %"tmp$0##0")  
+  %79 = tail call fastcc  {i64, i64, i1}  @"int_sequence.[|]<0>"(i64  %"tmp#0##0")  
   %80 = extractvalue {i64, i64, i1} %79, 0 
   %81 = extractvalue {i64, i64, i1} %79, 1 
   %82 = extractvalue {i64, i64, i1} %79, 2 
@@ -354,16 +354,16 @@ entry:
 if.then:
   tail call ccc  void  @print_int(i64  %80)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_sequence.gen$1<0>[6dacb8fd25]"(i64  %81, i64  %"tmp$3##0")  
+  tail call fastcc  void  @"int_sequence.gen#1<0>[6dacb8fd25]"(i64  %81, i64  %"tmp#3##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"int_sequence.gen$1<0>[6dacb8fd25]"(i64  %"tmp$0##0", i64  %"tmp$3##0")    {
+define external fastcc  void @"int_sequence.gen#1<0>[6dacb8fd25]"(i64  %"tmp#0##0", i64  %"tmp#3##0")    {
 entry:
-  %83 = tail call fastcc  {i64, i64, i1}  @"int_sequence.[|]<0>[785a827a1b]"(i64  %"tmp$0##0")  
+  %83 = tail call fastcc  {i64, i64, i1}  @"int_sequence.[|]<0>[785a827a1b]"(i64  %"tmp#0##0")  
   %84 = extractvalue {i64, i64, i1} %83, 0 
   %85 = extractvalue {i64, i64, i1} %83, 1 
   %86 = extractvalue {i64, i64, i1} %83, 2 
@@ -371,41 +371,41 @@ entry:
 if.then:
   tail call ccc  void  @print_int(i64  %84)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_sequence.gen$1<0>[6dacb8fd25]"(i64  %85, i64  %"tmp$3##0")  
+  tail call fastcc  void  @"int_sequence.gen#1<0>[6dacb8fd25]"(i64  %85, i64  %"tmp#3##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  i64 @"int_sequence.lower<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"int_sequence.lower<0>"(i64  %"#rec##0")    {
 entry:
-  %87 = inttoptr i64 %"$rec##0" to i64* 
+  %87 = inttoptr i64 %"#rec##0" to i64* 
   %88 = getelementptr  i64, i64* %87, i64 0 
   %89 = load  i64, i64* %88 
   ret i64 %89 
 }
 
 
-define external fastcc  i64 @"int_sequence.lower<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"int_sequence.lower<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %90 = trunc i64 16 to i32  
   %91 = tail call ccc  i8*  @wybe_malloc(i32  %90)  
   %92 = ptrtoint i8* %91 to i64 
   %93 = inttoptr i64 %92 to i8* 
-  %94 = inttoptr i64 %"$rec##0" to i8* 
+  %94 = inttoptr i64 %"#rec##0" to i8* 
   %95 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %93, i8*  %94, i32  %95, i32  8, i1  0)  
   %96 = inttoptr i64 %92 to i64* 
   %97 = getelementptr  i64, i64* %96, i64 0 
-  store  i64 %"$field##0", i64* %97 
+  store  i64 %"#field##0", i64* %97 
   ret i64 %92 
 }
 
 
-define external fastcc  i64 @"int_sequence.upper<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"int_sequence.upper<0>"(i64  %"#rec##0")    {
 entry:
-  %98 = add   i64 %"$rec##0", 8 
+  %98 = add   i64 %"#rec##0", 8 
   %99 = inttoptr i64 %98 to i64* 
   %100 = getelementptr  i64, i64* %99, i64 0 
   %101 = load  i64, i64* %100 
@@ -413,46 +413,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"int_sequence.upper<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"int_sequence.upper<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %102 = trunc i64 16 to i32  
   %103 = tail call ccc  i8*  @wybe_malloc(i32  %102)  
   %104 = ptrtoint i8* %103 to i64 
   %105 = inttoptr i64 %104 to i8* 
-  %106 = inttoptr i64 %"$rec##0" to i8* 
+  %106 = inttoptr i64 %"#rec##0" to i8* 
   %107 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %105, i8*  %106, i32  %107, i32  8, i1  0)  
   %108 = add   i64 %104, 8 
   %109 = inttoptr i64 %108 to i64* 
   %110 = getelementptr  i64, i64* %109, i64 0 
-  store  i64 %"$field##0", i64* %110 
+  store  i64 %"#field##0", i64* %110 
   ret i64 %104 
 }
 
 
-define external fastcc  i1 @"int_sequence.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"int_sequence.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %111 = inttoptr i64 %"$left##0" to i64* 
+  %111 = inttoptr i64 %"#left##0" to i64* 
   %112 = getelementptr  i64, i64* %111, i64 0 
   %113 = load  i64, i64* %112 
-  %114 = add   i64 %"$left##0", 8 
+  %114 = add   i64 %"#left##0", 8 
   %115 = inttoptr i64 %114 to i64* 
   %116 = getelementptr  i64, i64* %115, i64 0 
   %117 = load  i64, i64* %116 
-  %118 = inttoptr i64 %"$right##0" to i64* 
+  %118 = inttoptr i64 %"#right##0" to i64* 
   %119 = getelementptr  i64, i64* %118, i64 0 
   %120 = load  i64, i64* %119 
-  %121 = add   i64 %"$right##0", 8 
+  %121 = add   i64 %"#right##0", 8 
   %122 = inttoptr i64 %121 to i64* 
   %123 = getelementptr  i64, i64* %122, i64 0 
   %124 = load  i64, i64* %123 
-  %"1$tmp$7##0" = icmp eq i64 %113, %120 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %113, %120 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = icmp eq i64 %117, %124 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#0##0" = icmp eq i64 %117, %124 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }

--- a/test-cases/final-dump/io.exp
+++ b/test-cases/final-dump/io.exp
@@ -13,32 +13,32 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: io.<0>
-(io#0:wybe.phantom, ?io#2:wybe.phantom):
+(io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(100:wybe.int, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_int(200:wybe.int, ~#io#1:wybe.phantom, ?tmp$5#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$5#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
+    foreign c print_int(100:wybe.int, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(200:wybe.int, ~#io##1:wybe.phantom, ?tmp$5##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$5##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
 
 myprint_a > public {inline} (1 calls)
 0: io.myprint_a<0>
-myprint_a(x#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+myprint_a(x##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(~x#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~x##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 myprint_b > public {inline} (1 calls)
 0: io.myprint_b<0>
-myprint_b(x#0:wybe.int, ?y#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+myprint_b(x##0:wybe.int, ?y##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(~x#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign llvm move(200:wybe.int, ?y#0:wybe.int) @io:nn:nn
+    foreign c print_int(~x##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign llvm move(200:wybe.int, ?y##0:wybe.int) @io:nn:nn
 
   LLVM code       :
 
@@ -70,17 +70,17 @@ entry:
 }
 
 
-define external fastcc  void @"io.myprint_a<0>"(i64  %"x#0")    {
+define external fastcc  void @"io.myprint_a<0>"(i64  %"x##0")    {
 entry:
-  tail call ccc  void  @print_int(i64  %"x#0")  
+  tail call ccc  void  @print_int(i64  %"x##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  i64 @"io.myprint_b<0>"(i64  %"x#0")    {
+define external fastcc  i64 @"io.myprint_b<0>"(i64  %"x##0")    {
 entry:
-  tail call ccc  void  @print_int(i64  %"x#0")  
+  tail call ccc  void  @print_int(i64  %"x##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret i64 200 
 }

--- a/test-cases/final-dump/io.exp
+++ b/test-cases/final-dump/io.exp
@@ -16,10 +16,10 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(100:wybe.int, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign c print_int(200:wybe.int, ~#io##1:wybe.phantom, ?tmp$5##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$5##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_int(100:wybe.int, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(200:wybe.int, ~#io##1:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
 
 myprint_a > public {inline} (1 calls)
@@ -27,8 +27,8 @@ myprint_a > public {inline} (1 calls)
 myprint_a(x##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(~x##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~x##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 myprint_b > public {inline} (1 calls)
@@ -36,8 +36,8 @@ myprint_b > public {inline} (1 calls)
 myprint_b(x##0:wybe.int, ?y##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(~x##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~x##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     foreign llvm move(200:wybe.int, ?y##0:wybe.int) @io:nn:nn
 
   LLVM code       :

--- a/test-cases/final-dump/list_loop.exp
+++ b/test-cases/final-dump/list_loop.exp
@@ -262,13 +262,13 @@ entry:
 
 = > public (2 calls)
 0: list_loop.intlist.=<0>
-=(#left##0:list_loop.intlist, #right##0:list_loop.intlist, ?####0:wybe.bool):
+=(#left##0:list_loop.intlist, #right##0:list_loop.intlist, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~#left##0:list_loop.intlist, ~#right##0:list_loop.intlist, ?####0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:list_loop.intlist, ~#right##0:list_loop.intlist, ?#success##0:wybe.bool)
 
     1:
         foreign lpvm access(#left##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#head##0:wybe.int)
@@ -276,7 +276,7 @@ entry:
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
         case ~tmp#9##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign lpvm access(#right##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#head##0:wybe.int)
@@ -284,10 +284,10 @@ entry:
             foreign llvm icmp_eq(~#left#head##0:wybe.int, ~#right#head##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
             case ~tmp#4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
-                list_loop.intlist.=<0>(~#left#tail##0:list_loop.intlist, ~#right#tail##0:list_loop.intlist, ?####0:wybe.bool) #3
+                list_loop.intlist.=<0>(~#left#tail##0:list_loop.intlist, ~#right#tail##0:list_loop.intlist, ?#success##0:wybe.bool) #3
 
 
 
@@ -303,52 +303,52 @@ cons(head##0:wybe.int, tail##0:list_loop.intlist, ?#result##0:list_loop.intlist)
     foreign lpvm mutate(~#rec##1:list_loop.intlist, ?#result##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:list_loop.intlist)
 cons > public {inline} (12 calls)
 1: list_loop.intlist.cons<1>
-cons(?head##0:wybe.int, ?tail##0:list_loop.intlist, #result##0:list_loop.intlist, ?####0:wybe.bool):
+cons(?head##0:wybe.int, ?tail##0:list_loop.intlist, #result##0:list_loop.intlist, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?head##0:wybe.int)
         foreign llvm move(undef:list_loop.intlist, ?tail##0:list_loop.intlist)
 
     1:
         foreign lpvm access(#result##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
         foreign lpvm access(~#result##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:list_loop.intlist)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 head > public {inline} (0 calls)
 0: list_loop.intlist.head<0>
-head(#rec##0:list_loop.intlist, ?#result##0:wybe.int, ?####0:wybe.bool):
+head(#rec##0:list_loop.intlist, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign lpvm access(~#rec##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 head > public {inline} (0 calls)
 1: list_loop.intlist.head<1>
-head(#rec##0:list_loop.intlist, ?#rec##1:list_loop.intlist, #field##0:wybe.int, ?####0:wybe.bool):
+head(#rec##0:list_loop.intlist, ?#rec##1:list_loop.intlist, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:list_loop.intlist, ?#rec##1:list_loop.intlist)
 
     1:
         foreign lpvm mutate(~#rec##0:list_loop.intlist, ?#rec##1:list_loop.intlist, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -362,43 +362,43 @@ nil(?#result##0:list_loop.intlist):
 
 tail > public {inline} (0 calls)
 0: list_loop.intlist.tail<0>
-tail(#rec##0:list_loop.intlist, ?#result##0:list_loop.intlist, ?####0:wybe.bool):
+tail(#rec##0:list_loop.intlist, ?#result##0:list_loop.intlist, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:list_loop.intlist, ?#result##0:list_loop.intlist)
 
     1:
         foreign lpvm access(~#rec##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:list_loop.intlist)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 tail > public {inline} (0 calls)
 1: list_loop.intlist.tail<1>
-tail(#rec##0:list_loop.intlist, ?#rec##1:list_loop.intlist, #field##0:list_loop.intlist, ?####0:wybe.bool):
+tail(#rec##0:list_loop.intlist, ?#rec##1:list_loop.intlist, #field##0:list_loop.intlist, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:list_loop.intlist, ?#rec##1:list_loop.intlist)
 
     1:
         foreign lpvm {noalias} mutate(~#rec##0:list_loop.intlist, ?#rec##1:list_loop.intlist, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:list_loop.intlist)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: list_loop.intlist.~=<0>
-~=(#left##0:list_loop.intlist, #right##0:list_loop.intlist, ?####0:wybe.bool):
+~=(#left##0:list_loop.intlist, #right##0:list_loop.intlist, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     list_loop.intlist.=<0>(~#left##0:list_loop.intlist, ~#right##0:list_loop.intlist, ?tmp#0##0:wybe.bool) #0
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 
@@ -429,8 +429,8 @@ if.then:
   %"2#tmp#9##0" = icmp ne i64 %"#right##0", 0 
   br i1 %"2#tmp#9##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %"3#####0" 
+  %"3##success##0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3##success##0" 
 if.then1:
   %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
@@ -444,8 +444,8 @@ if.then1:
 if.else1:
   ret i1 0 
 if.then2:
-  %"6#####0" = tail call fastcc  i1  @"list_loop.intlist.=<0>"(i64  %7, i64  %14)  
-  ret i1 %"6#####0" 
+  %"6##success##0" = tail call fastcc  i1  @"list_loop.intlist.=<0>"(i64  %7, i64  %14)  
+  ret i1 %"6##success##0" 
 if.else2:
   ret i1 0 
 }
@@ -588,6 +588,6 @@ if.else:
 define external fastcc  i1 @"list_loop.intlist.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %"1#tmp#0##0" = tail call fastcc  i1  @"list_loop.intlist.=<0>"(i64  %"#left##0", i64  %"#right##0")  
-  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
-  ret i1 %"1#####0" 
+  %"1##success##0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1##success##0" 
 }

--- a/test-cases/final-dump/list_loop.exp
+++ b/test-cases/final-dump/list_loop.exp
@@ -22,83 +22,83 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: list_loop.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$8#0:list_loop.intlist)
-    foreign lpvm mutate(~tmp$8#0:list_loop.intlist, ?tmp$9#0:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-    foreign lpvm mutate(~tmp$9#0:list_loop.intlist, ?tmp$10#0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:list_loop.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp$13#0:list_loop.intlist)
-    foreign lpvm mutate(~tmp$13#0:list_loop.intlist, ?tmp$14#0:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm mutate(~tmp$14#0:list_loop.intlist, ?tmp$15#0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$10#0:list_loop.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp$18#0:list_loop.intlist)
-    foreign lpvm mutate(~tmp$18#0:list_loop.intlist, ?tmp$19#0:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp$19#0:list_loop.intlist, ?tmp$20#0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$15#0:list_loop.intlist)
-    list_loop.gen$1<0>(~io#0:wybe.phantom, ~tmp$20#0:list_loop.intlist, ~tmp$20#0:list_loop.intlist, ~tmp$15#0:list_loop.intlist, ~tmp$10#0:list_loop.intlist, 0:list_loop.intlist, ~tmp$20#0:list_loop.intlist, ?io#1:wybe.phantom) #4 @list_loop:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$8##0:list_loop.intlist)
+    foreign lpvm mutate(~tmp$8##0:list_loop.intlist, ?tmp$9##0:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+    foreign lpvm mutate(~tmp$9##0:list_loop.intlist, ?tmp$10##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:list_loop.intlist)
+    foreign lpvm alloc(16:wybe.int, ?tmp$13##0:list_loop.intlist)
+    foreign lpvm mutate(~tmp$13##0:list_loop.intlist, ?tmp$14##0:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+    foreign lpvm mutate(~tmp$14##0:list_loop.intlist, ?tmp$15##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$10##0:list_loop.intlist)
+    foreign lpvm alloc(16:wybe.int, ?tmp$18##0:list_loop.intlist)
+    foreign lpvm mutate(~tmp$18##0:list_loop.intlist, ?tmp$19##0:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp$19##0:list_loop.intlist, ?tmp$20##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$15##0:list_loop.intlist)
+    list_loop.gen$1<0>(~io##0:wybe.phantom, ~tmp$20##0:list_loop.intlist, ~tmp$20##0:list_loop.intlist, ~tmp$15##0:list_loop.intlist, ~tmp$10##0:list_loop.intlist, 0:list_loop.intlist, ~tmp$20##0:list_loop.intlist, ?io##1:wybe.phantom) #4 @list_loop:nn:nn
 
 
 gen$1 > (2 calls)
 0: list_loop.gen$1<0>
-gen$1(io#0:wybe.phantom, l#0:list_loop.intlist, tmp$0#0:list_loop.intlist, tmp$1#0:list_loop.intlist, tmp$2#0:list_loop.intlist, tmp$3#0:list_loop.intlist, x#0:list_loop.intlist, ?io#1:wybe.phantom):
+gen$1(io##0:wybe.phantom, l##0:list_loop.intlist, tmp$0##0:list_loop.intlist, tmp$1##0:list_loop.intlist, tmp$2##0:list_loop.intlist, tmp$3##0:list_loop.intlist, x##0:list_loop.intlist, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(l#0:wybe.int, 0:wybe.int, ?tmp$7#0:wybe.bool)
-    case ~tmp$7#0:wybe.bool of
+    foreign llvm icmp_ne(l##0:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.bool)
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(l#0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:wybe.int)
-        foreign lpvm access(~l#0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?l#1:list_loop.intlist)
-        foreign c print_int(h#0:wybe.int, ~io#0:wybe.phantom, ?tmp$16#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$16#0:wybe.phantom, ?tmp$17#0:wybe.phantom) @io:nn:nn
-        list_loop.gen$3<0>(~h#0:wybe.int, ~tmp$17#0:wybe.phantom, ~l#1:list_loop.intlist, ~x#0:list_loop.intlist, ~tmp$0#0:list_loop.intlist, ~tmp$1#0:list_loop.intlist, ~tmp$2#0:list_loop.intlist, ~tmp$3#0:list_loop.intlist, ~x#0:list_loop.intlist, ?io#1:wybe.phantom) #2 @list_loop:nn:nn
+        foreign lpvm access(l##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+        foreign lpvm access(~l##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?l##1:list_loop.intlist)
+        foreign c print_int(h##0:wybe.int, ~io##0:wybe.phantom, ?tmp$16##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$16##0:wybe.phantom, ?tmp$17##0:wybe.phantom) @io:nn:nn
+        list_loop.gen$3<0>(~h##0:wybe.int, ~tmp$17##0:wybe.phantom, ~l##1:list_loop.intlist, ~x##0:list_loop.intlist, ~tmp$0##0:list_loop.intlist, ~tmp$1##0:list_loop.intlist, ~tmp$2##0:list_loop.intlist, ~tmp$3##0:list_loop.intlist, ~x##0:list_loop.intlist, ?io##1:wybe.phantom) #2 @list_loop:nn:nn
 
 
 
 gen$2 > {inline} (1 calls)
 0: list_loop.gen$2<0>
-gen$2(h#0:wybe.int, io#0:wybe.phantom, l#0:list_loop.intlist, tmp$0#0:list_loop.intlist, tmp$1#0:list_loop.intlist, tmp$2#0:list_loop.intlist, tmp$3#0:list_loop.intlist, x#0:list_loop.intlist, ?io#2:wybe.phantom):
+gen$2(h##0:wybe.int, io##0:wybe.phantom, l##0:list_loop.intlist, tmp$0##0:list_loop.intlist, tmp$1##0:list_loop.intlist, tmp$2##0:list_loop.intlist, tmp$3##0:list_loop.intlist, x##0:list_loop.intlist, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(h#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$7#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$7#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    list_loop.gen$3<0>(~h#0:wybe.int, ~io#1:wybe.phantom, ~l#0:list_loop.intlist, ~x#0:list_loop.intlist, ~tmp$0#0:list_loop.intlist, ~tmp$1#0:list_loop.intlist, ~tmp$2#0:list_loop.intlist, ~tmp$3#0:list_loop.intlist, ~x#0:list_loop.intlist, ?io#2:wybe.phantom) #1 @list_loop:nn:nn
+    foreign c print_int(h##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    list_loop.gen$3<0>(~h##0:wybe.int, ~io##1:wybe.phantom, ~l##0:list_loop.intlist, ~x##0:list_loop.intlist, ~tmp$0##0:list_loop.intlist, ~tmp$1##0:list_loop.intlist, ~tmp$2##0:list_loop.intlist, ~tmp$3##0:list_loop.intlist, ~x##0:list_loop.intlist, ?io##2:wybe.phantom) #1 @list_loop:nn:nn
 
 
 gen$3 > (2 calls)
 0: list_loop.gen$3<0>
-gen$3(h#0:wybe.int, io#0:wybe.phantom, l#0:list_loop.intlist, l2#0:list_loop.intlist, tmp$0#0:list_loop.intlist, tmp$1#0:list_loop.intlist, tmp$2#0:list_loop.intlist, tmp$3#0:list_loop.intlist, x#0:list_loop.intlist, ?io#1:wybe.phantom):
+gen$3(h##0:wybe.int, io##0:wybe.phantom, l##0:list_loop.intlist, l2##0:list_loop.intlist, tmp$0##0:list_loop.intlist, tmp$1##0:list_loop.intlist, tmp$2##0:list_loop.intlist, tmp$3##0:list_loop.intlist, x##0:list_loop.intlist, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(l2#0:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.bool)
-    case ~tmp$6#0:wybe.bool of
+    foreign llvm icmp_ne(l2##0:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.bool)
+    case ~tmp$6##0:wybe.bool of
     0:
-        list_loop.gen$1<0>(~io#0:wybe.phantom, ~l#0:list_loop.intlist, ~tmp$0#0:list_loop.intlist, ~tmp$1#0:list_loop.intlist, ~tmp$2#0:list_loop.intlist, ~tmp$3#0:list_loop.intlist, ~x#0:list_loop.intlist, ?io#1:wybe.phantom) #2 @list_loop:nn:nn
+        list_loop.gen$1<0>(~io##0:wybe.phantom, ~l##0:list_loop.intlist, ~tmp$0##0:list_loop.intlist, ~tmp$1##0:list_loop.intlist, ~tmp$2##0:list_loop.intlist, ~tmp$3##0:list_loop.intlist, ~x##0:list_loop.intlist, ?io##1:wybe.phantom) #2 @list_loop:nn:nn
 
     1:
-        foreign lpvm access(l2#0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h2#0:wybe.int)
-        foreign lpvm access(~l2#0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?l2#1:list_loop.intlist)
-        foreign c print_string("    ":wybe.string, ~io#0:wybe.phantom, ?tmp$17#0:wybe.phantom) @io:nn:nn
-        foreign c print_int(h#0:wybe.int, ~tmp$17#0:wybe.phantom, ?tmp$18#0:wybe.phantom) @io:nn:nn
-        foreign c print_string(" ":wybe.string, ~tmp$18#0:wybe.phantom, ?tmp$19#0:wybe.phantom) @io:nn:nn
-        foreign c print_int(~h2#0:wybe.int, ~tmp$19#0:wybe.phantom, ?tmp$20#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$20#0:wybe.phantom, ?tmp$21#0:wybe.phantom) @io:nn:nn
-        list_loop.gen$3<0>(~h#0:wybe.int, ~tmp$21#0:wybe.phantom, ~l#0:list_loop.intlist, ~l2#1:list_loop.intlist, ~tmp$0#0:list_loop.intlist, ~tmp$1#0:list_loop.intlist, ~tmp$2#0:list_loop.intlist, ~tmp$3#0:list_loop.intlist, ~x#0:list_loop.intlist, ?io#1:wybe.phantom) #3 @list_loop:nn:nn
+        foreign lpvm access(l2##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h2##0:wybe.int)
+        foreign lpvm access(~l2##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?l2##1:list_loop.intlist)
+        foreign c print_string("    ":wybe.string, ~io##0:wybe.phantom, ?tmp$17##0:wybe.phantom) @io:nn:nn
+        foreign c print_int(h##0:wybe.int, ~tmp$17##0:wybe.phantom, ?tmp$18##0:wybe.phantom) @io:nn:nn
+        foreign c print_string(" ":wybe.string, ~tmp$18##0:wybe.phantom, ?tmp$19##0:wybe.phantom) @io:nn:nn
+        foreign c print_int(~h2##0:wybe.int, ~tmp$19##0:wybe.phantom, ?tmp$20##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$20##0:wybe.phantom, ?tmp$21##0:wybe.phantom) @io:nn:nn
+        list_loop.gen$3<0>(~h##0:wybe.int, ~tmp$21##0:wybe.phantom, ~l##0:list_loop.intlist, ~l2##1:list_loop.intlist, ~tmp$0##0:list_loop.intlist, ~tmp$1##0:list_loop.intlist, ~tmp$2##0:list_loop.intlist, ~tmp$3##0:list_loop.intlist, ~x##0:list_loop.intlist, ?io##1:wybe.phantom) #3 @list_loop:nn:nn
 
 
 
 gen$4 > {inline} (1 calls)
 0: list_loop.gen$4<0>
-gen$4(h#0:wybe.int, h2#0:wybe.int, io#0:wybe.phantom, l#0:list_loop.intlist, l2#0:list_loop.intlist, tmp$0#0:list_loop.intlist, tmp$1#0:list_loop.intlist, tmp$2#0:list_loop.intlist, tmp$3#0:list_loop.intlist, x#0:list_loop.intlist, ?io#5:wybe.phantom):
+gen$4(h##0:wybe.int, h2##0:wybe.int, io##0:wybe.phantom, l##0:list_loop.intlist, l2##0:list_loop.intlist, tmp$0##0:list_loop.intlist, tmp$1##0:list_loop.intlist, tmp$2##0:list_loop.intlist, tmp$3##0:list_loop.intlist, x##0:list_loop.intlist, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("    ":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_int(h#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string(" ":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign c print_int(~h2#0:wybe.int, ~#io#3:wybe.phantom, ?tmp$12#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$12#0:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    list_loop.gen$3<0>(~h#0:wybe.int, ~io#4:wybe.phantom, ~l#0:list_loop.intlist, ~l2#0:list_loop.intlist, ~tmp$0#0:list_loop.intlist, ~tmp$1#0:list_loop.intlist, ~tmp$2#0:list_loop.intlist, ~tmp$3#0:list_loop.intlist, ~x#0:list_loop.intlist, ?io#5:wybe.phantom) #4 @list_loop:nn:nn
+    foreign c print_string("    ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(h##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(" ":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign c print_int(~h2##0:wybe.int, ~#io##3:wybe.phantom, ?tmp$12##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$12##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    list_loop.gen$3<0>(~h##0:wybe.int, ~io##4:wybe.phantom, ~l##0:list_loop.intlist, ~l2##0:list_loop.intlist, ~tmp$0##0:list_loop.intlist, ~tmp$1##0:list_loop.intlist, ~tmp$2##0:list_loop.intlist, ~tmp$3##0:list_loop.intlist, ~x##0:list_loop.intlist, ?io##5:wybe.phantom) #4 @list_loop:nn:nn
 
   LLVM code       :
 
@@ -172,73 +172,73 @@ entry:
 }
 
 
-define external fastcc  void @"list_loop.gen$1<0>"(i64  %"l#0", i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"x#0")    {
+define external fastcc  void @"list_loop.gen$1<0>"(i64  %"l##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"x##0")    {
 entry:
-  %"1$tmp$7#0" = icmp ne i64 %"l#0", 0 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp ne i64 %"l##0", 0 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %25 = inttoptr i64 %"l#0" to i64* 
+  %25 = inttoptr i64 %"l##0" to i64* 
   %26 = getelementptr  i64, i64* %25, i64 0 
   %27 = load  i64, i64* %26 
-  %28 = add   i64 %"l#0", 8 
+  %28 = add   i64 %"l##0", 8 
   %29 = inttoptr i64 %28 to i64* 
   %30 = getelementptr  i64, i64* %29, i64 0 
   %31 = load  i64, i64* %30 
   tail call ccc  void  @print_int(i64  %27)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"list_loop.gen$3<0>"(i64  %27, i64  %31, i64  %"x#0", i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"x#0")  
+  tail call fastcc  void  @"list_loop.gen$3<0>"(i64  %27, i64  %31, i64  %"x##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"x##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"list_loop.gen$2<0>"(i64  %"h#0", i64  %"l#0", i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"x#0")    {
+define external fastcc  void @"list_loop.gen$2<0>"(i64  %"h##0", i64  %"l##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"x##0")    {
 entry:
-  tail call ccc  void  @print_int(i64  %"h#0")  
+  tail call ccc  void  @print_int(i64  %"h##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"list_loop.gen$3<0>"(i64  %"h#0", i64  %"l#0", i64  %"x#0", i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"x#0")  
+  tail call fastcc  void  @"list_loop.gen$3<0>"(i64  %"h##0", i64  %"l##0", i64  %"x##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"x##0")  
   ret void 
 }
 
 
-define external fastcc  void @"list_loop.gen$3<0>"(i64  %"h#0", i64  %"l#0", i64  %"l2#0", i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"x#0")    {
+define external fastcc  void @"list_loop.gen$3<0>"(i64  %"h##0", i64  %"l##0", i64  %"l2##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"x##0")    {
 entry:
-  %"1$tmp$6#0" = icmp ne i64 %"l2#0", 0 
-  br i1 %"1$tmp$6#0", label %if.then, label %if.else 
+  %"1$tmp$6##0" = icmp ne i64 %"l2##0", 0 
+  br i1 %"1$tmp$6##0", label %if.then, label %if.else 
 if.then:
-  %32 = inttoptr i64 %"l2#0" to i64* 
+  %32 = inttoptr i64 %"l2##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
-  %35 = add   i64 %"l2#0", 8 
+  %35 = add   i64 %"l2##0", 8 
   %36 = inttoptr i64 %35 to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
   %40 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @list_loop.39, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %40)  
-  tail call ccc  void  @print_int(i64  %"h#0")  
+  tail call ccc  void  @print_int(i64  %"h##0")  
   %42 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @list_loop.41, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %42)  
   tail call ccc  void  @print_int(i64  %34)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"list_loop.gen$3<0>"(i64  %"h#0", i64  %"l#0", i64  %38, i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"x#0")  
+  tail call fastcc  void  @"list_loop.gen$3<0>"(i64  %"h##0", i64  %"l##0", i64  %38, i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"x##0")  
   ret void 
 if.else:
-  tail call fastcc  void  @"list_loop.gen$1<0>"(i64  %"l#0", i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"x#0")  
+  tail call fastcc  void  @"list_loop.gen$1<0>"(i64  %"l##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"x##0")  
   ret void 
 }
 
 
-define external fastcc  void @"list_loop.gen$4<0>"(i64  %"h#0", i64  %"h2#0", i64  %"l#0", i64  %"l2#0", i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"x#0")    {
+define external fastcc  void @"list_loop.gen$4<0>"(i64  %"h##0", i64  %"h2##0", i64  %"l##0", i64  %"l2##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"x##0")    {
 entry:
   %44 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @list_loop.43, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %44)  
-  tail call ccc  void  @print_int(i64  %"h#0")  
+  tail call ccc  void  @print_int(i64  %"h##0")  
   %46 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @list_loop.45, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %46)  
-  tail call ccc  void  @print_int(i64  %"h2#0")  
+  tail call ccc  void  @print_int(i64  %"h2##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"list_loop.gen$3<0>"(i64  %"h#0", i64  %"l#0", i64  %"l2#0", i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"x#0")  
+  tail call fastcc  void  @"list_loop.gen$3<0>"(i64  %"h##0", i64  %"l##0", i64  %"l2##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"x##0")  
   ret void 
 }
 --------------------------------------------------
@@ -262,32 +262,32 @@ entry:
 
 = > public (2 calls)
 0: list_loop.intlist.=<0>
-=($left#0:list_loop.intlist, $right#0:list_loop.intlist, ?$$#0:wybe.bool):
+=($left##0:list_loop.intlist, $right##0:list_loop.intlist, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left#0:list_loop.intlist, ~$right#0:list_loop.intlist, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~$left##0:list_loop.intlist, ~$right##0:list_loop.intlist, ?$$##0:wybe.bool)
 
     1:
-        foreign lpvm access($left#0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$head#0:wybe.int)
-        foreign lpvm access(~$left#0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$tail#0:list_loop.intlist)
-        foreign llvm icmp_ne($right#0:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.bool)
-        case ~tmp$9#0:wybe.bool of
+        foreign lpvm access($left##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$head##0:wybe.int)
+        foreign lpvm access(~$left##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$tail##0:list_loop.intlist)
+        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
+        case ~tmp$9##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign lpvm access($right#0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$head#0:wybe.int)
-            foreign lpvm access(~$right#0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$tail#0:list_loop.intlist)
-            foreign llvm icmp_eq(~$left$head#0:wybe.int, ~$right$head#0:wybe.int, ?tmp$4#0:wybe.bool) @int:nn:nn
-            case ~tmp$4#0:wybe.bool of
+            foreign lpvm access($right##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$head##0:wybe.int)
+            foreign lpvm access(~$right##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$tail##0:list_loop.intlist)
+            foreign llvm icmp_eq(~$left$head##0:wybe.int, ~$right$head##0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
+            case ~tmp$4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                list_loop.intlist.=<0>(~$left$tail#0:list_loop.intlist, ~$right$tail#0:list_loop.intlist, ?$$#0:wybe.bool) #3
+                list_loop.intlist.=<0>(~$left$tail##0:list_loop.intlist, ~$right$tail##0:list_loop.intlist, ?$$##0:wybe.bool) #3
 
 
 
@@ -295,110 +295,110 @@ entry:
 
 cons > public {inline} (0 calls)
 0: list_loop.intlist.cons<0>
-cons(head#0:wybe.int, tail#0:list_loop.intlist, ?$#0:list_loop.intlist):
+cons(head##0:wybe.int, tail##0:list_loop.intlist, ?$##0:list_loop.intlist):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:list_loop.intlist)
-    foreign lpvm mutate(~$rec#0:list_loop.intlist, ?$rec#1:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:list_loop.intlist, ?$#0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail#0:list_loop.intlist)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:list_loop.intlist)
+    foreign lpvm mutate(~$rec##0:list_loop.intlist, ?$rec##1:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:list_loop.intlist, ?$##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:list_loop.intlist)
 cons > public {inline} (12 calls)
 1: list_loop.intlist.cons<1>
-cons(?head#0:wybe.int, ?tail#0:list_loop.intlist, $#0:list_loop.intlist, ?$$#0:wybe.bool):
+cons(?head##0:wybe.int, ?tail##0:list_loop.intlist, $##0:list_loop.intlist, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?head#0:wybe.int)
-        foreign llvm move(undef:list_loop.intlist, ?tail#0:list_loop.intlist)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?head##0:wybe.int)
+        foreign llvm move(undef:list_loop.intlist, ?tail##0:list_loop.intlist)
 
     1:
-        foreign lpvm access($#0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head#0:wybe.int)
-        foreign lpvm access(~$#0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail#0:list_loop.intlist)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access($##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
+        foreign lpvm access(~$##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:list_loop.intlist)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 head > public {inline} (0 calls)
 0: list_loop.intlist.head<0>
-head($rec#0:list_loop.intlist, ?$#0:wybe.int, ?$$#0:wybe.bool):
+head($rec##0:list_loop.intlist, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec#0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 head > public {inline} (0 calls)
 1: list_loop.intlist.head<1>
-head($rec#0:list_loop.intlist, ?$rec#1:list_loop.intlist, $field#0:wybe.int, ?$$#0:wybe.bool):
+head($rec##0:list_loop.intlist, ?$rec##1:list_loop.intlist, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:list_loop.intlist, ?$rec#1:list_loop.intlist)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:list_loop.intlist, ?$rec##1:list_loop.intlist)
 
     1:
-        foreign lpvm mutate(~$rec#0:list_loop.intlist, ?$rec#1:list_loop.intlist, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~$rec##0:list_loop.intlist, ?$rec##1:list_loop.intlist, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 nil > public {inline} (0 calls)
 0: list_loop.intlist.nil<0>
-nil(?$#0:list_loop.intlist):
+nil(?$##0:list_loop.intlist):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:list_loop.intlist, ?$#0:list_loop.intlist)
+    foreign llvm move(0:list_loop.intlist, ?$##0:list_loop.intlist)
 
 
 tail > public {inline} (0 calls)
 0: list_loop.intlist.tail<0>
-tail($rec#0:list_loop.intlist, ?$#0:list_loop.intlist, ?$$#0:wybe.bool):
+tail($rec##0:list_loop.intlist, ?$##0:list_loop.intlist, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:list_loop.intlist, ?$#0:list_loop.intlist)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:list_loop.intlist, ?$##0:list_loop.intlist)
 
     1:
-        foreign lpvm access(~$rec#0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:list_loop.intlist)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:list_loop.intlist)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 tail > public {inline} (0 calls)
 1: list_loop.intlist.tail<1>
-tail($rec#0:list_loop.intlist, ?$rec#1:list_loop.intlist, $field#0:list_loop.intlist, ?$$#0:wybe.bool):
+tail($rec##0:list_loop.intlist, ?$rec##1:list_loop.intlist, $field##0:list_loop.intlist, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:list_loop.intlist, ?$rec#1:list_loop.intlist)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:list_loop.intlist, ?$rec##1:list_loop.intlist)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec#0:list_loop.intlist, ?$rec#1:list_loop.intlist, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:list_loop.intlist)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm {noalias} mutate(~$rec##0:list_loop.intlist, ?$rec##1:list_loop.intlist, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:list_loop.intlist)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: list_loop.intlist.~=<0>
-~=($left#0:list_loop.intlist, $right#0:list_loop.intlist, ?$$#0:wybe.bool):
+~=($left##0:list_loop.intlist, $right##0:list_loop.intlist, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    list_loop.intlist.=<0>(~$left#0:list_loop.intlist, ~$right#0:list_loop.intlist, ?tmp$0#0:wybe.bool) #0
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    list_loop.intlist.=<0>(~$left##0:list_loop.intlist, ~$right##0:list_loop.intlist, ?tmp$0##0:wybe.bool) #0
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
   LLVM code       :
 
@@ -414,68 +414,68 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"list_loop.intlist.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"list_loop.intlist.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$left#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %"2$tmp$9#0" = icmp ne i64 %"$right#0", 0 
-  br i1 %"2$tmp$9#0", label %if.then1, label %if.else1 
+  %"2$tmp$9##0" = icmp ne i64 %"$right##0", 0 
+  br i1 %"2$tmp$9##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = icmp eq i64 %"$left#0", %"$right#0" 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
+  ret i1 %"3$$$##0" 
 if.then1:
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"4$tmp$4#0" = icmp eq i64 %3, %10 
-  br i1 %"4$tmp$4#0", label %if.then2, label %if.else2 
+  %"4$tmp$4##0" = icmp eq i64 %3, %10 
+  br i1 %"4$tmp$4##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$$$#0" = tail call fastcc  i1  @"list_loop.intlist.=<0>"(i64  %7, i64  %14)  
-  ret i1 %"6$$$#0" 
+  %"6$$$##0" = tail call fastcc  i1  @"list_loop.intlist.=<0>"(i64  %7, i64  %14)  
+  ret i1 %"6$$$##0" 
 if.else2:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"list_loop.intlist.cons<0>"(i64  %"head#0", i64  %"tail#0")    {
+define external fastcc  i64 @"list_loop.intlist.cons<0>"(i64  %"head##0", i64  %"tail##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"head#0", i64* %19 
+  store  i64 %"head##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"tail#0", i64* %22 
+  store  i64 %"tail##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64, i1} @"list_loop.intlist.cons<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64, i1} @"list_loop.intlist.cons<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -491,12 +491,12 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"list_loop.intlist.head<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"list_loop.intlist.head<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %36 = inttoptr i64 %"$rec#0" to i64* 
+  %36 = inttoptr i64 %"$rec##0" to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
   %39 = insertvalue {i64, i1} undef, i64 %38, 0 
@@ -509,26 +509,26 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"list_loop.intlist.head<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"list_loop.intlist.head<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %43 = trunc i64 16 to i32  
   %44 = tail call ccc  i8*  @wybe_malloc(i32  %43)  
   %45 = ptrtoint i8* %44 to i64 
   %46 = inttoptr i64 %45 to i8* 
-  %47 = inttoptr i64 %"$rec#0" to i8* 
+  %47 = inttoptr i64 %"$rec##0" to i8* 
   %48 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %46, i8*  %47, i32  %48, i32  8, i1  0)  
   %49 = inttoptr i64 %45 to i64* 
   %50 = getelementptr  i64, i64* %49, i64 0 
-  store  i64 %"$field#0", i64* %50 
+  store  i64 %"$field##0", i64* %50 
   %51 = insertvalue {i64, i1} undef, i64 %45, 0 
   %52 = insertvalue {i64, i1} %51, i1 1, 1 
   ret {i64, i1} %52 
 if.else:
-  %53 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %53 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %54 = insertvalue {i64, i1} %53, i1 0, 1 
   ret {i64, i1} %54 
 }
@@ -540,12 +540,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"list_loop.intlist.tail<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"list_loop.intlist.tail<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %55 = add   i64 %"$rec#0", 8 
+  %55 = add   i64 %"$rec##0", 8 
   %56 = inttoptr i64 %55 to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
@@ -559,35 +559,35 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"list_loop.intlist.tail<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"list_loop.intlist.tail<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %63 = trunc i64 16 to i32  
   %64 = tail call ccc  i8*  @wybe_malloc(i32  %63)  
   %65 = ptrtoint i8* %64 to i64 
   %66 = inttoptr i64 %65 to i8* 
-  %67 = inttoptr i64 %"$rec#0" to i8* 
+  %67 = inttoptr i64 %"$rec##0" to i8* 
   %68 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %66, i8*  %67, i32  %68, i32  8, i1  0)  
   %69 = add   i64 %65, 8 
   %70 = inttoptr i64 %69 to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
-  store  i64 %"$field#0", i64* %71 
+  store  i64 %"$field##0", i64* %71 
   %72 = insertvalue {i64, i1} undef, i64 %65, 0 
   %73 = insertvalue {i64, i1} %72, i1 1, 1 
   ret {i64, i1} %73 
 if.else:
-  %74 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %74 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %75 = insertvalue {i64, i1} %74, i1 0, 1 
   ret {i64, i1} %75 
 }
 
 
-define external fastcc  i1 @"list_loop.intlist.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"list_loop.intlist.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = tail call fastcc  i1  @"list_loop.intlist.=<0>"(i64  %"$left#0", i64  %"$right#0")  
-  %"1$$$#0" = xor i1 %"1$tmp$0#0", 1 
-  ret i1 %"1$$$#0" 
+  %"1$tmp$0##0" = tail call fastcc  i1  @"list_loop.intlist.=<0>"(i64  %"$left##0", i64  %"$right##0")  
+  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
+  ret i1 %"1$$$##0" 
 }

--- a/test-cases/final-dump/list_loop.exp
+++ b/test-cases/final-dump/list_loop.exp
@@ -25,80 +25,80 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$8##0:list_loop.intlist)
-    foreign lpvm mutate(~tmp$8##0:list_loop.intlist, ?tmp$9##0:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-    foreign lpvm mutate(~tmp$9##0:list_loop.intlist, ?tmp$10##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:list_loop.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp$13##0:list_loop.intlist)
-    foreign lpvm mutate(~tmp$13##0:list_loop.intlist, ?tmp$14##0:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm mutate(~tmp$14##0:list_loop.intlist, ?tmp$15##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$10##0:list_loop.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp$18##0:list_loop.intlist)
-    foreign lpvm mutate(~tmp$18##0:list_loop.intlist, ?tmp$19##0:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp$19##0:list_loop.intlist, ?tmp$20##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$15##0:list_loop.intlist)
-    list_loop.gen$1<0>(~io##0:wybe.phantom, ~tmp$20##0:list_loop.intlist, ~tmp$20##0:list_loop.intlist, ~tmp$15##0:list_loop.intlist, ~tmp$10##0:list_loop.intlist, 0:list_loop.intlist, ~tmp$20##0:list_loop.intlist, ?io##1:wybe.phantom) #4 @list_loop:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#8##0:list_loop.intlist)
+    foreign lpvm mutate(~tmp#8##0:list_loop.intlist, ?tmp#9##0:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+    foreign lpvm mutate(~tmp#9##0:list_loop.intlist, ?tmp#10##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:list_loop.intlist)
+    foreign lpvm alloc(16:wybe.int, ?tmp#13##0:list_loop.intlist)
+    foreign lpvm mutate(~tmp#13##0:list_loop.intlist, ?tmp#14##0:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+    foreign lpvm mutate(~tmp#14##0:list_loop.intlist, ?tmp#15##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#10##0:list_loop.intlist)
+    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:list_loop.intlist)
+    foreign lpvm mutate(~tmp#18##0:list_loop.intlist, ?tmp#19##0:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp#19##0:list_loop.intlist, ?tmp#20##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#15##0:list_loop.intlist)
+    list_loop.gen#1<0>(~io##0:wybe.phantom, ~tmp#20##0:list_loop.intlist, ~tmp#20##0:list_loop.intlist, ~tmp#15##0:list_loop.intlist, ~tmp#10##0:list_loop.intlist, 0:list_loop.intlist, ~tmp#20##0:list_loop.intlist, ?io##1:wybe.phantom) #4 @list_loop:nn:nn
 
 
-gen$1 > (2 calls)
-0: list_loop.gen$1<0>
-gen$1(io##0:wybe.phantom, l##0:list_loop.intlist, tmp$0##0:list_loop.intlist, tmp$1##0:list_loop.intlist, tmp$2##0:list_loop.intlist, tmp$3##0:list_loop.intlist, x##0:list_loop.intlist, ?io##1:wybe.phantom):
+gen#1 > (2 calls)
+0: list_loop.gen#1<0>
+gen#1(io##0:wybe.phantom, l##0:list_loop.intlist, tmp#0##0:list_loop.intlist, tmp#1##0:list_loop.intlist, tmp#2##0:list_loop.intlist, tmp#3##0:list_loop.intlist, x##0:list_loop.intlist, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(l##0:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.bool)
-    case ~tmp$7##0:wybe.bool of
+    foreign llvm icmp_ne(l##0:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.bool)
+    case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
         foreign lpvm access(l##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
         foreign lpvm access(~l##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?l##1:list_loop.intlist)
-        foreign c print_int(h##0:wybe.int, ~io##0:wybe.phantom, ?tmp$16##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$16##0:wybe.phantom, ?tmp$17##0:wybe.phantom) @io:nn:nn
-        list_loop.gen$3<0>(~h##0:wybe.int, ~tmp$17##0:wybe.phantom, ~l##1:list_loop.intlist, ~x##0:list_loop.intlist, ~tmp$0##0:list_loop.intlist, ~tmp$1##0:list_loop.intlist, ~tmp$2##0:list_loop.intlist, ~tmp$3##0:list_loop.intlist, ~x##0:list_loop.intlist, ?io##1:wybe.phantom) #2 @list_loop:nn:nn
+        foreign c print_int(h##0:wybe.int, ~io##0:wybe.phantom, ?tmp#16##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?tmp#17##0:wybe.phantom) @io:nn:nn
+        list_loop.gen#3<0>(~h##0:wybe.int, ~tmp#17##0:wybe.phantom, ~l##1:list_loop.intlist, ~x##0:list_loop.intlist, ~tmp#0##0:list_loop.intlist, ~tmp#1##0:list_loop.intlist, ~tmp#2##0:list_loop.intlist, ~tmp#3##0:list_loop.intlist, ~x##0:list_loop.intlist, ?io##1:wybe.phantom) #2 @list_loop:nn:nn
 
 
 
-gen$2 > {inline} (1 calls)
-0: list_loop.gen$2<0>
-gen$2(h##0:wybe.int, io##0:wybe.phantom, l##0:list_loop.intlist, tmp$0##0:list_loop.intlist, tmp$1##0:list_loop.intlist, tmp$2##0:list_loop.intlist, tmp$3##0:list_loop.intlist, x##0:list_loop.intlist, ?io##2:wybe.phantom):
+gen#2 > {inline} (1 calls)
+0: list_loop.gen#2<0>
+gen#2(h##0:wybe.int, io##0:wybe.phantom, l##0:list_loop.intlist, tmp#0##0:list_loop.intlist, tmp#1##0:list_loop.intlist, tmp#2##0:list_loop.intlist, tmp#3##0:list_loop.intlist, x##0:list_loop.intlist, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(h##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    list_loop.gen$3<0>(~h##0:wybe.int, ~io##1:wybe.phantom, ~l##0:list_loop.intlist, ~x##0:list_loop.intlist, ~tmp$0##0:list_loop.intlist, ~tmp$1##0:list_loop.intlist, ~tmp$2##0:list_loop.intlist, ~tmp$3##0:list_loop.intlist, ~x##0:list_loop.intlist, ?io##2:wybe.phantom) #1 @list_loop:nn:nn
+    foreign c print_int(h##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    list_loop.gen#3<0>(~h##0:wybe.int, ~io##1:wybe.phantom, ~l##0:list_loop.intlist, ~x##0:list_loop.intlist, ~tmp#0##0:list_loop.intlist, ~tmp#1##0:list_loop.intlist, ~tmp#2##0:list_loop.intlist, ~tmp#3##0:list_loop.intlist, ~x##0:list_loop.intlist, ?io##2:wybe.phantom) #1 @list_loop:nn:nn
 
 
-gen$3 > (2 calls)
-0: list_loop.gen$3<0>
-gen$3(h##0:wybe.int, io##0:wybe.phantom, l##0:list_loop.intlist, l2##0:list_loop.intlist, tmp$0##0:list_loop.intlist, tmp$1##0:list_loop.intlist, tmp$2##0:list_loop.intlist, tmp$3##0:list_loop.intlist, x##0:list_loop.intlist, ?io##1:wybe.phantom):
+gen#3 > (2 calls)
+0: list_loop.gen#3<0>
+gen#3(h##0:wybe.int, io##0:wybe.phantom, l##0:list_loop.intlist, l2##0:list_loop.intlist, tmp#0##0:list_loop.intlist, tmp#1##0:list_loop.intlist, tmp#2##0:list_loop.intlist, tmp#3##0:list_loop.intlist, x##0:list_loop.intlist, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(l2##0:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.bool)
-    case ~tmp$6##0:wybe.bool of
+    foreign llvm icmp_ne(l2##0:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.bool)
+    case ~tmp#6##0:wybe.bool of
     0:
-        list_loop.gen$1<0>(~io##0:wybe.phantom, ~l##0:list_loop.intlist, ~tmp$0##0:list_loop.intlist, ~tmp$1##0:list_loop.intlist, ~tmp$2##0:list_loop.intlist, ~tmp$3##0:list_loop.intlist, ~x##0:list_loop.intlist, ?io##1:wybe.phantom) #2 @list_loop:nn:nn
+        list_loop.gen#1<0>(~io##0:wybe.phantom, ~l##0:list_loop.intlist, ~tmp#0##0:list_loop.intlist, ~tmp#1##0:list_loop.intlist, ~tmp#2##0:list_loop.intlist, ~tmp#3##0:list_loop.intlist, ~x##0:list_loop.intlist, ?io##1:wybe.phantom) #2 @list_loop:nn:nn
 
     1:
         foreign lpvm access(l2##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h2##0:wybe.int)
         foreign lpvm access(~l2##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?l2##1:list_loop.intlist)
-        foreign c print_string("    ":wybe.string, ~io##0:wybe.phantom, ?tmp$17##0:wybe.phantom) @io:nn:nn
-        foreign c print_int(h##0:wybe.int, ~tmp$17##0:wybe.phantom, ?tmp$18##0:wybe.phantom) @io:nn:nn
-        foreign c print_string(" ":wybe.string, ~tmp$18##0:wybe.phantom, ?tmp$19##0:wybe.phantom) @io:nn:nn
-        foreign c print_int(~h2##0:wybe.int, ~tmp$19##0:wybe.phantom, ?tmp$20##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$20##0:wybe.phantom, ?tmp$21##0:wybe.phantom) @io:nn:nn
-        list_loop.gen$3<0>(~h##0:wybe.int, ~tmp$21##0:wybe.phantom, ~l##0:list_loop.intlist, ~l2##1:list_loop.intlist, ~tmp$0##0:list_loop.intlist, ~tmp$1##0:list_loop.intlist, ~tmp$2##0:list_loop.intlist, ~tmp$3##0:list_loop.intlist, ~x##0:list_loop.intlist, ?io##1:wybe.phantom) #3 @list_loop:nn:nn
+        foreign c print_string("    ":wybe.string, ~io##0:wybe.phantom, ?tmp#17##0:wybe.phantom) @io:nn:nn
+        foreign c print_int(h##0:wybe.int, ~tmp#17##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @io:nn:nn
+        foreign c print_string(" ":wybe.string, ~tmp#18##0:wybe.phantom, ?tmp#19##0:wybe.phantom) @io:nn:nn
+        foreign c print_int(~h2##0:wybe.int, ~tmp#19##0:wybe.phantom, ?tmp#20##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#20##0:wybe.phantom, ?tmp#21##0:wybe.phantom) @io:nn:nn
+        list_loop.gen#3<0>(~h##0:wybe.int, ~tmp#21##0:wybe.phantom, ~l##0:list_loop.intlist, ~l2##1:list_loop.intlist, ~tmp#0##0:list_loop.intlist, ~tmp#1##0:list_loop.intlist, ~tmp#2##0:list_loop.intlist, ~tmp#3##0:list_loop.intlist, ~x##0:list_loop.intlist, ?io##1:wybe.phantom) #3 @list_loop:nn:nn
 
 
 
-gen$4 > {inline} (1 calls)
-0: list_loop.gen$4<0>
-gen$4(h##0:wybe.int, h2##0:wybe.int, io##0:wybe.phantom, l##0:list_loop.intlist, l2##0:list_loop.intlist, tmp$0##0:list_loop.intlist, tmp$1##0:list_loop.intlist, tmp$2##0:list_loop.intlist, tmp$3##0:list_loop.intlist, x##0:list_loop.intlist, ?io##5:wybe.phantom):
+gen#4 > {inline} (1 calls)
+0: list_loop.gen#4<0>
+gen#4(h##0:wybe.int, h2##0:wybe.int, io##0:wybe.phantom, l##0:list_loop.intlist, l2##0:list_loop.intlist, tmp#0##0:list_loop.intlist, tmp#1##0:list_loop.intlist, tmp#2##0:list_loop.intlist, tmp#3##0:list_loop.intlist, x##0:list_loop.intlist, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("    ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     foreign c print_int(h##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string(" ":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign c print_int(~h2##0:wybe.int, ~#io##3:wybe.phantom, ?tmp$12##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$12##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    list_loop.gen$3<0>(~h##0:wybe.int, ~io##4:wybe.phantom, ~l##0:list_loop.intlist, ~l2##0:list_loop.intlist, ~tmp$0##0:list_loop.intlist, ~tmp$1##0:list_loop.intlist, ~tmp$2##0:list_loop.intlist, ~tmp$3##0:list_loop.intlist, ~x##0:list_loop.intlist, ?io##5:wybe.phantom) #4 @list_loop:nn:nn
+    foreign c print_int(~h2##0:wybe.int, ~#io##3:wybe.phantom, ?tmp#12##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#12##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    list_loop.gen#3<0>(~h##0:wybe.int, ~io##4:wybe.phantom, ~l##0:list_loop.intlist, ~l2##0:list_loop.intlist, ~tmp#0##0:list_loop.intlist, ~tmp#1##0:list_loop.intlist, ~tmp#2##0:list_loop.intlist, ~tmp#3##0:list_loop.intlist, ~x##0:list_loop.intlist, ?io##5:wybe.phantom) #4 @list_loop:nn:nn
 
   LLVM code       :
 
@@ -167,15 +167,15 @@ entry:
   %23 = inttoptr i64 %22 to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   store  i64 %11, i64* %24 
-  tail call fastcc  void  @"list_loop.gen$1<0>"(i64  %19, i64  %19, i64  %11, i64  %3, i64  0, i64  %19)  
+  tail call fastcc  void  @"list_loop.gen#1<0>"(i64  %19, i64  %19, i64  %11, i64  %3, i64  0, i64  %19)  
   ret void 
 }
 
 
-define external fastcc  void @"list_loop.gen$1<0>"(i64  %"l##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"x##0")    {
+define external fastcc  void @"list_loop.gen#1<0>"(i64  %"l##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"x##0")    {
 entry:
-  %"1$tmp$7##0" = icmp ne i64 %"l##0", 0 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp ne i64 %"l##0", 0 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %25 = inttoptr i64 %"l##0" to i64* 
   %26 = getelementptr  i64, i64* %25, i64 0 
@@ -186,26 +186,26 @@ if.then:
   %31 = load  i64, i64* %30 
   tail call ccc  void  @print_int(i64  %27)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"list_loop.gen$3<0>"(i64  %27, i64  %31, i64  %"x##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"x##0")  
+  tail call fastcc  void  @"list_loop.gen#3<0>"(i64  %27, i64  %31, i64  %"x##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"x##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"list_loop.gen$2<0>"(i64  %"h##0", i64  %"l##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"x##0")    {
+define external fastcc  void @"list_loop.gen#2<0>"(i64  %"h##0", i64  %"l##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"x##0")    {
 entry:
   tail call ccc  void  @print_int(i64  %"h##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"list_loop.gen$3<0>"(i64  %"h##0", i64  %"l##0", i64  %"x##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"x##0")  
+  tail call fastcc  void  @"list_loop.gen#3<0>"(i64  %"h##0", i64  %"l##0", i64  %"x##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"x##0")  
   ret void 
 }
 
 
-define external fastcc  void @"list_loop.gen$3<0>"(i64  %"h##0", i64  %"l##0", i64  %"l2##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"x##0")    {
+define external fastcc  void @"list_loop.gen#3<0>"(i64  %"h##0", i64  %"l##0", i64  %"l2##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"x##0")    {
 entry:
-  %"1$tmp$6##0" = icmp ne i64 %"l2##0", 0 
-  br i1 %"1$tmp$6##0", label %if.then, label %if.else 
+  %"1#tmp#6##0" = icmp ne i64 %"l2##0", 0 
+  br i1 %"1#tmp#6##0", label %if.then, label %if.else 
 if.then:
   %32 = inttoptr i64 %"l2##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
@@ -221,15 +221,15 @@ if.then:
   tail call ccc  void  @print_string(i64  %42)  
   tail call ccc  void  @print_int(i64  %34)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"list_loop.gen$3<0>"(i64  %"h##0", i64  %"l##0", i64  %38, i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"x##0")  
+  tail call fastcc  void  @"list_loop.gen#3<0>"(i64  %"h##0", i64  %"l##0", i64  %38, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"x##0")  
   ret void 
 if.else:
-  tail call fastcc  void  @"list_loop.gen$1<0>"(i64  %"l##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"x##0")  
+  tail call fastcc  void  @"list_loop.gen#1<0>"(i64  %"l##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"x##0")  
   ret void 
 }
 
 
-define external fastcc  void @"list_loop.gen$4<0>"(i64  %"h##0", i64  %"h2##0", i64  %"l##0", i64  %"l2##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"x##0")    {
+define external fastcc  void @"list_loop.gen#4<0>"(i64  %"h##0", i64  %"h2##0", i64  %"l##0", i64  %"l2##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"x##0")    {
 entry:
   %44 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @list_loop.43, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %44)  
@@ -238,7 +238,7 @@ entry:
   tail call ccc  void  @print_string(i64  %46)  
   tail call ccc  void  @print_int(i64  %"h2##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"list_loop.gen$3<0>"(i64  %"h##0", i64  %"l##0", i64  %"l2##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"x##0")  
+  tail call fastcc  void  @"list_loop.gen#3<0>"(i64  %"h##0", i64  %"l##0", i64  %"l2##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"x##0")  
   ret void 
 }
 --------------------------------------------------
@@ -262,32 +262,32 @@ entry:
 
 = > public (2 calls)
 0: list_loop.intlist.=<0>
-=($left##0:list_loop.intlist, $right##0:list_loop.intlist, ?$$##0:wybe.bool):
+=(#left##0:list_loop.intlist, #right##0:list_loop.intlist, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left##0:list_loop.intlist, ~$right##0:list_loop.intlist, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:list_loop.intlist, ~#right##0:list_loop.intlist, ?####0:wybe.bool)
 
     1:
-        foreign lpvm access($left##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$head##0:wybe.int)
-        foreign lpvm access(~$left##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$tail##0:list_loop.intlist)
-        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
-        case ~tmp$9##0:wybe.bool of
+        foreign lpvm access(#left##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#head##0:wybe.int)
+        foreign lpvm access(~#left##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#tail##0:list_loop.intlist)
+        foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
+        case ~tmp#9##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign lpvm access($right##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$head##0:wybe.int)
-            foreign lpvm access(~$right##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$tail##0:list_loop.intlist)
-            foreign llvm icmp_eq(~$left$head##0:wybe.int, ~$right$head##0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
-            case ~tmp$4##0:wybe.bool of
+            foreign lpvm access(#right##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#head##0:wybe.int)
+            foreign lpvm access(~#right##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#tail##0:list_loop.intlist)
+            foreign llvm icmp_eq(~#left#head##0:wybe.int, ~#right#head##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
+            case ~tmp#4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
             1:
-                list_loop.intlist.=<0>(~$left$tail##0:list_loop.intlist, ~$right$tail##0:list_loop.intlist, ?$$##0:wybe.bool) #3
+                list_loop.intlist.=<0>(~#left#tail##0:list_loop.intlist, ~#right#tail##0:list_loop.intlist, ?####0:wybe.bool) #3
 
 
 
@@ -295,110 +295,110 @@ entry:
 
 cons > public {inline} (0 calls)
 0: list_loop.intlist.cons<0>
-cons(head##0:wybe.int, tail##0:list_loop.intlist, ?$##0:list_loop.intlist):
+cons(head##0:wybe.int, tail##0:list_loop.intlist, ?###0:list_loop.intlist):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:list_loop.intlist)
-    foreign lpvm mutate(~$rec##0:list_loop.intlist, ?$rec##1:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:list_loop.intlist, ?$##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:list_loop.intlist)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:list_loop.intlist)
+    foreign lpvm mutate(~#rec##0:list_loop.intlist, ?#rec##1:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:list_loop.intlist, ?###0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:list_loop.intlist)
 cons > public {inline} (12 calls)
 1: list_loop.intlist.cons<1>
-cons(?head##0:wybe.int, ?tail##0:list_loop.intlist, $##0:list_loop.intlist, ?$$##0:wybe.bool):
+cons(?head##0:wybe.int, ?tail##0:list_loop.intlist, ###0:list_loop.intlist, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?head##0:wybe.int)
         foreign llvm move(undef:list_loop.intlist, ?tail##0:list_loop.intlist)
 
     1:
-        foreign lpvm access($##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
-        foreign lpvm access(~$##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:list_loop.intlist)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(###0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
+        foreign lpvm access(~###0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:list_loop.intlist)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 head > public {inline} (0 calls)
 0: list_loop.intlist.head<0>
-head($rec##0:list_loop.intlist, ?$##0:wybe.int, ?$$##0:wybe.bool):
+head(#rec##0:list_loop.intlist, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 head > public {inline} (0 calls)
 1: list_loop.intlist.head<1>
-head($rec##0:list_loop.intlist, ?$rec##1:list_loop.intlist, $field##0:wybe.int, ?$$##0:wybe.bool):
+head(#rec##0:list_loop.intlist, ?#rec##1:list_loop.intlist, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:list_loop.intlist, ?$rec##1:list_loop.intlist)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:list_loop.intlist, ?#rec##1:list_loop.intlist)
 
     1:
-        foreign lpvm mutate(~$rec##0:list_loop.intlist, ?$rec##1:list_loop.intlist, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~#rec##0:list_loop.intlist, ?#rec##1:list_loop.intlist, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 nil > public {inline} (0 calls)
 0: list_loop.intlist.nil<0>
-nil(?$##0:list_loop.intlist):
+nil(?###0:list_loop.intlist):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:list_loop.intlist, ?$##0:list_loop.intlist)
+    foreign llvm move(0:list_loop.intlist, ?###0:list_loop.intlist)
 
 
 tail > public {inline} (0 calls)
 0: list_loop.intlist.tail<0>
-tail($rec##0:list_loop.intlist, ?$##0:list_loop.intlist, ?$$##0:wybe.bool):
+tail(#rec##0:list_loop.intlist, ?###0:list_loop.intlist, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:list_loop.intlist, ?$##0:list_loop.intlist)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:list_loop.intlist, ?###0:list_loop.intlist)
 
     1:
-        foreign lpvm access(~$rec##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:list_loop.intlist)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:list_loop.intlist)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 tail > public {inline} (0 calls)
 1: list_loop.intlist.tail<1>
-tail($rec##0:list_loop.intlist, ?$rec##1:list_loop.intlist, $field##0:list_loop.intlist, ?$$##0:wybe.bool):
+tail(#rec##0:list_loop.intlist, ?#rec##1:list_loop.intlist, #field##0:list_loop.intlist, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:list_loop.intlist, ?$rec##1:list_loop.intlist)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:list_loop.intlist, ?#rec##1:list_loop.intlist)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec##0:list_loop.intlist, ?$rec##1:list_loop.intlist, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:list_loop.intlist)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm {noalias} mutate(~#rec##0:list_loop.intlist, ?#rec##1:list_loop.intlist, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:list_loop.intlist)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: list_loop.intlist.~=<0>
-~=($left##0:list_loop.intlist, $right##0:list_loop.intlist, ?$$##0:wybe.bool):
+~=(#left##0:list_loop.intlist, #right##0:list_loop.intlist, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    list_loop.intlist.=<0>(~$left##0:list_loop.intlist, ~$right##0:list_loop.intlist, ?tmp$0##0:wybe.bool) #0
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    list_loop.intlist.=<0>(~#left##0:list_loop.intlist, ~#right##0:list_loop.intlist, ?tmp#0##0:wybe.bool) #0
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
   LLVM code       :
 
@@ -414,38 +414,38 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"list_loop.intlist.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"list_loop.intlist.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#left##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %"2$tmp$9##0" = icmp ne i64 %"$right##0", 0 
-  br i1 %"2$tmp$9##0", label %if.then1, label %if.else1 
+  %"2#tmp#9##0" = icmp ne i64 %"#right##0", 0 
+  br i1 %"2#tmp#9##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3#####0" 
 if.then1:
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"4$tmp$4##0" = icmp eq i64 %3, %10 
-  br i1 %"4$tmp$4##0", label %if.then2, label %if.else2 
+  %"4#tmp#4##0" = icmp eq i64 %3, %10 
+  br i1 %"4#tmp#4##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$$$##0" = tail call fastcc  i1  @"list_loop.intlist.=<0>"(i64  %7, i64  %14)  
-  ret i1 %"6$$$##0" 
+  %"6#####0" = tail call fastcc  i1  @"list_loop.intlist.=<0>"(i64  %7, i64  %14)  
+  ret i1 %"6#####0" 
 if.else2:
   ret i1 0 
 }
@@ -467,15 +467,15 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"list_loop.intlist.cons<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64, i1} @"list_loop.intlist.cons<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -491,12 +491,12 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"list_loop.intlist.head<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"list_loop.intlist.head<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %36 = inttoptr i64 %"$rec##0" to i64* 
+  %36 = inttoptr i64 %"#rec##0" to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
   %39 = insertvalue {i64, i1} undef, i64 %38, 0 
@@ -509,26 +509,26 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"list_loop.intlist.head<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"list_loop.intlist.head<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %43 = trunc i64 16 to i32  
   %44 = tail call ccc  i8*  @wybe_malloc(i32  %43)  
   %45 = ptrtoint i8* %44 to i64 
   %46 = inttoptr i64 %45 to i8* 
-  %47 = inttoptr i64 %"$rec##0" to i8* 
+  %47 = inttoptr i64 %"#rec##0" to i8* 
   %48 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %46, i8*  %47, i32  %48, i32  8, i1  0)  
   %49 = inttoptr i64 %45 to i64* 
   %50 = getelementptr  i64, i64* %49, i64 0 
-  store  i64 %"$field##0", i64* %50 
+  store  i64 %"#field##0", i64* %50 
   %51 = insertvalue {i64, i1} undef, i64 %45, 0 
   %52 = insertvalue {i64, i1} %51, i1 1, 1 
   ret {i64, i1} %52 
 if.else:
-  %53 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %53 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %54 = insertvalue {i64, i1} %53, i1 0, 1 
   ret {i64, i1} %54 
 }
@@ -540,12 +540,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"list_loop.intlist.tail<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"list_loop.intlist.tail<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %55 = add   i64 %"$rec##0", 8 
+  %55 = add   i64 %"#rec##0", 8 
   %56 = inttoptr i64 %55 to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
@@ -559,35 +559,35 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"list_loop.intlist.tail<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"list_loop.intlist.tail<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %63 = trunc i64 16 to i32  
   %64 = tail call ccc  i8*  @wybe_malloc(i32  %63)  
   %65 = ptrtoint i8* %64 to i64 
   %66 = inttoptr i64 %65 to i8* 
-  %67 = inttoptr i64 %"$rec##0" to i8* 
+  %67 = inttoptr i64 %"#rec##0" to i8* 
   %68 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %66, i8*  %67, i32  %68, i32  8, i1  0)  
   %69 = add   i64 %65, 8 
   %70 = inttoptr i64 %69 to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
-  store  i64 %"$field##0", i64* %71 
+  store  i64 %"#field##0", i64* %71 
   %72 = insertvalue {i64, i1} undef, i64 %65, 0 
   %73 = insertvalue {i64, i1} %72, i1 1, 1 
   ret {i64, i1} %73 
 if.else:
-  %74 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %74 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %75 = insertvalue {i64, i1} %74, i1 0, 1 
   ret {i64, i1} %75 
 }
 
 
-define external fastcc  i1 @"list_loop.intlist.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"list_loop.intlist.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = tail call fastcc  i1  @"list_loop.intlist.=<0>"(i64  %"$left##0", i64  %"$right##0")  
-  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
-  ret i1 %"1$$$##0" 
+  %"1#tmp#0##0" = tail call fastcc  i1  @"list_loop.intlist.=<0>"(i64  %"#left##0", i64  %"#right##0")  
+  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1#####0" 
 }

--- a/test-cases/final-dump/list_loop.exp
+++ b/test-cases/final-dump/list_loop.exp
@@ -295,18 +295,18 @@ entry:
 
 cons > public {inline} (0 calls)
 0: list_loop.intlist.cons<0>
-cons(head##0:wybe.int, tail##0:list_loop.intlist, ?###0:list_loop.intlist):
+cons(head##0:wybe.int, tail##0:list_loop.intlist, ?#result##0:list_loop.intlist):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:list_loop.intlist)
     foreign lpvm mutate(~#rec##0:list_loop.intlist, ?#rec##1:list_loop.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:list_loop.intlist, ?###0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:list_loop.intlist)
+    foreign lpvm mutate(~#rec##1:list_loop.intlist, ?#result##0:list_loop.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:list_loop.intlist)
 cons > public {inline} (12 calls)
 1: list_loop.intlist.cons<1>
-cons(?head##0:wybe.int, ?tail##0:list_loop.intlist, ###0:list_loop.intlist, ?####0:wybe.bool):
+cons(?head##0:wybe.int, ?tail##0:list_loop.intlist, #result##0:list_loop.intlist, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
@@ -314,25 +314,25 @@ cons(?head##0:wybe.int, ?tail##0:list_loop.intlist, ###0:list_loop.intlist, ?###
         foreign llvm move(undef:list_loop.intlist, ?tail##0:list_loop.intlist)
 
     1:
-        foreign lpvm access(###0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
-        foreign lpvm access(~###0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:list_loop.intlist)
+        foreign lpvm access(#result##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
+        foreign lpvm access(~#result##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:list_loop.intlist)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 head > public {inline} (0 calls)
 0: list_loop.intlist.head<0>
-head(#rec##0:list_loop.intlist, ?###0:wybe.int, ?####0:wybe.bool):
+head(#rec##0:list_loop.intlist, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign lpvm access(~#rec##0:list_loop.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 head > public {inline} (0 calls)
@@ -354,25 +354,25 @@ head(#rec##0:list_loop.intlist, ?#rec##1:list_loop.intlist, #field##0:wybe.int, 
 
 nil > public {inline} (0 calls)
 0: list_loop.intlist.nil<0>
-nil(?###0:list_loop.intlist):
+nil(?#result##0:list_loop.intlist):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:list_loop.intlist, ?###0:list_loop.intlist)
+    foreign llvm move(0:list_loop.intlist, ?#result##0:list_loop.intlist)
 
 
 tail > public {inline} (0 calls)
 0: list_loop.intlist.tail<0>
-tail(#rec##0:list_loop.intlist, ?###0:list_loop.intlist, ?####0:wybe.bool):
+tail(#rec##0:list_loop.intlist, ?#result##0:list_loop.intlist, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:list_loop.intlist, ?###0:list_loop.intlist)
+        foreign llvm move(undef:list_loop.intlist, ?#result##0:list_loop.intlist)
 
     1:
-        foreign lpvm access(~#rec##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:list_loop.intlist)
+        foreign lpvm access(~#rec##0:list_loop.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:list_loop.intlist)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 tail > public {inline} (0 calls)
@@ -467,15 +467,15 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"list_loop.intlist.cons<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64, i1} @"list_loop.intlist.cons<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  %"1#tmp#0##0" = icmp ne i64 %"#result##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 

--- a/test-cases/final-dump/list_this.exp
+++ b/test-cases/final-dump/list_this.exp
@@ -19,147 +19,147 @@ AFTER EVERYTHING:
 
 append > public (1 calls)
 0: list_this.append<0>
-append(x##0:list_this(?T), y##0:list_this(?T), ?$##0:list_this(?T)):
- AliasPairs: [($##0,y##0)]
+append(x##0:list_this(?T), y##0:list_this(?T), ?###0:list_this(?T)):
+ AliasPairs: [(###0,y##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(list_this.append<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
-    case ~tmp$5##0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
+    case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~y##0:list_this(?T), ?$##0:list_this(?T)) @list_this:nn:nn
+        foreign llvm move(~y##0:list_this(?T), ?###0:list_this(?T)) @list_this:nn:nn
 
     1:
         foreign lpvm access(x##0:list_this(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:?T)
         foreign lpvm access(~x##0:list_this(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:list_this(?T))
-        list_this.append<0>(~t##0:list_this(?T), ~y##0:list_this(?T), ?tmp$2##0:list_this(?T)) #1 @list_this:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$8##0:list_this(?T))
-        foreign lpvm mutate(~tmp$8##0:list_this(?T), ?tmp$9##0:list_this(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:?T)
-        foreign lpvm mutate(~tmp$9##0:list_this(?T), ?$##0:list_this(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:list_this(?T))
+        list_this.append<0>(~t##0:list_this(?T), ~y##0:list_this(?T), ?tmp#2##0:list_this(?T)) #1 @list_this:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:list_this(?T))
+        foreign lpvm mutate(~tmp#8##0:list_this(?T), ?tmp#9##0:list_this(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:?T)
+        foreign lpvm mutate(~tmp#9##0:list_this(?T), ?###0:list_this(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:list_this(?T))
 
 
 
 car > public {inline} (0 calls)
 0: list_this.car<0>
-car($rec##0:list_this(?T), ?$##0:?T, ?$$##0:wybe.bool):
+car(#rec##0:list_this(?T), ?###0:?T, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:?T, ?$##0:?T)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:?T, ?###0:?T)
 
     1:
-        foreign lpvm access(~$rec##0:list_this(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:?T)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:list_this(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:?T)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 car > public {inline} (0 calls)
 1: list_this.car<1>
-car($rec##0:list_this(?T), ?$rec##1:list_this(?T), $field##0:?T, ?$$##0:wybe.bool):
+car(#rec##0:list_this(?T), ?#rec##1:list_this(?T), #field##0:?T, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:list_this(?T), ?$rec##1:list_this(?T))
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:list_this(?T), ?#rec##1:list_this(?T))
 
     1:
-        foreign lpvm mutate(~$rec##0:list_this(?T), ?$rec##1:list_this(?T), 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:?T)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~#rec##0:list_this(?T), ?#rec##1:list_this(?T), 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:?T)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 cdr > public {inline} (0 calls)
 0: list_this.cdr<0>
-cdr($rec##0:list_this(?T), ?$##0:list_this(?T), ?$$##0:wybe.bool):
+cdr(#rec##0:list_this(?T), ?###0:list_this(?T), ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:list_this(?T), ?$##0:list_this(?T))
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:list_this(?T), ?###0:list_this(?T))
 
     1:
-        foreign lpvm access(~$rec##0:list_this(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:list_this(?T))
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:list_this(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:list_this(?T))
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 cdr > public {inline} (0 calls)
 1: list_this.cdr<1>
-cdr($rec##0:list_this(?T), ?$rec##1:list_this(?T), $field##0:list_this(?T), ?$$##0:wybe.bool):
+cdr(#rec##0:list_this(?T), ?#rec##1:list_this(?T), #field##0:list_this(?T), ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:list_this(?T), ?$rec##1:list_this(?T))
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:list_this(?T), ?#rec##1:list_this(?T))
 
     1:
-        foreign lpvm {noalias} mutate(~$rec##0:list_this(?T), ?$rec##1:list_this(?T), 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:list_this(?T))
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm {noalias} mutate(~#rec##0:list_this(?T), ?#rec##1:list_this(?T), 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:list_this(?T))
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 cons > public {inline} (1 calls)
 0: list_this.cons<0>
-cons(car##0:?T, cdr##0:list_this(?T), ?$##0:list_this(?T)):
+cons(car##0:?T, cdr##0:list_this(?T), ?###0:list_this(?T)):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:list_this(?T))
-    foreign lpvm mutate(~$rec##0:list_this(?T), ?$rec##1:list_this(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~car##0:?T)
-    foreign lpvm mutate(~$rec##1:list_this(?T), ?$##0:list_this(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr##0:list_this(?T))
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:list_this(?T))
+    foreign lpvm mutate(~#rec##0:list_this(?T), ?#rec##1:list_this(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~car##0:?T)
+    foreign lpvm mutate(~#rec##1:list_this(?T), ?###0:list_this(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr##0:list_this(?T))
 cons > public {inline} (6 calls)
 1: list_this.cons<1>
-cons(?car##0:?T, ?cdr##0:list_this(?T), $##0:list_this(?T), ?$$##0:wybe.bool):
+cons(?car##0:?T, ?cdr##0:list_this(?T), ###0:list_this(?T), ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:?T, ?car##0:?T)
         foreign llvm move(undef:list_this(?T), ?cdr##0:list_this(?T))
 
     1:
-        foreign lpvm access($##0:list_this(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?car##0:?T)
-        foreign lpvm access(~$##0:list_this(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?cdr##0:list_this(?T))
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(###0:list_this(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?car##0:?T)
+        foreign lpvm access(~###0:list_this(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?cdr##0:list_this(?T))
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 length > public {inline} (0 calls)
 0: list_this.length<0>
-length(x##0:list_this(?T), ?$##0:wybe.int):
+length(x##0:list_this(?T), ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    list_this.length1<0>(~x##0:list_this(?T), 0:wybe.int, ?$##0:wybe.int) #0 @list_this:nn:nn
+    list_this.length1<0>(~x##0:list_this(?T), 0:wybe.int, ?###0:wybe.int) #0 @list_this:nn:nn
 
 
 length1 > (2 calls)
 0: list_this.length1<0>
-length1(x##0:list_this(?T), acc##0:wybe.int, ?$##0:wybe.int):
+length1(x##0:list_this(?T), acc##0:wybe.int, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
-    case ~tmp$5##0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
+    case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~acc##0:wybe.int, ?$##0:wybe.int) @list_this:nn:nn
+        foreign llvm move(~acc##0:wybe.int, ?###0:wybe.int) @list_this:nn:nn
 
     1:
         foreign lpvm access(~x##0:list_this(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:list_this(?T))
-        foreign llvm add(~acc##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
-        list_this.length1<0>(~t##0:list_this(?T), ~tmp$2##0:wybe.int, ?$##0:wybe.int) #2 @list_this:nn:nn
+        foreign llvm add(~acc##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
+        list_this.length1<0>(~t##0:list_this(?T), ~tmp#2##0:wybe.int, ?###0:wybe.int) #2 @list_this:nn:nn
 
 
 
 nil > public {inline} (0 calls)
 0: list_this.nil<0>
-nil(?$##0:list_this(?T)):
+nil(?###0:list_this(?T)):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:list_this(?T), ?$##0:list_this(?T))
+    foreign llvm move(0:list_this(?T), ?###0:list_this(?T))
 
   LLVM code       :
 
@@ -177,8 +177,8 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  i64 @"list_this.append<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$tmp$5##0" = icmp ne i64 %"x##0", 0 
-  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
+  %"1#tmp#5##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"x##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
@@ -187,7 +187,7 @@ if.then:
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %"2$tmp$2##0" = tail call fastcc  i64  @"list_this.append<0>"(i64  %7, i64  %"y##0")  
+  %"2#tmp#2##0" = tail call fastcc  i64  @"list_this.append<0>"(i64  %7, i64  %"y##0")  
   %8 = trunc i64 16 to i32  
   %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
   %10 = ptrtoint i8* %9 to i64 
@@ -197,19 +197,19 @@ if.then:
   %13 = add   i64 %10, 8 
   %14 = inttoptr i64 %13 to i64* 
   %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 %"2$tmp$2##0", i64* %15 
+  store  i64 %"2#tmp#2##0", i64* %15 
   ret i64 %10 
 if.else:
   ret i64 %"y##0" 
 }
 
 
-define external fastcc  {i64, i1} @"list_this.car<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"list_this.car<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %16 = inttoptr i64 %"$rec##0" to i64* 
+  %16 = inttoptr i64 %"#rec##0" to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
   %19 = insertvalue {i64, i1} undef, i64 %18, 0 
@@ -222,37 +222,37 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"list_this.car<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"list_this.car<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %23 = trunc i64 16 to i32  
   %24 = tail call ccc  i8*  @wybe_malloc(i32  %23)  
   %25 = ptrtoint i8* %24 to i64 
   %26 = inttoptr i64 %25 to i8* 
-  %27 = inttoptr i64 %"$rec##0" to i8* 
+  %27 = inttoptr i64 %"#rec##0" to i8* 
   %28 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %26, i8*  %27, i32  %28, i32  8, i1  0)  
   %29 = inttoptr i64 %25 to i64* 
   %30 = getelementptr  i64, i64* %29, i64 0 
-  store  i64 %"$field##0", i64* %30 
+  store  i64 %"#field##0", i64* %30 
   %31 = insertvalue {i64, i1} undef, i64 %25, 0 
   %32 = insertvalue {i64, i1} %31, i1 1, 1 
   ret {i64, i1} %32 
 if.else:
-  %33 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %33 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %34 = insertvalue {i64, i1} %33, i1 0, 1 
   ret {i64, i1} %34 
 }
 
 
-define external fastcc  {i64, i1} @"list_this.cdr<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"list_this.cdr<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %35 = add   i64 %"$rec##0", 8 
+  %35 = add   i64 %"#rec##0", 8 
   %36 = inttoptr i64 %35 to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
@@ -266,27 +266,27 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"list_this.cdr<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"list_this.cdr<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %43 = trunc i64 16 to i32  
   %44 = tail call ccc  i8*  @wybe_malloc(i32  %43)  
   %45 = ptrtoint i8* %44 to i64 
   %46 = inttoptr i64 %45 to i8* 
-  %47 = inttoptr i64 %"$rec##0" to i8* 
+  %47 = inttoptr i64 %"#rec##0" to i8* 
   %48 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %46, i8*  %47, i32  %48, i32  8, i1  0)  
   %49 = add   i64 %45, 8 
   %50 = inttoptr i64 %49 to i64* 
   %51 = getelementptr  i64, i64* %50, i64 0 
-  store  i64 %"$field##0", i64* %51 
+  store  i64 %"#field##0", i64* %51 
   %52 = insertvalue {i64, i1} undef, i64 %45, 0 
   %53 = insertvalue {i64, i1} %52, i1 1, 1 
   ret {i64, i1} %53 
 if.else:
-  %54 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %54 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %55 = insertvalue {i64, i1} %54, i1 0, 1 
   ret {i64, i1} %55 
 }
@@ -308,15 +308,15 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"list_this.cons<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64, i1} @"list_this.cons<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %64 = inttoptr i64 %"$##0" to i64* 
+  %64 = inttoptr i64 %"###0" to i64* 
   %65 = getelementptr  i64, i64* %64, i64 0 
   %66 = load  i64, i64* %65 
-  %67 = add   i64 %"$##0", 8 
+  %67 = add   i64 %"###0", 8 
   %68 = inttoptr i64 %67 to i64* 
   %69 = getelementptr  i64, i64* %68, i64 0 
   %70 = load  i64, i64* %69 
@@ -334,23 +334,23 @@ if.else:
 
 define external fastcc  i64 @"list_this.length<0>"(i64  %"x##0")    {
 entry:
-  %"1$$##0" = tail call fastcc  i64  @"list_this.length1<0>"(i64  %"x##0", i64  0)  
-  ret i64 %"1$$##0" 
+  %"1####0" = tail call fastcc  i64  @"list_this.length1<0>"(i64  %"x##0", i64  0)  
+  ret i64 %"1####0" 
 }
 
 
 define external fastcc  i64 @"list_this.length1<0>"(i64  %"x##0", i64  %"acc##0")    {
 entry:
-  %"1$tmp$5##0" = icmp ne i64 %"x##0", 0 
-  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
+  %"1#tmp#5##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
   %77 = add   i64 %"x##0", 8 
   %78 = inttoptr i64 %77 to i64* 
   %79 = getelementptr  i64, i64* %78, i64 0 
   %80 = load  i64, i64* %79 
-  %"2$tmp$2##0" = add   i64 %"acc##0", 1 
-  %"2$$##0" = tail call fastcc  i64  @"list_this.length1<0>"(i64  %80, i64  %"2$tmp$2##0")  
-  ret i64 %"2$$##0" 
+  %"2#tmp#2##0" = add   i64 %"acc##0", 1 
+  %"2####0" = tail call fastcc  i64  @"list_this.length1<0>"(i64  %80, i64  %"2#tmp#2##0")  
+  ret i64 %"2####0" 
 if.else:
   ret i64 %"acc##0" 
 }

--- a/test-cases/final-dump/list_this.exp
+++ b/test-cases/final-dump/list_this.exp
@@ -19,147 +19,147 @@ AFTER EVERYTHING:
 
 append > public (1 calls)
 0: list_this.append<0>
-append(x#0:list_this(?T), y#0:list_this(?T), ?$#0:list_this(?T)):
- AliasPairs: [($#0,y#0)]
+append(x##0:list_this(?T), y##0:list_this(?T), ?$##0:list_this(?T)):
+ AliasPairs: [($##0,y##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(list_this.append<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(x#0:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.bool)
-    case ~tmp$5#0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
+    case ~tmp$5##0:wybe.bool of
     0:
-        foreign llvm move(~y#0:list_this(?T), ?$#0:list_this(?T)) @list_this:nn:nn
+        foreign llvm move(~y##0:list_this(?T), ?$##0:list_this(?T)) @list_this:nn:nn
 
     1:
-        foreign lpvm access(x#0:list_this(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:?T)
-        foreign lpvm access(~x#0:list_this(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:list_this(?T))
-        list_this.append<0>(~t#0:list_this(?T), ~y#0:list_this(?T), ?tmp$2#0:list_this(?T)) #1 @list_this:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$8#0:list_this(?T))
-        foreign lpvm mutate(~tmp$8#0:list_this(?T), ?tmp$9#0:list_this(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h#0:?T)
-        foreign lpvm mutate(~tmp$9#0:list_this(?T), ?$#0:list_this(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:list_this(?T))
+        foreign lpvm access(x##0:list_this(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:?T)
+        foreign lpvm access(~x##0:list_this(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:list_this(?T))
+        list_this.append<0>(~t##0:list_this(?T), ~y##0:list_this(?T), ?tmp$2##0:list_this(?T)) #1 @list_this:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp$8##0:list_this(?T))
+        foreign lpvm mutate(~tmp$8##0:list_this(?T), ?tmp$9##0:list_this(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:?T)
+        foreign lpvm mutate(~tmp$9##0:list_this(?T), ?$##0:list_this(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:list_this(?T))
 
 
 
 car > public {inline} (0 calls)
 0: list_this.car<0>
-car($rec#0:list_this(?T), ?$#0:?T, ?$$#0:wybe.bool):
+car($rec##0:list_this(?T), ?$##0:?T, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:?T, ?$#0:?T)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:?T, ?$##0:?T)
 
     1:
-        foreign lpvm access(~$rec#0:list_this(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:?T)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:list_this(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:?T)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 car > public {inline} (0 calls)
 1: list_this.car<1>
-car($rec#0:list_this(?T), ?$rec#1:list_this(?T), $field#0:?T, ?$$#0:wybe.bool):
+car($rec##0:list_this(?T), ?$rec##1:list_this(?T), $field##0:?T, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:list_this(?T), ?$rec#1:list_this(?T))
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:list_this(?T), ?$rec##1:list_this(?T))
 
     1:
-        foreign lpvm mutate(~$rec#0:list_this(?T), ?$rec#1:list_this(?T), 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:?T)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~$rec##0:list_this(?T), ?$rec##1:list_this(?T), 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:?T)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 cdr > public {inline} (0 calls)
 0: list_this.cdr<0>
-cdr($rec#0:list_this(?T), ?$#0:list_this(?T), ?$$#0:wybe.bool):
+cdr($rec##0:list_this(?T), ?$##0:list_this(?T), ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:list_this(?T), ?$#0:list_this(?T))
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:list_this(?T), ?$##0:list_this(?T))
 
     1:
-        foreign lpvm access(~$rec#0:list_this(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:list_this(?T))
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:list_this(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:list_this(?T))
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 cdr > public {inline} (0 calls)
 1: list_this.cdr<1>
-cdr($rec#0:list_this(?T), ?$rec#1:list_this(?T), $field#0:list_this(?T), ?$$#0:wybe.bool):
+cdr($rec##0:list_this(?T), ?$rec##1:list_this(?T), $field##0:list_this(?T), ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:list_this(?T), ?$rec#1:list_this(?T))
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:list_this(?T), ?$rec##1:list_this(?T))
 
     1:
-        foreign lpvm {noalias} mutate(~$rec#0:list_this(?T), ?$rec#1:list_this(?T), 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:list_this(?T))
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm {noalias} mutate(~$rec##0:list_this(?T), ?$rec##1:list_this(?T), 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:list_this(?T))
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 cons > public {inline} (1 calls)
 0: list_this.cons<0>
-cons(car#0:?T, cdr#0:list_this(?T), ?$#0:list_this(?T)):
+cons(car##0:?T, cdr##0:list_this(?T), ?$##0:list_this(?T)):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:list_this(?T))
-    foreign lpvm mutate(~$rec#0:list_this(?T), ?$rec#1:list_this(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~car#0:?T)
-    foreign lpvm mutate(~$rec#1:list_this(?T), ?$#0:list_this(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr#0:list_this(?T))
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:list_this(?T))
+    foreign lpvm mutate(~$rec##0:list_this(?T), ?$rec##1:list_this(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~car##0:?T)
+    foreign lpvm mutate(~$rec##1:list_this(?T), ?$##0:list_this(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr##0:list_this(?T))
 cons > public {inline} (6 calls)
 1: list_this.cons<1>
-cons(?car#0:?T, ?cdr#0:list_this(?T), $#0:list_this(?T), ?$$#0:wybe.bool):
+cons(?car##0:?T, ?cdr##0:list_this(?T), $##0:list_this(?T), ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:?T, ?car#0:?T)
-        foreign llvm move(undef:list_this(?T), ?cdr#0:list_this(?T))
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:?T, ?car##0:?T)
+        foreign llvm move(undef:list_this(?T), ?cdr##0:list_this(?T))
 
     1:
-        foreign lpvm access($#0:list_this(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?car#0:?T)
-        foreign lpvm access(~$#0:list_this(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?cdr#0:list_this(?T))
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access($##0:list_this(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?car##0:?T)
+        foreign lpvm access(~$##0:list_this(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?cdr##0:list_this(?T))
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 length > public {inline} (0 calls)
 0: list_this.length<0>
-length(x#0:list_this(?T), ?$#0:wybe.int):
+length(x##0:list_this(?T), ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    list_this.length1<0>(~x#0:list_this(?T), 0:wybe.int, ?$#0:wybe.int) #0 @list_this:nn:nn
+    list_this.length1<0>(~x##0:list_this(?T), 0:wybe.int, ?$##0:wybe.int) #0 @list_this:nn:nn
 
 
 length1 > (2 calls)
 0: list_this.length1<0>
-length1(x#0:list_this(?T), acc#0:wybe.int, ?$#0:wybe.int):
+length1(x##0:list_this(?T), acc##0:wybe.int, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(x#0:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.bool)
-    case ~tmp$5#0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
+    case ~tmp$5##0:wybe.bool of
     0:
-        foreign llvm move(~acc#0:wybe.int, ?$#0:wybe.int) @list_this:nn:nn
+        foreign llvm move(~acc##0:wybe.int, ?$##0:wybe.int) @list_this:nn:nn
 
     1:
-        foreign lpvm access(~x#0:list_this(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:list_this(?T))
-        foreign llvm add(~acc#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int) @int:nn:nn
-        list_this.length1<0>(~t#0:list_this(?T), ~tmp$2#0:wybe.int, ?$#0:wybe.int) #2 @list_this:nn:nn
+        foreign lpvm access(~x##0:list_this(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:list_this(?T))
+        foreign llvm add(~acc##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
+        list_this.length1<0>(~t##0:list_this(?T), ~tmp$2##0:wybe.int, ?$##0:wybe.int) #2 @list_this:nn:nn
 
 
 
 nil > public {inline} (0 calls)
 0: list_this.nil<0>
-nil(?$#0:list_this(?T)):
+nil(?$##0:list_this(?T)):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:list_this(?T), ?$#0:list_this(?T))
+    foreign llvm move(0:list_this(?T), ?$##0:list_this(?T))
 
   LLVM code       :
 
@@ -175,19 +175,19 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i64 @"list_this.append<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"list_this.append<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$tmp$5#0" = icmp ne i64 %"x#0", 0 
-  br i1 %"1$tmp$5#0", label %if.then, label %if.else 
+  %"1$tmp$5##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"x#0" to i64* 
+  %1 = inttoptr i64 %"x##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"x#0", 8 
+  %4 = add   i64 %"x##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %"2$tmp$2#0" = tail call fastcc  i64  @"list_this.append<0>"(i64  %7, i64  %"y#0")  
+  %"2$tmp$2##0" = tail call fastcc  i64  @"list_this.append<0>"(i64  %7, i64  %"y##0")  
   %8 = trunc i64 16 to i32  
   %9 = tail call ccc  i8*  @wybe_malloc(i32  %8)  
   %10 = ptrtoint i8* %9 to i64 
@@ -197,19 +197,19 @@ if.then:
   %13 = add   i64 %10, 8 
   %14 = inttoptr i64 %13 to i64* 
   %15 = getelementptr  i64, i64* %14, i64 0 
-  store  i64 %"2$tmp$2#0", i64* %15 
+  store  i64 %"2$tmp$2##0", i64* %15 
   ret i64 %10 
 if.else:
-  ret i64 %"y#0" 
+  ret i64 %"y##0" 
 }
 
 
-define external fastcc  {i64, i1} @"list_this.car<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"list_this.car<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %16 = inttoptr i64 %"$rec#0" to i64* 
+  %16 = inttoptr i64 %"$rec##0" to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
   %19 = insertvalue {i64, i1} undef, i64 %18, 0 
@@ -222,37 +222,37 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"list_this.car<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"list_this.car<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %23 = trunc i64 16 to i32  
   %24 = tail call ccc  i8*  @wybe_malloc(i32  %23)  
   %25 = ptrtoint i8* %24 to i64 
   %26 = inttoptr i64 %25 to i8* 
-  %27 = inttoptr i64 %"$rec#0" to i8* 
+  %27 = inttoptr i64 %"$rec##0" to i8* 
   %28 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %26, i8*  %27, i32  %28, i32  8, i1  0)  
   %29 = inttoptr i64 %25 to i64* 
   %30 = getelementptr  i64, i64* %29, i64 0 
-  store  i64 %"$field#0", i64* %30 
+  store  i64 %"$field##0", i64* %30 
   %31 = insertvalue {i64, i1} undef, i64 %25, 0 
   %32 = insertvalue {i64, i1} %31, i1 1, 1 
   ret {i64, i1} %32 
 if.else:
-  %33 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %33 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %34 = insertvalue {i64, i1} %33, i1 0, 1 
   ret {i64, i1} %34 
 }
 
 
-define external fastcc  {i64, i1} @"list_this.cdr<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"list_this.cdr<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %35 = add   i64 %"$rec#0", 8 
+  %35 = add   i64 %"$rec##0", 8 
   %36 = inttoptr i64 %35 to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
@@ -266,57 +266,57 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"list_this.cdr<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"list_this.cdr<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %43 = trunc i64 16 to i32  
   %44 = tail call ccc  i8*  @wybe_malloc(i32  %43)  
   %45 = ptrtoint i8* %44 to i64 
   %46 = inttoptr i64 %45 to i8* 
-  %47 = inttoptr i64 %"$rec#0" to i8* 
+  %47 = inttoptr i64 %"$rec##0" to i8* 
   %48 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %46, i8*  %47, i32  %48, i32  8, i1  0)  
   %49 = add   i64 %45, 8 
   %50 = inttoptr i64 %49 to i64* 
   %51 = getelementptr  i64, i64* %50, i64 0 
-  store  i64 %"$field#0", i64* %51 
+  store  i64 %"$field##0", i64* %51 
   %52 = insertvalue {i64, i1} undef, i64 %45, 0 
   %53 = insertvalue {i64, i1} %52, i1 1, 1 
   ret {i64, i1} %53 
 if.else:
-  %54 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %54 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %55 = insertvalue {i64, i1} %54, i1 0, 1 
   ret {i64, i1} %55 
 }
 
 
-define external fastcc  i64 @"list_this.cons<0>"(i64  %"car#0", i64  %"cdr#0")    {
+define external fastcc  i64 @"list_this.cons<0>"(i64  %"car##0", i64  %"cdr##0")    {
 entry:
   %56 = trunc i64 16 to i32  
   %57 = tail call ccc  i8*  @wybe_malloc(i32  %56)  
   %58 = ptrtoint i8* %57 to i64 
   %59 = inttoptr i64 %58 to i64* 
   %60 = getelementptr  i64, i64* %59, i64 0 
-  store  i64 %"car#0", i64* %60 
+  store  i64 %"car##0", i64* %60 
   %61 = add   i64 %58, 8 
   %62 = inttoptr i64 %61 to i64* 
   %63 = getelementptr  i64, i64* %62, i64 0 
-  store  i64 %"cdr#0", i64* %63 
+  store  i64 %"cdr##0", i64* %63 
   ret i64 %58 
 }
 
 
-define external fastcc  {i64, i64, i1} @"list_this.cons<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64, i1} @"list_this.cons<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %64 = inttoptr i64 %"$#0" to i64* 
+  %64 = inttoptr i64 %"$##0" to i64* 
   %65 = getelementptr  i64, i64* %64, i64 0 
   %66 = load  i64, i64* %65 
-  %67 = add   i64 %"$#0", 8 
+  %67 = add   i64 %"$##0", 8 
   %68 = inttoptr i64 %67 to i64* 
   %69 = getelementptr  i64, i64* %68, i64 0 
   %70 = load  i64, i64* %69 
@@ -332,27 +332,27 @@ if.else:
 }
 
 
-define external fastcc  i64 @"list_this.length<0>"(i64  %"x#0")    {
+define external fastcc  i64 @"list_this.length<0>"(i64  %"x##0")    {
 entry:
-  %"1$$#0" = tail call fastcc  i64  @"list_this.length1<0>"(i64  %"x#0", i64  0)  
-  ret i64 %"1$$#0" 
+  %"1$$##0" = tail call fastcc  i64  @"list_this.length1<0>"(i64  %"x##0", i64  0)  
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  i64 @"list_this.length1<0>"(i64  %"x#0", i64  %"acc#0")    {
+define external fastcc  i64 @"list_this.length1<0>"(i64  %"x##0", i64  %"acc##0")    {
 entry:
-  %"1$tmp$5#0" = icmp ne i64 %"x#0", 0 
-  br i1 %"1$tmp$5#0", label %if.then, label %if.else 
+  %"1$tmp$5##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
 if.then:
-  %77 = add   i64 %"x#0", 8 
+  %77 = add   i64 %"x##0", 8 
   %78 = inttoptr i64 %77 to i64* 
   %79 = getelementptr  i64, i64* %78, i64 0 
   %80 = load  i64, i64* %79 
-  %"2$tmp$2#0" = add   i64 %"acc#0", 1 
-  %"2$$#0" = tail call fastcc  i64  @"list_this.length1<0>"(i64  %80, i64  %"2$tmp$2#0")  
-  ret i64 %"2$$#0" 
+  %"2$tmp$2##0" = add   i64 %"acc##0", 1 
+  %"2$$##0" = tail call fastcc  i64  @"list_this.length1<0>"(i64  %80, i64  %"2$tmp$2##0")  
+  ret i64 %"2$$##0" 
 if.else:
-  ret i64 %"acc#0" 
+  ret i64 %"acc##0" 
 }
 
 

--- a/test-cases/final-dump/list_this.exp
+++ b/test-cases/final-dump/list_this.exp
@@ -19,14 +19,14 @@ AFTER EVERYTHING:
 
 append > public (1 calls)
 0: list_this.append<0>
-append(x##0:list_this(?T), y##0:list_this(?T), ?###0:list_this(?T)):
- AliasPairs: [(###0,y##0)]
+append(x##0:list_this(?T), y##0:list_this(?T), ?#result##0:list_this(?T)):
+ AliasPairs: [(#result##0,y##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(list_this.append<0>,fromList [NonAliasedParamCond 0 [0]]))]
     foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
     case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~y##0:list_this(?T), ?###0:list_this(?T)) @list_this:nn:nn
+        foreign llvm move(~y##0:list_this(?T), ?#result##0:list_this(?T)) @list_this:nn:nn
 
     1:
         foreign lpvm access(x##0:list_this(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:?T)
@@ -34,23 +34,23 @@ append(x##0:list_this(?T), y##0:list_this(?T), ?###0:list_this(?T)):
         list_this.append<0>(~t##0:list_this(?T), ~y##0:list_this(?T), ?tmp#2##0:list_this(?T)) #1 @list_this:nn:nn
         foreign lpvm alloc(16:wybe.int, ?tmp#8##0:list_this(?T))
         foreign lpvm mutate(~tmp#8##0:list_this(?T), ?tmp#9##0:list_this(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:?T)
-        foreign lpvm mutate(~tmp#9##0:list_this(?T), ?###0:list_this(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:list_this(?T))
+        foreign lpvm mutate(~tmp#9##0:list_this(?T), ?#result##0:list_this(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:list_this(?T))
 
 
 
 car > public {inline} (0 calls)
 0: list_this.car<0>
-car(#rec##0:list_this(?T), ?###0:?T, ?####0:wybe.bool):
+car(#rec##0:list_this(?T), ?#result##0:?T, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:?T, ?###0:?T)
+        foreign llvm move(undef:?T, ?#result##0:?T)
 
     1:
-        foreign lpvm access(~#rec##0:list_this(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:?T)
+        foreign lpvm access(~#rec##0:list_this(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:?T)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 car > public {inline} (0 calls)
@@ -72,17 +72,17 @@ car(#rec##0:list_this(?T), ?#rec##1:list_this(?T), #field##0:?T, ?####0:wybe.boo
 
 cdr > public {inline} (0 calls)
 0: list_this.cdr<0>
-cdr(#rec##0:list_this(?T), ?###0:list_this(?T), ?####0:wybe.bool):
+cdr(#rec##0:list_this(?T), ?#result##0:list_this(?T), ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:list_this(?T), ?###0:list_this(?T))
+        foreign llvm move(undef:list_this(?T), ?#result##0:list_this(?T))
 
     1:
-        foreign lpvm access(~#rec##0:list_this(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:list_this(?T))
+        foreign lpvm access(~#rec##0:list_this(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:list_this(?T))
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 cdr > public {inline} (0 calls)
@@ -104,18 +104,18 @@ cdr(#rec##0:list_this(?T), ?#rec##1:list_this(?T), #field##0:list_this(?T), ?###
 
 cons > public {inline} (1 calls)
 0: list_this.cons<0>
-cons(car##0:?T, cdr##0:list_this(?T), ?###0:list_this(?T)):
+cons(car##0:?T, cdr##0:list_this(?T), ?#result##0:list_this(?T)):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:list_this(?T))
     foreign lpvm mutate(~#rec##0:list_this(?T), ?#rec##1:list_this(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~car##0:?T)
-    foreign lpvm mutate(~#rec##1:list_this(?T), ?###0:list_this(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr##0:list_this(?T))
+    foreign lpvm mutate(~#rec##1:list_this(?T), ?#result##0:list_this(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr##0:list_this(?T))
 cons > public {inline} (6 calls)
 1: list_this.cons<1>
-cons(?car##0:?T, ?cdr##0:list_this(?T), ###0:list_this(?T), ?####0:wybe.bool):
+cons(?car##0:?T, ?cdr##0:list_this(?T), #result##0:list_this(?T), ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
@@ -123,43 +123,43 @@ cons(?car##0:?T, ?cdr##0:list_this(?T), ###0:list_this(?T), ?####0:wybe.bool):
         foreign llvm move(undef:list_this(?T), ?cdr##0:list_this(?T))
 
     1:
-        foreign lpvm access(###0:list_this(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?car##0:?T)
-        foreign lpvm access(~###0:list_this(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?cdr##0:list_this(?T))
+        foreign lpvm access(#result##0:list_this(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?car##0:?T)
+        foreign lpvm access(~#result##0:list_this(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?cdr##0:list_this(?T))
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 length > public {inline} (0 calls)
 0: list_this.length<0>
-length(x##0:list_this(?T), ?###0:wybe.int):
+length(x##0:list_this(?T), ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    list_this.length1<0>(~x##0:list_this(?T), 0:wybe.int, ?###0:wybe.int) #0 @list_this:nn:nn
+    list_this.length1<0>(~x##0:list_this(?T), 0:wybe.int, ?#result##0:wybe.int) #0 @list_this:nn:nn
 
 
 length1 > (2 calls)
 0: list_this.length1<0>
-length1(x##0:list_this(?T), acc##0:wybe.int, ?###0:wybe.int):
+length1(x##0:list_this(?T), acc##0:wybe.int, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
     case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~acc##0:wybe.int, ?###0:wybe.int) @list_this:nn:nn
+        foreign llvm move(~acc##0:wybe.int, ?#result##0:wybe.int) @list_this:nn:nn
 
     1:
         foreign lpvm access(~x##0:list_this(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:list_this(?T))
         foreign llvm add(~acc##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
-        list_this.length1<0>(~t##0:list_this(?T), ~tmp#2##0:wybe.int, ?###0:wybe.int) #2 @list_this:nn:nn
+        list_this.length1<0>(~t##0:list_this(?T), ~tmp#2##0:wybe.int, ?#result##0:wybe.int) #2 @list_this:nn:nn
 
 
 
 nil > public {inline} (0 calls)
 0: list_this.nil<0>
-nil(?###0:list_this(?T)):
+nil(?#result##0:list_this(?T)):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:list_this(?T), ?###0:list_this(?T))
+    foreign llvm move(0:list_this(?T), ?#result##0:list_this(?T))
 
   LLVM code       :
 
@@ -308,15 +308,15 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"list_this.cons<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64, i1} @"list_this.cons<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  %"1#tmp#0##0" = icmp ne i64 %"#result##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %64 = inttoptr i64 %"###0" to i64* 
+  %64 = inttoptr i64 %"#result##0" to i64* 
   %65 = getelementptr  i64, i64* %64, i64 0 
   %66 = load  i64, i64* %65 
-  %67 = add   i64 %"###0", 8 
+  %67 = add   i64 %"#result##0", 8 
   %68 = inttoptr i64 %67 to i64* 
   %69 = getelementptr  i64, i64* %68, i64 0 
   %70 = load  i64, i64* %69 
@@ -334,8 +334,8 @@ if.else:
 
 define external fastcc  i64 @"list_this.length<0>"(i64  %"x##0")    {
 entry:
-  %"1####0" = tail call fastcc  i64  @"list_this.length1<0>"(i64  %"x##0", i64  0)  
-  ret i64 %"1####0" 
+  %"1##result##0" = tail call fastcc  i64  @"list_this.length1<0>"(i64  %"x##0", i64  0)  
+  ret i64 %"1##result##0" 
 }
 
 
@@ -349,8 +349,8 @@ if.then:
   %79 = getelementptr  i64, i64* %78, i64 0 
   %80 = load  i64, i64* %79 
   %"2#tmp#2##0" = add   i64 %"acc##0", 1 
-  %"2####0" = tail call fastcc  i64  @"list_this.length1<0>"(i64  %80, i64  %"2#tmp#2##0")  
-  ret i64 %"2####0" 
+  %"2##result##0" = tail call fastcc  i64  @"list_this.length1<0>"(i64  %80, i64  %"2#tmp#2##0")  
+  ret i64 %"2##result##0" 
 if.else:
   ret i64 %"acc##0" 
 }

--- a/test-cases/final-dump/list_this.exp
+++ b/test-cases/final-dump/list_this.exp
@@ -40,65 +40,65 @@ append(x##0:list_this(?T), y##0:list_this(?T), ?#result##0:list_this(?T)):
 
 car > public {inline} (0 calls)
 0: list_this.car<0>
-car(#rec##0:list_this(?T), ?#result##0:?T, ?####0:wybe.bool):
+car(#rec##0:list_this(?T), ?#result##0:?T, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:?T, ?#result##0:?T)
 
     1:
         foreign lpvm access(~#rec##0:list_this(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:?T)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 car > public {inline} (0 calls)
 1: list_this.car<1>
-car(#rec##0:list_this(?T), ?#rec##1:list_this(?T), #field##0:?T, ?####0:wybe.bool):
+car(#rec##0:list_this(?T), ?#rec##1:list_this(?T), #field##0:?T, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:list_this(?T), ?#rec##1:list_this(?T))
 
     1:
         foreign lpvm mutate(~#rec##0:list_this(?T), ?#rec##1:list_this(?T), 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:?T)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 cdr > public {inline} (0 calls)
 0: list_this.cdr<0>
-cdr(#rec##0:list_this(?T), ?#result##0:list_this(?T), ?####0:wybe.bool):
+cdr(#rec##0:list_this(?T), ?#result##0:list_this(?T), ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:list_this(?T), ?#result##0:list_this(?T))
 
     1:
         foreign lpvm access(~#rec##0:list_this(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:list_this(?T))
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 cdr > public {inline} (0 calls)
 1: list_this.cdr<1>
-cdr(#rec##0:list_this(?T), ?#rec##1:list_this(?T), #field##0:list_this(?T), ?####0:wybe.bool):
+cdr(#rec##0:list_this(?T), ?#rec##1:list_this(?T), #field##0:list_this(?T), ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:list_this(?T), ?#rec##1:list_this(?T))
 
     1:
         foreign lpvm {noalias} mutate(~#rec##0:list_this(?T), ?#rec##1:list_this(?T), 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:list_this(?T))
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -112,20 +112,20 @@ cons(car##0:?T, cdr##0:list_this(?T), ?#result##0:list_this(?T)):
     foreign lpvm mutate(~#rec##1:list_this(?T), ?#result##0:list_this(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr##0:list_this(?T))
 cons > public {inline} (6 calls)
 1: list_this.cons<1>
-cons(?car##0:?T, ?cdr##0:list_this(?T), #result##0:list_this(?T), ?####0:wybe.bool):
+cons(?car##0:?T, ?cdr##0:list_this(?T), #result##0:list_this(?T), ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:?T, ?car##0:?T)
         foreign llvm move(undef:list_this(?T), ?cdr##0:list_this(?T))
 
     1:
         foreign lpvm access(#result##0:list_this(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?car##0:?T)
         foreign lpvm access(~#result##0:list_this(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?cdr##0:list_this(?T))
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 

--- a/test-cases/final-dump/loop_bug.exp
+++ b/test-cases/final-dump/loop_bug.exp
@@ -20,33 +20,33 @@ AFTER EVERYTHING:
   submodules      : loop_bug.int_list
   procs           : 
 
-gen$1 > (2 calls)
-0: loop_bug.gen$1<0>
-gen$1([h##0:wybe.int], io##0:wybe.phantom, lst##0:loop_bug.int_list, t##0:loop_bug.int_list, ?io##1:wybe.phantom):
+gen#1 > (2 calls)
+0: loop_bug.gen#1<0>
+gen#1([h##0:wybe.int], io##0:wybe.phantom, lst##0:loop_bug.int_list, t##0:loop_bug.int_list, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(t##0:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.bool)
-    case ~tmp$2##0:wybe.bool of
+    foreign llvm icmp_ne(t##0:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.bool)
+    case ~tmp#2##0:wybe.bool of
     0:
         foreign c putchar(']':wybe.char, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
     1:
         foreign lpvm access(t##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##1:wybe.int)
         foreign lpvm access(~t##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##1:loop_bug.int_list)
-        foreign c print_string(", ":wybe.string, ~io##0:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
-        foreign c print_int(~h##1:wybe.int, ~tmp$7##0:wybe.phantom, ?tmp$8##0:wybe.phantom) @io:nn:nn
-        loop_bug.gen$1<0>(_:wybe.int, ~tmp$8##0:wybe.phantom, ~lst##0:loop_bug.int_list, ~t##1:loop_bug.int_list, ?io##1:wybe.phantom) #3 @loop_bug:nn:nn
+        foreign c print_string(", ":wybe.string, ~io##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
+        foreign c print_int(~h##1:wybe.int, ~tmp#7##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @io:nn:nn
+        loop_bug.gen#1<0>(_:wybe.int, ~tmp#8##0:wybe.phantom, ~lst##0:loop_bug.int_list, ~t##1:loop_bug.int_list, ?io##1:wybe.phantom) #3 @loop_bug:nn:nn
 
 
 
-gen$2 > {inline} (1 calls)
-0: loop_bug.gen$2<0>
-gen$2(h##0:wybe.int, io##0:wybe.phantom, lst##0:loop_bug.int_list, t##0:loop_bug.int_list, ?io##3:wybe.phantom):
+gen#2 > {inline} (1 calls)
+0: loop_bug.gen#2<0>
+gen#2(h##0:wybe.int, io##0:wybe.phantom, lst##0:loop_bug.int_list, t##0:loop_bug.int_list, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(", ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     foreign c print_int(~h##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    loop_bug.gen$1<0>(_:wybe.int, ~io##2:wybe.phantom, ~lst##0:loop_bug.int_list, ~t##0:loop_bug.int_list, ?io##3:wybe.phantom) #2 @loop_bug:nn:nn
+    loop_bug.gen#1<0>(_:wybe.int, ~io##2:wybe.phantom, ~lst##0:loop_bug.int_list, ~t##0:loop_bug.int_list, ?io##3:wybe.phantom) #2 @loop_bug:nn:nn
 
 
 print > public (0 calls)
@@ -55,8 +55,8 @@ print(lst##0:loop_bug.int_list, io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c putchar('[':wybe.char, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
-    case ~tmp$5##0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
+    case ~tmp#5##0:wybe.bool of
     0:
         foreign c putchar(']':wybe.char, ~#io##1:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
 
@@ -64,7 +64,7 @@ print(lst##0:loop_bug.int_list, io##0:wybe.phantom, ?io##3:wybe.phantom):
         foreign lpvm access(lst##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
         foreign lpvm access(lst##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:loop_bug.int_list)
         foreign c print_int(~h##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-        loop_bug.gen$1<0>(_:wybe.int, ~io##2:wybe.phantom, ~lst##0:loop_bug.int_list, ~t##0:loop_bug.int_list, ?io##3:wybe.phantom) #3 @loop_bug:nn:nn
+        loop_bug.gen#1<0>(_:wybe.int, ~io##2:wybe.phantom, ~lst##0:loop_bug.int_list, ~t##0:loop_bug.int_list, ?io##3:wybe.phantom) #3 @loop_bug:nn:nn
 
 
   LLVM code       :
@@ -96,10 +96,10 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"loop_bug.gen$1<0>"(i64  %"lst##0", i64  %"t##0")    {
+define external fastcc  void @"loop_bug.gen#1<0>"(i64  %"lst##0", i64  %"t##0")    {
 entry:
-  %"1$tmp$2##0" = icmp ne i64 %"t##0", 0 
-  br i1 %"1$tmp$2##0", label %if.then, label %if.else 
+  %"1#tmp#2##0" = icmp ne i64 %"t##0", 0 
+  br i1 %"1#tmp#2##0", label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"t##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
@@ -111,7 +111,7 @@ if.then:
   %9 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @loop_bug.8, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %9)  
   tail call ccc  void  @print_int(i64  %3)  
-  tail call fastcc  void  @"loop_bug.gen$1<0>"(i64  %"lst##0", i64  %7)  
+  tail call fastcc  void  @"loop_bug.gen#1<0>"(i64  %"lst##0", i64  %7)  
   ret void 
 if.else:
   tail call ccc  void  @putchar(i8  93)  
@@ -119,12 +119,12 @@ if.else:
 }
 
 
-define external fastcc  void @"loop_bug.gen$2<0>"(i64  %"h##0", i64  %"lst##0", i64  %"t##0")    {
+define external fastcc  void @"loop_bug.gen#2<0>"(i64  %"h##0", i64  %"lst##0", i64  %"t##0")    {
 entry:
   %11 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @loop_bug.10, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %11)  
   tail call ccc  void  @print_int(i64  %"h##0")  
-  tail call fastcc  void  @"loop_bug.gen$1<0>"(i64  %"lst##0", i64  %"t##0")  
+  tail call fastcc  void  @"loop_bug.gen#1<0>"(i64  %"lst##0", i64  %"t##0")  
   ret void 
 }
 
@@ -132,8 +132,8 @@ entry:
 define external fastcc  void @"loop_bug.print<0>"(i64  %"lst##0")    {
 entry:
   tail call ccc  void  @putchar(i8  91)  
-  %"1$tmp$5##0" = icmp ne i64 %"lst##0", 0 
-  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
+  %"1#tmp#5##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
   %12 = inttoptr i64 %"lst##0" to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
@@ -143,7 +143,7 @@ if.then:
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
   tail call ccc  void  @print_int(i64  %14)  
-  tail call fastcc  void  @"loop_bug.gen$1<0>"(i64  %"lst##0", i64  %18)  
+  tail call fastcc  void  @"loop_bug.gen#1<0>"(i64  %"lst##0", i64  %18)  
   ret void 
 if.else:
   tail call ccc  void  @putchar(i8  93)  
@@ -170,32 +170,32 @@ if.else:
 
 = > public (2 calls)
 0: loop_bug.int_list.=<0>
-=($left##0:loop_bug.int_list, $right##0:loop_bug.int_list, ?$$##0:wybe.bool):
+=(#left##0:loop_bug.int_list, #right##0:loop_bug.int_list, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left##0:loop_bug.int_list, ~$right##0:loop_bug.int_list, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:loop_bug.int_list, ~#right##0:loop_bug.int_list, ?####0:wybe.bool)
 
     1:
-        foreign lpvm access($left##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$head##0:wybe.int)
-        foreign lpvm access(~$left##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$tail##0:loop_bug.int_list)
-        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
-        case ~tmp$9##0:wybe.bool of
+        foreign lpvm access(#left##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#head##0:wybe.int)
+        foreign lpvm access(~#left##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#tail##0:loop_bug.int_list)
+        foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
+        case ~tmp#9##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign lpvm access($right##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$head##0:wybe.int)
-            foreign lpvm access(~$right##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$tail##0:loop_bug.int_list)
-            foreign llvm icmp_eq(~$left$head##0:wybe.int, ~$right$head##0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
-            case ~tmp$4##0:wybe.bool of
+            foreign lpvm access(#right##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#head##0:wybe.int)
+            foreign lpvm access(~#right##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#tail##0:loop_bug.int_list)
+            foreign llvm icmp_eq(~#left#head##0:wybe.int, ~#right#head##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
+            case ~tmp#4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
             1:
-                loop_bug.int_list.=<0>(~$left$tail##0:loop_bug.int_list, ~$right$tail##0:loop_bug.int_list, ?$$##0:wybe.bool) #3
+                loop_bug.int_list.=<0>(~#left#tail##0:loop_bug.int_list, ~#right#tail##0:loop_bug.int_list, ?####0:wybe.bool) #3
 
 
 
@@ -203,110 +203,110 @@ if.else:
 
 cons > public {inline} (0 calls)
 0: loop_bug.int_list.cons<0>
-cons(head##0:wybe.int, tail##0:loop_bug.int_list, ?$##0:loop_bug.int_list):
+cons(head##0:wybe.int, tail##0:loop_bug.int_list, ?###0:loop_bug.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:loop_bug.int_list)
-    foreign lpvm mutate(~$rec##0:loop_bug.int_list, ?$rec##1:loop_bug.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:loop_bug.int_list, ?$##0:loop_bug.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:loop_bug.int_list)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:loop_bug.int_list)
+    foreign lpvm mutate(~#rec##0:loop_bug.int_list, ?#rec##1:loop_bug.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:loop_bug.int_list, ?###0:loop_bug.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:loop_bug.int_list)
 cons > public {inline} (12 calls)
 1: loop_bug.int_list.cons<1>
-cons(?head##0:wybe.int, ?tail##0:loop_bug.int_list, $##0:loop_bug.int_list, ?$$##0:wybe.bool):
+cons(?head##0:wybe.int, ?tail##0:loop_bug.int_list, ###0:loop_bug.int_list, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?head##0:wybe.int)
         foreign llvm move(undef:loop_bug.int_list, ?tail##0:loop_bug.int_list)
 
     1:
-        foreign lpvm access($##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
-        foreign lpvm access(~$##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:loop_bug.int_list)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(###0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
+        foreign lpvm access(~###0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:loop_bug.int_list)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 head > public {inline} (0 calls)
 0: loop_bug.int_list.head<0>
-head($rec##0:loop_bug.int_list, ?$##0:wybe.int, ?$$##0:wybe.bool):
+head(#rec##0:loop_bug.int_list, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 head > public {inline} (0 calls)
 1: loop_bug.int_list.head<1>
-head($rec##0:loop_bug.int_list, ?$rec##1:loop_bug.int_list, $field##0:wybe.int, ?$$##0:wybe.bool):
+head(#rec##0:loop_bug.int_list, ?#rec##1:loop_bug.int_list, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:loop_bug.int_list, ?$rec##1:loop_bug.int_list)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:loop_bug.int_list, ?#rec##1:loop_bug.int_list)
 
     1:
-        foreign lpvm mutate(~$rec##0:loop_bug.int_list, ?$rec##1:loop_bug.int_list, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~#rec##0:loop_bug.int_list, ?#rec##1:loop_bug.int_list, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 nil > public {inline} (0 calls)
 0: loop_bug.int_list.nil<0>
-nil(?$##0:loop_bug.int_list):
+nil(?###0:loop_bug.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:loop_bug.int_list, ?$##0:loop_bug.int_list)
+    foreign llvm move(0:loop_bug.int_list, ?###0:loop_bug.int_list)
 
 
 tail > public {inline} (0 calls)
 0: loop_bug.int_list.tail<0>
-tail($rec##0:loop_bug.int_list, ?$##0:loop_bug.int_list, ?$$##0:wybe.bool):
+tail(#rec##0:loop_bug.int_list, ?###0:loop_bug.int_list, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:loop_bug.int_list, ?$##0:loop_bug.int_list)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:loop_bug.int_list, ?###0:loop_bug.int_list)
 
     1:
-        foreign lpvm access(~$rec##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:loop_bug.int_list)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:loop_bug.int_list)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 tail > public {inline} (0 calls)
 1: loop_bug.int_list.tail<1>
-tail($rec##0:loop_bug.int_list, ?$rec##1:loop_bug.int_list, $field##0:loop_bug.int_list, ?$$##0:wybe.bool):
+tail(#rec##0:loop_bug.int_list, ?#rec##1:loop_bug.int_list, #field##0:loop_bug.int_list, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:loop_bug.int_list, ?$rec##1:loop_bug.int_list)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:loop_bug.int_list, ?#rec##1:loop_bug.int_list)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec##0:loop_bug.int_list, ?$rec##1:loop_bug.int_list, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:loop_bug.int_list)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm {noalias} mutate(~#rec##0:loop_bug.int_list, ?#rec##1:loop_bug.int_list, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:loop_bug.int_list)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: loop_bug.int_list.~=<0>
-~=($left##0:loop_bug.int_list, $right##0:loop_bug.int_list, ?$$##0:wybe.bool):
+~=(#left##0:loop_bug.int_list, #right##0:loop_bug.int_list, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    loop_bug.int_list.=<0>(~$left##0:loop_bug.int_list, ~$right##0:loop_bug.int_list, ?tmp$0##0:wybe.bool) #0
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    loop_bug.int_list.=<0>(~#left##0:loop_bug.int_list, ~#right##0:loop_bug.int_list, ?tmp#0##0:wybe.bool) #0
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
   LLVM code       :
 
@@ -322,38 +322,38 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"loop_bug.int_list.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"loop_bug.int_list.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#left##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %"2$tmp$9##0" = icmp ne i64 %"$right##0", 0 
-  br i1 %"2$tmp$9##0", label %if.then1, label %if.else1 
+  %"2#tmp#9##0" = icmp ne i64 %"#right##0", 0 
+  br i1 %"2#tmp#9##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3#####0" 
 if.then1:
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"4$tmp$4##0" = icmp eq i64 %3, %10 
-  br i1 %"4$tmp$4##0", label %if.then2, label %if.else2 
+  %"4#tmp#4##0" = icmp eq i64 %3, %10 
+  br i1 %"4#tmp#4##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$$$##0" = tail call fastcc  i1  @"loop_bug.int_list.=<0>"(i64  %7, i64  %14)  
-  ret i1 %"6$$$##0" 
+  %"6#####0" = tail call fastcc  i1  @"loop_bug.int_list.=<0>"(i64  %7, i64  %14)  
+  ret i1 %"6#####0" 
 if.else2:
   ret i1 0 
 }
@@ -375,15 +375,15 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"loop_bug.int_list.cons<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64, i1} @"loop_bug.int_list.cons<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -399,12 +399,12 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"loop_bug.int_list.head<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"loop_bug.int_list.head<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %36 = inttoptr i64 %"$rec##0" to i64* 
+  %36 = inttoptr i64 %"#rec##0" to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
   %39 = insertvalue {i64, i1} undef, i64 %38, 0 
@@ -417,26 +417,26 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"loop_bug.int_list.head<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"loop_bug.int_list.head<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %43 = trunc i64 16 to i32  
   %44 = tail call ccc  i8*  @wybe_malloc(i32  %43)  
   %45 = ptrtoint i8* %44 to i64 
   %46 = inttoptr i64 %45 to i8* 
-  %47 = inttoptr i64 %"$rec##0" to i8* 
+  %47 = inttoptr i64 %"#rec##0" to i8* 
   %48 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %46, i8*  %47, i32  %48, i32  8, i1  0)  
   %49 = inttoptr i64 %45 to i64* 
   %50 = getelementptr  i64, i64* %49, i64 0 
-  store  i64 %"$field##0", i64* %50 
+  store  i64 %"#field##0", i64* %50 
   %51 = insertvalue {i64, i1} undef, i64 %45, 0 
   %52 = insertvalue {i64, i1} %51, i1 1, 1 
   ret {i64, i1} %52 
 if.else:
-  %53 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %53 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %54 = insertvalue {i64, i1} %53, i1 0, 1 
   ret {i64, i1} %54 
 }
@@ -448,12 +448,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"loop_bug.int_list.tail<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"loop_bug.int_list.tail<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %55 = add   i64 %"$rec##0", 8 
+  %55 = add   i64 %"#rec##0", 8 
   %56 = inttoptr i64 %55 to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
@@ -467,35 +467,35 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"loop_bug.int_list.tail<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"loop_bug.int_list.tail<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %63 = trunc i64 16 to i32  
   %64 = tail call ccc  i8*  @wybe_malloc(i32  %63)  
   %65 = ptrtoint i8* %64 to i64 
   %66 = inttoptr i64 %65 to i8* 
-  %67 = inttoptr i64 %"$rec##0" to i8* 
+  %67 = inttoptr i64 %"#rec##0" to i8* 
   %68 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %66, i8*  %67, i32  %68, i32  8, i1  0)  
   %69 = add   i64 %65, 8 
   %70 = inttoptr i64 %69 to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
-  store  i64 %"$field##0", i64* %71 
+  store  i64 %"#field##0", i64* %71 
   %72 = insertvalue {i64, i1} undef, i64 %65, 0 
   %73 = insertvalue {i64, i1} %72, i1 1, 1 
   ret {i64, i1} %73 
 if.else:
-  %74 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %74 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %75 = insertvalue {i64, i1} %74, i1 0, 1 
   ret {i64, i1} %75 
 }
 
 
-define external fastcc  i1 @"loop_bug.int_list.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"loop_bug.int_list.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = tail call fastcc  i1  @"loop_bug.int_list.=<0>"(i64  %"$left##0", i64  %"$right##0")  
-  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
-  ret i1 %"1$$$##0" 
+  %"1#tmp#0##0" = tail call fastcc  i1  @"loop_bug.int_list.=<0>"(i64  %"#left##0", i64  %"#right##0")  
+  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1#####0" 
 }

--- a/test-cases/final-dump/loop_bug.exp
+++ b/test-cases/final-dump/loop_bug.exp
@@ -203,18 +203,18 @@ if.else:
 
 cons > public {inline} (0 calls)
 0: loop_bug.int_list.cons<0>
-cons(head##0:wybe.int, tail##0:loop_bug.int_list, ?###0:loop_bug.int_list):
+cons(head##0:wybe.int, tail##0:loop_bug.int_list, ?#result##0:loop_bug.int_list):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:loop_bug.int_list)
     foreign lpvm mutate(~#rec##0:loop_bug.int_list, ?#rec##1:loop_bug.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:loop_bug.int_list, ?###0:loop_bug.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:loop_bug.int_list)
+    foreign lpvm mutate(~#rec##1:loop_bug.int_list, ?#result##0:loop_bug.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:loop_bug.int_list)
 cons > public {inline} (12 calls)
 1: loop_bug.int_list.cons<1>
-cons(?head##0:wybe.int, ?tail##0:loop_bug.int_list, ###0:loop_bug.int_list, ?####0:wybe.bool):
+cons(?head##0:wybe.int, ?tail##0:loop_bug.int_list, #result##0:loop_bug.int_list, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
@@ -222,25 +222,25 @@ cons(?head##0:wybe.int, ?tail##0:loop_bug.int_list, ###0:loop_bug.int_list, ?###
         foreign llvm move(undef:loop_bug.int_list, ?tail##0:loop_bug.int_list)
 
     1:
-        foreign lpvm access(###0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
-        foreign lpvm access(~###0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:loop_bug.int_list)
+        foreign lpvm access(#result##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
+        foreign lpvm access(~#result##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:loop_bug.int_list)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 head > public {inline} (0 calls)
 0: loop_bug.int_list.head<0>
-head(#rec##0:loop_bug.int_list, ?###0:wybe.int, ?####0:wybe.bool):
+head(#rec##0:loop_bug.int_list, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign lpvm access(~#rec##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 head > public {inline} (0 calls)
@@ -262,25 +262,25 @@ head(#rec##0:loop_bug.int_list, ?#rec##1:loop_bug.int_list, #field##0:wybe.int, 
 
 nil > public {inline} (0 calls)
 0: loop_bug.int_list.nil<0>
-nil(?###0:loop_bug.int_list):
+nil(?#result##0:loop_bug.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:loop_bug.int_list, ?###0:loop_bug.int_list)
+    foreign llvm move(0:loop_bug.int_list, ?#result##0:loop_bug.int_list)
 
 
 tail > public {inline} (0 calls)
 0: loop_bug.int_list.tail<0>
-tail(#rec##0:loop_bug.int_list, ?###0:loop_bug.int_list, ?####0:wybe.bool):
+tail(#rec##0:loop_bug.int_list, ?#result##0:loop_bug.int_list, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:loop_bug.int_list, ?###0:loop_bug.int_list)
+        foreign llvm move(undef:loop_bug.int_list, ?#result##0:loop_bug.int_list)
 
     1:
-        foreign lpvm access(~#rec##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:loop_bug.int_list)
+        foreign lpvm access(~#rec##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:loop_bug.int_list)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 tail > public {inline} (0 calls)
@@ -375,15 +375,15 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"loop_bug.int_list.cons<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64, i1} @"loop_bug.int_list.cons<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  %"1#tmp#0##0" = icmp ne i64 %"#result##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 

--- a/test-cases/final-dump/loop_bug.exp
+++ b/test-cases/final-dump/loop_bug.exp
@@ -170,13 +170,13 @@ if.else:
 
 = > public (2 calls)
 0: loop_bug.int_list.=<0>
-=(#left##0:loop_bug.int_list, #right##0:loop_bug.int_list, ?####0:wybe.bool):
+=(#left##0:loop_bug.int_list, #right##0:loop_bug.int_list, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~#left##0:loop_bug.int_list, ~#right##0:loop_bug.int_list, ?####0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:loop_bug.int_list, ~#right##0:loop_bug.int_list, ?#success##0:wybe.bool)
 
     1:
         foreign lpvm access(#left##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#head##0:wybe.int)
@@ -184,7 +184,7 @@ if.else:
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
         case ~tmp#9##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign lpvm access(#right##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#head##0:wybe.int)
@@ -192,10 +192,10 @@ if.else:
             foreign llvm icmp_eq(~#left#head##0:wybe.int, ~#right#head##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
             case ~tmp#4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
-                loop_bug.int_list.=<0>(~#left#tail##0:loop_bug.int_list, ~#right#tail##0:loop_bug.int_list, ?####0:wybe.bool) #3
+                loop_bug.int_list.=<0>(~#left#tail##0:loop_bug.int_list, ~#right#tail##0:loop_bug.int_list, ?#success##0:wybe.bool) #3
 
 
 
@@ -211,52 +211,52 @@ cons(head##0:wybe.int, tail##0:loop_bug.int_list, ?#result##0:loop_bug.int_list)
     foreign lpvm mutate(~#rec##1:loop_bug.int_list, ?#result##0:loop_bug.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:loop_bug.int_list)
 cons > public {inline} (12 calls)
 1: loop_bug.int_list.cons<1>
-cons(?head##0:wybe.int, ?tail##0:loop_bug.int_list, #result##0:loop_bug.int_list, ?####0:wybe.bool):
+cons(?head##0:wybe.int, ?tail##0:loop_bug.int_list, #result##0:loop_bug.int_list, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?head##0:wybe.int)
         foreign llvm move(undef:loop_bug.int_list, ?tail##0:loop_bug.int_list)
 
     1:
         foreign lpvm access(#result##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
         foreign lpvm access(~#result##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:loop_bug.int_list)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 head > public {inline} (0 calls)
 0: loop_bug.int_list.head<0>
-head(#rec##0:loop_bug.int_list, ?#result##0:wybe.int, ?####0:wybe.bool):
+head(#rec##0:loop_bug.int_list, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign lpvm access(~#rec##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 head > public {inline} (0 calls)
 1: loop_bug.int_list.head<1>
-head(#rec##0:loop_bug.int_list, ?#rec##1:loop_bug.int_list, #field##0:wybe.int, ?####0:wybe.bool):
+head(#rec##0:loop_bug.int_list, ?#rec##1:loop_bug.int_list, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:loop_bug.int_list, ?#rec##1:loop_bug.int_list)
 
     1:
         foreign lpvm mutate(~#rec##0:loop_bug.int_list, ?#rec##1:loop_bug.int_list, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -270,43 +270,43 @@ nil(?#result##0:loop_bug.int_list):
 
 tail > public {inline} (0 calls)
 0: loop_bug.int_list.tail<0>
-tail(#rec##0:loop_bug.int_list, ?#result##0:loop_bug.int_list, ?####0:wybe.bool):
+tail(#rec##0:loop_bug.int_list, ?#result##0:loop_bug.int_list, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:loop_bug.int_list, ?#result##0:loop_bug.int_list)
 
     1:
         foreign lpvm access(~#rec##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:loop_bug.int_list)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 tail > public {inline} (0 calls)
 1: loop_bug.int_list.tail<1>
-tail(#rec##0:loop_bug.int_list, ?#rec##1:loop_bug.int_list, #field##0:loop_bug.int_list, ?####0:wybe.bool):
+tail(#rec##0:loop_bug.int_list, ?#rec##1:loop_bug.int_list, #field##0:loop_bug.int_list, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:loop_bug.int_list, ?#rec##1:loop_bug.int_list)
 
     1:
         foreign lpvm {noalias} mutate(~#rec##0:loop_bug.int_list, ?#rec##1:loop_bug.int_list, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:loop_bug.int_list)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: loop_bug.int_list.~=<0>
-~=(#left##0:loop_bug.int_list, #right##0:loop_bug.int_list, ?####0:wybe.bool):
+~=(#left##0:loop_bug.int_list, #right##0:loop_bug.int_list, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     loop_bug.int_list.=<0>(~#left##0:loop_bug.int_list, ~#right##0:loop_bug.int_list, ?tmp#0##0:wybe.bool) #0
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 
@@ -337,8 +337,8 @@ if.then:
   %"2#tmp#9##0" = icmp ne i64 %"#right##0", 0 
   br i1 %"2#tmp#9##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %"3#####0" 
+  %"3##success##0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3##success##0" 
 if.then1:
   %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
@@ -352,8 +352,8 @@ if.then1:
 if.else1:
   ret i1 0 
 if.then2:
-  %"6#####0" = tail call fastcc  i1  @"loop_bug.int_list.=<0>"(i64  %7, i64  %14)  
-  ret i1 %"6#####0" 
+  %"6##success##0" = tail call fastcc  i1  @"loop_bug.int_list.=<0>"(i64  %7, i64  %14)  
+  ret i1 %"6##success##0" 
 if.else2:
   ret i1 0 
 }
@@ -496,6 +496,6 @@ if.else:
 define external fastcc  i1 @"loop_bug.int_list.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %"1#tmp#0##0" = tail call fastcc  i1  @"loop_bug.int_list.=<0>"(i64  %"#left##0", i64  %"#right##0")  
-  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
-  ret i1 %"1#####0" 
+  %"1##success##0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1##success##0" 
 }

--- a/test-cases/final-dump/loop_bug.exp
+++ b/test-cases/final-dump/loop_bug.exp
@@ -22,49 +22,49 @@ AFTER EVERYTHING:
 
 gen$1 > (2 calls)
 0: loop_bug.gen$1<0>
-gen$1([h#0:wybe.int], io#0:wybe.phantom, lst#0:loop_bug.int_list, t#0:loop_bug.int_list, ?io#1:wybe.phantom):
+gen$1([h##0:wybe.int], io##0:wybe.phantom, lst##0:loop_bug.int_list, t##0:loop_bug.int_list, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(t#0:wybe.int, 0:wybe.int, ?tmp$2#0:wybe.bool)
-    case ~tmp$2#0:wybe.bool of
+    foreign llvm icmp_ne(t##0:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.bool)
+    case ~tmp$2##0:wybe.bool of
     0:
-        foreign c putchar(']':wybe.char, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+        foreign c putchar(']':wybe.char, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
     1:
-        foreign lpvm access(t#0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#1:wybe.int)
-        foreign lpvm access(~t#0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#1:loop_bug.int_list)
-        foreign c print_string(", ":wybe.string, ~io#0:wybe.phantom, ?tmp$7#0:wybe.phantom) @io:nn:nn
-        foreign c print_int(~h#1:wybe.int, ~tmp$7#0:wybe.phantom, ?tmp$8#0:wybe.phantom) @io:nn:nn
-        loop_bug.gen$1<0>(_:wybe.int, ~tmp$8#0:wybe.phantom, ~lst#0:loop_bug.int_list, ~t#1:loop_bug.int_list, ?io#1:wybe.phantom) #3 @loop_bug:nn:nn
+        foreign lpvm access(t##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##1:wybe.int)
+        foreign lpvm access(~t##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##1:loop_bug.int_list)
+        foreign c print_string(", ":wybe.string, ~io##0:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
+        foreign c print_int(~h##1:wybe.int, ~tmp$7##0:wybe.phantom, ?tmp$8##0:wybe.phantom) @io:nn:nn
+        loop_bug.gen$1<0>(_:wybe.int, ~tmp$8##0:wybe.phantom, ~lst##0:loop_bug.int_list, ~t##1:loop_bug.int_list, ?io##1:wybe.phantom) #3 @loop_bug:nn:nn
 
 
 
 gen$2 > {inline} (1 calls)
 0: loop_bug.gen$2<0>
-gen$2(h#0:wybe.int, io#0:wybe.phantom, lst#0:loop_bug.int_list, t#0:loop_bug.int_list, ?io#3:wybe.phantom):
+gen$2(h##0:wybe.int, io##0:wybe.phantom, lst##0:loop_bug.int_list, t##0:loop_bug.int_list, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(", ":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_int(~h#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    loop_bug.gen$1<0>(_:wybe.int, ~io#2:wybe.phantom, ~lst#0:loop_bug.int_list, ~t#0:loop_bug.int_list, ?io#3:wybe.phantom) #2 @loop_bug:nn:nn
+    foreign c print_string(", ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~h##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    loop_bug.gen$1<0>(_:wybe.int, ~io##2:wybe.phantom, ~lst##0:loop_bug.int_list, ~t##0:loop_bug.int_list, ?io##3:wybe.phantom) #2 @loop_bug:nn:nn
 
 
 print > public (0 calls)
 0: loop_bug.print<0>
-print(lst#0:loop_bug.int_list, io#0:wybe.phantom, ?io#3:wybe.phantom):
+print(lst##0:loop_bug.int_list, io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c putchar('[':wybe.char, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign llvm icmp_ne(lst#0:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.bool)
-    case ~tmp$5#0:wybe.bool of
+    foreign c putchar('[':wybe.char, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
+    case ~tmp$5##0:wybe.bool of
     0:
-        foreign c putchar(']':wybe.char, ~#io#1:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
+        foreign c putchar(']':wybe.char, ~#io##1:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
 
     1:
-        foreign lpvm access(lst#0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:wybe.int)
-        foreign lpvm access(lst#0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:loop_bug.int_list)
-        foreign c print_int(~h#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-        loop_bug.gen$1<0>(_:wybe.int, ~io#2:wybe.phantom, ~lst#0:loop_bug.int_list, ~t#0:loop_bug.int_list, ?io#3:wybe.phantom) #3 @loop_bug:nn:nn
+        foreign lpvm access(lst##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+        foreign lpvm access(lst##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:loop_bug.int_list)
+        foreign c print_int(~h##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+        loop_bug.gen$1<0>(_:wybe.int, ~io##2:wybe.phantom, ~lst##0:loop_bug.int_list, ~t##0:loop_bug.int_list, ?io##3:wybe.phantom) #3 @loop_bug:nn:nn
 
 
   LLVM code       :
@@ -96,22 +96,22 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"loop_bug.gen$1<0>"(i64  %"lst#0", i64  %"t#0")    {
+define external fastcc  void @"loop_bug.gen$1<0>"(i64  %"lst##0", i64  %"t##0")    {
 entry:
-  %"1$tmp$2#0" = icmp ne i64 %"t#0", 0 
-  br i1 %"1$tmp$2#0", label %if.then, label %if.else 
+  %"1$tmp$2##0" = icmp ne i64 %"t##0", 0 
+  br i1 %"1$tmp$2##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"t#0" to i64* 
+  %1 = inttoptr i64 %"t##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"t#0", 8 
+  %4 = add   i64 %"t##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
   %9 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @loop_bug.8, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %9)  
   tail call ccc  void  @print_int(i64  %3)  
-  tail call fastcc  void  @"loop_bug.gen$1<0>"(i64  %"lst#0", i64  %7)  
+  tail call fastcc  void  @"loop_bug.gen$1<0>"(i64  %"lst##0", i64  %7)  
   ret void 
 if.else:
   tail call ccc  void  @putchar(i8  93)  
@@ -119,31 +119,31 @@ if.else:
 }
 
 
-define external fastcc  void @"loop_bug.gen$2<0>"(i64  %"h#0", i64  %"lst#0", i64  %"t#0")    {
+define external fastcc  void @"loop_bug.gen$2<0>"(i64  %"h##0", i64  %"lst##0", i64  %"t##0")    {
 entry:
   %11 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @loop_bug.10, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %11)  
-  tail call ccc  void  @print_int(i64  %"h#0")  
-  tail call fastcc  void  @"loop_bug.gen$1<0>"(i64  %"lst#0", i64  %"t#0")  
+  tail call ccc  void  @print_int(i64  %"h##0")  
+  tail call fastcc  void  @"loop_bug.gen$1<0>"(i64  %"lst##0", i64  %"t##0")  
   ret void 
 }
 
 
-define external fastcc  void @"loop_bug.print<0>"(i64  %"lst#0")    {
+define external fastcc  void @"loop_bug.print<0>"(i64  %"lst##0")    {
 entry:
   tail call ccc  void  @putchar(i8  91)  
-  %"1$tmp$5#0" = icmp ne i64 %"lst#0", 0 
-  br i1 %"1$tmp$5#0", label %if.then, label %if.else 
+  %"1$tmp$5##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
 if.then:
-  %12 = inttoptr i64 %"lst#0" to i64* 
+  %12 = inttoptr i64 %"lst##0" to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %15 = add   i64 %"lst#0", 8 
+  %15 = add   i64 %"lst##0", 8 
   %16 = inttoptr i64 %15 to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
   tail call ccc  void  @print_int(i64  %14)  
-  tail call fastcc  void  @"loop_bug.gen$1<0>"(i64  %"lst#0", i64  %18)  
+  tail call fastcc  void  @"loop_bug.gen$1<0>"(i64  %"lst##0", i64  %18)  
   ret void 
 if.else:
   tail call ccc  void  @putchar(i8  93)  
@@ -170,32 +170,32 @@ if.else:
 
 = > public (2 calls)
 0: loop_bug.int_list.=<0>
-=($left#0:loop_bug.int_list, $right#0:loop_bug.int_list, ?$$#0:wybe.bool):
+=($left##0:loop_bug.int_list, $right##0:loop_bug.int_list, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left#0:loop_bug.int_list, ~$right#0:loop_bug.int_list, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~$left##0:loop_bug.int_list, ~$right##0:loop_bug.int_list, ?$$##0:wybe.bool)
 
     1:
-        foreign lpvm access($left#0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$head#0:wybe.int)
-        foreign lpvm access(~$left#0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$tail#0:loop_bug.int_list)
-        foreign llvm icmp_ne($right#0:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.bool)
-        case ~tmp$9#0:wybe.bool of
+        foreign lpvm access($left##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$head##0:wybe.int)
+        foreign lpvm access(~$left##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$tail##0:loop_bug.int_list)
+        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
+        case ~tmp$9##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign lpvm access($right#0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$head#0:wybe.int)
-            foreign lpvm access(~$right#0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$tail#0:loop_bug.int_list)
-            foreign llvm icmp_eq(~$left$head#0:wybe.int, ~$right$head#0:wybe.int, ?tmp$4#0:wybe.bool) @int:nn:nn
-            case ~tmp$4#0:wybe.bool of
+            foreign lpvm access($right##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$head##0:wybe.int)
+            foreign lpvm access(~$right##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$tail##0:loop_bug.int_list)
+            foreign llvm icmp_eq(~$left$head##0:wybe.int, ~$right$head##0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
+            case ~tmp$4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                loop_bug.int_list.=<0>(~$left$tail#0:loop_bug.int_list, ~$right$tail#0:loop_bug.int_list, ?$$#0:wybe.bool) #3
+                loop_bug.int_list.=<0>(~$left$tail##0:loop_bug.int_list, ~$right$tail##0:loop_bug.int_list, ?$$##0:wybe.bool) #3
 
 
 
@@ -203,110 +203,110 @@ if.else:
 
 cons > public {inline} (0 calls)
 0: loop_bug.int_list.cons<0>
-cons(head#0:wybe.int, tail#0:loop_bug.int_list, ?$#0:loop_bug.int_list):
+cons(head##0:wybe.int, tail##0:loop_bug.int_list, ?$##0:loop_bug.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:loop_bug.int_list)
-    foreign lpvm mutate(~$rec#0:loop_bug.int_list, ?$rec#1:loop_bug.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:loop_bug.int_list, ?$#0:loop_bug.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail#0:loop_bug.int_list)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:loop_bug.int_list)
+    foreign lpvm mutate(~$rec##0:loop_bug.int_list, ?$rec##1:loop_bug.int_list, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:loop_bug.int_list, ?$##0:loop_bug.int_list, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:loop_bug.int_list)
 cons > public {inline} (12 calls)
 1: loop_bug.int_list.cons<1>
-cons(?head#0:wybe.int, ?tail#0:loop_bug.int_list, $#0:loop_bug.int_list, ?$$#0:wybe.bool):
+cons(?head##0:wybe.int, ?tail##0:loop_bug.int_list, $##0:loop_bug.int_list, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?head#0:wybe.int)
-        foreign llvm move(undef:loop_bug.int_list, ?tail#0:loop_bug.int_list)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?head##0:wybe.int)
+        foreign llvm move(undef:loop_bug.int_list, ?tail##0:loop_bug.int_list)
 
     1:
-        foreign lpvm access($#0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head#0:wybe.int)
-        foreign lpvm access(~$#0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail#0:loop_bug.int_list)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access($##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
+        foreign lpvm access(~$##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:loop_bug.int_list)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 head > public {inline} (0 calls)
 0: loop_bug.int_list.head<0>
-head($rec#0:loop_bug.int_list, ?$#0:wybe.int, ?$$#0:wybe.bool):
+head($rec##0:loop_bug.int_list, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec#0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:loop_bug.int_list, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 head > public {inline} (0 calls)
 1: loop_bug.int_list.head<1>
-head($rec#0:loop_bug.int_list, ?$rec#1:loop_bug.int_list, $field#0:wybe.int, ?$$#0:wybe.bool):
+head($rec##0:loop_bug.int_list, ?$rec##1:loop_bug.int_list, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:loop_bug.int_list, ?$rec#1:loop_bug.int_list)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:loop_bug.int_list, ?$rec##1:loop_bug.int_list)
 
     1:
-        foreign lpvm mutate(~$rec#0:loop_bug.int_list, ?$rec#1:loop_bug.int_list, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~$rec##0:loop_bug.int_list, ?$rec##1:loop_bug.int_list, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 nil > public {inline} (0 calls)
 0: loop_bug.int_list.nil<0>
-nil(?$#0:loop_bug.int_list):
+nil(?$##0:loop_bug.int_list):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:loop_bug.int_list, ?$#0:loop_bug.int_list)
+    foreign llvm move(0:loop_bug.int_list, ?$##0:loop_bug.int_list)
 
 
 tail > public {inline} (0 calls)
 0: loop_bug.int_list.tail<0>
-tail($rec#0:loop_bug.int_list, ?$#0:loop_bug.int_list, ?$$#0:wybe.bool):
+tail($rec##0:loop_bug.int_list, ?$##0:loop_bug.int_list, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:loop_bug.int_list, ?$#0:loop_bug.int_list)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:loop_bug.int_list, ?$##0:loop_bug.int_list)
 
     1:
-        foreign lpvm access(~$rec#0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:loop_bug.int_list)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:loop_bug.int_list, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:loop_bug.int_list)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 tail > public {inline} (0 calls)
 1: loop_bug.int_list.tail<1>
-tail($rec#0:loop_bug.int_list, ?$rec#1:loop_bug.int_list, $field#0:loop_bug.int_list, ?$$#0:wybe.bool):
+tail($rec##0:loop_bug.int_list, ?$rec##1:loop_bug.int_list, $field##0:loop_bug.int_list, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:loop_bug.int_list, ?$rec#1:loop_bug.int_list)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:loop_bug.int_list, ?$rec##1:loop_bug.int_list)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec#0:loop_bug.int_list, ?$rec#1:loop_bug.int_list, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:loop_bug.int_list)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm {noalias} mutate(~$rec##0:loop_bug.int_list, ?$rec##1:loop_bug.int_list, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:loop_bug.int_list)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: loop_bug.int_list.~=<0>
-~=($left#0:loop_bug.int_list, $right#0:loop_bug.int_list, ?$$#0:wybe.bool):
+~=($left##0:loop_bug.int_list, $right##0:loop_bug.int_list, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    loop_bug.int_list.=<0>(~$left#0:loop_bug.int_list, ~$right#0:loop_bug.int_list, ?tmp$0#0:wybe.bool) #0
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    loop_bug.int_list.=<0>(~$left##0:loop_bug.int_list, ~$right##0:loop_bug.int_list, ?tmp$0##0:wybe.bool) #0
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
   LLVM code       :
 
@@ -322,68 +322,68 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"loop_bug.int_list.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"loop_bug.int_list.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$left#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %"2$tmp$9#0" = icmp ne i64 %"$right#0", 0 
-  br i1 %"2$tmp$9#0", label %if.then1, label %if.else1 
+  %"2$tmp$9##0" = icmp ne i64 %"$right##0", 0 
+  br i1 %"2$tmp$9##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = icmp eq i64 %"$left#0", %"$right#0" 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
+  ret i1 %"3$$$##0" 
 if.then1:
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"4$tmp$4#0" = icmp eq i64 %3, %10 
-  br i1 %"4$tmp$4#0", label %if.then2, label %if.else2 
+  %"4$tmp$4##0" = icmp eq i64 %3, %10 
+  br i1 %"4$tmp$4##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$$$#0" = tail call fastcc  i1  @"loop_bug.int_list.=<0>"(i64  %7, i64  %14)  
-  ret i1 %"6$$$#0" 
+  %"6$$$##0" = tail call fastcc  i1  @"loop_bug.int_list.=<0>"(i64  %7, i64  %14)  
+  ret i1 %"6$$$##0" 
 if.else2:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"loop_bug.int_list.cons<0>"(i64  %"head#0", i64  %"tail#0")    {
+define external fastcc  i64 @"loop_bug.int_list.cons<0>"(i64  %"head##0", i64  %"tail##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"head#0", i64* %19 
+  store  i64 %"head##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"tail#0", i64* %22 
+  store  i64 %"tail##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64, i1} @"loop_bug.int_list.cons<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64, i1} @"loop_bug.int_list.cons<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -399,12 +399,12 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"loop_bug.int_list.head<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"loop_bug.int_list.head<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %36 = inttoptr i64 %"$rec#0" to i64* 
+  %36 = inttoptr i64 %"$rec##0" to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
   %39 = insertvalue {i64, i1} undef, i64 %38, 0 
@@ -417,26 +417,26 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"loop_bug.int_list.head<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"loop_bug.int_list.head<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %43 = trunc i64 16 to i32  
   %44 = tail call ccc  i8*  @wybe_malloc(i32  %43)  
   %45 = ptrtoint i8* %44 to i64 
   %46 = inttoptr i64 %45 to i8* 
-  %47 = inttoptr i64 %"$rec#0" to i8* 
+  %47 = inttoptr i64 %"$rec##0" to i8* 
   %48 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %46, i8*  %47, i32  %48, i32  8, i1  0)  
   %49 = inttoptr i64 %45 to i64* 
   %50 = getelementptr  i64, i64* %49, i64 0 
-  store  i64 %"$field#0", i64* %50 
+  store  i64 %"$field##0", i64* %50 
   %51 = insertvalue {i64, i1} undef, i64 %45, 0 
   %52 = insertvalue {i64, i1} %51, i1 1, 1 
   ret {i64, i1} %52 
 if.else:
-  %53 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %53 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %54 = insertvalue {i64, i1} %53, i1 0, 1 
   ret {i64, i1} %54 
 }
@@ -448,12 +448,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"loop_bug.int_list.tail<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"loop_bug.int_list.tail<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %55 = add   i64 %"$rec#0", 8 
+  %55 = add   i64 %"$rec##0", 8 
   %56 = inttoptr i64 %55 to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
@@ -467,35 +467,35 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"loop_bug.int_list.tail<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"loop_bug.int_list.tail<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %63 = trunc i64 16 to i32  
   %64 = tail call ccc  i8*  @wybe_malloc(i32  %63)  
   %65 = ptrtoint i8* %64 to i64 
   %66 = inttoptr i64 %65 to i8* 
-  %67 = inttoptr i64 %"$rec#0" to i8* 
+  %67 = inttoptr i64 %"$rec##0" to i8* 
   %68 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %66, i8*  %67, i32  %68, i32  8, i1  0)  
   %69 = add   i64 %65, 8 
   %70 = inttoptr i64 %69 to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
-  store  i64 %"$field#0", i64* %71 
+  store  i64 %"$field##0", i64* %71 
   %72 = insertvalue {i64, i1} undef, i64 %65, 0 
   %73 = insertvalue {i64, i1} %72, i1 1, 1 
   ret {i64, i1} %73 
 if.else:
-  %74 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %74 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %75 = insertvalue {i64, i1} %74, i1 0, 1 
   ret {i64, i1} %75 
 }
 
 
-define external fastcc  i1 @"loop_bug.int_list.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"loop_bug.int_list.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = tail call fastcc  i1  @"loop_bug.int_list.=<0>"(i64  %"$left#0", i64  %"$right#0")  
-  %"1$$$#0" = xor i1 %"1$tmp$0#0", 1 
-  ret i1 %"1$$$#0" 
+  %"1$tmp$0##0" = tail call fastcc  i1  @"loop_bug.int_list.=<0>"(i64  %"$left##0", i64  %"$right##0")  
+  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
+  ret i1 %"1$$$##0" 
 }

--- a/test-cases/final-dump/main_hello.exp
+++ b/test-cases/final-dump/main_hello.exp
@@ -20,29 +20,29 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: command_line.<0>
-(argc#0:wybe.int, [?argc#0:wybe.int], ?arguments#2:wybe.array(wybe.string), argv#0:wybe.array.raw_array(wybe.string), [?argv#0:wybe.array.raw_array(wybe.string)], ?command#2:wybe.string, ?exit_code#1:wybe.int, io#0:wybe.phantom, [?io#0:wybe.phantom]):
+(argc##0:wybe.int, [?argc##0:wybe.int], ?arguments##2:wybe.array(wybe.string), argv##0:wybe.array.raw_array(wybe.string), [?argv##0:wybe.array.raw_array(wybe.string)], ?command##2:wybe.string, ?exit_code##1:wybe.int, io##0:wybe.phantom, [?io##0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$9#0:wybe.array(?T))
-    foreign lpvm mutate(~tmp$9#0:wybe.array(?T), ?tmp$10#0:wybe.array(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc#0:wybe.int)
-    foreign lpvm mutate(~tmp$10#0:wybe.array(?T), ?tmp$1#0:wybe.array(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv#0:wybe.array.raw_array(?T))
-    wybe.array.[|]<0>(?command#2:?T, ?arguments#2:wybe.array(?T), ~tmp$1#0:wybe.array(?T), ?tmp$2#0:wybe.bool) #2 @command_line:nn:nn
-    case ~tmp$2#0:wybe.bool of
+    foreign lpvm alloc(16:wybe.int, ?tmp$9##0:wybe.array(?T))
+    foreign lpvm mutate(~tmp$9##0:wybe.array(?T), ?tmp$10##0:wybe.array(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
+    foreign lpvm mutate(~tmp$10##0:wybe.array(?T), ?tmp$1##0:wybe.array(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(?T))
+    wybe.array.[|]<0>(?command##2:?T, ?arguments##2:wybe.array(?T), ~tmp$1##0:wybe.array(?T), ?tmp$2##0:wybe.bool) #2 @command_line:nn:nn
+    case ~tmp$2##0:wybe.bool of
     0:
         foreign c {terminal,semipure} error_exit("command_line:17:10":wybe.string, "Erroneous program argument vector":wybe.string) @control:nn:nn
-        foreign llvm move(0:wybe.int, ?exit_code#1:wybe.int)
+        foreign llvm move(0:wybe.int, ?exit_code##1:wybe.int)
 
     1:
-        foreign llvm move(0:wybe.int, ?exit_code#1:wybe.int) @command_line:nn:nn
+        foreign llvm move(0:wybe.int, ?exit_code##1:wybe.int) @command_line:nn:nn
 
 
 
 set_exit_code > public {inline} (0 calls)
 0: command_line.set_exit_code<0>
-set_exit_code(code#0:wybe.int, [exit_code#0:wybe.int], ?exit_code#1:wybe.int):
+set_exit_code(code##0:wybe.int, [exit_code##0:wybe.int], ?exit_code##1:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(~code#0:wybe.int, ?exit_code#1:wybe.int) @command_line:nn:nn
+    foreign llvm move(~code##0:wybe.int, ?exit_code##1:wybe.int) @command_line:nn:nn
 
   LLVM code       :
 
@@ -70,18 +70,18 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  {i64, i64, i64} @"command_line.<0>"(i64  %"argc#0", i64  %"argv#0")    {
+define external fastcc  {i64, i64, i64} @"command_line.<0>"(i64  %"argc##0", i64  %"argv##0")    {
 entry:
   %1 = trunc i64 16 to i32  
   %2 = tail call ccc  i8*  @wybe_malloc(i32  %1)  
   %3 = ptrtoint i8* %2 to i64 
   %4 = inttoptr i64 %3 to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
-  store  i64 %"argc#0", i64* %5 
+  store  i64 %"argc##0", i64* %5 
   %6 = add   i64 %3, 8 
   %7 = inttoptr i64 %6 to i64* 
   %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"argv#0", i64* %8 
+  store  i64 %"argv##0", i64* %8 
   %9 = tail call fastcc  {i64, i64, i1}  @"wybe.array.[|]<0>"(i64  %3)  
   %10 = extractvalue {i64, i64, i1} %9, 0 
   %11 = extractvalue {i64, i64, i1} %9, 1 
@@ -103,9 +103,9 @@ if.else:
 }
 
 
-define external fastcc  i64 @"command_line.set_exit_code<0>"(i64  %"code#0")    {
+define external fastcc  i64 @"command_line.set_exit_code<0>"(i64  %"code##0")    {
 entry:
-  ret i64 %"code#0" 
+  ret i64 %"code##0" 
 }
 --------------------------------------------------
  Module main_hello
@@ -120,16 +120,16 @@ entry:
 
 *main* > public (0 calls)
 0: main_hello.<0>
-(arguments#0:wybe.array(wybe.string), [?arguments#0:wybe.array(wybe.string)], command#0:wybe.string, [?command#0:wybe.string], [exit_code#0:wybe.int], ?exit_code#1:wybe.int, io#0:wybe.phantom, ?io#3:wybe.phantom):
+(arguments##0:wybe.array(wybe.string), [?arguments##0:wybe.array(wybe.string)], command##0:wybe.string, [?command##0:wybe.string], [exit_code##0:wybe.int], ?exit_code##1:wybe.int, io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(42:wybe.int, ?#exit_code#1:wybe.int) @command_line:nn:nn
-    foreign c print_string("hello, world!":wybe.string, ~#io#0:wybe.phantom, ?tmp$5#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$5#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(arguments#0:wybe.array(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string(" command line argument(s)":wybe.string, ~#io#2:wybe.phantom, ?tmp$11#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$11#0:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
+    foreign llvm move(42:wybe.int, ?#exit_code##1:wybe.int) @command_line:nn:nn
+    foreign c print_string("hello, world!":wybe.string, ~#io##0:wybe.phantom, ?tmp$5##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$5##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(arguments##0:wybe.array(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(" command line argument(s)":wybe.string, ~#io##2:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$11##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -160,12 +160,12 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i64 @"main_hello.<0>"(i64  %"arguments#0", i64  %"command#0")    {
+define external fastcc  i64 @"main_hello.<0>"(i64  %"arguments##0", i64  %"command##0")    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @main_hello.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
   tail call ccc  void  @putchar(i8  10)  
-  %3 = inttoptr i64 %"arguments#0" to i64* 
+  %3 = inttoptr i64 %"arguments##0" to i64* 
   %4 = getelementptr  i64, i64* %3, i64 0 
   %5 = load  i64, i64* %4 
   tail call ccc  void  @print_int(i64  %5)  

--- a/test-cases/final-dump/main_hello.exp
+++ b/test-cases/final-dump/main_hello.exp
@@ -23,11 +23,11 @@ AFTER EVERYTHING:
 (argc##0:wybe.int, [?argc##0:wybe.int], ?arguments##2:wybe.array(wybe.string), argv##0:wybe.array.raw_array(wybe.string), [?argv##0:wybe.array.raw_array(wybe.string)], ?command##2:wybe.string, ?exit_code##1:wybe.int, io##0:wybe.phantom, [?io##0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$9##0:wybe.array(?T))
-    foreign lpvm mutate(~tmp$9##0:wybe.array(?T), ?tmp$10##0:wybe.array(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
-    foreign lpvm mutate(~tmp$10##0:wybe.array(?T), ?tmp$1##0:wybe.array(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(?T))
-    wybe.array.[|]<0>(?command##2:?T, ?arguments##2:wybe.array(?T), ~tmp$1##0:wybe.array(?T), ?tmp$2##0:wybe.bool) #2 @command_line:nn:nn
-    case ~tmp$2##0:wybe.bool of
+    foreign lpvm alloc(16:wybe.int, ?tmp#9##0:wybe.array(?T))
+    foreign lpvm mutate(~tmp#9##0:wybe.array(?T), ?tmp#10##0:wybe.array(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
+    foreign lpvm mutate(~tmp#10##0:wybe.array(?T), ?tmp#1##0:wybe.array(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(?T))
+    wybe.array.[|]<0>(?command##2:?T, ?arguments##2:wybe.array(?T), ~tmp#1##0:wybe.array(?T), ?tmp#2##0:wybe.bool) #2 @command_line:nn:nn
+    case ~tmp#2##0:wybe.bool of
     0:
         foreign c {terminal,semipure} error_exit("command_line:17:10":wybe.string, "Erroneous program argument vector":wybe.string) @control:nn:nn
         foreign llvm move(0:wybe.int, ?exit_code##1:wybe.int)
@@ -124,12 +124,12 @@ entry:
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(42:wybe.int, ?#exit_code##1:wybe.int) @command_line:nn:nn
-    foreign c print_string("hello, world!":wybe.string, ~#io##0:wybe.phantom, ?tmp$5##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$5##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(arguments##0:wybe.array(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    foreign c print_string(" command line argument(s)":wybe.string, ~#io##2:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$11##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign c print_string("hello, world!":wybe.string, ~#io##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(arguments##0:wybe.array(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(" command line argument(s)":wybe.string, ~#io##2:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/main_hello2.exp
+++ b/test-cases/final-dump/main_hello2.exp
@@ -15,8 +15,8 @@ AFTER EVERYTHING:
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("hello, ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign c print_string("world!":wybe.string, ~#io##1:wybe.phantom, ?tmp$4##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$4##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string("world!":wybe.string, ~#io##1:wybe.phantom, ?tmp#4##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#4##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/main_hello2.exp
+++ b/test-cases/final-dump/main_hello2.exp
@@ -11,12 +11,12 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: main_hello2.<0>
-(io#0:wybe.phantom, ?io#2:wybe.phantom):
+(io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("hello, ":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_string("world!":wybe.string, ~#io#1:wybe.phantom, ?tmp$4#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$4#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
+    foreign c print_string("hello, ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("world!":wybe.string, ~#io##1:wybe.phantom, ?tmp$4##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$4##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/mainless.exp
+++ b/test-cases/final-dump/mainless.exp
@@ -11,10 +11,10 @@ AFTER EVERYTHING:
 
 nothing_interesting > public {inline} (0 calls)
 0: mainless.nothing_interesting<0>
-nothing_interesting(?###0:wybe.int):
+nothing_interesting(?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(7:wybe.int, ?###0:wybe.int) @mainless:nn:nn
+    foreign llvm move(7:wybe.int, ?#result##0:wybe.int) @mainless:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/mainless.exp
+++ b/test-cases/final-dump/mainless.exp
@@ -11,10 +11,10 @@ AFTER EVERYTHING:
 
 nothing_interesting > public {inline} (0 calls)
 0: mainless.nothing_interesting<0>
-nothing_interesting(?$##0:wybe.int):
+nothing_interesting(?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(7:wybe.int, ?$##0:wybe.int) @mainless:nn:nn
+    foreign llvm move(7:wybe.int, ?###0:wybe.int) @mainless:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/mainless.exp
+++ b/test-cases/final-dump/mainless.exp
@@ -11,10 +11,10 @@ AFTER EVERYTHING:
 
 nothing_interesting > public {inline} (0 calls)
 0: mainless.nothing_interesting<0>
-nothing_interesting(?$#0:wybe.int):
+nothing_interesting(?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(7:wybe.int, ?$#0:wybe.int) @mainless:nn:nn
+    foreign llvm move(7:wybe.int, ?$##0:wybe.int) @mainless:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/mixed_fields.exp
+++ b/test-cases/final-dump/mixed_fields.exp
@@ -31,64 +31,64 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(32:wybe.int, ?tmp$8##0:mixed_fields)
-    foreign lpvm mutate(~tmp$8##0:mixed_fields, ?tmp$9##0:mixed_fields, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 'a':wybe.char)
-    foreign lpvm mutate(~tmp$9##0:mixed_fields, ?tmp$10##0:mixed_fields, 1:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 1:wybe.bool)
-    foreign lpvm mutate(~tmp$10##0:mixed_fields, ?tmp$11##0:mixed_fields, 2:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 'A':wybe.char)
-    foreign lpvm mutate(~tmp$11##0:mixed_fields, ?tmp$12##0:mixed_fields, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 3:wybe.int)
-    foreign lpvm mutate(~tmp$12##0:mixed_fields, ?tmp$13##0:mixed_fields, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 42:wybe.int)
-    foreign lpvm mutate(~tmp$13##0:mixed_fields, ?tmp$0##0:mixed_fields, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 17:wybe.int)
-    mixed_fields.printit<0>(~tmp$0##0:mixed_fields, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @mixed_fields:nn:nn
+    foreign lpvm alloc(32:wybe.int, ?tmp#8##0:mixed_fields)
+    foreign lpvm mutate(~tmp#8##0:mixed_fields, ?tmp#9##0:mixed_fields, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 'a':wybe.char)
+    foreign lpvm mutate(~tmp#9##0:mixed_fields, ?tmp#10##0:mixed_fields, 1:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 1:wybe.bool)
+    foreign lpvm mutate(~tmp#10##0:mixed_fields, ?tmp#11##0:mixed_fields, 2:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 'A':wybe.char)
+    foreign lpvm mutate(~tmp#11##0:mixed_fields, ?tmp#12##0:mixed_fields, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 3:wybe.int)
+    foreign lpvm mutate(~tmp#12##0:mixed_fields, ?tmp#13##0:mixed_fields, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 42:wybe.int)
+    foreign lpvm mutate(~tmp#13##0:mixed_fields, ?tmp#0##0:mixed_fields, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 17:wybe.int)
+    mixed_fields.printit<0>(~tmp#0##0:mixed_fields, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @mixed_fields:nn:nn
 
 
 = > public (1 calls)
 0: mixed_fields.=<0>
-=($left##0:mixed_fields, $right##0:mixed_fields, ?$$##0:wybe.bool):
+=(#left##0:mixed_fields, #right##0:mixed_fields, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$f2##0:wybe.char)
-    foreign lpvm access($left##0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$f4##0:wybe.bool)
-    foreign lpvm access($left##0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$f6##0:wybe.char)
-    foreign lpvm access($left##0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$f1##0:wybe.int)
-    foreign lpvm access($left##0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$f3##0:wybe.int)
-    foreign lpvm access(~$left##0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$f5##0:wybe.int)
-    foreign lpvm access($right##0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$f2##0:wybe.char)
-    foreign lpvm access($right##0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$f4##0:wybe.bool)
-    foreign lpvm access($right##0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$f6##0:wybe.char)
-    foreign lpvm access($right##0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$f1##0:wybe.int)
-    foreign lpvm access($right##0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$f3##0:wybe.int)
-    foreign lpvm access(~$right##0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$f5##0:wybe.int)
-    foreign llvm icmp_eq(~$left$f1##0:wybe.int, ~$right$f1##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#f2##0:wybe.char)
+    foreign lpvm access(#left##0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#f4##0:wybe.bool)
+    foreign lpvm access(#left##0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#f6##0:wybe.char)
+    foreign lpvm access(#left##0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#f1##0:wybe.int)
+    foreign lpvm access(#left##0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#f3##0:wybe.int)
+    foreign lpvm access(~#left##0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#f5##0:wybe.int)
+    foreign lpvm access(#right##0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#f2##0:wybe.char)
+    foreign lpvm access(#right##0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#f4##0:wybe.bool)
+    foreign lpvm access(#right##0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#f6##0:wybe.char)
+    foreign lpvm access(#right##0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#f1##0:wybe.int)
+    foreign lpvm access(#right##0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#f3##0:wybe.int)
+    foreign lpvm access(~#right##0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#f5##0:wybe.int)
+    foreign llvm icmp_eq(~#left#f1##0:wybe.int, ~#right#f1##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$f2##0:wybe.char, ~$right$f2##0:wybe.char, ?tmp$2##0:wybe.bool) @char:nn:nn
-        case ~tmp$2##0:wybe.bool of
+        foreign llvm icmp_eq(~#left#f2##0:wybe.char, ~#right#f2##0:wybe.char, ?tmp#2##0:wybe.bool) @char:nn:nn
+        case ~tmp#2##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~$left$f3##0:wybe.int, ~$right$f3##0:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
-            case ~tmp$3##0:wybe.bool of
+            foreign llvm icmp_eq(~#left#f3##0:wybe.int, ~#right#f3##0:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
+            case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
             1:
-                foreign llvm icmp_eq(~$left$f4##0:wybe.bool, ~$right$f4##0:wybe.bool, ?tmp$4##0:wybe.bool) @bool:nn:nn
-                case ~tmp$4##0:wybe.bool of
+                foreign llvm icmp_eq(~#left#f4##0:wybe.bool, ~#right#f4##0:wybe.bool, ?tmp#4##0:wybe.bool) @bool:nn:nn
+                case ~tmp#4##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                 1:
-                    foreign llvm icmp_eq(~$left$f5##0:wybe.int, ~$right$f5##0:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
-                    case ~tmp$5##0:wybe.bool of
+                    foreign llvm icmp_eq(~#left#f5##0:wybe.int, ~#right#f5##0:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
+                    case ~tmp#5##0:wybe.bool of
                     0:
-                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                     1:
-                        foreign llvm icmp_eq(~$left$f6##0:wybe.char, ~$right$f6##0:wybe.char, ?$$##0:wybe.bool) @char:nn:nn
+                        foreign llvm icmp_eq(~#left#f6##0:wybe.char, ~#right#f6##0:wybe.char, ?####0:wybe.bool) @char:nn:nn
 
 
 
@@ -98,111 +98,111 @@ AFTER EVERYTHING:
 
 f1 > public {inline} (1 calls)
 0: mixed_fields.f1<0>
-f1($rec##0:mixed_fields, ?$##0:wybe.int):
+f1(#rec##0:mixed_fields, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:wybe.int)
 f1 > public {inline} (0 calls)
 1: mixed_fields.f1<1>
-f1($rec##0:mixed_fields, ?$rec##1:mixed_fields, $field##0:wybe.int):
+f1(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:mixed_fields, ?$rec##1:mixed_fields, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:mixed_fields, ?#rec##1:mixed_fields, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 f2 > public {inline} (1 calls)
 0: mixed_fields.f2<0>
-f2($rec##0:mixed_fields, ?$##0:wybe.char):
+f2(#rec##0:mixed_fields, ?###0:wybe.char):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:wybe.char)
+    foreign lpvm access(~#rec##0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:wybe.char)
 f2 > public {inline} (0 calls)
 1: mixed_fields.f2<1>
-f2($rec##0:mixed_fields, ?$rec##1:mixed_fields, $field##0:wybe.char):
+f2(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.char):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:mixed_fields, ?$rec##1:mixed_fields, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:wybe.char)
+    foreign lpvm {noalias} mutate(~#rec##0:mixed_fields, ?#rec##1:mixed_fields, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.char)
 
 
 f3 > public {inline} (1 calls)
 0: mixed_fields.f3<0>
-f3($rec##0:mixed_fields, ?$##0:wybe.int):
+f3(#rec##0:mixed_fields, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:wybe.int)
 f3 > public {inline} (0 calls)
 1: mixed_fields.f3<1>
-f3($rec##0:mixed_fields, ?$rec##1:mixed_fields, $field##0:wybe.int):
+f3(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:mixed_fields, ?$rec##1:mixed_fields, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:mixed_fields, ?#rec##1:mixed_fields, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 f4 > public {inline} (1 calls)
 0: mixed_fields.f4<0>
-f4($rec##0:mixed_fields, ?$##0:wybe.bool):
+f4(#rec##0:mixed_fields, ?###0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:wybe.bool)
+    foreign lpvm access(~#rec##0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:wybe.bool)
 f4 > public {inline} (0 calls)
 1: mixed_fields.f4<1>
-f4($rec##0:mixed_fields, ?$rec##1:mixed_fields, $field##0:wybe.bool):
+f4(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:mixed_fields, ?$rec##1:mixed_fields, 1:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:wybe.bool)
+    foreign lpvm {noalias} mutate(~#rec##0:mixed_fields, ?#rec##1:mixed_fields, 1:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.bool)
 
 
 f5 > public {inline} (1 calls)
 0: mixed_fields.f5<0>
-f5($rec##0:mixed_fields, ?$##0:wybe.int):
+f5(#rec##0:mixed_fields, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:wybe.int)
 f5 > public {inline} (0 calls)
 1: mixed_fields.f5<1>
-f5($rec##0:mixed_fields, ?$rec##1:mixed_fields, $field##0:wybe.int):
+f5(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:mixed_fields, ?$rec##1:mixed_fields, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:mixed_fields, ?#rec##1:mixed_fields, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 f6 > public {inline} (1 calls)
 0: mixed_fields.f6<0>
-f6($rec##0:mixed_fields, ?$##0:wybe.char):
+f6(#rec##0:mixed_fields, ?###0:wybe.char):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:wybe.char)
+    foreign lpvm access(~#rec##0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:wybe.char)
 f6 > public {inline} (0 calls)
 1: mixed_fields.f6<1>
-f6($rec##0:mixed_fields, ?$rec##1:mixed_fields, $field##0:wybe.char):
+f6(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.char):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:mixed_fields, ?$rec##1:mixed_fields, 2:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:wybe.char)
+    foreign lpvm {noalias} mutate(~#rec##0:mixed_fields, ?#rec##1:mixed_fields, 2:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.char)
 
 
 mixed > public {inline} (1 calls)
 0: mixed_fields.mixed<0>
-mixed(f1##0:wybe.int, f2##0:wybe.char, f3##0:wybe.int, f4##0:wybe.bool, f5##0:wybe.int, f6##0:wybe.char, ?$##0:mixed_fields):
+mixed(f1##0:wybe.int, f2##0:wybe.char, f3##0:wybe.int, f4##0:wybe.bool, f5##0:wybe.int, f6##0:wybe.char, ?###0:mixed_fields):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(32:wybe.int, ?$rec##0:mixed_fields)
-    foreign lpvm mutate(~$rec##0:mixed_fields, ?$rec##1:mixed_fields, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f2##0:wybe.char)
-    foreign lpvm mutate(~$rec##1:mixed_fields, ?$rec##2:mixed_fields, 1:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f4##0:wybe.bool)
-    foreign lpvm mutate(~$rec##2:mixed_fields, ?$rec##3:mixed_fields, 2:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f6##0:wybe.char)
-    foreign lpvm mutate(~$rec##3:mixed_fields, ?$rec##4:mixed_fields, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f1##0:wybe.int)
-    foreign lpvm mutate(~$rec##4:mixed_fields, ?$rec##5:mixed_fields, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f3##0:wybe.int)
-    foreign lpvm mutate(~$rec##5:mixed_fields, ?$##0:mixed_fields, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f5##0:wybe.int)
+    foreign lpvm alloc(32:wybe.int, ?#rec##0:mixed_fields)
+    foreign lpvm mutate(~#rec##0:mixed_fields, ?#rec##1:mixed_fields, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f2##0:wybe.char)
+    foreign lpvm mutate(~#rec##1:mixed_fields, ?#rec##2:mixed_fields, 1:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f4##0:wybe.bool)
+    foreign lpvm mutate(~#rec##2:mixed_fields, ?#rec##3:mixed_fields, 2:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f6##0:wybe.char)
+    foreign lpvm mutate(~#rec##3:mixed_fields, ?#rec##4:mixed_fields, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f1##0:wybe.int)
+    foreign lpvm mutate(~#rec##4:mixed_fields, ?#rec##5:mixed_fields, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f3##0:wybe.int)
+    foreign lpvm mutate(~#rec##5:mixed_fields, ?###0:mixed_fields, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f5##0:wybe.int)
 mixed > public {inline} (22 calls)
 1: mixed_fields.mixed<1>
-mixed(?f1##0:wybe.int, ?f2##0:wybe.char, ?f3##0:wybe.int, ?f4##0:wybe.bool, ?f5##0:wybe.int, ?f6##0:wybe.char, $##0:mixed_fields):
+mixed(?f1##0:wybe.int, ?f2##0:wybe.char, ?f3##0:wybe.int, ?f4##0:wybe.bool, ?f5##0:wybe.int, ?f6##0:wybe.char, ###0:mixed_fields):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?f2##0:wybe.char)
-    foreign lpvm access($##0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?f4##0:wybe.bool)
-    foreign lpvm access($##0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?f6##0:wybe.char)
-    foreign lpvm access($##0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?f1##0:wybe.int)
-    foreign lpvm access($##0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?f3##0:wybe.int)
-    foreign lpvm access(~$##0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?f5##0:wybe.int)
+    foreign lpvm access(###0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?f2##0:wybe.char)
+    foreign lpvm access(###0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?f4##0:wybe.bool)
+    foreign lpvm access(###0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?f6##0:wybe.char)
+    foreign lpvm access(###0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?f1##0:wybe.int)
+    foreign lpvm access(###0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?f3##0:wybe.int)
+    foreign lpvm access(~###0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?f5##0:wybe.int)
 
 
 printit > public (1 calls)
@@ -210,33 +210,33 @@ printit > public (1 calls)
 printit(ob##0:mixed_fields, io##0:wybe.phantom, ?io##6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(ob##0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$9##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$9##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(ob##0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.char)
-    foreign c putchar(~tmp$1##0:wybe.char, ~#io##1:wybe.phantom, ?tmp$13##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$13##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    foreign lpvm access(ob##0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.int)
-    foreign c print_int(~tmp$2##0:wybe.int, ~#io##2:wybe.phantom, ?tmp$17##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$17##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(ob##0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.bool)
-    wybe.io.print<5>(~tmp$3##0:wybe.bool, ~#io##3:wybe.phantom, ?tmp$21##0:wybe.phantom) #12 @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$21##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign lpvm access(ob##0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign c print_int(~tmp$4##0:wybe.int, ~#io##4:wybe.phantom, ?tmp$25##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$25##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~ob##0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.char)
-    foreign c putchar(~tmp$5##0:wybe.char, ~#io##5:wybe.phantom, ?tmp$29##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$29##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+    foreign lpvm access(ob##0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#9##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(ob##0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.char)
+    foreign c putchar(~tmp#1##0:wybe.char, ~#io##1:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(ob##0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int)
+    foreign c print_int(~tmp#2##0:wybe.int, ~#io##2:wybe.phantom, ?tmp#17##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#17##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign lpvm access(ob##0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.bool)
+    wybe.io.print<5>(~tmp#3##0:wybe.bool, ~#io##3:wybe.phantom, ?tmp#21##0:wybe.phantom) #12 @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign lpvm access(ob##0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign c print_int(~tmp#4##0:wybe.int, ~#io##4:wybe.phantom, ?tmp#25##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#25##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~ob##0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.char)
+    foreign c putchar(~tmp#5##0:wybe.char, ~#io##5:wybe.phantom, ?tmp#29##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#29##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
 
 
 ~= > public {inline} (0 calls)
 0: mixed_fields.~=<0>
-~=($left##0:mixed_fields, $right##0:mixed_fields, ?$$##0:wybe.bool):
+~=(#left##0:mixed_fields, #right##0:mixed_fields, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    mixed_fields.=<0>(~$left##0:mixed_fields, ~$right##0:mixed_fields, ?tmp$0##0:wybe.bool) #0
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    mixed_fields.=<0>(~#left##0:mixed_fields, ~#right##0:mixed_fields, ?tmp#0##0:wybe.bool) #0
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
   LLVM code       :
 
@@ -294,87 +294,87 @@ entry:
 }
 
 
-define external fastcc  i1 @"mixed_fields.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"mixed_fields.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %21 = inttoptr i64 %"$left##0" to i8* 
+  %21 = inttoptr i64 %"#left##0" to i8* 
   %22 = getelementptr  i8, i8* %21, i64 0 
   %23 = load  i8, i8* %22 
-  %24 = add   i64 %"$left##0", 1 
+  %24 = add   i64 %"#left##0", 1 
   %25 = inttoptr i64 %24 to i1* 
   %26 = getelementptr  i1, i1* %25, i64 0 
   %27 = load  i1, i1* %26 
-  %28 = add   i64 %"$left##0", 2 
+  %28 = add   i64 %"#left##0", 2 
   %29 = inttoptr i64 %28 to i8* 
   %30 = getelementptr  i8, i8* %29, i64 0 
   %31 = load  i8, i8* %30 
-  %32 = add   i64 %"$left##0", 8 
+  %32 = add   i64 %"#left##0", 8 
   %33 = inttoptr i64 %32 to i64* 
   %34 = getelementptr  i64, i64* %33, i64 0 
   %35 = load  i64, i64* %34 
-  %36 = add   i64 %"$left##0", 16 
+  %36 = add   i64 %"#left##0", 16 
   %37 = inttoptr i64 %36 to i64* 
   %38 = getelementptr  i64, i64* %37, i64 0 
   %39 = load  i64, i64* %38 
-  %40 = add   i64 %"$left##0", 24 
+  %40 = add   i64 %"#left##0", 24 
   %41 = inttoptr i64 %40 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
   %43 = load  i64, i64* %42 
-  %44 = inttoptr i64 %"$right##0" to i8* 
+  %44 = inttoptr i64 %"#right##0" to i8* 
   %45 = getelementptr  i8, i8* %44, i64 0 
   %46 = load  i8, i8* %45 
-  %47 = add   i64 %"$right##0", 1 
+  %47 = add   i64 %"#right##0", 1 
   %48 = inttoptr i64 %47 to i1* 
   %49 = getelementptr  i1, i1* %48, i64 0 
   %50 = load  i1, i1* %49 
-  %51 = add   i64 %"$right##0", 2 
+  %51 = add   i64 %"#right##0", 2 
   %52 = inttoptr i64 %51 to i8* 
   %53 = getelementptr  i8, i8* %52, i64 0 
   %54 = load  i8, i8* %53 
-  %55 = add   i64 %"$right##0", 8 
+  %55 = add   i64 %"#right##0", 8 
   %56 = inttoptr i64 %55 to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$right##0", 16 
+  %59 = add   i64 %"#right##0", 16 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = add   i64 %"$right##0", 24 
+  %63 = add   i64 %"#right##0", 24 
   %64 = inttoptr i64 %63 to i64* 
   %65 = getelementptr  i64, i64* %64, i64 0 
   %66 = load  i64, i64* %65 
-  %"1$tmp$1##0" = icmp eq i64 %35, %58 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %35, %58 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = icmp eq i8 %23, %46 
-  br i1 %"2$tmp$2##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = icmp eq i8 %23, %46 
+  br i1 %"2#tmp#2##0", label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %"4$tmp$3##0" = icmp eq i64 %39, %62 
-  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
+  %"4#tmp#3##0" = icmp eq i64 %39, %62 
+  br i1 %"4#tmp#3##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$tmp$4##0" = icmp eq i1 %27, %50 
-  br i1 %"6$tmp$4##0", label %if.then3, label %if.else3 
+  %"6#tmp#4##0" = icmp eq i1 %27, %50 
+  br i1 %"6#tmp#4##0", label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %"8$tmp$5##0" = icmp eq i64 %43, %66 
-  br i1 %"8$tmp$5##0", label %if.then4, label %if.else4 
+  %"8#tmp#5##0" = icmp eq i64 %43, %66 
+  br i1 %"8#tmp#5##0", label %if.then4, label %if.else4 
 if.else3:
   ret i1 0 
 if.then4:
-  %"10$$$##0" = icmp eq i8 %31, %54 
-  ret i1 %"10$$$##0" 
+  %"10#####0" = icmp eq i8 %31, %54 
+  ret i1 %"10#####0" 
 if.else4:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"mixed_fields.f1<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"mixed_fields.f1<0>"(i64  %"#rec##0")    {
 entry:
-  %67 = add   i64 %"$rec##0", 8 
+  %67 = add   i64 %"#rec##0", 8 
   %68 = inttoptr i64 %67 to i64* 
   %69 = getelementptr  i64, i64* %68, i64 0 
   %70 = load  i64, i64* %69 
@@ -382,51 +382,51 @@ entry:
 }
 
 
-define external fastcc  i64 @"mixed_fields.f1<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"mixed_fields.f1<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %71 = trunc i64 32 to i32  
   %72 = tail call ccc  i8*  @wybe_malloc(i32  %71)  
   %73 = ptrtoint i8* %72 to i64 
   %74 = inttoptr i64 %73 to i8* 
-  %75 = inttoptr i64 %"$rec##0" to i8* 
+  %75 = inttoptr i64 %"#rec##0" to i8* 
   %76 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %74, i8*  %75, i32  %76, i32  8, i1  0)  
   %77 = add   i64 %73, 8 
   %78 = inttoptr i64 %77 to i64* 
   %79 = getelementptr  i64, i64* %78, i64 0 
-  store  i64 %"$field##0", i64* %79 
+  store  i64 %"#field##0", i64* %79 
   ret i64 %73 
 }
 
 
-define external fastcc  i8 @"mixed_fields.f2<0>"(i64  %"$rec##0")    {
+define external fastcc  i8 @"mixed_fields.f2<0>"(i64  %"#rec##0")    {
 entry:
-  %80 = inttoptr i64 %"$rec##0" to i8* 
+  %80 = inttoptr i64 %"#rec##0" to i8* 
   %81 = getelementptr  i8, i8* %80, i64 0 
   %82 = load  i8, i8* %81 
   ret i8 %82 
 }
 
 
-define external fastcc  i64 @"mixed_fields.f2<1>"(i64  %"$rec##0", i8  %"$field##0")    {
+define external fastcc  i64 @"mixed_fields.f2<1>"(i64  %"#rec##0", i8  %"#field##0")    {
 entry:
   %83 = trunc i64 32 to i32  
   %84 = tail call ccc  i8*  @wybe_malloc(i32  %83)  
   %85 = ptrtoint i8* %84 to i64 
   %86 = inttoptr i64 %85 to i8* 
-  %87 = inttoptr i64 %"$rec##0" to i8* 
+  %87 = inttoptr i64 %"#rec##0" to i8* 
   %88 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %86, i8*  %87, i32  %88, i32  8, i1  0)  
   %89 = inttoptr i64 %85 to i8* 
   %90 = getelementptr  i8, i8* %89, i64 0 
-  store  i8 %"$field##0", i8* %90 
+  store  i8 %"#field##0", i8* %90 
   ret i64 %85 
 }
 
 
-define external fastcc  i64 @"mixed_fields.f3<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"mixed_fields.f3<0>"(i64  %"#rec##0")    {
 entry:
-  %91 = add   i64 %"$rec##0", 16 
+  %91 = add   i64 %"#rec##0", 16 
   %92 = inttoptr i64 %91 to i64* 
   %93 = getelementptr  i64, i64* %92, i64 0 
   %94 = load  i64, i64* %93 
@@ -434,26 +434,26 @@ entry:
 }
 
 
-define external fastcc  i64 @"mixed_fields.f3<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"mixed_fields.f3<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %95 = trunc i64 32 to i32  
   %96 = tail call ccc  i8*  @wybe_malloc(i32  %95)  
   %97 = ptrtoint i8* %96 to i64 
   %98 = inttoptr i64 %97 to i8* 
-  %99 = inttoptr i64 %"$rec##0" to i8* 
+  %99 = inttoptr i64 %"#rec##0" to i8* 
   %100 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %98, i8*  %99, i32  %100, i32  8, i1  0)  
   %101 = add   i64 %97, 16 
   %102 = inttoptr i64 %101 to i64* 
   %103 = getelementptr  i64, i64* %102, i64 0 
-  store  i64 %"$field##0", i64* %103 
+  store  i64 %"#field##0", i64* %103 
   ret i64 %97 
 }
 
 
-define external fastcc  i1 @"mixed_fields.f4<0>"(i64  %"$rec##0")    {
+define external fastcc  i1 @"mixed_fields.f4<0>"(i64  %"#rec##0")    {
 entry:
-  %104 = add   i64 %"$rec##0", 1 
+  %104 = add   i64 %"#rec##0", 1 
   %105 = inttoptr i64 %104 to i1* 
   %106 = getelementptr  i1, i1* %105, i64 0 
   %107 = load  i1, i1* %106 
@@ -461,26 +461,26 @@ entry:
 }
 
 
-define external fastcc  i64 @"mixed_fields.f4<1>"(i64  %"$rec##0", i1  %"$field##0")    {
+define external fastcc  i64 @"mixed_fields.f4<1>"(i64  %"#rec##0", i1  %"#field##0")    {
 entry:
   %108 = trunc i64 32 to i32  
   %109 = tail call ccc  i8*  @wybe_malloc(i32  %108)  
   %110 = ptrtoint i8* %109 to i64 
   %111 = inttoptr i64 %110 to i8* 
-  %112 = inttoptr i64 %"$rec##0" to i8* 
+  %112 = inttoptr i64 %"#rec##0" to i8* 
   %113 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %111, i8*  %112, i32  %113, i32  8, i1  0)  
   %114 = add   i64 %110, 1 
   %115 = inttoptr i64 %114 to i1* 
   %116 = getelementptr  i1, i1* %115, i64 0 
-  store  i1 %"$field##0", i1* %116 
+  store  i1 %"#field##0", i1* %116 
   ret i64 %110 
 }
 
 
-define external fastcc  i64 @"mixed_fields.f5<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"mixed_fields.f5<0>"(i64  %"#rec##0")    {
 entry:
-  %117 = add   i64 %"$rec##0", 24 
+  %117 = add   i64 %"#rec##0", 24 
   %118 = inttoptr i64 %117 to i64* 
   %119 = getelementptr  i64, i64* %118, i64 0 
   %120 = load  i64, i64* %119 
@@ -488,26 +488,26 @@ entry:
 }
 
 
-define external fastcc  i64 @"mixed_fields.f5<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"mixed_fields.f5<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %121 = trunc i64 32 to i32  
   %122 = tail call ccc  i8*  @wybe_malloc(i32  %121)  
   %123 = ptrtoint i8* %122 to i64 
   %124 = inttoptr i64 %123 to i8* 
-  %125 = inttoptr i64 %"$rec##0" to i8* 
+  %125 = inttoptr i64 %"#rec##0" to i8* 
   %126 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %124, i8*  %125, i32  %126, i32  8, i1  0)  
   %127 = add   i64 %123, 24 
   %128 = inttoptr i64 %127 to i64* 
   %129 = getelementptr  i64, i64* %128, i64 0 
-  store  i64 %"$field##0", i64* %129 
+  store  i64 %"#field##0", i64* %129 
   ret i64 %123 
 }
 
 
-define external fastcc  i8 @"mixed_fields.f6<0>"(i64  %"$rec##0")    {
+define external fastcc  i8 @"mixed_fields.f6<0>"(i64  %"#rec##0")    {
 entry:
-  %130 = add   i64 %"$rec##0", 2 
+  %130 = add   i64 %"#rec##0", 2 
   %131 = inttoptr i64 %130 to i8* 
   %132 = getelementptr  i8, i8* %131, i64 0 
   %133 = load  i8, i8* %132 
@@ -515,19 +515,19 @@ entry:
 }
 
 
-define external fastcc  i64 @"mixed_fields.f6<1>"(i64  %"$rec##0", i8  %"$field##0")    {
+define external fastcc  i64 @"mixed_fields.f6<1>"(i64  %"#rec##0", i8  %"#field##0")    {
 entry:
   %134 = trunc i64 32 to i32  
   %135 = tail call ccc  i8*  @wybe_malloc(i32  %134)  
   %136 = ptrtoint i8* %135 to i64 
   %137 = inttoptr i64 %136 to i8* 
-  %138 = inttoptr i64 %"$rec##0" to i8* 
+  %138 = inttoptr i64 %"#rec##0" to i8* 
   %139 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %137, i8*  %138, i32  %139, i32  8, i1  0)  
   %140 = add   i64 %136, 2 
   %141 = inttoptr i64 %140 to i8* 
   %142 = getelementptr  i8, i8* %141, i64 0 
-  store  i8 %"$field##0", i8* %142 
+  store  i8 %"#field##0", i8* %142 
   ret i64 %136 
 }
 
@@ -564,28 +564,28 @@ entry:
 }
 
 
-define external fastcc  {i64, i8, i64, i1, i64, i8} @"mixed_fields.mixed<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i8, i64, i1, i64, i8} @"mixed_fields.mixed<1>"(i64  %"###0")    {
 entry:
-  %163 = inttoptr i64 %"$##0" to i8* 
+  %163 = inttoptr i64 %"###0" to i8* 
   %164 = getelementptr  i8, i8* %163, i64 0 
   %165 = load  i8, i8* %164 
-  %166 = add   i64 %"$##0", 1 
+  %166 = add   i64 %"###0", 1 
   %167 = inttoptr i64 %166 to i1* 
   %168 = getelementptr  i1, i1* %167, i64 0 
   %169 = load  i1, i1* %168 
-  %170 = add   i64 %"$##0", 2 
+  %170 = add   i64 %"###0", 2 
   %171 = inttoptr i64 %170 to i8* 
   %172 = getelementptr  i8, i8* %171, i64 0 
   %173 = load  i8, i8* %172 
-  %174 = add   i64 %"$##0", 8 
+  %174 = add   i64 %"###0", 8 
   %175 = inttoptr i64 %174 to i64* 
   %176 = getelementptr  i64, i64* %175, i64 0 
   %177 = load  i64, i64* %176 
-  %178 = add   i64 %"$##0", 16 
+  %178 = add   i64 %"###0", 16 
   %179 = inttoptr i64 %178 to i64* 
   %180 = getelementptr  i64, i64* %179, i64 0 
   %181 = load  i64, i64* %180 
-  %182 = add   i64 %"$##0", 24 
+  %182 = add   i64 %"###0", 24 
   %183 = inttoptr i64 %182 to i64* 
   %184 = getelementptr  i64, i64* %183, i64 0 
   %185 = load  i64, i64* %184 
@@ -640,9 +640,9 @@ entry:
 }
 
 
-define external fastcc  i1 @"mixed_fields.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"mixed_fields.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = tail call fastcc  i1  @"mixed_fields.=<0>"(i64  %"$left##0", i64  %"$right##0")  
-  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
-  ret i1 %"1$$$##0" 
+  %"1#tmp#0##0" = tail call fastcc  i1  @"mixed_fields.=<0>"(i64  %"#left##0", i64  %"#right##0")  
+  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1#####0" 
 }

--- a/test-cases/final-dump/mixed_fields.exp
+++ b/test-cases/final-dump/mixed_fields.exp
@@ -43,7 +43,7 @@ AFTER EVERYTHING:
 
 = > public (1 calls)
 0: mixed_fields.=<0>
-=(#left##0:mixed_fields, #right##0:mixed_fields, ?####0:wybe.bool):
+=(#left##0:mixed_fields, #right##0:mixed_fields, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#f2##0:wybe.char)
@@ -61,34 +61,34 @@ AFTER EVERYTHING:
     foreign llvm icmp_eq(~#left#f1##0:wybe.int, ~#right#f1##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~#left#f2##0:wybe.char, ~#right#f2##0:wybe.char, ?tmp#2##0:wybe.bool) @char:nn:nn
         case ~tmp#2##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign llvm icmp_eq(~#left#f3##0:wybe.int, ~#right#f3##0:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
             case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
                 foreign llvm icmp_eq(~#left#f4##0:wybe.bool, ~#right#f4##0:wybe.bool, ?tmp#4##0:wybe.bool) @bool:nn:nn
                 case ~tmp#4##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                 1:
                     foreign llvm icmp_eq(~#left#f5##0:wybe.int, ~#right#f5##0:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
                     case ~tmp#5##0:wybe.bool of
                     0:
-                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                     1:
-                        foreign llvm icmp_eq(~#left#f6##0:wybe.char, ~#right#f6##0:wybe.char, ?####0:wybe.bool) @char:nn:nn
+                        foreign llvm icmp_eq(~#left#f6##0:wybe.char, ~#right#f6##0:wybe.char, ?#success##0:wybe.bool) @char:nn:nn
 
 
 
@@ -232,11 +232,11 @@ printit(ob##0:mixed_fields, io##0:wybe.phantom, ?io##6:wybe.phantom):
 
 ~= > public {inline} (0 calls)
 0: mixed_fields.~=<0>
-~=(#left##0:mixed_fields, #right##0:mixed_fields, ?####0:wybe.bool):
+~=(#left##0:mixed_fields, #right##0:mixed_fields, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     mixed_fields.=<0>(~#left##0:mixed_fields, ~#right##0:mixed_fields, ?tmp#0##0:wybe.bool) #0
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 
@@ -365,8 +365,8 @@ if.then3:
 if.else3:
   ret i1 0 
 if.then4:
-  %"10#####0" = icmp eq i8 %31, %54 
-  ret i1 %"10#####0" 
+  %"10##success##0" = icmp eq i8 %31, %54 
+  ret i1 %"10##success##0" 
 if.else4:
   ret i1 0 
 }
@@ -643,6 +643,6 @@ entry:
 define external fastcc  i1 @"mixed_fields.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %"1#tmp#0##0" = tail call fastcc  i1  @"mixed_fields.=<0>"(i64  %"#left##0", i64  %"#right##0")  
-  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
-  ret i1 %"1#####0" 
+  %"1##success##0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1##success##0" 
 }

--- a/test-cases/final-dump/mixed_fields.exp
+++ b/test-cases/final-dump/mixed_fields.exp
@@ -98,10 +98,10 @@ AFTER EVERYTHING:
 
 f1 > public {inline} (1 calls)
 0: mixed_fields.f1<0>
-f1(#rec##0:mixed_fields, ?###0:wybe.int):
+f1(#rec##0:mixed_fields, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 f1 > public {inline} (0 calls)
 1: mixed_fields.f1<1>
 f1(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.int):
@@ -112,10 +112,10 @@ f1(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.int):
 
 f2 > public {inline} (1 calls)
 0: mixed_fields.f2<0>
-f2(#rec##0:mixed_fields, ?###0:wybe.char):
+f2(#rec##0:mixed_fields, ?#result##0:wybe.char):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:wybe.char)
+    foreign lpvm access(~#rec##0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.char)
 f2 > public {inline} (0 calls)
 1: mixed_fields.f2<1>
 f2(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.char):
@@ -126,10 +126,10 @@ f2(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.char):
 
 f3 > public {inline} (1 calls)
 0: mixed_fields.f3<0>
-f3(#rec##0:mixed_fields, ?###0:wybe.int):
+f3(#rec##0:mixed_fields, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 f3 > public {inline} (0 calls)
 1: mixed_fields.f3<1>
 f3(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.int):
@@ -140,10 +140,10 @@ f3(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.int):
 
 f4 > public {inline} (1 calls)
 0: mixed_fields.f4<0>
-f4(#rec##0:mixed_fields, ?###0:wybe.bool):
+f4(#rec##0:mixed_fields, ?#result##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:wybe.bool)
+    foreign lpvm access(~#rec##0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.bool)
 f4 > public {inline} (0 calls)
 1: mixed_fields.f4<1>
 f4(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.bool):
@@ -154,10 +154,10 @@ f4(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.bool):
 
 f5 > public {inline} (1 calls)
 0: mixed_fields.f5<0>
-f5(#rec##0:mixed_fields, ?###0:wybe.int):
+f5(#rec##0:mixed_fields, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 f5 > public {inline} (0 calls)
 1: mixed_fields.f5<1>
 f5(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.int):
@@ -168,10 +168,10 @@ f5(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.int):
 
 f6 > public {inline} (1 calls)
 0: mixed_fields.f6<0>
-f6(#rec##0:mixed_fields, ?###0:wybe.char):
+f6(#rec##0:mixed_fields, ?#result##0:wybe.char):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:wybe.char)
+    foreign lpvm access(~#rec##0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.char)
 f6 > public {inline} (0 calls)
 1: mixed_fields.f6<1>
 f6(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.char):
@@ -182,7 +182,7 @@ f6(#rec##0:mixed_fields, ?#rec##1:mixed_fields, #field##0:wybe.char):
 
 mixed > public {inline} (1 calls)
 0: mixed_fields.mixed<0>
-mixed(f1##0:wybe.int, f2##0:wybe.char, f3##0:wybe.int, f4##0:wybe.bool, f5##0:wybe.int, f6##0:wybe.char, ?###0:mixed_fields):
+mixed(f1##0:wybe.int, f2##0:wybe.char, f3##0:wybe.int, f4##0:wybe.bool, f5##0:wybe.int, f6##0:wybe.char, ?#result##0:mixed_fields):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(32:wybe.int, ?#rec##0:mixed_fields)
@@ -191,18 +191,18 @@ mixed(f1##0:wybe.int, f2##0:wybe.char, f3##0:wybe.int, f4##0:wybe.bool, f5##0:wy
     foreign lpvm mutate(~#rec##2:mixed_fields, ?#rec##3:mixed_fields, 2:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f6##0:wybe.char)
     foreign lpvm mutate(~#rec##3:mixed_fields, ?#rec##4:mixed_fields, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f1##0:wybe.int)
     foreign lpvm mutate(~#rec##4:mixed_fields, ?#rec##5:mixed_fields, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f3##0:wybe.int)
-    foreign lpvm mutate(~#rec##5:mixed_fields, ?###0:mixed_fields, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f5##0:wybe.int)
+    foreign lpvm mutate(~#rec##5:mixed_fields, ?#result##0:mixed_fields, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f5##0:wybe.int)
 mixed > public {inline} (22 calls)
 1: mixed_fields.mixed<1>
-mixed(?f1##0:wybe.int, ?f2##0:wybe.char, ?f3##0:wybe.int, ?f4##0:wybe.bool, ?f5##0:wybe.int, ?f6##0:wybe.char, ###0:mixed_fields):
+mixed(?f1##0:wybe.int, ?f2##0:wybe.char, ?f3##0:wybe.int, ?f4##0:wybe.bool, ?f5##0:wybe.int, ?f6##0:wybe.char, #result##0:mixed_fields):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?f2##0:wybe.char)
-    foreign lpvm access(###0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?f4##0:wybe.bool)
-    foreign lpvm access(###0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?f6##0:wybe.char)
-    foreign lpvm access(###0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?f1##0:wybe.int)
-    foreign lpvm access(###0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?f3##0:wybe.int)
-    foreign lpvm access(~###0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?f5##0:wybe.int)
+    foreign lpvm access(#result##0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?f2##0:wybe.char)
+    foreign lpvm access(#result##0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?f4##0:wybe.bool)
+    foreign lpvm access(#result##0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?f6##0:wybe.char)
+    foreign lpvm access(#result##0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?f1##0:wybe.int)
+    foreign lpvm access(#result##0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?f3##0:wybe.int)
+    foreign lpvm access(~#result##0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?f5##0:wybe.int)
 
 
 printit > public (1 calls)
@@ -564,28 +564,28 @@ entry:
 }
 
 
-define external fastcc  {i64, i8, i64, i1, i64, i8} @"mixed_fields.mixed<1>"(i64  %"###0")    {
+define external fastcc  {i64, i8, i64, i1, i64, i8} @"mixed_fields.mixed<1>"(i64  %"#result##0")    {
 entry:
-  %163 = inttoptr i64 %"###0" to i8* 
+  %163 = inttoptr i64 %"#result##0" to i8* 
   %164 = getelementptr  i8, i8* %163, i64 0 
   %165 = load  i8, i8* %164 
-  %166 = add   i64 %"###0", 1 
+  %166 = add   i64 %"#result##0", 1 
   %167 = inttoptr i64 %166 to i1* 
   %168 = getelementptr  i1, i1* %167, i64 0 
   %169 = load  i1, i1* %168 
-  %170 = add   i64 %"###0", 2 
+  %170 = add   i64 %"#result##0", 2 
   %171 = inttoptr i64 %170 to i8* 
   %172 = getelementptr  i8, i8* %171, i64 0 
   %173 = load  i8, i8* %172 
-  %174 = add   i64 %"###0", 8 
+  %174 = add   i64 %"#result##0", 8 
   %175 = inttoptr i64 %174 to i64* 
   %176 = getelementptr  i64, i64* %175, i64 0 
   %177 = load  i64, i64* %176 
-  %178 = add   i64 %"###0", 16 
+  %178 = add   i64 %"#result##0", 16 
   %179 = inttoptr i64 %178 to i64* 
   %180 = getelementptr  i64, i64* %179, i64 0 
   %181 = load  i64, i64* %180 
-  %182 = add   i64 %"###0", 24 
+  %182 = add   i64 %"#result##0", 24 
   %183 = inttoptr i64 %182 to i64* 
   %184 = getelementptr  i64, i64* %183, i64 0 
   %185 = load  i64, i64* %184 

--- a/test-cases/final-dump/mixed_fields.exp
+++ b/test-cases/final-dump/mixed_fields.exp
@@ -28,67 +28,67 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: mixed_fields.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(32:wybe.int, ?tmp$8#0:mixed_fields)
-    foreign lpvm mutate(~tmp$8#0:mixed_fields, ?tmp$9#0:mixed_fields, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 'a':wybe.char)
-    foreign lpvm mutate(~tmp$9#0:mixed_fields, ?tmp$10#0:mixed_fields, 1:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 1:wybe.bool)
-    foreign lpvm mutate(~tmp$10#0:mixed_fields, ?tmp$11#0:mixed_fields, 2:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 'A':wybe.char)
-    foreign lpvm mutate(~tmp$11#0:mixed_fields, ?tmp$12#0:mixed_fields, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 3:wybe.int)
-    foreign lpvm mutate(~tmp$12#0:mixed_fields, ?tmp$13#0:mixed_fields, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 42:wybe.int)
-    foreign lpvm mutate(~tmp$13#0:mixed_fields, ?tmp$0#0:mixed_fields, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 17:wybe.int)
-    mixed_fields.printit<0>(~tmp$0#0:mixed_fields, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #2 @mixed_fields:nn:nn
+    foreign lpvm alloc(32:wybe.int, ?tmp$8##0:mixed_fields)
+    foreign lpvm mutate(~tmp$8##0:mixed_fields, ?tmp$9##0:mixed_fields, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 'a':wybe.char)
+    foreign lpvm mutate(~tmp$9##0:mixed_fields, ?tmp$10##0:mixed_fields, 1:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 1:wybe.bool)
+    foreign lpvm mutate(~tmp$10##0:mixed_fields, ?tmp$11##0:mixed_fields, 2:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 'A':wybe.char)
+    foreign lpvm mutate(~tmp$11##0:mixed_fields, ?tmp$12##0:mixed_fields, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 3:wybe.int)
+    foreign lpvm mutate(~tmp$12##0:mixed_fields, ?tmp$13##0:mixed_fields, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 42:wybe.int)
+    foreign lpvm mutate(~tmp$13##0:mixed_fields, ?tmp$0##0:mixed_fields, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, 17:wybe.int)
+    mixed_fields.printit<0>(~tmp$0##0:mixed_fields, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @mixed_fields:nn:nn
 
 
 = > public (1 calls)
 0: mixed_fields.=<0>
-=($left#0:mixed_fields, $right#0:mixed_fields, ?$$#0:wybe.bool):
+=($left##0:mixed_fields, $right##0:mixed_fields, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$f2#0:wybe.char)
-    foreign lpvm access($left#0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$f4#0:wybe.bool)
-    foreign lpvm access($left#0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$f6#0:wybe.char)
-    foreign lpvm access($left#0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$f1#0:wybe.int)
-    foreign lpvm access($left#0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$f3#0:wybe.int)
-    foreign lpvm access(~$left#0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$f5#0:wybe.int)
-    foreign lpvm access($right#0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$f2#0:wybe.char)
-    foreign lpvm access($right#0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$f4#0:wybe.bool)
-    foreign lpvm access($right#0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$f6#0:wybe.char)
-    foreign lpvm access($right#0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$f1#0:wybe.int)
-    foreign lpvm access($right#0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$f3#0:wybe.int)
-    foreign lpvm access(~$right#0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$f5#0:wybe.int)
-    foreign llvm icmp_eq(~$left$f1#0:wybe.int, ~$right$f1#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$f2##0:wybe.char)
+    foreign lpvm access($left##0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$f4##0:wybe.bool)
+    foreign lpvm access($left##0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$f6##0:wybe.char)
+    foreign lpvm access($left##0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$f1##0:wybe.int)
+    foreign lpvm access($left##0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$f3##0:wybe.int)
+    foreign lpvm access(~$left##0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$f5##0:wybe.int)
+    foreign lpvm access($right##0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$f2##0:wybe.char)
+    foreign lpvm access($right##0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$f4##0:wybe.bool)
+    foreign lpvm access($right##0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$f6##0:wybe.char)
+    foreign lpvm access($right##0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$f1##0:wybe.int)
+    foreign lpvm access($right##0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$f3##0:wybe.int)
+    foreign lpvm access(~$right##0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$f5##0:wybe.int)
+    foreign llvm icmp_eq(~$left$f1##0:wybe.int, ~$right$f1##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$f2#0:wybe.char, ~$right$f2#0:wybe.char, ?tmp$2#0:wybe.bool) @char:nn:nn
-        case ~tmp$2#0:wybe.bool of
+        foreign llvm icmp_eq(~$left$f2##0:wybe.char, ~$right$f2##0:wybe.char, ?tmp$2##0:wybe.bool) @char:nn:nn
+        case ~tmp$2##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~$left$f3#0:wybe.int, ~$right$f3#0:wybe.int, ?tmp$3#0:wybe.bool) @int:nn:nn
-            case ~tmp$3#0:wybe.bool of
+            foreign llvm icmp_eq(~$left$f3##0:wybe.int, ~$right$f3##0:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
+            case ~tmp$3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                foreign llvm icmp_eq(~$left$f4#0:wybe.bool, ~$right$f4#0:wybe.bool, ?tmp$4#0:wybe.bool) @bool:nn:nn
-                case ~tmp$4#0:wybe.bool of
+                foreign llvm icmp_eq(~$left$f4##0:wybe.bool, ~$right$f4##0:wybe.bool, ?tmp$4##0:wybe.bool) @bool:nn:nn
+                case ~tmp$4##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                 1:
-                    foreign llvm icmp_eq(~$left$f5#0:wybe.int, ~$right$f5#0:wybe.int, ?tmp$5#0:wybe.bool) @int:nn:nn
-                    case ~tmp$5#0:wybe.bool of
+                    foreign llvm icmp_eq(~$left$f5##0:wybe.int, ~$right$f5##0:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
+                    case ~tmp$5##0:wybe.bool of
                     0:
-                        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                     1:
-                        foreign llvm icmp_eq(~$left$f6#0:wybe.char, ~$right$f6#0:wybe.char, ?$$#0:wybe.bool) @char:nn:nn
+                        foreign llvm icmp_eq(~$left$f6##0:wybe.char, ~$right$f6##0:wybe.char, ?$$##0:wybe.bool) @char:nn:nn
 
 
 
@@ -98,145 +98,145 @@ AFTER EVERYTHING:
 
 f1 > public {inline} (1 calls)
 0: mixed_fields.f1<0>
-f1($rec#0:mixed_fields, ?$#0:wybe.int):
+f1($rec##0:mixed_fields, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 f1 > public {inline} (0 calls)
 1: mixed_fields.f1<1>
-f1($rec#0:mixed_fields, ?$rec#1:mixed_fields, $field#0:wybe.int):
+f1($rec##0:mixed_fields, ?$rec##1:mixed_fields, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:mixed_fields, ?$rec#1:mixed_fields, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:mixed_fields, ?$rec##1:mixed_fields, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 f2 > public {inline} (1 calls)
 0: mixed_fields.f2<0>
-f2($rec#0:mixed_fields, ?$#0:wybe.char):
+f2($rec##0:mixed_fields, ?$##0:wybe.char):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$#0:wybe.char)
+    foreign lpvm access(~$rec##0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:wybe.char)
 f2 > public {inline} (0 calls)
 1: mixed_fields.f2<1>
-f2($rec#0:mixed_fields, ?$rec#1:mixed_fields, $field#0:wybe.char):
+f2($rec##0:mixed_fields, ?$rec##1:mixed_fields, $field##0:wybe.char):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:mixed_fields, ?$rec#1:mixed_fields, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field#0:wybe.char)
+    foreign lpvm {noalias} mutate(~$rec##0:mixed_fields, ?$rec##1:mixed_fields, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:wybe.char)
 
 
 f3 > public {inline} (1 calls)
 0: mixed_fields.f3<0>
-f3($rec#0:mixed_fields, ?$#0:wybe.int):
+f3($rec##0:mixed_fields, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 f3 > public {inline} (0 calls)
 1: mixed_fields.f3<1>
-f3($rec#0:mixed_fields, ?$rec#1:mixed_fields, $field#0:wybe.int):
+f3($rec##0:mixed_fields, ?$rec##1:mixed_fields, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:mixed_fields, ?$rec#1:mixed_fields, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:mixed_fields, ?$rec##1:mixed_fields, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 f4 > public {inline} (1 calls)
 0: mixed_fields.f4<0>
-f4($rec#0:mixed_fields, ?$#0:wybe.bool):
+f4($rec##0:mixed_fields, ?$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?$#0:wybe.bool)
+    foreign lpvm access(~$rec##0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:wybe.bool)
 f4 > public {inline} (0 calls)
 1: mixed_fields.f4<1>
-f4($rec#0:mixed_fields, ?$rec#1:mixed_fields, $field#0:wybe.bool):
+f4($rec##0:mixed_fields, ?$rec##1:mixed_fields, $field##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:mixed_fields, ?$rec#1:mixed_fields, 1:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field#0:wybe.bool)
+    foreign lpvm {noalias} mutate(~$rec##0:mixed_fields, ?$rec##1:mixed_fields, 1:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:wybe.bool)
 
 
 f5 > public {inline} (1 calls)
 0: mixed_fields.f5<0>
-f5($rec#0:mixed_fields, ?$#0:wybe.int):
+f5($rec##0:mixed_fields, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 f5 > public {inline} (0 calls)
 1: mixed_fields.f5<1>
-f5($rec#0:mixed_fields, ?$rec#1:mixed_fields, $field#0:wybe.int):
+f5($rec##0:mixed_fields, ?$rec##1:mixed_fields, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:mixed_fields, ?$rec#1:mixed_fields, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:mixed_fields, ?$rec##1:mixed_fields, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 f6 > public {inline} (1 calls)
 0: mixed_fields.f6<0>
-f6($rec#0:mixed_fields, ?$#0:wybe.char):
+f6($rec##0:mixed_fields, ?$##0:wybe.char):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?$#0:wybe.char)
+    foreign lpvm access(~$rec##0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:wybe.char)
 f6 > public {inline} (0 calls)
 1: mixed_fields.f6<1>
-f6($rec#0:mixed_fields, ?$rec#1:mixed_fields, $field#0:wybe.char):
+f6($rec##0:mixed_fields, ?$rec##1:mixed_fields, $field##0:wybe.char):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:mixed_fields, ?$rec#1:mixed_fields, 2:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field#0:wybe.char)
+    foreign lpvm {noalias} mutate(~$rec##0:mixed_fields, ?$rec##1:mixed_fields, 2:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:wybe.char)
 
 
 mixed > public {inline} (1 calls)
 0: mixed_fields.mixed<0>
-mixed(f1#0:wybe.int, f2#0:wybe.char, f3#0:wybe.int, f4#0:wybe.bool, f5#0:wybe.int, f6#0:wybe.char, ?$#0:mixed_fields):
+mixed(f1##0:wybe.int, f2##0:wybe.char, f3##0:wybe.int, f4##0:wybe.bool, f5##0:wybe.int, f6##0:wybe.char, ?$##0:mixed_fields):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(32:wybe.int, ?$rec#0:mixed_fields)
-    foreign lpvm mutate(~$rec#0:mixed_fields, ?$rec#1:mixed_fields, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f2#0:wybe.char)
-    foreign lpvm mutate(~$rec#1:mixed_fields, ?$rec#2:mixed_fields, 1:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f4#0:wybe.bool)
-    foreign lpvm mutate(~$rec#2:mixed_fields, ?$rec#3:mixed_fields, 2:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f6#0:wybe.char)
-    foreign lpvm mutate(~$rec#3:mixed_fields, ?$rec#4:mixed_fields, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f1#0:wybe.int)
-    foreign lpvm mutate(~$rec#4:mixed_fields, ?$rec#5:mixed_fields, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f3#0:wybe.int)
-    foreign lpvm mutate(~$rec#5:mixed_fields, ?$#0:mixed_fields, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f5#0:wybe.int)
+    foreign lpvm alloc(32:wybe.int, ?$rec##0:mixed_fields)
+    foreign lpvm mutate(~$rec##0:mixed_fields, ?$rec##1:mixed_fields, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f2##0:wybe.char)
+    foreign lpvm mutate(~$rec##1:mixed_fields, ?$rec##2:mixed_fields, 1:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f4##0:wybe.bool)
+    foreign lpvm mutate(~$rec##2:mixed_fields, ?$rec##3:mixed_fields, 2:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f6##0:wybe.char)
+    foreign lpvm mutate(~$rec##3:mixed_fields, ?$rec##4:mixed_fields, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f1##0:wybe.int)
+    foreign lpvm mutate(~$rec##4:mixed_fields, ?$rec##5:mixed_fields, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f3##0:wybe.int)
+    foreign lpvm mutate(~$rec##5:mixed_fields, ?$##0:mixed_fields, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~f5##0:wybe.int)
 mixed > public {inline} (22 calls)
 1: mixed_fields.mixed<1>
-mixed(?f1#0:wybe.int, ?f2#0:wybe.char, ?f3#0:wybe.int, ?f4#0:wybe.bool, ?f5#0:wybe.int, ?f6#0:wybe.char, $#0:mixed_fields):
+mixed(?f1##0:wybe.int, ?f2##0:wybe.char, ?f3##0:wybe.int, ?f4##0:wybe.bool, ?f5##0:wybe.int, ?f6##0:wybe.char, $##0:mixed_fields):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?f2#0:wybe.char)
-    foreign lpvm access($#0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?f4#0:wybe.bool)
-    foreign lpvm access($#0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?f6#0:wybe.char)
-    foreign lpvm access($#0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?f1#0:wybe.int)
-    foreign lpvm access($#0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?f3#0:wybe.int)
-    foreign lpvm access(~$#0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?f5#0:wybe.int)
+    foreign lpvm access($##0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?f2##0:wybe.char)
+    foreign lpvm access($##0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?f4##0:wybe.bool)
+    foreign lpvm access($##0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?f6##0:wybe.char)
+    foreign lpvm access($##0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?f1##0:wybe.int)
+    foreign lpvm access($##0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?f3##0:wybe.int)
+    foreign lpvm access(~$##0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?f5##0:wybe.int)
 
 
 printit > public (1 calls)
 0: mixed_fields.printit<0>
-printit(ob#0:mixed_fields, io#0:wybe.phantom, ?io#6:wybe.phantom):
+printit(ob##0:mixed_fields, io##0:wybe.phantom, ?io##6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(ob#0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$9#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$9#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(ob#0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.char)
-    foreign c putchar(~tmp$1#0:wybe.char, ~#io#1:wybe.phantom, ?tmp$13#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$13#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign lpvm access(ob#0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$2#0:wybe.int)
-    foreign c print_int(~tmp$2#0:wybe.int, ~#io#2:wybe.phantom, ?tmp$17#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$17#0:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(ob#0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.bool)
-    wybe.io.print<5>(~tmp$3#0:wybe.bool, ~#io#3:wybe.phantom, ?tmp$21#0:wybe.phantom) #12 @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$21#0:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign lpvm access(ob#0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign c print_int(~tmp$4#0:wybe.int, ~#io#4:wybe.phantom, ?tmp$25#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$25#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~ob#0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.char)
-    foreign c putchar(~tmp$5#0:wybe.char, ~#io#5:wybe.phantom, ?tmp$29#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$29#0:wybe.phantom, ?#io#6:wybe.phantom) @io:nn:nn
+    foreign lpvm access(ob##0:mixed_fields, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$9##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$9##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(ob##0:mixed_fields, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.char)
+    foreign c putchar(~tmp$1##0:wybe.char, ~#io##1:wybe.phantom, ?tmp$13##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$13##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(ob##0:mixed_fields, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.int)
+    foreign c print_int(~tmp$2##0:wybe.int, ~#io##2:wybe.phantom, ?tmp$17##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$17##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign lpvm access(ob##0:mixed_fields, 1:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.bool)
+    wybe.io.print<5>(~tmp$3##0:wybe.bool, ~#io##3:wybe.phantom, ?tmp$21##0:wybe.phantom) #12 @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$21##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign lpvm access(ob##0:mixed_fields, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign c print_int(~tmp$4##0:wybe.int, ~#io##4:wybe.phantom, ?tmp$25##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$25##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~ob##0:mixed_fields, 2:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.char)
+    foreign c putchar(~tmp$5##0:wybe.char, ~#io##5:wybe.phantom, ?tmp$29##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$29##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
 
 
 ~= > public {inline} (0 calls)
 0: mixed_fields.~=<0>
-~=($left#0:mixed_fields, $right#0:mixed_fields, ?$$#0:wybe.bool):
+~=($left##0:mixed_fields, $right##0:mixed_fields, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    mixed_fields.=<0>(~$left#0:mixed_fields, ~$right#0:mixed_fields, ?tmp$0#0:wybe.bool) #0
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    mixed_fields.=<0>(~$left##0:mixed_fields, ~$right##0:mixed_fields, ?tmp$0##0:wybe.bool) #0
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
   LLVM code       :
 
@@ -294,87 +294,87 @@ entry:
 }
 
 
-define external fastcc  i1 @"mixed_fields.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"mixed_fields.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %21 = inttoptr i64 %"$left#0" to i8* 
+  %21 = inttoptr i64 %"$left##0" to i8* 
   %22 = getelementptr  i8, i8* %21, i64 0 
   %23 = load  i8, i8* %22 
-  %24 = add   i64 %"$left#0", 1 
+  %24 = add   i64 %"$left##0", 1 
   %25 = inttoptr i64 %24 to i1* 
   %26 = getelementptr  i1, i1* %25, i64 0 
   %27 = load  i1, i1* %26 
-  %28 = add   i64 %"$left#0", 2 
+  %28 = add   i64 %"$left##0", 2 
   %29 = inttoptr i64 %28 to i8* 
   %30 = getelementptr  i8, i8* %29, i64 0 
   %31 = load  i8, i8* %30 
-  %32 = add   i64 %"$left#0", 8 
+  %32 = add   i64 %"$left##0", 8 
   %33 = inttoptr i64 %32 to i64* 
   %34 = getelementptr  i64, i64* %33, i64 0 
   %35 = load  i64, i64* %34 
-  %36 = add   i64 %"$left#0", 16 
+  %36 = add   i64 %"$left##0", 16 
   %37 = inttoptr i64 %36 to i64* 
   %38 = getelementptr  i64, i64* %37, i64 0 
   %39 = load  i64, i64* %38 
-  %40 = add   i64 %"$left#0", 24 
+  %40 = add   i64 %"$left##0", 24 
   %41 = inttoptr i64 %40 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
   %43 = load  i64, i64* %42 
-  %44 = inttoptr i64 %"$right#0" to i8* 
+  %44 = inttoptr i64 %"$right##0" to i8* 
   %45 = getelementptr  i8, i8* %44, i64 0 
   %46 = load  i8, i8* %45 
-  %47 = add   i64 %"$right#0", 1 
+  %47 = add   i64 %"$right##0", 1 
   %48 = inttoptr i64 %47 to i1* 
   %49 = getelementptr  i1, i1* %48, i64 0 
   %50 = load  i1, i1* %49 
-  %51 = add   i64 %"$right#0", 2 
+  %51 = add   i64 %"$right##0", 2 
   %52 = inttoptr i64 %51 to i8* 
   %53 = getelementptr  i8, i8* %52, i64 0 
   %54 = load  i8, i8* %53 
-  %55 = add   i64 %"$right#0", 8 
+  %55 = add   i64 %"$right##0", 8 
   %56 = inttoptr i64 %55 to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$right#0", 16 
+  %59 = add   i64 %"$right##0", 16 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = add   i64 %"$right#0", 24 
+  %63 = add   i64 %"$right##0", 24 
   %64 = inttoptr i64 %63 to i64* 
   %65 = getelementptr  i64, i64* %64, i64 0 
   %66 = load  i64, i64* %65 
-  %"1$tmp$1#0" = icmp eq i64 %35, %58 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %35, %58 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = icmp eq i8 %23, %46 
-  br i1 %"2$tmp$2#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = icmp eq i8 %23, %46 
+  br i1 %"2$tmp$2##0", label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %"4$tmp$3#0" = icmp eq i64 %39, %62 
-  br i1 %"4$tmp$3#0", label %if.then2, label %if.else2 
+  %"4$tmp$3##0" = icmp eq i64 %39, %62 
+  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$tmp$4#0" = icmp eq i1 %27, %50 
-  br i1 %"6$tmp$4#0", label %if.then3, label %if.else3 
+  %"6$tmp$4##0" = icmp eq i1 %27, %50 
+  br i1 %"6$tmp$4##0", label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %"8$tmp$5#0" = icmp eq i64 %43, %66 
-  br i1 %"8$tmp$5#0", label %if.then4, label %if.else4 
+  %"8$tmp$5##0" = icmp eq i64 %43, %66 
+  br i1 %"8$tmp$5##0", label %if.then4, label %if.else4 
 if.else3:
   ret i1 0 
 if.then4:
-  %"10$$$#0" = icmp eq i8 %31, %54 
-  ret i1 %"10$$$#0" 
+  %"10$$$##0" = icmp eq i8 %31, %54 
+  ret i1 %"10$$$##0" 
 if.else4:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"mixed_fields.f1<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"mixed_fields.f1<0>"(i64  %"$rec##0")    {
 entry:
-  %67 = add   i64 %"$rec#0", 8 
+  %67 = add   i64 %"$rec##0", 8 
   %68 = inttoptr i64 %67 to i64* 
   %69 = getelementptr  i64, i64* %68, i64 0 
   %70 = load  i64, i64* %69 
@@ -382,51 +382,51 @@ entry:
 }
 
 
-define external fastcc  i64 @"mixed_fields.f1<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"mixed_fields.f1<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %71 = trunc i64 32 to i32  
   %72 = tail call ccc  i8*  @wybe_malloc(i32  %71)  
   %73 = ptrtoint i8* %72 to i64 
   %74 = inttoptr i64 %73 to i8* 
-  %75 = inttoptr i64 %"$rec#0" to i8* 
+  %75 = inttoptr i64 %"$rec##0" to i8* 
   %76 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %74, i8*  %75, i32  %76, i32  8, i1  0)  
   %77 = add   i64 %73, 8 
   %78 = inttoptr i64 %77 to i64* 
   %79 = getelementptr  i64, i64* %78, i64 0 
-  store  i64 %"$field#0", i64* %79 
+  store  i64 %"$field##0", i64* %79 
   ret i64 %73 
 }
 
 
-define external fastcc  i8 @"mixed_fields.f2<0>"(i64  %"$rec#0")    {
+define external fastcc  i8 @"mixed_fields.f2<0>"(i64  %"$rec##0")    {
 entry:
-  %80 = inttoptr i64 %"$rec#0" to i8* 
+  %80 = inttoptr i64 %"$rec##0" to i8* 
   %81 = getelementptr  i8, i8* %80, i64 0 
   %82 = load  i8, i8* %81 
   ret i8 %82 
 }
 
 
-define external fastcc  i64 @"mixed_fields.f2<1>"(i64  %"$rec#0", i8  %"$field#0")    {
+define external fastcc  i64 @"mixed_fields.f2<1>"(i64  %"$rec##0", i8  %"$field##0")    {
 entry:
   %83 = trunc i64 32 to i32  
   %84 = tail call ccc  i8*  @wybe_malloc(i32  %83)  
   %85 = ptrtoint i8* %84 to i64 
   %86 = inttoptr i64 %85 to i8* 
-  %87 = inttoptr i64 %"$rec#0" to i8* 
+  %87 = inttoptr i64 %"$rec##0" to i8* 
   %88 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %86, i8*  %87, i32  %88, i32  8, i1  0)  
   %89 = inttoptr i64 %85 to i8* 
   %90 = getelementptr  i8, i8* %89, i64 0 
-  store  i8 %"$field#0", i8* %90 
+  store  i8 %"$field##0", i8* %90 
   ret i64 %85 
 }
 
 
-define external fastcc  i64 @"mixed_fields.f3<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"mixed_fields.f3<0>"(i64  %"$rec##0")    {
 entry:
-  %91 = add   i64 %"$rec#0", 16 
+  %91 = add   i64 %"$rec##0", 16 
   %92 = inttoptr i64 %91 to i64* 
   %93 = getelementptr  i64, i64* %92, i64 0 
   %94 = load  i64, i64* %93 
@@ -434,26 +434,26 @@ entry:
 }
 
 
-define external fastcc  i64 @"mixed_fields.f3<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"mixed_fields.f3<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %95 = trunc i64 32 to i32  
   %96 = tail call ccc  i8*  @wybe_malloc(i32  %95)  
   %97 = ptrtoint i8* %96 to i64 
   %98 = inttoptr i64 %97 to i8* 
-  %99 = inttoptr i64 %"$rec#0" to i8* 
+  %99 = inttoptr i64 %"$rec##0" to i8* 
   %100 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %98, i8*  %99, i32  %100, i32  8, i1  0)  
   %101 = add   i64 %97, 16 
   %102 = inttoptr i64 %101 to i64* 
   %103 = getelementptr  i64, i64* %102, i64 0 
-  store  i64 %"$field#0", i64* %103 
+  store  i64 %"$field##0", i64* %103 
   ret i64 %97 
 }
 
 
-define external fastcc  i1 @"mixed_fields.f4<0>"(i64  %"$rec#0")    {
+define external fastcc  i1 @"mixed_fields.f4<0>"(i64  %"$rec##0")    {
 entry:
-  %104 = add   i64 %"$rec#0", 1 
+  %104 = add   i64 %"$rec##0", 1 
   %105 = inttoptr i64 %104 to i1* 
   %106 = getelementptr  i1, i1* %105, i64 0 
   %107 = load  i1, i1* %106 
@@ -461,26 +461,26 @@ entry:
 }
 
 
-define external fastcc  i64 @"mixed_fields.f4<1>"(i64  %"$rec#0", i1  %"$field#0")    {
+define external fastcc  i64 @"mixed_fields.f4<1>"(i64  %"$rec##0", i1  %"$field##0")    {
 entry:
   %108 = trunc i64 32 to i32  
   %109 = tail call ccc  i8*  @wybe_malloc(i32  %108)  
   %110 = ptrtoint i8* %109 to i64 
   %111 = inttoptr i64 %110 to i8* 
-  %112 = inttoptr i64 %"$rec#0" to i8* 
+  %112 = inttoptr i64 %"$rec##0" to i8* 
   %113 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %111, i8*  %112, i32  %113, i32  8, i1  0)  
   %114 = add   i64 %110, 1 
   %115 = inttoptr i64 %114 to i1* 
   %116 = getelementptr  i1, i1* %115, i64 0 
-  store  i1 %"$field#0", i1* %116 
+  store  i1 %"$field##0", i1* %116 
   ret i64 %110 
 }
 
 
-define external fastcc  i64 @"mixed_fields.f5<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"mixed_fields.f5<0>"(i64  %"$rec##0")    {
 entry:
-  %117 = add   i64 %"$rec#0", 24 
+  %117 = add   i64 %"$rec##0", 24 
   %118 = inttoptr i64 %117 to i64* 
   %119 = getelementptr  i64, i64* %118, i64 0 
   %120 = load  i64, i64* %119 
@@ -488,26 +488,26 @@ entry:
 }
 
 
-define external fastcc  i64 @"mixed_fields.f5<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"mixed_fields.f5<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %121 = trunc i64 32 to i32  
   %122 = tail call ccc  i8*  @wybe_malloc(i32  %121)  
   %123 = ptrtoint i8* %122 to i64 
   %124 = inttoptr i64 %123 to i8* 
-  %125 = inttoptr i64 %"$rec#0" to i8* 
+  %125 = inttoptr i64 %"$rec##0" to i8* 
   %126 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %124, i8*  %125, i32  %126, i32  8, i1  0)  
   %127 = add   i64 %123, 24 
   %128 = inttoptr i64 %127 to i64* 
   %129 = getelementptr  i64, i64* %128, i64 0 
-  store  i64 %"$field#0", i64* %129 
+  store  i64 %"$field##0", i64* %129 
   ret i64 %123 
 }
 
 
-define external fastcc  i8 @"mixed_fields.f6<0>"(i64  %"$rec#0")    {
+define external fastcc  i8 @"mixed_fields.f6<0>"(i64  %"$rec##0")    {
 entry:
-  %130 = add   i64 %"$rec#0", 2 
+  %130 = add   i64 %"$rec##0", 2 
   %131 = inttoptr i64 %130 to i8* 
   %132 = getelementptr  i8, i8* %131, i64 0 
   %133 = load  i8, i8* %132 
@@ -515,77 +515,77 @@ entry:
 }
 
 
-define external fastcc  i64 @"mixed_fields.f6<1>"(i64  %"$rec#0", i8  %"$field#0")    {
+define external fastcc  i64 @"mixed_fields.f6<1>"(i64  %"$rec##0", i8  %"$field##0")    {
 entry:
   %134 = trunc i64 32 to i32  
   %135 = tail call ccc  i8*  @wybe_malloc(i32  %134)  
   %136 = ptrtoint i8* %135 to i64 
   %137 = inttoptr i64 %136 to i8* 
-  %138 = inttoptr i64 %"$rec#0" to i8* 
+  %138 = inttoptr i64 %"$rec##0" to i8* 
   %139 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %137, i8*  %138, i32  %139, i32  8, i1  0)  
   %140 = add   i64 %136, 2 
   %141 = inttoptr i64 %140 to i8* 
   %142 = getelementptr  i8, i8* %141, i64 0 
-  store  i8 %"$field#0", i8* %142 
+  store  i8 %"$field##0", i8* %142 
   ret i64 %136 
 }
 
 
-define external fastcc  i64 @"mixed_fields.mixed<0>"(i64  %"f1#0", i8  %"f2#0", i64  %"f3#0", i1  %"f4#0", i64  %"f5#0", i8  %"f6#0")    {
+define external fastcc  i64 @"mixed_fields.mixed<0>"(i64  %"f1##0", i8  %"f2##0", i64  %"f3##0", i1  %"f4##0", i64  %"f5##0", i8  %"f6##0")    {
 entry:
   %143 = trunc i64 32 to i32  
   %144 = tail call ccc  i8*  @wybe_malloc(i32  %143)  
   %145 = ptrtoint i8* %144 to i64 
   %146 = inttoptr i64 %145 to i8* 
   %147 = getelementptr  i8, i8* %146, i64 0 
-  store  i8 %"f2#0", i8* %147 
+  store  i8 %"f2##0", i8* %147 
   %148 = add   i64 %145, 1 
   %149 = inttoptr i64 %148 to i1* 
   %150 = getelementptr  i1, i1* %149, i64 0 
-  store  i1 %"f4#0", i1* %150 
+  store  i1 %"f4##0", i1* %150 
   %151 = add   i64 %145, 2 
   %152 = inttoptr i64 %151 to i8* 
   %153 = getelementptr  i8, i8* %152, i64 0 
-  store  i8 %"f6#0", i8* %153 
+  store  i8 %"f6##0", i8* %153 
   %154 = add   i64 %145, 8 
   %155 = inttoptr i64 %154 to i64* 
   %156 = getelementptr  i64, i64* %155, i64 0 
-  store  i64 %"f1#0", i64* %156 
+  store  i64 %"f1##0", i64* %156 
   %157 = add   i64 %145, 16 
   %158 = inttoptr i64 %157 to i64* 
   %159 = getelementptr  i64, i64* %158, i64 0 
-  store  i64 %"f3#0", i64* %159 
+  store  i64 %"f3##0", i64* %159 
   %160 = add   i64 %145, 24 
   %161 = inttoptr i64 %160 to i64* 
   %162 = getelementptr  i64, i64* %161, i64 0 
-  store  i64 %"f5#0", i64* %162 
+  store  i64 %"f5##0", i64* %162 
   ret i64 %145 
 }
 
 
-define external fastcc  {i64, i8, i64, i1, i64, i8} @"mixed_fields.mixed<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i8, i64, i1, i64, i8} @"mixed_fields.mixed<1>"(i64  %"$##0")    {
 entry:
-  %163 = inttoptr i64 %"$#0" to i8* 
+  %163 = inttoptr i64 %"$##0" to i8* 
   %164 = getelementptr  i8, i8* %163, i64 0 
   %165 = load  i8, i8* %164 
-  %166 = add   i64 %"$#0", 1 
+  %166 = add   i64 %"$##0", 1 
   %167 = inttoptr i64 %166 to i1* 
   %168 = getelementptr  i1, i1* %167, i64 0 
   %169 = load  i1, i1* %168 
-  %170 = add   i64 %"$#0", 2 
+  %170 = add   i64 %"$##0", 2 
   %171 = inttoptr i64 %170 to i8* 
   %172 = getelementptr  i8, i8* %171, i64 0 
   %173 = load  i8, i8* %172 
-  %174 = add   i64 %"$#0", 8 
+  %174 = add   i64 %"$##0", 8 
   %175 = inttoptr i64 %174 to i64* 
   %176 = getelementptr  i64, i64* %175, i64 0 
   %177 = load  i64, i64* %176 
-  %178 = add   i64 %"$#0", 16 
+  %178 = add   i64 %"$##0", 16 
   %179 = inttoptr i64 %178 to i64* 
   %180 = getelementptr  i64, i64* %179, i64 0 
   %181 = load  i64, i64* %180 
-  %182 = add   i64 %"$#0", 24 
+  %182 = add   i64 %"$##0", 24 
   %183 = inttoptr i64 %182 to i64* 
   %184 = getelementptr  i64, i64* %183, i64 0 
   %185 = load  i64, i64* %184 
@@ -599,38 +599,38 @@ entry:
 }
 
 
-define external fastcc  void @"mixed_fields.printit<0>"(i64  %"ob#0")    {
+define external fastcc  void @"mixed_fields.printit<0>"(i64  %"ob##0")    {
 entry:
-  %192 = add   i64 %"ob#0", 8 
+  %192 = add   i64 %"ob##0", 8 
   %193 = inttoptr i64 %192 to i64* 
   %194 = getelementptr  i64, i64* %193, i64 0 
   %195 = load  i64, i64* %194 
   tail call ccc  void  @print_int(i64  %195)  
   tail call ccc  void  @putchar(i8  10)  
-  %196 = inttoptr i64 %"ob#0" to i8* 
+  %196 = inttoptr i64 %"ob##0" to i8* 
   %197 = getelementptr  i8, i8* %196, i64 0 
   %198 = load  i8, i8* %197 
   tail call ccc  void  @putchar(i8  %198)  
   tail call ccc  void  @putchar(i8  10)  
-  %199 = add   i64 %"ob#0", 16 
+  %199 = add   i64 %"ob##0", 16 
   %200 = inttoptr i64 %199 to i64* 
   %201 = getelementptr  i64, i64* %200, i64 0 
   %202 = load  i64, i64* %201 
   tail call ccc  void  @print_int(i64  %202)  
   tail call ccc  void  @putchar(i8  10)  
-  %203 = add   i64 %"ob#0", 1 
+  %203 = add   i64 %"ob##0", 1 
   %204 = inttoptr i64 %203 to i1* 
   %205 = getelementptr  i1, i1* %204, i64 0 
   %206 = load  i1, i1* %205 
   tail call fastcc  void  @"wybe.io.print<5>"(i1  %206)  
   tail call ccc  void  @putchar(i8  10)  
-  %207 = add   i64 %"ob#0", 24 
+  %207 = add   i64 %"ob##0", 24 
   %208 = inttoptr i64 %207 to i64* 
   %209 = getelementptr  i64, i64* %208, i64 0 
   %210 = load  i64, i64* %209 
   tail call ccc  void  @print_int(i64  %210)  
   tail call ccc  void  @putchar(i8  10)  
-  %211 = add   i64 %"ob#0", 2 
+  %211 = add   i64 %"ob##0", 2 
   %212 = inttoptr i64 %211 to i8* 
   %213 = getelementptr  i8, i8* %212, i64 0 
   %214 = load  i8, i8* %213 
@@ -640,9 +640,9 @@ entry:
 }
 
 
-define external fastcc  i1 @"mixed_fields.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"mixed_fields.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = tail call fastcc  i1  @"mixed_fields.=<0>"(i64  %"$left#0", i64  %"$right#0")  
-  %"1$$$#0" = xor i1 %"1$tmp$0#0", 1 
-  ret i1 %"1$$$#0" 
+  %"1$tmp$0##0" = tail call fastcc  i1  @"mixed_fields.=<0>"(i64  %"$left##0", i64  %"$right##0")  
+  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
+  ret i1 %"1$$$##0" 
 }

--- a/test-cases/final-dump/multi_out.exp
+++ b/test-cases/final-dump/multi_out.exp
@@ -12,19 +12,19 @@ AFTER EVERYTHING:
 
 *main* > public {inline} (0 calls)
 0: multi_out.<0>
-(io#0:wybe.phantom, [?io#0:wybe.phantom]):
+(io##0:wybe.phantom, [?io##0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
 
 
 onetwothree > public {inline} (1 calls)
 0: multi_out.onetwothree<0>
-onetwothree(?x#0:wybe.int, ?y#0:wybe.int, ?z#0:wybe.int):
+onetwothree(?x##0:wybe.int, ?y##0:wybe.int, ?z##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(1:wybe.int, ?x#0:wybe.int) @multi_out:nn:nn
-    foreign llvm move(2:wybe.int, ?y#0:wybe.int) @multi_out:nn:nn
-    foreign llvm move(3:wybe.int, ?z#0:wybe.int) @multi_out:nn:nn
+    foreign llvm move(1:wybe.int, ?x##0:wybe.int) @multi_out:nn:nn
+    foreign llvm move(2:wybe.int, ?y##0:wybe.int) @multi_out:nn:nn
+    foreign llvm move(3:wybe.int, ?z##0:wybe.int) @multi_out:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/multi_specz.exp
+++ b/test-cases/final-dump/multi_specz.exp
@@ -428,7 +428,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
@@ -438,10 +438,10 @@ entry:
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -492,7 +492,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -503,11 +503,11 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -543,8 +543,8 @@ entry:
   %"1#tmp#1##0" = icmp eq i64 %3, %10 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2#####0" = icmp eq i64 %7, %14 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %7, %14 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -653,9 +653,9 @@ entry:
   br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#0##0" = icmp eq i64 %62, %69 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }

--- a/test-cases/final-dump/multi_specz.exp
+++ b/test-cases/final-dump/multi_specz.exp
@@ -16,99 +16,99 @@ AFTER EVERYTHING:
 
 *main* > public {inline} (0 calls)
 0: multi_specz.<0>
-(io#0:wybe.phantom, ?io#2:wybe.phantom):
+(io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    multi_specz.bar1<0>(~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @multi_specz:nn:nn
-    multi_specz.bar2<0>(~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #1 @multi_specz:nn:nn
+    multi_specz.bar1<0>(~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @multi_specz:nn:nn
+    multi_specz.bar2<0>(~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #1 @multi_specz:nn:nn
 
 
 bar1 > public (1 calls)
 0: multi_specz.bar1<0>
-bar1(io#0:wybe.phantom, ?io#6:wybe.phantom):
+bar1(io##0:wybe.phantom, ?io##6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(5,(multi_specz.foo<0>,fromList [NonAliasedParamCond 0 [],NonAliasedParamCond 1 []]))]
-    foreign lpvm alloc(16:wybe.int, ?tmp$6#0:position.position)
-    foreign lpvm mutate(~tmp$6#0:position.position, ?tmp$7#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$7#0:position.position, ?tmp$0#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$10#0:position.position)
-    foreign lpvm mutate(~tmp$10#0:position.position, ?tmp$11#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$11#0:position.position, ?tmp$1#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$14#0:position.position)
-    foreign lpvm mutate(~tmp$14#0:position.position, ?tmp$15#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$15#0:position.position, ?tmp$2#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$18#0:position.position)
-    foreign lpvm mutate(~tmp$18#0:position.position, ?tmp$19#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$19#0:position.position, ?tmp$3#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:wybe.int)
-    foreign c print_string("=============":wybe.string, ~#io#0:wybe.phantom, ?tmp$22#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$22#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    multi_specz.foo<0>[7477e50a09](~tmp$0#0:position.position, ~tmp$1#0:position.position, tmp$2#0:position.position, tmp$3#0:position.position, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #5 @multi_specz:nn:nn
-    foreign c print_string("-------------":wybe.string, ~#io#2:wybe.phantom, ?tmp$25#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$25#0:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~tmp$2#0:position.position, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #7 @multi_specz:nn:nn
-    position.printPosition<0>(~tmp$3#0:position.position, ~#io#4:wybe.phantom, ?#io#5:wybe.phantom) #8 @multi_specz:nn:nn
-    foreign c print_string("=============":wybe.string, ~#io#5:wybe.phantom, ?tmp$28#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$28#0:wybe.phantom, ?#io#6:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$6##0:position.position)
+    foreign lpvm mutate(~tmp$6##0:position.position, ?tmp$7##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp$7##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp$10##0:position.position)
+    foreign lpvm mutate(~tmp$10##0:position.position, ?tmp$11##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp$11##0:position.position, ?tmp$1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp$14##0:position.position)
+    foreign lpvm mutate(~tmp$14##0:position.position, ?tmp$15##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp$15##0:position.position, ?tmp$2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp$18##0:position.position)
+    foreign lpvm mutate(~tmp$18##0:position.position, ?tmp$19##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp$19##0:position.position, ?tmp$3##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:wybe.int)
+    foreign c print_string("=============":wybe.string, ~#io##0:wybe.phantom, ?tmp$22##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$22##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    multi_specz.foo<0>[7477e50a09](~tmp$0##0:position.position, ~tmp$1##0:position.position, tmp$2##0:position.position, tmp$3##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #5 @multi_specz:nn:nn
+    foreign c print_string("-------------":wybe.string, ~#io##2:wybe.phantom, ?tmp$25##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$25##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~tmp$2##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #7 @multi_specz:nn:nn
+    position.printPosition<0>(~tmp$3##0:position.position, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #8 @multi_specz:nn:nn
+    foreign c print_string("=============":wybe.string, ~#io##5:wybe.phantom, ?tmp$28##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$28##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
 
 
 bar2 > public (1 calls)
 0: multi_specz.bar2<0>
-bar2(io#0:wybe.phantom, ?io#8:wybe.phantom):
+bar2(io##0:wybe.phantom, ?io##8:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$6#0:position.position)
-    foreign lpvm mutate(~tmp$6#0:position.position, ?tmp$7#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$7#0:position.position, ?tmp$0#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$10#0:position.position)
-    foreign lpvm mutate(~tmp$10#0:position.position, ?tmp$11#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$11#0:position.position, ?tmp$1#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$14#0:position.position)
-    foreign lpvm mutate(~tmp$14#0:position.position, ?tmp$15#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$15#0:position.position, ?tmp$2#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$18#0:position.position)
-    foreign lpvm mutate(~tmp$18#0:position.position, ?tmp$19#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$19#0:position.position, ?tmp$3#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:wybe.int)
-    foreign c print_string("=============":wybe.string, ~#io#0:wybe.phantom, ?tmp$22#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$22#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    multi_specz.foo<0>(tmp$0#0:position.position, tmp$1#0:position.position, tmp$2#0:position.position, tmp$3#0:position.position, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #5 @multi_specz:nn:nn
-    foreign c print_string("-------------":wybe.string, ~#io#2:wybe.phantom, ?tmp$25#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$25#0:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~tmp$0#0:position.position, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #7 @multi_specz:nn:nn
-    position.printPosition<0>(~tmp$1#0:position.position, ~#io#4:wybe.phantom, ?#io#5:wybe.phantom) #8 @multi_specz:nn:nn
-    position.printPosition<0>(~tmp$2#0:position.position, ~#io#5:wybe.phantom, ?#io#6:wybe.phantom) #9 @multi_specz:nn:nn
-    position.printPosition<0>(~tmp$3#0:position.position, ~#io#6:wybe.phantom, ?#io#7:wybe.phantom) #10 @multi_specz:nn:nn
-    foreign c print_string("=============":wybe.string, ~#io#7:wybe.phantom, ?tmp$28#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$28#0:wybe.phantom, ?#io#8:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$6##0:position.position)
+    foreign lpvm mutate(~tmp$6##0:position.position, ?tmp$7##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp$7##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp$10##0:position.position)
+    foreign lpvm mutate(~tmp$10##0:position.position, ?tmp$11##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp$11##0:position.position, ?tmp$1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp$14##0:position.position)
+    foreign lpvm mutate(~tmp$14##0:position.position, ?tmp$15##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp$15##0:position.position, ?tmp$2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp$18##0:position.position)
+    foreign lpvm mutate(~tmp$18##0:position.position, ?tmp$19##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp$19##0:position.position, ?tmp$3##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:wybe.int)
+    foreign c print_string("=============":wybe.string, ~#io##0:wybe.phantom, ?tmp$22##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$22##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    multi_specz.foo<0>(tmp$0##0:position.position, tmp$1##0:position.position, tmp$2##0:position.position, tmp$3##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #5 @multi_specz:nn:nn
+    foreign c print_string("-------------":wybe.string, ~#io##2:wybe.phantom, ?tmp$25##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$25##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~tmp$0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #7 @multi_specz:nn:nn
+    position.printPosition<0>(~tmp$1##0:position.position, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #8 @multi_specz:nn:nn
+    position.printPosition<0>(~tmp$2##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #9 @multi_specz:nn:nn
+    position.printPosition<0>(~tmp$3##0:position.position, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) #10 @multi_specz:nn:nn
+    foreign c print_string("=============":wybe.string, ~#io##7:wybe.phantom, ?tmp$28##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$28##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
 
 
 foo > public (2 calls)
 0: multi_specz.foo<0>
-foo(x1#0:position.position, x2#0:position.position, x3#0:position.position, x4#0:position.position, io#0:wybe.phantom, ?io#4:wybe.phantom):
+foo(x1##0:position.position, x2##0:position.position, x3##0:position.position, x4##0:position.position, io##0:wybe.phantom, ?io##4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0,InterestingUnaliased 1,InterestingUnaliased 2,InterestingUnaliased 3]
  MultiSpeczDepInfo: [(0,(multi_specz.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [0]])),(1,(multi_specz.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [1]])),(2,(multi_specz.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [2]])),(3,(multi_specz.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [3]]))]
-    multi_specz.modifyAndPrint<0>(~x1#0:position.position, 111:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @multi_specz:nn:nn
-    multi_specz.modifyAndPrint<0>(~x2#0:position.position, 222:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #1 @multi_specz:nn:nn
-    multi_specz.modifyAndPrint<0>(~x3#0:position.position, 333:wybe.int, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) #2 @multi_specz:nn:nn
-    multi_specz.modifyAndPrint<0>(~x4#0:position.position, 444:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #3 @multi_specz:nn:nn
+    multi_specz.modifyAndPrint<0>(~x1##0:position.position, 111:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @multi_specz:nn:nn
+    multi_specz.modifyAndPrint<0>(~x2##0:position.position, 222:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #1 @multi_specz:nn:nn
+    multi_specz.modifyAndPrint<0>(~x3##0:position.position, 333:wybe.int, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #2 @multi_specz:nn:nn
+    multi_specz.modifyAndPrint<0>(~x4##0:position.position, 444:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #3 @multi_specz:nn:nn
  [7477e50a09] [NonAliasedParam 0,NonAliasedParam 1] :
-    multi_specz.modifyAndPrint<0>[410bae77d3](~x1#0:position.position, 111:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @multi_specz:nn:nn
-    multi_specz.modifyAndPrint<0>[410bae77d3](~x2#0:position.position, 222:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #1 @multi_specz:nn:nn
-    multi_specz.modifyAndPrint<0>(~x3#0:position.position, 333:wybe.int, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) #2 @multi_specz:nn:nn
-    multi_specz.modifyAndPrint<0>(~x4#0:position.position, 444:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #3 @multi_specz:nn:nn
+    multi_specz.modifyAndPrint<0>[410bae77d3](~x1##0:position.position, 111:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @multi_specz:nn:nn
+    multi_specz.modifyAndPrint<0>[410bae77d3](~x2##0:position.position, 222:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #1 @multi_specz:nn:nn
+    multi_specz.modifyAndPrint<0>(~x3##0:position.position, 333:wybe.int, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #2 @multi_specz:nn:nn
+    multi_specz.modifyAndPrint<0>(~x4##0:position.position, 444:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #3 @multi_specz:nn:nn
 
 
 modifyAndPrint > public (4 calls)
 0: multi_specz.modifyAndPrint<0>
-modifyAndPrint(pos#0:position.position, v#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+modifyAndPrint(pos##0:position.position, v##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
-    foreign lpvm {noalias} mutate(~%pos#0:position.position, ?%pos#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~v#0:wybe.int)
-    position.printPosition<0>(~pos#1:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #1 @multi_specz:nn:nn
+    foreign lpvm {noalias} mutate(~%pos##0:position.position, ?%pos##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
+    position.printPosition<0>(~pos##1:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @multi_specz:nn:nn
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm {noalias} mutate(~%pos#0:position.position, ?%pos#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v#0:wybe.int)
-    position.printPosition<0>(~pos#1:position.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #1 @multi_specz:nn:nn
+    foreign lpvm {noalias} mutate(~%pos##0:position.position, ?%pos##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
+    position.printPosition<0>(~pos##1:position.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @multi_specz:nn:nn
 
   LLVM code       :
 
@@ -277,49 +277,49 @@ entry:
 }
 
 
-define external fastcc  void @"multi_specz.foo<0>"(i64  %"x1#0", i64  %"x2#0", i64  %"x3#0", i64  %"x4#0")    {
+define external fastcc  void @"multi_specz.foo<0>"(i64  %"x1##0", i64  %"x2##0", i64  %"x3##0", i64  %"x4##0")    {
 entry:
-  tail call fastcc  void  @"multi_specz.modifyAndPrint<0>"(i64  %"x1#0", i64  111)  
-  tail call fastcc  void  @"multi_specz.modifyAndPrint<0>"(i64  %"x2#0", i64  222)  
-  tail call fastcc  void  @"multi_specz.modifyAndPrint<0>"(i64  %"x3#0", i64  333)  
-  tail call fastcc  void  @"multi_specz.modifyAndPrint<0>"(i64  %"x4#0", i64  444)  
+  tail call fastcc  void  @"multi_specz.modifyAndPrint<0>"(i64  %"x1##0", i64  111)  
+  tail call fastcc  void  @"multi_specz.modifyAndPrint<0>"(i64  %"x2##0", i64  222)  
+  tail call fastcc  void  @"multi_specz.modifyAndPrint<0>"(i64  %"x3##0", i64  333)  
+  tail call fastcc  void  @"multi_specz.modifyAndPrint<0>"(i64  %"x4##0", i64  444)  
   ret void 
 }
 
 
-define external fastcc  void @"multi_specz.foo<0>[7477e50a09]"(i64  %"x1#0", i64  %"x2#0", i64  %"x3#0", i64  %"x4#0")    {
+define external fastcc  void @"multi_specz.foo<0>[7477e50a09]"(i64  %"x1##0", i64  %"x2##0", i64  %"x3##0", i64  %"x4##0")    {
 entry:
-  tail call fastcc  void  @"multi_specz.modifyAndPrint<0>[410bae77d3]"(i64  %"x1#0", i64  111)  
-  tail call fastcc  void  @"multi_specz.modifyAndPrint<0>[410bae77d3]"(i64  %"x2#0", i64  222)  
-  tail call fastcc  void  @"multi_specz.modifyAndPrint<0>"(i64  %"x3#0", i64  333)  
-  tail call fastcc  void  @"multi_specz.modifyAndPrint<0>"(i64  %"x4#0", i64  444)  
+  tail call fastcc  void  @"multi_specz.modifyAndPrint<0>[410bae77d3]"(i64  %"x1##0", i64  111)  
+  tail call fastcc  void  @"multi_specz.modifyAndPrint<0>[410bae77d3]"(i64  %"x2##0", i64  222)  
+  tail call fastcc  void  @"multi_specz.modifyAndPrint<0>"(i64  %"x3##0", i64  333)  
+  tail call fastcc  void  @"multi_specz.modifyAndPrint<0>"(i64  %"x4##0", i64  444)  
   ret void 
 }
 
 
-define external fastcc  void @"multi_specz.modifyAndPrint<0>"(i64  %"pos#0", i64  %"v#0")    {
+define external fastcc  void @"multi_specz.modifyAndPrint<0>"(i64  %"pos##0", i64  %"v##0")    {
 entry:
   %77 = trunc i64 16 to i32  
   %78 = tail call ccc  i8*  @wybe_malloc(i32  %77)  
   %79 = ptrtoint i8* %78 to i64 
   %80 = inttoptr i64 %79 to i8* 
-  %81 = inttoptr i64 %"pos#0" to i8* 
+  %81 = inttoptr i64 %"pos##0" to i8* 
   %82 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %80, i8*  %81, i32  %82, i32  8, i1  0)  
   %83 = inttoptr i64 %79 to i64* 
   %84 = getelementptr  i64, i64* %83, i64 0 
-  store  i64 %"v#0", i64* %84 
+  store  i64 %"v##0", i64* %84 
   tail call fastcc  void  @"position.printPosition<0>"(i64  %79)  
   ret void 
 }
 
 
-define external fastcc  void @"multi_specz.modifyAndPrint<0>[410bae77d3]"(i64  %"pos#0", i64  %"v#0")    {
+define external fastcc  void @"multi_specz.modifyAndPrint<0>[410bae77d3]"(i64  %"pos##0", i64  %"v##0")    {
 entry:
-  %85 = inttoptr i64 %"pos#0" to i64* 
+  %85 = inttoptr i64 %"pos##0" to i64* 
   %86 = getelementptr  i64, i64* %85, i64 0 
-  store  i64 %"v#0", i64* %86 
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"pos#0")  
+  store  i64 %"v##0", i64* %86 
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"pos##0")  
   ret void 
 }
 --------------------------------------------------
@@ -344,17 +344,17 @@ entry:
 
 printPosition > public (0 calls)
 0: position.printPosition<0>
-printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string(",":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io#4:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -388,17 +388,17 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"position.printPosition<0>"(i64  %"pos#0")    {
+define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
-  %3 = inttoptr i64 %"pos#0" to i64* 
+  %3 = inttoptr i64 %"pos##0" to i64* 
   %4 = getelementptr  i64, i64* %3, i64 0 
   %5 = load  i64, i64* %4 
   tail call ccc  void  @print_int(i64  %5)  
   %7 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.6, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %7)  
-  %8 = add   i64 %"pos#0", 8 
+  %8 = add   i64 %"pos##0", 8 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
@@ -428,86 +428,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y#0:wybe.int)
-    foreign llvm icmp_eq(~$left$x#0:wybe.int, ~$right$x#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
+    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y#0:wybe.int, ~$right$y#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
-    foreign lpvm mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:position.position, ?$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
+    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
-    foreign lpvm access(~$#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y#0:wybe.int)
+    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec#0:position.position, ?$#0:wybe.int):
+x($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec#0:position.position, ?$#0:wybe.int):
+y($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -524,54 +524,54 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$#0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = icmp eq i64 %7, %14 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"x#0", i64* %19 
+  store  i64 %"x##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"y#0", i64* %22 
+  store  i64 %"y##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
 entry:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -581,34 +581,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec#0" to i64* 
+  %32 = inttoptr i64 %"$rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec#0" to i8* 
+  %39 = inttoptr i64 %"$rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field#0", i64* %42 
+  store  i64 %"$field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = add   i64 %"$rec#0", 8 
+  %43 = add   i64 %"$rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -616,46 +616,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec#0" to i8* 
+  %51 = inttoptr i64 %"$rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field#0", i64* %55 
+  store  i64 %"$field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %58, %65 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = icmp eq i64 %62, %69 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$0##0" = icmp eq i64 %62, %69 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }

--- a/test-cases/final-dump/multi_specz.exp
+++ b/test-cases/final-dump/multi_specz.exp
@@ -29,27 +29,27 @@ bar1(io##0:wybe.phantom, ?io##6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(5,(multi_specz.foo<0>,fromList [NonAliasedParamCond 0 [],NonAliasedParamCond 1 []]))]
-    foreign lpvm alloc(16:wybe.int, ?tmp$6##0:position.position)
-    foreign lpvm mutate(~tmp$6##0:position.position, ?tmp$7##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$7##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$10##0:position.position)
-    foreign lpvm mutate(~tmp$10##0:position.position, ?tmp$11##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$11##0:position.position, ?tmp$1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$14##0:position.position)
-    foreign lpvm mutate(~tmp$14##0:position.position, ?tmp$15##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$15##0:position.position, ?tmp$2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$18##0:position.position)
-    foreign lpvm mutate(~tmp$18##0:position.position, ?tmp$19##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$19##0:position.position, ?tmp$3##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:wybe.int)
-    foreign c print_string("=============":wybe.string, ~#io##0:wybe.phantom, ?tmp$22##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$22##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    multi_specz.foo<0>[7477e50a09](~tmp$0##0:position.position, ~tmp$1##0:position.position, tmp$2##0:position.position, tmp$3##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #5 @multi_specz:nn:nn
-    foreign c print_string("-------------":wybe.string, ~#io##2:wybe.phantom, ?tmp$25##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$25##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~tmp$2##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #7 @multi_specz:nn:nn
-    position.printPosition<0>(~tmp$3##0:position.position, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #8 @multi_specz:nn:nn
-    foreign c print_string("=============":wybe.string, ~#io##5:wybe.phantom, ?tmp$28##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$28##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#6##0:position.position)
+    foreign lpvm mutate(~tmp#6##0:position.position, ?tmp#7##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp#7##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#10##0:position.position)
+    foreign lpvm mutate(~tmp#10##0:position.position, ?tmp#11##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp#11##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:position.position)
+    foreign lpvm mutate(~tmp#14##0:position.position, ?tmp#15##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp#15##0:position.position, ?tmp#2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:position.position)
+    foreign lpvm mutate(~tmp#18##0:position.position, ?tmp#19##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp#19##0:position.position, ?tmp#3##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:wybe.int)
+    foreign c print_string("=============":wybe.string, ~#io##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#22##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    multi_specz.foo<0>[7477e50a09](~tmp#0##0:position.position, ~tmp#1##0:position.position, tmp#2##0:position.position, tmp#3##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #5 @multi_specz:nn:nn
+    foreign c print_string("-------------":wybe.string, ~#io##2:wybe.phantom, ?tmp#25##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#25##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~tmp#2##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #7 @multi_specz:nn:nn
+    position.printPosition<0>(~tmp#3##0:position.position, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #8 @multi_specz:nn:nn
+    foreign c print_string("=============":wybe.string, ~#io##5:wybe.phantom, ?tmp#28##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#28##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
 
 
 bar2 > public (1 calls)
@@ -57,29 +57,29 @@ bar2 > public (1 calls)
 bar2(io##0:wybe.phantom, ?io##8:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$6##0:position.position)
-    foreign lpvm mutate(~tmp$6##0:position.position, ?tmp$7##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$7##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$10##0:position.position)
-    foreign lpvm mutate(~tmp$10##0:position.position, ?tmp$11##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$11##0:position.position, ?tmp$1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$14##0:position.position)
-    foreign lpvm mutate(~tmp$14##0:position.position, ?tmp$15##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$15##0:position.position, ?tmp$2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$18##0:position.position)
-    foreign lpvm mutate(~tmp$18##0:position.position, ?tmp$19##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$19##0:position.position, ?tmp$3##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:wybe.int)
-    foreign c print_string("=============":wybe.string, ~#io##0:wybe.phantom, ?tmp$22##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$22##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    multi_specz.foo<0>(tmp$0##0:position.position, tmp$1##0:position.position, tmp$2##0:position.position, tmp$3##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #5 @multi_specz:nn:nn
-    foreign c print_string("-------------":wybe.string, ~#io##2:wybe.phantom, ?tmp$25##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$25##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~tmp$0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #7 @multi_specz:nn:nn
-    position.printPosition<0>(~tmp$1##0:position.position, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #8 @multi_specz:nn:nn
-    position.printPosition<0>(~tmp$2##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #9 @multi_specz:nn:nn
-    position.printPosition<0>(~tmp$3##0:position.position, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) #10 @multi_specz:nn:nn
-    foreign c print_string("=============":wybe.string, ~#io##7:wybe.phantom, ?tmp$28##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$28##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#6##0:position.position)
+    foreign lpvm mutate(~tmp#6##0:position.position, ?tmp#7##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp#7##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#10##0:position.position)
+    foreign lpvm mutate(~tmp#10##0:position.position, ?tmp#11##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp#11##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:position.position)
+    foreign lpvm mutate(~tmp#14##0:position.position, ?tmp#15##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp#15##0:position.position, ?tmp#2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:position.position)
+    foreign lpvm mutate(~tmp#18##0:position.position, ?tmp#19##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp#19##0:position.position, ?tmp#3##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:wybe.int)
+    foreign c print_string("=============":wybe.string, ~#io##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#22##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    multi_specz.foo<0>(tmp#0##0:position.position, tmp#1##0:position.position, tmp#2##0:position.position, tmp#3##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #5 @multi_specz:nn:nn
+    foreign c print_string("-------------":wybe.string, ~#io##2:wybe.phantom, ?tmp#25##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#25##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~tmp#0##0:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #7 @multi_specz:nn:nn
+    position.printPosition<0>(~tmp#1##0:position.position, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #8 @multi_specz:nn:nn
+    position.printPosition<0>(~tmp#2##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #9 @multi_specz:nn:nn
+    position.printPosition<0>(~tmp#3##0:position.position, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) #10 @multi_specz:nn:nn
+    foreign c print_string("=============":wybe.string, ~#io##7:wybe.phantom, ?tmp#28##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#28##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
 
 
 foo > public (2 calls)
@@ -348,13 +348,13 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -428,86 +428,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
-    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
-    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec##0:position.position, ?$##0:wybe.int):
+x(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec##0:position.position, ?$##0:wybe.int):
+y(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -524,27 +524,27 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$##0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$##0" 
+  %"2#####0" = icmp eq i64 %7, %14 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
@@ -566,12 +566,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
 entry:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -581,34 +581,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec##0" to i64* 
+  %32 = inttoptr i64 %"#rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec##0" to i8* 
+  %39 = inttoptr i64 %"#rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field##0", i64* %42 
+  store  i64 %"#field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = add   i64 %"$rec##0", 8 
+  %43 = add   i64 %"#rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -616,46 +616,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec##0" to i8* 
+  %51 = inttoptr i64 %"#rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field##0", i64* %55 
+  store  i64 %"#field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %58, %65 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = icmp eq i64 %62, %69 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#0##0" = icmp eq i64 %62, %69 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }

--- a/test-cases/final-dump/multi_specz.exp
+++ b/test-cases/final-dump/multi_specz.exp
@@ -447,27 +447,27 @@ entry:
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x(#rec##0:position.position, ?###0:wybe.int):
+x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -478,10 +478,10 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y(#rec##0:position.position, ?###0:wybe.int):
+y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -566,12 +566,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 

--- a/test-cases/final-dump/multi_specz_cyclic_exe.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_exe.exp
@@ -400,7 +400,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: multi_specz_cyclic_lib.position.=<0>
-=(#left##0:multi_specz_cyclic_lib.position, #right##0:multi_specz_cyclic_lib.position, ?####0:wybe.bool):
+=(#left##0:multi_specz_cyclic_lib.position, #right##0:multi_specz_cyclic_lib.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
@@ -410,10 +410,10 @@ entry:
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -464,7 +464,7 @@ y(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.posit
 
 ~= > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.~=<0>
-~=(#left##0:multi_specz_cyclic_lib.position, #right##0:multi_specz_cyclic_lib.position, ?####0:wybe.bool):
+~=(#left##0:multi_specz_cyclic_lib.position, #right##0:multi_specz_cyclic_lib.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -475,11 +475,11 @@ y(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.posit
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -515,8 +515,8 @@ entry:
   %"1#tmp#1##0" = icmp eq i64 %3, %10 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2#####0" = icmp eq i64 %7, %14 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %7, %14 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -625,11 +625,11 @@ entry:
   br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#0##0" = icmp eq i64 %62, %69 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }
 --------------------------------------------------
  Module multi_specz_cyclic_lib2

--- a/test-cases/final-dump/multi_specz_cyclic_exe.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_exe.exp
@@ -419,27 +419,27 @@ entry:
 
 position > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?###0:multi_specz_cyclic_lib.position):
+position(x##0:wybe.int, y##0:wybe.int, ?#result##0:multi_specz_cyclic_lib.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:multi_specz_cyclic_lib.position)
     foreign lpvm mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:multi_specz_cyclic_lib.position, ?###0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:multi_specz_cyclic_lib.position, ?#result##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: multi_specz_cyclic_lib.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, ###0:multi_specz_cyclic_lib.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:multi_specz_cyclic_lib.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~###0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~#result##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.x<0>
-x(#rec##0:multi_specz_cyclic_lib.position, ?###0:wybe.int):
+x(#rec##0:multi_specz_cyclic_lib.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 x > public {inline} (0 calls)
 1: multi_specz_cyclic_lib.position.x<1>
 x(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, #field##0:wybe.int):
@@ -450,10 +450,10 @@ x(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.posit
 
 y > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.y<0>
-y(#rec##0:multi_specz_cyclic_lib.position, ?###0:wybe.int):
+y(#rec##0:multi_specz_cyclic_lib.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 y > public {inline} (0 calls)
 1: multi_specz_cyclic_lib.position.y<1>
 y(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, #field##0:wybe.int):
@@ -538,12 +538,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"multi_specz_cyclic_lib.position.position<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"multi_specz_cyclic_lib.position.position<1>"(i64  %"#result##0")    {
 entry:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 

--- a/test-cases/final-dump/multi_specz_cyclic_exe.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_exe.exp
@@ -13,39 +13,39 @@ AFTER EVERYTHING:
 
 *main* > public {inline} (0 calls)
 0: multi_specz_cyclic_exe.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    multi_specz_cyclic_exe.main<0>(~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @multi_specz_cyclic_exe:nn:nn
+    multi_specz_cyclic_exe.main<0>(~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @multi_specz_cyclic_exe:nn:nn
 
 
 main > public (1 calls)
 0: multi_specz_cyclic_exe.main<0>
-main(io#0:wybe.phantom, ?io#6:wybe.phantom):
+main(io##0:wybe.phantom, ?io##6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(5,(multi_specz_cyclic_lib.foo1<0>,fromList [NonAliasedParamCond 0 [],NonAliasedParamCond 1 []]))]
-    foreign lpvm alloc(16:wybe.int, ?tmp$6#0:multi_specz_cyclic_lib.position)
-    foreign lpvm mutate(~tmp$6#0:multi_specz_cyclic_lib.position, ?tmp$7#0:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$7#0:multi_specz_cyclic_lib.position, ?tmp$0#0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$10#0:multi_specz_cyclic_lib.position)
-    foreign lpvm mutate(~tmp$10#0:multi_specz_cyclic_lib.position, ?tmp$11#0:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$11#0:multi_specz_cyclic_lib.position, ?tmp$1#0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$14#0:multi_specz_cyclic_lib.position)
-    foreign lpvm mutate(~tmp$14#0:multi_specz_cyclic_lib.position, ?tmp$15#0:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$15#0:multi_specz_cyclic_lib.position, ?tmp$2#0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$18#0:multi_specz_cyclic_lib.position)
-    foreign lpvm mutate(~tmp$18#0:multi_specz_cyclic_lib.position, ?tmp$19#0:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$19#0:multi_specz_cyclic_lib.position, ?tmp$3#0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:wybe.int)
-    foreign c print_string("=============":wybe.string, ~#io#0:wybe.phantom, ?tmp$22#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$22#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    multi_specz_cyclic_lib.foo1<0>[7477e50a09](~tmp$0#0:multi_specz_cyclic_lib.position, ~tmp$1#0:multi_specz_cyclic_lib.position, tmp$2#0:multi_specz_cyclic_lib.position, tmp$3#0:multi_specz_cyclic_lib.position, 3:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #5 @multi_specz_cyclic_exe:nn:nn
-    foreign c print_string("-------------":wybe.string, ~#io#2:wybe.phantom, ?tmp$25#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$25#0:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    multi_specz_cyclic_lib.printPosition<0>(~tmp$2#0:multi_specz_cyclic_lib.position, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #7 @multi_specz_cyclic_exe:nn:nn
-    multi_specz_cyclic_lib.printPosition<0>(~tmp$3#0:multi_specz_cyclic_lib.position, ~#io#4:wybe.phantom, ?#io#5:wybe.phantom) #8 @multi_specz_cyclic_exe:nn:nn
-    foreign c print_string("=============":wybe.string, ~#io#5:wybe.phantom, ?tmp$28#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$28#0:wybe.phantom, ?#io#6:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$6##0:multi_specz_cyclic_lib.position)
+    foreign lpvm mutate(~tmp$6##0:multi_specz_cyclic_lib.position, ?tmp$7##0:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp$7##0:multi_specz_cyclic_lib.position, ?tmp$0##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp$10##0:multi_specz_cyclic_lib.position)
+    foreign lpvm mutate(~tmp$10##0:multi_specz_cyclic_lib.position, ?tmp$11##0:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp$11##0:multi_specz_cyclic_lib.position, ?tmp$1##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp$14##0:multi_specz_cyclic_lib.position)
+    foreign lpvm mutate(~tmp$14##0:multi_specz_cyclic_lib.position, ?tmp$15##0:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp$15##0:multi_specz_cyclic_lib.position, ?tmp$2##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp$18##0:multi_specz_cyclic_lib.position)
+    foreign lpvm mutate(~tmp$18##0:multi_specz_cyclic_lib.position, ?tmp$19##0:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp$19##0:multi_specz_cyclic_lib.position, ?tmp$3##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:wybe.int)
+    foreign c print_string("=============":wybe.string, ~#io##0:wybe.phantom, ?tmp$22##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$22##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    multi_specz_cyclic_lib.foo1<0>[7477e50a09](~tmp$0##0:multi_specz_cyclic_lib.position, ~tmp$1##0:multi_specz_cyclic_lib.position, tmp$2##0:multi_specz_cyclic_lib.position, tmp$3##0:multi_specz_cyclic_lib.position, 3:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #5 @multi_specz_cyclic_exe:nn:nn
+    foreign c print_string("-------------":wybe.string, ~#io##2:wybe.phantom, ?tmp$25##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$25##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    multi_specz_cyclic_lib.printPosition<0>(~tmp$2##0:multi_specz_cyclic_lib.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #7 @multi_specz_cyclic_exe:nn:nn
+    multi_specz_cyclic_lib.printPosition<0>(~tmp$3##0:multi_specz_cyclic_lib.position, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #8 @multi_specz_cyclic_exe:nn:nn
+    foreign c print_string("=============":wybe.string, ~#io##5:wybe.phantom, ?tmp$28##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$28##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -170,76 +170,76 @@ entry:
 
 foo1 > public (0 calls)
 0: multi_specz_cyclic_lib.foo1<0>[7477e50a09]
-foo1(x1#0:multi_specz_cyclic_lib.position, x2#0:multi_specz_cyclic_lib.position, x3#0:multi_specz_cyclic_lib.position, x4#0:multi_specz_cyclic_lib.position, n#0:wybe.int, io#0:wybe.phantom, ?io#4:wybe.phantom):
+foo1(x1##0:multi_specz_cyclic_lib.position, x2##0:multi_specz_cyclic_lib.position, x3##0:multi_specz_cyclic_lib.position, x4##0:multi_specz_cyclic_lib.position, n##0:wybe.int, io##0:wybe.phantom, ?io##4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0,InterestingUnaliased 1,InterestingUnaliased 2,InterestingUnaliased 3]
  MultiSpeczDepInfo: [(2,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [0]])),(3,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [1]])),(4,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [2]])),(5,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [3]])),(6,(multi_specz_cyclic_lib2.foo2<0>,fromList [NonAliasedParamCond 0 [1],NonAliasedParamCond 1 [2],NonAliasedParamCond 2 [3],NonAliasedParamCond 3 [0]]))]
-    foreign llvm sub(~n#0:wybe.int, 1:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn
-    foreign llvm icmp_slt(tmp$0#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
+    foreign llvm icmp_slt(tmp$0##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        multi_specz_cyclic_lib2.foo2<0>(~x2#0:multi_specz_cyclic_lib.position, ~x3#0:multi_specz_cyclic_lib.position, ~x4#0:multi_specz_cyclic_lib.position, ~x1#0:multi_specz_cyclic_lib.position, ~tmp$0#0:wybe.int, ~#io#0:wybe.phantom, ?#io#4:wybe.phantom) #6 @multi_specz_cyclic_lib:nn:nn
+        multi_specz_cyclic_lib2.foo2<0>(~x2##0:multi_specz_cyclic_lib.position, ~x3##0:multi_specz_cyclic_lib.position, ~x4##0:multi_specz_cyclic_lib.position, ~x1##0:multi_specz_cyclic_lib.position, ~tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?#io##4:wybe.phantom) #6 @multi_specz_cyclic_lib:nn:nn
 
     1:
-        multi_specz_cyclic_lib.modifyAndPrint<0>(~x1#0:multi_specz_cyclic_lib.position, 111:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #2 @multi_specz_cyclic_lib:nn:nn
-        multi_specz_cyclic_lib.modifyAndPrint<0>(~x2#0:multi_specz_cyclic_lib.position, 222:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #3 @multi_specz_cyclic_lib:nn:nn
-        multi_specz_cyclic_lib.modifyAndPrint<0>(~x3#0:multi_specz_cyclic_lib.position, 333:wybe.int, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) #4 @multi_specz_cyclic_lib:nn:nn
-        multi_specz_cyclic_lib.modifyAndPrint<0>(~x4#0:multi_specz_cyclic_lib.position, 444:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #5 @multi_specz_cyclic_lib:nn:nn
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x1##0:multi_specz_cyclic_lib.position, 111:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @multi_specz_cyclic_lib:nn:nn
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x2##0:multi_specz_cyclic_lib.position, 222:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #3 @multi_specz_cyclic_lib:nn:nn
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x3##0:multi_specz_cyclic_lib.position, 333:wybe.int, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #4 @multi_specz_cyclic_lib:nn:nn
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x4##0:multi_specz_cyclic_lib.position, 444:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #5 @multi_specz_cyclic_lib:nn:nn
 
  [7477e50a09] [NonAliasedParam 0,NonAliasedParam 1] :
-    foreign llvm sub(~n#0:wybe.int, 1:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn
-    foreign llvm icmp_slt(tmp$0#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
+    foreign llvm icmp_slt(tmp$0##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        multi_specz_cyclic_lib2.foo2<0>[d4b0b4930c](~x2#0:multi_specz_cyclic_lib.position, ~x3#0:multi_specz_cyclic_lib.position, ~x4#0:multi_specz_cyclic_lib.position, ~x1#0:multi_specz_cyclic_lib.position, ~tmp$0#0:wybe.int, ~#io#0:wybe.phantom, ?#io#4:wybe.phantom) #6 @multi_specz_cyclic_lib:nn:nn
+        multi_specz_cyclic_lib2.foo2<0>[d4b0b4930c](~x2##0:multi_specz_cyclic_lib.position, ~x3##0:multi_specz_cyclic_lib.position, ~x4##0:multi_specz_cyclic_lib.position, ~x1##0:multi_specz_cyclic_lib.position, ~tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?#io##4:wybe.phantom) #6 @multi_specz_cyclic_lib:nn:nn
 
     1:
-        multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3](~x1#0:multi_specz_cyclic_lib.position, 111:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #2 @multi_specz_cyclic_lib:nn:nn
-        multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3](~x2#0:multi_specz_cyclic_lib.position, 222:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #3 @multi_specz_cyclic_lib:nn:nn
-        multi_specz_cyclic_lib.modifyAndPrint<0>(~x3#0:multi_specz_cyclic_lib.position, 333:wybe.int, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) #4 @multi_specz_cyclic_lib:nn:nn
-        multi_specz_cyclic_lib.modifyAndPrint<0>(~x4#0:multi_specz_cyclic_lib.position, 444:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #5 @multi_specz_cyclic_lib:nn:nn
+        multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3](~x1##0:multi_specz_cyclic_lib.position, 111:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @multi_specz_cyclic_lib:nn:nn
+        multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3](~x2##0:multi_specz_cyclic_lib.position, 222:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #3 @multi_specz_cyclic_lib:nn:nn
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x3##0:multi_specz_cyclic_lib.position, 333:wybe.int, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #4 @multi_specz_cyclic_lib:nn:nn
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x4##0:multi_specz_cyclic_lib.position, 444:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #5 @multi_specz_cyclic_lib:nn:nn
 
 
  [29a1d4275b] [NonAliasedParam 2,NonAliasedParam 3] :
-    foreign llvm sub(~n#0:wybe.int, 1:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn
-    foreign llvm icmp_slt(tmp$0#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
+    foreign llvm icmp_slt(tmp$0##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        multi_specz_cyclic_lib2.foo2<0>[ff3a297a4f](~x2#0:multi_specz_cyclic_lib.position, ~x3#0:multi_specz_cyclic_lib.position, ~x4#0:multi_specz_cyclic_lib.position, ~x1#0:multi_specz_cyclic_lib.position, ~tmp$0#0:wybe.int, ~#io#0:wybe.phantom, ?#io#4:wybe.phantom) #6 @multi_specz_cyclic_lib:nn:nn
+        multi_specz_cyclic_lib2.foo2<0>[ff3a297a4f](~x2##0:multi_specz_cyclic_lib.position, ~x3##0:multi_specz_cyclic_lib.position, ~x4##0:multi_specz_cyclic_lib.position, ~x1##0:multi_specz_cyclic_lib.position, ~tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?#io##4:wybe.phantom) #6 @multi_specz_cyclic_lib:nn:nn
 
     1:
-        multi_specz_cyclic_lib.modifyAndPrint<0>(~x1#0:multi_specz_cyclic_lib.position, 111:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #2 @multi_specz_cyclic_lib:nn:nn
-        multi_specz_cyclic_lib.modifyAndPrint<0>(~x2#0:multi_specz_cyclic_lib.position, 222:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #3 @multi_specz_cyclic_lib:nn:nn
-        multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3](~x3#0:multi_specz_cyclic_lib.position, 333:wybe.int, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) #4 @multi_specz_cyclic_lib:nn:nn
-        multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3](~x4#0:multi_specz_cyclic_lib.position, 444:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #5 @multi_specz_cyclic_lib:nn:nn
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x1##0:multi_specz_cyclic_lib.position, 111:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @multi_specz_cyclic_lib:nn:nn
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x2##0:multi_specz_cyclic_lib.position, 222:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #3 @multi_specz_cyclic_lib:nn:nn
+        multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3](~x3##0:multi_specz_cyclic_lib.position, 333:wybe.int, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #4 @multi_specz_cyclic_lib:nn:nn
+        multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3](~x4##0:multi_specz_cyclic_lib.position, 444:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #5 @multi_specz_cyclic_lib:nn:nn
 
 
 
 modifyAndPrint > public (4 calls)
 0: multi_specz_cyclic_lib.modifyAndPrint<0>
-modifyAndPrint(pos#0:multi_specz_cyclic_lib.position, v#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+modifyAndPrint(pos##0:multi_specz_cyclic_lib.position, v##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
-    foreign lpvm {noalias} mutate(~%pos#0:multi_specz_cyclic_lib.position, ?%pos#1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~v#0:wybe.int)
-    multi_specz_cyclic_lib.printPosition<0>(~pos#1:multi_specz_cyclic_lib.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #1 @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm {noalias} mutate(~%pos##0:multi_specz_cyclic_lib.position, ?%pos##1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
+    multi_specz_cyclic_lib.printPosition<0>(~pos##1:multi_specz_cyclic_lib.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @multi_specz_cyclic_lib:nn:nn
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm {noalias} mutate(~%pos#0:multi_specz_cyclic_lib.position, ?%pos#1:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v#0:wybe.int)
-    multi_specz_cyclic_lib.printPosition<0>(~pos#1:multi_specz_cyclic_lib.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #1 @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm {noalias} mutate(~%pos##0:multi_specz_cyclic_lib.position, ?%pos##1:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
+    multi_specz_cyclic_lib.printPosition<0>(~pos##1:multi_specz_cyclic_lib.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @multi_specz_cyclic_lib:nn:nn
 
 
 printPosition > public (1 calls)
 0: multi_specz_cyclic_lib.printPosition<0>
-printPosition(pos#0:multi_specz_cyclic_lib.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+printPosition(pos##0:multi_specz_cyclic_lib.position, io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos#0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string(",":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos#0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io#4:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -282,95 +282,95 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"multi_specz_cyclic_lib.foo1<0>"(i64  %"x1#0", i64  %"x2#0", i64  %"x3#0", i64  %"x4#0", i64  %"n#0")    {
+define external fastcc  void @"multi_specz_cyclic_lib.foo1<0>"(i64  %"x1##0", i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"n##0")    {
 entry:
-  %"1$tmp$0#0" = sub   i64 %"n#0", 1 
-  %"1$tmp$1#0" = icmp slt i64 %"1$tmp$0#0", 0 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = sub   i64 %"n##0", 1 
+  %"1$tmp$1##0" = icmp slt i64 %"1$tmp$0##0", 0 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x1#0", i64  111)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x2#0", i64  222)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x3#0", i64  333)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x4#0", i64  444)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x1##0", i64  111)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x2##0", i64  222)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x3##0", i64  333)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x4##0", i64  444)  
   ret void 
 if.else:
-  tail call fastcc  void  @"multi_specz_cyclic_lib2.foo2<0>"(i64  %"x2#0", i64  %"x3#0", i64  %"x4#0", i64  %"x1#0", i64  %"1$tmp$0#0")  
+  tail call fastcc  void  @"multi_specz_cyclic_lib2.foo2<0>"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1$tmp$0##0")  
   ret void 
 }
 
 
-define external fastcc  void @"multi_specz_cyclic_lib.foo1<0>[29a1d4275b]"(i64  %"x1#0", i64  %"x2#0", i64  %"x3#0", i64  %"x4#0", i64  %"n#0")    {
+define external fastcc  void @"multi_specz_cyclic_lib.foo1<0>[29a1d4275b]"(i64  %"x1##0", i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"n##0")    {
 entry:
-  %"1$tmp$0#0" = sub   i64 %"n#0", 1 
-  %"1$tmp$1#0" = icmp slt i64 %"1$tmp$0#0", 0 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = sub   i64 %"n##0", 1 
+  %"1$tmp$1##0" = icmp slt i64 %"1$tmp$0##0", 0 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x1#0", i64  111)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x2#0", i64  222)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3]"(i64  %"x3#0", i64  333)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3]"(i64  %"x4#0", i64  444)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x1##0", i64  111)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x2##0", i64  222)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3]"(i64  %"x3##0", i64  333)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3]"(i64  %"x4##0", i64  444)  
   ret void 
 if.else:
-  tail call fastcc  void  @"multi_specz_cyclic_lib2.foo2<0>[ff3a297a4f]"(i64  %"x2#0", i64  %"x3#0", i64  %"x4#0", i64  %"x1#0", i64  %"1$tmp$0#0")  
+  tail call fastcc  void  @"multi_specz_cyclic_lib2.foo2<0>[ff3a297a4f]"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1$tmp$0##0")  
   ret void 
 }
 
 
-define external fastcc  void @"multi_specz_cyclic_lib.foo1<0>[7477e50a09]"(i64  %"x1#0", i64  %"x2#0", i64  %"x3#0", i64  %"x4#0", i64  %"n#0")    {
+define external fastcc  void @"multi_specz_cyclic_lib.foo1<0>[7477e50a09]"(i64  %"x1##0", i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"n##0")    {
 entry:
-  %"1$tmp$0#0" = sub   i64 %"n#0", 1 
-  %"1$tmp$1#0" = icmp slt i64 %"1$tmp$0#0", 0 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = sub   i64 %"n##0", 1 
+  %"1$tmp$1##0" = icmp slt i64 %"1$tmp$0##0", 0 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3]"(i64  %"x1#0", i64  111)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3]"(i64  %"x2#0", i64  222)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x3#0", i64  333)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x4#0", i64  444)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3]"(i64  %"x1##0", i64  111)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3]"(i64  %"x2##0", i64  222)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x3##0", i64  333)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x4##0", i64  444)  
   ret void 
 if.else:
-  tail call fastcc  void  @"multi_specz_cyclic_lib2.foo2<0>[d4b0b4930c]"(i64  %"x2#0", i64  %"x3#0", i64  %"x4#0", i64  %"x1#0", i64  %"1$tmp$0#0")  
+  tail call fastcc  void  @"multi_specz_cyclic_lib2.foo2<0>[d4b0b4930c]"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1$tmp$0##0")  
   ret void 
 }
 
 
-define external fastcc  void @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"pos#0", i64  %"v#0")    {
+define external fastcc  void @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"pos##0", i64  %"v##0")    {
 entry:
   %1 = trunc i64 16 to i32  
   %2 = tail call ccc  i8*  @wybe_malloc(i32  %1)  
   %3 = ptrtoint i8* %2 to i64 
   %4 = inttoptr i64 %3 to i8* 
-  %5 = inttoptr i64 %"pos#0" to i8* 
+  %5 = inttoptr i64 %"pos##0" to i8* 
   %6 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i32  8, i1  0)  
   %7 = inttoptr i64 %3 to i64* 
   %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"v#0", i64* %8 
+  store  i64 %"v##0", i64* %8 
   tail call fastcc  void  @"multi_specz_cyclic_lib.printPosition<0>"(i64  %3)  
   ret void 
 }
 
 
-define external fastcc  void @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3]"(i64  %"pos#0", i64  %"v#0")    {
+define external fastcc  void @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3]"(i64  %"pos##0", i64  %"v##0")    {
 entry:
-  %9 = inttoptr i64 %"pos#0" to i64* 
+  %9 = inttoptr i64 %"pos##0" to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 %"v#0", i64* %10 
-  tail call fastcc  void  @"multi_specz_cyclic_lib.printPosition<0>"(i64  %"pos#0")  
+  store  i64 %"v##0", i64* %10 
+  tail call fastcc  void  @"multi_specz_cyclic_lib.printPosition<0>"(i64  %"pos##0")  
   ret void 
 }
 
 
-define external fastcc  void @"multi_specz_cyclic_lib.printPosition<0>"(i64  %"pos#0")    {
+define external fastcc  void @"multi_specz_cyclic_lib.printPosition<0>"(i64  %"pos##0")    {
 entry:
   %12 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @multi_specz_cyclic_lib.11, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %12)  
-  %13 = inttoptr i64 %"pos#0" to i64* 
+  %13 = inttoptr i64 %"pos##0" to i64* 
   %14 = getelementptr  i64, i64* %13, i64 0 
   %15 = load  i64, i64* %14 
   tail call ccc  void  @print_int(i64  %15)  
   %17 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @multi_specz_cyclic_lib.16, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %17)  
-  %18 = add   i64 %"pos#0", 8 
+  %18 = add   i64 %"pos##0", 8 
   %19 = inttoptr i64 %18 to i64* 
   %20 = getelementptr  i64, i64* %19, i64 0 
   %21 = load  i64, i64* %20 
@@ -400,86 +400,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: multi_specz_cyclic_lib.position.=<0>
-=($left#0:multi_specz_cyclic_lib.position, $right#0:multi_specz_cyclic_lib.position, ?$$#0:wybe.bool):
+=($left##0:multi_specz_cyclic_lib.position, $right##0:multi_specz_cyclic_lib.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
-    foreign lpvm access(~$left#0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y#0:wybe.int)
-    foreign lpvm access($right#0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x#0:wybe.int)
-    foreign lpvm access(~$right#0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y#0:wybe.int)
-    foreign llvm icmp_eq(~$left$x#0:wybe.int, ~$right$x#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
+    foreign lpvm access(~$left##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
+    foreign lpvm access($right##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
+    foreign lpvm access(~$right##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
+    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y#0:wybe.int, ~$right$y#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.position<0>
-position(x#0:wybe.int, y#0:wybe.int, ?$#0:multi_specz_cyclic_lib.position):
+position(x##0:wybe.int, y##0:wybe.int, ?$##0:multi_specz_cyclic_lib.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:multi_specz_cyclic_lib.position)
-    foreign lpvm mutate(~$rec#0:multi_specz_cyclic_lib.position, ?$rec#1:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:multi_specz_cyclic_lib.position, ?$#0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:multi_specz_cyclic_lib.position)
+    foreign lpvm mutate(~$rec##0:multi_specz_cyclic_lib.position, ?$rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:multi_specz_cyclic_lib.position, ?$##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: multi_specz_cyclic_lib.position.position<1>
-position(?x#0:wybe.int, ?y#0:wybe.int, $#0:multi_specz_cyclic_lib.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, $##0:multi_specz_cyclic_lib.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
-    foreign lpvm access(~$#0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y#0:wybe.int)
+    foreign lpvm access($##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~$##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.x<0>
-x($rec#0:multi_specz_cyclic_lib.position, ?$#0:wybe.int):
+x($rec##0:multi_specz_cyclic_lib.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 x > public {inline} (0 calls)
 1: multi_specz_cyclic_lib.position.x<1>
-x($rec#0:multi_specz_cyclic_lib.position, ?$rec#1:multi_specz_cyclic_lib.position, $field#0:wybe.int):
+x($rec##0:multi_specz_cyclic_lib.position, ?$rec##1:multi_specz_cyclic_lib.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:multi_specz_cyclic_lib.position, ?$rec#1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:multi_specz_cyclic_lib.position, ?$rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.y<0>
-y($rec#0:multi_specz_cyclic_lib.position, ?$#0:wybe.int):
+y($rec##0:multi_specz_cyclic_lib.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 y > public {inline} (0 calls)
 1: multi_specz_cyclic_lib.position.y<1>
-y($rec#0:multi_specz_cyclic_lib.position, ?$rec#1:multi_specz_cyclic_lib.position, $field#0:wybe.int):
+y($rec##0:multi_specz_cyclic_lib.position, ?$rec##1:multi_specz_cyclic_lib.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:multi_specz_cyclic_lib.position, ?$rec#1:multi_specz_cyclic_lib.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:multi_specz_cyclic_lib.position, ?$rec##1:multi_specz_cyclic_lib.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.~=<0>
-~=($left#0:multi_specz_cyclic_lib.position, $right#0:multi_specz_cyclic_lib.position, ?$$#0:wybe.bool):
+~=($left##0:multi_specz_cyclic_lib.position, $right##0:multi_specz_cyclic_lib.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -496,54 +496,54 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"multi_specz_cyclic_lib.position.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"multi_specz_cyclic_lib.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$#0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = icmp eq i64 %7, %14 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.position<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"x#0", i64* %19 
+  store  i64 %"x##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"y#0", i64* %22 
+  store  i64 %"y##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64} @"multi_specz_cyclic_lib.position.position<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"multi_specz_cyclic_lib.position.position<1>"(i64  %"$##0")    {
 entry:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -553,34 +553,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<0>"(i64  %"$rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec#0" to i64* 
+  %32 = inttoptr i64 %"$rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec#0" to i8* 
+  %39 = inttoptr i64 %"$rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field#0", i64* %42 
+  store  i64 %"$field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = add   i64 %"$rec#0", 8 
+  %43 = add   i64 %"$rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -588,48 +588,48 @@ entry:
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec#0" to i8* 
+  %51 = inttoptr i64 %"$rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field#0", i64* %55 
+  store  i64 %"$field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"multi_specz_cyclic_lib.position.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"multi_specz_cyclic_lib.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %58, %65 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = icmp eq i64 %62, %69 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$0##0" = icmp eq i64 %62, %69 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }
 --------------------------------------------------
  Module multi_specz_cyclic_lib2
@@ -644,48 +644,48 @@ if.else:
 
 foo2 > public (0 calls)
 0: multi_specz_cyclic_lib2.foo2<0>[ff3a297a4f]
-foo2(x1#0:multi_specz_cyclic_lib.position, x2#0:multi_specz_cyclic_lib.position, x3#0:multi_specz_cyclic_lib.position, x4#0:multi_specz_cyclic_lib.position, n#0:wybe.int, io#0:wybe.phantom, ?io#4:wybe.phantom):
+foo2(x1##0:multi_specz_cyclic_lib.position, x2##0:multi_specz_cyclic_lib.position, x3##0:multi_specz_cyclic_lib.position, x4##0:multi_specz_cyclic_lib.position, n##0:wybe.int, io##0:wybe.phantom, ?io##4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0,InterestingUnaliased 1,InterestingUnaliased 2,InterestingUnaliased 3]
  MultiSpeczDepInfo: [(2,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [0]])),(3,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [1]])),(4,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [2]])),(5,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [3]])),(6,(multi_specz_cyclic_lib.foo1<0>,fromList [NonAliasedParamCond 0 [1],NonAliasedParamCond 1 [2],NonAliasedParamCond 2 [3],NonAliasedParamCond 3 [0]]))]
-    foreign llvm sub(~n#0:wybe.int, 1:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn
-    foreign llvm icmp_slt(tmp$0#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
+    foreign llvm icmp_slt(tmp$0##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        multi_specz_cyclic_lib.foo1<0>(~x2#0:multi_specz_cyclic_lib.position, ~x3#0:multi_specz_cyclic_lib.position, ~x4#0:multi_specz_cyclic_lib.position, ~x1#0:multi_specz_cyclic_lib.position, ~tmp$0#0:wybe.int, ~#io#0:wybe.phantom, ?#io#4:wybe.phantom) #6 @multi_specz_cyclic_lib2:11:14
+        multi_specz_cyclic_lib.foo1<0>(~x2##0:multi_specz_cyclic_lib.position, ~x3##0:multi_specz_cyclic_lib.position, ~x4##0:multi_specz_cyclic_lib.position, ~x1##0:multi_specz_cyclic_lib.position, ~tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?#io##4:wybe.phantom) #6 @multi_specz_cyclic_lib2:11:14
 
     1:
-        multi_specz_cyclic_lib.modifyAndPrint<0>(~x1#0:multi_specz_cyclic_lib.position, 111:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #2 @multi_specz_cyclic_lib2:6:14
-        multi_specz_cyclic_lib.modifyAndPrint<0>(~x2#0:multi_specz_cyclic_lib.position, 222:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #3 @multi_specz_cyclic_lib2:7:14
-        multi_specz_cyclic_lib.modifyAndPrint<0>(~x3#0:multi_specz_cyclic_lib.position, 333:wybe.int, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) #4 @multi_specz_cyclic_lib2:8:14
-        multi_specz_cyclic_lib.modifyAndPrint<0>(~x4#0:multi_specz_cyclic_lib.position, 444:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #5 @multi_specz_cyclic_lib2:9:14
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x1##0:multi_specz_cyclic_lib.position, 111:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @multi_specz_cyclic_lib2:6:14
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x2##0:multi_specz_cyclic_lib.position, 222:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #3 @multi_specz_cyclic_lib2:7:14
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x3##0:multi_specz_cyclic_lib.position, 333:wybe.int, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #4 @multi_specz_cyclic_lib2:8:14
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x4##0:multi_specz_cyclic_lib.position, 444:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #5 @multi_specz_cyclic_lib2:9:14
 
  [d4b0b4930c] [NonAliasedParam 0,NonAliasedParam 3] :
-    foreign llvm sub(~n#0:wybe.int, 1:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn
-    foreign llvm icmp_slt(tmp$0#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
+    foreign llvm icmp_slt(tmp$0##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        multi_specz_cyclic_lib.foo1<0>[29a1d4275b](~x2#0:multi_specz_cyclic_lib.position, ~x3#0:multi_specz_cyclic_lib.position, ~x4#0:multi_specz_cyclic_lib.position, ~x1#0:multi_specz_cyclic_lib.position, ~tmp$0#0:wybe.int, ~#io#0:wybe.phantom, ?#io#4:wybe.phantom) #6 @multi_specz_cyclic_lib2:11:14
+        multi_specz_cyclic_lib.foo1<0>[29a1d4275b](~x2##0:multi_specz_cyclic_lib.position, ~x3##0:multi_specz_cyclic_lib.position, ~x4##0:multi_specz_cyclic_lib.position, ~x1##0:multi_specz_cyclic_lib.position, ~tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?#io##4:wybe.phantom) #6 @multi_specz_cyclic_lib2:11:14
 
     1:
-        multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3](~x1#0:multi_specz_cyclic_lib.position, 111:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #2 @multi_specz_cyclic_lib2:6:14
-        multi_specz_cyclic_lib.modifyAndPrint<0>(~x2#0:multi_specz_cyclic_lib.position, 222:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #3 @multi_specz_cyclic_lib2:7:14
-        multi_specz_cyclic_lib.modifyAndPrint<0>(~x3#0:multi_specz_cyclic_lib.position, 333:wybe.int, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) #4 @multi_specz_cyclic_lib2:8:14
-        multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3](~x4#0:multi_specz_cyclic_lib.position, 444:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #5 @multi_specz_cyclic_lib2:9:14
+        multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3](~x1##0:multi_specz_cyclic_lib.position, 111:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @multi_specz_cyclic_lib2:6:14
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x2##0:multi_specz_cyclic_lib.position, 222:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #3 @multi_specz_cyclic_lib2:7:14
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x3##0:multi_specz_cyclic_lib.position, 333:wybe.int, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #4 @multi_specz_cyclic_lib2:8:14
+        multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3](~x4##0:multi_specz_cyclic_lib.position, 444:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #5 @multi_specz_cyclic_lib2:9:14
 
 
  [ff3a297a4f] [NonAliasedParam 1,NonAliasedParam 2] :
-    foreign llvm sub(~n#0:wybe.int, 1:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn
-    foreign llvm icmp_slt(tmp$0#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
+    foreign llvm icmp_slt(tmp$0##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        multi_specz_cyclic_lib.foo1<0>[7477e50a09](~x2#0:multi_specz_cyclic_lib.position, ~x3#0:multi_specz_cyclic_lib.position, ~x4#0:multi_specz_cyclic_lib.position, ~x1#0:multi_specz_cyclic_lib.position, ~tmp$0#0:wybe.int, ~#io#0:wybe.phantom, ?#io#4:wybe.phantom) #6 @multi_specz_cyclic_lib2:11:14
+        multi_specz_cyclic_lib.foo1<0>[7477e50a09](~x2##0:multi_specz_cyclic_lib.position, ~x3##0:multi_specz_cyclic_lib.position, ~x4##0:multi_specz_cyclic_lib.position, ~x1##0:multi_specz_cyclic_lib.position, ~tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?#io##4:wybe.phantom) #6 @multi_specz_cyclic_lib2:11:14
 
     1:
-        multi_specz_cyclic_lib.modifyAndPrint<0>(~x1#0:multi_specz_cyclic_lib.position, 111:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #2 @multi_specz_cyclic_lib2:6:14
-        multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3](~x2#0:multi_specz_cyclic_lib.position, 222:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #3 @multi_specz_cyclic_lib2:7:14
-        multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3](~x3#0:multi_specz_cyclic_lib.position, 333:wybe.int, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) #4 @multi_specz_cyclic_lib2:8:14
-        multi_specz_cyclic_lib.modifyAndPrint<0>(~x4#0:multi_specz_cyclic_lib.position, 444:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #5 @multi_specz_cyclic_lib2:9:14
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x1##0:multi_specz_cyclic_lib.position, 111:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @multi_specz_cyclic_lib2:6:14
+        multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3](~x2##0:multi_specz_cyclic_lib.position, 222:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #3 @multi_specz_cyclic_lib2:7:14
+        multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3](~x3##0:multi_specz_cyclic_lib.position, 333:wybe.int, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #4 @multi_specz_cyclic_lib2:8:14
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x4##0:multi_specz_cyclic_lib.position, 444:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #5 @multi_specz_cyclic_lib2:9:14
 
 
   LLVM code       :
@@ -717,52 +717,52 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"multi_specz_cyclic_lib2.foo2<0>"(i64  %"x1#0", i64  %"x2#0", i64  %"x3#0", i64  %"x4#0", i64  %"n#0")    {
+define external fastcc  void @"multi_specz_cyclic_lib2.foo2<0>"(i64  %"x1##0", i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"n##0")    {
 entry:
-  %"1$tmp$0#0" = sub   i64 %"n#0", 1 
-  %"1$tmp$1#0" = icmp slt i64 %"1$tmp$0#0", 0 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = sub   i64 %"n##0", 1 
+  %"1$tmp$1##0" = icmp slt i64 %"1$tmp$0##0", 0 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x1#0", i64  111)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x2#0", i64  222)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x3#0", i64  333)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x4#0", i64  444)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x1##0", i64  111)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x2##0", i64  222)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x3##0", i64  333)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x4##0", i64  444)  
   ret void 
 if.else:
-  tail call fastcc  void  @"multi_specz_cyclic_lib.foo1<0>"(i64  %"x2#0", i64  %"x3#0", i64  %"x4#0", i64  %"x1#0", i64  %"1$tmp$0#0")  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.foo1<0>"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1$tmp$0##0")  
   ret void 
 }
 
 
-define external fastcc  void @"multi_specz_cyclic_lib2.foo2<0>[ff3a297a4f]"(i64  %"x1#0", i64  %"x2#0", i64  %"x3#0", i64  %"x4#0", i64  %"n#0")    {
+define external fastcc  void @"multi_specz_cyclic_lib2.foo2<0>[ff3a297a4f]"(i64  %"x1##0", i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"n##0")    {
 entry:
-  %"1$tmp$0#0" = sub   i64 %"n#0", 1 
-  %"1$tmp$1#0" = icmp slt i64 %"1$tmp$0#0", 0 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = sub   i64 %"n##0", 1 
+  %"1$tmp$1##0" = icmp slt i64 %"1$tmp$0##0", 0 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x1#0", i64  111)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3]"(i64  %"x2#0", i64  222)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3]"(i64  %"x3#0", i64  333)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x4#0", i64  444)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x1##0", i64  111)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3]"(i64  %"x2##0", i64  222)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3]"(i64  %"x3##0", i64  333)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x4##0", i64  444)  
   ret void 
 if.else:
-  tail call fastcc  void  @"multi_specz_cyclic_lib.foo1<0>[7477e50a09]"(i64  %"x2#0", i64  %"x3#0", i64  %"x4#0", i64  %"x1#0", i64  %"1$tmp$0#0")  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.foo1<0>[7477e50a09]"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1$tmp$0##0")  
   ret void 
 }
 
 
-define external fastcc  void @"multi_specz_cyclic_lib2.foo2<0>[d4b0b4930c]"(i64  %"x1#0", i64  %"x2#0", i64  %"x3#0", i64  %"x4#0", i64  %"n#0")    {
+define external fastcc  void @"multi_specz_cyclic_lib2.foo2<0>[d4b0b4930c]"(i64  %"x1##0", i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"n##0")    {
 entry:
-  %"1$tmp$0#0" = sub   i64 %"n#0", 1 
-  %"1$tmp$1#0" = icmp slt i64 %"1$tmp$0#0", 0 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = sub   i64 %"n##0", 1 
+  %"1$tmp$1##0" = icmp slt i64 %"1$tmp$0##0", 0 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3]"(i64  %"x1#0", i64  111)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x2#0", i64  222)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x3#0", i64  333)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3]"(i64  %"x4#0", i64  444)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3]"(i64  %"x1##0", i64  111)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x2##0", i64  222)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x3##0", i64  333)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3]"(i64  %"x4##0", i64  444)  
   ret void 
 if.else:
-  tail call fastcc  void  @"multi_specz_cyclic_lib.foo1<0>[29a1d4275b]"(i64  %"x2#0", i64  %"x3#0", i64  %"x4#0", i64  %"x1#0", i64  %"1$tmp$0#0")  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.foo1<0>[29a1d4275b]"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1$tmp$0##0")  
   ret void 
 }

--- a/test-cases/final-dump/multi_specz_cyclic_exe.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_exe.exp
@@ -25,27 +25,27 @@ main(io##0:wybe.phantom, ?io##6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(5,(multi_specz_cyclic_lib.foo1<0>,fromList [NonAliasedParamCond 0 [],NonAliasedParamCond 1 []]))]
-    foreign lpvm alloc(16:wybe.int, ?tmp$6##0:multi_specz_cyclic_lib.position)
-    foreign lpvm mutate(~tmp$6##0:multi_specz_cyclic_lib.position, ?tmp$7##0:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$7##0:multi_specz_cyclic_lib.position, ?tmp$0##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$10##0:multi_specz_cyclic_lib.position)
-    foreign lpvm mutate(~tmp$10##0:multi_specz_cyclic_lib.position, ?tmp$11##0:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$11##0:multi_specz_cyclic_lib.position, ?tmp$1##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$14##0:multi_specz_cyclic_lib.position)
-    foreign lpvm mutate(~tmp$14##0:multi_specz_cyclic_lib.position, ?tmp$15##0:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$15##0:multi_specz_cyclic_lib.position, ?tmp$2##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$18##0:multi_specz_cyclic_lib.position)
-    foreign lpvm mutate(~tmp$18##0:multi_specz_cyclic_lib.position, ?tmp$19##0:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp$19##0:multi_specz_cyclic_lib.position, ?tmp$3##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:wybe.int)
-    foreign c print_string("=============":wybe.string, ~#io##0:wybe.phantom, ?tmp$22##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$22##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    multi_specz_cyclic_lib.foo1<0>[7477e50a09](~tmp$0##0:multi_specz_cyclic_lib.position, ~tmp$1##0:multi_specz_cyclic_lib.position, tmp$2##0:multi_specz_cyclic_lib.position, tmp$3##0:multi_specz_cyclic_lib.position, 3:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #5 @multi_specz_cyclic_exe:nn:nn
-    foreign c print_string("-------------":wybe.string, ~#io##2:wybe.phantom, ?tmp$25##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$25##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    multi_specz_cyclic_lib.printPosition<0>(~tmp$2##0:multi_specz_cyclic_lib.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #7 @multi_specz_cyclic_exe:nn:nn
-    multi_specz_cyclic_lib.printPosition<0>(~tmp$3##0:multi_specz_cyclic_lib.position, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #8 @multi_specz_cyclic_exe:nn:nn
-    foreign c print_string("=============":wybe.string, ~#io##5:wybe.phantom, ?tmp$28##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$28##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#6##0:multi_specz_cyclic_lib.position)
+    foreign lpvm mutate(~tmp#6##0:multi_specz_cyclic_lib.position, ?tmp#7##0:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp#7##0:multi_specz_cyclic_lib.position, ?tmp#0##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#10##0:multi_specz_cyclic_lib.position)
+    foreign lpvm mutate(~tmp#10##0:multi_specz_cyclic_lib.position, ?tmp#11##0:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp#11##0:multi_specz_cyclic_lib.position, ?tmp#1##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:multi_specz_cyclic_lib.position)
+    foreign lpvm mutate(~tmp#14##0:multi_specz_cyclic_lib.position, ?tmp#15##0:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp#15##0:multi_specz_cyclic_lib.position, ?tmp#2##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:multi_specz_cyclic_lib.position)
+    foreign lpvm mutate(~tmp#18##0:multi_specz_cyclic_lib.position, ?tmp#19##0:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp#19##0:multi_specz_cyclic_lib.position, ?tmp#3##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:wybe.int)
+    foreign c print_string("=============":wybe.string, ~#io##0:wybe.phantom, ?tmp#22##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#22##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    multi_specz_cyclic_lib.foo1<0>[7477e50a09](~tmp#0##0:multi_specz_cyclic_lib.position, ~tmp#1##0:multi_specz_cyclic_lib.position, tmp#2##0:multi_specz_cyclic_lib.position, tmp#3##0:multi_specz_cyclic_lib.position, 3:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #5 @multi_specz_cyclic_exe:nn:nn
+    foreign c print_string("-------------":wybe.string, ~#io##2:wybe.phantom, ?tmp#25##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#25##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    multi_specz_cyclic_lib.printPosition<0>(~tmp#2##0:multi_specz_cyclic_lib.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #7 @multi_specz_cyclic_exe:nn:nn
+    multi_specz_cyclic_lib.printPosition<0>(~tmp#3##0:multi_specz_cyclic_lib.position, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) #8 @multi_specz_cyclic_exe:nn:nn
+    foreign c print_string("=============":wybe.string, ~#io##5:wybe.phantom, ?tmp#28##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#28##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -174,11 +174,11 @@ foo1(x1##0:multi_specz_cyclic_lib.position, x2##0:multi_specz_cyclic_lib.positio
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0,InterestingUnaliased 1,InterestingUnaliased 2,InterestingUnaliased 3]
  MultiSpeczDepInfo: [(2,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [0]])),(3,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [1]])),(4,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [2]])),(5,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [3]])),(6,(multi_specz_cyclic_lib2.foo2<0>,fromList [NonAliasedParamCond 0 [1],NonAliasedParamCond 1 [2],NonAliasedParamCond 2 [3],NonAliasedParamCond 3 [0]]))]
-    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
-    foreign llvm icmp_slt(tmp$0##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
+    foreign llvm icmp_slt(tmp#0##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        multi_specz_cyclic_lib2.foo2<0>(~x2##0:multi_specz_cyclic_lib.position, ~x3##0:multi_specz_cyclic_lib.position, ~x4##0:multi_specz_cyclic_lib.position, ~x1##0:multi_specz_cyclic_lib.position, ~tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?#io##4:wybe.phantom) #6 @multi_specz_cyclic_lib:nn:nn
+        multi_specz_cyclic_lib2.foo2<0>(~x2##0:multi_specz_cyclic_lib.position, ~x3##0:multi_specz_cyclic_lib.position, ~x4##0:multi_specz_cyclic_lib.position, ~x1##0:multi_specz_cyclic_lib.position, ~tmp#0##0:wybe.int, ~#io##0:wybe.phantom, ?#io##4:wybe.phantom) #6 @multi_specz_cyclic_lib:nn:nn
 
     1:
         multi_specz_cyclic_lib.modifyAndPrint<0>(~x1##0:multi_specz_cyclic_lib.position, 111:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @multi_specz_cyclic_lib:nn:nn
@@ -187,11 +187,11 @@ foo1(x1##0:multi_specz_cyclic_lib.position, x2##0:multi_specz_cyclic_lib.positio
         multi_specz_cyclic_lib.modifyAndPrint<0>(~x4##0:multi_specz_cyclic_lib.position, 444:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #5 @multi_specz_cyclic_lib:nn:nn
 
  [7477e50a09] [NonAliasedParam 0,NonAliasedParam 1] :
-    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
-    foreign llvm icmp_slt(tmp$0##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
+    foreign llvm icmp_slt(tmp#0##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        multi_specz_cyclic_lib2.foo2<0>[d4b0b4930c](~x2##0:multi_specz_cyclic_lib.position, ~x3##0:multi_specz_cyclic_lib.position, ~x4##0:multi_specz_cyclic_lib.position, ~x1##0:multi_specz_cyclic_lib.position, ~tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?#io##4:wybe.phantom) #6 @multi_specz_cyclic_lib:nn:nn
+        multi_specz_cyclic_lib2.foo2<0>[d4b0b4930c](~x2##0:multi_specz_cyclic_lib.position, ~x3##0:multi_specz_cyclic_lib.position, ~x4##0:multi_specz_cyclic_lib.position, ~x1##0:multi_specz_cyclic_lib.position, ~tmp#0##0:wybe.int, ~#io##0:wybe.phantom, ?#io##4:wybe.phantom) #6 @multi_specz_cyclic_lib:nn:nn
 
     1:
         multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3](~x1##0:multi_specz_cyclic_lib.position, 111:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @multi_specz_cyclic_lib:nn:nn
@@ -201,11 +201,11 @@ foo1(x1##0:multi_specz_cyclic_lib.position, x2##0:multi_specz_cyclic_lib.positio
 
 
  [29a1d4275b] [NonAliasedParam 2,NonAliasedParam 3] :
-    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
-    foreign llvm icmp_slt(tmp$0##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
+    foreign llvm icmp_slt(tmp#0##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        multi_specz_cyclic_lib2.foo2<0>[ff3a297a4f](~x2##0:multi_specz_cyclic_lib.position, ~x3##0:multi_specz_cyclic_lib.position, ~x4##0:multi_specz_cyclic_lib.position, ~x1##0:multi_specz_cyclic_lib.position, ~tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?#io##4:wybe.phantom) #6 @multi_specz_cyclic_lib:nn:nn
+        multi_specz_cyclic_lib2.foo2<0>[ff3a297a4f](~x2##0:multi_specz_cyclic_lib.position, ~x3##0:multi_specz_cyclic_lib.position, ~x4##0:multi_specz_cyclic_lib.position, ~x1##0:multi_specz_cyclic_lib.position, ~tmp#0##0:wybe.int, ~#io##0:wybe.phantom, ?#io##4:wybe.phantom) #6 @multi_specz_cyclic_lib:nn:nn
 
     1:
         multi_specz_cyclic_lib.modifyAndPrint<0>(~x1##0:multi_specz_cyclic_lib.position, 111:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @multi_specz_cyclic_lib:nn:nn
@@ -233,13 +233,13 @@ printPosition(pos##0:multi_specz_cyclic_lib.position, io##0:wybe.phantom, ?io##5
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -284,9 +284,9 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"multi_specz_cyclic_lib.foo1<0>"(i64  %"x1##0", i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"n##0")    {
 entry:
-  %"1$tmp$0##0" = sub   i64 %"n##0", 1 
-  %"1$tmp$1##0" = icmp slt i64 %"1$tmp$0##0", 0 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = sub   i64 %"n##0", 1 
+  %"1#tmp#1##0" = icmp slt i64 %"1#tmp#0##0", 0 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
   tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x1##0", i64  111)  
   tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x2##0", i64  222)  
@@ -294,16 +294,16 @@ if.then:
   tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x4##0", i64  444)  
   ret void 
 if.else:
-  tail call fastcc  void  @"multi_specz_cyclic_lib2.foo2<0>"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1$tmp$0##0")  
+  tail call fastcc  void  @"multi_specz_cyclic_lib2.foo2<0>"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1#tmp#0##0")  
   ret void 
 }
 
 
 define external fastcc  void @"multi_specz_cyclic_lib.foo1<0>[29a1d4275b]"(i64  %"x1##0", i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"n##0")    {
 entry:
-  %"1$tmp$0##0" = sub   i64 %"n##0", 1 
-  %"1$tmp$1##0" = icmp slt i64 %"1$tmp$0##0", 0 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = sub   i64 %"n##0", 1 
+  %"1#tmp#1##0" = icmp slt i64 %"1#tmp#0##0", 0 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
   tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x1##0", i64  111)  
   tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x2##0", i64  222)  
@@ -311,16 +311,16 @@ if.then:
   tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3]"(i64  %"x4##0", i64  444)  
   ret void 
 if.else:
-  tail call fastcc  void  @"multi_specz_cyclic_lib2.foo2<0>[ff3a297a4f]"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1$tmp$0##0")  
+  tail call fastcc  void  @"multi_specz_cyclic_lib2.foo2<0>[ff3a297a4f]"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1#tmp#0##0")  
   ret void 
 }
 
 
 define external fastcc  void @"multi_specz_cyclic_lib.foo1<0>[7477e50a09]"(i64  %"x1##0", i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"n##0")    {
 entry:
-  %"1$tmp$0##0" = sub   i64 %"n##0", 1 
-  %"1$tmp$1##0" = icmp slt i64 %"1$tmp$0##0", 0 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = sub   i64 %"n##0", 1 
+  %"1#tmp#1##0" = icmp slt i64 %"1#tmp#0##0", 0 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
   tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3]"(i64  %"x1##0", i64  111)  
   tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3]"(i64  %"x2##0", i64  222)  
@@ -328,7 +328,7 @@ if.then:
   tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x4##0", i64  444)  
   ret void 
 if.else:
-  tail call fastcc  void  @"multi_specz_cyclic_lib2.foo2<0>[d4b0b4930c]"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1$tmp$0##0")  
+  tail call fastcc  void  @"multi_specz_cyclic_lib2.foo2<0>[d4b0b4930c]"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1#tmp#0##0")  
   ret void 
 }
 
@@ -400,86 +400,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: multi_specz_cyclic_lib.position.=<0>
-=($left##0:multi_specz_cyclic_lib.position, $right##0:multi_specz_cyclic_lib.position, ?$$##0:wybe.bool):
+=(#left##0:multi_specz_cyclic_lib.position, #right##0:multi_specz_cyclic_lib.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
-    foreign lpvm access(~$left##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
-    foreign lpvm access($right##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
-    foreign lpvm access(~$right##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
-    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
+    foreign lpvm access(~#left##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
+    foreign lpvm access(#right##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
+    foreign lpvm access(~#right##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?$##0:multi_specz_cyclic_lib.position):
+position(x##0:wybe.int, y##0:wybe.int, ?###0:multi_specz_cyclic_lib.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:multi_specz_cyclic_lib.position)
-    foreign lpvm mutate(~$rec##0:multi_specz_cyclic_lib.position, ?$rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:multi_specz_cyclic_lib.position, ?$##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:multi_specz_cyclic_lib.position)
+    foreign lpvm mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:multi_specz_cyclic_lib.position, ?###0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: multi_specz_cyclic_lib.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, $##0:multi_specz_cyclic_lib.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, ###0:multi_specz_cyclic_lib.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~$##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(###0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~###0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.x<0>
-x($rec##0:multi_specz_cyclic_lib.position, ?$##0:wybe.int):
+x(#rec##0:multi_specz_cyclic_lib.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 x > public {inline} (0 calls)
 1: multi_specz_cyclic_lib.position.x<1>
-x($rec##0:multi_specz_cyclic_lib.position, ?$rec##1:multi_specz_cyclic_lib.position, $field##0:wybe.int):
+x(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:multi_specz_cyclic_lib.position, ?$rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.y<0>
-y($rec##0:multi_specz_cyclic_lib.position, ?$##0:wybe.int):
+y(#rec##0:multi_specz_cyclic_lib.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 y > public {inline} (0 calls)
 1: multi_specz_cyclic_lib.position.y<1>
-y($rec##0:multi_specz_cyclic_lib.position, ?$rec##1:multi_specz_cyclic_lib.position, $field##0:wybe.int):
+y(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:multi_specz_cyclic_lib.position, ?$rec##1:multi_specz_cyclic_lib.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.~=<0>
-~=($left##0:multi_specz_cyclic_lib.position, $right##0:multi_specz_cyclic_lib.position, ?$$##0:wybe.bool):
+~=(#left##0:multi_specz_cyclic_lib.position, #right##0:multi_specz_cyclic_lib.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -496,27 +496,27 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"multi_specz_cyclic_lib.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"multi_specz_cyclic_lib.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$##0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$##0" 
+  %"2#####0" = icmp eq i64 %7, %14 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
@@ -538,12 +538,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"multi_specz_cyclic_lib.position.position<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"multi_specz_cyclic_lib.position.position<1>"(i64  %"###0")    {
 entry:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -553,34 +553,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<0>"(i64  %"#rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec##0" to i64* 
+  %32 = inttoptr i64 %"#rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec##0" to i8* 
+  %39 = inttoptr i64 %"#rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field##0", i64* %42 
+  store  i64 %"#field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = add   i64 %"$rec##0", 8 
+  %43 = add   i64 %"#rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -588,48 +588,48 @@ entry:
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec##0" to i8* 
+  %51 = inttoptr i64 %"#rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field##0", i64* %55 
+  store  i64 %"#field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"multi_specz_cyclic_lib.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"multi_specz_cyclic_lib.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %58, %65 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = icmp eq i64 %62, %69 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#0##0" = icmp eq i64 %62, %69 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }
 --------------------------------------------------
  Module multi_specz_cyclic_lib2
@@ -648,11 +648,11 @@ foo2(x1##0:multi_specz_cyclic_lib.position, x2##0:multi_specz_cyclic_lib.positio
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0,InterestingUnaliased 1,InterestingUnaliased 2,InterestingUnaliased 3]
  MultiSpeczDepInfo: [(2,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [0]])),(3,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [1]])),(4,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [2]])),(5,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [3]])),(6,(multi_specz_cyclic_lib.foo1<0>,fromList [NonAliasedParamCond 0 [1],NonAliasedParamCond 1 [2],NonAliasedParamCond 2 [3],NonAliasedParamCond 3 [0]]))]
-    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
-    foreign llvm icmp_slt(tmp$0##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
+    foreign llvm icmp_slt(tmp#0##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        multi_specz_cyclic_lib.foo1<0>(~x2##0:multi_specz_cyclic_lib.position, ~x3##0:multi_specz_cyclic_lib.position, ~x4##0:multi_specz_cyclic_lib.position, ~x1##0:multi_specz_cyclic_lib.position, ~tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?#io##4:wybe.phantom) #6 @multi_specz_cyclic_lib2:11:14
+        multi_specz_cyclic_lib.foo1<0>(~x2##0:multi_specz_cyclic_lib.position, ~x3##0:multi_specz_cyclic_lib.position, ~x4##0:multi_specz_cyclic_lib.position, ~x1##0:multi_specz_cyclic_lib.position, ~tmp#0##0:wybe.int, ~#io##0:wybe.phantom, ?#io##4:wybe.phantom) #6 @multi_specz_cyclic_lib2:11:14
 
     1:
         multi_specz_cyclic_lib.modifyAndPrint<0>(~x1##0:multi_specz_cyclic_lib.position, 111:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @multi_specz_cyclic_lib2:6:14
@@ -661,11 +661,11 @@ foo2(x1##0:multi_specz_cyclic_lib.position, x2##0:multi_specz_cyclic_lib.positio
         multi_specz_cyclic_lib.modifyAndPrint<0>(~x4##0:multi_specz_cyclic_lib.position, 444:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #5 @multi_specz_cyclic_lib2:9:14
 
  [d4b0b4930c] [NonAliasedParam 0,NonAliasedParam 3] :
-    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
-    foreign llvm icmp_slt(tmp$0##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
+    foreign llvm icmp_slt(tmp#0##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        multi_specz_cyclic_lib.foo1<0>[29a1d4275b](~x2##0:multi_specz_cyclic_lib.position, ~x3##0:multi_specz_cyclic_lib.position, ~x4##0:multi_specz_cyclic_lib.position, ~x1##0:multi_specz_cyclic_lib.position, ~tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?#io##4:wybe.phantom) #6 @multi_specz_cyclic_lib2:11:14
+        multi_specz_cyclic_lib.foo1<0>[29a1d4275b](~x2##0:multi_specz_cyclic_lib.position, ~x3##0:multi_specz_cyclic_lib.position, ~x4##0:multi_specz_cyclic_lib.position, ~x1##0:multi_specz_cyclic_lib.position, ~tmp#0##0:wybe.int, ~#io##0:wybe.phantom, ?#io##4:wybe.phantom) #6 @multi_specz_cyclic_lib2:11:14
 
     1:
         multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3](~x1##0:multi_specz_cyclic_lib.position, 111:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @multi_specz_cyclic_lib2:6:14
@@ -675,11 +675,11 @@ foo2(x1##0:multi_specz_cyclic_lib.position, x2##0:multi_specz_cyclic_lib.positio
 
 
  [ff3a297a4f] [NonAliasedParam 1,NonAliasedParam 2] :
-    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
-    foreign llvm icmp_slt(tmp$0##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
+    foreign llvm icmp_slt(tmp#0##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        multi_specz_cyclic_lib.foo1<0>[7477e50a09](~x2##0:multi_specz_cyclic_lib.position, ~x3##0:multi_specz_cyclic_lib.position, ~x4##0:multi_specz_cyclic_lib.position, ~x1##0:multi_specz_cyclic_lib.position, ~tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?#io##4:wybe.phantom) #6 @multi_specz_cyclic_lib2:11:14
+        multi_specz_cyclic_lib.foo1<0>[7477e50a09](~x2##0:multi_specz_cyclic_lib.position, ~x3##0:multi_specz_cyclic_lib.position, ~x4##0:multi_specz_cyclic_lib.position, ~x1##0:multi_specz_cyclic_lib.position, ~tmp#0##0:wybe.int, ~#io##0:wybe.phantom, ?#io##4:wybe.phantom) #6 @multi_specz_cyclic_lib2:11:14
 
     1:
         multi_specz_cyclic_lib.modifyAndPrint<0>(~x1##0:multi_specz_cyclic_lib.position, 111:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @multi_specz_cyclic_lib2:6:14
@@ -719,9 +719,9 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"multi_specz_cyclic_lib2.foo2<0>"(i64  %"x1##0", i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"n##0")    {
 entry:
-  %"1$tmp$0##0" = sub   i64 %"n##0", 1 
-  %"1$tmp$1##0" = icmp slt i64 %"1$tmp$0##0", 0 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = sub   i64 %"n##0", 1 
+  %"1#tmp#1##0" = icmp slt i64 %"1#tmp#0##0", 0 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
   tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x1##0", i64  111)  
   tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x2##0", i64  222)  
@@ -729,16 +729,16 @@ if.then:
   tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x4##0", i64  444)  
   ret void 
 if.else:
-  tail call fastcc  void  @"multi_specz_cyclic_lib.foo1<0>"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1$tmp$0##0")  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.foo1<0>"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1#tmp#0##0")  
   ret void 
 }
 
 
 define external fastcc  void @"multi_specz_cyclic_lib2.foo2<0>[ff3a297a4f]"(i64  %"x1##0", i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"n##0")    {
 entry:
-  %"1$tmp$0##0" = sub   i64 %"n##0", 1 
-  %"1$tmp$1##0" = icmp slt i64 %"1$tmp$0##0", 0 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = sub   i64 %"n##0", 1 
+  %"1#tmp#1##0" = icmp slt i64 %"1#tmp#0##0", 0 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
   tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x1##0", i64  111)  
   tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3]"(i64  %"x2##0", i64  222)  
@@ -746,16 +746,16 @@ if.then:
   tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x4##0", i64  444)  
   ret void 
 if.else:
-  tail call fastcc  void  @"multi_specz_cyclic_lib.foo1<0>[7477e50a09]"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1$tmp$0##0")  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.foo1<0>[7477e50a09]"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1#tmp#0##0")  
   ret void 
 }
 
 
 define external fastcc  void @"multi_specz_cyclic_lib2.foo2<0>[d4b0b4930c]"(i64  %"x1##0", i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"n##0")    {
 entry:
-  %"1$tmp$0##0" = sub   i64 %"n##0", 1 
-  %"1$tmp$1##0" = icmp slt i64 %"1$tmp$0##0", 0 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = sub   i64 %"n##0", 1 
+  %"1#tmp#1##0" = icmp slt i64 %"1#tmp#0##0", 0 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
   tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3]"(i64  %"x1##0", i64  111)  
   tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x2##0", i64  222)  
@@ -763,6 +763,6 @@ if.then:
   tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>[410bae77d3]"(i64  %"x4##0", i64  444)  
   ret void 
 if.else:
-  tail call fastcc  void  @"multi_specz_cyclic_lib.foo1<0>[29a1d4275b]"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1$tmp$0##0")  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.foo1<0>[29a1d4275b]"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1#tmp#0##0")  
   ret void 
 }

--- a/test-cases/final-dump/multi_specz_cyclic_lib.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_lib.exp
@@ -24,46 +24,46 @@ AFTER EVERYTHING:
 
 foo1 > public (0 calls)
 0: multi_specz_cyclic_lib.foo1<0>
-foo1(x1#0:multi_specz_cyclic_lib.position, x2#0:multi_specz_cyclic_lib.position, x3#0:multi_specz_cyclic_lib.position, x4#0:multi_specz_cyclic_lib.position, n#0:wybe.int, io#0:wybe.phantom, ?io#4:wybe.phantom):
+foo1(x1##0:multi_specz_cyclic_lib.position, x2##0:multi_specz_cyclic_lib.position, x3##0:multi_specz_cyclic_lib.position, x4##0:multi_specz_cyclic_lib.position, n##0:wybe.int, io##0:wybe.phantom, ?io##4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0,InterestingUnaliased 1,InterestingUnaliased 2,InterestingUnaliased 3]
  MultiSpeczDepInfo: [(2,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [0]])),(3,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [1]])),(4,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [2]])),(5,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [3]])),(6,(multi_specz_cyclic_lib2.foo2<0>,fromList [NonAliasedParamCond 0 [1],NonAliasedParamCond 1 [2],NonAliasedParamCond 2 [3],NonAliasedParamCond 3 [0]]))]
-    foreign llvm sub(~n#0:wybe.int, 1:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn
-    foreign llvm icmp_slt(tmp$0#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
+    foreign llvm icmp_slt(tmp$0##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        multi_specz_cyclic_lib2.foo2<0>(~x2#0:multi_specz_cyclic_lib.position, ~x3#0:multi_specz_cyclic_lib.position, ~x4#0:multi_specz_cyclic_lib.position, ~x1#0:multi_specz_cyclic_lib.position, ~tmp$0#0:wybe.int, ~#io#0:wybe.phantom, ?#io#4:wybe.phantom) #6 @multi_specz_cyclic_lib:nn:nn
+        multi_specz_cyclic_lib2.foo2<0>(~x2##0:multi_specz_cyclic_lib.position, ~x3##0:multi_specz_cyclic_lib.position, ~x4##0:multi_specz_cyclic_lib.position, ~x1##0:multi_specz_cyclic_lib.position, ~tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?#io##4:wybe.phantom) #6 @multi_specz_cyclic_lib:nn:nn
 
     1:
-        multi_specz_cyclic_lib.modifyAndPrint<0>(~x1#0:multi_specz_cyclic_lib.position, 111:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #2 @multi_specz_cyclic_lib:nn:nn
-        multi_specz_cyclic_lib.modifyAndPrint<0>(~x2#0:multi_specz_cyclic_lib.position, 222:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #3 @multi_specz_cyclic_lib:nn:nn
-        multi_specz_cyclic_lib.modifyAndPrint<0>(~x3#0:multi_specz_cyclic_lib.position, 333:wybe.int, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) #4 @multi_specz_cyclic_lib:nn:nn
-        multi_specz_cyclic_lib.modifyAndPrint<0>(~x4#0:multi_specz_cyclic_lib.position, 444:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #5 @multi_specz_cyclic_lib:nn:nn
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x1##0:multi_specz_cyclic_lib.position, 111:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @multi_specz_cyclic_lib:nn:nn
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x2##0:multi_specz_cyclic_lib.position, 222:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #3 @multi_specz_cyclic_lib:nn:nn
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x3##0:multi_specz_cyclic_lib.position, 333:wybe.int, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #4 @multi_specz_cyclic_lib:nn:nn
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x4##0:multi_specz_cyclic_lib.position, 444:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #5 @multi_specz_cyclic_lib:nn:nn
 
 
 
 modifyAndPrint > public (4 calls)
 0: multi_specz_cyclic_lib.modifyAndPrint<0>
-modifyAndPrint(pos#0:multi_specz_cyclic_lib.position, v#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+modifyAndPrint(pos##0:multi_specz_cyclic_lib.position, v##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
-    foreign lpvm {noalias} mutate(~%pos#0:multi_specz_cyclic_lib.position, ?%pos#1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~v#0:wybe.int)
-    multi_specz_cyclic_lib.printPosition<0>(~pos#1:multi_specz_cyclic_lib.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #1 @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm {noalias} mutate(~%pos##0:multi_specz_cyclic_lib.position, ?%pos##1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
+    multi_specz_cyclic_lib.printPosition<0>(~pos##1:multi_specz_cyclic_lib.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @multi_specz_cyclic_lib:nn:nn
 
 
 printPosition > public (1 calls)
 0: multi_specz_cyclic_lib.printPosition<0>
-printPosition(pos#0:multi_specz_cyclic_lib.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+printPosition(pos##0:multi_specz_cyclic_lib.position, io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos#0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string(",":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos#0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io#4:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -100,51 +100,51 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"multi_specz_cyclic_lib.foo1<0>"(i64  %"x1#0", i64  %"x2#0", i64  %"x3#0", i64  %"x4#0", i64  %"n#0")    {
+define external fastcc  void @"multi_specz_cyclic_lib.foo1<0>"(i64  %"x1##0", i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"n##0")    {
 entry:
-  %"1$tmp$0#0" = sub   i64 %"n#0", 1 
-  %"1$tmp$1#0" = icmp slt i64 %"1$tmp$0#0", 0 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = sub   i64 %"n##0", 1 
+  %"1$tmp$1##0" = icmp slt i64 %"1$tmp$0##0", 0 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x1#0", i64  111)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x2#0", i64  222)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x3#0", i64  333)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x4#0", i64  444)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x1##0", i64  111)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x2##0", i64  222)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x3##0", i64  333)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x4##0", i64  444)  
   ret void 
 if.else:
-  tail call fastcc  void  @"multi_specz_cyclic_lib2.foo2<0>"(i64  %"x2#0", i64  %"x3#0", i64  %"x4#0", i64  %"x1#0", i64  %"1$tmp$0#0")  
+  tail call fastcc  void  @"multi_specz_cyclic_lib2.foo2<0>"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1$tmp$0##0")  
   ret void 
 }
 
 
-define external fastcc  void @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"pos#0", i64  %"v#0")    {
+define external fastcc  void @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"pos##0", i64  %"v##0")    {
 entry:
   %1 = trunc i64 16 to i32  
   %2 = tail call ccc  i8*  @wybe_malloc(i32  %1)  
   %3 = ptrtoint i8* %2 to i64 
   %4 = inttoptr i64 %3 to i8* 
-  %5 = inttoptr i64 %"pos#0" to i8* 
+  %5 = inttoptr i64 %"pos##0" to i8* 
   %6 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i32  8, i1  0)  
   %7 = inttoptr i64 %3 to i64* 
   %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"v#0", i64* %8 
+  store  i64 %"v##0", i64* %8 
   tail call fastcc  void  @"multi_specz_cyclic_lib.printPosition<0>"(i64  %3)  
   ret void 
 }
 
 
-define external fastcc  void @"multi_specz_cyclic_lib.printPosition<0>"(i64  %"pos#0")    {
+define external fastcc  void @"multi_specz_cyclic_lib.printPosition<0>"(i64  %"pos##0")    {
 entry:
   %10 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @multi_specz_cyclic_lib.9, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %10)  
-  %11 = inttoptr i64 %"pos#0" to i64* 
+  %11 = inttoptr i64 %"pos##0" to i64* 
   %12 = getelementptr  i64, i64* %11, i64 0 
   %13 = load  i64, i64* %12 
   tail call ccc  void  @print_int(i64  %13)  
   %15 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @multi_specz_cyclic_lib.14, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %15)  
-  %16 = add   i64 %"pos#0", 8 
+  %16 = add   i64 %"pos##0", 8 
   %17 = inttoptr i64 %16 to i64* 
   %18 = getelementptr  i64, i64* %17, i64 0 
   %19 = load  i64, i64* %18 
@@ -174,86 +174,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: multi_specz_cyclic_lib.position.=<0>
-=($left#0:multi_specz_cyclic_lib.position, $right#0:multi_specz_cyclic_lib.position, ?$$#0:wybe.bool):
+=($left##0:multi_specz_cyclic_lib.position, $right##0:multi_specz_cyclic_lib.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
-    foreign lpvm access(~$left#0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y#0:wybe.int)
-    foreign lpvm access($right#0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x#0:wybe.int)
-    foreign lpvm access(~$right#0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y#0:wybe.int)
-    foreign llvm icmp_eq(~$left$x#0:wybe.int, ~$right$x#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
+    foreign lpvm access(~$left##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
+    foreign lpvm access($right##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
+    foreign lpvm access(~$right##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
+    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y#0:wybe.int, ~$right$y#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.position<0>
-position(x#0:wybe.int, y#0:wybe.int, ?$#0:multi_specz_cyclic_lib.position):
+position(x##0:wybe.int, y##0:wybe.int, ?$##0:multi_specz_cyclic_lib.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:multi_specz_cyclic_lib.position)
-    foreign lpvm mutate(~$rec#0:multi_specz_cyclic_lib.position, ?$rec#1:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:multi_specz_cyclic_lib.position, ?$#0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:multi_specz_cyclic_lib.position)
+    foreign lpvm mutate(~$rec##0:multi_specz_cyclic_lib.position, ?$rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:multi_specz_cyclic_lib.position, ?$##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: multi_specz_cyclic_lib.position.position<1>
-position(?x#0:wybe.int, ?y#0:wybe.int, $#0:multi_specz_cyclic_lib.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, $##0:multi_specz_cyclic_lib.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
-    foreign lpvm access(~$#0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y#0:wybe.int)
+    foreign lpvm access($##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~$##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.x<0>
-x($rec#0:multi_specz_cyclic_lib.position, ?$#0:wybe.int):
+x($rec##0:multi_specz_cyclic_lib.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 x > public {inline} (0 calls)
 1: multi_specz_cyclic_lib.position.x<1>
-x($rec#0:multi_specz_cyclic_lib.position, ?$rec#1:multi_specz_cyclic_lib.position, $field#0:wybe.int):
+x($rec##0:multi_specz_cyclic_lib.position, ?$rec##1:multi_specz_cyclic_lib.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:multi_specz_cyclic_lib.position, ?$rec#1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:multi_specz_cyclic_lib.position, ?$rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.y<0>
-y($rec#0:multi_specz_cyclic_lib.position, ?$#0:wybe.int):
+y($rec##0:multi_specz_cyclic_lib.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 y > public {inline} (0 calls)
 1: multi_specz_cyclic_lib.position.y<1>
-y($rec#0:multi_specz_cyclic_lib.position, ?$rec#1:multi_specz_cyclic_lib.position, $field#0:wybe.int):
+y($rec##0:multi_specz_cyclic_lib.position, ?$rec##1:multi_specz_cyclic_lib.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:multi_specz_cyclic_lib.position, ?$rec#1:multi_specz_cyclic_lib.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:multi_specz_cyclic_lib.position, ?$rec##1:multi_specz_cyclic_lib.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.~=<0>
-~=($left#0:multi_specz_cyclic_lib.position, $right#0:multi_specz_cyclic_lib.position, ?$$#0:wybe.bool):
+~=($left##0:multi_specz_cyclic_lib.position, $right##0:multi_specz_cyclic_lib.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -270,54 +270,54 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"multi_specz_cyclic_lib.position.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"multi_specz_cyclic_lib.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$#0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = icmp eq i64 %7, %14 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.position<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"x#0", i64* %19 
+  store  i64 %"x##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"y#0", i64* %22 
+  store  i64 %"y##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64} @"multi_specz_cyclic_lib.position.position<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"multi_specz_cyclic_lib.position.position<1>"(i64  %"$##0")    {
 entry:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -327,34 +327,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<0>"(i64  %"$rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec#0" to i64* 
+  %32 = inttoptr i64 %"$rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec#0" to i8* 
+  %39 = inttoptr i64 %"$rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field#0", i64* %42 
+  store  i64 %"$field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = add   i64 %"$rec#0", 8 
+  %43 = add   i64 %"$rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -362,48 +362,48 @@ entry:
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec#0" to i8* 
+  %51 = inttoptr i64 %"$rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field#0", i64* %55 
+  store  i64 %"$field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"multi_specz_cyclic_lib.position.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"multi_specz_cyclic_lib.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %58, %65 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = icmp eq i64 %62, %69 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$0##0" = icmp eq i64 %62, %69 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }
 --------------------------------------------------
  Module multi_specz_cyclic_lib2
@@ -418,21 +418,21 @@ if.else:
 
 foo2 > public (0 calls)
 0: multi_specz_cyclic_lib2.foo2<0>
-foo2(x1#0:multi_specz_cyclic_lib.position, x2#0:multi_specz_cyclic_lib.position, x3#0:multi_specz_cyclic_lib.position, x4#0:multi_specz_cyclic_lib.position, n#0:wybe.int, io#0:wybe.phantom, ?io#4:wybe.phantom):
+foo2(x1##0:multi_specz_cyclic_lib.position, x2##0:multi_specz_cyclic_lib.position, x3##0:multi_specz_cyclic_lib.position, x4##0:multi_specz_cyclic_lib.position, n##0:wybe.int, io##0:wybe.phantom, ?io##4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0,InterestingUnaliased 1,InterestingUnaliased 2,InterestingUnaliased 3]
  MultiSpeczDepInfo: [(2,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [0]])),(3,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [1]])),(4,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [2]])),(5,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [3]])),(6,(multi_specz_cyclic_lib.foo1<0>,fromList [NonAliasedParamCond 0 [1],NonAliasedParamCond 1 [2],NonAliasedParamCond 2 [3],NonAliasedParamCond 3 [0]]))]
-    foreign llvm sub(~n#0:wybe.int, 1:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn
-    foreign llvm icmp_slt(tmp$0#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
+    foreign llvm icmp_slt(tmp$0##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        multi_specz_cyclic_lib.foo1<0>(~x2#0:multi_specz_cyclic_lib.position, ~x3#0:multi_specz_cyclic_lib.position, ~x4#0:multi_specz_cyclic_lib.position, ~x1#0:multi_specz_cyclic_lib.position, ~tmp$0#0:wybe.int, ~#io#0:wybe.phantom, ?#io#4:wybe.phantom) #6 @multi_specz_cyclic_lib2:11:14
+        multi_specz_cyclic_lib.foo1<0>(~x2##0:multi_specz_cyclic_lib.position, ~x3##0:multi_specz_cyclic_lib.position, ~x4##0:multi_specz_cyclic_lib.position, ~x1##0:multi_specz_cyclic_lib.position, ~tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?#io##4:wybe.phantom) #6 @multi_specz_cyclic_lib2:11:14
 
     1:
-        multi_specz_cyclic_lib.modifyAndPrint<0>(~x1#0:multi_specz_cyclic_lib.position, 111:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #2 @multi_specz_cyclic_lib2:6:14
-        multi_specz_cyclic_lib.modifyAndPrint<0>(~x2#0:multi_specz_cyclic_lib.position, 222:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #3 @multi_specz_cyclic_lib2:7:14
-        multi_specz_cyclic_lib.modifyAndPrint<0>(~x3#0:multi_specz_cyclic_lib.position, 333:wybe.int, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) #4 @multi_specz_cyclic_lib2:8:14
-        multi_specz_cyclic_lib.modifyAndPrint<0>(~x4#0:multi_specz_cyclic_lib.position, 444:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #5 @multi_specz_cyclic_lib2:9:14
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x1##0:multi_specz_cyclic_lib.position, 111:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @multi_specz_cyclic_lib2:6:14
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x2##0:multi_specz_cyclic_lib.position, 222:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #3 @multi_specz_cyclic_lib2:7:14
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x3##0:multi_specz_cyclic_lib.position, 333:wybe.int, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #4 @multi_specz_cyclic_lib2:8:14
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x4##0:multi_specz_cyclic_lib.position, 444:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #5 @multi_specz_cyclic_lib2:9:14
 
 
   LLVM code       :
@@ -455,18 +455,18 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"multi_specz_cyclic_lib2.foo2<0>"(i64  %"x1#0", i64  %"x2#0", i64  %"x3#0", i64  %"x4#0", i64  %"n#0")    {
+define external fastcc  void @"multi_specz_cyclic_lib2.foo2<0>"(i64  %"x1##0", i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"n##0")    {
 entry:
-  %"1$tmp$0#0" = sub   i64 %"n#0", 1 
-  %"1$tmp$1#0" = icmp slt i64 %"1$tmp$0#0", 0 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = sub   i64 %"n##0", 1 
+  %"1$tmp$1##0" = icmp slt i64 %"1$tmp$0##0", 0 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x1#0", i64  111)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x2#0", i64  222)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x3#0", i64  333)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x4#0", i64  444)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x1##0", i64  111)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x2##0", i64  222)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x3##0", i64  333)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x4##0", i64  444)  
   ret void 
 if.else:
-  tail call fastcc  void  @"multi_specz_cyclic_lib.foo1<0>"(i64  %"x2#0", i64  %"x3#0", i64  %"x4#0", i64  %"x1#0", i64  %"1$tmp$0#0")  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.foo1<0>"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1$tmp$0##0")  
   ret void 
 }

--- a/test-cases/final-dump/multi_specz_cyclic_lib.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_lib.exp
@@ -193,27 +193,27 @@ entry:
 
 position > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?###0:multi_specz_cyclic_lib.position):
+position(x##0:wybe.int, y##0:wybe.int, ?#result##0:multi_specz_cyclic_lib.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:multi_specz_cyclic_lib.position)
     foreign lpvm mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:multi_specz_cyclic_lib.position, ?###0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:multi_specz_cyclic_lib.position, ?#result##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: multi_specz_cyclic_lib.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, ###0:multi_specz_cyclic_lib.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:multi_specz_cyclic_lib.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~###0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~#result##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.x<0>
-x(#rec##0:multi_specz_cyclic_lib.position, ?###0:wybe.int):
+x(#rec##0:multi_specz_cyclic_lib.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 x > public {inline} (0 calls)
 1: multi_specz_cyclic_lib.position.x<1>
 x(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, #field##0:wybe.int):
@@ -224,10 +224,10 @@ x(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.posit
 
 y > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.y<0>
-y(#rec##0:multi_specz_cyclic_lib.position, ?###0:wybe.int):
+y(#rec##0:multi_specz_cyclic_lib.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 y > public {inline} (0 calls)
 1: multi_specz_cyclic_lib.position.y<1>
 y(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, #field##0:wybe.int):
@@ -312,12 +312,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"multi_specz_cyclic_lib.position.position<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"multi_specz_cyclic_lib.position.position<1>"(i64  %"#result##0")    {
 entry:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 

--- a/test-cases/final-dump/multi_specz_cyclic_lib.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_lib.exp
@@ -174,7 +174,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: multi_specz_cyclic_lib.position.=<0>
-=(#left##0:multi_specz_cyclic_lib.position, #right##0:multi_specz_cyclic_lib.position, ?####0:wybe.bool):
+=(#left##0:multi_specz_cyclic_lib.position, #right##0:multi_specz_cyclic_lib.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
@@ -184,10 +184,10 @@ entry:
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -238,7 +238,7 @@ y(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.posit
 
 ~= > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.~=<0>
-~=(#left##0:multi_specz_cyclic_lib.position, #right##0:multi_specz_cyclic_lib.position, ?####0:wybe.bool):
+~=(#left##0:multi_specz_cyclic_lib.position, #right##0:multi_specz_cyclic_lib.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -249,11 +249,11 @@ y(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.posit
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -289,8 +289,8 @@ entry:
   %"1#tmp#1##0" = icmp eq i64 %3, %10 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2#####0" = icmp eq i64 %7, %14 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %7, %14 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -399,11 +399,11 @@ entry:
   br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#0##0" = icmp eq i64 %62, %69 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }
 --------------------------------------------------
  Module multi_specz_cyclic_lib2

--- a/test-cases/final-dump/multi_specz_cyclic_lib.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_lib.exp
@@ -28,11 +28,11 @@ foo1(x1##0:multi_specz_cyclic_lib.position, x2##0:multi_specz_cyclic_lib.positio
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0,InterestingUnaliased 1,InterestingUnaliased 2,InterestingUnaliased 3]
  MultiSpeczDepInfo: [(2,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [0]])),(3,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [1]])),(4,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [2]])),(5,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [3]])),(6,(multi_specz_cyclic_lib2.foo2<0>,fromList [NonAliasedParamCond 0 [1],NonAliasedParamCond 1 [2],NonAliasedParamCond 2 [3],NonAliasedParamCond 3 [0]]))]
-    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
-    foreign llvm icmp_slt(tmp$0##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
+    foreign llvm icmp_slt(tmp#0##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        multi_specz_cyclic_lib2.foo2<0>(~x2##0:multi_specz_cyclic_lib.position, ~x3##0:multi_specz_cyclic_lib.position, ~x4##0:multi_specz_cyclic_lib.position, ~x1##0:multi_specz_cyclic_lib.position, ~tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?#io##4:wybe.phantom) #6 @multi_specz_cyclic_lib:nn:nn
+        multi_specz_cyclic_lib2.foo2<0>(~x2##0:multi_specz_cyclic_lib.position, ~x3##0:multi_specz_cyclic_lib.position, ~x4##0:multi_specz_cyclic_lib.position, ~x1##0:multi_specz_cyclic_lib.position, ~tmp#0##0:wybe.int, ~#io##0:wybe.phantom, ?#io##4:wybe.phantom) #6 @multi_specz_cyclic_lib:nn:nn
 
     1:
         multi_specz_cyclic_lib.modifyAndPrint<0>(~x1##0:multi_specz_cyclic_lib.position, 111:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @multi_specz_cyclic_lib:nn:nn
@@ -57,13 +57,13 @@ printPosition(pos##0:multi_specz_cyclic_lib.position, io##0:wybe.phantom, ?io##5
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -102,9 +102,9 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"multi_specz_cyclic_lib.foo1<0>"(i64  %"x1##0", i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"n##0")    {
 entry:
-  %"1$tmp$0##0" = sub   i64 %"n##0", 1 
-  %"1$tmp$1##0" = icmp slt i64 %"1$tmp$0##0", 0 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = sub   i64 %"n##0", 1 
+  %"1#tmp#1##0" = icmp slt i64 %"1#tmp#0##0", 0 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
   tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x1##0", i64  111)  
   tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x2##0", i64  222)  
@@ -112,7 +112,7 @@ if.then:
   tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x4##0", i64  444)  
   ret void 
 if.else:
-  tail call fastcc  void  @"multi_specz_cyclic_lib2.foo2<0>"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1$tmp$0##0")  
+  tail call fastcc  void  @"multi_specz_cyclic_lib2.foo2<0>"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1#tmp#0##0")  
   ret void 
 }
 
@@ -174,86 +174,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: multi_specz_cyclic_lib.position.=<0>
-=($left##0:multi_specz_cyclic_lib.position, $right##0:multi_specz_cyclic_lib.position, ?$$##0:wybe.bool):
+=(#left##0:multi_specz_cyclic_lib.position, #right##0:multi_specz_cyclic_lib.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
-    foreign lpvm access(~$left##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
-    foreign lpvm access($right##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
-    foreign lpvm access(~$right##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
-    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
+    foreign lpvm access(~#left##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
+    foreign lpvm access(#right##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
+    foreign lpvm access(~#right##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?$##0:multi_specz_cyclic_lib.position):
+position(x##0:wybe.int, y##0:wybe.int, ?###0:multi_specz_cyclic_lib.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:multi_specz_cyclic_lib.position)
-    foreign lpvm mutate(~$rec##0:multi_specz_cyclic_lib.position, ?$rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:multi_specz_cyclic_lib.position, ?$##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:multi_specz_cyclic_lib.position)
+    foreign lpvm mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:multi_specz_cyclic_lib.position, ?###0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: multi_specz_cyclic_lib.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, $##0:multi_specz_cyclic_lib.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, ###0:multi_specz_cyclic_lib.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~$##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(###0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~###0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.x<0>
-x($rec##0:multi_specz_cyclic_lib.position, ?$##0:wybe.int):
+x(#rec##0:multi_specz_cyclic_lib.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 x > public {inline} (0 calls)
 1: multi_specz_cyclic_lib.position.x<1>
-x($rec##0:multi_specz_cyclic_lib.position, ?$rec##1:multi_specz_cyclic_lib.position, $field##0:wybe.int):
+x(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:multi_specz_cyclic_lib.position, ?$rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.y<0>
-y($rec##0:multi_specz_cyclic_lib.position, ?$##0:wybe.int):
+y(#rec##0:multi_specz_cyclic_lib.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 y > public {inline} (0 calls)
 1: multi_specz_cyclic_lib.position.y<1>
-y($rec##0:multi_specz_cyclic_lib.position, ?$rec##1:multi_specz_cyclic_lib.position, $field##0:wybe.int):
+y(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:multi_specz_cyclic_lib.position, ?$rec##1:multi_specz_cyclic_lib.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.~=<0>
-~=($left##0:multi_specz_cyclic_lib.position, $right##0:multi_specz_cyclic_lib.position, ?$$##0:wybe.bool):
+~=(#left##0:multi_specz_cyclic_lib.position, #right##0:multi_specz_cyclic_lib.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -270,27 +270,27 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"multi_specz_cyclic_lib.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"multi_specz_cyclic_lib.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$##0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$##0" 
+  %"2#####0" = icmp eq i64 %7, %14 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
@@ -312,12 +312,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"multi_specz_cyclic_lib.position.position<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"multi_specz_cyclic_lib.position.position<1>"(i64  %"###0")    {
 entry:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -327,34 +327,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<0>"(i64  %"#rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec##0" to i64* 
+  %32 = inttoptr i64 %"#rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec##0" to i8* 
+  %39 = inttoptr i64 %"#rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field##0", i64* %42 
+  store  i64 %"#field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = add   i64 %"$rec##0", 8 
+  %43 = add   i64 %"#rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -362,48 +362,48 @@ entry:
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec##0" to i8* 
+  %51 = inttoptr i64 %"#rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field##0", i64* %55 
+  store  i64 %"#field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"multi_specz_cyclic_lib.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"multi_specz_cyclic_lib.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %58, %65 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = icmp eq i64 %62, %69 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#0##0" = icmp eq i64 %62, %69 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }
 --------------------------------------------------
  Module multi_specz_cyclic_lib2
@@ -422,11 +422,11 @@ foo2(x1##0:multi_specz_cyclic_lib.position, x2##0:multi_specz_cyclic_lib.positio
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0,InterestingUnaliased 1,InterestingUnaliased 2,InterestingUnaliased 3]
  MultiSpeczDepInfo: [(2,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [0]])),(3,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [1]])),(4,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [2]])),(5,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [3]])),(6,(multi_specz_cyclic_lib.foo1<0>,fromList [NonAliasedParamCond 0 [1],NonAliasedParamCond 1 [2],NonAliasedParamCond 2 [3],NonAliasedParamCond 3 [0]]))]
-    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
-    foreign llvm icmp_slt(tmp$0##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
+    foreign llvm icmp_slt(tmp#0##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        multi_specz_cyclic_lib.foo1<0>(~x2##0:multi_specz_cyclic_lib.position, ~x3##0:multi_specz_cyclic_lib.position, ~x4##0:multi_specz_cyclic_lib.position, ~x1##0:multi_specz_cyclic_lib.position, ~tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?#io##4:wybe.phantom) #6 @multi_specz_cyclic_lib2:11:14
+        multi_specz_cyclic_lib.foo1<0>(~x2##0:multi_specz_cyclic_lib.position, ~x3##0:multi_specz_cyclic_lib.position, ~x4##0:multi_specz_cyclic_lib.position, ~x1##0:multi_specz_cyclic_lib.position, ~tmp#0##0:wybe.int, ~#io##0:wybe.phantom, ?#io##4:wybe.phantom) #6 @multi_specz_cyclic_lib2:11:14
 
     1:
         multi_specz_cyclic_lib.modifyAndPrint<0>(~x1##0:multi_specz_cyclic_lib.position, 111:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @multi_specz_cyclic_lib2:6:14
@@ -457,9 +457,9 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"multi_specz_cyclic_lib2.foo2<0>"(i64  %"x1##0", i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"n##0")    {
 entry:
-  %"1$tmp$0##0" = sub   i64 %"n##0", 1 
-  %"1$tmp$1##0" = icmp slt i64 %"1$tmp$0##0", 0 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = sub   i64 %"n##0", 1 
+  %"1#tmp#1##0" = icmp slt i64 %"1#tmp#0##0", 0 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
   tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x1##0", i64  111)  
   tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x2##0", i64  222)  
@@ -467,6 +467,6 @@ if.then:
   tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x4##0", i64  444)  
   ret void 
 if.else:
-  tail call fastcc  void  @"multi_specz_cyclic_lib.foo1<0>"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1$tmp$0##0")  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.foo1<0>"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1#tmp#0##0")  
   ret void 
 }

--- a/test-cases/final-dump/multi_specz_cyclic_lib2.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_lib2.exp
@@ -24,46 +24,46 @@ AFTER EVERYTHING:
 
 foo1 > public (0 calls)
 0: multi_specz_cyclic_lib.foo1<0>
-foo1(x1#0:multi_specz_cyclic_lib.position, x2#0:multi_specz_cyclic_lib.position, x3#0:multi_specz_cyclic_lib.position, x4#0:multi_specz_cyclic_lib.position, n#0:wybe.int, io#0:wybe.phantom, ?io#4:wybe.phantom):
+foo1(x1##0:multi_specz_cyclic_lib.position, x2##0:multi_specz_cyclic_lib.position, x3##0:multi_specz_cyclic_lib.position, x4##0:multi_specz_cyclic_lib.position, n##0:wybe.int, io##0:wybe.phantom, ?io##4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0,InterestingUnaliased 1,InterestingUnaliased 2,InterestingUnaliased 3]
  MultiSpeczDepInfo: [(2,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [0]])),(3,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [1]])),(4,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [2]])),(5,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [3]])),(6,(multi_specz_cyclic_lib2.foo2<0>,fromList [NonAliasedParamCond 0 [1],NonAliasedParamCond 1 [2],NonAliasedParamCond 2 [3],NonAliasedParamCond 3 [0]]))]
-    foreign llvm sub(~n#0:wybe.int, 1:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn
-    foreign llvm icmp_slt(tmp$0#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
+    foreign llvm icmp_slt(tmp$0##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        multi_specz_cyclic_lib2.foo2<0>(~x2#0:multi_specz_cyclic_lib.position, ~x3#0:multi_specz_cyclic_lib.position, ~x4#0:multi_specz_cyclic_lib.position, ~x1#0:multi_specz_cyclic_lib.position, ~tmp$0#0:wybe.int, ~#io#0:wybe.phantom, ?#io#4:wybe.phantom) #6 @multi_specz_cyclic_lib:nn:nn
+        multi_specz_cyclic_lib2.foo2<0>(~x2##0:multi_specz_cyclic_lib.position, ~x3##0:multi_specz_cyclic_lib.position, ~x4##0:multi_specz_cyclic_lib.position, ~x1##0:multi_specz_cyclic_lib.position, ~tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?#io##4:wybe.phantom) #6 @multi_specz_cyclic_lib:nn:nn
 
     1:
-        multi_specz_cyclic_lib.modifyAndPrint<0>(~x1#0:multi_specz_cyclic_lib.position, 111:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #2 @multi_specz_cyclic_lib:nn:nn
-        multi_specz_cyclic_lib.modifyAndPrint<0>(~x2#0:multi_specz_cyclic_lib.position, 222:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #3 @multi_specz_cyclic_lib:nn:nn
-        multi_specz_cyclic_lib.modifyAndPrint<0>(~x3#0:multi_specz_cyclic_lib.position, 333:wybe.int, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) #4 @multi_specz_cyclic_lib:nn:nn
-        multi_specz_cyclic_lib.modifyAndPrint<0>(~x4#0:multi_specz_cyclic_lib.position, 444:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #5 @multi_specz_cyclic_lib:nn:nn
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x1##0:multi_specz_cyclic_lib.position, 111:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @multi_specz_cyclic_lib:nn:nn
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x2##0:multi_specz_cyclic_lib.position, 222:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #3 @multi_specz_cyclic_lib:nn:nn
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x3##0:multi_specz_cyclic_lib.position, 333:wybe.int, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #4 @multi_specz_cyclic_lib:nn:nn
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x4##0:multi_specz_cyclic_lib.position, 444:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #5 @multi_specz_cyclic_lib:nn:nn
 
 
 
 modifyAndPrint > public (4 calls)
 0: multi_specz_cyclic_lib.modifyAndPrint<0>
-modifyAndPrint(pos#0:multi_specz_cyclic_lib.position, v#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+modifyAndPrint(pos##0:multi_specz_cyclic_lib.position, v##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
-    foreign lpvm {noalias} mutate(~%pos#0:multi_specz_cyclic_lib.position, ?%pos#1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~v#0:wybe.int)
-    multi_specz_cyclic_lib.printPosition<0>(~pos#1:multi_specz_cyclic_lib.position, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #1 @multi_specz_cyclic_lib:nn:nn
+    foreign lpvm {noalias} mutate(~%pos##0:multi_specz_cyclic_lib.position, ?%pos##1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~v##0:wybe.int)
+    multi_specz_cyclic_lib.printPosition<0>(~pos##1:multi_specz_cyclic_lib.position, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @multi_specz_cyclic_lib:nn:nn
 
 
 printPosition > public (1 calls)
 0: multi_specz_cyclic_lib.printPosition<0>
-printPosition(pos#0:multi_specz_cyclic_lib.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+printPosition(pos##0:multi_specz_cyclic_lib.position, io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos#0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string(",":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos#0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io#4:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -100,51 +100,51 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"multi_specz_cyclic_lib.foo1<0>"(i64  %"x1#0", i64  %"x2#0", i64  %"x3#0", i64  %"x4#0", i64  %"n#0")    {
+define external fastcc  void @"multi_specz_cyclic_lib.foo1<0>"(i64  %"x1##0", i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"n##0")    {
 entry:
-  %"1$tmp$0#0" = sub   i64 %"n#0", 1 
-  %"1$tmp$1#0" = icmp slt i64 %"1$tmp$0#0", 0 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = sub   i64 %"n##0", 1 
+  %"1$tmp$1##0" = icmp slt i64 %"1$tmp$0##0", 0 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x1#0", i64  111)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x2#0", i64  222)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x3#0", i64  333)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x4#0", i64  444)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x1##0", i64  111)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x2##0", i64  222)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x3##0", i64  333)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x4##0", i64  444)  
   ret void 
 if.else:
-  tail call fastcc  void  @"multi_specz_cyclic_lib2.foo2<0>"(i64  %"x2#0", i64  %"x3#0", i64  %"x4#0", i64  %"x1#0", i64  %"1$tmp$0#0")  
+  tail call fastcc  void  @"multi_specz_cyclic_lib2.foo2<0>"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1$tmp$0##0")  
   ret void 
 }
 
 
-define external fastcc  void @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"pos#0", i64  %"v#0")    {
+define external fastcc  void @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"pos##0", i64  %"v##0")    {
 entry:
   %1 = trunc i64 16 to i32  
   %2 = tail call ccc  i8*  @wybe_malloc(i32  %1)  
   %3 = ptrtoint i8* %2 to i64 
   %4 = inttoptr i64 %3 to i8* 
-  %5 = inttoptr i64 %"pos#0" to i8* 
+  %5 = inttoptr i64 %"pos##0" to i8* 
   %6 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %4, i8*  %5, i32  %6, i32  8, i1  0)  
   %7 = inttoptr i64 %3 to i64* 
   %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 %"v#0", i64* %8 
+  store  i64 %"v##0", i64* %8 
   tail call fastcc  void  @"multi_specz_cyclic_lib.printPosition<0>"(i64  %3)  
   ret void 
 }
 
 
-define external fastcc  void @"multi_specz_cyclic_lib.printPosition<0>"(i64  %"pos#0")    {
+define external fastcc  void @"multi_specz_cyclic_lib.printPosition<0>"(i64  %"pos##0")    {
 entry:
   %10 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @multi_specz_cyclic_lib.9, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %10)  
-  %11 = inttoptr i64 %"pos#0" to i64* 
+  %11 = inttoptr i64 %"pos##0" to i64* 
   %12 = getelementptr  i64, i64* %11, i64 0 
   %13 = load  i64, i64* %12 
   tail call ccc  void  @print_int(i64  %13)  
   %15 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @multi_specz_cyclic_lib.14, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %15)  
-  %16 = add   i64 %"pos#0", 8 
+  %16 = add   i64 %"pos##0", 8 
   %17 = inttoptr i64 %16 to i64* 
   %18 = getelementptr  i64, i64* %17, i64 0 
   %19 = load  i64, i64* %18 
@@ -174,86 +174,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: multi_specz_cyclic_lib.position.=<0>
-=($left#0:multi_specz_cyclic_lib.position, $right#0:multi_specz_cyclic_lib.position, ?$$#0:wybe.bool):
+=($left##0:multi_specz_cyclic_lib.position, $right##0:multi_specz_cyclic_lib.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
-    foreign lpvm access(~$left#0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y#0:wybe.int)
-    foreign lpvm access($right#0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x#0:wybe.int)
-    foreign lpvm access(~$right#0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y#0:wybe.int)
-    foreign llvm icmp_eq(~$left$x#0:wybe.int, ~$right$x#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
+    foreign lpvm access(~$left##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
+    foreign lpvm access($right##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
+    foreign lpvm access(~$right##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
+    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y#0:wybe.int, ~$right$y#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.position<0>
-position(x#0:wybe.int, y#0:wybe.int, ?$#0:multi_specz_cyclic_lib.position):
+position(x##0:wybe.int, y##0:wybe.int, ?$##0:multi_specz_cyclic_lib.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:multi_specz_cyclic_lib.position)
-    foreign lpvm mutate(~$rec#0:multi_specz_cyclic_lib.position, ?$rec#1:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:multi_specz_cyclic_lib.position, ?$#0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:multi_specz_cyclic_lib.position)
+    foreign lpvm mutate(~$rec##0:multi_specz_cyclic_lib.position, ?$rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:multi_specz_cyclic_lib.position, ?$##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: multi_specz_cyclic_lib.position.position<1>
-position(?x#0:wybe.int, ?y#0:wybe.int, $#0:multi_specz_cyclic_lib.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, $##0:multi_specz_cyclic_lib.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
-    foreign lpvm access(~$#0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y#0:wybe.int)
+    foreign lpvm access($##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~$##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.x<0>
-x($rec#0:multi_specz_cyclic_lib.position, ?$#0:wybe.int):
+x($rec##0:multi_specz_cyclic_lib.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 x > public {inline} (0 calls)
 1: multi_specz_cyclic_lib.position.x<1>
-x($rec#0:multi_specz_cyclic_lib.position, ?$rec#1:multi_specz_cyclic_lib.position, $field#0:wybe.int):
+x($rec##0:multi_specz_cyclic_lib.position, ?$rec##1:multi_specz_cyclic_lib.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:multi_specz_cyclic_lib.position, ?$rec#1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:multi_specz_cyclic_lib.position, ?$rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.y<0>
-y($rec#0:multi_specz_cyclic_lib.position, ?$#0:wybe.int):
+y($rec##0:multi_specz_cyclic_lib.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 y > public {inline} (0 calls)
 1: multi_specz_cyclic_lib.position.y<1>
-y($rec#0:multi_specz_cyclic_lib.position, ?$rec#1:multi_specz_cyclic_lib.position, $field#0:wybe.int):
+y($rec##0:multi_specz_cyclic_lib.position, ?$rec##1:multi_specz_cyclic_lib.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:multi_specz_cyclic_lib.position, ?$rec#1:multi_specz_cyclic_lib.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:multi_specz_cyclic_lib.position, ?$rec##1:multi_specz_cyclic_lib.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.~=<0>
-~=($left#0:multi_specz_cyclic_lib.position, $right#0:multi_specz_cyclic_lib.position, ?$$#0:wybe.bool):
+~=($left##0:multi_specz_cyclic_lib.position, $right##0:multi_specz_cyclic_lib.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -270,54 +270,54 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"multi_specz_cyclic_lib.position.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"multi_specz_cyclic_lib.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$#0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = icmp eq i64 %7, %14 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.position<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"x#0", i64* %19 
+  store  i64 %"x##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"y#0", i64* %22 
+  store  i64 %"y##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64} @"multi_specz_cyclic_lib.position.position<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"multi_specz_cyclic_lib.position.position<1>"(i64  %"$##0")    {
 entry:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -327,34 +327,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<0>"(i64  %"$rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec#0" to i64* 
+  %32 = inttoptr i64 %"$rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec#0" to i8* 
+  %39 = inttoptr i64 %"$rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field#0", i64* %42 
+  store  i64 %"$field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = add   i64 %"$rec#0", 8 
+  %43 = add   i64 %"$rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -362,48 +362,48 @@ entry:
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec#0" to i8* 
+  %51 = inttoptr i64 %"$rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field#0", i64* %55 
+  store  i64 %"$field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"multi_specz_cyclic_lib.position.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"multi_specz_cyclic_lib.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %58, %65 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = icmp eq i64 %62, %69 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$0##0" = icmp eq i64 %62, %69 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }
 --------------------------------------------------
  Module multi_specz_cyclic_lib2
@@ -418,21 +418,21 @@ if.else:
 
 foo2 > public (0 calls)
 0: multi_specz_cyclic_lib2.foo2<0>
-foo2(x1#0:multi_specz_cyclic_lib.position, x2#0:multi_specz_cyclic_lib.position, x3#0:multi_specz_cyclic_lib.position, x4#0:multi_specz_cyclic_lib.position, n#0:wybe.int, io#0:wybe.phantom, ?io#4:wybe.phantom):
+foo2(x1##0:multi_specz_cyclic_lib.position, x2##0:multi_specz_cyclic_lib.position, x3##0:multi_specz_cyclic_lib.position, x4##0:multi_specz_cyclic_lib.position, n##0:wybe.int, io##0:wybe.phantom, ?io##4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0,InterestingUnaliased 1,InterestingUnaliased 2,InterestingUnaliased 3]
  MultiSpeczDepInfo: [(2,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [0]])),(3,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [1]])),(4,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [2]])),(5,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [3]])),(6,(multi_specz_cyclic_lib.foo1<0>,fromList [NonAliasedParamCond 0 [1],NonAliasedParamCond 1 [2],NonAliasedParamCond 2 [3],NonAliasedParamCond 3 [0]]))]
-    foreign llvm sub(~n#0:wybe.int, 1:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn
-    foreign llvm icmp_slt(tmp$0#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
+    foreign llvm icmp_slt(tmp$0##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        multi_specz_cyclic_lib.foo1<0>(~x2#0:multi_specz_cyclic_lib.position, ~x3#0:multi_specz_cyclic_lib.position, ~x4#0:multi_specz_cyclic_lib.position, ~x1#0:multi_specz_cyclic_lib.position, ~tmp$0#0:wybe.int, ~#io#0:wybe.phantom, ?#io#4:wybe.phantom) #6 @multi_specz_cyclic_lib2:11:14
+        multi_specz_cyclic_lib.foo1<0>(~x2##0:multi_specz_cyclic_lib.position, ~x3##0:multi_specz_cyclic_lib.position, ~x4##0:multi_specz_cyclic_lib.position, ~x1##0:multi_specz_cyclic_lib.position, ~tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?#io##4:wybe.phantom) #6 @multi_specz_cyclic_lib2:11:14
 
     1:
-        multi_specz_cyclic_lib.modifyAndPrint<0>(~x1#0:multi_specz_cyclic_lib.position, 111:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #2 @multi_specz_cyclic_lib2:6:14
-        multi_specz_cyclic_lib.modifyAndPrint<0>(~x2#0:multi_specz_cyclic_lib.position, 222:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #3 @multi_specz_cyclic_lib2:7:14
-        multi_specz_cyclic_lib.modifyAndPrint<0>(~x3#0:multi_specz_cyclic_lib.position, 333:wybe.int, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) #4 @multi_specz_cyclic_lib2:8:14
-        multi_specz_cyclic_lib.modifyAndPrint<0>(~x4#0:multi_specz_cyclic_lib.position, 444:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #5 @multi_specz_cyclic_lib2:9:14
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x1##0:multi_specz_cyclic_lib.position, 111:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @multi_specz_cyclic_lib2:6:14
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x2##0:multi_specz_cyclic_lib.position, 222:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #3 @multi_specz_cyclic_lib2:7:14
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x3##0:multi_specz_cyclic_lib.position, 333:wybe.int, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #4 @multi_specz_cyclic_lib2:8:14
+        multi_specz_cyclic_lib.modifyAndPrint<0>(~x4##0:multi_specz_cyclic_lib.position, 444:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #5 @multi_specz_cyclic_lib2:9:14
 
 
   LLVM code       :
@@ -455,18 +455,18 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"multi_specz_cyclic_lib2.foo2<0>"(i64  %"x1#0", i64  %"x2#0", i64  %"x3#0", i64  %"x4#0", i64  %"n#0")    {
+define external fastcc  void @"multi_specz_cyclic_lib2.foo2<0>"(i64  %"x1##0", i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"n##0")    {
 entry:
-  %"1$tmp$0#0" = sub   i64 %"n#0", 1 
-  %"1$tmp$1#0" = icmp slt i64 %"1$tmp$0#0", 0 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = sub   i64 %"n##0", 1 
+  %"1$tmp$1##0" = icmp slt i64 %"1$tmp$0##0", 0 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x1#0", i64  111)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x2#0", i64  222)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x3#0", i64  333)  
-  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x4#0", i64  444)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x1##0", i64  111)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x2##0", i64  222)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x3##0", i64  333)  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x4##0", i64  444)  
   ret void 
 if.else:
-  tail call fastcc  void  @"multi_specz_cyclic_lib.foo1<0>"(i64  %"x2#0", i64  %"x3#0", i64  %"x4#0", i64  %"x1#0", i64  %"1$tmp$0#0")  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.foo1<0>"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1$tmp$0##0")  
   ret void 
 }

--- a/test-cases/final-dump/multi_specz_cyclic_lib2.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_lib2.exp
@@ -193,27 +193,27 @@ entry:
 
 position > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?###0:multi_specz_cyclic_lib.position):
+position(x##0:wybe.int, y##0:wybe.int, ?#result##0:multi_specz_cyclic_lib.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:multi_specz_cyclic_lib.position)
     foreign lpvm mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:multi_specz_cyclic_lib.position, ?###0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:multi_specz_cyclic_lib.position, ?#result##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: multi_specz_cyclic_lib.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, ###0:multi_specz_cyclic_lib.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:multi_specz_cyclic_lib.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~###0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~#result##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.x<0>
-x(#rec##0:multi_specz_cyclic_lib.position, ?###0:wybe.int):
+x(#rec##0:multi_specz_cyclic_lib.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 x > public {inline} (0 calls)
 1: multi_specz_cyclic_lib.position.x<1>
 x(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, #field##0:wybe.int):
@@ -224,10 +224,10 @@ x(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.posit
 
 y > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.y<0>
-y(#rec##0:multi_specz_cyclic_lib.position, ?###0:wybe.int):
+y(#rec##0:multi_specz_cyclic_lib.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 y > public {inline} (0 calls)
 1: multi_specz_cyclic_lib.position.y<1>
 y(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, #field##0:wybe.int):
@@ -312,12 +312,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"multi_specz_cyclic_lib.position.position<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"multi_specz_cyclic_lib.position.position<1>"(i64  %"#result##0")    {
 entry:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 

--- a/test-cases/final-dump/multi_specz_cyclic_lib2.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_lib2.exp
@@ -174,7 +174,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: multi_specz_cyclic_lib.position.=<0>
-=(#left##0:multi_specz_cyclic_lib.position, #right##0:multi_specz_cyclic_lib.position, ?####0:wybe.bool):
+=(#left##0:multi_specz_cyclic_lib.position, #right##0:multi_specz_cyclic_lib.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
@@ -184,10 +184,10 @@ entry:
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -238,7 +238,7 @@ y(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.posit
 
 ~= > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.~=<0>
-~=(#left##0:multi_specz_cyclic_lib.position, #right##0:multi_specz_cyclic_lib.position, ?####0:wybe.bool):
+~=(#left##0:multi_specz_cyclic_lib.position, #right##0:multi_specz_cyclic_lib.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -249,11 +249,11 @@ y(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.posit
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -289,8 +289,8 @@ entry:
   %"1#tmp#1##0" = icmp eq i64 %3, %10 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2#####0" = icmp eq i64 %7, %14 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %7, %14 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -399,11 +399,11 @@ entry:
   br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#0##0" = icmp eq i64 %62, %69 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }
 --------------------------------------------------
  Module multi_specz_cyclic_lib2

--- a/test-cases/final-dump/multi_specz_cyclic_lib2.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_lib2.exp
@@ -28,11 +28,11 @@ foo1(x1##0:multi_specz_cyclic_lib.position, x2##0:multi_specz_cyclic_lib.positio
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0,InterestingUnaliased 1,InterestingUnaliased 2,InterestingUnaliased 3]
  MultiSpeczDepInfo: [(2,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [0]])),(3,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [1]])),(4,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [2]])),(5,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [3]])),(6,(multi_specz_cyclic_lib2.foo2<0>,fromList [NonAliasedParamCond 0 [1],NonAliasedParamCond 1 [2],NonAliasedParamCond 2 [3],NonAliasedParamCond 3 [0]]))]
-    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
-    foreign llvm icmp_slt(tmp$0##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
+    foreign llvm icmp_slt(tmp#0##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        multi_specz_cyclic_lib2.foo2<0>(~x2##0:multi_specz_cyclic_lib.position, ~x3##0:multi_specz_cyclic_lib.position, ~x4##0:multi_specz_cyclic_lib.position, ~x1##0:multi_specz_cyclic_lib.position, ~tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?#io##4:wybe.phantom) #6 @multi_specz_cyclic_lib:nn:nn
+        multi_specz_cyclic_lib2.foo2<0>(~x2##0:multi_specz_cyclic_lib.position, ~x3##0:multi_specz_cyclic_lib.position, ~x4##0:multi_specz_cyclic_lib.position, ~x1##0:multi_specz_cyclic_lib.position, ~tmp#0##0:wybe.int, ~#io##0:wybe.phantom, ?#io##4:wybe.phantom) #6 @multi_specz_cyclic_lib:nn:nn
 
     1:
         multi_specz_cyclic_lib.modifyAndPrint<0>(~x1##0:multi_specz_cyclic_lib.position, 111:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @multi_specz_cyclic_lib:nn:nn
@@ -57,13 +57,13 @@ printPosition(pos##0:multi_specz_cyclic_lib.position, io##0:wybe.phantom, ?io##5
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -102,9 +102,9 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"multi_specz_cyclic_lib.foo1<0>"(i64  %"x1##0", i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"n##0")    {
 entry:
-  %"1$tmp$0##0" = sub   i64 %"n##0", 1 
-  %"1$tmp$1##0" = icmp slt i64 %"1$tmp$0##0", 0 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = sub   i64 %"n##0", 1 
+  %"1#tmp#1##0" = icmp slt i64 %"1#tmp#0##0", 0 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
   tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x1##0", i64  111)  
   tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x2##0", i64  222)  
@@ -112,7 +112,7 @@ if.then:
   tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x4##0", i64  444)  
   ret void 
 if.else:
-  tail call fastcc  void  @"multi_specz_cyclic_lib2.foo2<0>"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1$tmp$0##0")  
+  tail call fastcc  void  @"multi_specz_cyclic_lib2.foo2<0>"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1#tmp#0##0")  
   ret void 
 }
 
@@ -174,86 +174,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: multi_specz_cyclic_lib.position.=<0>
-=($left##0:multi_specz_cyclic_lib.position, $right##0:multi_specz_cyclic_lib.position, ?$$##0:wybe.bool):
+=(#left##0:multi_specz_cyclic_lib.position, #right##0:multi_specz_cyclic_lib.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
-    foreign lpvm access(~$left##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
-    foreign lpvm access($right##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
-    foreign lpvm access(~$right##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
-    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
+    foreign lpvm access(~#left##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
+    foreign lpvm access(#right##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
+    foreign lpvm access(~#right##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?$##0:multi_specz_cyclic_lib.position):
+position(x##0:wybe.int, y##0:wybe.int, ?###0:multi_specz_cyclic_lib.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:multi_specz_cyclic_lib.position)
-    foreign lpvm mutate(~$rec##0:multi_specz_cyclic_lib.position, ?$rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:multi_specz_cyclic_lib.position, ?$##0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:multi_specz_cyclic_lib.position)
+    foreign lpvm mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:multi_specz_cyclic_lib.position, ?###0:multi_specz_cyclic_lib.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: multi_specz_cyclic_lib.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, $##0:multi_specz_cyclic_lib.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, ###0:multi_specz_cyclic_lib.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~$##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(###0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~###0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.x<0>
-x($rec##0:multi_specz_cyclic_lib.position, ?$##0:wybe.int):
+x(#rec##0:multi_specz_cyclic_lib.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 x > public {inline} (0 calls)
 1: multi_specz_cyclic_lib.position.x<1>
-x($rec##0:multi_specz_cyclic_lib.position, ?$rec##1:multi_specz_cyclic_lib.position, $field##0:wybe.int):
+x(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:multi_specz_cyclic_lib.position, ?$rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.y<0>
-y($rec##0:multi_specz_cyclic_lib.position, ?$##0:wybe.int):
+y(#rec##0:multi_specz_cyclic_lib.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 y > public {inline} (0 calls)
 1: multi_specz_cyclic_lib.position.y<1>
-y($rec##0:multi_specz_cyclic_lib.position, ?$rec##1:multi_specz_cyclic_lib.position, $field##0:wybe.int):
+y(#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:multi_specz_cyclic_lib.position, ?$rec##1:multi_specz_cyclic_lib.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:multi_specz_cyclic_lib.position, ?#rec##1:multi_specz_cyclic_lib.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: multi_specz_cyclic_lib.position.~=<0>
-~=($left##0:multi_specz_cyclic_lib.position, $right##0:multi_specz_cyclic_lib.position, ?$$##0:wybe.bool):
+~=(#left##0:multi_specz_cyclic_lib.position, #right##0:multi_specz_cyclic_lib.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:multi_specz_cyclic_lib.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:multi_specz_cyclic_lib.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -270,27 +270,27 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"multi_specz_cyclic_lib.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"multi_specz_cyclic_lib.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$##0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$##0" 
+  %"2#####0" = icmp eq i64 %7, %14 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
@@ -312,12 +312,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"multi_specz_cyclic_lib.position.position<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"multi_specz_cyclic_lib.position.position<1>"(i64  %"###0")    {
 entry:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -327,34 +327,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<0>"(i64  %"#rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec##0" to i64* 
+  %32 = inttoptr i64 %"#rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec##0" to i8* 
+  %39 = inttoptr i64 %"#rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field##0", i64* %42 
+  store  i64 %"#field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = add   i64 %"$rec##0", 8 
+  %43 = add   i64 %"#rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -362,48 +362,48 @@ entry:
 }
 
 
-define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"multi_specz_cyclic_lib.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec##0" to i8* 
+  %51 = inttoptr i64 %"#rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field##0", i64* %55 
+  store  i64 %"#field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"multi_specz_cyclic_lib.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"multi_specz_cyclic_lib.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %58, %65 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = icmp eq i64 %62, %69 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#0##0" = icmp eq i64 %62, %69 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }
 --------------------------------------------------
  Module multi_specz_cyclic_lib2
@@ -422,11 +422,11 @@ foo2(x1##0:multi_specz_cyclic_lib.position, x2##0:multi_specz_cyclic_lib.positio
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0,InterestingUnaliased 1,InterestingUnaliased 2,InterestingUnaliased 3]
  MultiSpeczDepInfo: [(2,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [0]])),(3,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [1]])),(4,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [2]])),(5,(multi_specz_cyclic_lib.modifyAndPrint<0>,fromList [NonAliasedParamCond 0 [3]])),(6,(multi_specz_cyclic_lib.foo1<0>,fromList [NonAliasedParamCond 0 [1],NonAliasedParamCond 1 [2],NonAliasedParamCond 2 [3],NonAliasedParamCond 3 [0]]))]
-    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
-    foreign llvm icmp_slt(tmp$0##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
+    foreign llvm icmp_slt(tmp#0##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        multi_specz_cyclic_lib.foo1<0>(~x2##0:multi_specz_cyclic_lib.position, ~x3##0:multi_specz_cyclic_lib.position, ~x4##0:multi_specz_cyclic_lib.position, ~x1##0:multi_specz_cyclic_lib.position, ~tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?#io##4:wybe.phantom) #6 @multi_specz_cyclic_lib2:11:14
+        multi_specz_cyclic_lib.foo1<0>(~x2##0:multi_specz_cyclic_lib.position, ~x3##0:multi_specz_cyclic_lib.position, ~x4##0:multi_specz_cyclic_lib.position, ~x1##0:multi_specz_cyclic_lib.position, ~tmp#0##0:wybe.int, ~#io##0:wybe.phantom, ?#io##4:wybe.phantom) #6 @multi_specz_cyclic_lib2:11:14
 
     1:
         multi_specz_cyclic_lib.modifyAndPrint<0>(~x1##0:multi_specz_cyclic_lib.position, 111:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @multi_specz_cyclic_lib2:6:14
@@ -457,9 +457,9 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"multi_specz_cyclic_lib2.foo2<0>"(i64  %"x1##0", i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"n##0")    {
 entry:
-  %"1$tmp$0##0" = sub   i64 %"n##0", 1 
-  %"1$tmp$1##0" = icmp slt i64 %"1$tmp$0##0", 0 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = sub   i64 %"n##0", 1 
+  %"1#tmp#1##0" = icmp slt i64 %"1#tmp#0##0", 0 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
   tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x1##0", i64  111)  
   tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x2##0", i64  222)  
@@ -467,6 +467,6 @@ if.then:
   tail call fastcc  void  @"multi_specz_cyclic_lib.modifyAndPrint<0>"(i64  %"x4##0", i64  444)  
   ret void 
 if.else:
-  tail call fastcc  void  @"multi_specz_cyclic_lib.foo1<0>"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1$tmp$0##0")  
+  tail call fastcc  void  @"multi_specz_cyclic_lib.foo1<0>"(i64  %"x2##0", i64  %"x3##0", i64  %"x4##0", i64  %"x1##0", i64  %"1#tmp#0##0")  
   ret void 
 }

--- a/test-cases/final-dump/multi_specz_reverse.exp
+++ b/test-cases/final-dump/multi_specz_reverse.exp
@@ -28,41 +28,41 @@ AFTER EVERYTHING:
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(20,(multi_specz_reverse.list_reverse_helper<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm alloc(16:wybe.int, ?tmp$13##0:multi_specz_reverse.intlist)
-    foreign lpvm mutate(~tmp$13##0:multi_specz_reverse.intlist, ?tmp$14##0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    foreign lpvm mutate(~tmp$14##0:multi_specz_reverse.intlist, ?tmp$15##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:multi_specz_reverse.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp$18##0:multi_specz_reverse.intlist)
-    foreign lpvm mutate(~tmp$18##0:multi_specz_reverse.intlist, ?tmp$19##0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 9:wybe.int)
-    foreign lpvm mutate(~tmp$19##0:multi_specz_reverse.intlist, ?tmp$20##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$15##0:multi_specz_reverse.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp$23##0:multi_specz_reverse.intlist)
-    foreign lpvm mutate(~tmp$23##0:multi_specz_reverse.intlist, ?tmp$24##0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 8:wybe.int)
-    foreign lpvm mutate(~tmp$24##0:multi_specz_reverse.intlist, ?tmp$25##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$20##0:multi_specz_reverse.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp$28##0:multi_specz_reverse.intlist)
-    foreign lpvm mutate(~tmp$28##0:multi_specz_reverse.intlist, ?tmp$29##0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 7:wybe.int)
-    foreign lpvm mutate(~tmp$29##0:multi_specz_reverse.intlist, ?tmp$30##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$25##0:multi_specz_reverse.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp$33##0:multi_specz_reverse.intlist)
-    foreign lpvm mutate(~tmp$33##0:multi_specz_reverse.intlist, ?tmp$34##0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 6:wybe.int)
-    foreign lpvm mutate(~tmp$34##0:multi_specz_reverse.intlist, ?tmp$35##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$30##0:multi_specz_reverse.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp$38##0:multi_specz_reverse.intlist)
-    foreign lpvm mutate(~tmp$38##0:multi_specz_reverse.intlist, ?tmp$39##0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 5:wybe.int)
-    foreign lpvm mutate(~tmp$39##0:multi_specz_reverse.intlist, ?tmp$40##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$35##0:multi_specz_reverse.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp$43##0:multi_specz_reverse.intlist)
-    foreign lpvm mutate(~tmp$43##0:multi_specz_reverse.intlist, ?tmp$44##0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:wybe.int)
-    foreign lpvm mutate(~tmp$44##0:multi_specz_reverse.intlist, ?tmp$45##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$40##0:multi_specz_reverse.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp$48##0:multi_specz_reverse.intlist)
-    foreign lpvm mutate(~tmp$48##0:multi_specz_reverse.intlist, ?tmp$49##0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-    foreign lpvm mutate(~tmp$49##0:multi_specz_reverse.intlist, ?tmp$50##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$45##0:multi_specz_reverse.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp$53##0:multi_specz_reverse.intlist)
-    foreign lpvm mutate(~tmp$53##0:multi_specz_reverse.intlist, ?tmp$54##0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm mutate(~tmp$54##0:multi_specz_reverse.intlist, ?tmp$55##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$50##0:multi_specz_reverse.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp$58##0:multi_specz_reverse.intlist)
-    foreign lpvm mutate(~tmp$58##0:multi_specz_reverse.intlist, ?tmp$59##0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp$59##0:multi_specz_reverse.intlist, ?tmp$60##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$55##0:multi_specz_reverse.intlist)
-    multi_specz_reverse.list_reverse_helper<0>[04d1467a4d](~tmp$60##0:multi_specz_reverse.intlist, 0:multi_specz_reverse.intlist, ?%foo##1:multi_specz_reverse.intlist) #20 @multi_specz_reverse:11:45
+    foreign lpvm alloc(16:wybe.int, ?tmp#13##0:multi_specz_reverse.intlist)
+    foreign lpvm mutate(~tmp#13##0:multi_specz_reverse.intlist, ?tmp#14##0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    foreign lpvm mutate(~tmp#14##0:multi_specz_reverse.intlist, ?tmp#15##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:multi_specz_reverse.intlist)
+    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:multi_specz_reverse.intlist)
+    foreign lpvm mutate(~tmp#18##0:multi_specz_reverse.intlist, ?tmp#19##0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 9:wybe.int)
+    foreign lpvm mutate(~tmp#19##0:multi_specz_reverse.intlist, ?tmp#20##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#15##0:multi_specz_reverse.intlist)
+    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:multi_specz_reverse.intlist)
+    foreign lpvm mutate(~tmp#23##0:multi_specz_reverse.intlist, ?tmp#24##0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 8:wybe.int)
+    foreign lpvm mutate(~tmp#24##0:multi_specz_reverse.intlist, ?tmp#25##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#20##0:multi_specz_reverse.intlist)
+    foreign lpvm alloc(16:wybe.int, ?tmp#28##0:multi_specz_reverse.intlist)
+    foreign lpvm mutate(~tmp#28##0:multi_specz_reverse.intlist, ?tmp#29##0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 7:wybe.int)
+    foreign lpvm mutate(~tmp#29##0:multi_specz_reverse.intlist, ?tmp#30##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#25##0:multi_specz_reverse.intlist)
+    foreign lpvm alloc(16:wybe.int, ?tmp#33##0:multi_specz_reverse.intlist)
+    foreign lpvm mutate(~tmp#33##0:multi_specz_reverse.intlist, ?tmp#34##0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 6:wybe.int)
+    foreign lpvm mutate(~tmp#34##0:multi_specz_reverse.intlist, ?tmp#35##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#30##0:multi_specz_reverse.intlist)
+    foreign lpvm alloc(16:wybe.int, ?tmp#38##0:multi_specz_reverse.intlist)
+    foreign lpvm mutate(~tmp#38##0:multi_specz_reverse.intlist, ?tmp#39##0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 5:wybe.int)
+    foreign lpvm mutate(~tmp#39##0:multi_specz_reverse.intlist, ?tmp#40##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#35##0:multi_specz_reverse.intlist)
+    foreign lpvm alloc(16:wybe.int, ?tmp#43##0:multi_specz_reverse.intlist)
+    foreign lpvm mutate(~tmp#43##0:multi_specz_reverse.intlist, ?tmp#44##0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:wybe.int)
+    foreign lpvm mutate(~tmp#44##0:multi_specz_reverse.intlist, ?tmp#45##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#40##0:multi_specz_reverse.intlist)
+    foreign lpvm alloc(16:wybe.int, ?tmp#48##0:multi_specz_reverse.intlist)
+    foreign lpvm mutate(~tmp#48##0:multi_specz_reverse.intlist, ?tmp#49##0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+    foreign lpvm mutate(~tmp#49##0:multi_specz_reverse.intlist, ?tmp#50##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#45##0:multi_specz_reverse.intlist)
+    foreign lpvm alloc(16:wybe.int, ?tmp#53##0:multi_specz_reverse.intlist)
+    foreign lpvm mutate(~tmp#53##0:multi_specz_reverse.intlist, ?tmp#54##0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+    foreign lpvm mutate(~tmp#54##0:multi_specz_reverse.intlist, ?tmp#55##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#50##0:multi_specz_reverse.intlist)
+    foreign lpvm alloc(16:wybe.int, ?tmp#58##0:multi_specz_reverse.intlist)
+    foreign lpvm mutate(~tmp#58##0:multi_specz_reverse.intlist, ?tmp#59##0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp#59##0:multi_specz_reverse.intlist, ?tmp#60##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#55##0:multi_specz_reverse.intlist)
+    multi_specz_reverse.list_reverse_helper<0>[04d1467a4d](~tmp#60##0:multi_specz_reverse.intlist, 0:multi_specz_reverse.intlist, ?%foo##1:multi_specz_reverse.intlist) #20 @multi_specz_reverse:11:45
     multi_specz_reverse.list_print<0>(foo##1:multi_specz_reverse.intlist, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #12 @multi_specz_reverse:18:2
     foreign c putchar('\n':wybe.char, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @wybe:nn:nn
-    foreign c print_string("============================":wybe.string, ~#io##2:wybe.phantom, ?tmp$65##0:wybe.phantom) @wybe:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$65##0:wybe.phantom, ?#io##3:wybe.phantom) @wybe:nn:nn
+    foreign c print_string("============================":wybe.string, ~#io##2:wybe.phantom, ?tmp#65##0:wybe.phantom) @wybe:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#65##0:wybe.phantom, ?#io##3:wybe.phantom) @wybe:nn:nn
     multi_specz_reverse.list_reverse_helper<0>(%foo##1:multi_specz_reverse.intlist, 0:multi_specz_reverse.intlist, ?%foo##2:multi_specz_reverse.intlist) #21 @multi_specz_reverse:11:45
     multi_specz_reverse.list_print<0>(~foo##2:multi_specz_reverse.intlist, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #16 @multi_specz_reverse:25:2
     foreign c putchar('\n':wybe.char, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @wybe:nn:nn
@@ -74,8 +74,8 @@ list_print > public (4 calls)
 0: list_print(x##0:multi_specz_reverse.intlist, io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(x##0:multi_specz_reverse.intlist, 0:wybe.int, ?tmp$2##0:wybe.bool)
-    case ~tmp$2##0:wybe.bool of
+    foreign llvm icmp_ne(x##0:multi_specz_reverse.intlist, 0:wybe.int, ?tmp#2##0:wybe.bool)
+    case ~tmp#2##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##3:wybe.phantom)
 
@@ -89,40 +89,40 @@ list_print > public (4 calls)
 
 
 list_reverse > public {inline} (2 calls)
-0: list_reverse(lst##0:multi_specz_reverse.intlist, ?$##0:multi_specz_reverse.intlist):
+0: list_reverse(lst##0:multi_specz_reverse.intlist, ?###0:multi_specz_reverse.intlist):
  AliasPairs: []
  InterestingCallProperties: []
-    multi_specz_reverse.list_reverse_helper<0>(~lst##0:multi_specz_reverse.intlist, 0:multi_specz_reverse.intlist, ?$##0:multi_specz_reverse.intlist) #1 @multi_specz_reverse:11:45
+    multi_specz_reverse.list_reverse_helper<0>(~lst##0:multi_specz_reverse.intlist, 0:multi_specz_reverse.intlist, ?###0:multi_specz_reverse.intlist) #1 @multi_specz_reverse:11:45
 
 
 list_reverse_helper > public (2 calls)
-0: list_reverse_helper(lst##0:multi_specz_reverse.intlist, acc##0:multi_specz_reverse.intlist, ?$##0:multi_specz_reverse.intlist):
- AliasPairs: [($##0,acc##0)]
+0: list_reverse_helper(lst##0:multi_specz_reverse.intlist, acc##0:multi_specz_reverse.intlist, ?###0:multi_specz_reverse.intlist):
+ AliasPairs: [(###0,acc##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(multi_specz_reverse.list_reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(lst##0:multi_specz_reverse.intlist, 0:wybe.int, ?tmp$5##0:wybe.bool)
-    case ~tmp$5##0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:multi_specz_reverse.intlist, 0:wybe.int, ?tmp#5##0:wybe.bool)
+    case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~acc##0:multi_specz_reverse.intlist, ?$##0:multi_specz_reverse.intlist) @multi_specz_reverse:13:5
+        foreign llvm move(~acc##0:multi_specz_reverse.intlist, ?###0:multi_specz_reverse.intlist) @multi_specz_reverse:13:5
 
     1:
         foreign lpvm access(lst##0:multi_specz_reverse.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
         foreign lpvm access(~lst##0:multi_specz_reverse.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:multi_specz_reverse.intlist)
-        foreign lpvm alloc(16:wybe.int, ?tmp$8##0:multi_specz_reverse.intlist)
-        foreign lpvm mutate(~tmp$8##0:multi_specz_reverse.intlist, ?tmp$9##0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-        foreign lpvm mutate(~tmp$9##0:multi_specz_reverse.intlist, ?tmp$10##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~acc##0:multi_specz_reverse.intlist)
-        multi_specz_reverse.list_reverse_helper<0>(~t##0:multi_specz_reverse.intlist, ~tmp$10##0:multi_specz_reverse.intlist, ?$##0:multi_specz_reverse.intlist) #2 @multi_specz_reverse:14:29
+        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:multi_specz_reverse.intlist)
+        foreign lpvm mutate(~tmp#8##0:multi_specz_reverse.intlist, ?tmp#9##0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+        foreign lpvm mutate(~tmp#9##0:multi_specz_reverse.intlist, ?tmp#10##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~acc##0:multi_specz_reverse.intlist)
+        multi_specz_reverse.list_reverse_helper<0>(~t##0:multi_specz_reverse.intlist, ~tmp#10##0:multi_specz_reverse.intlist, ?###0:multi_specz_reverse.intlist) #2 @multi_specz_reverse:14:29
 
  [04d1467a4d] [NonAliasedParam 0] :
-    foreign llvm icmp_ne(lst##0:multi_specz_reverse.intlist, 0:wybe.int, ?tmp$5##0:wybe.bool)
-    case ~tmp$5##0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:multi_specz_reverse.intlist, 0:wybe.int, ?tmp#5##0:wybe.bool)
+    case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~acc##0:multi_specz_reverse.intlist, ?$##0:multi_specz_reverse.intlist) @multi_specz_reverse:13:5
+        foreign llvm move(~acc##0:multi_specz_reverse.intlist, ?###0:multi_specz_reverse.intlist) @multi_specz_reverse:13:5
 
     1:
         foreign lpvm access(lst##0:multi_specz_reverse.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:multi_specz_reverse.intlist)
-        foreign lpvm mutate(~lst##0:multi_specz_reverse.intlist, ?tmp$10##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~acc##0:multi_specz_reverse.intlist)
-        multi_specz_reverse.list_reverse_helper<0>[04d1467a4d](~t##0:multi_specz_reverse.intlist, ~tmp$10##0:multi_specz_reverse.intlist, ?$##0:multi_specz_reverse.intlist) #2 @multi_specz_reverse:14:29
+        foreign lpvm mutate(~lst##0:multi_specz_reverse.intlist, ?tmp#10##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~acc##0:multi_specz_reverse.intlist)
+        multi_specz_reverse.list_reverse_helper<0>[04d1467a4d](~t##0:multi_specz_reverse.intlist, ~tmp#10##0:multi_specz_reverse.intlist, ?###0:multi_specz_reverse.intlist) #2 @multi_specz_reverse:14:29
 
 
   LLVM code       :
@@ -256,16 +256,16 @@ entry:
   %79 = inttoptr i64 %78 to i64* 
   %80 = getelementptr  i64, i64* %79, i64 0 
   store  i64 %67, i64* %80 
-  %"1$foo##1" = tail call fastcc  i64  @"multi_specz_reverse.list_reverse_helper<0>[04d1467a4d]"(i64  %75, i64  0)  
-  tail call fastcc  void  @"multi_specz_reverse.list_print<0>"(i64  %"1$foo##1")  
+  %"1#foo##1" = tail call fastcc  i64  @"multi_specz_reverse.list_reverse_helper<0>[04d1467a4d]"(i64  %75, i64  0)  
+  tail call fastcc  void  @"multi_specz_reverse.list_print<0>"(i64  %"1#foo##1")  
   tail call ccc  void  @putchar(i8  10)  
   %82 = ptrtoint i8* getelementptr inbounds ([29 x i8], [29 x i8]* @multi_specz_reverse.81, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %82)  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$foo##2" = tail call fastcc  i64  @"multi_specz_reverse.list_reverse_helper<0>"(i64  %"1$foo##1", i64  0)  
-  tail call fastcc  void  @"multi_specz_reverse.list_print<0>"(i64  %"1$foo##2")  
+  %"1#foo##2" = tail call fastcc  i64  @"multi_specz_reverse.list_reverse_helper<0>"(i64  %"1#foo##1", i64  0)  
+  tail call fastcc  void  @"multi_specz_reverse.list_print<0>"(i64  %"1#foo##2")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"multi_specz_reverse.list_print<0>"(i64  %"1$foo##1")  
+  tail call fastcc  void  @"multi_specz_reverse.list_print<0>"(i64  %"1#foo##1")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -273,8 +273,8 @@ entry:
 
 define external fastcc  void @"multi_specz_reverse.list_print<0>"(i64  %"x##0")    {
 entry:
-  %"1$tmp$2##0" = icmp ne i64 %"x##0", 0 
-  br i1 %"1$tmp$2##0", label %if.then, label %if.else 
+  %"1#tmp#2##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1#tmp#2##0", label %if.then, label %if.else 
 if.then:
   %83 = inttoptr i64 %"x##0" to i64* 
   %84 = getelementptr  i64, i64* %83, i64 0 
@@ -295,15 +295,15 @@ if.else:
 
 define external fastcc  i64 @"multi_specz_reverse.list_reverse<0>"(i64  %"lst##0")    {
 entry:
-  %"1$$##0" = tail call fastcc  i64  @"multi_specz_reverse.list_reverse_helper<0>"(i64  %"lst##0", i64  0)  
-  ret i64 %"1$$##0" 
+  %"1####0" = tail call fastcc  i64  @"multi_specz_reverse.list_reverse_helper<0>"(i64  %"lst##0", i64  0)  
+  ret i64 %"1####0" 
 }
 
 
 define external fastcc  i64 @"multi_specz_reverse.list_reverse_helper<0>"(i64  %"lst##0", i64  %"acc##0")    {
 entry:
-  %"1$tmp$5##0" = icmp ne i64 %"lst##0", 0 
-  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
+  %"1#tmp#5##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
   %92 = inttoptr i64 %"lst##0" to i64* 
   %93 = getelementptr  i64, i64* %92, i64 0 
@@ -322,8 +322,8 @@ if.then:
   %105 = inttoptr i64 %104 to i64* 
   %106 = getelementptr  i64, i64* %105, i64 0 
   store  i64 %"acc##0", i64* %106 
-  %"2$$##0" = tail call fastcc  i64  @"multi_specz_reverse.list_reverse_helper<0>"(i64  %98, i64  %101)  
-  ret i64 %"2$$##0" 
+  %"2####0" = tail call fastcc  i64  @"multi_specz_reverse.list_reverse_helper<0>"(i64  %98, i64  %101)  
+  ret i64 %"2####0" 
 if.else:
   ret i64 %"acc##0" 
 }
@@ -331,8 +331,8 @@ if.else:
 
 define external fastcc  i64 @"multi_specz_reverse.list_reverse_helper<0>[04d1467a4d]"(i64  %"lst##0", i64  %"acc##0")    {
 entry:
-  %"1$tmp$5##0" = icmp ne i64 %"lst##0", 0 
-  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
+  %"1#tmp#5##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
   %107 = add   i64 %"lst##0", 8 
   %108 = inttoptr i64 %107 to i64* 
@@ -342,8 +342,8 @@ if.then:
   %112 = inttoptr i64 %111 to i64* 
   %113 = getelementptr  i64, i64* %112, i64 0 
   store  i64 %"acc##0", i64* %113 
-  %"2$$##0" = tail call fastcc  i64  @"multi_specz_reverse.list_reverse_helper<0>[04d1467a4d]"(i64  %110, i64  %"lst##0")  
-  ret i64 %"2$$##0" 
+  %"2####0" = tail call fastcc  i64  @"multi_specz_reverse.list_reverse_helper<0>[04d1467a4d]"(i64  %110, i64  %"lst##0")  
+  ret i64 %"2####0" 
 if.else:
   ret i64 %"acc##0" 
 }
@@ -367,134 +367,134 @@ if.else:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left##0:multi_specz_reverse.intlist, $right##0:multi_specz_reverse.intlist, ?$$##0:wybe.bool):
+0: /=(#left##0:multi_specz_reverse.intlist, #right##0:multi_specz_reverse.intlist, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    multi_specz_reverse.intlist.=<0>(~$left##0:multi_specz_reverse.intlist, ~$right##0:multi_specz_reverse.intlist, ?tmp$0##0:wybe.bool) ##0
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    multi_specz_reverse.intlist.=<0>(~#left##0:multi_specz_reverse.intlist, ~#right##0:multi_specz_reverse.intlist, ?tmp#0##0:wybe.bool) ##0
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
 = > public (2 calls)
-0: =($left##0:multi_specz_reverse.intlist, $right##0:multi_specz_reverse.intlist, ?$$##0:wybe.bool):
+0: =(#left##0:multi_specz_reverse.intlist, #right##0:multi_specz_reverse.intlist, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left##0:!wybe.int, 0:wybe.int, ?tmp$0##0:!wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#left##0:!wybe.int, 0:wybe.int, ?tmp#0##0:!wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left##0:multi_specz_reverse.intlist, ~$right##0:multi_specz_reverse.intlist, ?$$##0:!wybe.bool)
+        foreign llvm icmp_eq(~#left##0:multi_specz_reverse.intlist, ~#right##0:multi_specz_reverse.intlist, ?####0:!wybe.bool)
 
     1:
-        foreign lpvm access($left##0:multi_specz_reverse.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$head##0:wybe.int)
-        foreign lpvm access(~$left##0:multi_specz_reverse.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$tail##0:multi_specz_reverse.intlist)
-        foreign llvm icmp_ne($right##0:multi_specz_reverse.intlist, 0:wybe.int, ?tmp$9##0:wybe.bool)
-        case ~tmp$9##0:wybe.bool of
+        foreign lpvm access(#left##0:multi_specz_reverse.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#head##0:wybe.int)
+        foreign lpvm access(~#left##0:multi_specz_reverse.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#tail##0:multi_specz_reverse.intlist)
+        foreign llvm icmp_ne(#right##0:multi_specz_reverse.intlist, 0:wybe.int, ?tmp#9##0:wybe.bool)
+        case ~tmp#9##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign lpvm access($right##0:multi_specz_reverse.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$head##0:wybe.int)
-            foreign lpvm access(~$right##0:multi_specz_reverse.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$tail##0:multi_specz_reverse.intlist)
-            foreign llvm icmp_eq(~$left$head##0:wybe.int, ~$right$head##0:wybe.int, ?tmp$4##0:wybe.bool) @wybe:nn:nn
-            case ~tmp$4##0:wybe.bool of
+            foreign lpvm access(#right##0:multi_specz_reverse.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#head##0:wybe.int)
+            foreign lpvm access(~#right##0:multi_specz_reverse.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#tail##0:multi_specz_reverse.intlist)
+            foreign llvm icmp_eq(~#left#head##0:wybe.int, ~#right#head##0:wybe.int, ?tmp#4##0:wybe.bool) @wybe:nn:nn
+            case ~tmp#4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
             1:
-                multi_specz_reverse.intlist.=<0>(~$left$tail##0:multi_specz_reverse.intlist, ~$right$tail##0:multi_specz_reverse.intlist, ?$$##0:wybe.bool) ##3
+                multi_specz_reverse.intlist.=<0>(~#left#tail##0:multi_specz_reverse.intlist, ~#right#tail##0:multi_specz_reverse.intlist, ?####0:wybe.bool) ##3
 
 
 
 
 
 [] > public {inline} (0 calls)
-0: [](?$##0:multi_specz_reverse.intlist):
+0: [](?###0:multi_specz_reverse.intlist):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:multi_specz_reverse.intlist, ?$##0:multi_specz_reverse.intlist)
+    foreign llvm move(0:multi_specz_reverse.intlist, ?###0:multi_specz_reverse.intlist)
 
 
 [|] > public {inline} (0 calls)
-0: [|](head##0:wybe.int, tail##0:multi_specz_reverse.intlist, ?$##0:multi_specz_reverse.intlist):
+0: [|](head##0:wybe.int, tail##0:multi_specz_reverse.intlist, ?###0:multi_specz_reverse.intlist):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:multi_specz_reverse.intlist)
-    foreign lpvm mutate(~%$rec##0:multi_specz_reverse.intlist, ?%$rec##1:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
-    foreign lpvm mutate(~%$rec##1:multi_specz_reverse.intlist, ?%$##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:multi_specz_reverse.intlist)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:multi_specz_reverse.intlist)
+    foreign lpvm mutate(~%#rec##0:multi_specz_reverse.intlist, ?%#rec##1:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
+    foreign lpvm mutate(~%#rec##1:multi_specz_reverse.intlist, ?%###0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:multi_specz_reverse.intlist)
 [|] > public {inline} (12 calls)
-1: [|](?head##0:wybe.int, ?tail##0:multi_specz_reverse.intlist, $##0:multi_specz_reverse.intlist, ?$$##0:wybe.bool):
+1: [|](?head##0:wybe.int, ?tail##0:multi_specz_reverse.intlist, ###0:multi_specz_reverse.intlist, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($##0:!wybe.int, 0:wybe.int, ?tmp$0##0:!wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(###0:!wybe.int, 0:wybe.int, ?tmp#0##0:!wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?head##0:wybe.int)
         foreign llvm move(undef:multi_specz_reverse.intlist, ?tail##0:multi_specz_reverse.intlist)
 
     1:
-        foreign lpvm access($##0:multi_specz_reverse.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
-        foreign lpvm access(~$##0:multi_specz_reverse.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:multi_specz_reverse.intlist)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(###0:multi_specz_reverse.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
+        foreign lpvm access(~###0:multi_specz_reverse.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:multi_specz_reverse.intlist)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 head > public {inline} (0 calls)
-0: head($rec##0:multi_specz_reverse.intlist, ?$##0:wybe.int, ?$$##0:wybe.bool):
+0: head(#rec##0:multi_specz_reverse.intlist, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:!wybe.int, 0:wybe.int, ?tmp$0##0:!wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:!wybe.int, 0:wybe.int, ?tmp#0##0:!wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec##0:multi_specz_reverse.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:multi_specz_reverse.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 head > public {inline} (0 calls)
-1: head($rec##0:multi_specz_reverse.intlist, ?$rec##1:multi_specz_reverse.intlist, $field##0:wybe.int, ?$$##0:wybe.bool):
+1: head(#rec##0:multi_specz_reverse.intlist, ?#rec##1:multi_specz_reverse.intlist, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:!wybe.int, 0:wybe.int, ?tmp$0##0:!wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:!wybe.int, 0:wybe.int, ?tmp#0##0:!wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multi_specz_reverse.intlist, ?$rec##1:multi_specz_reverse.intlist)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multi_specz_reverse.intlist, ?#rec##1:multi_specz_reverse.intlist)
 
     1:
-        foreign lpvm mutate(~%$rec##0:multi_specz_reverse.intlist, ?%$rec##1:multi_specz_reverse.intlist, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~%#rec##0:multi_specz_reverse.intlist, ?%#rec##1:multi_specz_reverse.intlist, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 tail > public {inline} (0 calls)
-0: tail($rec##0:multi_specz_reverse.intlist, ?$##0:multi_specz_reverse.intlist, ?$$##0:wybe.bool):
+0: tail(#rec##0:multi_specz_reverse.intlist, ?###0:multi_specz_reverse.intlist, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:!wybe.int, 0:wybe.int, ?tmp$0##0:!wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:!wybe.int, 0:wybe.int, ?tmp#0##0:!wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:multi_specz_reverse.intlist, ?$##0:multi_specz_reverse.intlist)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:multi_specz_reverse.intlist, ?###0:multi_specz_reverse.intlist)
 
     1:
-        foreign lpvm access(~$rec##0:multi_specz_reverse.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:multi_specz_reverse.intlist)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:multi_specz_reverse.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:multi_specz_reverse.intlist)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 tail > public {inline} (0 calls)
-1: tail($rec##0:multi_specz_reverse.intlist, ?$rec##1:multi_specz_reverse.intlist, $field##0:multi_specz_reverse.intlist, ?$$##0:wybe.bool):
+1: tail(#rec##0:multi_specz_reverse.intlist, ?#rec##1:multi_specz_reverse.intlist, #field##0:multi_specz_reverse.intlist, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:!wybe.int, 0:wybe.int, ?tmp$0##0:!wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:!wybe.int, 0:wybe.int, ?tmp#0##0:!wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multi_specz_reverse.intlist, ?$rec##1:multi_specz_reverse.intlist)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multi_specz_reverse.intlist, ?#rec##1:multi_specz_reverse.intlist)
 
     1:
-        foreign lpvm {noalias} mutate(~%$rec##0:multi_specz_reverse.intlist, ?%$rec##1:multi_specz_reverse.intlist, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:multi_specz_reverse.intlist)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm {noalias} mutate(~%#rec##0:multi_specz_reverse.intlist, ?%#rec##1:multi_specz_reverse.intlist, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:multi_specz_reverse.intlist)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -511,46 +511,46 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"multi_specz_reverse.intlist./=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"multi_specz_reverse.intlist./=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = tail call fastcc  i1  @"multi_specz_reverse.intlist.=<0>"(i64  %"$left##0", i64  %"$right##0")  
-  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
-  ret i1 %"1$$$##0" 
+  %"1#tmp#0##0" = tail call fastcc  i1  @"multi_specz_reverse.intlist.=<0>"(i64  %"#left##0", i64  %"#right##0")  
+  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1#####0" 
 }
 
 
-define external fastcc  i1 @"multi_specz_reverse.intlist.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"multi_specz_reverse.intlist.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#left##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %"2$tmp$9##0" = icmp ne i64 %"$right##0", 0 
-  br i1 %"2$tmp$9##0", label %if.then1, label %if.else1 
+  %"2#tmp#9##0" = icmp ne i64 %"#right##0", 0 
+  br i1 %"2#tmp#9##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3#####0" 
 if.then1:
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"4$tmp$4##0" = icmp eq i64 %3, %10 
-  br i1 %"4$tmp$4##0", label %if.then2, label %if.else2 
+  %"4#tmp#4##0" = icmp eq i64 %3, %10 
+  br i1 %"4#tmp#4##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$$$##0" = tail call fastcc  i1  @"multi_specz_reverse.intlist.=<0>"(i64  %7, i64  %14)  
-  ret i1 %"6$$$##0" 
+  %"6#####0" = tail call fastcc  i1  @"multi_specz_reverse.intlist.=<0>"(i64  %7, i64  %14)  
+  ret i1 %"6#####0" 
 if.else2:
   ret i1 0 
 }
@@ -578,15 +578,15 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"multi_specz_reverse.intlist.[|]<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64, i1} @"multi_specz_reverse.intlist.[|]<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -602,12 +602,12 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multi_specz_reverse.intlist.head<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"multi_specz_reverse.intlist.head<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %36 = inttoptr i64 %"$rec##0" to i64* 
+  %36 = inttoptr i64 %"#rec##0" to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
   %39 = insertvalue {i64, i1} undef, i64 %38, 0 
@@ -620,37 +620,37 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multi_specz_reverse.intlist.head<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"multi_specz_reverse.intlist.head<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %43 = trunc i64 16 to i32  
   %44 = tail call ccc  i8*  @wybe_malloc(i32  %43)  
   %45 = ptrtoint i8* %44 to i64 
   %46 = inttoptr i64 %45 to i8* 
-  %47 = inttoptr i64 %"$rec##0" to i8* 
+  %47 = inttoptr i64 %"#rec##0" to i8* 
   %48 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %46, i8*  %47, i32  %48, i32  8, i1  0)  
   %49 = inttoptr i64 %45 to i64* 
   %50 = getelementptr  i64, i64* %49, i64 0 
-  store  i64 %"$field##0", i64* %50 
+  store  i64 %"#field##0", i64* %50 
   %51 = insertvalue {i64, i1} undef, i64 %45, 0 
   %52 = insertvalue {i64, i1} %51, i1 1, 1 
   ret {i64, i1} %52 
 if.else:
-  %53 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %53 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %54 = insertvalue {i64, i1} %53, i1 0, 1 
   ret {i64, i1} %54 
 }
 
 
-define external fastcc  {i64, i1} @"multi_specz_reverse.intlist.tail<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"multi_specz_reverse.intlist.tail<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %55 = add   i64 %"$rec##0", 8 
+  %55 = add   i64 %"#rec##0", 8 
   %56 = inttoptr i64 %55 to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
@@ -664,27 +664,27 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multi_specz_reverse.intlist.tail<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"multi_specz_reverse.intlist.tail<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %63 = trunc i64 16 to i32  
   %64 = tail call ccc  i8*  @wybe_malloc(i32  %63)  
   %65 = ptrtoint i8* %64 to i64 
   %66 = inttoptr i64 %65 to i8* 
-  %67 = inttoptr i64 %"$rec##0" to i8* 
+  %67 = inttoptr i64 %"#rec##0" to i8* 
   %68 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %66, i8*  %67, i32  %68, i32  8, i1  0)  
   %69 = add   i64 %65, 8 
   %70 = inttoptr i64 %69 to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
-  store  i64 %"$field##0", i64* %71 
+  store  i64 %"#field##0", i64* %71 
   %72 = insertvalue {i64, i1} undef, i64 %65, 0 
   %73 = insertvalue {i64, i1} %72, i1 1, 1 
   ret {i64, i1} %73 
 if.else:
-  %74 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %74 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %75 = insertvalue {i64, i1} %74, i1 0, 1 
   ret {i64, i1} %75 
 }

--- a/test-cases/final-dump/multi_specz_reverse.exp
+++ b/test-cases/final-dump/multi_specz_reverse.exp
@@ -24,105 +24,105 @@ AFTER EVERYTHING:
   procs           : 
 
 *main* > public (0 calls)
-0: (argc#0:wybe.int, [?argc#0:wybe.int], argv#0:wybe.int, [?argv#0:wybe.int], exit_code#0:wybe.int, [?exit_code#0:wybe.int], io#0:wybe.phantom, ?io#7:wybe.phantom):
+0: (argc##0:wybe.int, [?argc##0:wybe.int], argv##0:wybe.int, [?argv##0:wybe.int], exit_code##0:wybe.int, [?exit_code##0:wybe.int], io##0:wybe.phantom, ?io##7:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(20,(multi_specz_reverse.list_reverse_helper<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm alloc(16:wybe.int, ?tmp$13#0:multi_specz_reverse.intlist)
-    foreign lpvm mutate(~tmp$13#0:multi_specz_reverse.intlist, ?tmp$14#0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    foreign lpvm mutate(~tmp$14#0:multi_specz_reverse.intlist, ?tmp$15#0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:multi_specz_reverse.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp$18#0:multi_specz_reverse.intlist)
-    foreign lpvm mutate(~tmp$18#0:multi_specz_reverse.intlist, ?tmp$19#0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 9:wybe.int)
-    foreign lpvm mutate(~tmp$19#0:multi_specz_reverse.intlist, ?tmp$20#0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$15#0:multi_specz_reverse.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp$23#0:multi_specz_reverse.intlist)
-    foreign lpvm mutate(~tmp$23#0:multi_specz_reverse.intlist, ?tmp$24#0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 8:wybe.int)
-    foreign lpvm mutate(~tmp$24#0:multi_specz_reverse.intlist, ?tmp$25#0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$20#0:multi_specz_reverse.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp$28#0:multi_specz_reverse.intlist)
-    foreign lpvm mutate(~tmp$28#0:multi_specz_reverse.intlist, ?tmp$29#0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 7:wybe.int)
-    foreign lpvm mutate(~tmp$29#0:multi_specz_reverse.intlist, ?tmp$30#0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$25#0:multi_specz_reverse.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp$33#0:multi_specz_reverse.intlist)
-    foreign lpvm mutate(~tmp$33#0:multi_specz_reverse.intlist, ?tmp$34#0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 6:wybe.int)
-    foreign lpvm mutate(~tmp$34#0:multi_specz_reverse.intlist, ?tmp$35#0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$30#0:multi_specz_reverse.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp$38#0:multi_specz_reverse.intlist)
-    foreign lpvm mutate(~tmp$38#0:multi_specz_reverse.intlist, ?tmp$39#0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 5:wybe.int)
-    foreign lpvm mutate(~tmp$39#0:multi_specz_reverse.intlist, ?tmp$40#0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$35#0:multi_specz_reverse.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp$43#0:multi_specz_reverse.intlist)
-    foreign lpvm mutate(~tmp$43#0:multi_specz_reverse.intlist, ?tmp$44#0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:wybe.int)
-    foreign lpvm mutate(~tmp$44#0:multi_specz_reverse.intlist, ?tmp$45#0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$40#0:multi_specz_reverse.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp$48#0:multi_specz_reverse.intlist)
-    foreign lpvm mutate(~tmp$48#0:multi_specz_reverse.intlist, ?tmp$49#0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-    foreign lpvm mutate(~tmp$49#0:multi_specz_reverse.intlist, ?tmp$50#0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$45#0:multi_specz_reverse.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp$53#0:multi_specz_reverse.intlist)
-    foreign lpvm mutate(~tmp$53#0:multi_specz_reverse.intlist, ?tmp$54#0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm mutate(~tmp$54#0:multi_specz_reverse.intlist, ?tmp$55#0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$50#0:multi_specz_reverse.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp$58#0:multi_specz_reverse.intlist)
-    foreign lpvm mutate(~tmp$58#0:multi_specz_reverse.intlist, ?tmp$59#0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp$59#0:multi_specz_reverse.intlist, ?tmp$60#0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$55#0:multi_specz_reverse.intlist)
-    multi_specz_reverse.list_reverse_helper<0>[04d1467a4d](~tmp$60#0:multi_specz_reverse.intlist, 0:multi_specz_reverse.intlist, ?%foo#1:multi_specz_reverse.intlist) #20 @multi_specz_reverse:11:45
-    multi_specz_reverse.list_print<0>(foo#1:multi_specz_reverse.intlist, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #12 @multi_specz_reverse:18:2
-    foreign c putchar('\n':wybe.char, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @wybe:nn:nn
-    foreign c print_string("============================":wybe.string, ~#io#2:wybe.phantom, ?tmp$65#0:wybe.phantom) @wybe:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$65#0:wybe.phantom, ?#io#3:wybe.phantom) @wybe:nn:nn
-    multi_specz_reverse.list_reverse_helper<0>(%foo#1:multi_specz_reverse.intlist, 0:multi_specz_reverse.intlist, ?%foo#2:multi_specz_reverse.intlist) #21 @multi_specz_reverse:11:45
-    multi_specz_reverse.list_print<0>(~foo#2:multi_specz_reverse.intlist, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #16 @multi_specz_reverse:25:2
-    foreign c putchar('\n':wybe.char, ~#io#4:wybe.phantom, ?#io#5:wybe.phantom) @wybe:nn:nn
-    multi_specz_reverse.list_print<0>(~foo#1:multi_specz_reverse.intlist, ~#io#5:wybe.phantom, ?#io#6:wybe.phantom) #18 @multi_specz_reverse:27:2
-    foreign c putchar('\n':wybe.char, ~#io#6:wybe.phantom, ?#io#7:wybe.phantom) @wybe:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$13##0:multi_specz_reverse.intlist)
+    foreign lpvm mutate(~tmp$13##0:multi_specz_reverse.intlist, ?tmp$14##0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    foreign lpvm mutate(~tmp$14##0:multi_specz_reverse.intlist, ?tmp$15##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:multi_specz_reverse.intlist)
+    foreign lpvm alloc(16:wybe.int, ?tmp$18##0:multi_specz_reverse.intlist)
+    foreign lpvm mutate(~tmp$18##0:multi_specz_reverse.intlist, ?tmp$19##0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 9:wybe.int)
+    foreign lpvm mutate(~tmp$19##0:multi_specz_reverse.intlist, ?tmp$20##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$15##0:multi_specz_reverse.intlist)
+    foreign lpvm alloc(16:wybe.int, ?tmp$23##0:multi_specz_reverse.intlist)
+    foreign lpvm mutate(~tmp$23##0:multi_specz_reverse.intlist, ?tmp$24##0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 8:wybe.int)
+    foreign lpvm mutate(~tmp$24##0:multi_specz_reverse.intlist, ?tmp$25##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$20##0:multi_specz_reverse.intlist)
+    foreign lpvm alloc(16:wybe.int, ?tmp$28##0:multi_specz_reverse.intlist)
+    foreign lpvm mutate(~tmp$28##0:multi_specz_reverse.intlist, ?tmp$29##0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 7:wybe.int)
+    foreign lpvm mutate(~tmp$29##0:multi_specz_reverse.intlist, ?tmp$30##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$25##0:multi_specz_reverse.intlist)
+    foreign lpvm alloc(16:wybe.int, ?tmp$33##0:multi_specz_reverse.intlist)
+    foreign lpvm mutate(~tmp$33##0:multi_specz_reverse.intlist, ?tmp$34##0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 6:wybe.int)
+    foreign lpvm mutate(~tmp$34##0:multi_specz_reverse.intlist, ?tmp$35##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$30##0:multi_specz_reverse.intlist)
+    foreign lpvm alloc(16:wybe.int, ?tmp$38##0:multi_specz_reverse.intlist)
+    foreign lpvm mutate(~tmp$38##0:multi_specz_reverse.intlist, ?tmp$39##0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 5:wybe.int)
+    foreign lpvm mutate(~tmp$39##0:multi_specz_reverse.intlist, ?tmp$40##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$35##0:multi_specz_reverse.intlist)
+    foreign lpvm alloc(16:wybe.int, ?tmp$43##0:multi_specz_reverse.intlist)
+    foreign lpvm mutate(~tmp$43##0:multi_specz_reverse.intlist, ?tmp$44##0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:wybe.int)
+    foreign lpvm mutate(~tmp$44##0:multi_specz_reverse.intlist, ?tmp$45##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$40##0:multi_specz_reverse.intlist)
+    foreign lpvm alloc(16:wybe.int, ?tmp$48##0:multi_specz_reverse.intlist)
+    foreign lpvm mutate(~tmp$48##0:multi_specz_reverse.intlist, ?tmp$49##0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+    foreign lpvm mutate(~tmp$49##0:multi_specz_reverse.intlist, ?tmp$50##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$45##0:multi_specz_reverse.intlist)
+    foreign lpvm alloc(16:wybe.int, ?tmp$53##0:multi_specz_reverse.intlist)
+    foreign lpvm mutate(~tmp$53##0:multi_specz_reverse.intlist, ?tmp$54##0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+    foreign lpvm mutate(~tmp$54##0:multi_specz_reverse.intlist, ?tmp$55##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$50##0:multi_specz_reverse.intlist)
+    foreign lpvm alloc(16:wybe.int, ?tmp$58##0:multi_specz_reverse.intlist)
+    foreign lpvm mutate(~tmp$58##0:multi_specz_reverse.intlist, ?tmp$59##0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp$59##0:multi_specz_reverse.intlist, ?tmp$60##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$55##0:multi_specz_reverse.intlist)
+    multi_specz_reverse.list_reverse_helper<0>[04d1467a4d](~tmp$60##0:multi_specz_reverse.intlist, 0:multi_specz_reverse.intlist, ?%foo##1:multi_specz_reverse.intlist) #20 @multi_specz_reverse:11:45
+    multi_specz_reverse.list_print<0>(foo##1:multi_specz_reverse.intlist, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #12 @multi_specz_reverse:18:2
+    foreign c putchar('\n':wybe.char, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @wybe:nn:nn
+    foreign c print_string("============================":wybe.string, ~#io##2:wybe.phantom, ?tmp$65##0:wybe.phantom) @wybe:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$65##0:wybe.phantom, ?#io##3:wybe.phantom) @wybe:nn:nn
+    multi_specz_reverse.list_reverse_helper<0>(%foo##1:multi_specz_reverse.intlist, 0:multi_specz_reverse.intlist, ?%foo##2:multi_specz_reverse.intlist) #21 @multi_specz_reverse:11:45
+    multi_specz_reverse.list_print<0>(~foo##2:multi_specz_reverse.intlist, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #16 @multi_specz_reverse:25:2
+    foreign c putchar('\n':wybe.char, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @wybe:nn:nn
+    multi_specz_reverse.list_print<0>(~foo##1:multi_specz_reverse.intlist, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #18 @multi_specz_reverse:27:2
+    foreign c putchar('\n':wybe.char, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) @wybe:nn:nn
 
 
 list_print > public (4 calls)
-0: list_print(x#0:multi_specz_reverse.intlist, io#0:wybe.phantom, ?io#3:wybe.phantom):
+0: list_print(x##0:multi_specz_reverse.intlist, io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(x#0:multi_specz_reverse.intlist, 0:wybe.int, ?tmp$2#0:wybe.bool)
-    case ~tmp$2#0:wybe.bool of
+    foreign llvm icmp_ne(x##0:multi_specz_reverse.intlist, 0:wybe.int, ?tmp$2##0:wybe.bool)
+    case ~tmp$2##0:wybe.bool of
     0:
-        foreign llvm move(~io#0:wybe.phantom, ?io#3:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##3:wybe.phantom)
 
     1:
-        foreign lpvm access(x#0:multi_specz_reverse.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:wybe.int)
-        foreign lpvm access(~x#0:multi_specz_reverse.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:multi_specz_reverse.intlist)
-        foreign c print_int(~h#0:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @wybe:nn:nn
-        foreign c print_string(" ":wybe.string, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @wybe:nn:nn
-        multi_specz_reverse.list_print<0>(~t#0:multi_specz_reverse.intlist, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) #3 @multi_specz_reverse:7:10
+        foreign lpvm access(x##0:multi_specz_reverse.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+        foreign lpvm access(~x##0:multi_specz_reverse.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:multi_specz_reverse.intlist)
+        foreign c print_int(~h##0:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @wybe:nn:nn
+        foreign c print_string(" ":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @wybe:nn:nn
+        multi_specz_reverse.list_print<0>(~t##0:multi_specz_reverse.intlist, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @multi_specz_reverse:7:10
 
 
 
 list_reverse > public {inline} (2 calls)
-0: list_reverse(lst#0:multi_specz_reverse.intlist, ?$#0:multi_specz_reverse.intlist):
+0: list_reverse(lst##0:multi_specz_reverse.intlist, ?$##0:multi_specz_reverse.intlist):
  AliasPairs: []
  InterestingCallProperties: []
-    multi_specz_reverse.list_reverse_helper<0>(~lst#0:multi_specz_reverse.intlist, 0:multi_specz_reverse.intlist, ?$#0:multi_specz_reverse.intlist) #1 @multi_specz_reverse:11:45
+    multi_specz_reverse.list_reverse_helper<0>(~lst##0:multi_specz_reverse.intlist, 0:multi_specz_reverse.intlist, ?$##0:multi_specz_reverse.intlist) #1 @multi_specz_reverse:11:45
 
 
 list_reverse_helper > public (2 calls)
-0: list_reverse_helper(lst#0:multi_specz_reverse.intlist, acc#0:multi_specz_reverse.intlist, ?$#0:multi_specz_reverse.intlist):
- AliasPairs: [($#0,acc#0)]
+0: list_reverse_helper(lst##0:multi_specz_reverse.intlist, acc##0:multi_specz_reverse.intlist, ?$##0:multi_specz_reverse.intlist):
+ AliasPairs: [($##0,acc##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(multi_specz_reverse.list_reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(lst#0:multi_specz_reverse.intlist, 0:wybe.int, ?tmp$5#0:wybe.bool)
-    case ~tmp$5#0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:multi_specz_reverse.intlist, 0:wybe.int, ?tmp$5##0:wybe.bool)
+    case ~tmp$5##0:wybe.bool of
     0:
-        foreign llvm move(~acc#0:multi_specz_reverse.intlist, ?$#0:multi_specz_reverse.intlist) @multi_specz_reverse:13:5
+        foreign llvm move(~acc##0:multi_specz_reverse.intlist, ?$##0:multi_specz_reverse.intlist) @multi_specz_reverse:13:5
 
     1:
-        foreign lpvm access(lst#0:multi_specz_reverse.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:wybe.int)
-        foreign lpvm access(~lst#0:multi_specz_reverse.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:multi_specz_reverse.intlist)
-        foreign lpvm alloc(16:wybe.int, ?tmp$8#0:multi_specz_reverse.intlist)
-        foreign lpvm mutate(~tmp$8#0:multi_specz_reverse.intlist, ?tmp$9#0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h#0:wybe.int)
-        foreign lpvm mutate(~tmp$9#0:multi_specz_reverse.intlist, ?tmp$10#0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~acc#0:multi_specz_reverse.intlist)
-        multi_specz_reverse.list_reverse_helper<0>(~t#0:multi_specz_reverse.intlist, ~tmp$10#0:multi_specz_reverse.intlist, ?$#0:multi_specz_reverse.intlist) #2 @multi_specz_reverse:14:29
+        foreign lpvm access(lst##0:multi_specz_reverse.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+        foreign lpvm access(~lst##0:multi_specz_reverse.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:multi_specz_reverse.intlist)
+        foreign lpvm alloc(16:wybe.int, ?tmp$8##0:multi_specz_reverse.intlist)
+        foreign lpvm mutate(~tmp$8##0:multi_specz_reverse.intlist, ?tmp$9##0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+        foreign lpvm mutate(~tmp$9##0:multi_specz_reverse.intlist, ?tmp$10##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~acc##0:multi_specz_reverse.intlist)
+        multi_specz_reverse.list_reverse_helper<0>(~t##0:multi_specz_reverse.intlist, ~tmp$10##0:multi_specz_reverse.intlist, ?$##0:multi_specz_reverse.intlist) #2 @multi_specz_reverse:14:29
 
  [04d1467a4d] [NonAliasedParam 0] :
-    foreign llvm icmp_ne(lst#0:multi_specz_reverse.intlist, 0:wybe.int, ?tmp$5#0:wybe.bool)
-    case ~tmp$5#0:wybe.bool of
+    foreign llvm icmp_ne(lst##0:multi_specz_reverse.intlist, 0:wybe.int, ?tmp$5##0:wybe.bool)
+    case ~tmp$5##0:wybe.bool of
     0:
-        foreign llvm move(~acc#0:multi_specz_reverse.intlist, ?$#0:multi_specz_reverse.intlist) @multi_specz_reverse:13:5
+        foreign llvm move(~acc##0:multi_specz_reverse.intlist, ?$##0:multi_specz_reverse.intlist) @multi_specz_reverse:13:5
 
     1:
-        foreign lpvm access(lst#0:multi_specz_reverse.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:multi_specz_reverse.intlist)
-        foreign lpvm mutate(~lst#0:multi_specz_reverse.intlist, ?tmp$10#0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~acc#0:multi_specz_reverse.intlist)
-        multi_specz_reverse.list_reverse_helper<0>[04d1467a4d](~t#0:multi_specz_reverse.intlist, ~tmp$10#0:multi_specz_reverse.intlist, ?$#0:multi_specz_reverse.intlist) #2 @multi_specz_reverse:14:29
+        foreign lpvm access(lst##0:multi_specz_reverse.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:multi_specz_reverse.intlist)
+        foreign lpvm mutate(~lst##0:multi_specz_reverse.intlist, ?tmp$10##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~acc##0:multi_specz_reverse.intlist)
+        multi_specz_reverse.list_reverse_helper<0>[04d1467a4d](~t##0:multi_specz_reverse.intlist, ~tmp$10##0:multi_specz_reverse.intlist, ?$##0:multi_specz_reverse.intlist) #2 @multi_specz_reverse:14:29
 
 
   LLVM code       :
@@ -154,7 +154,7 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"multi_specz_reverse.<0>"(i64  %"argc#0", i64  %"argv#0", i64  %"exit_code#0")    {
+define external fastcc  void @"multi_specz_reverse.<0>"(i64  %"argc##0", i64  %"argv##0", i64  %"exit_code##0")    {
 entry:
   %1 = trunc i64 16 to i32  
   %2 = tail call ccc  i8*  @wybe_malloc(i32  %1)  
@@ -256,30 +256,30 @@ entry:
   %79 = inttoptr i64 %78 to i64* 
   %80 = getelementptr  i64, i64* %79, i64 0 
   store  i64 %67, i64* %80 
-  %"1$foo#1" = tail call fastcc  i64  @"multi_specz_reverse.list_reverse_helper<0>[04d1467a4d]"(i64  %75, i64  0)  
-  tail call fastcc  void  @"multi_specz_reverse.list_print<0>"(i64  %"1$foo#1")  
+  %"1$foo##1" = tail call fastcc  i64  @"multi_specz_reverse.list_reverse_helper<0>[04d1467a4d]"(i64  %75, i64  0)  
+  tail call fastcc  void  @"multi_specz_reverse.list_print<0>"(i64  %"1$foo##1")  
   tail call ccc  void  @putchar(i8  10)  
   %82 = ptrtoint i8* getelementptr inbounds ([29 x i8], [29 x i8]* @multi_specz_reverse.81, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %82)  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$foo#2" = tail call fastcc  i64  @"multi_specz_reverse.list_reverse_helper<0>"(i64  %"1$foo#1", i64  0)  
-  tail call fastcc  void  @"multi_specz_reverse.list_print<0>"(i64  %"1$foo#2")  
+  %"1$foo##2" = tail call fastcc  i64  @"multi_specz_reverse.list_reverse_helper<0>"(i64  %"1$foo##1", i64  0)  
+  tail call fastcc  void  @"multi_specz_reverse.list_print<0>"(i64  %"1$foo##2")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"multi_specz_reverse.list_print<0>"(i64  %"1$foo#1")  
+  tail call fastcc  void  @"multi_specz_reverse.list_print<0>"(i64  %"1$foo##1")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  void @"multi_specz_reverse.list_print<0>"(i64  %"x#0")    {
+define external fastcc  void @"multi_specz_reverse.list_print<0>"(i64  %"x##0")    {
 entry:
-  %"1$tmp$2#0" = icmp ne i64 %"x#0", 0 
-  br i1 %"1$tmp$2#0", label %if.then, label %if.else 
+  %"1$tmp$2##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1$tmp$2##0", label %if.then, label %if.else 
 if.then:
-  %83 = inttoptr i64 %"x#0" to i64* 
+  %83 = inttoptr i64 %"x##0" to i64* 
   %84 = getelementptr  i64, i64* %83, i64 0 
   %85 = load  i64, i64* %84 
-  %86 = add   i64 %"x#0", 8 
+  %86 = add   i64 %"x##0", 8 
   %87 = inttoptr i64 %86 to i64* 
   %88 = getelementptr  i64, i64* %87, i64 0 
   %89 = load  i64, i64* %88 
@@ -293,22 +293,22 @@ if.else:
 }
 
 
-define external fastcc  i64 @"multi_specz_reverse.list_reverse<0>"(i64  %"lst#0")    {
+define external fastcc  i64 @"multi_specz_reverse.list_reverse<0>"(i64  %"lst##0")    {
 entry:
-  %"1$$#0" = tail call fastcc  i64  @"multi_specz_reverse.list_reverse_helper<0>"(i64  %"lst#0", i64  0)  
-  ret i64 %"1$$#0" 
+  %"1$$##0" = tail call fastcc  i64  @"multi_specz_reverse.list_reverse_helper<0>"(i64  %"lst##0", i64  0)  
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  i64 @"multi_specz_reverse.list_reverse_helper<0>"(i64  %"lst#0", i64  %"acc#0")    {
+define external fastcc  i64 @"multi_specz_reverse.list_reverse_helper<0>"(i64  %"lst##0", i64  %"acc##0")    {
 entry:
-  %"1$tmp$5#0" = icmp ne i64 %"lst#0", 0 
-  br i1 %"1$tmp$5#0", label %if.then, label %if.else 
+  %"1$tmp$5##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
 if.then:
-  %92 = inttoptr i64 %"lst#0" to i64* 
+  %92 = inttoptr i64 %"lst##0" to i64* 
   %93 = getelementptr  i64, i64* %92, i64 0 
   %94 = load  i64, i64* %93 
-  %95 = add   i64 %"lst#0", 8 
+  %95 = add   i64 %"lst##0", 8 
   %96 = inttoptr i64 %95 to i64* 
   %97 = getelementptr  i64, i64* %96, i64 0 
   %98 = load  i64, i64* %97 
@@ -321,31 +321,31 @@ if.then:
   %104 = add   i64 %101, 8 
   %105 = inttoptr i64 %104 to i64* 
   %106 = getelementptr  i64, i64* %105, i64 0 
-  store  i64 %"acc#0", i64* %106 
-  %"2$$#0" = tail call fastcc  i64  @"multi_specz_reverse.list_reverse_helper<0>"(i64  %98, i64  %101)  
-  ret i64 %"2$$#0" 
+  store  i64 %"acc##0", i64* %106 
+  %"2$$##0" = tail call fastcc  i64  @"multi_specz_reverse.list_reverse_helper<0>"(i64  %98, i64  %101)  
+  ret i64 %"2$$##0" 
 if.else:
-  ret i64 %"acc#0" 
+  ret i64 %"acc##0" 
 }
 
 
-define external fastcc  i64 @"multi_specz_reverse.list_reverse_helper<0>[04d1467a4d]"(i64  %"lst#0", i64  %"acc#0")    {
+define external fastcc  i64 @"multi_specz_reverse.list_reverse_helper<0>[04d1467a4d]"(i64  %"lst##0", i64  %"acc##0")    {
 entry:
-  %"1$tmp$5#0" = icmp ne i64 %"lst#0", 0 
-  br i1 %"1$tmp$5#0", label %if.then, label %if.else 
+  %"1$tmp$5##0" = icmp ne i64 %"lst##0", 0 
+  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
 if.then:
-  %107 = add   i64 %"lst#0", 8 
+  %107 = add   i64 %"lst##0", 8 
   %108 = inttoptr i64 %107 to i64* 
   %109 = getelementptr  i64, i64* %108, i64 0 
   %110 = load  i64, i64* %109 
-  %111 = add   i64 %"lst#0", 8 
+  %111 = add   i64 %"lst##0", 8 
   %112 = inttoptr i64 %111 to i64* 
   %113 = getelementptr  i64, i64* %112, i64 0 
-  store  i64 %"acc#0", i64* %113 
-  %"2$$#0" = tail call fastcc  i64  @"multi_specz_reverse.list_reverse_helper<0>[04d1467a4d]"(i64  %110, i64  %"lst#0")  
-  ret i64 %"2$$#0" 
+  store  i64 %"acc##0", i64* %113 
+  %"2$$##0" = tail call fastcc  i64  @"multi_specz_reverse.list_reverse_helper<0>[04d1467a4d]"(i64  %110, i64  %"lst##0")  
+  ret i64 %"2$$##0" 
 if.else:
-  ret i64 %"acc#0" 
+  ret i64 %"acc##0" 
 }
 --------------------------------------------------
  Module multi_specz_reverse.intlist
@@ -367,134 +367,134 @@ if.else:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=($left#0:multi_specz_reverse.intlist, $right#0:multi_specz_reverse.intlist, ?$$#0:wybe.bool):
+0: /=($left##0:multi_specz_reverse.intlist, $right##0:multi_specz_reverse.intlist, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    multi_specz_reverse.intlist.=<0>(~$left#0:multi_specz_reverse.intlist, ~$right#0:multi_specz_reverse.intlist, ?tmp$0#0:wybe.bool) #0
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    multi_specz_reverse.intlist.=<0>(~$left##0:multi_specz_reverse.intlist, ~$right##0:multi_specz_reverse.intlist, ?tmp$0##0:wybe.bool) ##0
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
 = > public (2 calls)
-0: =($left#0:multi_specz_reverse.intlist, $right#0:multi_specz_reverse.intlist, ?$$#0:wybe.bool):
+0: =($left##0:multi_specz_reverse.intlist, $right##0:multi_specz_reverse.intlist, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($left##0:!wybe.int, 0:wybe.int, ?tmp$0##0:!wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left#0:multi_specz_reverse.intlist, ~$right#0:multi_specz_reverse.intlist, ?$$#0:!wybe.bool)
+        foreign llvm icmp_eq(~$left##0:multi_specz_reverse.intlist, ~$right##0:multi_specz_reverse.intlist, ?$$##0:!wybe.bool)
 
     1:
-        foreign lpvm access($left#0:multi_specz_reverse.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$head#0:wybe.int)
-        foreign lpvm access(~$left#0:multi_specz_reverse.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$tail#0:multi_specz_reverse.intlist)
-        foreign llvm icmp_ne($right#0:multi_specz_reverse.intlist, 0:wybe.int, ?tmp$9#0:wybe.bool)
-        case ~tmp$9#0:wybe.bool of
+        foreign lpvm access($left##0:multi_specz_reverse.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$head##0:wybe.int)
+        foreign lpvm access(~$left##0:multi_specz_reverse.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$tail##0:multi_specz_reverse.intlist)
+        foreign llvm icmp_ne($right##0:multi_specz_reverse.intlist, 0:wybe.int, ?tmp$9##0:wybe.bool)
+        case ~tmp$9##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign lpvm access($right#0:multi_specz_reverse.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$head#0:wybe.int)
-            foreign lpvm access(~$right#0:multi_specz_reverse.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$tail#0:multi_specz_reverse.intlist)
-            foreign llvm icmp_eq(~$left$head#0:wybe.int, ~$right$head#0:wybe.int, ?tmp$4#0:wybe.bool) @wybe:nn:nn
-            case ~tmp$4#0:wybe.bool of
+            foreign lpvm access($right##0:multi_specz_reverse.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$head##0:wybe.int)
+            foreign lpvm access(~$right##0:multi_specz_reverse.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$tail##0:multi_specz_reverse.intlist)
+            foreign llvm icmp_eq(~$left$head##0:wybe.int, ~$right$head##0:wybe.int, ?tmp$4##0:wybe.bool) @wybe:nn:nn
+            case ~tmp$4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                multi_specz_reverse.intlist.=<0>(~$left$tail#0:multi_specz_reverse.intlist, ~$right$tail#0:multi_specz_reverse.intlist, ?$$#0:wybe.bool) #3
+                multi_specz_reverse.intlist.=<0>(~$left$tail##0:multi_specz_reverse.intlist, ~$right$tail##0:multi_specz_reverse.intlist, ?$$##0:wybe.bool) ##3
 
 
 
 
 
 [] > public {inline} (0 calls)
-0: [](?$#0:multi_specz_reverse.intlist):
+0: [](?$##0:multi_specz_reverse.intlist):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:multi_specz_reverse.intlist, ?$#0:multi_specz_reverse.intlist)
+    foreign llvm move(0:multi_specz_reverse.intlist, ?$##0:multi_specz_reverse.intlist)
 
 
 [|] > public {inline} (0 calls)
-0: [|](head#0:wybe.int, tail#0:multi_specz_reverse.intlist, ?$#0:multi_specz_reverse.intlist):
+0: [|](head##0:wybe.int, tail##0:multi_specz_reverse.intlist, ?$##0:multi_specz_reverse.intlist):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:multi_specz_reverse.intlist)
-    foreign lpvm mutate(~%$rec#0:multi_specz_reverse.intlist, ?%$rec#1:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head#0:wybe.int)
-    foreign lpvm mutate(~%$rec#1:multi_specz_reverse.intlist, ?%$#0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail#0:multi_specz_reverse.intlist)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:multi_specz_reverse.intlist)
+    foreign lpvm mutate(~%$rec##0:multi_specz_reverse.intlist, ?%$rec##1:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
+    foreign lpvm mutate(~%$rec##1:multi_specz_reverse.intlist, ?%$##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:multi_specz_reverse.intlist)
 [|] > public {inline} (12 calls)
-1: [|](?head#0:wybe.int, ?tail#0:multi_specz_reverse.intlist, $#0:multi_specz_reverse.intlist, ?$$#0:wybe.bool):
+1: [|](?head##0:wybe.int, ?tail##0:multi_specz_reverse.intlist, $##0:multi_specz_reverse.intlist, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($##0:!wybe.int, 0:wybe.int, ?tmp$0##0:!wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?head#0:wybe.int)
-        foreign llvm move(undef:multi_specz_reverse.intlist, ?tail#0:multi_specz_reverse.intlist)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?head##0:wybe.int)
+        foreign llvm move(undef:multi_specz_reverse.intlist, ?tail##0:multi_specz_reverse.intlist)
 
     1:
-        foreign lpvm access($#0:multi_specz_reverse.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head#0:wybe.int)
-        foreign lpvm access(~$#0:multi_specz_reverse.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail#0:multi_specz_reverse.intlist)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access($##0:multi_specz_reverse.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
+        foreign lpvm access(~$##0:multi_specz_reverse.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:multi_specz_reverse.intlist)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 head > public {inline} (0 calls)
-0: head($rec#0:multi_specz_reverse.intlist, ?$#0:wybe.int, ?$$#0:wybe.bool):
+0: head($rec##0:multi_specz_reverse.intlist, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:!wybe.int, 0:wybe.int, ?tmp$0##0:!wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec#0:multi_specz_reverse.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:multi_specz_reverse.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 head > public {inline} (0 calls)
-1: head($rec#0:multi_specz_reverse.intlist, ?$rec#1:multi_specz_reverse.intlist, $field#0:wybe.int, ?$$#0:wybe.bool):
+1: head($rec##0:multi_specz_reverse.intlist, ?$rec##1:multi_specz_reverse.intlist, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:!wybe.int, 0:wybe.int, ?tmp$0##0:!wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multi_specz_reverse.intlist, ?$rec#1:multi_specz_reverse.intlist)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multi_specz_reverse.intlist, ?$rec##1:multi_specz_reverse.intlist)
 
     1:
-        foreign lpvm mutate(~%$rec#0:multi_specz_reverse.intlist, ?%$rec#1:multi_specz_reverse.intlist, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~%$rec##0:multi_specz_reverse.intlist, ?%$rec##1:multi_specz_reverse.intlist, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 tail > public {inline} (0 calls)
-0: tail($rec#0:multi_specz_reverse.intlist, ?$#0:multi_specz_reverse.intlist, ?$$#0:wybe.bool):
+0: tail($rec##0:multi_specz_reverse.intlist, ?$##0:multi_specz_reverse.intlist, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:!wybe.int, 0:wybe.int, ?tmp$0##0:!wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:multi_specz_reverse.intlist, ?$#0:multi_specz_reverse.intlist)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:multi_specz_reverse.intlist, ?$##0:multi_specz_reverse.intlist)
 
     1:
-        foreign lpvm access(~$rec#0:multi_specz_reverse.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:multi_specz_reverse.intlist)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:multi_specz_reverse.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:multi_specz_reverse.intlist)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 tail > public {inline} (0 calls)
-1: tail($rec#0:multi_specz_reverse.intlist, ?$rec#1:multi_specz_reverse.intlist, $field#0:multi_specz_reverse.intlist, ?$$#0:wybe.bool):
+1: tail($rec##0:multi_specz_reverse.intlist, ?$rec##1:multi_specz_reverse.intlist, $field##0:multi_specz_reverse.intlist, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:!wybe.int, 0:wybe.int, ?tmp$0#0:!wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:!wybe.int, 0:wybe.int, ?tmp$0##0:!wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multi_specz_reverse.intlist, ?$rec#1:multi_specz_reverse.intlist)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multi_specz_reverse.intlist, ?$rec##1:multi_specz_reverse.intlist)
 
     1:
-        foreign lpvm {noalias} mutate(~%$rec#0:multi_specz_reverse.intlist, ?%$rec#1:multi_specz_reverse.intlist, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:multi_specz_reverse.intlist)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm {noalias} mutate(~%$rec##0:multi_specz_reverse.intlist, ?%$rec##1:multi_specz_reverse.intlist, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:multi_specz_reverse.intlist)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -511,46 +511,46 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"multi_specz_reverse.intlist./=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"multi_specz_reverse.intlist./=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = tail call fastcc  i1  @"multi_specz_reverse.intlist.=<0>"(i64  %"$left#0", i64  %"$right#0")  
-  %"1$$$#0" = xor i1 %"1$tmp$0#0", 1 
-  ret i1 %"1$$$#0" 
+  %"1$tmp$0##0" = tail call fastcc  i1  @"multi_specz_reverse.intlist.=<0>"(i64  %"$left##0", i64  %"$right##0")  
+  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
+  ret i1 %"1$$$##0" 
 }
 
 
-define external fastcc  i1 @"multi_specz_reverse.intlist.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"multi_specz_reverse.intlist.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$left#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %"2$tmp$9#0" = icmp ne i64 %"$right#0", 0 
-  br i1 %"2$tmp$9#0", label %if.then1, label %if.else1 
+  %"2$tmp$9##0" = icmp ne i64 %"$right##0", 0 
+  br i1 %"2$tmp$9##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = icmp eq i64 %"$left#0", %"$right#0" 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
+  ret i1 %"3$$$##0" 
 if.then1:
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"4$tmp$4#0" = icmp eq i64 %3, %10 
-  br i1 %"4$tmp$4#0", label %if.then2, label %if.else2 
+  %"4$tmp$4##0" = icmp eq i64 %3, %10 
+  br i1 %"4$tmp$4##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$$$#0" = tail call fastcc  i1  @"multi_specz_reverse.intlist.=<0>"(i64  %7, i64  %14)  
-  ret i1 %"6$$$#0" 
+  %"6$$$##0" = tail call fastcc  i1  @"multi_specz_reverse.intlist.=<0>"(i64  %7, i64  %14)  
+  ret i1 %"6$$$##0" 
 if.else2:
   ret i1 0 
 }
@@ -562,31 +562,31 @@ entry:
 }
 
 
-define external fastcc  i64 @"multi_specz_reverse.intlist.[|]<0>"(i64  %"head#0", i64  %"tail#0")    {
+define external fastcc  i64 @"multi_specz_reverse.intlist.[|]<0>"(i64  %"head##0", i64  %"tail##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"head#0", i64* %19 
+  store  i64 %"head##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"tail#0", i64* %22 
+  store  i64 %"tail##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64, i1} @"multi_specz_reverse.intlist.[|]<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64, i1} @"multi_specz_reverse.intlist.[|]<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -602,12 +602,12 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multi_specz_reverse.intlist.head<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"multi_specz_reverse.intlist.head<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %36 = inttoptr i64 %"$rec#0" to i64* 
+  %36 = inttoptr i64 %"$rec##0" to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
   %39 = insertvalue {i64, i1} undef, i64 %38, 0 
@@ -620,37 +620,37 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multi_specz_reverse.intlist.head<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"multi_specz_reverse.intlist.head<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %43 = trunc i64 16 to i32  
   %44 = tail call ccc  i8*  @wybe_malloc(i32  %43)  
   %45 = ptrtoint i8* %44 to i64 
   %46 = inttoptr i64 %45 to i8* 
-  %47 = inttoptr i64 %"$rec#0" to i8* 
+  %47 = inttoptr i64 %"$rec##0" to i8* 
   %48 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %46, i8*  %47, i32  %48, i32  8, i1  0)  
   %49 = inttoptr i64 %45 to i64* 
   %50 = getelementptr  i64, i64* %49, i64 0 
-  store  i64 %"$field#0", i64* %50 
+  store  i64 %"$field##0", i64* %50 
   %51 = insertvalue {i64, i1} undef, i64 %45, 0 
   %52 = insertvalue {i64, i1} %51, i1 1, 1 
   ret {i64, i1} %52 
 if.else:
-  %53 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %53 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %54 = insertvalue {i64, i1} %53, i1 0, 1 
   ret {i64, i1} %54 
 }
 
 
-define external fastcc  {i64, i1} @"multi_specz_reverse.intlist.tail<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"multi_specz_reverse.intlist.tail<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %55 = add   i64 %"$rec#0", 8 
+  %55 = add   i64 %"$rec##0", 8 
   %56 = inttoptr i64 %55 to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
@@ -664,27 +664,27 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multi_specz_reverse.intlist.tail<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"multi_specz_reverse.intlist.tail<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %63 = trunc i64 16 to i32  
   %64 = tail call ccc  i8*  @wybe_malloc(i32  %63)  
   %65 = ptrtoint i8* %64 to i64 
   %66 = inttoptr i64 %65 to i8* 
-  %67 = inttoptr i64 %"$rec#0" to i8* 
+  %67 = inttoptr i64 %"$rec##0" to i8* 
   %68 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %66, i8*  %67, i32  %68, i32  8, i1  0)  
   %69 = add   i64 %65, 8 
   %70 = inttoptr i64 %69 to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
-  store  i64 %"$field#0", i64* %71 
+  store  i64 %"$field##0", i64* %71 
   %72 = insertvalue {i64, i1} undef, i64 %65, 0 
   %73 = insertvalue {i64, i1} %72, i1 1, 1 
   ret {i64, i1} %73 
 if.else:
-  %74 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %74 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %75 = insertvalue {i64, i1} %74, i1 0, 1 
   ret {i64, i1} %75 
 }

--- a/test-cases/final-dump/multi_specz_reverse.exp
+++ b/test-cases/final-dump/multi_specz_reverse.exp
@@ -295,8 +295,8 @@ if.else:
 
 define external fastcc  i64 @"multi_specz_reverse.list_reverse<0>"(i64  %"lst##0")    {
 entry:
-  %"1####0" = tail call fastcc  i64  @"multi_specz_reverse.list_reverse_helper<0>"(i64  %"lst##0", i64  0)  
-  ret i64 %"1####0" 
+  %"1#success##0" = tail call fastcc  i64  @"multi_specz_reverse.list_reverse_helper<0>"(i64  %"lst##0", i64  0)  
+  ret i64 %"1#success##0" 
 }
 
 
@@ -322,8 +322,8 @@ if.then:
   %105 = inttoptr i64 %104 to i64* 
   %106 = getelementptr  i64, i64* %105, i64 0 
   store  i64 %"acc##0", i64* %106 
-  %"2####0" = tail call fastcc  i64  @"multi_specz_reverse.list_reverse_helper<0>"(i64  %98, i64  %101)  
-  ret i64 %"2####0" 
+  %"2#success##0" = tail call fastcc  i64  @"multi_specz_reverse.list_reverse_helper<0>"(i64  %98, i64  %101)  
+  ret i64 %"2#success##0" 
 if.else:
   ret i64 %"acc##0" 
 }
@@ -342,8 +342,8 @@ if.then:
   %112 = inttoptr i64 %111 to i64* 
   %113 = getelementptr  i64, i64* %112, i64 0 
   store  i64 %"acc##0", i64* %113 
-  %"2####0" = tail call fastcc  i64  @"multi_specz_reverse.list_reverse_helper<0>[04d1467a4d]"(i64  %110, i64  %"lst##0")  
-  ret i64 %"2####0" 
+  %"2#success##0" = tail call fastcc  i64  @"multi_specz_reverse.list_reverse_helper<0>[04d1467a4d]"(i64  %110, i64  %"lst##0")  
+  ret i64 %"2#success##0" 
 if.else:
   ret i64 %"acc##0" 
 }
@@ -367,21 +367,21 @@ if.else:
   procs           : 
 
 /= > public {inline} (0 calls)
-0: /=(#left##0:multi_specz_reverse.intlist, #right##0:multi_specz_reverse.intlist, ?####0:wybe.bool):
+0: /=(#left##0:multi_specz_reverse.intlist, #right##0:multi_specz_reverse.intlist, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     multi_specz_reverse.intlist.=<0>(~#left##0:multi_specz_reverse.intlist, ~#right##0:multi_specz_reverse.intlist, ?tmp#0##0:wybe.bool) ##0
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
 = > public (2 calls)
-0: =(#left##0:multi_specz_reverse.intlist, #right##0:multi_specz_reverse.intlist, ?####0:wybe.bool):
+0: =(#left##0:multi_specz_reverse.intlist, #right##0:multi_specz_reverse.intlist, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#left##0:!wybe.int, 0:wybe.int, ?tmp#0##0:!wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~#left##0:multi_specz_reverse.intlist, ~#right##0:multi_specz_reverse.intlist, ?####0:!wybe.bool)
+        foreign llvm icmp_eq(~#left##0:multi_specz_reverse.intlist, ~#right##0:multi_specz_reverse.intlist, ?#success##0:!wybe.bool)
 
     1:
         foreign lpvm access(#left##0:multi_specz_reverse.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#head##0:wybe.int)
@@ -389,7 +389,7 @@ if.else:
         foreign llvm icmp_ne(#right##0:multi_specz_reverse.intlist, 0:wybe.int, ?tmp#9##0:wybe.bool)
         case ~tmp#9##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign lpvm access(#right##0:multi_specz_reverse.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#head##0:wybe.int)
@@ -397,10 +397,10 @@ if.else:
             foreign llvm icmp_eq(~#left#head##0:wybe.int, ~#right#head##0:wybe.int, ?tmp#4##0:wybe.bool) @wybe:nn:nn
             case ~tmp#4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
-                multi_specz_reverse.intlist.=<0>(~#left#tail##0:multi_specz_reverse.intlist, ~#right#tail##0:multi_specz_reverse.intlist, ?####0:wybe.bool) ##3
+                multi_specz_reverse.intlist.=<0>(~#left#tail##0:multi_specz_reverse.intlist, ~#right#tail##0:multi_specz_reverse.intlist, ?#success##0:wybe.bool) ##3
 
 
 
@@ -421,80 +421,80 @@ if.else:
     foreign lpvm mutate(~%#rec##0:multi_specz_reverse.intlist, ?%#rec##1:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
     foreign lpvm mutate(~%#rec##1:multi_specz_reverse.intlist, ?%#result##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:multi_specz_reverse.intlist)
 [|] > public {inline} (12 calls)
-1: [|](?head##0:wybe.int, ?tail##0:multi_specz_reverse.intlist, #result##0:multi_specz_reverse.intlist, ?####0:wybe.bool):
+1: [|](?head##0:wybe.int, ?tail##0:multi_specz_reverse.intlist, #result##0:multi_specz_reverse.intlist, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:!wybe.int, 0:wybe.int, ?tmp#0##0:!wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?head##0:wybe.int)
         foreign llvm move(undef:multi_specz_reverse.intlist, ?tail##0:multi_specz_reverse.intlist)
 
     1:
         foreign lpvm access(#result##0:multi_specz_reverse.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
         foreign lpvm access(~#result##0:multi_specz_reverse.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:multi_specz_reverse.intlist)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 head > public {inline} (0 calls)
-0: head(#rec##0:multi_specz_reverse.intlist, ?#result##0:wybe.int, ?####0:wybe.bool):
+0: head(#rec##0:multi_specz_reverse.intlist, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:!wybe.int, 0:wybe.int, ?tmp#0##0:!wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign lpvm access(~#rec##0:multi_specz_reverse.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 head > public {inline} (0 calls)
-1: head(#rec##0:multi_specz_reverse.intlist, ?#rec##1:multi_specz_reverse.intlist, #field##0:wybe.int, ?####0:wybe.bool):
+1: head(#rec##0:multi_specz_reverse.intlist, ?#rec##1:multi_specz_reverse.intlist, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:!wybe.int, 0:wybe.int, ?tmp#0##0:!wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multi_specz_reverse.intlist, ?#rec##1:multi_specz_reverse.intlist)
 
     1:
         foreign lpvm mutate(~%#rec##0:multi_specz_reverse.intlist, ?%#rec##1:multi_specz_reverse.intlist, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 tail > public {inline} (0 calls)
-0: tail(#rec##0:multi_specz_reverse.intlist, ?#result##0:multi_specz_reverse.intlist, ?####0:wybe.bool):
+0: tail(#rec##0:multi_specz_reverse.intlist, ?#result##0:multi_specz_reverse.intlist, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:!wybe.int, 0:wybe.int, ?tmp#0##0:!wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:multi_specz_reverse.intlist, ?#result##0:multi_specz_reverse.intlist)
 
     1:
         foreign lpvm access(~#rec##0:multi_specz_reverse.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:multi_specz_reverse.intlist)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 tail > public {inline} (0 calls)
-1: tail(#rec##0:multi_specz_reverse.intlist, ?#rec##1:multi_specz_reverse.intlist, #field##0:multi_specz_reverse.intlist, ?####0:wybe.bool):
+1: tail(#rec##0:multi_specz_reverse.intlist, ?#rec##1:multi_specz_reverse.intlist, #field##0:multi_specz_reverse.intlist, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:!wybe.int, 0:wybe.int, ?tmp#0##0:!wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multi_specz_reverse.intlist, ?#rec##1:multi_specz_reverse.intlist)
 
     1:
         foreign lpvm {noalias} mutate(~%#rec##0:multi_specz_reverse.intlist, ?%#rec##1:multi_specz_reverse.intlist, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:multi_specz_reverse.intlist)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -514,8 +514,8 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 define external fastcc  i1 @"multi_specz_reverse.intlist./=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %"1#tmp#0##0" = tail call fastcc  i1  @"multi_specz_reverse.intlist.=<0>"(i64  %"#left##0", i64  %"#right##0")  
-  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
-  ret i1 %"1#####0" 
+  %"1##success##0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1##success##0" 
 }
 
 
@@ -534,8 +534,8 @@ if.then:
   %"2#tmp#9##0" = icmp ne i64 %"#right##0", 0 
   br i1 %"2#tmp#9##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %"3#####0" 
+  %"3##success##0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3##success##0" 
 if.then1:
   %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
@@ -549,8 +549,8 @@ if.then1:
 if.else1:
   ret i1 0 
 if.then2:
-  %"6#####0" = tail call fastcc  i1  @"multi_specz_reverse.intlist.=<0>"(i64  %7, i64  %14)  
-  ret i1 %"6#####0" 
+  %"6##success##0" = tail call fastcc  i1  @"multi_specz_reverse.intlist.=<0>"(i64  %7, i64  %14)  
+  ret i1 %"6##success##0" 
 if.else2:
   ret i1 0 
 }

--- a/test-cases/final-dump/multi_specz_reverse.exp
+++ b/test-cases/final-dump/multi_specz_reverse.exp
@@ -89,21 +89,21 @@ list_print > public (4 calls)
 
 
 list_reverse > public {inline} (2 calls)
-0: list_reverse(lst##0:multi_specz_reverse.intlist, ?###0:multi_specz_reverse.intlist):
+0: list_reverse(lst##0:multi_specz_reverse.intlist, ?#result##0:multi_specz_reverse.intlist):
  AliasPairs: []
  InterestingCallProperties: []
-    multi_specz_reverse.list_reverse_helper<0>(~lst##0:multi_specz_reverse.intlist, 0:multi_specz_reverse.intlist, ?###0:multi_specz_reverse.intlist) #1 @multi_specz_reverse:11:45
+    multi_specz_reverse.list_reverse_helper<0>(~lst##0:multi_specz_reverse.intlist, 0:multi_specz_reverse.intlist, ?#result##0:multi_specz_reverse.intlist) #1 @multi_specz_reverse:11:45
 
 
 list_reverse_helper > public (2 calls)
-0: list_reverse_helper(lst##0:multi_specz_reverse.intlist, acc##0:multi_specz_reverse.intlist, ?###0:multi_specz_reverse.intlist):
- AliasPairs: [(###0,acc##0)]
+0: list_reverse_helper(lst##0:multi_specz_reverse.intlist, acc##0:multi_specz_reverse.intlist, ?#result##0:multi_specz_reverse.intlist):
+ AliasPairs: [(#result##0,acc##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(multi_specz_reverse.list_reverse_helper<0>,fromList [NonAliasedParamCond 0 [0]]))]
     foreign llvm icmp_ne(lst##0:multi_specz_reverse.intlist, 0:wybe.int, ?tmp#5##0:wybe.bool)
     case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~acc##0:multi_specz_reverse.intlist, ?###0:multi_specz_reverse.intlist) @multi_specz_reverse:13:5
+        foreign llvm move(~acc##0:multi_specz_reverse.intlist, ?#result##0:multi_specz_reverse.intlist) @multi_specz_reverse:13:5
 
     1:
         foreign lpvm access(lst##0:multi_specz_reverse.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
@@ -111,18 +111,18 @@ list_reverse_helper > public (2 calls)
         foreign lpvm alloc(16:wybe.int, ?tmp#8##0:multi_specz_reverse.intlist)
         foreign lpvm mutate(~tmp#8##0:multi_specz_reverse.intlist, ?tmp#9##0:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
         foreign lpvm mutate(~tmp#9##0:multi_specz_reverse.intlist, ?tmp#10##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~acc##0:multi_specz_reverse.intlist)
-        multi_specz_reverse.list_reverse_helper<0>(~t##0:multi_specz_reverse.intlist, ~tmp#10##0:multi_specz_reverse.intlist, ?###0:multi_specz_reverse.intlist) #2 @multi_specz_reverse:14:29
+        multi_specz_reverse.list_reverse_helper<0>(~t##0:multi_specz_reverse.intlist, ~tmp#10##0:multi_specz_reverse.intlist, ?#result##0:multi_specz_reverse.intlist) #2 @multi_specz_reverse:14:29
 
  [04d1467a4d] [NonAliasedParam 0] :
     foreign llvm icmp_ne(lst##0:multi_specz_reverse.intlist, 0:wybe.int, ?tmp#5##0:wybe.bool)
     case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~acc##0:multi_specz_reverse.intlist, ?###0:multi_specz_reverse.intlist) @multi_specz_reverse:13:5
+        foreign llvm move(~acc##0:multi_specz_reverse.intlist, ?#result##0:multi_specz_reverse.intlist) @multi_specz_reverse:13:5
 
     1:
         foreign lpvm access(lst##0:multi_specz_reverse.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:multi_specz_reverse.intlist)
         foreign lpvm mutate(~lst##0:multi_specz_reverse.intlist, ?tmp#10##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~acc##0:multi_specz_reverse.intlist)
-        multi_specz_reverse.list_reverse_helper<0>[04d1467a4d](~t##0:multi_specz_reverse.intlist, ~tmp#10##0:multi_specz_reverse.intlist, ?###0:multi_specz_reverse.intlist) #2 @multi_specz_reverse:14:29
+        multi_specz_reverse.list_reverse_helper<0>[04d1467a4d](~t##0:multi_specz_reverse.intlist, ~tmp#10##0:multi_specz_reverse.intlist, ?#result##0:multi_specz_reverse.intlist) #2 @multi_specz_reverse:14:29
 
 
   LLVM code       :
@@ -407,24 +407,24 @@ if.else:
 
 
 [] > public {inline} (0 calls)
-0: [](?###0:multi_specz_reverse.intlist):
+0: [](?#result##0:multi_specz_reverse.intlist):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:multi_specz_reverse.intlist, ?###0:multi_specz_reverse.intlist)
+    foreign llvm move(0:multi_specz_reverse.intlist, ?#result##0:multi_specz_reverse.intlist)
 
 
 [|] > public {inline} (0 calls)
-0: [|](head##0:wybe.int, tail##0:multi_specz_reverse.intlist, ?###0:multi_specz_reverse.intlist):
+0: [|](head##0:wybe.int, tail##0:multi_specz_reverse.intlist, ?#result##0:multi_specz_reverse.intlist):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:multi_specz_reverse.intlist)
     foreign lpvm mutate(~%#rec##0:multi_specz_reverse.intlist, ?%#rec##1:multi_specz_reverse.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
-    foreign lpvm mutate(~%#rec##1:multi_specz_reverse.intlist, ?%###0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:multi_specz_reverse.intlist)
+    foreign lpvm mutate(~%#rec##1:multi_specz_reverse.intlist, ?%#result##0:multi_specz_reverse.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:multi_specz_reverse.intlist)
 [|] > public {inline} (12 calls)
-1: [|](?head##0:wybe.int, ?tail##0:multi_specz_reverse.intlist, ###0:multi_specz_reverse.intlist, ?####0:wybe.bool):
+1: [|](?head##0:wybe.int, ?tail##0:multi_specz_reverse.intlist, #result##0:multi_specz_reverse.intlist, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(###0:!wybe.int, 0:wybe.int, ?tmp#0##0:!wybe.bool)
+    foreign llvm icmp_ne(#result##0:!wybe.int, 0:wybe.int, ?tmp#0##0:!wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
@@ -432,24 +432,24 @@ if.else:
         foreign llvm move(undef:multi_specz_reverse.intlist, ?tail##0:multi_specz_reverse.intlist)
 
     1:
-        foreign lpvm access(###0:multi_specz_reverse.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
-        foreign lpvm access(~###0:multi_specz_reverse.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:multi_specz_reverse.intlist)
+        foreign lpvm access(#result##0:multi_specz_reverse.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
+        foreign lpvm access(~#result##0:multi_specz_reverse.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:multi_specz_reverse.intlist)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 head > public {inline} (0 calls)
-0: head(#rec##0:multi_specz_reverse.intlist, ?###0:wybe.int, ?####0:wybe.bool):
+0: head(#rec##0:multi_specz_reverse.intlist, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:!wybe.int, 0:wybe.int, ?tmp#0##0:!wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:multi_specz_reverse.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign lpvm access(~#rec##0:multi_specz_reverse.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 head > public {inline} (0 calls)
@@ -469,17 +469,17 @@ head > public {inline} (0 calls)
 
 
 tail > public {inline} (0 calls)
-0: tail(#rec##0:multi_specz_reverse.intlist, ?###0:multi_specz_reverse.intlist, ?####0:wybe.bool):
+0: tail(#rec##0:multi_specz_reverse.intlist, ?#result##0:multi_specz_reverse.intlist, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:!wybe.int, 0:wybe.int, ?tmp#0##0:!wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:multi_specz_reverse.intlist, ?###0:multi_specz_reverse.intlist)
+        foreign llvm move(undef:multi_specz_reverse.intlist, ?#result##0:multi_specz_reverse.intlist)
 
     1:
-        foreign lpvm access(~#rec##0:multi_specz_reverse.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:multi_specz_reverse.intlist)
+        foreign lpvm access(~#rec##0:multi_specz_reverse.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:multi_specz_reverse.intlist)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 tail > public {inline} (0 calls)
@@ -578,15 +578,15 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"multi_specz_reverse.intlist.[|]<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64, i1} @"multi_specz_reverse.intlist.[|]<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  %"1#tmp#0##0" = icmp ne i64 %"#result##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 

--- a/test-cases/final-dump/multictr.exp
+++ b/test-cases/final-dump/multictr.exp
@@ -209,10 +209,10 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 = > public {inline} (1 calls)
 0: multictr.card.=<0>
-=(#left##0:multictr.card, #right##0:multictr.card, ?####0:wybe.bool):
+=(#left##0:multictr.card, #right##0:multictr.card, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(~#left##0:multictr.card, ~#right##0:multictr.card, ?####0:wybe.bool)
+    foreign llvm icmp_eq(~#left##0:multictr.card, ~#right##0:multictr.card, ?#success##0:wybe.bool)
 
 
 card > public {inline} (0 calls)
@@ -270,11 +270,11 @@ suit(#rec##0:multictr.card, ?#rec##2:multictr.card, #field##0:multictr.suit):
 
 ~= > public {inline} (0 calls)
 0: multictr.card.~=<0>
-~=(#left##0:multictr.card, #right##0:multictr.card, ?####0:wybe.bool):
+~=(#left##0:multictr.card, #right##0:multictr.card, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_eq(~#left##0:multictr.card, ~#right##0:multictr.card, ?tmp#0##0:wybe.bool)
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 
@@ -292,8 +292,8 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  i1 @"multictr.card.=<0>"(i6  %"#left##0", i6  %"#right##0")    {
 entry:
-  %"1#####0" = icmp eq i6 %"#left##0", %"#right##0" 
-  ret i1 %"1#####0" 
+  %"1##success##0" = icmp eq i6 %"#left##0", %"#right##0" 
+  ret i1 %"1##success##0" 
 }
 
 
@@ -359,8 +359,8 @@ entry:
 define external fastcc  i1 @"multictr.card.~=<0>"(i6  %"#left##0", i6  %"#right##0")    {
 entry:
   %"1#tmp#0##0" = icmp eq i6 %"#left##0", %"#right##0" 
-  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
-  ret i1 %"1#####0" 
+  %"1##success##0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1##success##0" 
 }
 --------------------------------------------------
  Module multictr.complicated
@@ -448,13 +448,13 @@ entry:
 
 = > public (1 calls)
 0: multictr.complicated.=<0>
-=(#left##0:multictr.complicated, #right##0:multictr.complicated, ?####0:wybe.bool):
+=(#left##0:multictr.complicated, #right##0:multictr.complicated, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#left##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~#left##0:multictr.complicated, ~#right##0:multictr.complicated, ?####0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:multictr.complicated, ~#right##0:multictr.complicated, ?#success##0:wybe.bool)
 
     1:
         foreign llvm and(#left##0:wybe.int, 7:wybe.int, ?tmp#55##0:wybe.int)
@@ -482,7 +482,7 @@ entry:
                                     foreign llvm icmp_eq(~tmp#55##0:wybe.int, 7:wybe.int, ?tmp#84##0:wybe.bool)
                                     case ~tmp#84##0:wybe.bool of
                                     0:
-                                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                     1:
                                         foreign lpvm access(#left##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#85##0:16 bit unsigned)
@@ -516,32 +516,32 @@ entry:
                                                                             foreign llvm icmp_eq(~tmp#85##0:16 bit unsigned, 16:16 bit unsigned, ?tmp#140##0:wybe.bool)
                                                                             case ~tmp#140##0:wybe.bool of
                                                                             0:
-                                                                                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                                                                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                                             1:
                                                                                 foreign lpvm access(~#left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#left#f17##0:wybe.int)
                                                                                 foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#142##0:wybe.bool)
                                                                                 case ~tmp#142##0:wybe.bool of
                                                                                 0:
-                                                                                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                                                                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                                                 1:
                                                                                     foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#143##0:wybe.int)
                                                                                     foreign llvm icmp_eq(~tmp#143##0:wybe.int, 7:wybe.int, ?tmp#144##0:wybe.bool)
                                                                                     case ~tmp#144##0:wybe.bool of
                                                                                     0:
-                                                                                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                                                                        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                                                     1:
                                                                                         foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#145##0:16 bit unsigned)
                                                                                         foreign llvm icmp_eq(~tmp#145##0:16 bit unsigned, 16:16 bit unsigned, ?tmp#146##0:wybe.bool)
                                                                                         case ~tmp#146##0:wybe.bool of
                                                                                         0:
-                                                                                            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                                                                            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                                                         1:
                                                                                             foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f17##0:wybe.int)
-                                                                                            foreign llvm icmp_eq(~#left#f17##0:wybe.int, ~#right#f17##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+                                                                                            foreign llvm icmp_eq(~#left#f17##0:wybe.int, ~#right#f17##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -552,25 +552,25 @@ entry:
                                                                             foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#136##0:wybe.bool)
                                                                             case ~tmp#136##0:wybe.bool of
                                                                             0:
-                                                                                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                                                                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                                             1:
                                                                                 foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#137##0:wybe.int)
                                                                                 foreign llvm icmp_eq(~tmp#137##0:wybe.int, 7:wybe.int, ?tmp#138##0:wybe.bool)
                                                                                 case ~tmp#138##0:wybe.bool of
                                                                                 0:
-                                                                                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                                                                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                                                 1:
                                                                                     foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#139##0:16 bit unsigned)
                                                                                     foreign llvm icmp_eq(~tmp#139##0:16 bit unsigned, 15:16 bit unsigned, ?tmp#140##0:wybe.bool)
                                                                                     case ~tmp#140##0:wybe.bool of
                                                                                     0:
-                                                                                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                                                                        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                                                     1:
                                                                                         foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f16##0:wybe.int)
-                                                                                        foreign llvm icmp_eq(~#left#f16##0:wybe.int, ~#right#f16##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+                                                                                        foreign llvm icmp_eq(~#left#f16##0:wybe.int, ~#right#f16##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -581,25 +581,25 @@ entry:
                                                                         foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#130##0:wybe.bool)
                                                                         case ~tmp#130##0:wybe.bool of
                                                                         0:
-                                                                            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                                                            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                                         1:
                                                                             foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#131##0:wybe.int)
                                                                             foreign llvm icmp_eq(~tmp#131##0:wybe.int, 7:wybe.int, ?tmp#132##0:wybe.bool)
                                                                             case ~tmp#132##0:wybe.bool of
                                                                             0:
-                                                                                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                                                                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                                             1:
                                                                                 foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#133##0:16 bit unsigned)
                                                                                 foreign llvm icmp_eq(~tmp#133##0:16 bit unsigned, 14:16 bit unsigned, ?tmp#134##0:wybe.bool)
                                                                                 case ~tmp#134##0:wybe.bool of
                                                                                 0:
-                                                                                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                                                                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                                                 1:
                                                                                     foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f15##0:wybe.int)
-                                                                                    foreign llvm icmp_eq(~#left#f15##0:wybe.int, ~#right#f15##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+                                                                                    foreign llvm icmp_eq(~#left#f15##0:wybe.int, ~#right#f15##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -610,25 +610,25 @@ entry:
                                                                     foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#124##0:wybe.bool)
                                                                     case ~tmp#124##0:wybe.bool of
                                                                     0:
-                                                                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                                                        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                                     1:
                                                                         foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#125##0:wybe.int)
                                                                         foreign llvm icmp_eq(~tmp#125##0:wybe.int, 7:wybe.int, ?tmp#126##0:wybe.bool)
                                                                         case ~tmp#126##0:wybe.bool of
                                                                         0:
-                                                                            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                                                            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                                         1:
                                                                             foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#127##0:16 bit unsigned)
                                                                             foreign llvm icmp_eq(~tmp#127##0:16 bit unsigned, 13:16 bit unsigned, ?tmp#128##0:wybe.bool)
                                                                             case ~tmp#128##0:wybe.bool of
                                                                             0:
-                                                                                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                                                                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                                             1:
                                                                                 foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f14##0:wybe.int)
-                                                                                foreign llvm icmp_eq(~#left#f14##0:wybe.int, ~#right#f14##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+                                                                                foreign llvm icmp_eq(~#left#f14##0:wybe.int, ~#right#f14##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -639,25 +639,25 @@ entry:
                                                                 foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#118##0:wybe.bool)
                                                                 case ~tmp#118##0:wybe.bool of
                                                                 0:
-                                                                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                                                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                                 1:
                                                                     foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#119##0:wybe.int)
                                                                     foreign llvm icmp_eq(~tmp#119##0:wybe.int, 7:wybe.int, ?tmp#120##0:wybe.bool)
                                                                     case ~tmp#120##0:wybe.bool of
                                                                     0:
-                                                                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                                                        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                                     1:
                                                                         foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#121##0:16 bit unsigned)
                                                                         foreign llvm icmp_eq(~tmp#121##0:16 bit unsigned, 12:16 bit unsigned, ?tmp#122##0:wybe.bool)
                                                                         case ~tmp#122##0:wybe.bool of
                                                                         0:
-                                                                            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                                                            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                                         1:
                                                                             foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f13##0:wybe.int)
-                                                                            foreign llvm icmp_eq(~#left#f13##0:wybe.int, ~#right#f13##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+                                                                            foreign llvm icmp_eq(~#left#f13##0:wybe.int, ~#right#f13##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -668,25 +668,25 @@ entry:
                                                             foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#112##0:wybe.bool)
                                                             case ~tmp#112##0:wybe.bool of
                                                             0:
-                                                                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                                                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                             1:
                                                                 foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#113##0:wybe.int)
                                                                 foreign llvm icmp_eq(~tmp#113##0:wybe.int, 7:wybe.int, ?tmp#114##0:wybe.bool)
                                                                 case ~tmp#114##0:wybe.bool of
                                                                 0:
-                                                                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                                                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                                 1:
                                                                     foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#115##0:16 bit unsigned)
                                                                     foreign llvm icmp_eq(~tmp#115##0:16 bit unsigned, 11:16 bit unsigned, ?tmp#116##0:wybe.bool)
                                                                     case ~tmp#116##0:wybe.bool of
                                                                     0:
-                                                                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                                                        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                                     1:
                                                                         foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f12##0:wybe.int)
-                                                                        foreign llvm icmp_eq(~#left#f12##0:wybe.int, ~#right#f12##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+                                                                        foreign llvm icmp_eq(~#left#f12##0:wybe.int, ~#right#f12##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -697,25 +697,25 @@ entry:
                                                         foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#106##0:wybe.bool)
                                                         case ~tmp#106##0:wybe.bool of
                                                         0:
-                                                            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                                            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                         1:
                                                             foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#107##0:wybe.int)
                                                             foreign llvm icmp_eq(~tmp#107##0:wybe.int, 7:wybe.int, ?tmp#108##0:wybe.bool)
                                                             case ~tmp#108##0:wybe.bool of
                                                             0:
-                                                                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                                                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                             1:
                                                                 foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#109##0:16 bit unsigned)
                                                                 foreign llvm icmp_eq(~tmp#109##0:16 bit unsigned, 10:16 bit unsigned, ?tmp#110##0:wybe.bool)
                                                                 case ~tmp#110##0:wybe.bool of
                                                                 0:
-                                                                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                                                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                                 1:
                                                                     foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f11##0:wybe.int)
-                                                                    foreign llvm icmp_eq(~#left#f11##0:wybe.int, ~#right#f11##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+                                                                    foreign llvm icmp_eq(~#left#f11##0:wybe.int, ~#right#f11##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -726,25 +726,25 @@ entry:
                                                     foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#100##0:wybe.bool)
                                                     case ~tmp#100##0:wybe.bool of
                                                     0:
-                                                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                                        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                     1:
                                                         foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#101##0:wybe.int)
                                                         foreign llvm icmp_eq(~tmp#101##0:wybe.int, 7:wybe.int, ?tmp#102##0:wybe.bool)
                                                         case ~tmp#102##0:wybe.bool of
                                                         0:
-                                                            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                                            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                         1:
                                                             foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#103##0:16 bit unsigned)
                                                             foreign llvm icmp_eq(~tmp#103##0:16 bit unsigned, 9:16 bit unsigned, ?tmp#104##0:wybe.bool)
                                                             case ~tmp#104##0:wybe.bool of
                                                             0:
-                                                                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                                                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                             1:
                                                                 foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f10##0:wybe.int)
-                                                                foreign llvm icmp_eq(~#left#f10##0:wybe.int, ~#right#f10##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+                                                                foreign llvm icmp_eq(~#left#f10##0:wybe.int, ~#right#f10##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -755,25 +755,25 @@ entry:
                                                 foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#94##0:wybe.bool)
                                                 case ~tmp#94##0:wybe.bool of
                                                 0:
-                                                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                 1:
                                                     foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#95##0:wybe.int)
                                                     foreign llvm icmp_eq(~tmp#95##0:wybe.int, 7:wybe.int, ?tmp#96##0:wybe.bool)
                                                     case ~tmp#96##0:wybe.bool of
                                                     0:
-                                                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                                        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                     1:
                                                         foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#97##0:16 bit unsigned)
                                                         foreign llvm icmp_eq(~tmp#97##0:16 bit unsigned, 8:16 bit unsigned, ?tmp#98##0:wybe.bool)
                                                         case ~tmp#98##0:wybe.bool of
                                                         0:
-                                                            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                                            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                         1:
                                                             foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f09##0:wybe.int)
-                                                            foreign llvm icmp_eq(~#left#f09##0:wybe.int, ~#right#f09##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+                                                            foreign llvm icmp_eq(~#left#f09##0:wybe.int, ~#right#f09##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -784,25 +784,25 @@ entry:
                                             foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#88##0:wybe.bool)
                                             case ~tmp#88##0:wybe.bool of
                                             0:
-                                                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                             1:
                                                 foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#89##0:wybe.int)
                                                 foreign llvm icmp_eq(~tmp#89##0:wybe.int, 7:wybe.int, ?tmp#90##0:wybe.bool)
                                                 case ~tmp#90##0:wybe.bool of
                                                 0:
-                                                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                 1:
                                                     foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#91##0:16 bit unsigned)
                                                     foreign llvm icmp_eq(~tmp#91##0:16 bit unsigned, 7:16 bit unsigned, ?tmp#92##0:wybe.bool)
                                                     case ~tmp#92##0:wybe.bool of
                                                     0:
-                                                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                                        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                                     1:
                                                         foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f08##0:wybe.int)
-                                                        foreign llvm icmp_eq(~#left#f08##0:wybe.int, ~#right#f08##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+                                                        foreign llvm icmp_eq(~#left#f08##0:wybe.int, ~#right#f08##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -814,18 +814,18 @@ entry:
                                     foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#82##0:wybe.bool)
                                     case ~tmp#82##0:wybe.bool of
                                     0:
-                                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                     1:
                                         foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#83##0:wybe.int)
                                         foreign llvm icmp_eq(~tmp#83##0:wybe.int, 6:wybe.int, ?tmp#84##0:wybe.bool)
                                         case ~tmp#84##0:wybe.bool of
                                         0:
-                                            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                         1:
                                             foreign lpvm access(~#right##0:multictr.complicated, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?#right#f07##0:wybe.int)
-                                            foreign llvm icmp_eq(~#left#f07##0:wybe.int, ~#right#f07##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+                                            foreign llvm icmp_eq(~#left#f07##0:wybe.int, ~#right#f07##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -835,18 +835,18 @@ entry:
                                 foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#78##0:wybe.bool)
                                 case ~tmp#78##0:wybe.bool of
                                 0:
-                                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                 1:
                                     foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#79##0:wybe.int)
                                     foreign llvm icmp_eq(~tmp#79##0:wybe.int, 5:wybe.int, ?tmp#80##0:wybe.bool)
                                     case ~tmp#80##0:wybe.bool of
                                     0:
-                                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                     1:
                                         foreign lpvm access(~#right##0:multictr.complicated, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?#right#f06##0:wybe.int)
-                                        foreign llvm icmp_eq(~#left#f06##0:wybe.int, ~#right#f06##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+                                        foreign llvm icmp_eq(~#left#f06##0:wybe.int, ~#right#f06##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -856,18 +856,18 @@ entry:
                             foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#74##0:wybe.bool)
                             case ~tmp#74##0:wybe.bool of
                             0:
-                                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                             1:
                                 foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#75##0:wybe.int)
                                 foreign llvm icmp_eq(~tmp#75##0:wybe.int, 4:wybe.int, ?tmp#76##0:wybe.bool)
                                 case ~tmp#76##0:wybe.bool of
                                 0:
-                                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                 1:
                                     foreign lpvm access(~#right##0:multictr.complicated, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?#right#f05##0:wybe.int)
-                                    foreign llvm icmp_eq(~#left#f05##0:wybe.int, ~#right#f05##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+                                    foreign llvm icmp_eq(~#left#f05##0:wybe.int, ~#right#f05##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -877,18 +877,18 @@ entry:
                         foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#70##0:wybe.bool)
                         case ~tmp#70##0:wybe.bool of
                         0:
-                            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                         1:
                             foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#71##0:wybe.int)
                             foreign llvm icmp_eq(~tmp#71##0:wybe.int, 3:wybe.int, ?tmp#72##0:wybe.bool)
                             case ~tmp#72##0:wybe.bool of
                             0:
-                                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                             1:
                                 foreign lpvm access(~#right##0:multictr.complicated, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?#right#f04##0:wybe.int)
-                                foreign llvm icmp_eq(~#left#f04##0:wybe.int, ~#right#f04##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+                                foreign llvm icmp_eq(~#left#f04##0:wybe.int, ~#right#f04##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -898,18 +898,18 @@ entry:
                     foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#66##0:wybe.bool)
                     case ~tmp#66##0:wybe.bool of
                     0:
-                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                     1:
                         foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#67##0:wybe.int)
                         foreign llvm icmp_eq(~tmp#67##0:wybe.int, 2:wybe.int, ?tmp#68##0:wybe.bool)
                         case ~tmp#68##0:wybe.bool of
                         0:
-                            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                         1:
                             foreign lpvm access(~#right##0:multictr.complicated, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#right#f03##0:wybe.int)
-                            foreign llvm icmp_eq(~#left#f03##0:wybe.int, ~#right#f03##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+                            foreign llvm icmp_eq(~#left#f03##0:wybe.int, ~#right#f03##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -919,18 +919,18 @@ entry:
                 foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#62##0:wybe.bool)
                 case ~tmp#62##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                 1:
                     foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#63##0:wybe.int)
                     foreign llvm icmp_eq(~tmp#63##0:wybe.int, 1:wybe.int, ?tmp#64##0:wybe.bool)
                     case ~tmp#64##0:wybe.bool of
                     0:
-                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                     1:
                         foreign lpvm access(~#right##0:multictr.complicated, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#right#f02##0:wybe.int)
-                        foreign llvm icmp_eq(~#left#f02##0:wybe.int, ~#right#f02##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+                        foreign llvm icmp_eq(~#left#f02##0:wybe.int, ~#right#f02##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -940,18 +940,18 @@ entry:
             foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#58##0:wybe.bool)
             case ~tmp#58##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
                 foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#59##0:wybe.int)
                 foreign llvm icmp_eq(~tmp#59##0:wybe.int, 0:wybe.int, ?tmp#60##0:wybe.bool)
                 case ~tmp#60##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                 1:
                     foreign lpvm access(~#right##0:multictr.complicated, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#right#f01##0:wybe.int)
-                    foreign llvm icmp_eq(~#left#f01##0:wybe.int, ~#right#f01##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+                    foreign llvm icmp_eq(~#left#f01##0:wybe.int, ~#right#f01##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -975,13 +975,13 @@ c01(f01##0:wybe.int, ?#result##0:multictr.complicated):
     foreign lpvm mutate(~#rec##0:multictr.complicated, ?#result##0:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f01##0:wybe.int)
 c01 > public {inline} (40 calls)
 1: multictr.complicated.c01<1>
-c01(?f01##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
+c01(?f01##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#result##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f01##0:wybe.int)
 
     1:
@@ -989,12 +989,12 @@ c01(?f01##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?f01##0:wybe.int)
 
         1:
             foreign lpvm access(~#result##0:multictr.complicated, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?f01##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -1009,13 +1009,13 @@ c02(f02##0:wybe.int, ?#result##0:multictr.complicated):
     foreign llvm or(~#rec##1:multictr.complicated, 1:wybe.int, ?#result##0:multictr.complicated)
 c02 > public {inline} (35 calls)
 1: multictr.complicated.c02<1>
-c02(?f02##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
+c02(?f02##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#result##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f02##0:wybe.int)
 
     1:
@@ -1023,12 +1023,12 @@ c02(?f02##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?f02##0:wybe.int)
 
         1:
             foreign lpvm access(~#result##0:multictr.complicated, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?f02##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -1043,13 +1043,13 @@ c03(f03##0:wybe.int, ?#result##0:multictr.complicated):
     foreign llvm or(~#rec##1:multictr.complicated, 2:wybe.int, ?#result##0:multictr.complicated)
 c03 > public {inline} (33 calls)
 1: multictr.complicated.c03<1>
-c03(?f03##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
+c03(?f03##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#result##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f03##0:wybe.int)
 
     1:
@@ -1057,12 +1057,12 @@ c03(?f03##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 2:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?f03##0:wybe.int)
 
         1:
             foreign lpvm access(~#result##0:multictr.complicated, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?f03##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -1077,13 +1077,13 @@ c04(f04##0:wybe.int, ?#result##0:multictr.complicated):
     foreign llvm or(~#rec##1:multictr.complicated, 3:wybe.int, ?#result##0:multictr.complicated)
 c04 > public {inline} (31 calls)
 1: multictr.complicated.c04<1>
-c04(?f04##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
+c04(?f04##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#result##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f04##0:wybe.int)
 
     1:
@@ -1091,12 +1091,12 @@ c04(?f04##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 3:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?f04##0:wybe.int)
 
         1:
             foreign lpvm access(~#result##0:multictr.complicated, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?f04##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -1111,13 +1111,13 @@ c05(f05##0:wybe.int, ?#result##0:multictr.complicated):
     foreign llvm or(~#rec##1:multictr.complicated, 4:wybe.int, ?#result##0:multictr.complicated)
 c05 > public {inline} (29 calls)
 1: multictr.complicated.c05<1>
-c05(?f05##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
+c05(?f05##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#result##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f05##0:wybe.int)
 
     1:
@@ -1125,12 +1125,12 @@ c05(?f05##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 4:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?f05##0:wybe.int)
 
         1:
             foreign lpvm access(~#result##0:multictr.complicated, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?f05##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -1145,13 +1145,13 @@ c06(f06##0:wybe.int, ?#result##0:multictr.complicated):
     foreign llvm or(~#rec##1:multictr.complicated, 5:wybe.int, ?#result##0:multictr.complicated)
 c06 > public {inline} (27 calls)
 1: multictr.complicated.c06<1>
-c06(?f06##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
+c06(?f06##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#result##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f06##0:wybe.int)
 
     1:
@@ -1159,12 +1159,12 @@ c06(?f06##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 5:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?f06##0:wybe.int)
 
         1:
             foreign lpvm access(~#result##0:multictr.complicated, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?f06##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -1179,13 +1179,13 @@ c07(f07##0:wybe.int, ?#result##0:multictr.complicated):
     foreign llvm or(~#rec##1:multictr.complicated, 6:wybe.int, ?#result##0:multictr.complicated)
 c07 > public {inline} (25 calls)
 1: multictr.complicated.c07<1>
-c07(?f07##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
+c07(?f07##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#result##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f07##0:wybe.int)
 
     1:
@@ -1193,12 +1193,12 @@ c07(?f07##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 6:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?f07##0:wybe.int)
 
         1:
             foreign lpvm access(~#result##0:multictr.complicated, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?f07##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -1214,13 +1214,13 @@ c08(f08##0:wybe.int, ?#result##0:multictr.complicated):
     foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated)
 c08 > public {inline} (23 calls)
 1: multictr.complicated.c08<1>
-c08(?f08##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
+c08(?f08##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#result##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f08##0:wybe.int)
 
     1:
@@ -1228,7 +1228,7 @@ c08(?f08##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?f08##0:wybe.int)
 
         1:
@@ -1236,12 +1236,12 @@ c08(?f08##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 7:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
                 foreign llvm move(undef:wybe.int, ?f08##0:wybe.int)
 
             1:
                 foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f08##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -1258,13 +1258,13 @@ c09(f09##0:wybe.int, ?#result##0:multictr.complicated):
     foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated)
 c09 > public {inline} (21 calls)
 1: multictr.complicated.c09<1>
-c09(?f09##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
+c09(?f09##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#result##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f09##0:wybe.int)
 
     1:
@@ -1272,7 +1272,7 @@ c09(?f09##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?f09##0:wybe.int)
 
         1:
@@ -1280,12 +1280,12 @@ c09(?f09##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 8:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
                 foreign llvm move(undef:wybe.int, ?f09##0:wybe.int)
 
             1:
                 foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f09##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -1302,13 +1302,13 @@ c10(f10##0:wybe.int, ?#result##0:multictr.complicated):
     foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated)
 c10 > public {inline} (19 calls)
 1: multictr.complicated.c10<1>
-c10(?f10##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
+c10(?f10##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#result##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f10##0:wybe.int)
 
     1:
@@ -1316,7 +1316,7 @@ c10(?f10##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?f10##0:wybe.int)
 
         1:
@@ -1324,12 +1324,12 @@ c10(?f10##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 9:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
                 foreign llvm move(undef:wybe.int, ?f10##0:wybe.int)
 
             1:
                 foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f10##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -1346,13 +1346,13 @@ c11(f11##0:wybe.int, ?#result##0:multictr.complicated):
     foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated)
 c11 > public {inline} (17 calls)
 1: multictr.complicated.c11<1>
-c11(?f11##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
+c11(?f11##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#result##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f11##0:wybe.int)
 
     1:
@@ -1360,7 +1360,7 @@ c11(?f11##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?f11##0:wybe.int)
 
         1:
@@ -1368,12 +1368,12 @@ c11(?f11##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 10:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
                 foreign llvm move(undef:wybe.int, ?f11##0:wybe.int)
 
             1:
                 foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f11##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -1390,13 +1390,13 @@ c12(f12##0:wybe.int, ?#result##0:multictr.complicated):
     foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated)
 c12 > public {inline} (15 calls)
 1: multictr.complicated.c12<1>
-c12(?f12##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
+c12(?f12##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#result##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f12##0:wybe.int)
 
     1:
@@ -1404,7 +1404,7 @@ c12(?f12##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?f12##0:wybe.int)
 
         1:
@@ -1412,12 +1412,12 @@ c12(?f12##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 11:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
                 foreign llvm move(undef:wybe.int, ?f12##0:wybe.int)
 
             1:
                 foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f12##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -1434,13 +1434,13 @@ c13(f13##0:wybe.int, ?#result##0:multictr.complicated):
     foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated)
 c13 > public {inline} (13 calls)
 1: multictr.complicated.c13<1>
-c13(?f13##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
+c13(?f13##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#result##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f13##0:wybe.int)
 
     1:
@@ -1448,7 +1448,7 @@ c13(?f13##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?f13##0:wybe.int)
 
         1:
@@ -1456,12 +1456,12 @@ c13(?f13##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 12:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
                 foreign llvm move(undef:wybe.int, ?f13##0:wybe.int)
 
             1:
                 foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f13##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -1478,13 +1478,13 @@ c14(f14##0:wybe.int, ?#result##0:multictr.complicated):
     foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated)
 c14 > public {inline} (11 calls)
 1: multictr.complicated.c14<1>
-c14(?f14##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
+c14(?f14##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#result##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f14##0:wybe.int)
 
     1:
@@ -1492,7 +1492,7 @@ c14(?f14##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?f14##0:wybe.int)
 
         1:
@@ -1500,12 +1500,12 @@ c14(?f14##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 13:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
                 foreign llvm move(undef:wybe.int, ?f14##0:wybe.int)
 
             1:
                 foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f14##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -1522,13 +1522,13 @@ c15(f15##0:wybe.int, ?#result##0:multictr.complicated):
     foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated)
 c15 > public {inline} (9 calls)
 1: multictr.complicated.c15<1>
-c15(?f15##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
+c15(?f15##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#result##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f15##0:wybe.int)
 
     1:
@@ -1536,7 +1536,7 @@ c15(?f15##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?f15##0:wybe.int)
 
         1:
@@ -1544,12 +1544,12 @@ c15(?f15##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 14:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
                 foreign llvm move(undef:wybe.int, ?f15##0:wybe.int)
 
             1:
                 foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f15##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -1566,13 +1566,13 @@ c16(f16##0:wybe.int, ?#result##0:multictr.complicated):
     foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated)
 c16 > public {inline} (7 calls)
 1: multictr.complicated.c16<1>
-c16(?f16##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
+c16(?f16##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#result##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f16##0:wybe.int)
 
     1:
@@ -1580,7 +1580,7 @@ c16(?f16##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?f16##0:wybe.int)
 
         1:
@@ -1588,12 +1588,12 @@ c16(?f16##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 15:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
                 foreign llvm move(undef:wybe.int, ?f16##0:wybe.int)
 
             1:
                 foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f16##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -1610,13 +1610,13 @@ c17(f17##0:wybe.int, ?#result##0:multictr.complicated):
     foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated)
 c17 > public {inline} (5 calls)
 1: multictr.complicated.c17<1>
-c17(?f17##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
+c17(?f17##0:wybe.int, #result##0:multictr.complicated, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#result##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f17##0:wybe.int)
 
     1:
@@ -1624,7 +1624,7 @@ c17(?f17##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?f17##0:wybe.int)
 
         1:
@@ -1632,12 +1632,12 @@ c17(?f17##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 16:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
                 foreign llvm move(undef:wybe.int, ?f17##0:wybe.int)
 
             1:
                 foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f17##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -1645,13 +1645,13 @@ c17(?f17##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
 
 f01 > public {inline} (0 calls)
 0: multictr.complicated.f01<0>
-f01(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
+f01(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
@@ -1659,23 +1659,23 @@ f01(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
             foreign lpvm access(~#rec##0:multictr.complicated, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 f01 > public {inline} (0 calls)
 1: multictr.complicated.f01<1>
-f01(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?####0:wybe.bool):
+f01(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
     1:
@@ -1683,25 +1683,25 @@ f01(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
             foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 
 f02 > public {inline} (0 calls)
 0: multictr.complicated.f02<0>
-f02(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
+f02(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
@@ -1709,23 +1709,23 @@ f02(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
             foreign lpvm access(~#rec##0:multictr.complicated, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#result##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 f02 > public {inline} (0 calls)
 1: multictr.complicated.f02<1>
-f02(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?####0:wybe.bool):
+f02(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
     1:
@@ -1733,25 +1733,25 @@ f02(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
             foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, -1:wybe.int, 0:wybe.int, 8:wybe.int, 1:wybe.int, ~#field##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 
 f03 > public {inline} (0 calls)
 0: multictr.complicated.f03<0>
-f03(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
+f03(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
@@ -1759,23 +1759,23 @@ f03(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 2:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
             foreign lpvm access(~#rec##0:multictr.complicated, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#result##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 f03 > public {inline} (0 calls)
 1: multictr.complicated.f03<1>
-f03(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?####0:wybe.bool):
+f03(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
     1:
@@ -1783,25 +1783,25 @@ f03(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 2:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
             foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, -2:wybe.int, 0:wybe.int, 8:wybe.int, 2:wybe.int, ~#field##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 
 f04 > public {inline} (0 calls)
 0: multictr.complicated.f04<0>
-f04(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
+f04(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
@@ -1809,23 +1809,23 @@ f04(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 3:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
             foreign lpvm access(~#rec##0:multictr.complicated, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?#result##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 f04 > public {inline} (0 calls)
 1: multictr.complicated.f04<1>
-f04(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?####0:wybe.bool):
+f04(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
     1:
@@ -1833,25 +1833,25 @@ f04(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 3:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
             foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, -3:wybe.int, 0:wybe.int, 8:wybe.int, 3:wybe.int, ~#field##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 
 f05 > public {inline} (0 calls)
 0: multictr.complicated.f05<0>
-f05(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
+f05(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
@@ -1859,23 +1859,23 @@ f05(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 4:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
             foreign lpvm access(~#rec##0:multictr.complicated, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?#result##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 f05 > public {inline} (0 calls)
 1: multictr.complicated.f05<1>
-f05(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?####0:wybe.bool):
+f05(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
     1:
@@ -1883,25 +1883,25 @@ f05(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 4:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
             foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, -4:wybe.int, 0:wybe.int, 8:wybe.int, 4:wybe.int, ~#field##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 
 f06 > public {inline} (0 calls)
 0: multictr.complicated.f06<0>
-f06(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
+f06(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
@@ -1909,23 +1909,23 @@ f06(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 5:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
             foreign lpvm access(~#rec##0:multictr.complicated, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?#result##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 f06 > public {inline} (0 calls)
 1: multictr.complicated.f06<1>
-f06(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?####0:wybe.bool):
+f06(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
     1:
@@ -1933,25 +1933,25 @@ f06(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 5:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
             foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, -5:wybe.int, 0:wybe.int, 8:wybe.int, 5:wybe.int, ~#field##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 
 f07 > public {inline} (0 calls)
 0: multictr.complicated.f07<0>
-f07(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
+f07(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
@@ -1959,23 +1959,23 @@ f07(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 6:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
             foreign lpvm access(~#rec##0:multictr.complicated, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?#result##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 f07 > public {inline} (0 calls)
 1: multictr.complicated.f07<1>
-f07(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?####0:wybe.bool):
+f07(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
     1:
@@ -1983,25 +1983,25 @@ f07(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 6:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
             foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, -6:wybe.int, 0:wybe.int, 8:wybe.int, 6:wybe.int, ~#field##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 
 f08 > public {inline} (0 calls)
 0: multictr.complicated.f08<0>
-f08(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
+f08(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
@@ -2009,7 +2009,7 @@ f08(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
@@ -2017,24 +2017,24 @@ f08(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 7:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
                 foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
             1:
                 foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 f08 > public {inline} (0 calls)
 1: multictr.complicated.f08<1>
-f08(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?####0:wybe.bool):
+f08(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
     1:
@@ -2042,7 +2042,7 @@ f08(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
@@ -2050,12 +2050,12 @@ f08(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 7:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
                 foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
             1:
                 foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -2063,13 +2063,13 @@ f08(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 f09 > public {inline} (0 calls)
 0: multictr.complicated.f09<0>
-f09(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
+f09(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
@@ -2077,7 +2077,7 @@ f09(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
@@ -2085,24 +2085,24 @@ f09(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 8:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
                 foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
             1:
                 foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 f09 > public {inline} (0 calls)
 1: multictr.complicated.f09<1>
-f09(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?####0:wybe.bool):
+f09(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
     1:
@@ -2110,7 +2110,7 @@ f09(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
@@ -2118,12 +2118,12 @@ f09(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 8:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
                 foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
             1:
                 foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -2131,13 +2131,13 @@ f09(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 f10 > public {inline} (0 calls)
 0: multictr.complicated.f10<0>
-f10(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
+f10(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
@@ -2145,7 +2145,7 @@ f10(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
@@ -2153,24 +2153,24 @@ f10(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 9:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
                 foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
             1:
                 foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 f10 > public {inline} (0 calls)
 1: multictr.complicated.f10<1>
-f10(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?####0:wybe.bool):
+f10(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
     1:
@@ -2178,7 +2178,7 @@ f10(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
@@ -2186,12 +2186,12 @@ f10(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 9:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
                 foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
             1:
                 foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -2199,13 +2199,13 @@ f10(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 f11 > public {inline} (0 calls)
 0: multictr.complicated.f11<0>
-f11(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
+f11(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
@@ -2213,7 +2213,7 @@ f11(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
@@ -2221,24 +2221,24 @@ f11(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 10:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
                 foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
             1:
                 foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 f11 > public {inline} (0 calls)
 1: multictr.complicated.f11<1>
-f11(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?####0:wybe.bool):
+f11(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
     1:
@@ -2246,7 +2246,7 @@ f11(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
@@ -2254,12 +2254,12 @@ f11(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 10:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
                 foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
             1:
                 foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -2267,13 +2267,13 @@ f11(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 f12 > public {inline} (0 calls)
 0: multictr.complicated.f12<0>
-f12(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
+f12(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
@@ -2281,7 +2281,7 @@ f12(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
@@ -2289,24 +2289,24 @@ f12(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 11:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
                 foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
             1:
                 foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 f12 > public {inline} (0 calls)
 1: multictr.complicated.f12<1>
-f12(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?####0:wybe.bool):
+f12(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
     1:
@@ -2314,7 +2314,7 @@ f12(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
@@ -2322,12 +2322,12 @@ f12(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 11:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
                 foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
             1:
                 foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -2335,13 +2335,13 @@ f12(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 f13 > public {inline} (0 calls)
 0: multictr.complicated.f13<0>
-f13(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
+f13(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
@@ -2349,7 +2349,7 @@ f13(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
@@ -2357,24 +2357,24 @@ f13(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 12:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
                 foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
             1:
                 foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 f13 > public {inline} (0 calls)
 1: multictr.complicated.f13<1>
-f13(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?####0:wybe.bool):
+f13(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
     1:
@@ -2382,7 +2382,7 @@ f13(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
@@ -2390,12 +2390,12 @@ f13(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 12:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
                 foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
             1:
                 foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -2403,13 +2403,13 @@ f13(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 f14 > public {inline} (0 calls)
 0: multictr.complicated.f14<0>
-f14(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
+f14(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
@@ -2417,7 +2417,7 @@ f14(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
@@ -2425,24 +2425,24 @@ f14(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 13:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
                 foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
             1:
                 foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 f14 > public {inline} (0 calls)
 1: multictr.complicated.f14<1>
-f14(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?####0:wybe.bool):
+f14(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
     1:
@@ -2450,7 +2450,7 @@ f14(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
@@ -2458,12 +2458,12 @@ f14(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 13:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
                 foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
             1:
                 foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -2471,13 +2471,13 @@ f14(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 f15 > public {inline} (0 calls)
 0: multictr.complicated.f15<0>
-f15(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
+f15(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
@@ -2485,7 +2485,7 @@ f15(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
@@ -2493,24 +2493,24 @@ f15(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 14:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
                 foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
             1:
                 foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 f15 > public {inline} (0 calls)
 1: multictr.complicated.f15<1>
-f15(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?####0:wybe.bool):
+f15(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
     1:
@@ -2518,7 +2518,7 @@ f15(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
@@ -2526,12 +2526,12 @@ f15(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 14:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
                 foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
             1:
                 foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -2539,13 +2539,13 @@ f15(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 f16 > public {inline} (0 calls)
 0: multictr.complicated.f16<0>
-f16(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
+f16(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
@@ -2553,7 +2553,7 @@ f16(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
@@ -2561,24 +2561,24 @@ f16(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 15:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
                 foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
             1:
                 foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 f16 > public {inline} (0 calls)
 1: multictr.complicated.f16<1>
-f16(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?####0:wybe.bool):
+f16(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
     1:
@@ -2586,7 +2586,7 @@ f16(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
@@ -2594,12 +2594,12 @@ f16(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 15:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
                 foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
             1:
                 foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -2607,13 +2607,13 @@ f16(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 f17 > public {inline} (0 calls)
 0: multictr.complicated.f17<0>
-f17(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
+f17(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
@@ -2621,7 +2621,7 @@ f17(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
@@ -2629,24 +2629,24 @@ f17(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 16:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
                 foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
             1:
                 foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 f17 > public {inline} (0 calls)
 1: multictr.complicated.f17<1>
-f17(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?####0:wybe.bool):
+f17(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
     1:
@@ -2654,7 +2654,7 @@ f17(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
@@ -2662,12 +2662,12 @@ f17(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 16:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
                 foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
             1:
                 foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -2699,11 +2699,11 @@ winter(?#result##0:multictr.complicated):
 
 ~= > public {inline} (0 calls)
 0: multictr.complicated.~=<0>
-~=(#left##0:multictr.complicated, #right##0:multictr.complicated, ?####0:wybe.bool):
+~=(#left##0:multictr.complicated, #right##0:multictr.complicated, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     multictr.complicated.=<0>(~#left##0:multictr.complicated, ~#right##0:multictr.complicated, ?tmp#0##0:wybe.bool) #0
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 
@@ -2728,8 +2728,8 @@ if.then:
   %"2#tmp#56##0" = icmp eq i64 %"2#tmp#55##0", 0 
   br i1 %"2#tmp#56##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %"3#####0" 
+  %"3##success##0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3##success##0" 
 if.then1:
   %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
@@ -2749,8 +2749,8 @@ if.then3:
   %4 = inttoptr i64 %"#right##0" to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
   %6 = load  i64, i64* %5 
-  %"8#####0" = icmp eq i64 %3, %6 
-  ret i1 %"8#####0" 
+  %"8##success##0" = icmp eq i64 %3, %6 
+  ret i1 %"8##success##0" 
 if.else3:
   ret i1 0 
 if.then4:
@@ -2774,8 +2774,8 @@ if.then6:
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"14#####0" = icmp eq i64 %10, %14 
-  ret i1 %"14#####0" 
+  %"14##success##0" = icmp eq i64 %10, %14 
+  ret i1 %"14##success##0" 
 if.else6:
   ret i1 0 
 if.then7:
@@ -2799,8 +2799,8 @@ if.then9:
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %"20#####0" = icmp eq i64 %18, %22 
-  ret i1 %"20#####0" 
+  %"20##success##0" = icmp eq i64 %18, %22 
+  ret i1 %"20##success##0" 
 if.else9:
   ret i1 0 
 if.then10:
@@ -2824,8 +2824,8 @@ if.then12:
   %28 = inttoptr i64 %27 to i64* 
   %29 = getelementptr  i64, i64* %28, i64 0 
   %30 = load  i64, i64* %29 
-  %"26#####0" = icmp eq i64 %26, %30 
-  ret i1 %"26#####0" 
+  %"26##success##0" = icmp eq i64 %26, %30 
+  ret i1 %"26##success##0" 
 if.else12:
   ret i1 0 
 if.then13:
@@ -2849,8 +2849,8 @@ if.then15:
   %36 = inttoptr i64 %35 to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
-  %"32#####0" = icmp eq i64 %34, %38 
-  ret i1 %"32#####0" 
+  %"32##success##0" = icmp eq i64 %34, %38 
+  ret i1 %"32##success##0" 
 if.else15:
   ret i1 0 
 if.then16:
@@ -2874,8 +2874,8 @@ if.then18:
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
-  %"38#####0" = icmp eq i64 %42, %46 
-  ret i1 %"38#####0" 
+  %"38##success##0" = icmp eq i64 %42, %46 
+  ret i1 %"38##success##0" 
 if.else18:
   ret i1 0 
 if.then19:
@@ -2899,8 +2899,8 @@ if.then21:
   %52 = inttoptr i64 %51 to i64* 
   %53 = getelementptr  i64, i64* %52, i64 0 
   %54 = load  i64, i64* %53 
-  %"44#####0" = icmp eq i64 %50, %54 
-  ret i1 %"44#####0" 
+  %"44##success##0" = icmp eq i64 %50, %54 
+  ret i1 %"44##success##0" 
 if.else21:
   ret i1 0 
 if.then22:
@@ -2942,8 +2942,8 @@ if.then26:
   %68 = inttoptr i64 %67 to i64* 
   %69 = getelementptr  i64, i64* %68, i64 0 
   %70 = load  i64, i64* %69 
-  %"54#####0" = icmp eq i64 %62, %70 
-  ret i1 %"54#####0" 
+  %"54##success##0" = icmp eq i64 %62, %70 
+  ret i1 %"54##success##0" 
 if.else26:
   ret i1 0 
 if.then27:
@@ -2976,8 +2976,8 @@ if.then30:
   %80 = inttoptr i64 %79 to i64* 
   %81 = getelementptr  i64, i64* %80, i64 0 
   %82 = load  i64, i64* %81 
-  %"62#####0" = icmp eq i64 %74, %82 
-  ret i1 %"62#####0" 
+  %"62##success##0" = icmp eq i64 %74, %82 
+  ret i1 %"62##success##0" 
 if.else30:
   ret i1 0 
 if.then31:
@@ -3010,8 +3010,8 @@ if.then34:
   %92 = inttoptr i64 %91 to i64* 
   %93 = getelementptr  i64, i64* %92, i64 0 
   %94 = load  i64, i64* %93 
-  %"70#####0" = icmp eq i64 %86, %94 
-  ret i1 %"70#####0" 
+  %"70##success##0" = icmp eq i64 %86, %94 
+  ret i1 %"70##success##0" 
 if.else34:
   ret i1 0 
 if.then35:
@@ -3044,8 +3044,8 @@ if.then38:
   %104 = inttoptr i64 %103 to i64* 
   %105 = getelementptr  i64, i64* %104, i64 0 
   %106 = load  i64, i64* %105 
-  %"78#####0" = icmp eq i64 %98, %106 
-  ret i1 %"78#####0" 
+  %"78##success##0" = icmp eq i64 %98, %106 
+  ret i1 %"78##success##0" 
 if.else38:
   ret i1 0 
 if.then39:
@@ -3078,8 +3078,8 @@ if.then42:
   %116 = inttoptr i64 %115 to i64* 
   %117 = getelementptr  i64, i64* %116, i64 0 
   %118 = load  i64, i64* %117 
-  %"86#####0" = icmp eq i64 %110, %118 
-  ret i1 %"86#####0" 
+  %"86##success##0" = icmp eq i64 %110, %118 
+  ret i1 %"86##success##0" 
 if.else42:
   ret i1 0 
 if.then43:
@@ -3112,8 +3112,8 @@ if.then46:
   %128 = inttoptr i64 %127 to i64* 
   %129 = getelementptr  i64, i64* %128, i64 0 
   %130 = load  i64, i64* %129 
-  %"94#####0" = icmp eq i64 %122, %130 
-  ret i1 %"94#####0" 
+  %"94##success##0" = icmp eq i64 %122, %130 
+  ret i1 %"94##success##0" 
 if.else46:
   ret i1 0 
 if.then47:
@@ -3146,8 +3146,8 @@ if.then50:
   %140 = inttoptr i64 %139 to i64* 
   %141 = getelementptr  i64, i64* %140, i64 0 
   %142 = load  i64, i64* %141 
-  %"102#####0" = icmp eq i64 %134, %142 
-  ret i1 %"102#####0" 
+  %"102##success##0" = icmp eq i64 %134, %142 
+  ret i1 %"102##success##0" 
 if.else50:
   ret i1 0 
 if.then51:
@@ -3180,8 +3180,8 @@ if.then54:
   %152 = inttoptr i64 %151 to i64* 
   %153 = getelementptr  i64, i64* %152, i64 0 
   %154 = load  i64, i64* %153 
-  %"110#####0" = icmp eq i64 %146, %154 
-  ret i1 %"110#####0" 
+  %"110##success##0" = icmp eq i64 %146, %154 
+  ret i1 %"110##success##0" 
 if.else54:
   ret i1 0 
 if.then55:
@@ -3214,8 +3214,8 @@ if.then58:
   %164 = inttoptr i64 %163 to i64* 
   %165 = getelementptr  i64, i64* %164, i64 0 
   %166 = load  i64, i64* %165 
-  %"118#####0" = icmp eq i64 %158, %166 
-  ret i1 %"118#####0" 
+  %"118##success##0" = icmp eq i64 %158, %166 
+  ret i1 %"118##success##0" 
 if.else58:
   ret i1 0 
 if.then59:
@@ -3247,8 +3247,8 @@ if.then62:
   %176 = inttoptr i64 %175 to i64* 
   %177 = getelementptr  i64, i64* %176, i64 0 
   %178 = load  i64, i64* %177 
-  %"126#####0" = icmp eq i64 %170, %178 
-  ret i1 %"126#####0" 
+  %"126##success##0" = icmp eq i64 %170, %178 
+  ret i1 %"126##success##0" 
 if.else62:
   ret i1 0 
 }
@@ -5396,8 +5396,8 @@ entry:
 define external fastcc  i1 @"multictr.complicated.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %"1#tmp#0##0" = tail call fastcc  i1  @"multictr.complicated.=<0>"(i64  %"#left##0", i64  %"#right##0")  
-  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
-  ret i1 %"1#####0" 
+  %"1##success##0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1##success##0" 
 }
 --------------------------------------------------
  Module multictr.length
@@ -5417,10 +5417,10 @@ entry:
 
 = > public {inline} (1 calls)
 0: multictr.length.=<0>
-=(#left##0:multictr.length, #right##0:multictr.length, ?####0:wybe.bool):
+=(#left##0:multictr.length, #right##0:multictr.length, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(~#left##0:multictr.length, ~#right##0:multictr.length, ?####0:wybe.bool)
+    foreign llvm icmp_eq(~#left##0:multictr.length, ~#right##0:multictr.length, ?#success##0:wybe.bool)
 
 
 metres > public {inline} (0 calls)
@@ -5453,11 +5453,11 @@ value([#rec##0:multictr.length], ?#rec##2:multictr.length, #field##0:wybe.float)
 
 ~= > public {inline} (0 calls)
 0: multictr.length.~=<0>
-~=(#left##0:multictr.length, #right##0:multictr.length, ?####0:wybe.bool):
+~=(#left##0:multictr.length, #right##0:multictr.length, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_eq(~#left##0:multictr.length, ~#right##0:multictr.length, ?tmp#0##0:wybe.bool)
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 
@@ -5475,8 +5475,8 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  i1 @"multictr.length.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1#####0" = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %"1#####0" 
+  %"1##success##0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"1##success##0" 
 }
 
 
@@ -5511,8 +5511,8 @@ entry:
 define external fastcc  i1 @"multictr.length.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %"1#tmp#0##0" = icmp eq i64 %"#left##0", %"#right##0" 
-  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
-  ret i1 %"1#####0" 
+  %"1##success##0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1##success##0" 
 }
 --------------------------------------------------
  Module multictr.maybe_int
@@ -5533,24 +5533,24 @@ entry:
 
 = > public (1 calls)
 0: multictr.maybe_int.=<0>
-=(#left##0:multictr.maybe_int, #right##0:multictr.maybe_int, ?####0:wybe.bool):
+=(#left##0:multictr.maybe_int, #right##0:multictr.maybe_int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~#left##0:multictr.maybe_int, ~#right##0:multictr.maybe_int, ?####0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:multictr.maybe_int, ~#right##0:multictr.maybe_int, ?#success##0:wybe.bool)
 
     1:
         foreign lpvm access(~#left##0:multictr.maybe_int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#left#value##0:wybe.int)
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool)
         case ~tmp#8##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign lpvm access(~#right##0:multictr.maybe_int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#right#value##0:wybe.int)
-            foreign llvm icmp_eq(~#left#value##0:wybe.int, ~#right#value##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+            foreign llvm icmp_eq(~#left#value##0:wybe.int, ~#right#value##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -5564,18 +5564,18 @@ just(value##0:wybe.int, ?#result##0:multictr.maybe_int):
     foreign lpvm mutate(~#rec##0:multictr.maybe_int, ?#result##0:multictr.maybe_int, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~value##0:wybe.int)
 just > public {inline} (8 calls)
 1: multictr.maybe_int.just<1>
-just(?value##0:wybe.int, #result##0:multictr.maybe_int, ?####0:wybe.bool):
+just(?value##0:wybe.int, #result##0:multictr.maybe_int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?value##0:wybe.int)
 
     1:
         foreign lpvm access(~#result##0:multictr.maybe_int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?value##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -5589,43 +5589,43 @@ nothing(?#result##0:multictr.maybe_int):
 
 value > public {inline} (0 calls)
 0: multictr.maybe_int.value<0>
-value(#rec##0:multictr.maybe_int, ?#result##0:wybe.int, ?####0:wybe.bool):
+value(#rec##0:multictr.maybe_int, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign lpvm access(~#rec##0:multictr.maybe_int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 value > public {inline} (0 calls)
 1: multictr.maybe_int.value<1>
-value(#rec##0:multictr.maybe_int, ?#rec##1:multictr.maybe_int, #field##0:wybe.int, ?####0:wybe.bool):
+value(#rec##0:multictr.maybe_int, ?#rec##1:multictr.maybe_int, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multictr.maybe_int, ?#rec##1:multictr.maybe_int)
 
     1:
         foreign lpvm {noalias} mutate(~#rec##0:multictr.maybe_int, ?#rec##1:multictr.maybe_int, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: multictr.maybe_int.~=<0>
-~=(#left##0:multictr.maybe_int, #right##0:multictr.maybe_int, ?####0:wybe.bool):
+~=(#left##0:multictr.maybe_int, #right##0:multictr.maybe_int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     multictr.maybe_int.=<0>(~#left##0:multictr.maybe_int, ~#right##0:multictr.maybe_int, ?tmp#0##0:wybe.bool) #0
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 
@@ -5652,14 +5652,14 @@ if.then:
   %"2#tmp#8##0" = icmp ne i64 %"#right##0", 0 
   br i1 %"2#tmp#8##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %"3#####0" 
+  %"3##success##0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3##success##0" 
 if.then1:
   %4 = inttoptr i64 %"#right##0" to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
   %6 = load  i64, i64* %5 
-  %"4#####0" = icmp eq i64 %3, %6 
-  ret i1 %"4#####0" 
+  %"4##success##0" = icmp eq i64 %3, %6 
+  ret i1 %"4##success##0" 
 if.else1:
   ret i1 0 
 }
@@ -5747,8 +5747,8 @@ if.else:
 define external fastcc  i1 @"multictr.maybe_int.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %"1#tmp#0##0" = tail call fastcc  i1  @"multictr.maybe_int.=<0>"(i64  %"#left##0", i64  %"#right##0")  
-  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
-  ret i1 %"1#####0" 
+  %"1##success##0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1##success##0" 
 }
 --------------------------------------------------
  Module multictr.number
@@ -5772,7 +5772,7 @@ entry:
 
 = > public (1 calls)
 0: multictr.number.=<0>
-=(#left##0:multictr.number, #right##0:multictr.number, ?####0:wybe.bool):
+=(#left##0:multictr.number, #right##0:multictr.number, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#left##0:wybe.int, 1:wybe.int, ?tmp#8##0:wybe.int)
@@ -5782,7 +5782,7 @@ entry:
         foreign llvm icmp_eq(~tmp#8##0:wybe.int, 1:wybe.int, ?tmp#12##0:wybe.bool)
         case ~tmp#12##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign lpvm access(~#left##0:multictr.number, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#left#float_value##0:wybe.float)
@@ -5790,11 +5790,11 @@ entry:
             foreign llvm icmp_eq(~tmp#14##0:wybe.int, 1:wybe.int, ?tmp#15##0:wybe.bool)
             case ~tmp#15##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
                 foreign lpvm access(~#right##0:multictr.number, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#right#float_value##0:wybe.float)
-                foreign llvm fcmp_eq(~#left#float_value##0:wybe.float, ~#right#float_value##0:wybe.float, ?####0:wybe.bool) @float:nn:nn
+                foreign llvm fcmp_eq(~#left#float_value##0:wybe.float, ~#right#float_value##0:wybe.float, ?#success##0:wybe.bool) @float:nn:nn
 
 
 
@@ -5804,11 +5804,11 @@ entry:
         foreign llvm icmp_eq(~tmp#11##0:wybe.int, 0:wybe.int, ?tmp#12##0:wybe.bool)
         case ~tmp#12##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign lpvm access(~#right##0:multictr.number, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#right#int_value##0:wybe.int)
-            foreign llvm icmp_eq(~#left#int_value##0:wybe.int, ~#right#int_value##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+            foreign llvm icmp_eq(~#left#int_value##0:wybe.int, ~#right#int_value##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -5823,53 +5823,53 @@ float(float_value##0:wybe.float, ?#result##0:multictr.number):
     foreign llvm or(~#rec##1:multictr.number, 1:wybe.int, ?#result##0:multictr.number)
 float > public {inline} (5 calls)
 1: multictr.number.float<1>
-float(?float_value##0:wybe.float, #result##0:multictr.number, ?####0:wybe.bool):
+float(?float_value##0:wybe.float, #result##0:multictr.number, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#result##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.float, ?float_value##0:wybe.float)
 
     1:
         foreign lpvm access(~#result##0:multictr.number, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?float_value##0:wybe.float)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 float_value > public {inline} (0 calls)
 0: multictr.number.float_value<0>
-float_value(#rec##0:multictr.number, ?#result##0:wybe.float, ?####0:wybe.bool):
+float_value(#rec##0:multictr.number, ?#result##0:wybe.float, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.float, ?#result##0:wybe.float)
 
     1:
         foreign lpvm access(~#rec##0:multictr.number, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#result##0:wybe.float)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 float_value > public {inline} (0 calls)
 1: multictr.number.float_value<1>
-float_value(#rec##0:multictr.number, ?#rec##1:multictr.number, #field##0:wybe.float, ?####0:wybe.bool):
+float_value(#rec##0:multictr.number, ?#rec##1:multictr.number, #field##0:wybe.float, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multictr.number, ?#rec##1:multictr.number)
 
     1:
         foreign lpvm {noalias} mutate(~#rec##0:multictr.number, ?#rec##1:multictr.number, -1:wybe.int, 0:wybe.int, 8:wybe.int, 1:wybe.int, ~#field##0:wybe.float)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -5882,63 +5882,63 @@ int(int_value##0:wybe.int, ?#result##0:multictr.number):
     foreign lpvm mutate(~#rec##0:multictr.number, ?#result##0:multictr.number, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~int_value##0:wybe.int)
 int > public {inline} (10 calls)
 1: multictr.number.int<1>
-int(?int_value##0:wybe.int, #result##0:multictr.number, ?####0:wybe.bool):
+int(?int_value##0:wybe.int, #result##0:multictr.number, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#result##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?int_value##0:wybe.int)
 
     1:
         foreign lpvm access(~#result##0:multictr.number, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?int_value##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 int_value > public {inline} (0 calls)
 0: multictr.number.int_value<0>
-int_value(#rec##0:multictr.number, ?#result##0:wybe.int, ?####0:wybe.bool):
+int_value(#rec##0:multictr.number, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign lpvm access(~#rec##0:multictr.number, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 int_value > public {inline} (0 calls)
 1: multictr.number.int_value<1>
-int_value(#rec##0:multictr.number, ?#rec##1:multictr.number, #field##0:wybe.int, ?####0:wybe.bool):
+int_value(#rec##0:multictr.number, ?#rec##1:multictr.number, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multictr.number, ?#rec##1:multictr.number)
 
     1:
         foreign lpvm {noalias} mutate(~#rec##0:multictr.number, ?#rec##1:multictr.number, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: multictr.number.~=<0>
-~=(#left##0:multictr.number, #right##0:multictr.number, ?####0:wybe.bool):
+~=(#left##0:multictr.number, #right##0:multictr.number, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     multictr.number.=<0>(~#left##0:multictr.number, ~#right##0:multictr.number, ?tmp#0##0:wybe.bool) #0
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 
@@ -5973,8 +5973,8 @@ if.then1:
   %4 = inttoptr i64 %"#right##0" to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
   %6 = load  i64, i64* %5 
-  %"4#####0" = icmp eq i64 %3, %6 
-  ret i1 %"4#####0" 
+  %"4##success##0" = icmp eq i64 %3, %6 
+  ret i1 %"4##success##0" 
 if.else1:
   ret i1 0 
 if.then2:
@@ -5992,8 +5992,8 @@ if.then3:
   %12 = inttoptr i64 %11 to double* 
   %13 = getelementptr  double, double* %12, i64 0 
   %14 = load  double, double* %13 
-  %"8#####0" = fcmp oeq double %10, %14 
-  ret i1 %"8#####0" 
+  %"8##success##0" = fcmp oeq double %10, %14 
+  ret i1 %"8##success##0" 
 if.else3:
   ret i1 0 
 }
@@ -6160,8 +6160,8 @@ if.else:
 define external fastcc  i1 @"multictr.number.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %"1#tmp#0##0" = tail call fastcc  i1  @"multictr.number.=<0>"(i64  %"#left##0", i64  %"#right##0")  
-  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
-  ret i1 %"1#####0" 
+  %"1##success##0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1##success##0" 
 }
 --------------------------------------------------
  Module multictr.perhaps
@@ -6181,10 +6181,10 @@ entry:
 
 = > public {inline} (1 calls)
 0: multictr.perhaps.=<0>
-=(#left##0:multictr.perhaps, #right##0:multictr.perhaps, ?####0:wybe.bool):
+=(#left##0:multictr.perhaps, #right##0:multictr.perhaps, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(~#left##0:multictr.perhaps, ~#right##0:multictr.perhaps, ?####0:wybe.bool)
+    foreign llvm icmp_eq(~#left##0:multictr.perhaps, ~#right##0:multictr.perhaps, ?#success##0:wybe.bool)
 
 
 content > public {inline} (0 calls)
@@ -6217,11 +6217,11 @@ perhaps(?content##0:multictr.maybe_int, #result##0:multictr.perhaps):
 
 ~= > public {inline} (0 calls)
 0: multictr.perhaps.~=<0>
-~=(#left##0:multictr.perhaps, #right##0:multictr.perhaps, ?####0:wybe.bool):
+~=(#left##0:multictr.perhaps, #right##0:multictr.perhaps, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_eq(~#left##0:multictr.perhaps, ~#right##0:multictr.perhaps, ?tmp#0##0:wybe.bool)
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 
@@ -6239,8 +6239,8 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  i1 @"multictr.perhaps.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1#####0" = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %"1#####0" 
+  %"1##success##0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"1##success##0" 
 }
 
 
@@ -6271,8 +6271,8 @@ entry:
 define external fastcc  i1 @"multictr.perhaps.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %"1#tmp#0##0" = icmp eq i64 %"#left##0", %"#right##0" 
-  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
-  ret i1 %"1#####0" 
+  %"1##success##0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1##success##0" 
 }
 --------------------------------------------------
  Module multictr.rank
@@ -6301,10 +6301,10 @@ entry:
 
 = > public {inline} (1 calls)
 0: multictr.rank.=<0>
-=(#left##0:multictr.rank, #right##0:multictr.rank, ?####0:wybe.bool):
+=(#left##0:multictr.rank, #right##0:multictr.rank, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(~#left##0:multictr.rank, ~#right##0:multictr.rank, ?####0:wybe.bool)
+    foreign llvm icmp_eq(~#left##0:multictr.rank, ~#right##0:multictr.rank, ?#success##0:wybe.bool)
 
 
 ace > public {inline} (0 calls)
@@ -6413,11 +6413,11 @@ r9(?#result##0:multictr.rank):
 
 ~= > public {inline} (0 calls)
 0: multictr.rank.~=<0>
-~=(#left##0:multictr.rank, #right##0:multictr.rank, ?####0:wybe.bool):
+~=(#left##0:multictr.rank, #right##0:multictr.rank, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_eq(~#left##0:multictr.rank, ~#right##0:multictr.rank, ?tmp#0##0:wybe.bool)
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 
@@ -6435,8 +6435,8 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  i1 @"multictr.rank.=<0>"(i4  %"#left##0", i4  %"#right##0")    {
 entry:
-  %"1#####0" = icmp eq i4 %"#left##0", %"#right##0" 
-  ret i1 %"1#####0" 
+  %"1##success##0" = icmp eq i4 %"#left##0", %"#right##0" 
+  ret i1 %"1##success##0" 
 }
 
 
@@ -6521,8 +6521,8 @@ entry:
 define external fastcc  i1 @"multictr.rank.~=<0>"(i4  %"#left##0", i4  %"#right##0")    {
 entry:
   %"1#tmp#0##0" = icmp eq i4 %"#left##0", %"#right##0" 
-  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
-  ret i1 %"1#####0" 
+  %"1##success##0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1##success##0" 
 }
 --------------------------------------------------
  Module multictr.simple
@@ -6549,13 +6549,13 @@ entry:
 
 = > public (1 calls)
 0: multictr.simple.=<0>
-=(#left##0:multictr.simple, #right##0:multictr.simple, ?####0:wybe.bool):
+=(#left##0:multictr.simple, #right##0:multictr.simple, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~#left##0:multictr.simple, ~#right##0:multictr.simple, ?####0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:multictr.simple, ~#right##0:multictr.simple, ?#success##0:wybe.bool)
 
     1:
         foreign llvm and(#left##0:wybe.int, 1:wybe.int, ?tmp#11##0:wybe.int)
@@ -6565,7 +6565,7 @@ entry:
             foreign llvm icmp_eq(~tmp#11##0:wybe.int, 1:wybe.int, ?tmp#16##0:wybe.bool)
             case ~tmp#16##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
                 foreign lpvm access(#left##0:multictr.simple, -1:wybe.int, 16:wybe.int, 1:wybe.int, ?#left#two_field1##0:wybe.int)
@@ -6573,14 +6573,14 @@ entry:
                 foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#18##0:wybe.bool)
                 case ~tmp#18##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                 1:
                     foreign llvm and(#right##0:wybe.int, 1:wybe.int, ?tmp#19##0:wybe.int)
                     foreign llvm icmp_eq(~tmp#19##0:wybe.int, 1:wybe.int, ?tmp#20##0:wybe.bool)
                     case ~tmp#20##0:wybe.bool of
                     0:
-                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                     1:
                         foreign lpvm access(#right##0:multictr.simple, -1:wybe.int, 16:wybe.int, 1:wybe.int, ?#right#two_field1##0:wybe.int)
@@ -6588,10 +6588,10 @@ entry:
                         foreign llvm icmp_eq(~#left#two_field1##0:wybe.int, ~#right#two_field1##0:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
                         case ~tmp#5##0:wybe.bool of
                         0:
-                            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                         1:
-                            foreign llvm icmp_eq(~#left#two_field2##0:wybe.int, ~#right#two_field2##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+                            foreign llvm icmp_eq(~#left#two_field2##0:wybe.int, ~#right#two_field2##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -6602,18 +6602,18 @@ entry:
             foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#14##0:wybe.bool)
             case ~tmp#14##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
                 foreign llvm and(#right##0:wybe.int, 1:wybe.int, ?tmp#15##0:wybe.int)
                 foreign llvm icmp_eq(~tmp#15##0:wybe.int, 0:wybe.int, ?tmp#16##0:wybe.bool)
                 case ~tmp#16##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                 1:
                     foreign lpvm access(~#right##0:multictr.simple, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#right#one_field##0:wybe.int)
-                    foreign llvm icmp_eq(~#left#one_field##0:wybe.int, ~#right#one_field##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+                    foreign llvm icmp_eq(~#left#one_field##0:wybe.int, ~#right#one_field##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -6629,13 +6629,13 @@ one(one_field##0:wybe.int, ?#result##0:multictr.simple):
     foreign lpvm mutate(~#rec##0:multictr.simple, ?#result##0:multictr.simple, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~one_field##0:wybe.int)
 one > public {inline} (11 calls)
 1: multictr.simple.one<1>
-one(?one_field##0:wybe.int, #result##0:multictr.simple, ?####0:wybe.bool):
+one(?one_field##0:wybe.int, #result##0:multictr.simple, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?one_field##0:wybe.int)
 
     1:
@@ -6643,25 +6643,25 @@ one(?one_field##0:wybe.int, #result##0:multictr.simple, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?one_field##0:wybe.int)
 
         1:
             foreign lpvm access(~#result##0:multictr.simple, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?one_field##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 
 one_field > public {inline} (0 calls)
 0: multictr.simple.one_field<0>
-one_field(#rec##0:multictr.simple, ?#result##0:wybe.int, ?####0:wybe.bool):
+one_field(#rec##0:multictr.simple, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
@@ -6669,23 +6669,23 @@ one_field(#rec##0:multictr.simple, ?#result##0:wybe.int, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
             foreign lpvm access(~#rec##0:multictr.simple, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 one_field > public {inline} (0 calls)
 1: multictr.simple.one_field<1>
-one_field(#rec##0:multictr.simple, ?#rec##1:multictr.simple, #field##0:wybe.int, ?####0:wybe.bool):
+one_field(#rec##0:multictr.simple, ?#rec##1:multictr.simple, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multictr.simple, ?#rec##1:multictr.simple)
 
     1:
@@ -6693,12 +6693,12 @@ one_field(#rec##0:multictr.simple, ?#rec##1:multictr.simple, #field##0:wybe.int,
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(~#rec##0:multictr.simple, ?#rec##1:multictr.simple)
 
         1:
             foreign lpvm {noalias} mutate(~#rec##0:multictr.simple, ?#rec##1:multictr.simple, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -6714,13 +6714,13 @@ two(two_field1##0:wybe.int, two_field2##0:wybe.int, ?#result##0:multictr.simple)
     foreign llvm or(~#rec##2:multictr.simple, 1:wybe.int, ?#result##0:multictr.simple)
 two > public {inline} (7 calls)
 1: multictr.simple.two<1>
-two(?two_field1##0:wybe.int, ?two_field2##0:wybe.int, #result##0:multictr.simple, ?####0:wybe.bool):
+two(?two_field1##0:wybe.int, ?two_field2##0:wybe.int, #result##0:multictr.simple, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?two_field1##0:wybe.int)
         foreign llvm move(undef:wybe.int, ?two_field2##0:wybe.int)
 
@@ -6729,27 +6729,27 @@ two(?two_field1##0:wybe.int, ?two_field2##0:wybe.int, #result##0:multictr.simple
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?two_field1##0:wybe.int)
             foreign llvm move(undef:wybe.int, ?two_field2##0:wybe.int)
 
         1:
             foreign lpvm access(#result##0:multictr.simple, -1:wybe.int, 16:wybe.int, 1:wybe.int, ?two_field1##0:wybe.int)
             foreign lpvm access(~#result##0:multictr.simple, 7:wybe.int, 16:wybe.int, 1:wybe.int, ?two_field2##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 
 two_field1 > public {inline} (0 calls)
 0: multictr.simple.two_field1<0>
-two_field1(#rec##0:multictr.simple, ?#result##0:wybe.int, ?####0:wybe.bool):
+two_field1(#rec##0:multictr.simple, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
@@ -6757,23 +6757,23 @@ two_field1(#rec##0:multictr.simple, ?#result##0:wybe.int, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
             foreign lpvm access(~#rec##0:multictr.simple, -1:wybe.int, 16:wybe.int, 1:wybe.int, ?#result##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 two_field1 > public {inline} (0 calls)
 1: multictr.simple.two_field1<1>
-two_field1(#rec##0:multictr.simple, ?#rec##1:multictr.simple, #field##0:wybe.int, ?####0:wybe.bool):
+two_field1(#rec##0:multictr.simple, ?#rec##1:multictr.simple, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multictr.simple, ?#rec##1:multictr.simple)
 
     1:
@@ -6781,25 +6781,25 @@ two_field1(#rec##0:multictr.simple, ?#rec##1:multictr.simple, #field##0:wybe.int
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(~#rec##0:multictr.simple, ?#rec##1:multictr.simple)
 
         1:
             foreign lpvm {noalias} mutate(~#rec##0:multictr.simple, ?#rec##1:multictr.simple, -1:wybe.int, 0:wybe.int, 16:wybe.int, 1:wybe.int, ~#field##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 
 two_field2 > public {inline} (0 calls)
 0: multictr.simple.two_field2<0>
-two_field2(#rec##0:multictr.simple, ?#result##0:wybe.int, ?####0:wybe.bool):
+two_field2(#rec##0:multictr.simple, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
@@ -6807,23 +6807,23 @@ two_field2(#rec##0:multictr.simple, ?#result##0:wybe.int, ?####0:wybe.bool):
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
             foreign lpvm access(~#rec##0:multictr.simple, 7:wybe.int, 16:wybe.int, 1:wybe.int, ?#result##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 two_field2 > public {inline} (0 calls)
 1: multictr.simple.two_field2<1>
-two_field2(#rec##0:multictr.simple, ?#rec##1:multictr.simple, #field##0:wybe.int, ?####0:wybe.bool):
+two_field2(#rec##0:multictr.simple, ?#rec##1:multictr.simple, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multictr.simple, ?#rec##1:multictr.simple)
 
     1:
@@ -6831,12 +6831,12 @@ two_field2(#rec##0:multictr.simple, ?#rec##1:multictr.simple, #field##0:wybe.int
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(~#rec##0:multictr.simple, ?#rec##1:multictr.simple)
 
         1:
             foreign lpvm {noalias} mutate(~#rec##0:multictr.simple, ?#rec##1:multictr.simple, 7:wybe.int, 0:wybe.int, 16:wybe.int, 1:wybe.int, ~#field##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -6851,11 +6851,11 @@ zero(?#result##0:multictr.simple):
 
 ~= > public {inline} (0 calls)
 0: multictr.simple.~=<0>
-~=(#left##0:multictr.simple, #right##0:multictr.simple, ?####0:wybe.bool):
+~=(#left##0:multictr.simple, #right##0:multictr.simple, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     multictr.simple.=<0>(~#left##0:multictr.simple, ~#right##0:multictr.simple, ?tmp#0##0:wybe.bool) #0
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 
@@ -6880,8 +6880,8 @@ if.then:
   %"2#tmp#12##0" = icmp eq i64 %"2#tmp#11##0", 0 
   br i1 %"2#tmp#12##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %"3#####0" 
+  %"3##success##0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3##success##0" 
 if.then1:
   %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
@@ -6901,8 +6901,8 @@ if.then3:
   %4 = inttoptr i64 %"#right##0" to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
   %6 = load  i64, i64* %5 
-  %"8#####0" = icmp eq i64 %3, %6 
-  ret i1 %"8#####0" 
+  %"8##success##0" = icmp eq i64 %3, %6 
+  ret i1 %"8##success##0" 
 if.else3:
   ret i1 0 
 if.then4:
@@ -6938,8 +6938,8 @@ if.then6:
 if.else6:
   ret i1 0 
 if.then7:
-  %"16#####0" = icmp eq i64 %14, %22 
-  ret i1 %"16#####0" 
+  %"16##success##0" = icmp eq i64 %14, %22 
+  ret i1 %"16##success##0" 
 if.else7:
   ret i1 0 
 }
@@ -7228,8 +7228,8 @@ entry:
 define external fastcc  i1 @"multictr.simple.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %"1#tmp#0##0" = tail call fastcc  i1  @"multictr.simple.=<0>"(i64  %"#left##0", i64  %"#right##0")  
-  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
-  ret i1 %"1#####0" 
+  %"1##success##0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1##success##0" 
 }
 --------------------------------------------------
  Module multictr.suit
@@ -7249,10 +7249,10 @@ entry:
 
 = > public {inline} (1 calls)
 0: multictr.suit.=<0>
-=(#left##0:multictr.suit, #right##0:multictr.suit, ?####0:wybe.bool):
+=(#left##0:multictr.suit, #right##0:multictr.suit, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(~#left##0:multictr.suit, ~#right##0:multictr.suit, ?####0:wybe.bool)
+    foreign llvm icmp_eq(~#left##0:multictr.suit, ~#right##0:multictr.suit, ?#success##0:wybe.bool)
 
 
 clubs > public {inline} (0 calls)
@@ -7289,11 +7289,11 @@ spades(?#result##0:multictr.suit):
 
 ~= > public {inline} (0 calls)
 0: multictr.suit.~=<0>
-~=(#left##0:multictr.suit, #right##0:multictr.suit, ?####0:wybe.bool):
+~=(#left##0:multictr.suit, #right##0:multictr.suit, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_eq(~#left##0:multictr.suit, ~#right##0:multictr.suit, ?tmp#0##0:wybe.bool)
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 
@@ -7311,8 +7311,8 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  i1 @"multictr.suit.=<0>"(i2  %"#left##0", i2  %"#right##0")    {
 entry:
-  %"1#####0" = icmp eq i2 %"#left##0", %"#right##0" 
-  ret i1 %"1#####0" 
+  %"1##success##0" = icmp eq i2 %"#left##0", %"#right##0" 
+  ret i1 %"1##success##0" 
 }
 
 
@@ -7343,8 +7343,8 @@ entry:
 define external fastcc  i1 @"multictr.suit.~=<0>"(i2  %"#left##0", i2  %"#right##0")    {
 entry:
   %"1#tmp#0##0" = icmp eq i2 %"#left##0", %"#right##0" 
-  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
-  ret i1 %"1#####0" 
+  %"1##success##0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1##success##0" 
 }
 --------------------------------------------------
  Module multictr.unit
@@ -7361,10 +7361,10 @@ entry:
 
 = > public {inline} (1 calls)
 0: multictr.unit.=<0>
-=([#left##0:multictr.unit], [#right##0:multictr.unit], ?####0:wybe.bool):
+=([#left##0:multictr.unit], [#right##0:multictr.unit], ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 unit > public {inline} (0 calls)
@@ -7377,10 +7377,10 @@ unit(?#result##0:multictr.unit):
 
 ~= > public {inline} (0 calls)
 0: multictr.unit.~=<0>
-~=([#left##0:multictr.unit], [#right##0:multictr.unit], ?####0:wybe.bool):
+~=([#left##0:multictr.unit], [#right##0:multictr.unit], ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 

--- a/test-cases/final-dump/multictr.exp
+++ b/test-cases/final-dump/multictr.exp
@@ -217,31 +217,31 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 card > public {inline} (0 calls)
 0: multictr.card.card<0>
-card(suit##0:multictr.suit, rank##0:multictr.rank, ?###3:multictr.card):
+card(suit##0:multictr.suit, rank##0:multictr.rank, ?#result##3:multictr.card):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm shl(~rank##0:multictr.card, 2:multictr.card, ?#temp##1:multictr.card)
-    foreign llvm or(~#temp##1:multictr.card, ~suit##0:multictr.card, ?###3:multictr.card)
+    foreign llvm or(~#temp##1:multictr.card, ~suit##0:multictr.card, ?#result##3:multictr.card)
 card > public {inline} (0 calls)
 1: multictr.card.card<1>
-card(?suit##0:multictr.suit, ?rank##0:multictr.rank, ###0:multictr.card):
+card(?suit##0:multictr.suit, ?rank##0:multictr.rank, #result##0:multictr.card):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and(###0:multictr.card, 3:multictr.card, ?#temp2##0:multictr.card)
+    foreign llvm and(#result##0:multictr.card, 3:multictr.card, ?#temp2##0:multictr.card)
     foreign lpvm cast(~#temp2##0:multictr.card, ?suit##0:multictr.suit)
-    foreign llvm lshr(~###0:multictr.card, 2:multictr.card, ?#temp##1:multictr.card)
+    foreign llvm lshr(~#result##0:multictr.card, 2:multictr.card, ?#temp##1:multictr.card)
     foreign llvm and(~#temp##1:multictr.card, 15:multictr.card, ?#temp2##1:multictr.card)
     foreign lpvm cast(~#temp2##1:multictr.card, ?rank##0:multictr.rank)
 
 
 rank > public {inline} (0 calls)
 0: multictr.card.rank<0>
-rank(#rec##0:multictr.card, ?###0:multictr.rank):
+rank(#rec##0:multictr.card, ?#result##0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm lshr(~#rec##0:multictr.card, 2:multictr.card, ?#rec##1:multictr.card)
     foreign llvm and(~#rec##1:multictr.card, 15:multictr.card, ?#field##0:multictr.card)
-    foreign lpvm cast(~#field##0:multictr.card, ?###0:multictr.rank)
+    foreign lpvm cast(~#field##0:multictr.card, ?#result##0:multictr.rank)
 rank > public {inline} (0 calls)
 1: multictr.card.rank<1>
 rank(#rec##0:multictr.card, ?#rec##2:multictr.card, #field##0:multictr.rank):
@@ -254,11 +254,11 @@ rank(#rec##0:multictr.card, ?#rec##2:multictr.card, #field##0:multictr.rank):
 
 suit > public {inline} (0 calls)
 0: multictr.card.suit<0>
-suit(#rec##0:multictr.card, ?###0:multictr.suit):
+suit(#rec##0:multictr.card, ?#result##0:multictr.suit):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(~#rec##0:multictr.card, 3:multictr.card, ?#field##0:multictr.card)
-    foreign lpvm cast(~#field##0:multictr.card, ?###0:multictr.suit)
+    foreign lpvm cast(~#field##0:multictr.card, ?#result##0:multictr.suit)
 suit > public {inline} (0 calls)
 1: multictr.card.suit<1>
 suit(#rec##0:multictr.card, ?#rec##2:multictr.card, #field##0:multictr.suit):
@@ -302,16 +302,16 @@ entry:
   %1 = zext i4 %"rank##0" to i6  
   %"1##temp##1" = shl   i6 %1, 2 
   %2 = zext i2 %"suit##0" to i6  
-  %"1####3" = or i6 %"1##temp##1", %2 
-  ret i6 %"1####3" 
+  %"1##result##3" = or i6 %"1##temp##1", %2 
+  ret i6 %"1##result##3" 
 }
 
 
-define external fastcc  {i2, i4} @"multictr.card.card<1>"(i6  %"###0")    {
+define external fastcc  {i2, i4} @"multictr.card.card<1>"(i6  %"#result##0")    {
 entry:
-  %"1##temp2##0" = and i6 %"###0", 3 
+  %"1##temp2##0" = and i6 %"#result##0", 3 
   %3 = trunc i6 %"1##temp2##0" to i2  
-  %"1##temp##1" = lshr  i6 %"###0", 2 
+  %"1##temp##1" = lshr  i6 %"#result##0", 2 
   %"1##temp2##1" = and i6 %"1##temp##1", 15 
   %4 = trunc i6 %"1##temp2##1" to i4  
   %5 = insertvalue {i2, i4} undef, i2 %3, 0 
@@ -960,32 +960,32 @@ entry:
 
 autumn > public {inline} (0 calls)
 0: multictr.complicated.autumn<0>
-autumn(?###0:multictr.complicated):
+autumn(?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(3:multictr.complicated, ?###0:multictr.complicated)
+    foreign llvm move(3:multictr.complicated, ?#result##0:multictr.complicated)
 
 
 c01 > public {inline} (0 calls)
 0: multictr.complicated.c01<0>
-c01(f01##0:wybe.int, ?###0:multictr.complicated):
+c01(f01##0:wybe.int, ?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated)
-    foreign lpvm mutate(~#rec##0:multictr.complicated, ?###0:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f01##0:wybe.int)
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#result##0:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f01##0:wybe.int)
 c01 > public {inline} (40 calls)
 1: multictr.complicated.c01<1>
-c01(?f01##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
+c01(?f01##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge(###0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_uge(#result##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f01##0:wybe.int)
 
     1:
-        foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm and(#result##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
@@ -993,7 +993,7 @@ c01(?f01##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?f01##0:wybe.int)
 
         1:
-            foreign lpvm access(~###0:multictr.complicated, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?f01##0:wybe.int)
+            foreign lpvm access(~#result##0:multictr.complicated, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?f01##0:wybe.int)
             foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -1001,25 +1001,25 @@ c01(?f01##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
 
 c02 > public {inline} (0 calls)
 0: multictr.complicated.c02<0>
-c02(f02##0:wybe.int, ?###0:multictr.complicated):
+c02(f02##0:wybe.int, ?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated)
     foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f02##0:wybe.int)
-    foreign llvm or(~#rec##1:multictr.complicated, 1:wybe.int, ?###0:multictr.complicated)
+    foreign llvm or(~#rec##1:multictr.complicated, 1:wybe.int, ?#result##0:multictr.complicated)
 c02 > public {inline} (35 calls)
 1: multictr.complicated.c02<1>
-c02(?f02##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
+c02(?f02##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge(###0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_uge(#result##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f02##0:wybe.int)
 
     1:
-        foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm and(#result##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
@@ -1027,7 +1027,7 @@ c02(?f02##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?f02##0:wybe.int)
 
         1:
-            foreign lpvm access(~###0:multictr.complicated, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?f02##0:wybe.int)
+            foreign lpvm access(~#result##0:multictr.complicated, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?f02##0:wybe.int)
             foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -1035,25 +1035,25 @@ c02(?f02##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
 
 c03 > public {inline} (0 calls)
 0: multictr.complicated.c03<0>
-c03(f03##0:wybe.int, ?###0:multictr.complicated):
+c03(f03##0:wybe.int, ?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated)
     foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f03##0:wybe.int)
-    foreign llvm or(~#rec##1:multictr.complicated, 2:wybe.int, ?###0:multictr.complicated)
+    foreign llvm or(~#rec##1:multictr.complicated, 2:wybe.int, ?#result##0:multictr.complicated)
 c03 > public {inline} (33 calls)
 1: multictr.complicated.c03<1>
-c03(?f03##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
+c03(?f03##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge(###0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_uge(#result##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f03##0:wybe.int)
 
     1:
-        foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm and(#result##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 2:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
@@ -1061,7 +1061,7 @@ c03(?f03##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?f03##0:wybe.int)
 
         1:
-            foreign lpvm access(~###0:multictr.complicated, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?f03##0:wybe.int)
+            foreign lpvm access(~#result##0:multictr.complicated, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?f03##0:wybe.int)
             foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -1069,25 +1069,25 @@ c03(?f03##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
 
 c04 > public {inline} (0 calls)
 0: multictr.complicated.c04<0>
-c04(f04##0:wybe.int, ?###0:multictr.complicated):
+c04(f04##0:wybe.int, ?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated)
     foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f04##0:wybe.int)
-    foreign llvm or(~#rec##1:multictr.complicated, 3:wybe.int, ?###0:multictr.complicated)
+    foreign llvm or(~#rec##1:multictr.complicated, 3:wybe.int, ?#result##0:multictr.complicated)
 c04 > public {inline} (31 calls)
 1: multictr.complicated.c04<1>
-c04(?f04##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
+c04(?f04##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge(###0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_uge(#result##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f04##0:wybe.int)
 
     1:
-        foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm and(#result##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 3:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
@@ -1095,7 +1095,7 @@ c04(?f04##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?f04##0:wybe.int)
 
         1:
-            foreign lpvm access(~###0:multictr.complicated, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?f04##0:wybe.int)
+            foreign lpvm access(~#result##0:multictr.complicated, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?f04##0:wybe.int)
             foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -1103,25 +1103,25 @@ c04(?f04##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
 
 c05 > public {inline} (0 calls)
 0: multictr.complicated.c05<0>
-c05(f05##0:wybe.int, ?###0:multictr.complicated):
+c05(f05##0:wybe.int, ?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated)
     foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f05##0:wybe.int)
-    foreign llvm or(~#rec##1:multictr.complicated, 4:wybe.int, ?###0:multictr.complicated)
+    foreign llvm or(~#rec##1:multictr.complicated, 4:wybe.int, ?#result##0:multictr.complicated)
 c05 > public {inline} (29 calls)
 1: multictr.complicated.c05<1>
-c05(?f05##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
+c05(?f05##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge(###0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_uge(#result##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f05##0:wybe.int)
 
     1:
-        foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm and(#result##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 4:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
@@ -1129,7 +1129,7 @@ c05(?f05##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?f05##0:wybe.int)
 
         1:
-            foreign lpvm access(~###0:multictr.complicated, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?f05##0:wybe.int)
+            foreign lpvm access(~#result##0:multictr.complicated, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?f05##0:wybe.int)
             foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -1137,25 +1137,25 @@ c05(?f05##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
 
 c06 > public {inline} (0 calls)
 0: multictr.complicated.c06<0>
-c06(f06##0:wybe.int, ?###0:multictr.complicated):
+c06(f06##0:wybe.int, ?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated)
     foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f06##0:wybe.int)
-    foreign llvm or(~#rec##1:multictr.complicated, 5:wybe.int, ?###0:multictr.complicated)
+    foreign llvm or(~#rec##1:multictr.complicated, 5:wybe.int, ?#result##0:multictr.complicated)
 c06 > public {inline} (27 calls)
 1: multictr.complicated.c06<1>
-c06(?f06##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
+c06(?f06##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge(###0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_uge(#result##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f06##0:wybe.int)
 
     1:
-        foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm and(#result##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 5:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
@@ -1163,7 +1163,7 @@ c06(?f06##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?f06##0:wybe.int)
 
         1:
-            foreign lpvm access(~###0:multictr.complicated, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?f06##0:wybe.int)
+            foreign lpvm access(~#result##0:multictr.complicated, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?f06##0:wybe.int)
             foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -1171,25 +1171,25 @@ c06(?f06##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
 
 c07 > public {inline} (0 calls)
 0: multictr.complicated.c07<0>
-c07(f07##0:wybe.int, ?###0:multictr.complicated):
+c07(f07##0:wybe.int, ?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated)
     foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f07##0:wybe.int)
-    foreign llvm or(~#rec##1:multictr.complicated, 6:wybe.int, ?###0:multictr.complicated)
+    foreign llvm or(~#rec##1:multictr.complicated, 6:wybe.int, ?#result##0:multictr.complicated)
 c07 > public {inline} (25 calls)
 1: multictr.complicated.c07<1>
-c07(?f07##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
+c07(?f07##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge(###0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_uge(#result##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f07##0:wybe.int)
 
     1:
-        foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm and(#result##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 6:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
@@ -1197,7 +1197,7 @@ c07(?f07##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?f07##0:wybe.int)
 
         1:
-            foreign lpvm access(~###0:multictr.complicated, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?f07##0:wybe.int)
+            foreign lpvm access(~#result##0:multictr.complicated, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?f07##0:wybe.int)
             foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -1205,26 +1205,26 @@ c07(?f07##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
 
 c08 > public {inline} (0 calls)
 0: multictr.complicated.c08<0>
-c08(f08##0:wybe.int, ?###0:multictr.complicated):
+c08(f08##0:wybe.int, ?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated)
     foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 7:wybe.int)
     foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f08##0:wybe.int)
-    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?###0:multictr.complicated)
+    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated)
 c08 > public {inline} (23 calls)
 1: multictr.complicated.c08<1>
-c08(?f08##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
+c08(?f08##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge(###0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_uge(#result##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f08##0:wybe.int)
 
     1:
-        foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm and(#result##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
@@ -1232,7 +1232,7 @@ c08(?f08##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?f08##0:wybe.int)
 
         1:
-            foreign lpvm access(###0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#result##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 7:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -1240,7 +1240,7 @@ c08(?f08##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
                 foreign llvm move(undef:wybe.int, ?f08##0:wybe.int)
 
             1:
-                foreign lpvm access(~###0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f08##0:wybe.int)
+                foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f08##0:wybe.int)
                 foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -1249,26 +1249,26 @@ c08(?f08##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
 
 c09 > public {inline} (0 calls)
 0: multictr.complicated.c09<0>
-c09(f09##0:wybe.int, ?###0:multictr.complicated):
+c09(f09##0:wybe.int, ?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated)
     foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 8:wybe.int)
     foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f09##0:wybe.int)
-    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?###0:multictr.complicated)
+    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated)
 c09 > public {inline} (21 calls)
 1: multictr.complicated.c09<1>
-c09(?f09##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
+c09(?f09##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge(###0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_uge(#result##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f09##0:wybe.int)
 
     1:
-        foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm and(#result##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
@@ -1276,7 +1276,7 @@ c09(?f09##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?f09##0:wybe.int)
 
         1:
-            foreign lpvm access(###0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#result##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 8:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -1284,7 +1284,7 @@ c09(?f09##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
                 foreign llvm move(undef:wybe.int, ?f09##0:wybe.int)
 
             1:
-                foreign lpvm access(~###0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f09##0:wybe.int)
+                foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f09##0:wybe.int)
                 foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -1293,26 +1293,26 @@ c09(?f09##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
 
 c10 > public {inline} (0 calls)
 0: multictr.complicated.c10<0>
-c10(f10##0:wybe.int, ?###0:multictr.complicated):
+c10(f10##0:wybe.int, ?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated)
     foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 9:wybe.int)
     foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f10##0:wybe.int)
-    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?###0:multictr.complicated)
+    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated)
 c10 > public {inline} (19 calls)
 1: multictr.complicated.c10<1>
-c10(?f10##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
+c10(?f10##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge(###0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_uge(#result##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f10##0:wybe.int)
 
     1:
-        foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm and(#result##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
@@ -1320,7 +1320,7 @@ c10(?f10##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?f10##0:wybe.int)
 
         1:
-            foreign lpvm access(###0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#result##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 9:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -1328,7 +1328,7 @@ c10(?f10##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
                 foreign llvm move(undef:wybe.int, ?f10##0:wybe.int)
 
             1:
-                foreign lpvm access(~###0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f10##0:wybe.int)
+                foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f10##0:wybe.int)
                 foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -1337,26 +1337,26 @@ c10(?f10##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
 
 c11 > public {inline} (0 calls)
 0: multictr.complicated.c11<0>
-c11(f11##0:wybe.int, ?###0:multictr.complicated):
+c11(f11##0:wybe.int, ?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated)
     foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
     foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f11##0:wybe.int)
-    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?###0:multictr.complicated)
+    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated)
 c11 > public {inline} (17 calls)
 1: multictr.complicated.c11<1>
-c11(?f11##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
+c11(?f11##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge(###0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_uge(#result##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f11##0:wybe.int)
 
     1:
-        foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm and(#result##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
@@ -1364,7 +1364,7 @@ c11(?f11##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?f11##0:wybe.int)
 
         1:
-            foreign lpvm access(###0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#result##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 10:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -1372,7 +1372,7 @@ c11(?f11##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
                 foreign llvm move(undef:wybe.int, ?f11##0:wybe.int)
 
             1:
-                foreign lpvm access(~###0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f11##0:wybe.int)
+                foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f11##0:wybe.int)
                 foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -1381,26 +1381,26 @@ c11(?f11##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
 
 c12 > public {inline} (0 calls)
 0: multictr.complicated.c12<0>
-c12(f12##0:wybe.int, ?###0:multictr.complicated):
+c12(f12##0:wybe.int, ?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated)
     foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 11:wybe.int)
     foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f12##0:wybe.int)
-    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?###0:multictr.complicated)
+    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated)
 c12 > public {inline} (15 calls)
 1: multictr.complicated.c12<1>
-c12(?f12##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
+c12(?f12##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge(###0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_uge(#result##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f12##0:wybe.int)
 
     1:
-        foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm and(#result##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
@@ -1408,7 +1408,7 @@ c12(?f12##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?f12##0:wybe.int)
 
         1:
-            foreign lpvm access(###0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#result##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 11:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -1416,7 +1416,7 @@ c12(?f12##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
                 foreign llvm move(undef:wybe.int, ?f12##0:wybe.int)
 
             1:
-                foreign lpvm access(~###0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f12##0:wybe.int)
+                foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f12##0:wybe.int)
                 foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -1425,26 +1425,26 @@ c12(?f12##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
 
 c13 > public {inline} (0 calls)
 0: multictr.complicated.c13<0>
-c13(f13##0:wybe.int, ?###0:multictr.complicated):
+c13(f13##0:wybe.int, ?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated)
     foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 12:wybe.int)
     foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f13##0:wybe.int)
-    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?###0:multictr.complicated)
+    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated)
 c13 > public {inline} (13 calls)
 1: multictr.complicated.c13<1>
-c13(?f13##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
+c13(?f13##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge(###0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_uge(#result##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f13##0:wybe.int)
 
     1:
-        foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm and(#result##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
@@ -1452,7 +1452,7 @@ c13(?f13##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?f13##0:wybe.int)
 
         1:
-            foreign lpvm access(###0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#result##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 12:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -1460,7 +1460,7 @@ c13(?f13##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
                 foreign llvm move(undef:wybe.int, ?f13##0:wybe.int)
 
             1:
-                foreign lpvm access(~###0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f13##0:wybe.int)
+                foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f13##0:wybe.int)
                 foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -1469,26 +1469,26 @@ c13(?f13##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
 
 c14 > public {inline} (0 calls)
 0: multictr.complicated.c14<0>
-c14(f14##0:wybe.int, ?###0:multictr.complicated):
+c14(f14##0:wybe.int, ?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated)
     foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 13:wybe.int)
     foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f14##0:wybe.int)
-    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?###0:multictr.complicated)
+    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated)
 c14 > public {inline} (11 calls)
 1: multictr.complicated.c14<1>
-c14(?f14##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
+c14(?f14##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge(###0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_uge(#result##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f14##0:wybe.int)
 
     1:
-        foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm and(#result##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
@@ -1496,7 +1496,7 @@ c14(?f14##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?f14##0:wybe.int)
 
         1:
-            foreign lpvm access(###0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#result##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 13:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -1504,7 +1504,7 @@ c14(?f14##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
                 foreign llvm move(undef:wybe.int, ?f14##0:wybe.int)
 
             1:
-                foreign lpvm access(~###0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f14##0:wybe.int)
+                foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f14##0:wybe.int)
                 foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -1513,26 +1513,26 @@ c14(?f14##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
 
 c15 > public {inline} (0 calls)
 0: multictr.complicated.c15<0>
-c15(f15##0:wybe.int, ?###0:multictr.complicated):
+c15(f15##0:wybe.int, ?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated)
     foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 14:wybe.int)
     foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f15##0:wybe.int)
-    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?###0:multictr.complicated)
+    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated)
 c15 > public {inline} (9 calls)
 1: multictr.complicated.c15<1>
-c15(?f15##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
+c15(?f15##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge(###0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_uge(#result##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f15##0:wybe.int)
 
     1:
-        foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm and(#result##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
@@ -1540,7 +1540,7 @@ c15(?f15##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?f15##0:wybe.int)
 
         1:
-            foreign lpvm access(###0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#result##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 14:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -1548,7 +1548,7 @@ c15(?f15##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
                 foreign llvm move(undef:wybe.int, ?f15##0:wybe.int)
 
             1:
-                foreign lpvm access(~###0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f15##0:wybe.int)
+                foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f15##0:wybe.int)
                 foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -1557,26 +1557,26 @@ c15(?f15##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
 
 c16 > public {inline} (0 calls)
 0: multictr.complicated.c16<0>
-c16(f16##0:wybe.int, ?###0:multictr.complicated):
+c16(f16##0:wybe.int, ?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated)
     foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 15:wybe.int)
     foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f16##0:wybe.int)
-    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?###0:multictr.complicated)
+    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated)
 c16 > public {inline} (7 calls)
 1: multictr.complicated.c16<1>
-c16(?f16##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
+c16(?f16##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge(###0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_uge(#result##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f16##0:wybe.int)
 
     1:
-        foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm and(#result##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
@@ -1584,7 +1584,7 @@ c16(?f16##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?f16##0:wybe.int)
 
         1:
-            foreign lpvm access(###0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#result##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 15:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -1592,7 +1592,7 @@ c16(?f16##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
                 foreign llvm move(undef:wybe.int, ?f16##0:wybe.int)
 
             1:
-                foreign lpvm access(~###0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f16##0:wybe.int)
+                foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f16##0:wybe.int)
                 foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -1601,26 +1601,26 @@ c16(?f16##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
 
 c17 > public {inline} (0 calls)
 0: multictr.complicated.c17<0>
-c17(f17##0:wybe.int, ?###0:multictr.complicated):
+c17(f17##0:wybe.int, ?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated)
     foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 16:wybe.int)
     foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f17##0:wybe.int)
-    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?###0:multictr.complicated)
+    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?#result##0:multictr.complicated)
 c17 > public {inline} (5 calls)
 1: multictr.complicated.c17<1>
-c17(?f17##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
+c17(?f17##0:wybe.int, #result##0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge(###0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_uge(#result##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f17##0:wybe.int)
 
     1:
-        foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm and(#result##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
@@ -1628,7 +1628,7 @@ c17(?f17##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?f17##0:wybe.int)
 
         1:
-            foreign lpvm access(###0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign lpvm access(#result##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
             foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 16:16 bit unsigned, ?tmp#3##0:wybe.bool)
             case ~tmp#3##0:wybe.bool of
             0:
@@ -1636,7 +1636,7 @@ c17(?f17##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
                 foreign llvm move(undef:wybe.int, ?f17##0:wybe.int)
 
             1:
-                foreign lpvm access(~###0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f17##0:wybe.int)
+                foreign lpvm access(~#result##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f17##0:wybe.int)
                 foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -1645,14 +1645,14 @@ c17(?f17##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
 
 f01 > public {inline} (0 calls)
 0: multictr.complicated.f01<0>
-f01(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
+f01(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
@@ -1660,10 +1660,10 @@ f01(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
         case ~tmp#1##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+            foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(~#rec##0:multictr.complicated, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?###0:wybe.int)
+            foreign lpvm access(~#rec##0:multictr.complicated, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
             foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -1695,14 +1695,14 @@ f01(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 f02 > public {inline} (0 calls)
 0: multictr.complicated.f02<0>
-f02(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
+f02(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
@@ -1710,10 +1710,10 @@ f02(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
         case ~tmp#1##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+            foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(~#rec##0:multictr.complicated, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?###0:wybe.int)
+            foreign lpvm access(~#rec##0:multictr.complicated, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#result##0:wybe.int)
             foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -1745,14 +1745,14 @@ f02(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 f03 > public {inline} (0 calls)
 0: multictr.complicated.f03<0>
-f03(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
+f03(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
@@ -1760,10 +1760,10 @@ f03(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
         case ~tmp#1##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+            foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(~#rec##0:multictr.complicated, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?###0:wybe.int)
+            foreign lpvm access(~#rec##0:multictr.complicated, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#result##0:wybe.int)
             foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -1795,14 +1795,14 @@ f03(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 f04 > public {inline} (0 calls)
 0: multictr.complicated.f04<0>
-f04(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
+f04(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
@@ -1810,10 +1810,10 @@ f04(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
         case ~tmp#1##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+            foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(~#rec##0:multictr.complicated, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?###0:wybe.int)
+            foreign lpvm access(~#rec##0:multictr.complicated, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?#result##0:wybe.int)
             foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -1845,14 +1845,14 @@ f04(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 f05 > public {inline} (0 calls)
 0: multictr.complicated.f05<0>
-f05(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
+f05(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
@@ -1860,10 +1860,10 @@ f05(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
         case ~tmp#1##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+            foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(~#rec##0:multictr.complicated, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?###0:wybe.int)
+            foreign lpvm access(~#rec##0:multictr.complicated, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?#result##0:wybe.int)
             foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -1895,14 +1895,14 @@ f05(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 f06 > public {inline} (0 calls)
 0: multictr.complicated.f06<0>
-f06(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
+f06(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
@@ -1910,10 +1910,10 @@ f06(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
         case ~tmp#1##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+            foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(~#rec##0:multictr.complicated, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?###0:wybe.int)
+            foreign lpvm access(~#rec##0:multictr.complicated, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?#result##0:wybe.int)
             foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -1945,14 +1945,14 @@ f06(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 f07 > public {inline} (0 calls)
 0: multictr.complicated.f07<0>
-f07(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
+f07(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
@@ -1960,10 +1960,10 @@ f07(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
         case ~tmp#1##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+            foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(~#rec##0:multictr.complicated, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?###0:wybe.int)
+            foreign lpvm access(~#rec##0:multictr.complicated, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?#result##0:wybe.int)
             foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -1995,14 +1995,14 @@ f07(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 f08 > public {inline} (0 calls)
 0: multictr.complicated.f08<0>
-f08(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
+f08(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
@@ -2010,7 +2010,7 @@ f08(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
         case ~tmp#1##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+            foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
             foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
@@ -2018,10 +2018,10 @@ f08(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
             case ~tmp#3##0:wybe.bool of
             0:
                 foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+                foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
             1:
-                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?###0:wybe.int)
+                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
                 foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -2063,14 +2063,14 @@ f08(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 f09 > public {inline} (0 calls)
 0: multictr.complicated.f09<0>
-f09(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
+f09(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
@@ -2078,7 +2078,7 @@ f09(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
         case ~tmp#1##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+            foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
             foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
@@ -2086,10 +2086,10 @@ f09(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
             case ~tmp#3##0:wybe.bool of
             0:
                 foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+                foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
             1:
-                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?###0:wybe.int)
+                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
                 foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -2131,14 +2131,14 @@ f09(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 f10 > public {inline} (0 calls)
 0: multictr.complicated.f10<0>
-f10(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
+f10(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
@@ -2146,7 +2146,7 @@ f10(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
         case ~tmp#1##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+            foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
             foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
@@ -2154,10 +2154,10 @@ f10(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
             case ~tmp#3##0:wybe.bool of
             0:
                 foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+                foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
             1:
-                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?###0:wybe.int)
+                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
                 foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -2199,14 +2199,14 @@ f10(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 f11 > public {inline} (0 calls)
 0: multictr.complicated.f11<0>
-f11(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
+f11(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
@@ -2214,7 +2214,7 @@ f11(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
         case ~tmp#1##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+            foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
             foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
@@ -2222,10 +2222,10 @@ f11(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
             case ~tmp#3##0:wybe.bool of
             0:
                 foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+                foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
             1:
-                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?###0:wybe.int)
+                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
                 foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -2267,14 +2267,14 @@ f11(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 f12 > public {inline} (0 calls)
 0: multictr.complicated.f12<0>
-f12(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
+f12(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
@@ -2282,7 +2282,7 @@ f12(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
         case ~tmp#1##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+            foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
             foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
@@ -2290,10 +2290,10 @@ f12(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
             case ~tmp#3##0:wybe.bool of
             0:
                 foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+                foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
             1:
-                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?###0:wybe.int)
+                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
                 foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -2335,14 +2335,14 @@ f12(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 f13 > public {inline} (0 calls)
 0: multictr.complicated.f13<0>
-f13(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
+f13(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
@@ -2350,7 +2350,7 @@ f13(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
         case ~tmp#1##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+            foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
             foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
@@ -2358,10 +2358,10 @@ f13(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
             case ~tmp#3##0:wybe.bool of
             0:
                 foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+                foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
             1:
-                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?###0:wybe.int)
+                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
                 foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -2403,14 +2403,14 @@ f13(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 f14 > public {inline} (0 calls)
 0: multictr.complicated.f14<0>
-f14(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
+f14(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
@@ -2418,7 +2418,7 @@ f14(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
         case ~tmp#1##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+            foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
             foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
@@ -2426,10 +2426,10 @@ f14(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
             case ~tmp#3##0:wybe.bool of
             0:
                 foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+                foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
             1:
-                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?###0:wybe.int)
+                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
                 foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -2471,14 +2471,14 @@ f14(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 f15 > public {inline} (0 calls)
 0: multictr.complicated.f15<0>
-f15(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
+f15(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
@@ -2486,7 +2486,7 @@ f15(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
         case ~tmp#1##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+            foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
             foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
@@ -2494,10 +2494,10 @@ f15(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
             case ~tmp#3##0:wybe.bool of
             0:
                 foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+                foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
             1:
-                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?###0:wybe.int)
+                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
                 foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -2539,14 +2539,14 @@ f15(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 f16 > public {inline} (0 calls)
 0: multictr.complicated.f16<0>
-f16(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
+f16(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
@@ -2554,7 +2554,7 @@ f16(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
         case ~tmp#1##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+            foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
             foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
@@ -2562,10 +2562,10 @@ f16(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
             case ~tmp#3##0:wybe.bool of
             0:
                 foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+                foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
             1:
-                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?###0:wybe.int)
+                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
                 foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -2607,14 +2607,14 @@ f16(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 f17 > public {inline} (0 calls)
 0: multictr.complicated.f17<0>
-f17(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
+f17(#rec##0:multictr.complicated, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
@@ -2622,7 +2622,7 @@ f17(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
         case ~tmp#1##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+            foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
             foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
@@ -2630,10 +2630,10 @@ f17(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
             case ~tmp#3##0:wybe.bool of
             0:
                 foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+                foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
             1:
-                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?###0:wybe.int)
+                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
                 foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -2675,26 +2675,26 @@ f17(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.
 
 spring > public {inline} (0 calls)
 0: multictr.complicated.spring<0>
-spring(?###0:multictr.complicated):
+spring(?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(1:multictr.complicated, ?###0:multictr.complicated)
+    foreign llvm move(1:multictr.complicated, ?#result##0:multictr.complicated)
 
 
 summer > public {inline} (0 calls)
 0: multictr.complicated.summer<0>
-summer(?###0:multictr.complicated):
+summer(?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(2:multictr.complicated, ?###0:multictr.complicated)
+    foreign llvm move(2:multictr.complicated, ?#result##0:multictr.complicated)
 
 
 winter > public {inline} (0 calls)
 0: multictr.complicated.winter<0>
-winter(?###0:multictr.complicated):
+winter(?#result##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:multictr.complicated, ?###0:multictr.complicated)
+    foreign llvm move(0:multictr.complicated, ?#result##0:multictr.complicated)
 
 
 ~= > public {inline} (0 calls)
@@ -3272,12 +3272,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c01<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c01<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp uge i64 %"###0", 4 
+  %"1#tmp#0##0" = icmp uge i64 %"#result##0", 4 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2#tmp#2##0" = and i64 %"###0", 7 
+  %"2#tmp#2##0" = and i64 %"#result##0", 7 
   %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 0 
   br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
@@ -3285,7 +3285,7 @@ if.else:
   %192 = insertvalue {i64, i1} %191, i1 0, 1 
   ret {i64, i1} %192 
 if.then1:
-  %184 = inttoptr i64 %"###0" to i64* 
+  %184 = inttoptr i64 %"#result##0" to i64* 
   %185 = getelementptr  i64, i64* %184, i64 0 
   %186 = load  i64, i64* %185 
   %187 = insertvalue {i64, i1} undef, i64 %186, 0 
@@ -3306,17 +3306,17 @@ entry:
   %196 = inttoptr i64 %195 to i64* 
   %197 = getelementptr  i64, i64* %196, i64 0 
   store  i64 %"f02##0", i64* %197 
-  %"1####0" = or i64 %195, 1 
-  ret i64 %"1####0" 
+  %"1##result##0" = or i64 %195, 1 
+  ret i64 %"1##result##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c02<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c02<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp uge i64 %"###0", 4 
+  %"1#tmp#0##0" = icmp uge i64 %"#result##0", 4 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2#tmp#2##0" = and i64 %"###0", 7 
+  %"2#tmp#2##0" = and i64 %"#result##0", 7 
   %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 1 
   br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
@@ -3324,7 +3324,7 @@ if.else:
   %207 = insertvalue {i64, i1} %206, i1 0, 1 
   ret {i64, i1} %207 
 if.then1:
-  %198 = add   i64 %"###0", -1 
+  %198 = add   i64 %"#result##0", -1 
   %199 = inttoptr i64 %198 to i64* 
   %200 = getelementptr  i64, i64* %199, i64 0 
   %201 = load  i64, i64* %200 
@@ -3346,17 +3346,17 @@ entry:
   %211 = inttoptr i64 %210 to i64* 
   %212 = getelementptr  i64, i64* %211, i64 0 
   store  i64 %"f03##0", i64* %212 
-  %"1####0" = or i64 %210, 2 
-  ret i64 %"1####0" 
+  %"1##result##0" = or i64 %210, 2 
+  ret i64 %"1##result##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c03<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c03<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp uge i64 %"###0", 4 
+  %"1#tmp#0##0" = icmp uge i64 %"#result##0", 4 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2#tmp#2##0" = and i64 %"###0", 7 
+  %"2#tmp#2##0" = and i64 %"#result##0", 7 
   %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 2 
   br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
@@ -3364,7 +3364,7 @@ if.else:
   %222 = insertvalue {i64, i1} %221, i1 0, 1 
   ret {i64, i1} %222 
 if.then1:
-  %213 = add   i64 %"###0", -2 
+  %213 = add   i64 %"#result##0", -2 
   %214 = inttoptr i64 %213 to i64* 
   %215 = getelementptr  i64, i64* %214, i64 0 
   %216 = load  i64, i64* %215 
@@ -3386,17 +3386,17 @@ entry:
   %226 = inttoptr i64 %225 to i64* 
   %227 = getelementptr  i64, i64* %226, i64 0 
   store  i64 %"f04##0", i64* %227 
-  %"1####0" = or i64 %225, 3 
-  ret i64 %"1####0" 
+  %"1##result##0" = or i64 %225, 3 
+  ret i64 %"1##result##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c04<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c04<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp uge i64 %"###0", 4 
+  %"1#tmp#0##0" = icmp uge i64 %"#result##0", 4 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2#tmp#2##0" = and i64 %"###0", 7 
+  %"2#tmp#2##0" = and i64 %"#result##0", 7 
   %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 3 
   br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
@@ -3404,7 +3404,7 @@ if.else:
   %237 = insertvalue {i64, i1} %236, i1 0, 1 
   ret {i64, i1} %237 
 if.then1:
-  %228 = add   i64 %"###0", -3 
+  %228 = add   i64 %"#result##0", -3 
   %229 = inttoptr i64 %228 to i64* 
   %230 = getelementptr  i64, i64* %229, i64 0 
   %231 = load  i64, i64* %230 
@@ -3426,17 +3426,17 @@ entry:
   %241 = inttoptr i64 %240 to i64* 
   %242 = getelementptr  i64, i64* %241, i64 0 
   store  i64 %"f05##0", i64* %242 
-  %"1####0" = or i64 %240, 4 
-  ret i64 %"1####0" 
+  %"1##result##0" = or i64 %240, 4 
+  ret i64 %"1##result##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c05<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c05<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp uge i64 %"###0", 4 
+  %"1#tmp#0##0" = icmp uge i64 %"#result##0", 4 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2#tmp#2##0" = and i64 %"###0", 7 
+  %"2#tmp#2##0" = and i64 %"#result##0", 7 
   %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 4 
   br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
@@ -3444,7 +3444,7 @@ if.else:
   %252 = insertvalue {i64, i1} %251, i1 0, 1 
   ret {i64, i1} %252 
 if.then1:
-  %243 = add   i64 %"###0", -4 
+  %243 = add   i64 %"#result##0", -4 
   %244 = inttoptr i64 %243 to i64* 
   %245 = getelementptr  i64, i64* %244, i64 0 
   %246 = load  i64, i64* %245 
@@ -3466,17 +3466,17 @@ entry:
   %256 = inttoptr i64 %255 to i64* 
   %257 = getelementptr  i64, i64* %256, i64 0 
   store  i64 %"f06##0", i64* %257 
-  %"1####0" = or i64 %255, 5 
-  ret i64 %"1####0" 
+  %"1##result##0" = or i64 %255, 5 
+  ret i64 %"1##result##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c06<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c06<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp uge i64 %"###0", 4 
+  %"1#tmp#0##0" = icmp uge i64 %"#result##0", 4 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2#tmp#2##0" = and i64 %"###0", 7 
+  %"2#tmp#2##0" = and i64 %"#result##0", 7 
   %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 5 
   br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
@@ -3484,7 +3484,7 @@ if.else:
   %267 = insertvalue {i64, i1} %266, i1 0, 1 
   ret {i64, i1} %267 
 if.then1:
-  %258 = add   i64 %"###0", -5 
+  %258 = add   i64 %"#result##0", -5 
   %259 = inttoptr i64 %258 to i64* 
   %260 = getelementptr  i64, i64* %259, i64 0 
   %261 = load  i64, i64* %260 
@@ -3506,17 +3506,17 @@ entry:
   %271 = inttoptr i64 %270 to i64* 
   %272 = getelementptr  i64, i64* %271, i64 0 
   store  i64 %"f07##0", i64* %272 
-  %"1####0" = or i64 %270, 6 
-  ret i64 %"1####0" 
+  %"1##result##0" = or i64 %270, 6 
+  ret i64 %"1##result##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c07<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c07<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp uge i64 %"###0", 4 
+  %"1#tmp#0##0" = icmp uge i64 %"#result##0", 4 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2#tmp#2##0" = and i64 %"###0", 7 
+  %"2#tmp#2##0" = and i64 %"#result##0", 7 
   %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 6 
   br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
@@ -3524,7 +3524,7 @@ if.else:
   %282 = insertvalue {i64, i1} %281, i1 0, 1 
   ret {i64, i1} %282 
 if.then1:
-  %273 = add   i64 %"###0", -6 
+  %273 = add   i64 %"#result##0", -6 
   %274 = inttoptr i64 %273 to i64* 
   %275 = getelementptr  i64, i64* %274, i64 0 
   %276 = load  i64, i64* %275 
@@ -3550,17 +3550,17 @@ entry:
   %289 = inttoptr i64 %288 to i64* 
   %290 = getelementptr  i64, i64* %289, i64 0 
   store  i64 %"f08##0", i64* %290 
-  %"1####0" = or i64 %285, 7 
-  ret i64 %"1####0" 
+  %"1##result##0" = or i64 %285, 7 
+  ret i64 %"1##result##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c08<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c08<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp uge i64 %"###0", 4 
+  %"1#tmp#0##0" = icmp uge i64 %"#result##0", 4 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2#tmp#2##0" = and i64 %"###0", 7 
+  %"2#tmp#2##0" = and i64 %"#result##0", 7 
   %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
   br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
@@ -3568,7 +3568,7 @@ if.else:
   %306 = insertvalue {i64, i1} %305, i1 0, 1 
   ret {i64, i1} %306 
 if.then1:
-  %291 = add   i64 %"###0", -7 
+  %291 = add   i64 %"#result##0", -7 
   %292 = inttoptr i64 %291 to i16* 
   %293 = getelementptr  i16, i16* %292, i64 0 
   %294 = load  i16, i16* %293 
@@ -3579,7 +3579,7 @@ if.else1:
   %304 = insertvalue {i64, i1} %303, i1 0, 1 
   ret {i64, i1} %304 
 if.then2:
-  %295 = add   i64 %"###0", 1 
+  %295 = add   i64 %"#result##0", 1 
   %296 = inttoptr i64 %295 to i64* 
   %297 = getelementptr  i64, i64* %296, i64 0 
   %298 = load  i64, i64* %297 
@@ -3605,17 +3605,17 @@ entry:
   %313 = inttoptr i64 %312 to i64* 
   %314 = getelementptr  i64, i64* %313, i64 0 
   store  i64 %"f09##0", i64* %314 
-  %"1####0" = or i64 %309, 7 
-  ret i64 %"1####0" 
+  %"1##result##0" = or i64 %309, 7 
+  ret i64 %"1##result##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c09<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c09<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp uge i64 %"###0", 4 
+  %"1#tmp#0##0" = icmp uge i64 %"#result##0", 4 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2#tmp#2##0" = and i64 %"###0", 7 
+  %"2#tmp#2##0" = and i64 %"#result##0", 7 
   %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
   br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
@@ -3623,7 +3623,7 @@ if.else:
   %330 = insertvalue {i64, i1} %329, i1 0, 1 
   ret {i64, i1} %330 
 if.then1:
-  %315 = add   i64 %"###0", -7 
+  %315 = add   i64 %"#result##0", -7 
   %316 = inttoptr i64 %315 to i16* 
   %317 = getelementptr  i16, i16* %316, i64 0 
   %318 = load  i16, i16* %317 
@@ -3634,7 +3634,7 @@ if.else1:
   %328 = insertvalue {i64, i1} %327, i1 0, 1 
   ret {i64, i1} %328 
 if.then2:
-  %319 = add   i64 %"###0", 1 
+  %319 = add   i64 %"#result##0", 1 
   %320 = inttoptr i64 %319 to i64* 
   %321 = getelementptr  i64, i64* %320, i64 0 
   %322 = load  i64, i64* %321 
@@ -3660,17 +3660,17 @@ entry:
   %337 = inttoptr i64 %336 to i64* 
   %338 = getelementptr  i64, i64* %337, i64 0 
   store  i64 %"f10##0", i64* %338 
-  %"1####0" = or i64 %333, 7 
-  ret i64 %"1####0" 
+  %"1##result##0" = or i64 %333, 7 
+  ret i64 %"1##result##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c10<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c10<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp uge i64 %"###0", 4 
+  %"1#tmp#0##0" = icmp uge i64 %"#result##0", 4 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2#tmp#2##0" = and i64 %"###0", 7 
+  %"2#tmp#2##0" = and i64 %"#result##0", 7 
   %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
   br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
@@ -3678,7 +3678,7 @@ if.else:
   %354 = insertvalue {i64, i1} %353, i1 0, 1 
   ret {i64, i1} %354 
 if.then1:
-  %339 = add   i64 %"###0", -7 
+  %339 = add   i64 %"#result##0", -7 
   %340 = inttoptr i64 %339 to i16* 
   %341 = getelementptr  i16, i16* %340, i64 0 
   %342 = load  i16, i16* %341 
@@ -3689,7 +3689,7 @@ if.else1:
   %352 = insertvalue {i64, i1} %351, i1 0, 1 
   ret {i64, i1} %352 
 if.then2:
-  %343 = add   i64 %"###0", 1 
+  %343 = add   i64 %"#result##0", 1 
   %344 = inttoptr i64 %343 to i64* 
   %345 = getelementptr  i64, i64* %344, i64 0 
   %346 = load  i64, i64* %345 
@@ -3715,17 +3715,17 @@ entry:
   %361 = inttoptr i64 %360 to i64* 
   %362 = getelementptr  i64, i64* %361, i64 0 
   store  i64 %"f11##0", i64* %362 
-  %"1####0" = or i64 %357, 7 
-  ret i64 %"1####0" 
+  %"1##result##0" = or i64 %357, 7 
+  ret i64 %"1##result##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c11<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c11<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp uge i64 %"###0", 4 
+  %"1#tmp#0##0" = icmp uge i64 %"#result##0", 4 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2#tmp#2##0" = and i64 %"###0", 7 
+  %"2#tmp#2##0" = and i64 %"#result##0", 7 
   %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
   br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
@@ -3733,7 +3733,7 @@ if.else:
   %378 = insertvalue {i64, i1} %377, i1 0, 1 
   ret {i64, i1} %378 
 if.then1:
-  %363 = add   i64 %"###0", -7 
+  %363 = add   i64 %"#result##0", -7 
   %364 = inttoptr i64 %363 to i16* 
   %365 = getelementptr  i16, i16* %364, i64 0 
   %366 = load  i16, i16* %365 
@@ -3744,7 +3744,7 @@ if.else1:
   %376 = insertvalue {i64, i1} %375, i1 0, 1 
   ret {i64, i1} %376 
 if.then2:
-  %367 = add   i64 %"###0", 1 
+  %367 = add   i64 %"#result##0", 1 
   %368 = inttoptr i64 %367 to i64* 
   %369 = getelementptr  i64, i64* %368, i64 0 
   %370 = load  i64, i64* %369 
@@ -3770,17 +3770,17 @@ entry:
   %385 = inttoptr i64 %384 to i64* 
   %386 = getelementptr  i64, i64* %385, i64 0 
   store  i64 %"f12##0", i64* %386 
-  %"1####0" = or i64 %381, 7 
-  ret i64 %"1####0" 
+  %"1##result##0" = or i64 %381, 7 
+  ret i64 %"1##result##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c12<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c12<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp uge i64 %"###0", 4 
+  %"1#tmp#0##0" = icmp uge i64 %"#result##0", 4 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2#tmp#2##0" = and i64 %"###0", 7 
+  %"2#tmp#2##0" = and i64 %"#result##0", 7 
   %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
   br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
@@ -3788,7 +3788,7 @@ if.else:
   %402 = insertvalue {i64, i1} %401, i1 0, 1 
   ret {i64, i1} %402 
 if.then1:
-  %387 = add   i64 %"###0", -7 
+  %387 = add   i64 %"#result##0", -7 
   %388 = inttoptr i64 %387 to i16* 
   %389 = getelementptr  i16, i16* %388, i64 0 
   %390 = load  i16, i16* %389 
@@ -3799,7 +3799,7 @@ if.else1:
   %400 = insertvalue {i64, i1} %399, i1 0, 1 
   ret {i64, i1} %400 
 if.then2:
-  %391 = add   i64 %"###0", 1 
+  %391 = add   i64 %"#result##0", 1 
   %392 = inttoptr i64 %391 to i64* 
   %393 = getelementptr  i64, i64* %392, i64 0 
   %394 = load  i64, i64* %393 
@@ -3825,17 +3825,17 @@ entry:
   %409 = inttoptr i64 %408 to i64* 
   %410 = getelementptr  i64, i64* %409, i64 0 
   store  i64 %"f13##0", i64* %410 
-  %"1####0" = or i64 %405, 7 
-  ret i64 %"1####0" 
+  %"1##result##0" = or i64 %405, 7 
+  ret i64 %"1##result##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c13<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c13<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp uge i64 %"###0", 4 
+  %"1#tmp#0##0" = icmp uge i64 %"#result##0", 4 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2#tmp#2##0" = and i64 %"###0", 7 
+  %"2#tmp#2##0" = and i64 %"#result##0", 7 
   %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
   br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
@@ -3843,7 +3843,7 @@ if.else:
   %426 = insertvalue {i64, i1} %425, i1 0, 1 
   ret {i64, i1} %426 
 if.then1:
-  %411 = add   i64 %"###0", -7 
+  %411 = add   i64 %"#result##0", -7 
   %412 = inttoptr i64 %411 to i16* 
   %413 = getelementptr  i16, i16* %412, i64 0 
   %414 = load  i16, i16* %413 
@@ -3854,7 +3854,7 @@ if.else1:
   %424 = insertvalue {i64, i1} %423, i1 0, 1 
   ret {i64, i1} %424 
 if.then2:
-  %415 = add   i64 %"###0", 1 
+  %415 = add   i64 %"#result##0", 1 
   %416 = inttoptr i64 %415 to i64* 
   %417 = getelementptr  i64, i64* %416, i64 0 
   %418 = load  i64, i64* %417 
@@ -3880,17 +3880,17 @@ entry:
   %433 = inttoptr i64 %432 to i64* 
   %434 = getelementptr  i64, i64* %433, i64 0 
   store  i64 %"f14##0", i64* %434 
-  %"1####0" = or i64 %429, 7 
-  ret i64 %"1####0" 
+  %"1##result##0" = or i64 %429, 7 
+  ret i64 %"1##result##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c14<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c14<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp uge i64 %"###0", 4 
+  %"1#tmp#0##0" = icmp uge i64 %"#result##0", 4 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2#tmp#2##0" = and i64 %"###0", 7 
+  %"2#tmp#2##0" = and i64 %"#result##0", 7 
   %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
   br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
@@ -3898,7 +3898,7 @@ if.else:
   %450 = insertvalue {i64, i1} %449, i1 0, 1 
   ret {i64, i1} %450 
 if.then1:
-  %435 = add   i64 %"###0", -7 
+  %435 = add   i64 %"#result##0", -7 
   %436 = inttoptr i64 %435 to i16* 
   %437 = getelementptr  i16, i16* %436, i64 0 
   %438 = load  i16, i16* %437 
@@ -3909,7 +3909,7 @@ if.else1:
   %448 = insertvalue {i64, i1} %447, i1 0, 1 
   ret {i64, i1} %448 
 if.then2:
-  %439 = add   i64 %"###0", 1 
+  %439 = add   i64 %"#result##0", 1 
   %440 = inttoptr i64 %439 to i64* 
   %441 = getelementptr  i64, i64* %440, i64 0 
   %442 = load  i64, i64* %441 
@@ -3935,17 +3935,17 @@ entry:
   %457 = inttoptr i64 %456 to i64* 
   %458 = getelementptr  i64, i64* %457, i64 0 
   store  i64 %"f15##0", i64* %458 
-  %"1####0" = or i64 %453, 7 
-  ret i64 %"1####0" 
+  %"1##result##0" = or i64 %453, 7 
+  ret i64 %"1##result##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c15<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c15<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp uge i64 %"###0", 4 
+  %"1#tmp#0##0" = icmp uge i64 %"#result##0", 4 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2#tmp#2##0" = and i64 %"###0", 7 
+  %"2#tmp#2##0" = and i64 %"#result##0", 7 
   %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
   br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
@@ -3953,7 +3953,7 @@ if.else:
   %474 = insertvalue {i64, i1} %473, i1 0, 1 
   ret {i64, i1} %474 
 if.then1:
-  %459 = add   i64 %"###0", -7 
+  %459 = add   i64 %"#result##0", -7 
   %460 = inttoptr i64 %459 to i16* 
   %461 = getelementptr  i16, i16* %460, i64 0 
   %462 = load  i16, i16* %461 
@@ -3964,7 +3964,7 @@ if.else1:
   %472 = insertvalue {i64, i1} %471, i1 0, 1 
   ret {i64, i1} %472 
 if.then2:
-  %463 = add   i64 %"###0", 1 
+  %463 = add   i64 %"#result##0", 1 
   %464 = inttoptr i64 %463 to i64* 
   %465 = getelementptr  i64, i64* %464, i64 0 
   %466 = load  i64, i64* %465 
@@ -3990,17 +3990,17 @@ entry:
   %481 = inttoptr i64 %480 to i64* 
   %482 = getelementptr  i64, i64* %481, i64 0 
   store  i64 %"f16##0", i64* %482 
-  %"1####0" = or i64 %477, 7 
-  ret i64 %"1####0" 
+  %"1##result##0" = or i64 %477, 7 
+  ret i64 %"1##result##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c16<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c16<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp uge i64 %"###0", 4 
+  %"1#tmp#0##0" = icmp uge i64 %"#result##0", 4 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2#tmp#2##0" = and i64 %"###0", 7 
+  %"2#tmp#2##0" = and i64 %"#result##0", 7 
   %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
   br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
@@ -4008,7 +4008,7 @@ if.else:
   %498 = insertvalue {i64, i1} %497, i1 0, 1 
   ret {i64, i1} %498 
 if.then1:
-  %483 = add   i64 %"###0", -7 
+  %483 = add   i64 %"#result##0", -7 
   %484 = inttoptr i64 %483 to i16* 
   %485 = getelementptr  i16, i16* %484, i64 0 
   %486 = load  i16, i16* %485 
@@ -4019,7 +4019,7 @@ if.else1:
   %496 = insertvalue {i64, i1} %495, i1 0, 1 
   ret {i64, i1} %496 
 if.then2:
-  %487 = add   i64 %"###0", 1 
+  %487 = add   i64 %"#result##0", 1 
   %488 = inttoptr i64 %487 to i64* 
   %489 = getelementptr  i64, i64* %488, i64 0 
   %490 = load  i64, i64* %489 
@@ -4045,17 +4045,17 @@ entry:
   %505 = inttoptr i64 %504 to i64* 
   %506 = getelementptr  i64, i64* %505, i64 0 
   store  i64 %"f17##0", i64* %506 
-  %"1####0" = or i64 %501, 7 
-  ret i64 %"1####0" 
+  %"1##result##0" = or i64 %501, 7 
+  ret i64 %"1##result##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c17<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c17<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp uge i64 %"###0", 4 
+  %"1#tmp#0##0" = icmp uge i64 %"#result##0", 4 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2#tmp#2##0" = and i64 %"###0", 7 
+  %"2#tmp#2##0" = and i64 %"#result##0", 7 
   %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
   br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
@@ -4063,7 +4063,7 @@ if.else:
   %522 = insertvalue {i64, i1} %521, i1 0, 1 
   ret {i64, i1} %522 
 if.then1:
-  %507 = add   i64 %"###0", -7 
+  %507 = add   i64 %"#result##0", -7 
   %508 = inttoptr i64 %507 to i16* 
   %509 = getelementptr  i16, i16* %508, i64 0 
   %510 = load  i16, i16* %509 
@@ -4074,7 +4074,7 @@ if.else1:
   %520 = insertvalue {i64, i1} %519, i1 0, 1 
   ret {i64, i1} %520 
 if.then2:
-  %511 = add   i64 %"###0", 1 
+  %511 = add   i64 %"#result##0", 1 
   %512 = inttoptr i64 %511 to i64* 
   %513 = getelementptr  i64, i64* %512, i64 0 
   %514 = load  i64, i64* %513 
@@ -5425,24 +5425,24 @@ entry:
 
 metres > public {inline} (0 calls)
 0: multictr.length.metres<0>
-metres(value##0:wybe.float, ?###2:multictr.length):
+metres(value##0:wybe.float, ?#result##2:multictr.length):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(~value##0:multictr.length, ?###2:multictr.length)
+    foreign llvm move(~value##0:multictr.length, ?#result##2:multictr.length)
 metres > public {inline} (0 calls)
 1: multictr.length.metres<1>
-metres(?value##0:wybe.float, ###0:multictr.length):
+metres(?value##0:wybe.float, #result##0:multictr.length):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm cast(~###0:multictr.length, ?value##0:wybe.float)
+    foreign lpvm cast(~#result##0:multictr.length, ?value##0:wybe.float)
 
 
 value > public {inline} (0 calls)
 0: multictr.length.value<0>
-value(#rec##0:multictr.length, ?###0:wybe.float):
+value(#rec##0:multictr.length, ?#result##0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm cast(~#rec##0:multictr.length, ?###0:wybe.float)
+    foreign lpvm cast(~#rec##0:multictr.length, ?#result##0:wybe.float)
 value > public {inline} (0 calls)
 1: multictr.length.value<1>
 value([#rec##0:multictr.length], ?#rec##2:multictr.length, #field##0:wybe.float):
@@ -5487,9 +5487,9 @@ entry:
 }
 
 
-define external fastcc  double @"multictr.length.metres<1>"(i64  %"###0")    {
+define external fastcc  double @"multictr.length.metres<1>"(i64  %"#result##0")    {
 entry:
-  %2 = bitcast i64 %"###0" to double 
+  %2 = bitcast i64 %"#result##0" to double 
   ret double %2 
 }
 
@@ -5557,49 +5557,49 @@ entry:
 
 just > public {inline} (0 calls)
 0: multictr.maybe_int.just<0>
-just(value##0:wybe.int, ?###0:multictr.maybe_int):
+just(value##0:wybe.int, ?#result##0:multictr.maybe_int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.maybe_int)
-    foreign lpvm mutate(~#rec##0:multictr.maybe_int, ?###0:multictr.maybe_int, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~value##0:wybe.int)
+    foreign lpvm mutate(~#rec##0:multictr.maybe_int, ?#result##0:multictr.maybe_int, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~value##0:wybe.int)
 just > public {inline} (8 calls)
 1: multictr.maybe_int.just<1>
-just(?value##0:wybe.int, ###0:multictr.maybe_int, ?####0:wybe.bool):
+just(?value##0:wybe.int, #result##0:multictr.maybe_int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?value##0:wybe.int)
 
     1:
-        foreign lpvm access(~###0:multictr.maybe_int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?value##0:wybe.int)
+        foreign lpvm access(~#result##0:multictr.maybe_int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?value##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 nothing > public {inline} (0 calls)
 0: multictr.maybe_int.nothing<0>
-nothing(?###0:multictr.maybe_int):
+nothing(?#result##0:multictr.maybe_int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:multictr.maybe_int, ?###0:multictr.maybe_int)
+    foreign llvm move(0:multictr.maybe_int, ?#result##0:multictr.maybe_int)
 
 
 value > public {inline} (0 calls)
 0: multictr.maybe_int.value<0>
-value(#rec##0:multictr.maybe_int, ?###0:wybe.int, ?####0:wybe.bool):
+value(#rec##0:multictr.maybe_int, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:multictr.maybe_int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign lpvm access(~#rec##0:multictr.maybe_int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 value > public {inline} (0 calls)
@@ -5677,12 +5677,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.maybe_int.just<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"multictr.maybe_int.just<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  %"1#tmp#0##0" = icmp ne i64 %"#result##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %12 = inttoptr i64 %"###0" to i64* 
+  %12 = inttoptr i64 %"#result##0" to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
   %15 = insertvalue {i64, i1} undef, i64 %14, 0 
@@ -5815,18 +5815,18 @@ entry:
 
 float > public {inline} (0 calls)
 0: multictr.number.float<0>
-float(float_value##0:wybe.float, ?###0:multictr.number):
+float(float_value##0:wybe.float, ?#result##0:multictr.number):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.number)
     foreign lpvm mutate(~#rec##0:multictr.number, ?#rec##1:multictr.number, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~float_value##0:wybe.float)
-    foreign llvm or(~#rec##1:multictr.number, 1:wybe.int, ?###0:multictr.number)
+    foreign llvm or(~#rec##1:multictr.number, 1:wybe.int, ?#result##0:multictr.number)
 float > public {inline} (5 calls)
 1: multictr.number.float<1>
-float(?float_value##0:wybe.float, ###0:multictr.number, ?####0:wybe.bool):
+float(?float_value##0:wybe.float, #result##0:multictr.number, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and(###0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm and(#result##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
@@ -5834,14 +5834,14 @@ float(?float_value##0:wybe.float, ###0:multictr.number, ?####0:wybe.bool):
         foreign llvm move(undef:wybe.float, ?float_value##0:wybe.float)
 
     1:
-        foreign lpvm access(~###0:multictr.number, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?float_value##0:wybe.float)
+        foreign lpvm access(~#result##0:multictr.number, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?float_value##0:wybe.float)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 float_value > public {inline} (0 calls)
 0: multictr.number.float_value<0>
-float_value(#rec##0:multictr.number, ?###0:wybe.float, ?####0:wybe.bool):
+float_value(#rec##0:multictr.number, ?#result##0:wybe.float, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int)
@@ -5849,10 +5849,10 @@ float_value(#rec##0:multictr.number, ?###0:wybe.float, ?####0:wybe.bool):
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.float, ?###0:wybe.float)
+        foreign llvm move(undef:wybe.float, ?#result##0:wybe.float)
 
     1:
-        foreign lpvm access(~#rec##0:multictr.number, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?###0:wybe.float)
+        foreign lpvm access(~#rec##0:multictr.number, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#result##0:wybe.float)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 float_value > public {inline} (0 calls)
@@ -5875,17 +5875,17 @@ float_value(#rec##0:multictr.number, ?#rec##1:multictr.number, #field##0:wybe.fl
 
 int > public {inline} (0 calls)
 0: multictr.number.int<0>
-int(int_value##0:wybe.int, ?###0:multictr.number):
+int(int_value##0:wybe.int, ?#result##0:multictr.number):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.number)
-    foreign lpvm mutate(~#rec##0:multictr.number, ?###0:multictr.number, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~int_value##0:wybe.int)
+    foreign lpvm mutate(~#rec##0:multictr.number, ?#result##0:multictr.number, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~int_value##0:wybe.int)
 int > public {inline} (10 calls)
 1: multictr.number.int<1>
-int(?int_value##0:wybe.int, ###0:multictr.number, ?####0:wybe.bool):
+int(?int_value##0:wybe.int, #result##0:multictr.number, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and(###0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm and(#result##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
@@ -5893,14 +5893,14 @@ int(?int_value##0:wybe.int, ###0:multictr.number, ?####0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?int_value##0:wybe.int)
 
     1:
-        foreign lpvm access(~###0:multictr.number, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?int_value##0:wybe.int)
+        foreign lpvm access(~#result##0:multictr.number, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?int_value##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 int_value > public {inline} (0 calls)
 0: multictr.number.int_value<0>
-int_value(#rec##0:multictr.number, ?###0:wybe.int, ?####0:wybe.bool):
+int_value(#rec##0:multictr.number, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int)
@@ -5908,10 +5908,10 @@ int_value(#rec##0:multictr.number, ?###0:wybe.int, ?####0:wybe.bool):
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:multictr.number, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign lpvm access(~#rec##0:multictr.number, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 int_value > public {inline} (0 calls)
@@ -6007,18 +6007,18 @@ entry:
   %18 = inttoptr i64 %17 to double* 
   %19 = getelementptr  double, double* %18, i64 0 
   store  double %"float_value##0", double* %19 
-  %"1####0" = or i64 %17, 1 
-  ret i64 %"1####0" 
+  %"1##result##0" = or i64 %17, 1 
+  ret i64 %"1##result##0" 
 }
 
 
-define external fastcc  {double, i1} @"multictr.number.float<1>"(i64  %"###0")    {
+define external fastcc  {double, i1} @"multictr.number.float<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#1##0" = and i64 %"###0", 1 
+  %"1#tmp#1##0" = and i64 %"#result##0", 1 
   %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 1 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %20 = add   i64 %"###0", -1 
+  %20 = add   i64 %"#result##0", -1 
   %21 = inttoptr i64 %20 to double* 
   %22 = getelementptr  double, double* %21, i64 0 
   %23 = load  double, double* %22 
@@ -6093,13 +6093,13 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.number.int<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"multictr.number.int<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#1##0" = and i64 %"###0", 1 
+  %"1#tmp#1##0" = and i64 %"#result##0", 1 
   %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %56 = inttoptr i64 %"###0" to i64* 
+  %56 = inttoptr i64 %"#result##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
   %59 = insertvalue {i64, i1} undef, i64 %58, 0 
@@ -6189,10 +6189,10 @@ entry:
 
 content > public {inline} (0 calls)
 0: multictr.perhaps.content<0>
-content(#rec##0:multictr.perhaps, ?###0:multictr.maybe_int):
+content(#rec##0:multictr.perhaps, ?#result##0:multictr.maybe_int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm cast(~#rec##0:multictr.perhaps, ?###0:multictr.maybe_int)
+    foreign lpvm cast(~#rec##0:multictr.perhaps, ?#result##0:multictr.maybe_int)
 content > public {inline} (0 calls)
 1: multictr.perhaps.content<1>
 content([#rec##0:multictr.perhaps], ?#rec##2:multictr.perhaps, #field##0:multictr.maybe_int):
@@ -6203,16 +6203,16 @@ content([#rec##0:multictr.perhaps], ?#rec##2:multictr.perhaps, #field##0:multict
 
 perhaps > public {inline} (0 calls)
 0: multictr.perhaps.perhaps<0>
-perhaps(content##0:multictr.maybe_int, ?###2:multictr.perhaps):
+perhaps(content##0:multictr.maybe_int, ?#result##2:multictr.perhaps):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(~content##0:multictr.perhaps, ?###2:multictr.perhaps)
+    foreign llvm move(~content##0:multictr.perhaps, ?#result##2:multictr.perhaps)
 perhaps > public {inline} (0 calls)
 1: multictr.perhaps.perhaps<1>
-perhaps(?content##0:multictr.maybe_int, ###0:multictr.perhaps):
+perhaps(?content##0:multictr.maybe_int, #result##0:multictr.perhaps):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm cast(~###0:multictr.perhaps, ?content##0:multictr.maybe_int)
+    foreign lpvm cast(~#result##0:multictr.perhaps, ?content##0:multictr.maybe_int)
 
 
 ~= > public {inline} (0 calls)
@@ -6262,9 +6262,9 @@ entry:
 }
 
 
-define external fastcc  i64 @"multictr.perhaps.perhaps<1>"(i64  %"###0")    {
+define external fastcc  i64 @"multictr.perhaps.perhaps<1>"(i64  %"#result##0")    {
 entry:
-  ret i64 %"###0" 
+  ret i64 %"#result##0" 
 }
 
 
@@ -6309,106 +6309,106 @@ entry:
 
 ace > public {inline} (0 calls)
 0: multictr.rank.ace<0>
-ace(?###0:multictr.rank):
+ace(?#result##0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(12:multictr.rank, ?###0:multictr.rank)
+    foreign llvm move(12:multictr.rank, ?#result##0:multictr.rank)
 
 
 jack > public {inline} (0 calls)
 0: multictr.rank.jack<0>
-jack(?###0:multictr.rank):
+jack(?#result##0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(9:multictr.rank, ?###0:multictr.rank)
+    foreign llvm move(9:multictr.rank, ?#result##0:multictr.rank)
 
 
 king > public {inline} (0 calls)
 0: multictr.rank.king<0>
-king(?###0:multictr.rank):
+king(?#result##0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(11:multictr.rank, ?###0:multictr.rank)
+    foreign llvm move(11:multictr.rank, ?#result##0:multictr.rank)
 
 
 queen > public {inline} (0 calls)
 0: multictr.rank.queen<0>
-queen(?###0:multictr.rank):
+queen(?#result##0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(10:multictr.rank, ?###0:multictr.rank)
+    foreign llvm move(10:multictr.rank, ?#result##0:multictr.rank)
 
 
 r10 > public {inline} (0 calls)
 0: multictr.rank.r10<0>
-r10(?###0:multictr.rank):
+r10(?#result##0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(8:multictr.rank, ?###0:multictr.rank)
+    foreign llvm move(8:multictr.rank, ?#result##0:multictr.rank)
 
 
 r2 > public {inline} (0 calls)
 0: multictr.rank.r2<0>
-r2(?###0:multictr.rank):
+r2(?#result##0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:multictr.rank, ?###0:multictr.rank)
+    foreign llvm move(0:multictr.rank, ?#result##0:multictr.rank)
 
 
 r3 > public {inline} (0 calls)
 0: multictr.rank.r3<0>
-r3(?###0:multictr.rank):
+r3(?#result##0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(1:multictr.rank, ?###0:multictr.rank)
+    foreign llvm move(1:multictr.rank, ?#result##0:multictr.rank)
 
 
 r4 > public {inline} (0 calls)
 0: multictr.rank.r4<0>
-r4(?###0:multictr.rank):
+r4(?#result##0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(2:multictr.rank, ?###0:multictr.rank)
+    foreign llvm move(2:multictr.rank, ?#result##0:multictr.rank)
 
 
 r5 > public {inline} (0 calls)
 0: multictr.rank.r5<0>
-r5(?###0:multictr.rank):
+r5(?#result##0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(3:multictr.rank, ?###0:multictr.rank)
+    foreign llvm move(3:multictr.rank, ?#result##0:multictr.rank)
 
 
 r6 > public {inline} (0 calls)
 0: multictr.rank.r6<0>
-r6(?###0:multictr.rank):
+r6(?#result##0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(4:multictr.rank, ?###0:multictr.rank)
+    foreign llvm move(4:multictr.rank, ?#result##0:multictr.rank)
 
 
 r7 > public {inline} (0 calls)
 0: multictr.rank.r7<0>
-r7(?###0:multictr.rank):
+r7(?#result##0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(5:multictr.rank, ?###0:multictr.rank)
+    foreign llvm move(5:multictr.rank, ?#result##0:multictr.rank)
 
 
 r8 > public {inline} (0 calls)
 0: multictr.rank.r8<0>
-r8(?###0:multictr.rank):
+r8(?#result##0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(6:multictr.rank, ?###0:multictr.rank)
+    foreign llvm move(6:multictr.rank, ?#result##0:multictr.rank)
 
 
 r9 > public {inline} (0 calls)
 0: multictr.rank.r9<0>
-r9(?###0:multictr.rank):
+r9(?#result##0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(7:multictr.rank, ?###0:multictr.rank)
+    foreign llvm move(7:multictr.rank, ?#result##0:multictr.rank)
 
 
 ~= > public {inline} (0 calls)
@@ -6622,24 +6622,24 @@ entry:
 
 one > public {inline} (0 calls)
 0: multictr.simple.one<0>
-one(one_field##0:wybe.int, ?###0:multictr.simple):
+one(one_field##0:wybe.int, ?#result##0:multictr.simple):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.simple)
-    foreign lpvm mutate(~#rec##0:multictr.simple, ?###0:multictr.simple, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~one_field##0:wybe.int)
+    foreign lpvm mutate(~#rec##0:multictr.simple, ?#result##0:multictr.simple, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~one_field##0:wybe.int)
 one > public {inline} (11 calls)
 1: multictr.simple.one<1>
-one(?one_field##0:wybe.int, ###0:multictr.simple, ?####0:wybe.bool):
+one(?one_field##0:wybe.int, #result##0:multictr.simple, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?one_field##0:wybe.int)
 
     1:
-        foreign llvm and(###0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm and(#result##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int)
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
@@ -6647,7 +6647,7 @@ one(?one_field##0:wybe.int, ###0:multictr.simple, ?####0:wybe.bool):
             foreign llvm move(undef:wybe.int, ?one_field##0:wybe.int)
 
         1:
-            foreign lpvm access(~###0:multictr.simple, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?one_field##0:wybe.int)
+            foreign lpvm access(~#result##0:multictr.simple, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?one_field##0:wybe.int)
             foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -6655,14 +6655,14 @@ one(?one_field##0:wybe.int, ###0:multictr.simple, ?####0:wybe.bool):
 
 one_field > public {inline} (0 calls)
 0: multictr.simple.one_field<0>
-one_field(#rec##0:multictr.simple, ?###0:wybe.int, ?####0:wybe.bool):
+one_field(#rec##0:multictr.simple, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign llvm and(#rec##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int)
@@ -6670,10 +6670,10 @@ one_field(#rec##0:multictr.simple, ?###0:wybe.int, ?####0:wybe.bool):
         case ~tmp#1##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+            foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(~#rec##0:multictr.simple, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?###0:wybe.int)
+            foreign lpvm access(~#rec##0:multictr.simple, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
             foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -6705,19 +6705,19 @@ one_field(#rec##0:multictr.simple, ?#rec##1:multictr.simple, #field##0:wybe.int,
 
 two > public {inline} (0 calls)
 0: multictr.simple.two<0>
-two(two_field1##0:wybe.int, two_field2##0:wybe.int, ?###0:multictr.simple):
+two(two_field1##0:wybe.int, two_field2##0:wybe.int, ?#result##0:multictr.simple):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.simple)
     foreign lpvm mutate(~#rec##0:multictr.simple, ?#rec##1:multictr.simple, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~two_field1##0:wybe.int)
     foreign lpvm mutate(~#rec##1:multictr.simple, ?#rec##2:multictr.simple, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~two_field2##0:wybe.int)
-    foreign llvm or(~#rec##2:multictr.simple, 1:wybe.int, ?###0:multictr.simple)
+    foreign llvm or(~#rec##2:multictr.simple, 1:wybe.int, ?#result##0:multictr.simple)
 two > public {inline} (7 calls)
 1: multictr.simple.two<1>
-two(?two_field1##0:wybe.int, ?two_field2##0:wybe.int, ###0:multictr.simple, ?####0:wybe.bool):
+two(?two_field1##0:wybe.int, ?two_field2##0:wybe.int, #result##0:multictr.simple, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
@@ -6725,7 +6725,7 @@ two(?two_field1##0:wybe.int, ?two_field2##0:wybe.int, ###0:multictr.simple, ?###
         foreign llvm move(undef:wybe.int, ?two_field2##0:wybe.int)
 
     1:
-        foreign llvm and(###0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm and(#result##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int)
         foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
         case ~tmp#1##0:wybe.bool of
         0:
@@ -6734,8 +6734,8 @@ two(?two_field1##0:wybe.int, ?two_field2##0:wybe.int, ###0:multictr.simple, ?###
             foreign llvm move(undef:wybe.int, ?two_field2##0:wybe.int)
 
         1:
-            foreign lpvm access(###0:multictr.simple, -1:wybe.int, 16:wybe.int, 1:wybe.int, ?two_field1##0:wybe.int)
-            foreign lpvm access(~###0:multictr.simple, 7:wybe.int, 16:wybe.int, 1:wybe.int, ?two_field2##0:wybe.int)
+            foreign lpvm access(#result##0:multictr.simple, -1:wybe.int, 16:wybe.int, 1:wybe.int, ?two_field1##0:wybe.int)
+            foreign lpvm access(~#result##0:multictr.simple, 7:wybe.int, 16:wybe.int, 1:wybe.int, ?two_field2##0:wybe.int)
             foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -6743,14 +6743,14 @@ two(?two_field1##0:wybe.int, ?two_field2##0:wybe.int, ###0:multictr.simple, ?###
 
 two_field1 > public {inline} (0 calls)
 0: multictr.simple.two_field1<0>
-two_field1(#rec##0:multictr.simple, ?###0:wybe.int, ?####0:wybe.bool):
+two_field1(#rec##0:multictr.simple, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign llvm and(#rec##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int)
@@ -6758,10 +6758,10 @@ two_field1(#rec##0:multictr.simple, ?###0:wybe.int, ?####0:wybe.bool):
         case ~tmp#1##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+            foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(~#rec##0:multictr.simple, -1:wybe.int, 16:wybe.int, 1:wybe.int, ?###0:wybe.int)
+            foreign lpvm access(~#rec##0:multictr.simple, -1:wybe.int, 16:wybe.int, 1:wybe.int, ?#result##0:wybe.int)
             foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -6793,14 +6793,14 @@ two_field1(#rec##0:multictr.simple, ?#rec##1:multictr.simple, #field##0:wybe.int
 
 two_field2 > public {inline} (0 calls)
 0: multictr.simple.two_field2<0>
-two_field2(#rec##0:multictr.simple, ?###0:wybe.int, ?####0:wybe.bool):
+two_field2(#rec##0:multictr.simple, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign llvm and(#rec##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int)
@@ -6808,10 +6808,10 @@ two_field2(#rec##0:multictr.simple, ?###0:wybe.int, ?####0:wybe.bool):
         case ~tmp#1##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+            foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
         1:
-            foreign lpvm access(~#rec##0:multictr.simple, 7:wybe.int, 16:wybe.int, 1:wybe.int, ?###0:wybe.int)
+            foreign lpvm access(~#rec##0:multictr.simple, 7:wybe.int, 16:wybe.int, 1:wybe.int, ?#result##0:wybe.int)
             foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
@@ -6843,10 +6843,10 @@ two_field2(#rec##0:multictr.simple, ?#rec##1:multictr.simple, #field##0:wybe.int
 
 zero > public {inline} (0 calls)
 0: multictr.simple.zero<0>
-zero(?###0:multictr.simple):
+zero(?#result##0:multictr.simple):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:multictr.simple, ?###0:multictr.simple)
+    foreign llvm move(0:multictr.simple, ?#result##0:multictr.simple)
 
 
 ~= > public {inline} (0 calls)
@@ -6957,12 +6957,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.simple.one<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"multictr.simple.one<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  %"1#tmp#0##0" = icmp ne i64 %"#result##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2#tmp#2##0" = and i64 %"###0", 1 
+  %"2#tmp#2##0" = and i64 %"#result##0", 1 
   %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 0 
   br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
@@ -6970,7 +6970,7 @@ if.else:
   %36 = insertvalue {i64, i1} %35, i1 0, 1 
   ret {i64, i1} %36 
 if.then1:
-  %28 = inttoptr i64 %"###0" to i64* 
+  %28 = inttoptr i64 %"#result##0" to i64* 
   %29 = getelementptr  i64, i64* %28, i64 0 
   %30 = load  i64, i64* %29 
   %31 = insertvalue {i64, i1} undef, i64 %30, 0 
@@ -7054,17 +7054,17 @@ entry:
   %66 = inttoptr i64 %65 to i64* 
   %67 = getelementptr  i64, i64* %66, i64 0 
   store  i64 %"two_field2##0", i64* %67 
-  %"1####0" = or i64 %62, 1 
-  ret i64 %"1####0" 
+  %"1##result##0" = or i64 %62, 1 
+  ret i64 %"1##result##0" 
 }
 
 
-define external fastcc  {i64, i64, i1} @"multictr.simple.two<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64, i1} @"multictr.simple.two<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  %"1#tmp#0##0" = icmp ne i64 %"#result##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2#tmp#2##0" = and i64 %"###0", 1 
+  %"2#tmp#2##0" = and i64 %"#result##0", 1 
   %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 1 
   br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
@@ -7073,11 +7073,11 @@ if.else:
   %84 = insertvalue {i64, i64, i1} %83, i1 0, 2 
   ret {i64, i64, i1} %84 
 if.then1:
-  %68 = add   i64 %"###0", -1 
+  %68 = add   i64 %"#result##0", -1 
   %69 = inttoptr i64 %68 to i64* 
   %70 = getelementptr  i64, i64* %69, i64 0 
   %71 = load  i64, i64* %70 
-  %72 = add   i64 %"###0", 7 
+  %72 = add   i64 %"#result##0", 7 
   %73 = inttoptr i64 %72 to i64* 
   %74 = getelementptr  i64, i64* %73, i64 0 
   %75 = load  i64, i64* %74 
@@ -7257,34 +7257,34 @@ entry:
 
 clubs > public {inline} (0 calls)
 0: multictr.suit.clubs<0>
-clubs(?###0:multictr.suit):
+clubs(?#result##0:multictr.suit):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:multictr.suit, ?###0:multictr.suit)
+    foreign llvm move(0:multictr.suit, ?#result##0:multictr.suit)
 
 
 diamonds > public {inline} (0 calls)
 0: multictr.suit.diamonds<0>
-diamonds(?###0:multictr.suit):
+diamonds(?#result##0:multictr.suit):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(1:multictr.suit, ?###0:multictr.suit)
+    foreign llvm move(1:multictr.suit, ?#result##0:multictr.suit)
 
 
 hearts > public {inline} (0 calls)
 0: multictr.suit.hearts<0>
-hearts(?###0:multictr.suit):
+hearts(?#result##0:multictr.suit):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(2:multictr.suit, ?###0:multictr.suit)
+    foreign llvm move(2:multictr.suit, ?#result##0:multictr.suit)
 
 
 spades > public {inline} (0 calls)
 0: multictr.suit.spades<0>
-spades(?###0:multictr.suit):
+spades(?#result##0:multictr.suit):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(3:multictr.suit, ?###0:multictr.suit)
+    foreign llvm move(3:multictr.suit, ?#result##0:multictr.suit)
 
 
 ~= > public {inline} (0 calls)
@@ -7369,10 +7369,10 @@ entry:
 
 unit > public {inline} (0 calls)
 0: multictr.unit.unit<0>
-unit(?###0:multictr.unit):
+unit(?#result##0:multictr.unit):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:multictr.unit, ?###0:multictr.unit)
+    foreign llvm move(0:multictr.unit, ?#result##0:multictr.unit)
 
 
 ~= > public {inline} (0 calls)

--- a/test-cases/final-dump/multictr.exp
+++ b/test-cases/final-dump/multictr.exp
@@ -209,72 +209,72 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 = > public {inline} (1 calls)
 0: multictr.card.=<0>
-=($left#0:multictr.card, $right#0:multictr.card, ?$$#0:wybe.bool):
+=($left##0:multictr.card, $right##0:multictr.card, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(~$left#0:multictr.card, ~$right#0:multictr.card, ?$$#0:wybe.bool)
+    foreign llvm icmp_eq(~$left##0:multictr.card, ~$right##0:multictr.card, ?$$##0:wybe.bool)
 
 
 card > public {inline} (0 calls)
 0: multictr.card.card<0>
-card(suit#0:multictr.suit, rank#0:multictr.rank, ?$#3:multictr.card):
+card(suit##0:multictr.suit, rank##0:multictr.rank, ?$##3:multictr.card):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm shl(~rank#0:multictr.card, 2:multictr.card, ?$temp#1:multictr.card)
-    foreign llvm or(~$temp#1:multictr.card, ~suit#0:multictr.card, ?$#3:multictr.card)
+    foreign llvm shl(~rank##0:multictr.card, 2:multictr.card, ?$temp##1:multictr.card)
+    foreign llvm or(~$temp##1:multictr.card, ~suit##0:multictr.card, ?$##3:multictr.card)
 card > public {inline} (0 calls)
 1: multictr.card.card<1>
-card(?suit#0:multictr.suit, ?rank#0:multictr.rank, $#0:multictr.card):
+card(?suit##0:multictr.suit, ?rank##0:multictr.rank, $##0:multictr.card):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($#0:multictr.card, 3:multictr.card, ?$temp2#0:multictr.card)
-    foreign lpvm cast(~$temp2#0:multictr.card, ?suit#0:multictr.suit)
-    foreign llvm lshr(~$#0:multictr.card, 2:multictr.card, ?$temp#1:multictr.card)
-    foreign llvm and(~$temp#1:multictr.card, 15:multictr.card, ?$temp2#1:multictr.card)
-    foreign lpvm cast(~$temp2#1:multictr.card, ?rank#0:multictr.rank)
+    foreign llvm and($##0:multictr.card, 3:multictr.card, ?$temp2##0:multictr.card)
+    foreign lpvm cast(~$temp2##0:multictr.card, ?suit##0:multictr.suit)
+    foreign llvm lshr(~$##0:multictr.card, 2:multictr.card, ?$temp##1:multictr.card)
+    foreign llvm and(~$temp##1:multictr.card, 15:multictr.card, ?$temp2##1:multictr.card)
+    foreign lpvm cast(~$temp2##1:multictr.card, ?rank##0:multictr.rank)
 
 
 rank > public {inline} (0 calls)
 0: multictr.card.rank<0>
-rank($rec#0:multictr.card, ?$#0:multictr.rank):
+rank($rec##0:multictr.card, ?$##0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm lshr(~$rec#0:multictr.card, 2:multictr.card, ?$rec#1:multictr.card)
-    foreign llvm and(~$rec#1:multictr.card, 15:multictr.card, ?$field#0:multictr.card)
-    foreign lpvm cast(~$field#0:multictr.card, ?$#0:multictr.rank)
+    foreign llvm lshr(~$rec##0:multictr.card, 2:multictr.card, ?$rec##1:multictr.card)
+    foreign llvm and(~$rec##1:multictr.card, 15:multictr.card, ?$field##0:multictr.card)
+    foreign lpvm cast(~$field##0:multictr.card, ?$##0:multictr.rank)
 rank > public {inline} (0 calls)
 1: multictr.card.rank<1>
-rank($rec#0:multictr.card, ?$rec#2:multictr.card, $field#0:multictr.rank):
+rank($rec##0:multictr.card, ?$rec##2:multictr.card, $field##0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and(~$rec#0:multictr.card, -61:multictr.card, ?$rec#1:multictr.card)
-    foreign llvm shl(~$field#0:multictr.card, 2:multictr.card, ?$temp#0:multictr.card)
-    foreign llvm or(~$rec#1:multictr.card, ~$temp#0:multictr.card, ?$rec#2:multictr.card)
+    foreign llvm and(~$rec##0:multictr.card, -61:multictr.card, ?$rec##1:multictr.card)
+    foreign llvm shl(~$field##0:multictr.card, 2:multictr.card, ?$temp##0:multictr.card)
+    foreign llvm or(~$rec##1:multictr.card, ~$temp##0:multictr.card, ?$rec##2:multictr.card)
 
 
 suit > public {inline} (0 calls)
 0: multictr.card.suit<0>
-suit($rec#0:multictr.card, ?$#0:multictr.suit):
+suit($rec##0:multictr.card, ?$##0:multictr.suit):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and(~$rec#0:multictr.card, 3:multictr.card, ?$field#0:multictr.card)
-    foreign lpvm cast(~$field#0:multictr.card, ?$#0:multictr.suit)
+    foreign llvm and(~$rec##0:multictr.card, 3:multictr.card, ?$field##0:multictr.card)
+    foreign lpvm cast(~$field##0:multictr.card, ?$##0:multictr.suit)
 suit > public {inline} (0 calls)
 1: multictr.card.suit<1>
-suit($rec#0:multictr.card, ?$rec#2:multictr.card, $field#0:multictr.suit):
+suit($rec##0:multictr.card, ?$rec##2:multictr.card, $field##0:multictr.suit):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and(~$rec#0:multictr.card, -4:multictr.card, ?$rec#1:multictr.card)
-    foreign llvm or(~$field#0:multictr.card, ~$rec#1:multictr.card, ?$rec#2:multictr.card)
+    foreign llvm and(~$rec##0:multictr.card, -4:multictr.card, ?$rec##1:multictr.card)
+    foreign llvm or(~$field##0:multictr.card, ~$rec##1:multictr.card, ?$rec##2:multictr.card)
 
 
 ~= > public {inline} (0 calls)
 0: multictr.card.~=<0>
-~=($left#0:multictr.card, $right#0:multictr.card, ?$$#0:wybe.bool):
+~=($left##0:multictr.card, $right##0:multictr.card, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(~$left#0:multictr.card, ~$right#0:multictr.card, ?tmp$0#0:wybe.bool)
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    foreign llvm icmp_eq(~$left##0:multictr.card, ~$right##0:multictr.card, ?tmp$0##0:wybe.bool)
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
   LLVM code       :
 
@@ -290,77 +290,77 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"multictr.card.=<0>"(i6  %"$left#0", i6  %"$right#0")    {
+define external fastcc  i1 @"multictr.card.=<0>"(i6  %"$left##0", i6  %"$right##0")    {
 entry:
-  %"1$$$#0" = icmp eq i6 %"$left#0", %"$right#0" 
-  ret i1 %"1$$$#0" 
+  %"1$$$##0" = icmp eq i6 %"$left##0", %"$right##0" 
+  ret i1 %"1$$$##0" 
 }
 
 
-define external fastcc  i6 @"multictr.card.card<0>"(i2  %"suit#0", i4  %"rank#0")    {
+define external fastcc  i6 @"multictr.card.card<0>"(i2  %"suit##0", i4  %"rank##0")    {
 entry:
-  %1 = zext i4 %"rank#0" to i6  
-  %"1$$temp#1" = shl   i6 %1, 2 
-  %2 = zext i2 %"suit#0" to i6  
-  %"1$$#3" = or i6 %"1$$temp#1", %2 
-  ret i6 %"1$$#3" 
+  %1 = zext i4 %"rank##0" to i6  
+  %"1$$temp##1" = shl   i6 %1, 2 
+  %2 = zext i2 %"suit##0" to i6  
+  %"1$$##3" = or i6 %"1$$temp##1", %2 
+  ret i6 %"1$$##3" 
 }
 
 
-define external fastcc  {i2, i4} @"multictr.card.card<1>"(i6  %"$#0")    {
+define external fastcc  {i2, i4} @"multictr.card.card<1>"(i6  %"$##0")    {
 entry:
-  %"1$$temp2#0" = and i6 %"$#0", 3 
-  %3 = trunc i6 %"1$$temp2#0" to i2  
-  %"1$$temp#1" = lshr  i6 %"$#0", 2 
-  %"1$$temp2#1" = and i6 %"1$$temp#1", 15 
-  %4 = trunc i6 %"1$$temp2#1" to i4  
+  %"1$$temp2##0" = and i6 %"$##0", 3 
+  %3 = trunc i6 %"1$$temp2##0" to i2  
+  %"1$$temp##1" = lshr  i6 %"$##0", 2 
+  %"1$$temp2##1" = and i6 %"1$$temp##1", 15 
+  %4 = trunc i6 %"1$$temp2##1" to i4  
   %5 = insertvalue {i2, i4} undef, i2 %3, 0 
   %6 = insertvalue {i2, i4} %5, i4 %4, 1 
   ret {i2, i4} %6 
 }
 
 
-define external fastcc  i4 @"multictr.card.rank<0>"(i6  %"$rec#0")    {
+define external fastcc  i4 @"multictr.card.rank<0>"(i6  %"$rec##0")    {
 entry:
-  %"1$$rec#1" = lshr  i6 %"$rec#0", 2 
-  %"1$$field#0" = and i6 %"1$$rec#1", 15 
-  %7 = trunc i6 %"1$$field#0" to i4  
+  %"1$$rec##1" = lshr  i6 %"$rec##0", 2 
+  %"1$$field##0" = and i6 %"1$$rec##1", 15 
+  %7 = trunc i6 %"1$$field##0" to i4  
   ret i4 %7 
 }
 
 
-define external fastcc  i6 @"multictr.card.rank<1>"(i6  %"$rec#0", i4  %"$field#0")    {
+define external fastcc  i6 @"multictr.card.rank<1>"(i6  %"$rec##0", i4  %"$field##0")    {
 entry:
-  %"1$$rec#1" = and i6 %"$rec#0", -61 
-  %8 = zext i4 %"$field#0" to i6  
-  %"1$$temp#0" = shl   i6 %8, 2 
-  %"1$$rec#2" = or i6 %"1$$rec#1", %"1$$temp#0" 
-  ret i6 %"1$$rec#2" 
+  %"1$$rec##1" = and i6 %"$rec##0", -61 
+  %8 = zext i4 %"$field##0" to i6  
+  %"1$$temp##0" = shl   i6 %8, 2 
+  %"1$$rec##2" = or i6 %"1$$rec##1", %"1$$temp##0" 
+  ret i6 %"1$$rec##2" 
 }
 
 
-define external fastcc  i2 @"multictr.card.suit<0>"(i6  %"$rec#0")    {
+define external fastcc  i2 @"multictr.card.suit<0>"(i6  %"$rec##0")    {
 entry:
-  %"1$$field#0" = and i6 %"$rec#0", 3 
-  %9 = trunc i6 %"1$$field#0" to i2  
+  %"1$$field##0" = and i6 %"$rec##0", 3 
+  %9 = trunc i6 %"1$$field##0" to i2  
   ret i2 %9 
 }
 
 
-define external fastcc  i6 @"multictr.card.suit<1>"(i6  %"$rec#0", i2  %"$field#0")    {
+define external fastcc  i6 @"multictr.card.suit<1>"(i6  %"$rec##0", i2  %"$field##0")    {
 entry:
-  %"1$$rec#1" = and i6 %"$rec#0", -4 
-  %10 = zext i2 %"$field#0" to i6  
-  %"1$$rec#2" = or i6 %10, %"1$$rec#1" 
-  ret i6 %"1$$rec#2" 
+  %"1$$rec##1" = and i6 %"$rec##0", -4 
+  %10 = zext i2 %"$field##0" to i6  
+  %"1$$rec##2" = or i6 %10, %"1$$rec##1" 
+  ret i6 %"1$$rec##2" 
 }
 
 
-define external fastcc  i1 @"multictr.card.~=<0>"(i6  %"$left#0", i6  %"$right#0")    {
+define external fastcc  i1 @"multictr.card.~=<0>"(i6  %"$left##0", i6  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = icmp eq i6 %"$left#0", %"$right#0" 
-  %"1$$$#0" = xor i1 %"1$tmp$0#0", 1 
-  ret i1 %"1$$$#0" 
+  %"1$tmp$0##0" = icmp eq i6 %"$left##0", %"$right##0" 
+  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
+  ret i1 %"1$$$##0" 
 }
 --------------------------------------------------
  Module multictr.complicated
@@ -448,361 +448,361 @@ entry:
 
 = > public (1 calls)
 0: multictr.complicated.=<0>
-=($left#0:multictr.complicated, $right#0:multictr.complicated, ?$$#0:wybe.bool):
+=($left##0:multictr.complicated, $right##0:multictr.complicated, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($left#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($left##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left#0:multictr.complicated, ~$right#0:multictr.complicated, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~$left##0:multictr.complicated, ~$right##0:multictr.complicated, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm and($left#0:wybe.int, 7:wybe.int, ?tmp$55#0:wybe.int)
-        foreign llvm icmp_eq(tmp$55#0:wybe.int, 0:wybe.int, ?tmp$56#0:wybe.bool)
-        case ~tmp$56#0:wybe.bool of
+        foreign llvm and($left##0:wybe.int, 7:wybe.int, ?tmp$55##0:wybe.int)
+        foreign llvm icmp_eq(tmp$55##0:wybe.int, 0:wybe.int, ?tmp$56##0:wybe.bool)
+        case ~tmp$56##0:wybe.bool of
         0:
-            foreign llvm icmp_eq(tmp$55#0:wybe.int, 1:wybe.int, ?tmp$60#0:wybe.bool)
-            case ~tmp$60#0:wybe.bool of
+            foreign llvm icmp_eq(tmp$55##0:wybe.int, 1:wybe.int, ?tmp$60##0:wybe.bool)
+            case ~tmp$60##0:wybe.bool of
             0:
-                foreign llvm icmp_eq(tmp$55#0:wybe.int, 2:wybe.int, ?tmp$64#0:wybe.bool)
-                case ~tmp$64#0:wybe.bool of
+                foreign llvm icmp_eq(tmp$55##0:wybe.int, 2:wybe.int, ?tmp$64##0:wybe.bool)
+                case ~tmp$64##0:wybe.bool of
                 0:
-                    foreign llvm icmp_eq(tmp$55#0:wybe.int, 3:wybe.int, ?tmp$68#0:wybe.bool)
-                    case ~tmp$68#0:wybe.bool of
+                    foreign llvm icmp_eq(tmp$55##0:wybe.int, 3:wybe.int, ?tmp$68##0:wybe.bool)
+                    case ~tmp$68##0:wybe.bool of
                     0:
-                        foreign llvm icmp_eq(tmp$55#0:wybe.int, 4:wybe.int, ?tmp$72#0:wybe.bool)
-                        case ~tmp$72#0:wybe.bool of
+                        foreign llvm icmp_eq(tmp$55##0:wybe.int, 4:wybe.int, ?tmp$72##0:wybe.bool)
+                        case ~tmp$72##0:wybe.bool of
                         0:
-                            foreign llvm icmp_eq(tmp$55#0:wybe.int, 5:wybe.int, ?tmp$76#0:wybe.bool)
-                            case ~tmp$76#0:wybe.bool of
+                            foreign llvm icmp_eq(tmp$55##0:wybe.int, 5:wybe.int, ?tmp$76##0:wybe.bool)
+                            case ~tmp$76##0:wybe.bool of
                             0:
-                                foreign llvm icmp_eq(tmp$55#0:wybe.int, 6:wybe.int, ?tmp$80#0:wybe.bool)
-                                case ~tmp$80#0:wybe.bool of
+                                foreign llvm icmp_eq(tmp$55##0:wybe.int, 6:wybe.int, ?tmp$80##0:wybe.bool)
+                                case ~tmp$80##0:wybe.bool of
                                 0:
-                                    foreign llvm icmp_eq(~tmp$55#0:wybe.int, 7:wybe.int, ?tmp$84#0:wybe.bool)
-                                    case ~tmp$84#0:wybe.bool of
+                                    foreign llvm icmp_eq(~tmp$55##0:wybe.int, 7:wybe.int, ?tmp$84##0:wybe.bool)
+                                    case ~tmp$84##0:wybe.bool of
                                     0:
-                                        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                     1:
-                                        foreign lpvm access($left#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp$85#0:16 bit unsigned)
-                                        foreign llvm icmp_eq(tmp$85#0:16 bit unsigned, 7:16 bit unsigned, ?tmp$86#0:wybe.bool)
-                                        case ~tmp$86#0:wybe.bool of
+                                        foreign lpvm access($left##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp$85##0:16 bit unsigned)
+                                        foreign llvm icmp_eq(tmp$85##0:16 bit unsigned, 7:16 bit unsigned, ?tmp$86##0:wybe.bool)
+                                        case ~tmp$86##0:wybe.bool of
                                         0:
-                                            foreign llvm icmp_eq(tmp$85#0:16 bit unsigned, 8:16 bit unsigned, ?tmp$92#0:wybe.bool)
-                                            case ~tmp$92#0:wybe.bool of
+                                            foreign llvm icmp_eq(tmp$85##0:16 bit unsigned, 8:16 bit unsigned, ?tmp$92##0:wybe.bool)
+                                            case ~tmp$92##0:wybe.bool of
                                             0:
-                                                foreign llvm icmp_eq(tmp$85#0:16 bit unsigned, 9:16 bit unsigned, ?tmp$98#0:wybe.bool)
-                                                case ~tmp$98#0:wybe.bool of
+                                                foreign llvm icmp_eq(tmp$85##0:16 bit unsigned, 9:16 bit unsigned, ?tmp$98##0:wybe.bool)
+                                                case ~tmp$98##0:wybe.bool of
                                                 0:
-                                                    foreign llvm icmp_eq(tmp$85#0:16 bit unsigned, 10:16 bit unsigned, ?tmp$104#0:wybe.bool)
-                                                    case ~tmp$104#0:wybe.bool of
+                                                    foreign llvm icmp_eq(tmp$85##0:16 bit unsigned, 10:16 bit unsigned, ?tmp$104##0:wybe.bool)
+                                                    case ~tmp$104##0:wybe.bool of
                                                     0:
-                                                        foreign llvm icmp_eq(tmp$85#0:16 bit unsigned, 11:16 bit unsigned, ?tmp$110#0:wybe.bool)
-                                                        case ~tmp$110#0:wybe.bool of
+                                                        foreign llvm icmp_eq(tmp$85##0:16 bit unsigned, 11:16 bit unsigned, ?tmp$110##0:wybe.bool)
+                                                        case ~tmp$110##0:wybe.bool of
                                                         0:
-                                                            foreign llvm icmp_eq(tmp$85#0:16 bit unsigned, 12:16 bit unsigned, ?tmp$116#0:wybe.bool)
-                                                            case ~tmp$116#0:wybe.bool of
+                                                            foreign llvm icmp_eq(tmp$85##0:16 bit unsigned, 12:16 bit unsigned, ?tmp$116##0:wybe.bool)
+                                                            case ~tmp$116##0:wybe.bool of
                                                             0:
-                                                                foreign llvm icmp_eq(tmp$85#0:16 bit unsigned, 13:16 bit unsigned, ?tmp$122#0:wybe.bool)
-                                                                case ~tmp$122#0:wybe.bool of
+                                                                foreign llvm icmp_eq(tmp$85##0:16 bit unsigned, 13:16 bit unsigned, ?tmp$122##0:wybe.bool)
+                                                                case ~tmp$122##0:wybe.bool of
                                                                 0:
-                                                                    foreign llvm icmp_eq(tmp$85#0:16 bit unsigned, 14:16 bit unsigned, ?tmp$128#0:wybe.bool)
-                                                                    case ~tmp$128#0:wybe.bool of
+                                                                    foreign llvm icmp_eq(tmp$85##0:16 bit unsigned, 14:16 bit unsigned, ?tmp$128##0:wybe.bool)
+                                                                    case ~tmp$128##0:wybe.bool of
                                                                     0:
-                                                                        foreign llvm icmp_eq(tmp$85#0:16 bit unsigned, 15:16 bit unsigned, ?tmp$134#0:wybe.bool)
-                                                                        case ~tmp$134#0:wybe.bool of
+                                                                        foreign llvm icmp_eq(tmp$85##0:16 bit unsigned, 15:16 bit unsigned, ?tmp$134##0:wybe.bool)
+                                                                        case ~tmp$134##0:wybe.bool of
                                                                         0:
-                                                                            foreign llvm icmp_eq(~tmp$85#0:16 bit unsigned, 16:16 bit unsigned, ?tmp$140#0:wybe.bool)
-                                                                            case ~tmp$140#0:wybe.bool of
+                                                                            foreign llvm icmp_eq(~tmp$85##0:16 bit unsigned, 16:16 bit unsigned, ?tmp$140##0:wybe.bool)
+                                                                            case ~tmp$140##0:wybe.bool of
                                                                             0:
-                                                                                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                                                                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                                                             1:
-                                                                                foreign lpvm access(~$left#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$left$f17#0:wybe.int)
-                                                                                foreign llvm icmp_uge($right#0:wybe.int, 4:wybe.int, ?tmp$142#0:wybe.bool)
-                                                                                case ~tmp$142#0:wybe.bool of
+                                                                                foreign lpvm access(~$left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$left$f17##0:wybe.int)
+                                                                                foreign llvm icmp_uge($right##0:wybe.int, 4:wybe.int, ?tmp$142##0:wybe.bool)
+                                                                                case ~tmp$142##0:wybe.bool of
                                                                                 0:
-                                                                                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                                                                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                                                                 1:
-                                                                                    foreign llvm and($right#0:wybe.int, 7:wybe.int, ?tmp$143#0:wybe.int)
-                                                                                    foreign llvm icmp_eq(~tmp$143#0:wybe.int, 7:wybe.int, ?tmp$144#0:wybe.bool)
-                                                                                    case ~tmp$144#0:wybe.bool of
+                                                                                    foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$143##0:wybe.int)
+                                                                                    foreign llvm icmp_eq(~tmp$143##0:wybe.int, 7:wybe.int, ?tmp$144##0:wybe.bool)
+                                                                                    case ~tmp$144##0:wybe.bool of
                                                                                     0:
-                                                                                        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                                                                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                                                                     1:
-                                                                                        foreign lpvm access($right#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp$145#0:16 bit unsigned)
-                                                                                        foreign llvm icmp_eq(~tmp$145#0:16 bit unsigned, 16:16 bit unsigned, ?tmp$146#0:wybe.bool)
-                                                                                        case ~tmp$146#0:wybe.bool of
+                                                                                        foreign lpvm access($right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp$145##0:16 bit unsigned)
+                                                                                        foreign llvm icmp_eq(~tmp$145##0:16 bit unsigned, 16:16 bit unsigned, ?tmp$146##0:wybe.bool)
+                                                                                        case ~tmp$146##0:wybe.bool of
                                                                                         0:
-                                                                                            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                                                                            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                                                                         1:
-                                                                                            foreign lpvm access(~$right#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$right$f17#0:wybe.int)
-                                                                                            foreign llvm icmp_eq(~$left$f17#0:wybe.int, ~$right$f17#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+                                                                                            foreign lpvm access(~$right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$right$f17##0:wybe.int)
+                                                                                            foreign llvm icmp_eq(~$left$f17##0:wybe.int, ~$right$f17##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 
 
                                                                         1:
-                                                                            foreign lpvm access(~$left#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$left$f16#0:wybe.int)
-                                                                            foreign llvm icmp_uge($right#0:wybe.int, 4:wybe.int, ?tmp$136#0:wybe.bool)
-                                                                            case ~tmp$136#0:wybe.bool of
+                                                                            foreign lpvm access(~$left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$left$f16##0:wybe.int)
+                                                                            foreign llvm icmp_uge($right##0:wybe.int, 4:wybe.int, ?tmp$136##0:wybe.bool)
+                                                                            case ~tmp$136##0:wybe.bool of
                                                                             0:
-                                                                                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                                                                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                                                             1:
-                                                                                foreign llvm and($right#0:wybe.int, 7:wybe.int, ?tmp$137#0:wybe.int)
-                                                                                foreign llvm icmp_eq(~tmp$137#0:wybe.int, 7:wybe.int, ?tmp$138#0:wybe.bool)
-                                                                                case ~tmp$138#0:wybe.bool of
+                                                                                foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$137##0:wybe.int)
+                                                                                foreign llvm icmp_eq(~tmp$137##0:wybe.int, 7:wybe.int, ?tmp$138##0:wybe.bool)
+                                                                                case ~tmp$138##0:wybe.bool of
                                                                                 0:
-                                                                                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                                                                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                                                                 1:
-                                                                                    foreign lpvm access($right#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp$139#0:16 bit unsigned)
-                                                                                    foreign llvm icmp_eq(~tmp$139#0:16 bit unsigned, 15:16 bit unsigned, ?tmp$140#0:wybe.bool)
-                                                                                    case ~tmp$140#0:wybe.bool of
+                                                                                    foreign lpvm access($right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp$139##0:16 bit unsigned)
+                                                                                    foreign llvm icmp_eq(~tmp$139##0:16 bit unsigned, 15:16 bit unsigned, ?tmp$140##0:wybe.bool)
+                                                                                    case ~tmp$140##0:wybe.bool of
                                                                                     0:
-                                                                                        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                                                                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                                                                     1:
-                                                                                        foreign lpvm access(~$right#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$right$f16#0:wybe.int)
-                                                                                        foreign llvm icmp_eq(~$left$f16#0:wybe.int, ~$right$f16#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+                                                                                        foreign lpvm access(~$right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$right$f16##0:wybe.int)
+                                                                                        foreign llvm icmp_eq(~$left$f16##0:wybe.int, ~$right$f16##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 
 
                                                                     1:
-                                                                        foreign lpvm access(~$left#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$left$f15#0:wybe.int)
-                                                                        foreign llvm icmp_uge($right#0:wybe.int, 4:wybe.int, ?tmp$130#0:wybe.bool)
-                                                                        case ~tmp$130#0:wybe.bool of
+                                                                        foreign lpvm access(~$left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$left$f15##0:wybe.int)
+                                                                        foreign llvm icmp_uge($right##0:wybe.int, 4:wybe.int, ?tmp$130##0:wybe.bool)
+                                                                        case ~tmp$130##0:wybe.bool of
                                                                         0:
-                                                                            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                                                            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                                                         1:
-                                                                            foreign llvm and($right#0:wybe.int, 7:wybe.int, ?tmp$131#0:wybe.int)
-                                                                            foreign llvm icmp_eq(~tmp$131#0:wybe.int, 7:wybe.int, ?tmp$132#0:wybe.bool)
-                                                                            case ~tmp$132#0:wybe.bool of
+                                                                            foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$131##0:wybe.int)
+                                                                            foreign llvm icmp_eq(~tmp$131##0:wybe.int, 7:wybe.int, ?tmp$132##0:wybe.bool)
+                                                                            case ~tmp$132##0:wybe.bool of
                                                                             0:
-                                                                                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                                                                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                                                             1:
-                                                                                foreign lpvm access($right#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp$133#0:16 bit unsigned)
-                                                                                foreign llvm icmp_eq(~tmp$133#0:16 bit unsigned, 14:16 bit unsigned, ?tmp$134#0:wybe.bool)
-                                                                                case ~tmp$134#0:wybe.bool of
+                                                                                foreign lpvm access($right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp$133##0:16 bit unsigned)
+                                                                                foreign llvm icmp_eq(~tmp$133##0:16 bit unsigned, 14:16 bit unsigned, ?tmp$134##0:wybe.bool)
+                                                                                case ~tmp$134##0:wybe.bool of
                                                                                 0:
-                                                                                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                                                                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                                                                 1:
-                                                                                    foreign lpvm access(~$right#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$right$f15#0:wybe.int)
-                                                                                    foreign llvm icmp_eq(~$left$f15#0:wybe.int, ~$right$f15#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+                                                                                    foreign lpvm access(~$right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$right$f15##0:wybe.int)
+                                                                                    foreign llvm icmp_eq(~$left$f15##0:wybe.int, ~$right$f15##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 
 
                                                                 1:
-                                                                    foreign lpvm access(~$left#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$left$f14#0:wybe.int)
-                                                                    foreign llvm icmp_uge($right#0:wybe.int, 4:wybe.int, ?tmp$124#0:wybe.bool)
-                                                                    case ~tmp$124#0:wybe.bool of
+                                                                    foreign lpvm access(~$left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$left$f14##0:wybe.int)
+                                                                    foreign llvm icmp_uge($right##0:wybe.int, 4:wybe.int, ?tmp$124##0:wybe.bool)
+                                                                    case ~tmp$124##0:wybe.bool of
                                                                     0:
-                                                                        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                                                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                                                     1:
-                                                                        foreign llvm and($right#0:wybe.int, 7:wybe.int, ?tmp$125#0:wybe.int)
-                                                                        foreign llvm icmp_eq(~tmp$125#0:wybe.int, 7:wybe.int, ?tmp$126#0:wybe.bool)
-                                                                        case ~tmp$126#0:wybe.bool of
+                                                                        foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$125##0:wybe.int)
+                                                                        foreign llvm icmp_eq(~tmp$125##0:wybe.int, 7:wybe.int, ?tmp$126##0:wybe.bool)
+                                                                        case ~tmp$126##0:wybe.bool of
                                                                         0:
-                                                                            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                                                            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                                                         1:
-                                                                            foreign lpvm access($right#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp$127#0:16 bit unsigned)
-                                                                            foreign llvm icmp_eq(~tmp$127#0:16 bit unsigned, 13:16 bit unsigned, ?tmp$128#0:wybe.bool)
-                                                                            case ~tmp$128#0:wybe.bool of
+                                                                            foreign lpvm access($right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp$127##0:16 bit unsigned)
+                                                                            foreign llvm icmp_eq(~tmp$127##0:16 bit unsigned, 13:16 bit unsigned, ?tmp$128##0:wybe.bool)
+                                                                            case ~tmp$128##0:wybe.bool of
                                                                             0:
-                                                                                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                                                                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                                                             1:
-                                                                                foreign lpvm access(~$right#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$right$f14#0:wybe.int)
-                                                                                foreign llvm icmp_eq(~$left$f14#0:wybe.int, ~$right$f14#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+                                                                                foreign lpvm access(~$right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$right$f14##0:wybe.int)
+                                                                                foreign llvm icmp_eq(~$left$f14##0:wybe.int, ~$right$f14##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 
 
                                                             1:
-                                                                foreign lpvm access(~$left#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$left$f13#0:wybe.int)
-                                                                foreign llvm icmp_uge($right#0:wybe.int, 4:wybe.int, ?tmp$118#0:wybe.bool)
-                                                                case ~tmp$118#0:wybe.bool of
+                                                                foreign lpvm access(~$left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$left$f13##0:wybe.int)
+                                                                foreign llvm icmp_uge($right##0:wybe.int, 4:wybe.int, ?tmp$118##0:wybe.bool)
+                                                                case ~tmp$118##0:wybe.bool of
                                                                 0:
-                                                                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                                                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                                                 1:
-                                                                    foreign llvm and($right#0:wybe.int, 7:wybe.int, ?tmp$119#0:wybe.int)
-                                                                    foreign llvm icmp_eq(~tmp$119#0:wybe.int, 7:wybe.int, ?tmp$120#0:wybe.bool)
-                                                                    case ~tmp$120#0:wybe.bool of
+                                                                    foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$119##0:wybe.int)
+                                                                    foreign llvm icmp_eq(~tmp$119##0:wybe.int, 7:wybe.int, ?tmp$120##0:wybe.bool)
+                                                                    case ~tmp$120##0:wybe.bool of
                                                                     0:
-                                                                        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                                                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                                                     1:
-                                                                        foreign lpvm access($right#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp$121#0:16 bit unsigned)
-                                                                        foreign llvm icmp_eq(~tmp$121#0:16 bit unsigned, 12:16 bit unsigned, ?tmp$122#0:wybe.bool)
-                                                                        case ~tmp$122#0:wybe.bool of
+                                                                        foreign lpvm access($right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp$121##0:16 bit unsigned)
+                                                                        foreign llvm icmp_eq(~tmp$121##0:16 bit unsigned, 12:16 bit unsigned, ?tmp$122##0:wybe.bool)
+                                                                        case ~tmp$122##0:wybe.bool of
                                                                         0:
-                                                                            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                                                            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                                                         1:
-                                                                            foreign lpvm access(~$right#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$right$f13#0:wybe.int)
-                                                                            foreign llvm icmp_eq(~$left$f13#0:wybe.int, ~$right$f13#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+                                                                            foreign lpvm access(~$right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$right$f13##0:wybe.int)
+                                                                            foreign llvm icmp_eq(~$left$f13##0:wybe.int, ~$right$f13##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 
 
                                                         1:
-                                                            foreign lpvm access(~$left#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$left$f12#0:wybe.int)
-                                                            foreign llvm icmp_uge($right#0:wybe.int, 4:wybe.int, ?tmp$112#0:wybe.bool)
-                                                            case ~tmp$112#0:wybe.bool of
+                                                            foreign lpvm access(~$left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$left$f12##0:wybe.int)
+                                                            foreign llvm icmp_uge($right##0:wybe.int, 4:wybe.int, ?tmp$112##0:wybe.bool)
+                                                            case ~tmp$112##0:wybe.bool of
                                                             0:
-                                                                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                                                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                                             1:
-                                                                foreign llvm and($right#0:wybe.int, 7:wybe.int, ?tmp$113#0:wybe.int)
-                                                                foreign llvm icmp_eq(~tmp$113#0:wybe.int, 7:wybe.int, ?tmp$114#0:wybe.bool)
-                                                                case ~tmp$114#0:wybe.bool of
+                                                                foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$113##0:wybe.int)
+                                                                foreign llvm icmp_eq(~tmp$113##0:wybe.int, 7:wybe.int, ?tmp$114##0:wybe.bool)
+                                                                case ~tmp$114##0:wybe.bool of
                                                                 0:
-                                                                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                                                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                                                 1:
-                                                                    foreign lpvm access($right#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp$115#0:16 bit unsigned)
-                                                                    foreign llvm icmp_eq(~tmp$115#0:16 bit unsigned, 11:16 bit unsigned, ?tmp$116#0:wybe.bool)
-                                                                    case ~tmp$116#0:wybe.bool of
+                                                                    foreign lpvm access($right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp$115##0:16 bit unsigned)
+                                                                    foreign llvm icmp_eq(~tmp$115##0:16 bit unsigned, 11:16 bit unsigned, ?tmp$116##0:wybe.bool)
+                                                                    case ~tmp$116##0:wybe.bool of
                                                                     0:
-                                                                        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                                                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                                                     1:
-                                                                        foreign lpvm access(~$right#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$right$f12#0:wybe.int)
-                                                                        foreign llvm icmp_eq(~$left$f12#0:wybe.int, ~$right$f12#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+                                                                        foreign lpvm access(~$right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$right$f12##0:wybe.int)
+                                                                        foreign llvm icmp_eq(~$left$f12##0:wybe.int, ~$right$f12##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 
 
                                                     1:
-                                                        foreign lpvm access(~$left#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$left$f11#0:wybe.int)
-                                                        foreign llvm icmp_uge($right#0:wybe.int, 4:wybe.int, ?tmp$106#0:wybe.bool)
-                                                        case ~tmp$106#0:wybe.bool of
+                                                        foreign lpvm access(~$left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$left$f11##0:wybe.int)
+                                                        foreign llvm icmp_uge($right##0:wybe.int, 4:wybe.int, ?tmp$106##0:wybe.bool)
+                                                        case ~tmp$106##0:wybe.bool of
                                                         0:
-                                                            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                                            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                                         1:
-                                                            foreign llvm and($right#0:wybe.int, 7:wybe.int, ?tmp$107#0:wybe.int)
-                                                            foreign llvm icmp_eq(~tmp$107#0:wybe.int, 7:wybe.int, ?tmp$108#0:wybe.bool)
-                                                            case ~tmp$108#0:wybe.bool of
+                                                            foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$107##0:wybe.int)
+                                                            foreign llvm icmp_eq(~tmp$107##0:wybe.int, 7:wybe.int, ?tmp$108##0:wybe.bool)
+                                                            case ~tmp$108##0:wybe.bool of
                                                             0:
-                                                                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                                                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                                             1:
-                                                                foreign lpvm access($right#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp$109#0:16 bit unsigned)
-                                                                foreign llvm icmp_eq(~tmp$109#0:16 bit unsigned, 10:16 bit unsigned, ?tmp$110#0:wybe.bool)
-                                                                case ~tmp$110#0:wybe.bool of
+                                                                foreign lpvm access($right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp$109##0:16 bit unsigned)
+                                                                foreign llvm icmp_eq(~tmp$109##0:16 bit unsigned, 10:16 bit unsigned, ?tmp$110##0:wybe.bool)
+                                                                case ~tmp$110##0:wybe.bool of
                                                                 0:
-                                                                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                                                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                                                 1:
-                                                                    foreign lpvm access(~$right#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$right$f11#0:wybe.int)
-                                                                    foreign llvm icmp_eq(~$left$f11#0:wybe.int, ~$right$f11#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+                                                                    foreign lpvm access(~$right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$right$f11##0:wybe.int)
+                                                                    foreign llvm icmp_eq(~$left$f11##0:wybe.int, ~$right$f11##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 
 
                                                 1:
-                                                    foreign lpvm access(~$left#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$left$f10#0:wybe.int)
-                                                    foreign llvm icmp_uge($right#0:wybe.int, 4:wybe.int, ?tmp$100#0:wybe.bool)
-                                                    case ~tmp$100#0:wybe.bool of
+                                                    foreign lpvm access(~$left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$left$f10##0:wybe.int)
+                                                    foreign llvm icmp_uge($right##0:wybe.int, 4:wybe.int, ?tmp$100##0:wybe.bool)
+                                                    case ~tmp$100##0:wybe.bool of
                                                     0:
-                                                        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                                     1:
-                                                        foreign llvm and($right#0:wybe.int, 7:wybe.int, ?tmp$101#0:wybe.int)
-                                                        foreign llvm icmp_eq(~tmp$101#0:wybe.int, 7:wybe.int, ?tmp$102#0:wybe.bool)
-                                                        case ~tmp$102#0:wybe.bool of
+                                                        foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$101##0:wybe.int)
+                                                        foreign llvm icmp_eq(~tmp$101##0:wybe.int, 7:wybe.int, ?tmp$102##0:wybe.bool)
+                                                        case ~tmp$102##0:wybe.bool of
                                                         0:
-                                                            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                                            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                                         1:
-                                                            foreign lpvm access($right#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp$103#0:16 bit unsigned)
-                                                            foreign llvm icmp_eq(~tmp$103#0:16 bit unsigned, 9:16 bit unsigned, ?tmp$104#0:wybe.bool)
-                                                            case ~tmp$104#0:wybe.bool of
+                                                            foreign lpvm access($right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp$103##0:16 bit unsigned)
+                                                            foreign llvm icmp_eq(~tmp$103##0:16 bit unsigned, 9:16 bit unsigned, ?tmp$104##0:wybe.bool)
+                                                            case ~tmp$104##0:wybe.bool of
                                                             0:
-                                                                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                                                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                                             1:
-                                                                foreign lpvm access(~$right#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$right$f10#0:wybe.int)
-                                                                foreign llvm icmp_eq(~$left$f10#0:wybe.int, ~$right$f10#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+                                                                foreign lpvm access(~$right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$right$f10##0:wybe.int)
+                                                                foreign llvm icmp_eq(~$left$f10##0:wybe.int, ~$right$f10##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 
 
                                             1:
-                                                foreign lpvm access(~$left#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$left$f09#0:wybe.int)
-                                                foreign llvm icmp_uge($right#0:wybe.int, 4:wybe.int, ?tmp$94#0:wybe.bool)
-                                                case ~tmp$94#0:wybe.bool of
+                                                foreign lpvm access(~$left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$left$f09##0:wybe.int)
+                                                foreign llvm icmp_uge($right##0:wybe.int, 4:wybe.int, ?tmp$94##0:wybe.bool)
+                                                case ~tmp$94##0:wybe.bool of
                                                 0:
-                                                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                                 1:
-                                                    foreign llvm and($right#0:wybe.int, 7:wybe.int, ?tmp$95#0:wybe.int)
-                                                    foreign llvm icmp_eq(~tmp$95#0:wybe.int, 7:wybe.int, ?tmp$96#0:wybe.bool)
-                                                    case ~tmp$96#0:wybe.bool of
+                                                    foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$95##0:wybe.int)
+                                                    foreign llvm icmp_eq(~tmp$95##0:wybe.int, 7:wybe.int, ?tmp$96##0:wybe.bool)
+                                                    case ~tmp$96##0:wybe.bool of
                                                     0:
-                                                        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                                     1:
-                                                        foreign lpvm access($right#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp$97#0:16 bit unsigned)
-                                                        foreign llvm icmp_eq(~tmp$97#0:16 bit unsigned, 8:16 bit unsigned, ?tmp$98#0:wybe.bool)
-                                                        case ~tmp$98#0:wybe.bool of
+                                                        foreign lpvm access($right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp$97##0:16 bit unsigned)
+                                                        foreign llvm icmp_eq(~tmp$97##0:16 bit unsigned, 8:16 bit unsigned, ?tmp$98##0:wybe.bool)
+                                                        case ~tmp$98##0:wybe.bool of
                                                         0:
-                                                            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                                            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                                         1:
-                                                            foreign lpvm access(~$right#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$right$f09#0:wybe.int)
-                                                            foreign llvm icmp_eq(~$left$f09#0:wybe.int, ~$right$f09#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+                                                            foreign lpvm access(~$right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$right$f09##0:wybe.int)
+                                                            foreign llvm icmp_eq(~$left$f09##0:wybe.int, ~$right$f09##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 
 
                                         1:
-                                            foreign lpvm access(~$left#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$left$f08#0:wybe.int)
-                                            foreign llvm icmp_uge($right#0:wybe.int, 4:wybe.int, ?tmp$88#0:wybe.bool)
-                                            case ~tmp$88#0:wybe.bool of
+                                            foreign lpvm access(~$left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$left$f08##0:wybe.int)
+                                            foreign llvm icmp_uge($right##0:wybe.int, 4:wybe.int, ?tmp$88##0:wybe.bool)
+                                            case ~tmp$88##0:wybe.bool of
                                             0:
-                                                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                             1:
-                                                foreign llvm and($right#0:wybe.int, 7:wybe.int, ?tmp$89#0:wybe.int)
-                                                foreign llvm icmp_eq(~tmp$89#0:wybe.int, 7:wybe.int, ?tmp$90#0:wybe.bool)
-                                                case ~tmp$90#0:wybe.bool of
+                                                foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$89##0:wybe.int)
+                                                foreign llvm icmp_eq(~tmp$89##0:wybe.int, 7:wybe.int, ?tmp$90##0:wybe.bool)
+                                                case ~tmp$90##0:wybe.bool of
                                                 0:
-                                                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                                 1:
-                                                    foreign lpvm access($right#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp$91#0:16 bit unsigned)
-                                                    foreign llvm icmp_eq(~tmp$91#0:16 bit unsigned, 7:16 bit unsigned, ?tmp$92#0:wybe.bool)
-                                                    case ~tmp$92#0:wybe.bool of
+                                                    foreign lpvm access($right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp$91##0:16 bit unsigned)
+                                                    foreign llvm icmp_eq(~tmp$91##0:16 bit unsigned, 7:16 bit unsigned, ?tmp$92##0:wybe.bool)
+                                                    case ~tmp$92##0:wybe.bool of
                                                     0:
-                                                        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                                     1:
-                                                        foreign lpvm access(~$right#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$right$f08#0:wybe.int)
-                                                        foreign llvm icmp_eq(~$left$f08#0:wybe.int, ~$right$f08#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+                                                        foreign lpvm access(~$right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$right$f08##0:wybe.int)
+                                                        foreign llvm icmp_eq(~$left$f08##0:wybe.int, ~$right$f08##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
@@ -810,148 +810,148 @@ entry:
 
 
                                 1:
-                                    foreign lpvm access(~$left#0:multictr.complicated, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?$left$f07#0:wybe.int)
-                                    foreign llvm icmp_uge($right#0:wybe.int, 4:wybe.int, ?tmp$82#0:wybe.bool)
-                                    case ~tmp$82#0:wybe.bool of
+                                    foreign lpvm access(~$left##0:multictr.complicated, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?$left$f07##0:wybe.int)
+                                    foreign llvm icmp_uge($right##0:wybe.int, 4:wybe.int, ?tmp$82##0:wybe.bool)
+                                    case ~tmp$82##0:wybe.bool of
                                     0:
-                                        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                     1:
-                                        foreign llvm and($right#0:wybe.int, 7:wybe.int, ?tmp$83#0:wybe.int)
-                                        foreign llvm icmp_eq(~tmp$83#0:wybe.int, 6:wybe.int, ?tmp$84#0:wybe.bool)
-                                        case ~tmp$84#0:wybe.bool of
+                                        foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$83##0:wybe.int)
+                                        foreign llvm icmp_eq(~tmp$83##0:wybe.int, 6:wybe.int, ?tmp$84##0:wybe.bool)
+                                        case ~tmp$84##0:wybe.bool of
                                         0:
-                                            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                         1:
-                                            foreign lpvm access(~$right#0:multictr.complicated, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?$right$f07#0:wybe.int)
-                                            foreign llvm icmp_eq(~$left$f07#0:wybe.int, ~$right$f07#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+                                            foreign lpvm access(~$right##0:multictr.complicated, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?$right$f07##0:wybe.int)
+                                            foreign llvm icmp_eq(~$left$f07##0:wybe.int, ~$right$f07##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 
                             1:
-                                foreign lpvm access(~$left#0:multictr.complicated, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?$left$f06#0:wybe.int)
-                                foreign llvm icmp_uge($right#0:wybe.int, 4:wybe.int, ?tmp$78#0:wybe.bool)
-                                case ~tmp$78#0:wybe.bool of
+                                foreign lpvm access(~$left##0:multictr.complicated, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?$left$f06##0:wybe.int)
+                                foreign llvm icmp_uge($right##0:wybe.int, 4:wybe.int, ?tmp$78##0:wybe.bool)
+                                case ~tmp$78##0:wybe.bool of
                                 0:
-                                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                 1:
-                                    foreign llvm and($right#0:wybe.int, 7:wybe.int, ?tmp$79#0:wybe.int)
-                                    foreign llvm icmp_eq(~tmp$79#0:wybe.int, 5:wybe.int, ?tmp$80#0:wybe.bool)
-                                    case ~tmp$80#0:wybe.bool of
+                                    foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$79##0:wybe.int)
+                                    foreign llvm icmp_eq(~tmp$79##0:wybe.int, 5:wybe.int, ?tmp$80##0:wybe.bool)
+                                    case ~tmp$80##0:wybe.bool of
                                     0:
-                                        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                     1:
-                                        foreign lpvm access(~$right#0:multictr.complicated, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?$right$f06#0:wybe.int)
-                                        foreign llvm icmp_eq(~$left$f06#0:wybe.int, ~$right$f06#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+                                        foreign lpvm access(~$right##0:multictr.complicated, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?$right$f06##0:wybe.int)
+                                        foreign llvm icmp_eq(~$left$f06##0:wybe.int, ~$right$f06##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 
                         1:
-                            foreign lpvm access(~$left#0:multictr.complicated, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?$left$f05#0:wybe.int)
-                            foreign llvm icmp_uge($right#0:wybe.int, 4:wybe.int, ?tmp$74#0:wybe.bool)
-                            case ~tmp$74#0:wybe.bool of
+                            foreign lpvm access(~$left##0:multictr.complicated, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?$left$f05##0:wybe.int)
+                            foreign llvm icmp_uge($right##0:wybe.int, 4:wybe.int, ?tmp$74##0:wybe.bool)
+                            case ~tmp$74##0:wybe.bool of
                             0:
-                                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                             1:
-                                foreign llvm and($right#0:wybe.int, 7:wybe.int, ?tmp$75#0:wybe.int)
-                                foreign llvm icmp_eq(~tmp$75#0:wybe.int, 4:wybe.int, ?tmp$76#0:wybe.bool)
-                                case ~tmp$76#0:wybe.bool of
+                                foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$75##0:wybe.int)
+                                foreign llvm icmp_eq(~tmp$75##0:wybe.int, 4:wybe.int, ?tmp$76##0:wybe.bool)
+                                case ~tmp$76##0:wybe.bool of
                                 0:
-                                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                 1:
-                                    foreign lpvm access(~$right#0:multictr.complicated, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?$right$f05#0:wybe.int)
-                                    foreign llvm icmp_eq(~$left$f05#0:wybe.int, ~$right$f05#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+                                    foreign lpvm access(~$right##0:multictr.complicated, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?$right$f05##0:wybe.int)
+                                    foreign llvm icmp_eq(~$left$f05##0:wybe.int, ~$right$f05##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 
                     1:
-                        foreign lpvm access(~$left#0:multictr.complicated, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?$left$f04#0:wybe.int)
-                        foreign llvm icmp_uge($right#0:wybe.int, 4:wybe.int, ?tmp$70#0:wybe.bool)
-                        case ~tmp$70#0:wybe.bool of
+                        foreign lpvm access(~$left##0:multictr.complicated, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?$left$f04##0:wybe.int)
+                        foreign llvm icmp_uge($right##0:wybe.int, 4:wybe.int, ?tmp$70##0:wybe.bool)
+                        case ~tmp$70##0:wybe.bool of
                         0:
-                            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                         1:
-                            foreign llvm and($right#0:wybe.int, 7:wybe.int, ?tmp$71#0:wybe.int)
-                            foreign llvm icmp_eq(~tmp$71#0:wybe.int, 3:wybe.int, ?tmp$72#0:wybe.bool)
-                            case ~tmp$72#0:wybe.bool of
+                            foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$71##0:wybe.int)
+                            foreign llvm icmp_eq(~tmp$71##0:wybe.int, 3:wybe.int, ?tmp$72##0:wybe.bool)
+                            case ~tmp$72##0:wybe.bool of
                             0:
-                                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                             1:
-                                foreign lpvm access(~$right#0:multictr.complicated, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?$right$f04#0:wybe.int)
-                                foreign llvm icmp_eq(~$left$f04#0:wybe.int, ~$right$f04#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+                                foreign lpvm access(~$right##0:multictr.complicated, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?$right$f04##0:wybe.int)
+                                foreign llvm icmp_eq(~$left$f04##0:wybe.int, ~$right$f04##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 
                 1:
-                    foreign lpvm access(~$left#0:multictr.complicated, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$left$f03#0:wybe.int)
-                    foreign llvm icmp_uge($right#0:wybe.int, 4:wybe.int, ?tmp$66#0:wybe.bool)
-                    case ~tmp$66#0:wybe.bool of
+                    foreign lpvm access(~$left##0:multictr.complicated, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$left$f03##0:wybe.int)
+                    foreign llvm icmp_uge($right##0:wybe.int, 4:wybe.int, ?tmp$66##0:wybe.bool)
+                    case ~tmp$66##0:wybe.bool of
                     0:
-                        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                     1:
-                        foreign llvm and($right#0:wybe.int, 7:wybe.int, ?tmp$67#0:wybe.int)
-                        foreign llvm icmp_eq(~tmp$67#0:wybe.int, 2:wybe.int, ?tmp$68#0:wybe.bool)
-                        case ~tmp$68#0:wybe.bool of
+                        foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$67##0:wybe.int)
+                        foreign llvm icmp_eq(~tmp$67##0:wybe.int, 2:wybe.int, ?tmp$68##0:wybe.bool)
+                        case ~tmp$68##0:wybe.bool of
                         0:
-                            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                         1:
-                            foreign lpvm access(~$right#0:multictr.complicated, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$right$f03#0:wybe.int)
-                            foreign llvm icmp_eq(~$left$f03#0:wybe.int, ~$right$f03#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+                            foreign lpvm access(~$right##0:multictr.complicated, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$right$f03##0:wybe.int)
+                            foreign llvm icmp_eq(~$left$f03##0:wybe.int, ~$right$f03##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 
             1:
-                foreign lpvm access(~$left#0:multictr.complicated, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$left$f02#0:wybe.int)
-                foreign llvm icmp_uge($right#0:wybe.int, 4:wybe.int, ?tmp$62#0:wybe.bool)
-                case ~tmp$62#0:wybe.bool of
+                foreign lpvm access(~$left##0:multictr.complicated, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$left$f02##0:wybe.int)
+                foreign llvm icmp_uge($right##0:wybe.int, 4:wybe.int, ?tmp$62##0:wybe.bool)
+                case ~tmp$62##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                 1:
-                    foreign llvm and($right#0:wybe.int, 7:wybe.int, ?tmp$63#0:wybe.int)
-                    foreign llvm icmp_eq(~tmp$63#0:wybe.int, 1:wybe.int, ?tmp$64#0:wybe.bool)
-                    case ~tmp$64#0:wybe.bool of
+                    foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$63##0:wybe.int)
+                    foreign llvm icmp_eq(~tmp$63##0:wybe.int, 1:wybe.int, ?tmp$64##0:wybe.bool)
+                    case ~tmp$64##0:wybe.bool of
                     0:
-                        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                     1:
-                        foreign lpvm access(~$right#0:multictr.complicated, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$right$f02#0:wybe.int)
-                        foreign llvm icmp_eq(~$left$f02#0:wybe.int, ~$right$f02#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+                        foreign lpvm access(~$right##0:multictr.complicated, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$right$f02##0:wybe.int)
+                        foreign llvm icmp_eq(~$left$f02##0:wybe.int, ~$right$f02##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 
         1:
-            foreign lpvm access(~$left#0:multictr.complicated, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$left$f01#0:wybe.int)
-            foreign llvm icmp_uge($right#0:wybe.int, 4:wybe.int, ?tmp$58#0:wybe.bool)
-            case ~tmp$58#0:wybe.bool of
+            foreign lpvm access(~$left##0:multictr.complicated, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$left$f01##0:wybe.int)
+            foreign llvm icmp_uge($right##0:wybe.int, 4:wybe.int, ?tmp$58##0:wybe.bool)
+            case ~tmp$58##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                foreign llvm and($right#0:wybe.int, 7:wybe.int, ?tmp$59#0:wybe.int)
-                foreign llvm icmp_eq(~tmp$59#0:wybe.int, 0:wybe.int, ?tmp$60#0:wybe.bool)
-                case ~tmp$60#0:wybe.bool of
+                foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$59##0:wybe.int)
+                foreign llvm icmp_eq(~tmp$59##0:wybe.int, 0:wybe.int, ?tmp$60##0:wybe.bool)
+                case ~tmp$60##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                 1:
-                    foreign lpvm access(~$right#0:multictr.complicated, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$right$f01#0:wybe.int)
-                    foreign llvm icmp_eq(~$left$f01#0:wybe.int, ~$right$f01#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+                    foreign lpvm access(~$right##0:multictr.complicated, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$right$f01##0:wybe.int)
+                    foreign llvm icmp_eq(~$left$f01##0:wybe.int, ~$right$f01##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
@@ -960,288 +960,288 @@ entry:
 
 autumn > public {inline} (0 calls)
 0: multictr.complicated.autumn<0>
-autumn(?$#0:multictr.complicated):
+autumn(?$##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(3:multictr.complicated, ?$#0:multictr.complicated)
+    foreign llvm move(3:multictr.complicated, ?$##0:multictr.complicated)
 
 
 c01 > public {inline} (0 calls)
 0: multictr.complicated.c01<0>
-c01(f01#0:wybe.int, ?$#0:multictr.complicated):
+c01(f01##0:wybe.int, ?$##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr.complicated)
-    foreign lpvm mutate(~$rec#0:multictr.complicated, ?$#0:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f01#0:wybe.int)
+    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr.complicated)
+    foreign lpvm mutate(~$rec##0:multictr.complicated, ?$##0:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f01##0:wybe.int)
 c01 > public {inline} (40 calls)
 1: multictr.complicated.c01<1>
-c01(?f01#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
+c01(?f01##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?f01#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?f01##0:wybe.int)
 
     1:
-        foreign llvm and($#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?f01#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?f01##0:wybe.int)
 
         1:
-            foreign lpvm access(~$#0:multictr.complicated, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?f01#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm access(~$##0:multictr.complicated, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?f01##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 c02 > public {inline} (0 calls)
 0: multictr.complicated.c02<0>
-c02(f02#0:wybe.int, ?$#0:multictr.complicated):
+c02(f02##0:wybe.int, ?$##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr.complicated)
-    foreign lpvm mutate(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f02#0:wybe.int)
-    foreign llvm or(~$rec#1:multictr.complicated, 1:wybe.int, ?$#0:multictr.complicated)
+    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr.complicated)
+    foreign lpvm mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f02##0:wybe.int)
+    foreign llvm or(~$rec##1:multictr.complicated, 1:wybe.int, ?$##0:multictr.complicated)
 c02 > public {inline} (35 calls)
 1: multictr.complicated.c02<1>
-c02(?f02#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
+c02(?f02##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?f02#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?f02##0:wybe.int)
 
     1:
-        foreign llvm and($#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 1:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?f02#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?f02##0:wybe.int)
 
         1:
-            foreign lpvm access(~$#0:multictr.complicated, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?f02#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm access(~$##0:multictr.complicated, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?f02##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 c03 > public {inline} (0 calls)
 0: multictr.complicated.c03<0>
-c03(f03#0:wybe.int, ?$#0:multictr.complicated):
+c03(f03##0:wybe.int, ?$##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr.complicated)
-    foreign lpvm mutate(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f03#0:wybe.int)
-    foreign llvm or(~$rec#1:multictr.complicated, 2:wybe.int, ?$#0:multictr.complicated)
+    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr.complicated)
+    foreign lpvm mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f03##0:wybe.int)
+    foreign llvm or(~$rec##1:multictr.complicated, 2:wybe.int, ?$##0:multictr.complicated)
 c03 > public {inline} (33 calls)
 1: multictr.complicated.c03<1>
-c03(?f03#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
+c03(?f03##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?f03#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?f03##0:wybe.int)
 
     1:
-        foreign llvm and($#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 2:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 2:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?f03#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?f03##0:wybe.int)
 
         1:
-            foreign lpvm access(~$#0:multictr.complicated, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?f03#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm access(~$##0:multictr.complicated, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?f03##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 c04 > public {inline} (0 calls)
 0: multictr.complicated.c04<0>
-c04(f04#0:wybe.int, ?$#0:multictr.complicated):
+c04(f04##0:wybe.int, ?$##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr.complicated)
-    foreign lpvm mutate(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f04#0:wybe.int)
-    foreign llvm or(~$rec#1:multictr.complicated, 3:wybe.int, ?$#0:multictr.complicated)
+    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr.complicated)
+    foreign lpvm mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f04##0:wybe.int)
+    foreign llvm or(~$rec##1:multictr.complicated, 3:wybe.int, ?$##0:multictr.complicated)
 c04 > public {inline} (31 calls)
 1: multictr.complicated.c04<1>
-c04(?f04#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
+c04(?f04##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?f04#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?f04##0:wybe.int)
 
     1:
-        foreign llvm and($#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 3:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 3:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?f04#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?f04##0:wybe.int)
 
         1:
-            foreign lpvm access(~$#0:multictr.complicated, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?f04#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm access(~$##0:multictr.complicated, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?f04##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 c05 > public {inline} (0 calls)
 0: multictr.complicated.c05<0>
-c05(f05#0:wybe.int, ?$#0:multictr.complicated):
+c05(f05##0:wybe.int, ?$##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr.complicated)
-    foreign lpvm mutate(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f05#0:wybe.int)
-    foreign llvm or(~$rec#1:multictr.complicated, 4:wybe.int, ?$#0:multictr.complicated)
+    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr.complicated)
+    foreign lpvm mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f05##0:wybe.int)
+    foreign llvm or(~$rec##1:multictr.complicated, 4:wybe.int, ?$##0:multictr.complicated)
 c05 > public {inline} (29 calls)
 1: multictr.complicated.c05<1>
-c05(?f05#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
+c05(?f05##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?f05#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?f05##0:wybe.int)
 
     1:
-        foreign llvm and($#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 4:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 4:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?f05#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?f05##0:wybe.int)
 
         1:
-            foreign lpvm access(~$#0:multictr.complicated, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?f05#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm access(~$##0:multictr.complicated, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?f05##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 c06 > public {inline} (0 calls)
 0: multictr.complicated.c06<0>
-c06(f06#0:wybe.int, ?$#0:multictr.complicated):
+c06(f06##0:wybe.int, ?$##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr.complicated)
-    foreign lpvm mutate(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f06#0:wybe.int)
-    foreign llvm or(~$rec#1:multictr.complicated, 5:wybe.int, ?$#0:multictr.complicated)
+    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr.complicated)
+    foreign lpvm mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f06##0:wybe.int)
+    foreign llvm or(~$rec##1:multictr.complicated, 5:wybe.int, ?$##0:multictr.complicated)
 c06 > public {inline} (27 calls)
 1: multictr.complicated.c06<1>
-c06(?f06#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
+c06(?f06##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?f06#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?f06##0:wybe.int)
 
     1:
-        foreign llvm and($#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 5:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 5:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?f06#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?f06##0:wybe.int)
 
         1:
-            foreign lpvm access(~$#0:multictr.complicated, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?f06#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm access(~$##0:multictr.complicated, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?f06##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 c07 > public {inline} (0 calls)
 0: multictr.complicated.c07<0>
-c07(f07#0:wybe.int, ?$#0:multictr.complicated):
+c07(f07##0:wybe.int, ?$##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr.complicated)
-    foreign lpvm mutate(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f07#0:wybe.int)
-    foreign llvm or(~$rec#1:multictr.complicated, 6:wybe.int, ?$#0:multictr.complicated)
+    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr.complicated)
+    foreign lpvm mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f07##0:wybe.int)
+    foreign llvm or(~$rec##1:multictr.complicated, 6:wybe.int, ?$##0:multictr.complicated)
 c07 > public {inline} (25 calls)
 1: multictr.complicated.c07<1>
-c07(?f07#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
+c07(?f07##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?f07#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?f07##0:wybe.int)
 
     1:
-        foreign llvm and($#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 6:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 6:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?f07#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?f07##0:wybe.int)
 
         1:
-            foreign lpvm access(~$#0:multictr.complicated, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?f07#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm access(~$##0:multictr.complicated, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?f07##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 c08 > public {inline} (0 calls)
 0: multictr.complicated.c08<0>
-c08(f08#0:wybe.int, ?$#0:multictr.complicated):
+c08(f08##0:wybe.int, ?$##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:multictr.complicated)
-    foreign lpvm mutate(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 7:wybe.int)
-    foreign lpvm mutate(~$rec#1:multictr.complicated, ?$rec#2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f08#0:wybe.int)
-    foreign llvm or(~$rec#2:multictr.complicated, 7:wybe.int, ?$#0:multictr.complicated)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:multictr.complicated)
+    foreign lpvm mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 7:wybe.int)
+    foreign lpvm mutate(~$rec##1:multictr.complicated, ?$rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f08##0:wybe.int)
+    foreign llvm or(~$rec##2:multictr.complicated, 7:wybe.int, ?$##0:multictr.complicated)
 c08 > public {inline} (23 calls)
 1: multictr.complicated.c08<1>
-c08(?f08#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
+c08(?f08##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?f08#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?f08##0:wybe.int)
 
     1:
-        foreign llvm and($#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?f08#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?f08##0:wybe.int)
 
         1:
-            foreign lpvm access($#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag#0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag#0:16 bit unsigned, 7:16 bit unsigned, ?tmp$3#0:wybe.bool)
-            case ~tmp$3#0:wybe.bool of
+            foreign lpvm access($##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 7:16 bit unsigned, ?tmp$3##0:wybe.bool)
+            case ~tmp$3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?f08#0:wybe.int)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(undef:wybe.int, ?f08##0:wybe.int)
 
             1:
-                foreign lpvm access(~$#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f08#0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+                foreign lpvm access(~$##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f08##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
@@ -1249,43 +1249,43 @@ c08(?f08#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
 
 c09 > public {inline} (0 calls)
 0: multictr.complicated.c09<0>
-c09(f09#0:wybe.int, ?$#0:multictr.complicated):
+c09(f09##0:wybe.int, ?$##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:multictr.complicated)
-    foreign lpvm mutate(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 8:wybe.int)
-    foreign lpvm mutate(~$rec#1:multictr.complicated, ?$rec#2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f09#0:wybe.int)
-    foreign llvm or(~$rec#2:multictr.complicated, 7:wybe.int, ?$#0:multictr.complicated)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:multictr.complicated)
+    foreign lpvm mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 8:wybe.int)
+    foreign lpvm mutate(~$rec##1:multictr.complicated, ?$rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f09##0:wybe.int)
+    foreign llvm or(~$rec##2:multictr.complicated, 7:wybe.int, ?$##0:multictr.complicated)
 c09 > public {inline} (21 calls)
 1: multictr.complicated.c09<1>
-c09(?f09#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
+c09(?f09##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?f09#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?f09##0:wybe.int)
 
     1:
-        foreign llvm and($#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?f09#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?f09##0:wybe.int)
 
         1:
-            foreign lpvm access($#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag#0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag#0:16 bit unsigned, 8:16 bit unsigned, ?tmp$3#0:wybe.bool)
-            case ~tmp$3#0:wybe.bool of
+            foreign lpvm access($##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 8:16 bit unsigned, ?tmp$3##0:wybe.bool)
+            case ~tmp$3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?f09#0:wybe.int)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(undef:wybe.int, ?f09##0:wybe.int)
 
             1:
-                foreign lpvm access(~$#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f09#0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+                foreign lpvm access(~$##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f09##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
@@ -1293,43 +1293,43 @@ c09(?f09#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
 
 c10 > public {inline} (0 calls)
 0: multictr.complicated.c10<0>
-c10(f10#0:wybe.int, ?$#0:multictr.complicated):
+c10(f10##0:wybe.int, ?$##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:multictr.complicated)
-    foreign lpvm mutate(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 9:wybe.int)
-    foreign lpvm mutate(~$rec#1:multictr.complicated, ?$rec#2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f10#0:wybe.int)
-    foreign llvm or(~$rec#2:multictr.complicated, 7:wybe.int, ?$#0:multictr.complicated)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:multictr.complicated)
+    foreign lpvm mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 9:wybe.int)
+    foreign lpvm mutate(~$rec##1:multictr.complicated, ?$rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f10##0:wybe.int)
+    foreign llvm or(~$rec##2:multictr.complicated, 7:wybe.int, ?$##0:multictr.complicated)
 c10 > public {inline} (19 calls)
 1: multictr.complicated.c10<1>
-c10(?f10#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
+c10(?f10##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?f10#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?f10##0:wybe.int)
 
     1:
-        foreign llvm and($#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?f10#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?f10##0:wybe.int)
 
         1:
-            foreign lpvm access($#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag#0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag#0:16 bit unsigned, 9:16 bit unsigned, ?tmp$3#0:wybe.bool)
-            case ~tmp$3#0:wybe.bool of
+            foreign lpvm access($##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 9:16 bit unsigned, ?tmp$3##0:wybe.bool)
+            case ~tmp$3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?f10#0:wybe.int)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(undef:wybe.int, ?f10##0:wybe.int)
 
             1:
-                foreign lpvm access(~$#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f10#0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+                foreign lpvm access(~$##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f10##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
@@ -1337,43 +1337,43 @@ c10(?f10#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
 
 c11 > public {inline} (0 calls)
 0: multictr.complicated.c11<0>
-c11(f11#0:wybe.int, ?$#0:multictr.complicated):
+c11(f11##0:wybe.int, ?$##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:multictr.complicated)
-    foreign lpvm mutate(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    foreign lpvm mutate(~$rec#1:multictr.complicated, ?$rec#2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f11#0:wybe.int)
-    foreign llvm or(~$rec#2:multictr.complicated, 7:wybe.int, ?$#0:multictr.complicated)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:multictr.complicated)
+    foreign lpvm mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    foreign lpvm mutate(~$rec##1:multictr.complicated, ?$rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f11##0:wybe.int)
+    foreign llvm or(~$rec##2:multictr.complicated, 7:wybe.int, ?$##0:multictr.complicated)
 c11 > public {inline} (17 calls)
 1: multictr.complicated.c11<1>
-c11(?f11#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
+c11(?f11##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?f11#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?f11##0:wybe.int)
 
     1:
-        foreign llvm and($#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?f11#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?f11##0:wybe.int)
 
         1:
-            foreign lpvm access($#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag#0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag#0:16 bit unsigned, 10:16 bit unsigned, ?tmp$3#0:wybe.bool)
-            case ~tmp$3#0:wybe.bool of
+            foreign lpvm access($##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 10:16 bit unsigned, ?tmp$3##0:wybe.bool)
+            case ~tmp$3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?f11#0:wybe.int)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(undef:wybe.int, ?f11##0:wybe.int)
 
             1:
-                foreign lpvm access(~$#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f11#0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+                foreign lpvm access(~$##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f11##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
@@ -1381,43 +1381,43 @@ c11(?f11#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
 
 c12 > public {inline} (0 calls)
 0: multictr.complicated.c12<0>
-c12(f12#0:wybe.int, ?$#0:multictr.complicated):
+c12(f12##0:wybe.int, ?$##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:multictr.complicated)
-    foreign lpvm mutate(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 11:wybe.int)
-    foreign lpvm mutate(~$rec#1:multictr.complicated, ?$rec#2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f12#0:wybe.int)
-    foreign llvm or(~$rec#2:multictr.complicated, 7:wybe.int, ?$#0:multictr.complicated)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:multictr.complicated)
+    foreign lpvm mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 11:wybe.int)
+    foreign lpvm mutate(~$rec##1:multictr.complicated, ?$rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f12##0:wybe.int)
+    foreign llvm or(~$rec##2:multictr.complicated, 7:wybe.int, ?$##0:multictr.complicated)
 c12 > public {inline} (15 calls)
 1: multictr.complicated.c12<1>
-c12(?f12#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
+c12(?f12##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?f12#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?f12##0:wybe.int)
 
     1:
-        foreign llvm and($#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?f12#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?f12##0:wybe.int)
 
         1:
-            foreign lpvm access($#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag#0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag#0:16 bit unsigned, 11:16 bit unsigned, ?tmp$3#0:wybe.bool)
-            case ~tmp$3#0:wybe.bool of
+            foreign lpvm access($##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 11:16 bit unsigned, ?tmp$3##0:wybe.bool)
+            case ~tmp$3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?f12#0:wybe.int)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(undef:wybe.int, ?f12##0:wybe.int)
 
             1:
-                foreign lpvm access(~$#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f12#0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+                foreign lpvm access(~$##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f12##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
@@ -1425,43 +1425,43 @@ c12(?f12#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
 
 c13 > public {inline} (0 calls)
 0: multictr.complicated.c13<0>
-c13(f13#0:wybe.int, ?$#0:multictr.complicated):
+c13(f13##0:wybe.int, ?$##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:multictr.complicated)
-    foreign lpvm mutate(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 12:wybe.int)
-    foreign lpvm mutate(~$rec#1:multictr.complicated, ?$rec#2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f13#0:wybe.int)
-    foreign llvm or(~$rec#2:multictr.complicated, 7:wybe.int, ?$#0:multictr.complicated)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:multictr.complicated)
+    foreign lpvm mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 12:wybe.int)
+    foreign lpvm mutate(~$rec##1:multictr.complicated, ?$rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f13##0:wybe.int)
+    foreign llvm or(~$rec##2:multictr.complicated, 7:wybe.int, ?$##0:multictr.complicated)
 c13 > public {inline} (13 calls)
 1: multictr.complicated.c13<1>
-c13(?f13#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
+c13(?f13##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?f13#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?f13##0:wybe.int)
 
     1:
-        foreign llvm and($#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?f13#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?f13##0:wybe.int)
 
         1:
-            foreign lpvm access($#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag#0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag#0:16 bit unsigned, 12:16 bit unsigned, ?tmp$3#0:wybe.bool)
-            case ~tmp$3#0:wybe.bool of
+            foreign lpvm access($##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 12:16 bit unsigned, ?tmp$3##0:wybe.bool)
+            case ~tmp$3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?f13#0:wybe.int)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(undef:wybe.int, ?f13##0:wybe.int)
 
             1:
-                foreign lpvm access(~$#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f13#0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+                foreign lpvm access(~$##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f13##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
@@ -1469,43 +1469,43 @@ c13(?f13#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
 
 c14 > public {inline} (0 calls)
 0: multictr.complicated.c14<0>
-c14(f14#0:wybe.int, ?$#0:multictr.complicated):
+c14(f14##0:wybe.int, ?$##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:multictr.complicated)
-    foreign lpvm mutate(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 13:wybe.int)
-    foreign lpvm mutate(~$rec#1:multictr.complicated, ?$rec#2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f14#0:wybe.int)
-    foreign llvm or(~$rec#2:multictr.complicated, 7:wybe.int, ?$#0:multictr.complicated)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:multictr.complicated)
+    foreign lpvm mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 13:wybe.int)
+    foreign lpvm mutate(~$rec##1:multictr.complicated, ?$rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f14##0:wybe.int)
+    foreign llvm or(~$rec##2:multictr.complicated, 7:wybe.int, ?$##0:multictr.complicated)
 c14 > public {inline} (11 calls)
 1: multictr.complicated.c14<1>
-c14(?f14#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
+c14(?f14##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?f14#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?f14##0:wybe.int)
 
     1:
-        foreign llvm and($#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?f14#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?f14##0:wybe.int)
 
         1:
-            foreign lpvm access($#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag#0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag#0:16 bit unsigned, 13:16 bit unsigned, ?tmp$3#0:wybe.bool)
-            case ~tmp$3#0:wybe.bool of
+            foreign lpvm access($##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 13:16 bit unsigned, ?tmp$3##0:wybe.bool)
+            case ~tmp$3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?f14#0:wybe.int)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(undef:wybe.int, ?f14##0:wybe.int)
 
             1:
-                foreign lpvm access(~$#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f14#0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+                foreign lpvm access(~$##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f14##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
@@ -1513,43 +1513,43 @@ c14(?f14#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
 
 c15 > public {inline} (0 calls)
 0: multictr.complicated.c15<0>
-c15(f15#0:wybe.int, ?$#0:multictr.complicated):
+c15(f15##0:wybe.int, ?$##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:multictr.complicated)
-    foreign lpvm mutate(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 14:wybe.int)
-    foreign lpvm mutate(~$rec#1:multictr.complicated, ?$rec#2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f15#0:wybe.int)
-    foreign llvm or(~$rec#2:multictr.complicated, 7:wybe.int, ?$#0:multictr.complicated)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:multictr.complicated)
+    foreign lpvm mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 14:wybe.int)
+    foreign lpvm mutate(~$rec##1:multictr.complicated, ?$rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f15##0:wybe.int)
+    foreign llvm or(~$rec##2:multictr.complicated, 7:wybe.int, ?$##0:multictr.complicated)
 c15 > public {inline} (9 calls)
 1: multictr.complicated.c15<1>
-c15(?f15#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
+c15(?f15##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?f15#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?f15##0:wybe.int)
 
     1:
-        foreign llvm and($#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?f15#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?f15##0:wybe.int)
 
         1:
-            foreign lpvm access($#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag#0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag#0:16 bit unsigned, 14:16 bit unsigned, ?tmp$3#0:wybe.bool)
-            case ~tmp$3#0:wybe.bool of
+            foreign lpvm access($##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 14:16 bit unsigned, ?tmp$3##0:wybe.bool)
+            case ~tmp$3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?f15#0:wybe.int)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(undef:wybe.int, ?f15##0:wybe.int)
 
             1:
-                foreign lpvm access(~$#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f15#0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+                foreign lpvm access(~$##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f15##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
@@ -1557,43 +1557,43 @@ c15(?f15#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
 
 c16 > public {inline} (0 calls)
 0: multictr.complicated.c16<0>
-c16(f16#0:wybe.int, ?$#0:multictr.complicated):
+c16(f16##0:wybe.int, ?$##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:multictr.complicated)
-    foreign lpvm mutate(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 15:wybe.int)
-    foreign lpvm mutate(~$rec#1:multictr.complicated, ?$rec#2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f16#0:wybe.int)
-    foreign llvm or(~$rec#2:multictr.complicated, 7:wybe.int, ?$#0:multictr.complicated)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:multictr.complicated)
+    foreign lpvm mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 15:wybe.int)
+    foreign lpvm mutate(~$rec##1:multictr.complicated, ?$rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f16##0:wybe.int)
+    foreign llvm or(~$rec##2:multictr.complicated, 7:wybe.int, ?$##0:multictr.complicated)
 c16 > public {inline} (7 calls)
 1: multictr.complicated.c16<1>
-c16(?f16#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
+c16(?f16##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?f16#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?f16##0:wybe.int)
 
     1:
-        foreign llvm and($#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?f16#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?f16##0:wybe.int)
 
         1:
-            foreign lpvm access($#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag#0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag#0:16 bit unsigned, 15:16 bit unsigned, ?tmp$3#0:wybe.bool)
-            case ~tmp$3#0:wybe.bool of
+            foreign lpvm access($##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 15:16 bit unsigned, ?tmp$3##0:wybe.bool)
+            case ~tmp$3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?f16#0:wybe.int)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(undef:wybe.int, ?f16##0:wybe.int)
 
             1:
-                foreign lpvm access(~$#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f16#0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+                foreign lpvm access(~$##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f16##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
@@ -1601,43 +1601,43 @@ c16(?f16#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
 
 c17 > public {inline} (0 calls)
 0: multictr.complicated.c17<0>
-c17(f17#0:wybe.int, ?$#0:multictr.complicated):
+c17(f17##0:wybe.int, ?$##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:multictr.complicated)
-    foreign lpvm mutate(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 16:wybe.int)
-    foreign lpvm mutate(~$rec#1:multictr.complicated, ?$rec#2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f17#0:wybe.int)
-    foreign llvm or(~$rec#2:multictr.complicated, 7:wybe.int, ?$#0:multictr.complicated)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:multictr.complicated)
+    foreign lpvm mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 16:wybe.int)
+    foreign lpvm mutate(~$rec##1:multictr.complicated, ?$rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f17##0:wybe.int)
+    foreign llvm or(~$rec##2:multictr.complicated, 7:wybe.int, ?$##0:multictr.complicated)
 c17 > public {inline} (5 calls)
 1: multictr.complicated.c17<1>
-c17(?f17#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
+c17(?f17##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?f17#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?f17##0:wybe.int)
 
     1:
-        foreign llvm and($#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?f17#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?f17##0:wybe.int)
 
         1:
-            foreign lpvm access($#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag#0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag#0:16 bit unsigned, 16:16 bit unsigned, ?tmp$3#0:wybe.bool)
-            case ~tmp$3#0:wybe.bool of
+            foreign lpvm access($##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 16:16 bit unsigned, ?tmp$3##0:wybe.bool)
+            case ~tmp$3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?f17#0:wybe.int)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(undef:wybe.int, ?f17##0:wybe.int)
 
             1:
-                foreign lpvm access(~$#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f17#0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+                foreign lpvm access(~$##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f17##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
@@ -1645,417 +1645,417 @@ c17(?f17#0:wybe.int, $#0:multictr.complicated, ?$$#0:wybe.bool):
 
 f01 > public {inline} (0 calls)
 0: multictr.complicated.f01<0>
-f01($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
+f01($rec##0:multictr.complicated, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
         1:
-            foreign lpvm access(~$rec#0:multictr.complicated, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm access(~$rec##0:multictr.complicated, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 f01 > public {inline} (0 calls)
 1: multictr.complicated.f01<1>
-f01($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
+f01($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
         1:
-            foreign lpvm {noalias} mutate(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm {noalias} mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 f02 > public {inline} (0 calls)
 0: multictr.complicated.f02<0>
-f02($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
+f02($rec##0:multictr.complicated, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 1:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
         1:
-            foreign lpvm access(~$rec#0:multictr.complicated, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm access(~$rec##0:multictr.complicated, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 f02 > public {inline} (0 calls)
 1: multictr.complicated.f02<1>
-f02($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
+f02($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 1:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
         1:
-            foreign lpvm {noalias} mutate(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated, -1:wybe.int, 0:wybe.int, 8:wybe.int, 1:wybe.int, ~$field#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm {noalias} mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, -1:wybe.int, 0:wybe.int, 8:wybe.int, 1:wybe.int, ~$field##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 f03 > public {inline} (0 calls)
 0: multictr.complicated.f03<0>
-f03($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
+f03($rec##0:multictr.complicated, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 2:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 2:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
         1:
-            foreign lpvm access(~$rec#0:multictr.complicated, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm access(~$rec##0:multictr.complicated, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 f03 > public {inline} (0 calls)
 1: multictr.complicated.f03<1>
-f03($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
+f03($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 2:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 2:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
         1:
-            foreign lpvm {noalias} mutate(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated, -2:wybe.int, 0:wybe.int, 8:wybe.int, 2:wybe.int, ~$field#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm {noalias} mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, -2:wybe.int, 0:wybe.int, 8:wybe.int, 2:wybe.int, ~$field##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 f04 > public {inline} (0 calls)
 0: multictr.complicated.f04<0>
-f04($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
+f04($rec##0:multictr.complicated, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 3:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 3:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
         1:
-            foreign lpvm access(~$rec#0:multictr.complicated, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?$#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm access(~$rec##0:multictr.complicated, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 f04 > public {inline} (0 calls)
 1: multictr.complicated.f04<1>
-f04($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
+f04($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 3:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 3:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
         1:
-            foreign lpvm {noalias} mutate(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated, -3:wybe.int, 0:wybe.int, 8:wybe.int, 3:wybe.int, ~$field#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm {noalias} mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, -3:wybe.int, 0:wybe.int, 8:wybe.int, 3:wybe.int, ~$field##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 f05 > public {inline} (0 calls)
 0: multictr.complicated.f05<0>
-f05($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
+f05($rec##0:multictr.complicated, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 4:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 4:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
         1:
-            foreign lpvm access(~$rec#0:multictr.complicated, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?$#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm access(~$rec##0:multictr.complicated, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 f05 > public {inline} (0 calls)
 1: multictr.complicated.f05<1>
-f05($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
+f05($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 4:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 4:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
         1:
-            foreign lpvm {noalias} mutate(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated, -4:wybe.int, 0:wybe.int, 8:wybe.int, 4:wybe.int, ~$field#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm {noalias} mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, -4:wybe.int, 0:wybe.int, 8:wybe.int, 4:wybe.int, ~$field##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 f06 > public {inline} (0 calls)
 0: multictr.complicated.f06<0>
-f06($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
+f06($rec##0:multictr.complicated, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 5:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 5:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
         1:
-            foreign lpvm access(~$rec#0:multictr.complicated, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?$#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm access(~$rec##0:multictr.complicated, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 f06 > public {inline} (0 calls)
 1: multictr.complicated.f06<1>
-f06($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
+f06($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 5:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 5:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
         1:
-            foreign lpvm {noalias} mutate(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated, -5:wybe.int, 0:wybe.int, 8:wybe.int, 5:wybe.int, ~$field#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm {noalias} mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, -5:wybe.int, 0:wybe.int, 8:wybe.int, 5:wybe.int, ~$field##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 f07 > public {inline} (0 calls)
 0: multictr.complicated.f07<0>
-f07($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
+f07($rec##0:multictr.complicated, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 6:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 6:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
         1:
-            foreign lpvm access(~$rec#0:multictr.complicated, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?$#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm access(~$rec##0:multictr.complicated, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 f07 > public {inline} (0 calls)
 1: multictr.complicated.f07<1>
-f07($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
+f07($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 6:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 6:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
         1:
-            foreign lpvm {noalias} mutate(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated, -6:wybe.int, 0:wybe.int, 8:wybe.int, 6:wybe.int, ~$field#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm {noalias} mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, -6:wybe.int, 0:wybe.int, 8:wybe.int, 6:wybe.int, ~$field##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 f08 > public {inline} (0 calls)
 0: multictr.complicated.f08<0>
-f08($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
+f08($rec##0:multictr.complicated, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
         1:
-            foreign lpvm access($rec#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag#0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag#0:16 bit unsigned, 7:16 bit unsigned, ?tmp$3#0:wybe.bool)
-            case ~tmp$3#0:wybe.bool of
+            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 7:16 bit unsigned, ?tmp$3##0:wybe.bool)
+            case ~tmp$3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
             1:
-                foreign lpvm access(~$rec#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$#0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+                foreign lpvm access(~$rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 f08 > public {inline} (0 calls)
 1: multictr.complicated.f08<1>
-f08($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
+f08($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
         1:
-            foreign lpvm access($rec#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag#0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag#0:16 bit unsigned, 7:16 bit unsigned, ?tmp$3#0:wybe.bool)
-            case ~tmp$3#0:wybe.bool of
+            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 7:16 bit unsigned, ?tmp$3##0:wybe.bool)
+            case ~tmp$3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-                foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
             1:
-                foreign lpvm {noalias} mutate(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~$field#0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+                foreign lpvm {noalias} mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~$field##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
@@ -2063,67 +2063,67 @@ f08($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int
 
 f09 > public {inline} (0 calls)
 0: multictr.complicated.f09<0>
-f09($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
+f09($rec##0:multictr.complicated, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
         1:
-            foreign lpvm access($rec#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag#0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag#0:16 bit unsigned, 8:16 bit unsigned, ?tmp$3#0:wybe.bool)
-            case ~tmp$3#0:wybe.bool of
+            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 8:16 bit unsigned, ?tmp$3##0:wybe.bool)
+            case ~tmp$3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
             1:
-                foreign lpvm access(~$rec#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$#0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+                foreign lpvm access(~$rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 f09 > public {inline} (0 calls)
 1: multictr.complicated.f09<1>
-f09($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
+f09($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
         1:
-            foreign lpvm access($rec#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag#0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag#0:16 bit unsigned, 8:16 bit unsigned, ?tmp$3#0:wybe.bool)
-            case ~tmp$3#0:wybe.bool of
+            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 8:16 bit unsigned, ?tmp$3##0:wybe.bool)
+            case ~tmp$3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-                foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
             1:
-                foreign lpvm {noalias} mutate(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~$field#0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+                foreign lpvm {noalias} mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~$field##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
@@ -2131,67 +2131,67 @@ f09($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int
 
 f10 > public {inline} (0 calls)
 0: multictr.complicated.f10<0>
-f10($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
+f10($rec##0:multictr.complicated, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
         1:
-            foreign lpvm access($rec#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag#0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag#0:16 bit unsigned, 9:16 bit unsigned, ?tmp$3#0:wybe.bool)
-            case ~tmp$3#0:wybe.bool of
+            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 9:16 bit unsigned, ?tmp$3##0:wybe.bool)
+            case ~tmp$3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
             1:
-                foreign lpvm access(~$rec#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$#0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+                foreign lpvm access(~$rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 f10 > public {inline} (0 calls)
 1: multictr.complicated.f10<1>
-f10($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
+f10($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
         1:
-            foreign lpvm access($rec#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag#0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag#0:16 bit unsigned, 9:16 bit unsigned, ?tmp$3#0:wybe.bool)
-            case ~tmp$3#0:wybe.bool of
+            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 9:16 bit unsigned, ?tmp$3##0:wybe.bool)
+            case ~tmp$3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-                foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
             1:
-                foreign lpvm {noalias} mutate(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~$field#0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+                foreign lpvm {noalias} mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~$field##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
@@ -2199,67 +2199,67 @@ f10($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int
 
 f11 > public {inline} (0 calls)
 0: multictr.complicated.f11<0>
-f11($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
+f11($rec##0:multictr.complicated, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
         1:
-            foreign lpvm access($rec#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag#0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag#0:16 bit unsigned, 10:16 bit unsigned, ?tmp$3#0:wybe.bool)
-            case ~tmp$3#0:wybe.bool of
+            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 10:16 bit unsigned, ?tmp$3##0:wybe.bool)
+            case ~tmp$3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
             1:
-                foreign lpvm access(~$rec#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$#0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+                foreign lpvm access(~$rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 f11 > public {inline} (0 calls)
 1: multictr.complicated.f11<1>
-f11($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
+f11($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
         1:
-            foreign lpvm access($rec#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag#0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag#0:16 bit unsigned, 10:16 bit unsigned, ?tmp$3#0:wybe.bool)
-            case ~tmp$3#0:wybe.bool of
+            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 10:16 bit unsigned, ?tmp$3##0:wybe.bool)
+            case ~tmp$3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-                foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
             1:
-                foreign lpvm {noalias} mutate(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~$field#0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+                foreign lpvm {noalias} mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~$field##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
@@ -2267,67 +2267,67 @@ f11($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int
 
 f12 > public {inline} (0 calls)
 0: multictr.complicated.f12<0>
-f12($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
+f12($rec##0:multictr.complicated, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
         1:
-            foreign lpvm access($rec#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag#0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag#0:16 bit unsigned, 11:16 bit unsigned, ?tmp$3#0:wybe.bool)
-            case ~tmp$3#0:wybe.bool of
+            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 11:16 bit unsigned, ?tmp$3##0:wybe.bool)
+            case ~tmp$3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
             1:
-                foreign lpvm access(~$rec#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$#0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+                foreign lpvm access(~$rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 f12 > public {inline} (0 calls)
 1: multictr.complicated.f12<1>
-f12($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
+f12($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
         1:
-            foreign lpvm access($rec#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag#0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag#0:16 bit unsigned, 11:16 bit unsigned, ?tmp$3#0:wybe.bool)
-            case ~tmp$3#0:wybe.bool of
+            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 11:16 bit unsigned, ?tmp$3##0:wybe.bool)
+            case ~tmp$3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-                foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
             1:
-                foreign lpvm {noalias} mutate(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~$field#0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+                foreign lpvm {noalias} mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~$field##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
@@ -2335,67 +2335,67 @@ f12($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int
 
 f13 > public {inline} (0 calls)
 0: multictr.complicated.f13<0>
-f13($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
+f13($rec##0:multictr.complicated, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
         1:
-            foreign lpvm access($rec#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag#0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag#0:16 bit unsigned, 12:16 bit unsigned, ?tmp$3#0:wybe.bool)
-            case ~tmp$3#0:wybe.bool of
+            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 12:16 bit unsigned, ?tmp$3##0:wybe.bool)
+            case ~tmp$3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
             1:
-                foreign lpvm access(~$rec#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$#0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+                foreign lpvm access(~$rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 f13 > public {inline} (0 calls)
 1: multictr.complicated.f13<1>
-f13($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
+f13($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
         1:
-            foreign lpvm access($rec#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag#0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag#0:16 bit unsigned, 12:16 bit unsigned, ?tmp$3#0:wybe.bool)
-            case ~tmp$3#0:wybe.bool of
+            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 12:16 bit unsigned, ?tmp$3##0:wybe.bool)
+            case ~tmp$3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-                foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
             1:
-                foreign lpvm {noalias} mutate(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~$field#0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+                foreign lpvm {noalias} mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~$field##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
@@ -2403,67 +2403,67 @@ f13($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int
 
 f14 > public {inline} (0 calls)
 0: multictr.complicated.f14<0>
-f14($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
+f14($rec##0:multictr.complicated, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
         1:
-            foreign lpvm access($rec#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag#0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag#0:16 bit unsigned, 13:16 bit unsigned, ?tmp$3#0:wybe.bool)
-            case ~tmp$3#0:wybe.bool of
+            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 13:16 bit unsigned, ?tmp$3##0:wybe.bool)
+            case ~tmp$3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
             1:
-                foreign lpvm access(~$rec#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$#0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+                foreign lpvm access(~$rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 f14 > public {inline} (0 calls)
 1: multictr.complicated.f14<1>
-f14($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
+f14($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
         1:
-            foreign lpvm access($rec#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag#0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag#0:16 bit unsigned, 13:16 bit unsigned, ?tmp$3#0:wybe.bool)
-            case ~tmp$3#0:wybe.bool of
+            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 13:16 bit unsigned, ?tmp$3##0:wybe.bool)
+            case ~tmp$3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-                foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
             1:
-                foreign lpvm {noalias} mutate(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~$field#0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+                foreign lpvm {noalias} mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~$field##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
@@ -2471,67 +2471,67 @@ f14($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int
 
 f15 > public {inline} (0 calls)
 0: multictr.complicated.f15<0>
-f15($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
+f15($rec##0:multictr.complicated, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
         1:
-            foreign lpvm access($rec#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag#0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag#0:16 bit unsigned, 14:16 bit unsigned, ?tmp$3#0:wybe.bool)
-            case ~tmp$3#0:wybe.bool of
+            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 14:16 bit unsigned, ?tmp$3##0:wybe.bool)
+            case ~tmp$3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
             1:
-                foreign lpvm access(~$rec#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$#0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+                foreign lpvm access(~$rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 f15 > public {inline} (0 calls)
 1: multictr.complicated.f15<1>
-f15($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
+f15($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
         1:
-            foreign lpvm access($rec#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag#0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag#0:16 bit unsigned, 14:16 bit unsigned, ?tmp$3#0:wybe.bool)
-            case ~tmp$3#0:wybe.bool of
+            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 14:16 bit unsigned, ?tmp$3##0:wybe.bool)
+            case ~tmp$3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-                foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
             1:
-                foreign lpvm {noalias} mutate(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~$field#0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+                foreign lpvm {noalias} mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~$field##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
@@ -2539,67 +2539,67 @@ f15($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int
 
 f16 > public {inline} (0 calls)
 0: multictr.complicated.f16<0>
-f16($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
+f16($rec##0:multictr.complicated, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
         1:
-            foreign lpvm access($rec#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag#0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag#0:16 bit unsigned, 15:16 bit unsigned, ?tmp$3#0:wybe.bool)
-            case ~tmp$3#0:wybe.bool of
+            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 15:16 bit unsigned, ?tmp$3##0:wybe.bool)
+            case ~tmp$3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
             1:
-                foreign lpvm access(~$rec#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$#0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+                foreign lpvm access(~$rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 f16 > public {inline} (0 calls)
 1: multictr.complicated.f16<1>
-f16($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
+f16($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
         1:
-            foreign lpvm access($rec#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag#0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag#0:16 bit unsigned, 15:16 bit unsigned, ?tmp$3#0:wybe.bool)
-            case ~tmp$3#0:wybe.bool of
+            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 15:16 bit unsigned, ?tmp$3##0:wybe.bool)
+            case ~tmp$3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-                foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
             1:
-                foreign lpvm {noalias} mutate(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~$field#0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+                foreign lpvm {noalias} mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~$field##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
@@ -2607,67 +2607,67 @@ f16($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int
 
 f17 > public {inline} (0 calls)
 0: multictr.complicated.f17<0>
-f17($rec#0:multictr.complicated, ?$#0:wybe.int, ?$$#0:wybe.bool):
+f17($rec##0:multictr.complicated, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
         1:
-            foreign lpvm access($rec#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag#0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag#0:16 bit unsigned, 16:16 bit unsigned, ?tmp$3#0:wybe.bool)
-            case ~tmp$3#0:wybe.bool of
+            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 16:16 bit unsigned, ?tmp$3##0:wybe.bool)
+            case ~tmp$3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
             1:
-                foreign lpvm access(~$rec#0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$#0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+                foreign lpvm access(~$rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 f17 > public {inline} (0 calls)
 1: multictr.complicated.f17<1>
-f17($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int, ?$$#0:wybe.bool):
+f17($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
         1:
-            foreign lpvm access($rec#0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag#0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag#0:16 bit unsigned, 16:16 bit unsigned, ?tmp$3#0:wybe.bool)
-            case ~tmp$3#0:wybe.bool of
+            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 16:16 bit unsigned, ?tmp$3##0:wybe.bool)
+            case ~tmp$3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-                foreign llvm move(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
 
             1:
-                foreign lpvm {noalias} mutate(~$rec#0:multictr.complicated, ?$rec#1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~$field#0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+                foreign lpvm {noalias} mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~$field##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
@@ -2675,35 +2675,35 @@ f17($rec#0:multictr.complicated, ?$rec#1:multictr.complicated, $field#0:wybe.int
 
 spring > public {inline} (0 calls)
 0: multictr.complicated.spring<0>
-spring(?$#0:multictr.complicated):
+spring(?$##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(1:multictr.complicated, ?$#0:multictr.complicated)
+    foreign llvm move(1:multictr.complicated, ?$##0:multictr.complicated)
 
 
 summer > public {inline} (0 calls)
 0: multictr.complicated.summer<0>
-summer(?$#0:multictr.complicated):
+summer(?$##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(2:multictr.complicated, ?$#0:multictr.complicated)
+    foreign llvm move(2:multictr.complicated, ?$##0:multictr.complicated)
 
 
 winter > public {inline} (0 calls)
 0: multictr.complicated.winter<0>
-winter(?$#0:multictr.complicated):
+winter(?$##0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:multictr.complicated, ?$#0:multictr.complicated)
+    foreign llvm move(0:multictr.complicated, ?$##0:multictr.complicated)
 
 
 ~= > public {inline} (0 calls)
 0: multictr.complicated.~=<0>
-~=($left#0:multictr.complicated, $right#0:multictr.complicated, ?$$#0:wybe.bool):
+~=($left##0:multictr.complicated, $right##0:multictr.complicated, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    multictr.complicated.=<0>(~$left#0:multictr.complicated, ~$right#0:multictr.complicated, ?tmp$0#0:wybe.bool) #0
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    multictr.complicated.=<0>(~$left##0:multictr.complicated, ~$right##0:multictr.complicated, ?tmp$0##0:wybe.bool) #0
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
   LLVM code       :
 
@@ -2719,536 +2719,536 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"multictr.complicated.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"multictr.complicated.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$left#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$left##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$55#0" = and i64 %"$left#0", 7 
-  %"2$tmp$56#0" = icmp eq i64 %"2$tmp$55#0", 0 
-  br i1 %"2$tmp$56#0", label %if.then1, label %if.else1 
+  %"2$tmp$55##0" = and i64 %"$left##0", 7 
+  %"2$tmp$56##0" = icmp eq i64 %"2$tmp$55##0", 0 
+  br i1 %"2$tmp$56##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = icmp eq i64 %"$left#0", %"$right#0" 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
+  ret i1 %"3$$$##0" 
 if.then1:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %"4$tmp$58#0" = icmp uge i64 %"$right#0", 4 
-  br i1 %"4$tmp$58#0", label %if.then2, label %if.else2 
+  %"4$tmp$58##0" = icmp uge i64 %"$right##0", 4 
+  br i1 %"4$tmp$58##0", label %if.then2, label %if.else2 
 if.else1:
-  %"5$tmp$60#0" = icmp eq i64 %"2$tmp$55#0", 1 
-  br i1 %"5$tmp$60#0", label %if.then4, label %if.else4 
+  %"5$tmp$60##0" = icmp eq i64 %"2$tmp$55##0", 1 
+  br i1 %"5$tmp$60##0", label %if.then4, label %if.else4 
 if.then2:
-  %"6$tmp$59#0" = and i64 %"$right#0", 7 
-  %"6$tmp$60#0" = icmp eq i64 %"6$tmp$59#0", 0 
-  br i1 %"6$tmp$60#0", label %if.then3, label %if.else3 
+  %"6$tmp$59##0" = and i64 %"$right##0", 7 
+  %"6$tmp$60##0" = icmp eq i64 %"6$tmp$59##0", 0 
+  br i1 %"6$tmp$60##0", label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %4 = inttoptr i64 %"$right#0" to i64* 
+  %4 = inttoptr i64 %"$right##0" to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
   %6 = load  i64, i64* %5 
-  %"8$$$#0" = icmp eq i64 %3, %6 
-  ret i1 %"8$$$#0" 
+  %"8$$$##0" = icmp eq i64 %3, %6 
+  ret i1 %"8$$$##0" 
 if.else3:
   ret i1 0 
 if.then4:
-  %7 = add   i64 %"$left#0", -1 
+  %7 = add   i64 %"$left##0", -1 
   %8 = inttoptr i64 %7 to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %"10$tmp$62#0" = icmp uge i64 %"$right#0", 4 
-  br i1 %"10$tmp$62#0", label %if.then5, label %if.else5 
+  %"10$tmp$62##0" = icmp uge i64 %"$right##0", 4 
+  br i1 %"10$tmp$62##0", label %if.then5, label %if.else5 
 if.else4:
-  %"11$tmp$64#0" = icmp eq i64 %"2$tmp$55#0", 2 
-  br i1 %"11$tmp$64#0", label %if.then7, label %if.else7 
+  %"11$tmp$64##0" = icmp eq i64 %"2$tmp$55##0", 2 
+  br i1 %"11$tmp$64##0", label %if.then7, label %if.else7 
 if.then5:
-  %"12$tmp$63#0" = and i64 %"$right#0", 7 
-  %"12$tmp$64#0" = icmp eq i64 %"12$tmp$63#0", 1 
-  br i1 %"12$tmp$64#0", label %if.then6, label %if.else6 
+  %"12$tmp$63##0" = and i64 %"$right##0", 7 
+  %"12$tmp$64##0" = icmp eq i64 %"12$tmp$63##0", 1 
+  br i1 %"12$tmp$64##0", label %if.then6, label %if.else6 
 if.else5:
   ret i1 0 
 if.then6:
-  %11 = add   i64 %"$right#0", -1 
+  %11 = add   i64 %"$right##0", -1 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"14$$$#0" = icmp eq i64 %10, %14 
-  ret i1 %"14$$$#0" 
+  %"14$$$##0" = icmp eq i64 %10, %14 
+  ret i1 %"14$$$##0" 
 if.else6:
   ret i1 0 
 if.then7:
-  %15 = add   i64 %"$left#0", -2 
+  %15 = add   i64 %"$left##0", -2 
   %16 = inttoptr i64 %15 to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
-  %"16$tmp$66#0" = icmp uge i64 %"$right#0", 4 
-  br i1 %"16$tmp$66#0", label %if.then8, label %if.else8 
+  %"16$tmp$66##0" = icmp uge i64 %"$right##0", 4 
+  br i1 %"16$tmp$66##0", label %if.then8, label %if.else8 
 if.else7:
-  %"17$tmp$68#0" = icmp eq i64 %"2$tmp$55#0", 3 
-  br i1 %"17$tmp$68#0", label %if.then10, label %if.else10 
+  %"17$tmp$68##0" = icmp eq i64 %"2$tmp$55##0", 3 
+  br i1 %"17$tmp$68##0", label %if.then10, label %if.else10 
 if.then8:
-  %"18$tmp$67#0" = and i64 %"$right#0", 7 
-  %"18$tmp$68#0" = icmp eq i64 %"18$tmp$67#0", 2 
-  br i1 %"18$tmp$68#0", label %if.then9, label %if.else9 
+  %"18$tmp$67##0" = and i64 %"$right##0", 7 
+  %"18$tmp$68##0" = icmp eq i64 %"18$tmp$67##0", 2 
+  br i1 %"18$tmp$68##0", label %if.then9, label %if.else9 
 if.else8:
   ret i1 0 
 if.then9:
-  %19 = add   i64 %"$right#0", -2 
+  %19 = add   i64 %"$right##0", -2 
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %"20$$$#0" = icmp eq i64 %18, %22 
-  ret i1 %"20$$$#0" 
+  %"20$$$##0" = icmp eq i64 %18, %22 
+  ret i1 %"20$$$##0" 
 if.else9:
   ret i1 0 
 if.then10:
-  %23 = add   i64 %"$left#0", -3 
+  %23 = add   i64 %"$left##0", -3 
   %24 = inttoptr i64 %23 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
   %26 = load  i64, i64* %25 
-  %"22$tmp$70#0" = icmp uge i64 %"$right#0", 4 
-  br i1 %"22$tmp$70#0", label %if.then11, label %if.else11 
+  %"22$tmp$70##0" = icmp uge i64 %"$right##0", 4 
+  br i1 %"22$tmp$70##0", label %if.then11, label %if.else11 
 if.else10:
-  %"23$tmp$72#0" = icmp eq i64 %"2$tmp$55#0", 4 
-  br i1 %"23$tmp$72#0", label %if.then13, label %if.else13 
+  %"23$tmp$72##0" = icmp eq i64 %"2$tmp$55##0", 4 
+  br i1 %"23$tmp$72##0", label %if.then13, label %if.else13 
 if.then11:
-  %"24$tmp$71#0" = and i64 %"$right#0", 7 
-  %"24$tmp$72#0" = icmp eq i64 %"24$tmp$71#0", 3 
-  br i1 %"24$tmp$72#0", label %if.then12, label %if.else12 
+  %"24$tmp$71##0" = and i64 %"$right##0", 7 
+  %"24$tmp$72##0" = icmp eq i64 %"24$tmp$71##0", 3 
+  br i1 %"24$tmp$72##0", label %if.then12, label %if.else12 
 if.else11:
   ret i1 0 
 if.then12:
-  %27 = add   i64 %"$right#0", -3 
+  %27 = add   i64 %"$right##0", -3 
   %28 = inttoptr i64 %27 to i64* 
   %29 = getelementptr  i64, i64* %28, i64 0 
   %30 = load  i64, i64* %29 
-  %"26$$$#0" = icmp eq i64 %26, %30 
-  ret i1 %"26$$$#0" 
+  %"26$$$##0" = icmp eq i64 %26, %30 
+  ret i1 %"26$$$##0" 
 if.else12:
   ret i1 0 
 if.then13:
-  %31 = add   i64 %"$left#0", -4 
+  %31 = add   i64 %"$left##0", -4 
   %32 = inttoptr i64 %31 to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
-  %"28$tmp$74#0" = icmp uge i64 %"$right#0", 4 
-  br i1 %"28$tmp$74#0", label %if.then14, label %if.else14 
+  %"28$tmp$74##0" = icmp uge i64 %"$right##0", 4 
+  br i1 %"28$tmp$74##0", label %if.then14, label %if.else14 
 if.else13:
-  %"29$tmp$76#0" = icmp eq i64 %"2$tmp$55#0", 5 
-  br i1 %"29$tmp$76#0", label %if.then16, label %if.else16 
+  %"29$tmp$76##0" = icmp eq i64 %"2$tmp$55##0", 5 
+  br i1 %"29$tmp$76##0", label %if.then16, label %if.else16 
 if.then14:
-  %"30$tmp$75#0" = and i64 %"$right#0", 7 
-  %"30$tmp$76#0" = icmp eq i64 %"30$tmp$75#0", 4 
-  br i1 %"30$tmp$76#0", label %if.then15, label %if.else15 
+  %"30$tmp$75##0" = and i64 %"$right##0", 7 
+  %"30$tmp$76##0" = icmp eq i64 %"30$tmp$75##0", 4 
+  br i1 %"30$tmp$76##0", label %if.then15, label %if.else15 
 if.else14:
   ret i1 0 
 if.then15:
-  %35 = add   i64 %"$right#0", -4 
+  %35 = add   i64 %"$right##0", -4 
   %36 = inttoptr i64 %35 to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
-  %"32$$$#0" = icmp eq i64 %34, %38 
-  ret i1 %"32$$$#0" 
+  %"32$$$##0" = icmp eq i64 %34, %38 
+  ret i1 %"32$$$##0" 
 if.else15:
   ret i1 0 
 if.then16:
-  %39 = add   i64 %"$left#0", -5 
+  %39 = add   i64 %"$left##0", -5 
   %40 = inttoptr i64 %39 to i64* 
   %41 = getelementptr  i64, i64* %40, i64 0 
   %42 = load  i64, i64* %41 
-  %"34$tmp$78#0" = icmp uge i64 %"$right#0", 4 
-  br i1 %"34$tmp$78#0", label %if.then17, label %if.else17 
+  %"34$tmp$78##0" = icmp uge i64 %"$right##0", 4 
+  br i1 %"34$tmp$78##0", label %if.then17, label %if.else17 
 if.else16:
-  %"35$tmp$80#0" = icmp eq i64 %"2$tmp$55#0", 6 
-  br i1 %"35$tmp$80#0", label %if.then19, label %if.else19 
+  %"35$tmp$80##0" = icmp eq i64 %"2$tmp$55##0", 6 
+  br i1 %"35$tmp$80##0", label %if.then19, label %if.else19 
 if.then17:
-  %"36$tmp$79#0" = and i64 %"$right#0", 7 
-  %"36$tmp$80#0" = icmp eq i64 %"36$tmp$79#0", 5 
-  br i1 %"36$tmp$80#0", label %if.then18, label %if.else18 
+  %"36$tmp$79##0" = and i64 %"$right##0", 7 
+  %"36$tmp$80##0" = icmp eq i64 %"36$tmp$79##0", 5 
+  br i1 %"36$tmp$80##0", label %if.then18, label %if.else18 
 if.else17:
   ret i1 0 
 if.then18:
-  %43 = add   i64 %"$right#0", -5 
+  %43 = add   i64 %"$right##0", -5 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
-  %"38$$$#0" = icmp eq i64 %42, %46 
-  ret i1 %"38$$$#0" 
+  %"38$$$##0" = icmp eq i64 %42, %46 
+  ret i1 %"38$$$##0" 
 if.else18:
   ret i1 0 
 if.then19:
-  %47 = add   i64 %"$left#0", -6 
+  %47 = add   i64 %"$left##0", -6 
   %48 = inttoptr i64 %47 to i64* 
   %49 = getelementptr  i64, i64* %48, i64 0 
   %50 = load  i64, i64* %49 
-  %"40$tmp$82#0" = icmp uge i64 %"$right#0", 4 
-  br i1 %"40$tmp$82#0", label %if.then20, label %if.else20 
+  %"40$tmp$82##0" = icmp uge i64 %"$right##0", 4 
+  br i1 %"40$tmp$82##0", label %if.then20, label %if.else20 
 if.else19:
-  %"41$tmp$84#0" = icmp eq i64 %"2$tmp$55#0", 7 
-  br i1 %"41$tmp$84#0", label %if.then22, label %if.else22 
+  %"41$tmp$84##0" = icmp eq i64 %"2$tmp$55##0", 7 
+  br i1 %"41$tmp$84##0", label %if.then22, label %if.else22 
 if.then20:
-  %"42$tmp$83#0" = and i64 %"$right#0", 7 
-  %"42$tmp$84#0" = icmp eq i64 %"42$tmp$83#0", 6 
-  br i1 %"42$tmp$84#0", label %if.then21, label %if.else21 
+  %"42$tmp$83##0" = and i64 %"$right##0", 7 
+  %"42$tmp$84##0" = icmp eq i64 %"42$tmp$83##0", 6 
+  br i1 %"42$tmp$84##0", label %if.then21, label %if.else21 
 if.else20:
   ret i1 0 
 if.then21:
-  %51 = add   i64 %"$right#0", -6 
+  %51 = add   i64 %"$right##0", -6 
   %52 = inttoptr i64 %51 to i64* 
   %53 = getelementptr  i64, i64* %52, i64 0 
   %54 = load  i64, i64* %53 
-  %"44$$$#0" = icmp eq i64 %50, %54 
-  ret i1 %"44$$$#0" 
+  %"44$$$##0" = icmp eq i64 %50, %54 
+  ret i1 %"44$$$##0" 
 if.else21:
   ret i1 0 
 if.then22:
-  %55 = add   i64 %"$left#0", -7 
+  %55 = add   i64 %"$left##0", -7 
   %56 = inttoptr i64 %55 to i16* 
   %57 = getelementptr  i16, i16* %56, i64 0 
   %58 = load  i16, i16* %57 
-  %"46$tmp$86#0" = icmp eq i16 %58, 7 
-  br i1 %"46$tmp$86#0", label %if.then23, label %if.else23 
+  %"46$tmp$86##0" = icmp eq i16 %58, 7 
+  br i1 %"46$tmp$86##0", label %if.then23, label %if.else23 
 if.else22:
   ret i1 0 
 if.then23:
-  %59 = add   i64 %"$left#0", 1 
+  %59 = add   i64 %"$left##0", 1 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %"48$tmp$88#0" = icmp uge i64 %"$right#0", 4 
-  br i1 %"48$tmp$88#0", label %if.then24, label %if.else24 
+  %"48$tmp$88##0" = icmp uge i64 %"$right##0", 4 
+  br i1 %"48$tmp$88##0", label %if.then24, label %if.else24 
 if.else23:
-  %"49$tmp$92#0" = icmp eq i16 %58, 8 
-  br i1 %"49$tmp$92#0", label %if.then27, label %if.else27 
+  %"49$tmp$92##0" = icmp eq i16 %58, 8 
+  br i1 %"49$tmp$92##0", label %if.then27, label %if.else27 
 if.then24:
-  %"50$tmp$89#0" = and i64 %"$right#0", 7 
-  %"50$tmp$90#0" = icmp eq i64 %"50$tmp$89#0", 7 
-  br i1 %"50$tmp$90#0", label %if.then25, label %if.else25 
+  %"50$tmp$89##0" = and i64 %"$right##0", 7 
+  %"50$tmp$90##0" = icmp eq i64 %"50$tmp$89##0", 7 
+  br i1 %"50$tmp$90##0", label %if.then25, label %if.else25 
 if.else24:
   ret i1 0 
 if.then25:
-  %63 = add   i64 %"$right#0", -7 
+  %63 = add   i64 %"$right##0", -7 
   %64 = inttoptr i64 %63 to i16* 
   %65 = getelementptr  i16, i16* %64, i64 0 
   %66 = load  i16, i16* %65 
-  %"52$tmp$92#0" = icmp eq i16 %66, 7 
-  br i1 %"52$tmp$92#0", label %if.then26, label %if.else26 
+  %"52$tmp$92##0" = icmp eq i16 %66, 7 
+  br i1 %"52$tmp$92##0", label %if.then26, label %if.else26 
 if.else25:
   ret i1 0 
 if.then26:
-  %67 = add   i64 %"$right#0", 1 
+  %67 = add   i64 %"$right##0", 1 
   %68 = inttoptr i64 %67 to i64* 
   %69 = getelementptr  i64, i64* %68, i64 0 
   %70 = load  i64, i64* %69 
-  %"54$$$#0" = icmp eq i64 %62, %70 
-  ret i1 %"54$$$#0" 
+  %"54$$$##0" = icmp eq i64 %62, %70 
+  ret i1 %"54$$$##0" 
 if.else26:
   ret i1 0 
 if.then27:
-  %71 = add   i64 %"$left#0", 1 
+  %71 = add   i64 %"$left##0", 1 
   %72 = inttoptr i64 %71 to i64* 
   %73 = getelementptr  i64, i64* %72, i64 0 
   %74 = load  i64, i64* %73 
-  %"56$tmp$94#0" = icmp uge i64 %"$right#0", 4 
-  br i1 %"56$tmp$94#0", label %if.then28, label %if.else28 
+  %"56$tmp$94##0" = icmp uge i64 %"$right##0", 4 
+  br i1 %"56$tmp$94##0", label %if.then28, label %if.else28 
 if.else27:
-  %"57$tmp$98#0" = icmp eq i16 %58, 9 
-  br i1 %"57$tmp$98#0", label %if.then31, label %if.else31 
+  %"57$tmp$98##0" = icmp eq i16 %58, 9 
+  br i1 %"57$tmp$98##0", label %if.then31, label %if.else31 
 if.then28:
-  %"58$tmp$95#0" = and i64 %"$right#0", 7 
-  %"58$tmp$96#0" = icmp eq i64 %"58$tmp$95#0", 7 
-  br i1 %"58$tmp$96#0", label %if.then29, label %if.else29 
+  %"58$tmp$95##0" = and i64 %"$right##0", 7 
+  %"58$tmp$96##0" = icmp eq i64 %"58$tmp$95##0", 7 
+  br i1 %"58$tmp$96##0", label %if.then29, label %if.else29 
 if.else28:
   ret i1 0 
 if.then29:
-  %75 = add   i64 %"$right#0", -7 
+  %75 = add   i64 %"$right##0", -7 
   %76 = inttoptr i64 %75 to i16* 
   %77 = getelementptr  i16, i16* %76, i64 0 
   %78 = load  i16, i16* %77 
-  %"60$tmp$98#0" = icmp eq i16 %78, 8 
-  br i1 %"60$tmp$98#0", label %if.then30, label %if.else30 
+  %"60$tmp$98##0" = icmp eq i16 %78, 8 
+  br i1 %"60$tmp$98##0", label %if.then30, label %if.else30 
 if.else29:
   ret i1 0 
 if.then30:
-  %79 = add   i64 %"$right#0", 1 
+  %79 = add   i64 %"$right##0", 1 
   %80 = inttoptr i64 %79 to i64* 
   %81 = getelementptr  i64, i64* %80, i64 0 
   %82 = load  i64, i64* %81 
-  %"62$$$#0" = icmp eq i64 %74, %82 
-  ret i1 %"62$$$#0" 
+  %"62$$$##0" = icmp eq i64 %74, %82 
+  ret i1 %"62$$$##0" 
 if.else30:
   ret i1 0 
 if.then31:
-  %83 = add   i64 %"$left#0", 1 
+  %83 = add   i64 %"$left##0", 1 
   %84 = inttoptr i64 %83 to i64* 
   %85 = getelementptr  i64, i64* %84, i64 0 
   %86 = load  i64, i64* %85 
-  %"64$tmp$100#0" = icmp uge i64 %"$right#0", 4 
-  br i1 %"64$tmp$100#0", label %if.then32, label %if.else32 
+  %"64$tmp$100##0" = icmp uge i64 %"$right##0", 4 
+  br i1 %"64$tmp$100##0", label %if.then32, label %if.else32 
 if.else31:
-  %"65$tmp$104#0" = icmp eq i16 %58, 10 
-  br i1 %"65$tmp$104#0", label %if.then35, label %if.else35 
+  %"65$tmp$104##0" = icmp eq i16 %58, 10 
+  br i1 %"65$tmp$104##0", label %if.then35, label %if.else35 
 if.then32:
-  %"66$tmp$101#0" = and i64 %"$right#0", 7 
-  %"66$tmp$102#0" = icmp eq i64 %"66$tmp$101#0", 7 
-  br i1 %"66$tmp$102#0", label %if.then33, label %if.else33 
+  %"66$tmp$101##0" = and i64 %"$right##0", 7 
+  %"66$tmp$102##0" = icmp eq i64 %"66$tmp$101##0", 7 
+  br i1 %"66$tmp$102##0", label %if.then33, label %if.else33 
 if.else32:
   ret i1 0 
 if.then33:
-  %87 = add   i64 %"$right#0", -7 
+  %87 = add   i64 %"$right##0", -7 
   %88 = inttoptr i64 %87 to i16* 
   %89 = getelementptr  i16, i16* %88, i64 0 
   %90 = load  i16, i16* %89 
-  %"68$tmp$104#0" = icmp eq i16 %90, 9 
-  br i1 %"68$tmp$104#0", label %if.then34, label %if.else34 
+  %"68$tmp$104##0" = icmp eq i16 %90, 9 
+  br i1 %"68$tmp$104##0", label %if.then34, label %if.else34 
 if.else33:
   ret i1 0 
 if.then34:
-  %91 = add   i64 %"$right#0", 1 
+  %91 = add   i64 %"$right##0", 1 
   %92 = inttoptr i64 %91 to i64* 
   %93 = getelementptr  i64, i64* %92, i64 0 
   %94 = load  i64, i64* %93 
-  %"70$$$#0" = icmp eq i64 %86, %94 
-  ret i1 %"70$$$#0" 
+  %"70$$$##0" = icmp eq i64 %86, %94 
+  ret i1 %"70$$$##0" 
 if.else34:
   ret i1 0 
 if.then35:
-  %95 = add   i64 %"$left#0", 1 
+  %95 = add   i64 %"$left##0", 1 
   %96 = inttoptr i64 %95 to i64* 
   %97 = getelementptr  i64, i64* %96, i64 0 
   %98 = load  i64, i64* %97 
-  %"72$tmp$106#0" = icmp uge i64 %"$right#0", 4 
-  br i1 %"72$tmp$106#0", label %if.then36, label %if.else36 
+  %"72$tmp$106##0" = icmp uge i64 %"$right##0", 4 
+  br i1 %"72$tmp$106##0", label %if.then36, label %if.else36 
 if.else35:
-  %"73$tmp$110#0" = icmp eq i16 %58, 11 
-  br i1 %"73$tmp$110#0", label %if.then39, label %if.else39 
+  %"73$tmp$110##0" = icmp eq i16 %58, 11 
+  br i1 %"73$tmp$110##0", label %if.then39, label %if.else39 
 if.then36:
-  %"74$tmp$107#0" = and i64 %"$right#0", 7 
-  %"74$tmp$108#0" = icmp eq i64 %"74$tmp$107#0", 7 
-  br i1 %"74$tmp$108#0", label %if.then37, label %if.else37 
+  %"74$tmp$107##0" = and i64 %"$right##0", 7 
+  %"74$tmp$108##0" = icmp eq i64 %"74$tmp$107##0", 7 
+  br i1 %"74$tmp$108##0", label %if.then37, label %if.else37 
 if.else36:
   ret i1 0 
 if.then37:
-  %99 = add   i64 %"$right#0", -7 
+  %99 = add   i64 %"$right##0", -7 
   %100 = inttoptr i64 %99 to i16* 
   %101 = getelementptr  i16, i16* %100, i64 0 
   %102 = load  i16, i16* %101 
-  %"76$tmp$110#0" = icmp eq i16 %102, 10 
-  br i1 %"76$tmp$110#0", label %if.then38, label %if.else38 
+  %"76$tmp$110##0" = icmp eq i16 %102, 10 
+  br i1 %"76$tmp$110##0", label %if.then38, label %if.else38 
 if.else37:
   ret i1 0 
 if.then38:
-  %103 = add   i64 %"$right#0", 1 
+  %103 = add   i64 %"$right##0", 1 
   %104 = inttoptr i64 %103 to i64* 
   %105 = getelementptr  i64, i64* %104, i64 0 
   %106 = load  i64, i64* %105 
-  %"78$$$#0" = icmp eq i64 %98, %106 
-  ret i1 %"78$$$#0" 
+  %"78$$$##0" = icmp eq i64 %98, %106 
+  ret i1 %"78$$$##0" 
 if.else38:
   ret i1 0 
 if.then39:
-  %107 = add   i64 %"$left#0", 1 
+  %107 = add   i64 %"$left##0", 1 
   %108 = inttoptr i64 %107 to i64* 
   %109 = getelementptr  i64, i64* %108, i64 0 
   %110 = load  i64, i64* %109 
-  %"80$tmp$112#0" = icmp uge i64 %"$right#0", 4 
-  br i1 %"80$tmp$112#0", label %if.then40, label %if.else40 
+  %"80$tmp$112##0" = icmp uge i64 %"$right##0", 4 
+  br i1 %"80$tmp$112##0", label %if.then40, label %if.else40 
 if.else39:
-  %"81$tmp$116#0" = icmp eq i16 %58, 12 
-  br i1 %"81$tmp$116#0", label %if.then43, label %if.else43 
+  %"81$tmp$116##0" = icmp eq i16 %58, 12 
+  br i1 %"81$tmp$116##0", label %if.then43, label %if.else43 
 if.then40:
-  %"82$tmp$113#0" = and i64 %"$right#0", 7 
-  %"82$tmp$114#0" = icmp eq i64 %"82$tmp$113#0", 7 
-  br i1 %"82$tmp$114#0", label %if.then41, label %if.else41 
+  %"82$tmp$113##0" = and i64 %"$right##0", 7 
+  %"82$tmp$114##0" = icmp eq i64 %"82$tmp$113##0", 7 
+  br i1 %"82$tmp$114##0", label %if.then41, label %if.else41 
 if.else40:
   ret i1 0 
 if.then41:
-  %111 = add   i64 %"$right#0", -7 
+  %111 = add   i64 %"$right##0", -7 
   %112 = inttoptr i64 %111 to i16* 
   %113 = getelementptr  i16, i16* %112, i64 0 
   %114 = load  i16, i16* %113 
-  %"84$tmp$116#0" = icmp eq i16 %114, 11 
-  br i1 %"84$tmp$116#0", label %if.then42, label %if.else42 
+  %"84$tmp$116##0" = icmp eq i16 %114, 11 
+  br i1 %"84$tmp$116##0", label %if.then42, label %if.else42 
 if.else41:
   ret i1 0 
 if.then42:
-  %115 = add   i64 %"$right#0", 1 
+  %115 = add   i64 %"$right##0", 1 
   %116 = inttoptr i64 %115 to i64* 
   %117 = getelementptr  i64, i64* %116, i64 0 
   %118 = load  i64, i64* %117 
-  %"86$$$#0" = icmp eq i64 %110, %118 
-  ret i1 %"86$$$#0" 
+  %"86$$$##0" = icmp eq i64 %110, %118 
+  ret i1 %"86$$$##0" 
 if.else42:
   ret i1 0 
 if.then43:
-  %119 = add   i64 %"$left#0", 1 
+  %119 = add   i64 %"$left##0", 1 
   %120 = inttoptr i64 %119 to i64* 
   %121 = getelementptr  i64, i64* %120, i64 0 
   %122 = load  i64, i64* %121 
-  %"88$tmp$118#0" = icmp uge i64 %"$right#0", 4 
-  br i1 %"88$tmp$118#0", label %if.then44, label %if.else44 
+  %"88$tmp$118##0" = icmp uge i64 %"$right##0", 4 
+  br i1 %"88$tmp$118##0", label %if.then44, label %if.else44 
 if.else43:
-  %"89$tmp$122#0" = icmp eq i16 %58, 13 
-  br i1 %"89$tmp$122#0", label %if.then47, label %if.else47 
+  %"89$tmp$122##0" = icmp eq i16 %58, 13 
+  br i1 %"89$tmp$122##0", label %if.then47, label %if.else47 
 if.then44:
-  %"90$tmp$119#0" = and i64 %"$right#0", 7 
-  %"90$tmp$120#0" = icmp eq i64 %"90$tmp$119#0", 7 
-  br i1 %"90$tmp$120#0", label %if.then45, label %if.else45 
+  %"90$tmp$119##0" = and i64 %"$right##0", 7 
+  %"90$tmp$120##0" = icmp eq i64 %"90$tmp$119##0", 7 
+  br i1 %"90$tmp$120##0", label %if.then45, label %if.else45 
 if.else44:
   ret i1 0 
 if.then45:
-  %123 = add   i64 %"$right#0", -7 
+  %123 = add   i64 %"$right##0", -7 
   %124 = inttoptr i64 %123 to i16* 
   %125 = getelementptr  i16, i16* %124, i64 0 
   %126 = load  i16, i16* %125 
-  %"92$tmp$122#0" = icmp eq i16 %126, 12 
-  br i1 %"92$tmp$122#0", label %if.then46, label %if.else46 
+  %"92$tmp$122##0" = icmp eq i16 %126, 12 
+  br i1 %"92$tmp$122##0", label %if.then46, label %if.else46 
 if.else45:
   ret i1 0 
 if.then46:
-  %127 = add   i64 %"$right#0", 1 
+  %127 = add   i64 %"$right##0", 1 
   %128 = inttoptr i64 %127 to i64* 
   %129 = getelementptr  i64, i64* %128, i64 0 
   %130 = load  i64, i64* %129 
-  %"94$$$#0" = icmp eq i64 %122, %130 
-  ret i1 %"94$$$#0" 
+  %"94$$$##0" = icmp eq i64 %122, %130 
+  ret i1 %"94$$$##0" 
 if.else46:
   ret i1 0 
 if.then47:
-  %131 = add   i64 %"$left#0", 1 
+  %131 = add   i64 %"$left##0", 1 
   %132 = inttoptr i64 %131 to i64* 
   %133 = getelementptr  i64, i64* %132, i64 0 
   %134 = load  i64, i64* %133 
-  %"96$tmp$124#0" = icmp uge i64 %"$right#0", 4 
-  br i1 %"96$tmp$124#0", label %if.then48, label %if.else48 
+  %"96$tmp$124##0" = icmp uge i64 %"$right##0", 4 
+  br i1 %"96$tmp$124##0", label %if.then48, label %if.else48 
 if.else47:
-  %"97$tmp$128#0" = icmp eq i16 %58, 14 
-  br i1 %"97$tmp$128#0", label %if.then51, label %if.else51 
+  %"97$tmp$128##0" = icmp eq i16 %58, 14 
+  br i1 %"97$tmp$128##0", label %if.then51, label %if.else51 
 if.then48:
-  %"98$tmp$125#0" = and i64 %"$right#0", 7 
-  %"98$tmp$126#0" = icmp eq i64 %"98$tmp$125#0", 7 
-  br i1 %"98$tmp$126#0", label %if.then49, label %if.else49 
+  %"98$tmp$125##0" = and i64 %"$right##0", 7 
+  %"98$tmp$126##0" = icmp eq i64 %"98$tmp$125##0", 7 
+  br i1 %"98$tmp$126##0", label %if.then49, label %if.else49 
 if.else48:
   ret i1 0 
 if.then49:
-  %135 = add   i64 %"$right#0", -7 
+  %135 = add   i64 %"$right##0", -7 
   %136 = inttoptr i64 %135 to i16* 
   %137 = getelementptr  i16, i16* %136, i64 0 
   %138 = load  i16, i16* %137 
-  %"100$tmp$128#0" = icmp eq i16 %138, 13 
-  br i1 %"100$tmp$128#0", label %if.then50, label %if.else50 
+  %"100$tmp$128##0" = icmp eq i16 %138, 13 
+  br i1 %"100$tmp$128##0", label %if.then50, label %if.else50 
 if.else49:
   ret i1 0 
 if.then50:
-  %139 = add   i64 %"$right#0", 1 
+  %139 = add   i64 %"$right##0", 1 
   %140 = inttoptr i64 %139 to i64* 
   %141 = getelementptr  i64, i64* %140, i64 0 
   %142 = load  i64, i64* %141 
-  %"102$$$#0" = icmp eq i64 %134, %142 
-  ret i1 %"102$$$#0" 
+  %"102$$$##0" = icmp eq i64 %134, %142 
+  ret i1 %"102$$$##0" 
 if.else50:
   ret i1 0 
 if.then51:
-  %143 = add   i64 %"$left#0", 1 
+  %143 = add   i64 %"$left##0", 1 
   %144 = inttoptr i64 %143 to i64* 
   %145 = getelementptr  i64, i64* %144, i64 0 
   %146 = load  i64, i64* %145 
-  %"104$tmp$130#0" = icmp uge i64 %"$right#0", 4 
-  br i1 %"104$tmp$130#0", label %if.then52, label %if.else52 
+  %"104$tmp$130##0" = icmp uge i64 %"$right##0", 4 
+  br i1 %"104$tmp$130##0", label %if.then52, label %if.else52 
 if.else51:
-  %"105$tmp$134#0" = icmp eq i16 %58, 15 
-  br i1 %"105$tmp$134#0", label %if.then55, label %if.else55 
+  %"105$tmp$134##0" = icmp eq i16 %58, 15 
+  br i1 %"105$tmp$134##0", label %if.then55, label %if.else55 
 if.then52:
-  %"106$tmp$131#0" = and i64 %"$right#0", 7 
-  %"106$tmp$132#0" = icmp eq i64 %"106$tmp$131#0", 7 
-  br i1 %"106$tmp$132#0", label %if.then53, label %if.else53 
+  %"106$tmp$131##0" = and i64 %"$right##0", 7 
+  %"106$tmp$132##0" = icmp eq i64 %"106$tmp$131##0", 7 
+  br i1 %"106$tmp$132##0", label %if.then53, label %if.else53 
 if.else52:
   ret i1 0 
 if.then53:
-  %147 = add   i64 %"$right#0", -7 
+  %147 = add   i64 %"$right##0", -7 
   %148 = inttoptr i64 %147 to i16* 
   %149 = getelementptr  i16, i16* %148, i64 0 
   %150 = load  i16, i16* %149 
-  %"108$tmp$134#0" = icmp eq i16 %150, 14 
-  br i1 %"108$tmp$134#0", label %if.then54, label %if.else54 
+  %"108$tmp$134##0" = icmp eq i16 %150, 14 
+  br i1 %"108$tmp$134##0", label %if.then54, label %if.else54 
 if.else53:
   ret i1 0 
 if.then54:
-  %151 = add   i64 %"$right#0", 1 
+  %151 = add   i64 %"$right##0", 1 
   %152 = inttoptr i64 %151 to i64* 
   %153 = getelementptr  i64, i64* %152, i64 0 
   %154 = load  i64, i64* %153 
-  %"110$$$#0" = icmp eq i64 %146, %154 
-  ret i1 %"110$$$#0" 
+  %"110$$$##0" = icmp eq i64 %146, %154 
+  ret i1 %"110$$$##0" 
 if.else54:
   ret i1 0 
 if.then55:
-  %155 = add   i64 %"$left#0", 1 
+  %155 = add   i64 %"$left##0", 1 
   %156 = inttoptr i64 %155 to i64* 
   %157 = getelementptr  i64, i64* %156, i64 0 
   %158 = load  i64, i64* %157 
-  %"112$tmp$136#0" = icmp uge i64 %"$right#0", 4 
-  br i1 %"112$tmp$136#0", label %if.then56, label %if.else56 
+  %"112$tmp$136##0" = icmp uge i64 %"$right##0", 4 
+  br i1 %"112$tmp$136##0", label %if.then56, label %if.else56 
 if.else55:
-  %"113$tmp$140#0" = icmp eq i16 %58, 16 
-  br i1 %"113$tmp$140#0", label %if.then59, label %if.else59 
+  %"113$tmp$140##0" = icmp eq i16 %58, 16 
+  br i1 %"113$tmp$140##0", label %if.then59, label %if.else59 
 if.then56:
-  %"114$tmp$137#0" = and i64 %"$right#0", 7 
-  %"114$tmp$138#0" = icmp eq i64 %"114$tmp$137#0", 7 
-  br i1 %"114$tmp$138#0", label %if.then57, label %if.else57 
+  %"114$tmp$137##0" = and i64 %"$right##0", 7 
+  %"114$tmp$138##0" = icmp eq i64 %"114$tmp$137##0", 7 
+  br i1 %"114$tmp$138##0", label %if.then57, label %if.else57 
 if.else56:
   ret i1 0 
 if.then57:
-  %159 = add   i64 %"$right#0", -7 
+  %159 = add   i64 %"$right##0", -7 
   %160 = inttoptr i64 %159 to i16* 
   %161 = getelementptr  i16, i16* %160, i64 0 
   %162 = load  i16, i16* %161 
-  %"116$tmp$140#0" = icmp eq i16 %162, 15 
-  br i1 %"116$tmp$140#0", label %if.then58, label %if.else58 
+  %"116$tmp$140##0" = icmp eq i16 %162, 15 
+  br i1 %"116$tmp$140##0", label %if.then58, label %if.else58 
 if.else57:
   ret i1 0 
 if.then58:
-  %163 = add   i64 %"$right#0", 1 
+  %163 = add   i64 %"$right##0", 1 
   %164 = inttoptr i64 %163 to i64* 
   %165 = getelementptr  i64, i64* %164, i64 0 
   %166 = load  i64, i64* %165 
-  %"118$$$#0" = icmp eq i64 %158, %166 
-  ret i1 %"118$$$#0" 
+  %"118$$$##0" = icmp eq i64 %158, %166 
+  ret i1 %"118$$$##0" 
 if.else58:
   ret i1 0 
 if.then59:
-  %167 = add   i64 %"$left#0", 1 
+  %167 = add   i64 %"$left##0", 1 
   %168 = inttoptr i64 %167 to i64* 
   %169 = getelementptr  i64, i64* %168, i64 0 
   %170 = load  i64, i64* %169 
-  %"120$tmp$142#0" = icmp uge i64 %"$right#0", 4 
-  br i1 %"120$tmp$142#0", label %if.then60, label %if.else60 
+  %"120$tmp$142##0" = icmp uge i64 %"$right##0", 4 
+  br i1 %"120$tmp$142##0", label %if.then60, label %if.else60 
 if.else59:
   ret i1 0 
 if.then60:
-  %"122$tmp$143#0" = and i64 %"$right#0", 7 
-  %"122$tmp$144#0" = icmp eq i64 %"122$tmp$143#0", 7 
-  br i1 %"122$tmp$144#0", label %if.then61, label %if.else61 
+  %"122$tmp$143##0" = and i64 %"$right##0", 7 
+  %"122$tmp$144##0" = icmp eq i64 %"122$tmp$143##0", 7 
+  br i1 %"122$tmp$144##0", label %if.then61, label %if.else61 
 if.else60:
   ret i1 0 
 if.then61:
-  %171 = add   i64 %"$right#0", -7 
+  %171 = add   i64 %"$right##0", -7 
   %172 = inttoptr i64 %171 to i16* 
   %173 = getelementptr  i16, i16* %172, i64 0 
   %174 = load  i16, i16* %173 
-  %"124$tmp$146#0" = icmp eq i16 %174, 16 
-  br i1 %"124$tmp$146#0", label %if.then62, label %if.else62 
+  %"124$tmp$146##0" = icmp eq i16 %174, 16 
+  br i1 %"124$tmp$146##0", label %if.then62, label %if.else62 
 if.else61:
   ret i1 0 
 if.then62:
-  %175 = add   i64 %"$right#0", 1 
+  %175 = add   i64 %"$right##0", 1 
   %176 = inttoptr i64 %175 to i64* 
   %177 = getelementptr  i64, i64* %176, i64 0 
   %178 = load  i64, i64* %177 
-  %"126$$$#0" = icmp eq i64 %170, %178 
-  ret i1 %"126$$$#0" 
+  %"126$$$##0" = icmp eq i64 %170, %178 
+  ret i1 %"126$$$##0" 
 if.else62:
   ret i1 0 
 }
@@ -3260,32 +3260,32 @@ entry:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.c01<0>"(i64  %"f01#0")    {
+define external fastcc  i64 @"multictr.complicated.c01<0>"(i64  %"f01##0")    {
 entry:
   %179 = trunc i64 8 to i32  
   %180 = tail call ccc  i8*  @wybe_malloc(i32  %179)  
   %181 = ptrtoint i8* %180 to i64 
   %182 = inttoptr i64 %181 to i64* 
   %183 = getelementptr  i64, i64* %182, i64 0 
-  store  i64 %"f01#0", i64* %183 
+  store  i64 %"f01##0", i64* %183 
   ret i64 %181 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c01<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c01<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 0 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 0 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %191 = insertvalue {i64, i1} undef, i64 undef, 0 
   %192 = insertvalue {i64, i1} %191, i1 0, 1 
   ret {i64, i1} %192 
 if.then1:
-  %184 = inttoptr i64 %"$#0" to i64* 
+  %184 = inttoptr i64 %"$##0" to i64* 
   %185 = getelementptr  i64, i64* %184, i64 0 
   %186 = load  i64, i64* %185 
   %187 = insertvalue {i64, i1} undef, i64 %186, 0 
@@ -3298,33 +3298,33 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.c02<0>"(i64  %"f02#0")    {
+define external fastcc  i64 @"multictr.complicated.c02<0>"(i64  %"f02##0")    {
 entry:
   %193 = trunc i64 8 to i32  
   %194 = tail call ccc  i8*  @wybe_malloc(i32  %193)  
   %195 = ptrtoint i8* %194 to i64 
   %196 = inttoptr i64 %195 to i64* 
   %197 = getelementptr  i64, i64* %196, i64 0 
-  store  i64 %"f02#0", i64* %197 
-  %"1$$#0" = or i64 %195, 1 
-  ret i64 %"1$$#0" 
+  store  i64 %"f02##0", i64* %197 
+  %"1$$##0" = or i64 %195, 1 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c02<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c02<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 1 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 1 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %206 = insertvalue {i64, i1} undef, i64 undef, 0 
   %207 = insertvalue {i64, i1} %206, i1 0, 1 
   ret {i64, i1} %207 
 if.then1:
-  %198 = add   i64 %"$#0", -1 
+  %198 = add   i64 %"$##0", -1 
   %199 = inttoptr i64 %198 to i64* 
   %200 = getelementptr  i64, i64* %199, i64 0 
   %201 = load  i64, i64* %200 
@@ -3338,33 +3338,33 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.c03<0>"(i64  %"f03#0")    {
+define external fastcc  i64 @"multictr.complicated.c03<0>"(i64  %"f03##0")    {
 entry:
   %208 = trunc i64 8 to i32  
   %209 = tail call ccc  i8*  @wybe_malloc(i32  %208)  
   %210 = ptrtoint i8* %209 to i64 
   %211 = inttoptr i64 %210 to i64* 
   %212 = getelementptr  i64, i64* %211, i64 0 
-  store  i64 %"f03#0", i64* %212 
-  %"1$$#0" = or i64 %210, 2 
-  ret i64 %"1$$#0" 
+  store  i64 %"f03##0", i64* %212 
+  %"1$$##0" = or i64 %210, 2 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c03<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c03<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 2 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 2 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %221 = insertvalue {i64, i1} undef, i64 undef, 0 
   %222 = insertvalue {i64, i1} %221, i1 0, 1 
   ret {i64, i1} %222 
 if.then1:
-  %213 = add   i64 %"$#0", -2 
+  %213 = add   i64 %"$##0", -2 
   %214 = inttoptr i64 %213 to i64* 
   %215 = getelementptr  i64, i64* %214, i64 0 
   %216 = load  i64, i64* %215 
@@ -3378,33 +3378,33 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.c04<0>"(i64  %"f04#0")    {
+define external fastcc  i64 @"multictr.complicated.c04<0>"(i64  %"f04##0")    {
 entry:
   %223 = trunc i64 8 to i32  
   %224 = tail call ccc  i8*  @wybe_malloc(i32  %223)  
   %225 = ptrtoint i8* %224 to i64 
   %226 = inttoptr i64 %225 to i64* 
   %227 = getelementptr  i64, i64* %226, i64 0 
-  store  i64 %"f04#0", i64* %227 
-  %"1$$#0" = or i64 %225, 3 
-  ret i64 %"1$$#0" 
+  store  i64 %"f04##0", i64* %227 
+  %"1$$##0" = or i64 %225, 3 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c04<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c04<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 3 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 3 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %236 = insertvalue {i64, i1} undef, i64 undef, 0 
   %237 = insertvalue {i64, i1} %236, i1 0, 1 
   ret {i64, i1} %237 
 if.then1:
-  %228 = add   i64 %"$#0", -3 
+  %228 = add   i64 %"$##0", -3 
   %229 = inttoptr i64 %228 to i64* 
   %230 = getelementptr  i64, i64* %229, i64 0 
   %231 = load  i64, i64* %230 
@@ -3418,33 +3418,33 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.c05<0>"(i64  %"f05#0")    {
+define external fastcc  i64 @"multictr.complicated.c05<0>"(i64  %"f05##0")    {
 entry:
   %238 = trunc i64 8 to i32  
   %239 = tail call ccc  i8*  @wybe_malloc(i32  %238)  
   %240 = ptrtoint i8* %239 to i64 
   %241 = inttoptr i64 %240 to i64* 
   %242 = getelementptr  i64, i64* %241, i64 0 
-  store  i64 %"f05#0", i64* %242 
-  %"1$$#0" = or i64 %240, 4 
-  ret i64 %"1$$#0" 
+  store  i64 %"f05##0", i64* %242 
+  %"1$$##0" = or i64 %240, 4 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c05<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c05<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 4 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 4 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %251 = insertvalue {i64, i1} undef, i64 undef, 0 
   %252 = insertvalue {i64, i1} %251, i1 0, 1 
   ret {i64, i1} %252 
 if.then1:
-  %243 = add   i64 %"$#0", -4 
+  %243 = add   i64 %"$##0", -4 
   %244 = inttoptr i64 %243 to i64* 
   %245 = getelementptr  i64, i64* %244, i64 0 
   %246 = load  i64, i64* %245 
@@ -3458,33 +3458,33 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.c06<0>"(i64  %"f06#0")    {
+define external fastcc  i64 @"multictr.complicated.c06<0>"(i64  %"f06##0")    {
 entry:
   %253 = trunc i64 8 to i32  
   %254 = tail call ccc  i8*  @wybe_malloc(i32  %253)  
   %255 = ptrtoint i8* %254 to i64 
   %256 = inttoptr i64 %255 to i64* 
   %257 = getelementptr  i64, i64* %256, i64 0 
-  store  i64 %"f06#0", i64* %257 
-  %"1$$#0" = or i64 %255, 5 
-  ret i64 %"1$$#0" 
+  store  i64 %"f06##0", i64* %257 
+  %"1$$##0" = or i64 %255, 5 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c06<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c06<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 5 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 5 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %266 = insertvalue {i64, i1} undef, i64 undef, 0 
   %267 = insertvalue {i64, i1} %266, i1 0, 1 
   ret {i64, i1} %267 
 if.then1:
-  %258 = add   i64 %"$#0", -5 
+  %258 = add   i64 %"$##0", -5 
   %259 = inttoptr i64 %258 to i64* 
   %260 = getelementptr  i64, i64* %259, i64 0 
   %261 = load  i64, i64* %260 
@@ -3498,33 +3498,33 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.c07<0>"(i64  %"f07#0")    {
+define external fastcc  i64 @"multictr.complicated.c07<0>"(i64  %"f07##0")    {
 entry:
   %268 = trunc i64 8 to i32  
   %269 = tail call ccc  i8*  @wybe_malloc(i32  %268)  
   %270 = ptrtoint i8* %269 to i64 
   %271 = inttoptr i64 %270 to i64* 
   %272 = getelementptr  i64, i64* %271, i64 0 
-  store  i64 %"f07#0", i64* %272 
-  %"1$$#0" = or i64 %270, 6 
-  ret i64 %"1$$#0" 
+  store  i64 %"f07##0", i64* %272 
+  %"1$$##0" = or i64 %270, 6 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c07<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c07<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 6 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 6 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %281 = insertvalue {i64, i1} undef, i64 undef, 0 
   %282 = insertvalue {i64, i1} %281, i1 0, 1 
   ret {i64, i1} %282 
 if.then1:
-  %273 = add   i64 %"$#0", -6 
+  %273 = add   i64 %"$##0", -6 
   %274 = inttoptr i64 %273 to i64* 
   %275 = getelementptr  i64, i64* %274, i64 0 
   %276 = load  i64, i64* %275 
@@ -3538,7 +3538,7 @@ if.else1:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.c08<0>"(i64  %"f08#0")    {
+define external fastcc  i64 @"multictr.complicated.c08<0>"(i64  %"f08##0")    {
 entry:
   %283 = trunc i64 16 to i32  
   %284 = tail call ccc  i8*  @wybe_malloc(i32  %283)  
@@ -3549,37 +3549,37 @@ entry:
   %288 = add   i64 %285, 8 
   %289 = inttoptr i64 %288 to i64* 
   %290 = getelementptr  i64, i64* %289, i64 0 
-  store  i64 %"f08#0", i64* %290 
-  %"1$$#0" = or i64 %285, 7 
-  ret i64 %"1$$#0" 
+  store  i64 %"f08##0", i64* %290 
+  %"1$$##0" = or i64 %285, 7 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c08<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c08<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 7 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %305 = insertvalue {i64, i1} undef, i64 undef, 0 
   %306 = insertvalue {i64, i1} %305, i1 0, 1 
   ret {i64, i1} %306 
 if.then1:
-  %291 = add   i64 %"$#0", -7 
+  %291 = add   i64 %"$##0", -7 
   %292 = inttoptr i64 %291 to i16* 
   %293 = getelementptr  i16, i16* %292, i64 0 
   %294 = load  i16, i16* %293 
-  %"4$tmp$3#0" = icmp eq i16 %294, 7 
-  br i1 %"4$tmp$3#0", label %if.then2, label %if.else2 
+  %"4$tmp$3##0" = icmp eq i16 %294, 7 
+  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
 if.else1:
   %303 = insertvalue {i64, i1} undef, i64 undef, 0 
   %304 = insertvalue {i64, i1} %303, i1 0, 1 
   ret {i64, i1} %304 
 if.then2:
-  %295 = add   i64 %"$#0", 1 
+  %295 = add   i64 %"$##0", 1 
   %296 = inttoptr i64 %295 to i64* 
   %297 = getelementptr  i64, i64* %296, i64 0 
   %298 = load  i64, i64* %297 
@@ -3593,7 +3593,7 @@ if.else2:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.c09<0>"(i64  %"f09#0")    {
+define external fastcc  i64 @"multictr.complicated.c09<0>"(i64  %"f09##0")    {
 entry:
   %307 = trunc i64 16 to i32  
   %308 = tail call ccc  i8*  @wybe_malloc(i32  %307)  
@@ -3604,37 +3604,37 @@ entry:
   %312 = add   i64 %309, 8 
   %313 = inttoptr i64 %312 to i64* 
   %314 = getelementptr  i64, i64* %313, i64 0 
-  store  i64 %"f09#0", i64* %314 
-  %"1$$#0" = or i64 %309, 7 
-  ret i64 %"1$$#0" 
+  store  i64 %"f09##0", i64* %314 
+  %"1$$##0" = or i64 %309, 7 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c09<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c09<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 7 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %329 = insertvalue {i64, i1} undef, i64 undef, 0 
   %330 = insertvalue {i64, i1} %329, i1 0, 1 
   ret {i64, i1} %330 
 if.then1:
-  %315 = add   i64 %"$#0", -7 
+  %315 = add   i64 %"$##0", -7 
   %316 = inttoptr i64 %315 to i16* 
   %317 = getelementptr  i16, i16* %316, i64 0 
   %318 = load  i16, i16* %317 
-  %"4$tmp$3#0" = icmp eq i16 %318, 8 
-  br i1 %"4$tmp$3#0", label %if.then2, label %if.else2 
+  %"4$tmp$3##0" = icmp eq i16 %318, 8 
+  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
 if.else1:
   %327 = insertvalue {i64, i1} undef, i64 undef, 0 
   %328 = insertvalue {i64, i1} %327, i1 0, 1 
   ret {i64, i1} %328 
 if.then2:
-  %319 = add   i64 %"$#0", 1 
+  %319 = add   i64 %"$##0", 1 
   %320 = inttoptr i64 %319 to i64* 
   %321 = getelementptr  i64, i64* %320, i64 0 
   %322 = load  i64, i64* %321 
@@ -3648,7 +3648,7 @@ if.else2:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.c10<0>"(i64  %"f10#0")    {
+define external fastcc  i64 @"multictr.complicated.c10<0>"(i64  %"f10##0")    {
 entry:
   %331 = trunc i64 16 to i32  
   %332 = tail call ccc  i8*  @wybe_malloc(i32  %331)  
@@ -3659,37 +3659,37 @@ entry:
   %336 = add   i64 %333, 8 
   %337 = inttoptr i64 %336 to i64* 
   %338 = getelementptr  i64, i64* %337, i64 0 
-  store  i64 %"f10#0", i64* %338 
-  %"1$$#0" = or i64 %333, 7 
-  ret i64 %"1$$#0" 
+  store  i64 %"f10##0", i64* %338 
+  %"1$$##0" = or i64 %333, 7 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c10<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c10<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 7 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %353 = insertvalue {i64, i1} undef, i64 undef, 0 
   %354 = insertvalue {i64, i1} %353, i1 0, 1 
   ret {i64, i1} %354 
 if.then1:
-  %339 = add   i64 %"$#0", -7 
+  %339 = add   i64 %"$##0", -7 
   %340 = inttoptr i64 %339 to i16* 
   %341 = getelementptr  i16, i16* %340, i64 0 
   %342 = load  i16, i16* %341 
-  %"4$tmp$3#0" = icmp eq i16 %342, 9 
-  br i1 %"4$tmp$3#0", label %if.then2, label %if.else2 
+  %"4$tmp$3##0" = icmp eq i16 %342, 9 
+  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
 if.else1:
   %351 = insertvalue {i64, i1} undef, i64 undef, 0 
   %352 = insertvalue {i64, i1} %351, i1 0, 1 
   ret {i64, i1} %352 
 if.then2:
-  %343 = add   i64 %"$#0", 1 
+  %343 = add   i64 %"$##0", 1 
   %344 = inttoptr i64 %343 to i64* 
   %345 = getelementptr  i64, i64* %344, i64 0 
   %346 = load  i64, i64* %345 
@@ -3703,7 +3703,7 @@ if.else2:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.c11<0>"(i64  %"f11#0")    {
+define external fastcc  i64 @"multictr.complicated.c11<0>"(i64  %"f11##0")    {
 entry:
   %355 = trunc i64 16 to i32  
   %356 = tail call ccc  i8*  @wybe_malloc(i32  %355)  
@@ -3714,37 +3714,37 @@ entry:
   %360 = add   i64 %357, 8 
   %361 = inttoptr i64 %360 to i64* 
   %362 = getelementptr  i64, i64* %361, i64 0 
-  store  i64 %"f11#0", i64* %362 
-  %"1$$#0" = or i64 %357, 7 
-  ret i64 %"1$$#0" 
+  store  i64 %"f11##0", i64* %362 
+  %"1$$##0" = or i64 %357, 7 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c11<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c11<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 7 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %377 = insertvalue {i64, i1} undef, i64 undef, 0 
   %378 = insertvalue {i64, i1} %377, i1 0, 1 
   ret {i64, i1} %378 
 if.then1:
-  %363 = add   i64 %"$#0", -7 
+  %363 = add   i64 %"$##0", -7 
   %364 = inttoptr i64 %363 to i16* 
   %365 = getelementptr  i16, i16* %364, i64 0 
   %366 = load  i16, i16* %365 
-  %"4$tmp$3#0" = icmp eq i16 %366, 10 
-  br i1 %"4$tmp$3#0", label %if.then2, label %if.else2 
+  %"4$tmp$3##0" = icmp eq i16 %366, 10 
+  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
 if.else1:
   %375 = insertvalue {i64, i1} undef, i64 undef, 0 
   %376 = insertvalue {i64, i1} %375, i1 0, 1 
   ret {i64, i1} %376 
 if.then2:
-  %367 = add   i64 %"$#0", 1 
+  %367 = add   i64 %"$##0", 1 
   %368 = inttoptr i64 %367 to i64* 
   %369 = getelementptr  i64, i64* %368, i64 0 
   %370 = load  i64, i64* %369 
@@ -3758,7 +3758,7 @@ if.else2:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.c12<0>"(i64  %"f12#0")    {
+define external fastcc  i64 @"multictr.complicated.c12<0>"(i64  %"f12##0")    {
 entry:
   %379 = trunc i64 16 to i32  
   %380 = tail call ccc  i8*  @wybe_malloc(i32  %379)  
@@ -3769,37 +3769,37 @@ entry:
   %384 = add   i64 %381, 8 
   %385 = inttoptr i64 %384 to i64* 
   %386 = getelementptr  i64, i64* %385, i64 0 
-  store  i64 %"f12#0", i64* %386 
-  %"1$$#0" = or i64 %381, 7 
-  ret i64 %"1$$#0" 
+  store  i64 %"f12##0", i64* %386 
+  %"1$$##0" = or i64 %381, 7 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c12<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c12<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 7 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %401 = insertvalue {i64, i1} undef, i64 undef, 0 
   %402 = insertvalue {i64, i1} %401, i1 0, 1 
   ret {i64, i1} %402 
 if.then1:
-  %387 = add   i64 %"$#0", -7 
+  %387 = add   i64 %"$##0", -7 
   %388 = inttoptr i64 %387 to i16* 
   %389 = getelementptr  i16, i16* %388, i64 0 
   %390 = load  i16, i16* %389 
-  %"4$tmp$3#0" = icmp eq i16 %390, 11 
-  br i1 %"4$tmp$3#0", label %if.then2, label %if.else2 
+  %"4$tmp$3##0" = icmp eq i16 %390, 11 
+  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
 if.else1:
   %399 = insertvalue {i64, i1} undef, i64 undef, 0 
   %400 = insertvalue {i64, i1} %399, i1 0, 1 
   ret {i64, i1} %400 
 if.then2:
-  %391 = add   i64 %"$#0", 1 
+  %391 = add   i64 %"$##0", 1 
   %392 = inttoptr i64 %391 to i64* 
   %393 = getelementptr  i64, i64* %392, i64 0 
   %394 = load  i64, i64* %393 
@@ -3813,7 +3813,7 @@ if.else2:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.c13<0>"(i64  %"f13#0")    {
+define external fastcc  i64 @"multictr.complicated.c13<0>"(i64  %"f13##0")    {
 entry:
   %403 = trunc i64 16 to i32  
   %404 = tail call ccc  i8*  @wybe_malloc(i32  %403)  
@@ -3824,37 +3824,37 @@ entry:
   %408 = add   i64 %405, 8 
   %409 = inttoptr i64 %408 to i64* 
   %410 = getelementptr  i64, i64* %409, i64 0 
-  store  i64 %"f13#0", i64* %410 
-  %"1$$#0" = or i64 %405, 7 
-  ret i64 %"1$$#0" 
+  store  i64 %"f13##0", i64* %410 
+  %"1$$##0" = or i64 %405, 7 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c13<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c13<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 7 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %425 = insertvalue {i64, i1} undef, i64 undef, 0 
   %426 = insertvalue {i64, i1} %425, i1 0, 1 
   ret {i64, i1} %426 
 if.then1:
-  %411 = add   i64 %"$#0", -7 
+  %411 = add   i64 %"$##0", -7 
   %412 = inttoptr i64 %411 to i16* 
   %413 = getelementptr  i16, i16* %412, i64 0 
   %414 = load  i16, i16* %413 
-  %"4$tmp$3#0" = icmp eq i16 %414, 12 
-  br i1 %"4$tmp$3#0", label %if.then2, label %if.else2 
+  %"4$tmp$3##0" = icmp eq i16 %414, 12 
+  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
 if.else1:
   %423 = insertvalue {i64, i1} undef, i64 undef, 0 
   %424 = insertvalue {i64, i1} %423, i1 0, 1 
   ret {i64, i1} %424 
 if.then2:
-  %415 = add   i64 %"$#0", 1 
+  %415 = add   i64 %"$##0", 1 
   %416 = inttoptr i64 %415 to i64* 
   %417 = getelementptr  i64, i64* %416, i64 0 
   %418 = load  i64, i64* %417 
@@ -3868,7 +3868,7 @@ if.else2:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.c14<0>"(i64  %"f14#0")    {
+define external fastcc  i64 @"multictr.complicated.c14<0>"(i64  %"f14##0")    {
 entry:
   %427 = trunc i64 16 to i32  
   %428 = tail call ccc  i8*  @wybe_malloc(i32  %427)  
@@ -3879,37 +3879,37 @@ entry:
   %432 = add   i64 %429, 8 
   %433 = inttoptr i64 %432 to i64* 
   %434 = getelementptr  i64, i64* %433, i64 0 
-  store  i64 %"f14#0", i64* %434 
-  %"1$$#0" = or i64 %429, 7 
-  ret i64 %"1$$#0" 
+  store  i64 %"f14##0", i64* %434 
+  %"1$$##0" = or i64 %429, 7 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c14<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c14<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 7 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %449 = insertvalue {i64, i1} undef, i64 undef, 0 
   %450 = insertvalue {i64, i1} %449, i1 0, 1 
   ret {i64, i1} %450 
 if.then1:
-  %435 = add   i64 %"$#0", -7 
+  %435 = add   i64 %"$##0", -7 
   %436 = inttoptr i64 %435 to i16* 
   %437 = getelementptr  i16, i16* %436, i64 0 
   %438 = load  i16, i16* %437 
-  %"4$tmp$3#0" = icmp eq i16 %438, 13 
-  br i1 %"4$tmp$3#0", label %if.then2, label %if.else2 
+  %"4$tmp$3##0" = icmp eq i16 %438, 13 
+  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
 if.else1:
   %447 = insertvalue {i64, i1} undef, i64 undef, 0 
   %448 = insertvalue {i64, i1} %447, i1 0, 1 
   ret {i64, i1} %448 
 if.then2:
-  %439 = add   i64 %"$#0", 1 
+  %439 = add   i64 %"$##0", 1 
   %440 = inttoptr i64 %439 to i64* 
   %441 = getelementptr  i64, i64* %440, i64 0 
   %442 = load  i64, i64* %441 
@@ -3923,7 +3923,7 @@ if.else2:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.c15<0>"(i64  %"f15#0")    {
+define external fastcc  i64 @"multictr.complicated.c15<0>"(i64  %"f15##0")    {
 entry:
   %451 = trunc i64 16 to i32  
   %452 = tail call ccc  i8*  @wybe_malloc(i32  %451)  
@@ -3934,37 +3934,37 @@ entry:
   %456 = add   i64 %453, 8 
   %457 = inttoptr i64 %456 to i64* 
   %458 = getelementptr  i64, i64* %457, i64 0 
-  store  i64 %"f15#0", i64* %458 
-  %"1$$#0" = or i64 %453, 7 
-  ret i64 %"1$$#0" 
+  store  i64 %"f15##0", i64* %458 
+  %"1$$##0" = or i64 %453, 7 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c15<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c15<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 7 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %473 = insertvalue {i64, i1} undef, i64 undef, 0 
   %474 = insertvalue {i64, i1} %473, i1 0, 1 
   ret {i64, i1} %474 
 if.then1:
-  %459 = add   i64 %"$#0", -7 
+  %459 = add   i64 %"$##0", -7 
   %460 = inttoptr i64 %459 to i16* 
   %461 = getelementptr  i16, i16* %460, i64 0 
   %462 = load  i16, i16* %461 
-  %"4$tmp$3#0" = icmp eq i16 %462, 14 
-  br i1 %"4$tmp$3#0", label %if.then2, label %if.else2 
+  %"4$tmp$3##0" = icmp eq i16 %462, 14 
+  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
 if.else1:
   %471 = insertvalue {i64, i1} undef, i64 undef, 0 
   %472 = insertvalue {i64, i1} %471, i1 0, 1 
   ret {i64, i1} %472 
 if.then2:
-  %463 = add   i64 %"$#0", 1 
+  %463 = add   i64 %"$##0", 1 
   %464 = inttoptr i64 %463 to i64* 
   %465 = getelementptr  i64, i64* %464, i64 0 
   %466 = load  i64, i64* %465 
@@ -3978,7 +3978,7 @@ if.else2:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.c16<0>"(i64  %"f16#0")    {
+define external fastcc  i64 @"multictr.complicated.c16<0>"(i64  %"f16##0")    {
 entry:
   %475 = trunc i64 16 to i32  
   %476 = tail call ccc  i8*  @wybe_malloc(i32  %475)  
@@ -3989,37 +3989,37 @@ entry:
   %480 = add   i64 %477, 8 
   %481 = inttoptr i64 %480 to i64* 
   %482 = getelementptr  i64, i64* %481, i64 0 
-  store  i64 %"f16#0", i64* %482 
-  %"1$$#0" = or i64 %477, 7 
-  ret i64 %"1$$#0" 
+  store  i64 %"f16##0", i64* %482 
+  %"1$$##0" = or i64 %477, 7 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c16<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c16<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 7 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %497 = insertvalue {i64, i1} undef, i64 undef, 0 
   %498 = insertvalue {i64, i1} %497, i1 0, 1 
   ret {i64, i1} %498 
 if.then1:
-  %483 = add   i64 %"$#0", -7 
+  %483 = add   i64 %"$##0", -7 
   %484 = inttoptr i64 %483 to i16* 
   %485 = getelementptr  i16, i16* %484, i64 0 
   %486 = load  i16, i16* %485 
-  %"4$tmp$3#0" = icmp eq i16 %486, 15 
-  br i1 %"4$tmp$3#0", label %if.then2, label %if.else2 
+  %"4$tmp$3##0" = icmp eq i16 %486, 15 
+  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
 if.else1:
   %495 = insertvalue {i64, i1} undef, i64 undef, 0 
   %496 = insertvalue {i64, i1} %495, i1 0, 1 
   ret {i64, i1} %496 
 if.then2:
-  %487 = add   i64 %"$#0", 1 
+  %487 = add   i64 %"$##0", 1 
   %488 = inttoptr i64 %487 to i64* 
   %489 = getelementptr  i64, i64* %488, i64 0 
   %490 = load  i64, i64* %489 
@@ -4033,7 +4033,7 @@ if.else2:
 }
 
 
-define external fastcc  i64 @"multictr.complicated.c17<0>"(i64  %"f17#0")    {
+define external fastcc  i64 @"multictr.complicated.c17<0>"(i64  %"f17##0")    {
 entry:
   %499 = trunc i64 16 to i32  
   %500 = tail call ccc  i8*  @wybe_malloc(i32  %499)  
@@ -4044,37 +4044,37 @@ entry:
   %504 = add   i64 %501, 8 
   %505 = inttoptr i64 %504 to i64* 
   %506 = getelementptr  i64, i64* %505, i64 0 
-  store  i64 %"f17#0", i64* %506 
-  %"1$$#0" = or i64 %501, 7 
-  ret i64 %"1$$#0" 
+  store  i64 %"f17##0", i64* %506 
+  %"1$$##0" = or i64 %501, 7 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c17<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c17<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 7 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %521 = insertvalue {i64, i1} undef, i64 undef, 0 
   %522 = insertvalue {i64, i1} %521, i1 0, 1 
   ret {i64, i1} %522 
 if.then1:
-  %507 = add   i64 %"$#0", -7 
+  %507 = add   i64 %"$##0", -7 
   %508 = inttoptr i64 %507 to i16* 
   %509 = getelementptr  i16, i16* %508, i64 0 
   %510 = load  i16, i16* %509 
-  %"4$tmp$3#0" = icmp eq i16 %510, 16 
-  br i1 %"4$tmp$3#0", label %if.then2, label %if.else2 
+  %"4$tmp$3##0" = icmp eq i16 %510, 16 
+  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
 if.else1:
   %519 = insertvalue {i64, i1} undef, i64 undef, 0 
   %520 = insertvalue {i64, i1} %519, i1 0, 1 
   ret {i64, i1} %520 
 if.then2:
-  %511 = add   i64 %"$#0", 1 
+  %511 = add   i64 %"$##0", 1 
   %512 = inttoptr i64 %511 to i64* 
   %513 = getelementptr  i64, i64* %512, i64 0 
   %514 = load  i64, i64* %513 
@@ -4088,20 +4088,20 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f01<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f01<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$rec#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 0 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 0 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %530 = insertvalue {i64, i1} undef, i64 undef, 0 
   %531 = insertvalue {i64, i1} %530, i1 0, 1 
   ret {i64, i1} %531 
 if.then1:
-  %523 = inttoptr i64 %"$rec#0" to i64* 
+  %523 = inttoptr i64 %"$rec##0" to i64* 
   %524 = getelementptr  i64, i64* %523, i64 0 
   %525 = load  i64, i64* %524 
   %526 = insertvalue {i64, i1} undef, i64 %525, 0 
@@ -4114,16 +4114,16 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f01<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f01<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$rec#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 0 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 0 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
-  %544 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %544 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %545 = insertvalue {i64, i1} %544, i1 0, 1 
   ret {i64, i1} %545 
 if.then1:
@@ -4131,36 +4131,36 @@ if.then1:
   %533 = tail call ccc  i8*  @wybe_malloc(i32  %532)  
   %534 = ptrtoint i8* %533 to i64 
   %535 = inttoptr i64 %534 to i8* 
-  %536 = inttoptr i64 %"$rec#0" to i8* 
+  %536 = inttoptr i64 %"$rec##0" to i8* 
   %537 = trunc i64 8 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %535, i8*  %536, i32  %537, i32  8, i1  0)  
   %538 = inttoptr i64 %534 to i64* 
   %539 = getelementptr  i64, i64* %538, i64 0 
-  store  i64 %"$field#0", i64* %539 
+  store  i64 %"$field##0", i64* %539 
   %540 = insertvalue {i64, i1} undef, i64 %534, 0 
   %541 = insertvalue {i64, i1} %540, i1 1, 1 
   ret {i64, i1} %541 
 if.else1:
-  %542 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %542 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %543 = insertvalue {i64, i1} %542, i1 0, 1 
   ret {i64, i1} %543 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f02<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f02<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$rec#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 1 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 1 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %554 = insertvalue {i64, i1} undef, i64 undef, 0 
   %555 = insertvalue {i64, i1} %554, i1 0, 1 
   ret {i64, i1} %555 
 if.then1:
-  %546 = add   i64 %"$rec#0", -1 
+  %546 = add   i64 %"$rec##0", -1 
   %547 = inttoptr i64 %546 to i64* 
   %548 = getelementptr  i64, i64* %547, i64 0 
   %549 = load  i64, i64* %548 
@@ -4174,16 +4174,16 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f02<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f02<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$rec#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 1 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 1 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
-  %571 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %571 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %572 = insertvalue {i64, i1} %571, i1 0, 1 
   ret {i64, i1} %572 
 if.then1:
@@ -4191,7 +4191,7 @@ if.then1:
   %557 = tail call ccc  i8*  @wybe_malloc(i32  %556)  
   %558 = ptrtoint i8* %557 to i64 
   %559 = add   i64 %558, 1 
-  %560 = sub   i64 %"$rec#0", 1 
+  %560 = sub   i64 %"$rec##0", 1 
   %561 = inttoptr i64 %558 to i8* 
   %562 = inttoptr i64 %560 to i8* 
   %563 = trunc i64 8 to i32  
@@ -4199,31 +4199,31 @@ if.then1:
   %564 = add   i64 %559, -1 
   %565 = inttoptr i64 %564 to i64* 
   %566 = getelementptr  i64, i64* %565, i64 0 
-  store  i64 %"$field#0", i64* %566 
+  store  i64 %"$field##0", i64* %566 
   %567 = insertvalue {i64, i1} undef, i64 %559, 0 
   %568 = insertvalue {i64, i1} %567, i1 1, 1 
   ret {i64, i1} %568 
 if.else1:
-  %569 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %569 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %570 = insertvalue {i64, i1} %569, i1 0, 1 
   ret {i64, i1} %570 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f03<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f03<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$rec#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 2 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 2 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %581 = insertvalue {i64, i1} undef, i64 undef, 0 
   %582 = insertvalue {i64, i1} %581, i1 0, 1 
   ret {i64, i1} %582 
 if.then1:
-  %573 = add   i64 %"$rec#0", -2 
+  %573 = add   i64 %"$rec##0", -2 
   %574 = inttoptr i64 %573 to i64* 
   %575 = getelementptr  i64, i64* %574, i64 0 
   %576 = load  i64, i64* %575 
@@ -4237,16 +4237,16 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f03<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f03<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$rec#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 2 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 2 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
-  %598 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %598 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %599 = insertvalue {i64, i1} %598, i1 0, 1 
   ret {i64, i1} %599 
 if.then1:
@@ -4254,7 +4254,7 @@ if.then1:
   %584 = tail call ccc  i8*  @wybe_malloc(i32  %583)  
   %585 = ptrtoint i8* %584 to i64 
   %586 = add   i64 %585, 2 
-  %587 = sub   i64 %"$rec#0", 2 
+  %587 = sub   i64 %"$rec##0", 2 
   %588 = inttoptr i64 %585 to i8* 
   %589 = inttoptr i64 %587 to i8* 
   %590 = trunc i64 8 to i32  
@@ -4262,31 +4262,31 @@ if.then1:
   %591 = add   i64 %586, -2 
   %592 = inttoptr i64 %591 to i64* 
   %593 = getelementptr  i64, i64* %592, i64 0 
-  store  i64 %"$field#0", i64* %593 
+  store  i64 %"$field##0", i64* %593 
   %594 = insertvalue {i64, i1} undef, i64 %586, 0 
   %595 = insertvalue {i64, i1} %594, i1 1, 1 
   ret {i64, i1} %595 
 if.else1:
-  %596 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %596 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %597 = insertvalue {i64, i1} %596, i1 0, 1 
   ret {i64, i1} %597 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f04<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f04<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$rec#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 3 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 3 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %608 = insertvalue {i64, i1} undef, i64 undef, 0 
   %609 = insertvalue {i64, i1} %608, i1 0, 1 
   ret {i64, i1} %609 
 if.then1:
-  %600 = add   i64 %"$rec#0", -3 
+  %600 = add   i64 %"$rec##0", -3 
   %601 = inttoptr i64 %600 to i64* 
   %602 = getelementptr  i64, i64* %601, i64 0 
   %603 = load  i64, i64* %602 
@@ -4300,16 +4300,16 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f04<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f04<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$rec#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 3 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 3 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
-  %625 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %625 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %626 = insertvalue {i64, i1} %625, i1 0, 1 
   ret {i64, i1} %626 
 if.then1:
@@ -4317,7 +4317,7 @@ if.then1:
   %611 = tail call ccc  i8*  @wybe_malloc(i32  %610)  
   %612 = ptrtoint i8* %611 to i64 
   %613 = add   i64 %612, 3 
-  %614 = sub   i64 %"$rec#0", 3 
+  %614 = sub   i64 %"$rec##0", 3 
   %615 = inttoptr i64 %612 to i8* 
   %616 = inttoptr i64 %614 to i8* 
   %617 = trunc i64 8 to i32  
@@ -4325,31 +4325,31 @@ if.then1:
   %618 = add   i64 %613, -3 
   %619 = inttoptr i64 %618 to i64* 
   %620 = getelementptr  i64, i64* %619, i64 0 
-  store  i64 %"$field#0", i64* %620 
+  store  i64 %"$field##0", i64* %620 
   %621 = insertvalue {i64, i1} undef, i64 %613, 0 
   %622 = insertvalue {i64, i1} %621, i1 1, 1 
   ret {i64, i1} %622 
 if.else1:
-  %623 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %623 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %624 = insertvalue {i64, i1} %623, i1 0, 1 
   ret {i64, i1} %624 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f05<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f05<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$rec#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 4 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 4 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %635 = insertvalue {i64, i1} undef, i64 undef, 0 
   %636 = insertvalue {i64, i1} %635, i1 0, 1 
   ret {i64, i1} %636 
 if.then1:
-  %627 = add   i64 %"$rec#0", -4 
+  %627 = add   i64 %"$rec##0", -4 
   %628 = inttoptr i64 %627 to i64* 
   %629 = getelementptr  i64, i64* %628, i64 0 
   %630 = load  i64, i64* %629 
@@ -4363,16 +4363,16 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f05<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f05<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$rec#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 4 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 4 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
-  %652 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %652 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %653 = insertvalue {i64, i1} %652, i1 0, 1 
   ret {i64, i1} %653 
 if.then1:
@@ -4380,7 +4380,7 @@ if.then1:
   %638 = tail call ccc  i8*  @wybe_malloc(i32  %637)  
   %639 = ptrtoint i8* %638 to i64 
   %640 = add   i64 %639, 4 
-  %641 = sub   i64 %"$rec#0", 4 
+  %641 = sub   i64 %"$rec##0", 4 
   %642 = inttoptr i64 %639 to i8* 
   %643 = inttoptr i64 %641 to i8* 
   %644 = trunc i64 8 to i32  
@@ -4388,31 +4388,31 @@ if.then1:
   %645 = add   i64 %640, -4 
   %646 = inttoptr i64 %645 to i64* 
   %647 = getelementptr  i64, i64* %646, i64 0 
-  store  i64 %"$field#0", i64* %647 
+  store  i64 %"$field##0", i64* %647 
   %648 = insertvalue {i64, i1} undef, i64 %640, 0 
   %649 = insertvalue {i64, i1} %648, i1 1, 1 
   ret {i64, i1} %649 
 if.else1:
-  %650 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %650 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %651 = insertvalue {i64, i1} %650, i1 0, 1 
   ret {i64, i1} %651 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f06<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f06<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$rec#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 5 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 5 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %662 = insertvalue {i64, i1} undef, i64 undef, 0 
   %663 = insertvalue {i64, i1} %662, i1 0, 1 
   ret {i64, i1} %663 
 if.then1:
-  %654 = add   i64 %"$rec#0", -5 
+  %654 = add   i64 %"$rec##0", -5 
   %655 = inttoptr i64 %654 to i64* 
   %656 = getelementptr  i64, i64* %655, i64 0 
   %657 = load  i64, i64* %656 
@@ -4426,16 +4426,16 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f06<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f06<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$rec#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 5 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 5 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
-  %679 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %679 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %680 = insertvalue {i64, i1} %679, i1 0, 1 
   ret {i64, i1} %680 
 if.then1:
@@ -4443,7 +4443,7 @@ if.then1:
   %665 = tail call ccc  i8*  @wybe_malloc(i32  %664)  
   %666 = ptrtoint i8* %665 to i64 
   %667 = add   i64 %666, 5 
-  %668 = sub   i64 %"$rec#0", 5 
+  %668 = sub   i64 %"$rec##0", 5 
   %669 = inttoptr i64 %666 to i8* 
   %670 = inttoptr i64 %668 to i8* 
   %671 = trunc i64 8 to i32  
@@ -4451,31 +4451,31 @@ if.then1:
   %672 = add   i64 %667, -5 
   %673 = inttoptr i64 %672 to i64* 
   %674 = getelementptr  i64, i64* %673, i64 0 
-  store  i64 %"$field#0", i64* %674 
+  store  i64 %"$field##0", i64* %674 
   %675 = insertvalue {i64, i1} undef, i64 %667, 0 
   %676 = insertvalue {i64, i1} %675, i1 1, 1 
   ret {i64, i1} %676 
 if.else1:
-  %677 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %677 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %678 = insertvalue {i64, i1} %677, i1 0, 1 
   ret {i64, i1} %678 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f07<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f07<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$rec#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 6 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 6 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %689 = insertvalue {i64, i1} undef, i64 undef, 0 
   %690 = insertvalue {i64, i1} %689, i1 0, 1 
   ret {i64, i1} %690 
 if.then1:
-  %681 = add   i64 %"$rec#0", -6 
+  %681 = add   i64 %"$rec##0", -6 
   %682 = inttoptr i64 %681 to i64* 
   %683 = getelementptr  i64, i64* %682, i64 0 
   %684 = load  i64, i64* %683 
@@ -4489,16 +4489,16 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f07<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f07<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$rec#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 6 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 6 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
-  %706 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %706 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %707 = insertvalue {i64, i1} %706, i1 0, 1 
   ret {i64, i1} %707 
 if.then1:
@@ -4506,7 +4506,7 @@ if.then1:
   %692 = tail call ccc  i8*  @wybe_malloc(i32  %691)  
   %693 = ptrtoint i8* %692 to i64 
   %694 = add   i64 %693, 6 
-  %695 = sub   i64 %"$rec#0", 6 
+  %695 = sub   i64 %"$rec##0", 6 
   %696 = inttoptr i64 %693 to i8* 
   %697 = inttoptr i64 %695 to i8* 
   %698 = trunc i64 8 to i32  
@@ -4514,42 +4514,42 @@ if.then1:
   %699 = add   i64 %694, -6 
   %700 = inttoptr i64 %699 to i64* 
   %701 = getelementptr  i64, i64* %700, i64 0 
-  store  i64 %"$field#0", i64* %701 
+  store  i64 %"$field##0", i64* %701 
   %702 = insertvalue {i64, i1} undef, i64 %694, 0 
   %703 = insertvalue {i64, i1} %702, i1 1, 1 
   ret {i64, i1} %703 
 if.else1:
-  %704 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %704 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %705 = insertvalue {i64, i1} %704, i1 0, 1 
   ret {i64, i1} %705 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f08<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f08<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$rec#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 7 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %722 = insertvalue {i64, i1} undef, i64 undef, 0 
   %723 = insertvalue {i64, i1} %722, i1 0, 1 
   ret {i64, i1} %723 
 if.then1:
-  %708 = add   i64 %"$rec#0", -7 
+  %708 = add   i64 %"$rec##0", -7 
   %709 = inttoptr i64 %708 to i16* 
   %710 = getelementptr  i16, i16* %709, i64 0 
   %711 = load  i16, i16* %710 
-  %"4$tmp$3#0" = icmp eq i16 %711, 7 
-  br i1 %"4$tmp$3#0", label %if.then2, label %if.else2 
+  %"4$tmp$3##0" = icmp eq i16 %711, 7 
+  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
 if.else1:
   %720 = insertvalue {i64, i1} undef, i64 undef, 0 
   %721 = insertvalue {i64, i1} %720, i1 0, 1 
   ret {i64, i1} %721 
 if.then2:
-  %712 = add   i64 %"$rec#0", 1 
+  %712 = add   i64 %"$rec##0", 1 
   %713 = inttoptr i64 %712 to i64* 
   %714 = getelementptr  i64, i64* %713, i64 0 
   %715 = load  i64, i64* %714 
@@ -4563,27 +4563,27 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f08<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f08<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$rec#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 7 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
-  %745 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %745 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %746 = insertvalue {i64, i1} %745, i1 0, 1 
   ret {i64, i1} %746 
 if.then1:
-  %724 = add   i64 %"$rec#0", -7 
+  %724 = add   i64 %"$rec##0", -7 
   %725 = inttoptr i64 %724 to i16* 
   %726 = getelementptr  i16, i16* %725, i64 0 
   %727 = load  i16, i16* %726 
-  %"4$tmp$3#0" = icmp eq i16 %727, 7 
-  br i1 %"4$tmp$3#0", label %if.then2, label %if.else2 
+  %"4$tmp$3##0" = icmp eq i16 %727, 7 
+  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
 if.else1:
-  %743 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %743 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %744 = insertvalue {i64, i1} %743, i1 0, 1 
   ret {i64, i1} %744 
 if.then2:
@@ -4591,7 +4591,7 @@ if.then2:
   %729 = tail call ccc  i8*  @wybe_malloc(i32  %728)  
   %730 = ptrtoint i8* %729 to i64 
   %731 = add   i64 %730, 7 
-  %732 = sub   i64 %"$rec#0", 7 
+  %732 = sub   i64 %"$rec##0", 7 
   %733 = inttoptr i64 %730 to i8* 
   %734 = inttoptr i64 %732 to i8* 
   %735 = trunc i64 16 to i32  
@@ -4599,42 +4599,42 @@ if.then2:
   %736 = add   i64 %731, 1 
   %737 = inttoptr i64 %736 to i64* 
   %738 = getelementptr  i64, i64* %737, i64 0 
-  store  i64 %"$field#0", i64* %738 
+  store  i64 %"$field##0", i64* %738 
   %739 = insertvalue {i64, i1} undef, i64 %731, 0 
   %740 = insertvalue {i64, i1} %739, i1 1, 1 
   ret {i64, i1} %740 
 if.else2:
-  %741 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %741 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %742 = insertvalue {i64, i1} %741, i1 0, 1 
   ret {i64, i1} %742 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f09<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f09<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$rec#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 7 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %761 = insertvalue {i64, i1} undef, i64 undef, 0 
   %762 = insertvalue {i64, i1} %761, i1 0, 1 
   ret {i64, i1} %762 
 if.then1:
-  %747 = add   i64 %"$rec#0", -7 
+  %747 = add   i64 %"$rec##0", -7 
   %748 = inttoptr i64 %747 to i16* 
   %749 = getelementptr  i16, i16* %748, i64 0 
   %750 = load  i16, i16* %749 
-  %"4$tmp$3#0" = icmp eq i16 %750, 8 
-  br i1 %"4$tmp$3#0", label %if.then2, label %if.else2 
+  %"4$tmp$3##0" = icmp eq i16 %750, 8 
+  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
 if.else1:
   %759 = insertvalue {i64, i1} undef, i64 undef, 0 
   %760 = insertvalue {i64, i1} %759, i1 0, 1 
   ret {i64, i1} %760 
 if.then2:
-  %751 = add   i64 %"$rec#0", 1 
+  %751 = add   i64 %"$rec##0", 1 
   %752 = inttoptr i64 %751 to i64* 
   %753 = getelementptr  i64, i64* %752, i64 0 
   %754 = load  i64, i64* %753 
@@ -4648,27 +4648,27 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f09<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f09<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$rec#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 7 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
-  %784 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %784 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %785 = insertvalue {i64, i1} %784, i1 0, 1 
   ret {i64, i1} %785 
 if.then1:
-  %763 = add   i64 %"$rec#0", -7 
+  %763 = add   i64 %"$rec##0", -7 
   %764 = inttoptr i64 %763 to i16* 
   %765 = getelementptr  i16, i16* %764, i64 0 
   %766 = load  i16, i16* %765 
-  %"4$tmp$3#0" = icmp eq i16 %766, 8 
-  br i1 %"4$tmp$3#0", label %if.then2, label %if.else2 
+  %"4$tmp$3##0" = icmp eq i16 %766, 8 
+  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
 if.else1:
-  %782 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %782 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %783 = insertvalue {i64, i1} %782, i1 0, 1 
   ret {i64, i1} %783 
 if.then2:
@@ -4676,7 +4676,7 @@ if.then2:
   %768 = tail call ccc  i8*  @wybe_malloc(i32  %767)  
   %769 = ptrtoint i8* %768 to i64 
   %770 = add   i64 %769, 7 
-  %771 = sub   i64 %"$rec#0", 7 
+  %771 = sub   i64 %"$rec##0", 7 
   %772 = inttoptr i64 %769 to i8* 
   %773 = inttoptr i64 %771 to i8* 
   %774 = trunc i64 16 to i32  
@@ -4684,42 +4684,42 @@ if.then2:
   %775 = add   i64 %770, 1 
   %776 = inttoptr i64 %775 to i64* 
   %777 = getelementptr  i64, i64* %776, i64 0 
-  store  i64 %"$field#0", i64* %777 
+  store  i64 %"$field##0", i64* %777 
   %778 = insertvalue {i64, i1} undef, i64 %770, 0 
   %779 = insertvalue {i64, i1} %778, i1 1, 1 
   ret {i64, i1} %779 
 if.else2:
-  %780 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %780 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %781 = insertvalue {i64, i1} %780, i1 0, 1 
   ret {i64, i1} %781 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f10<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f10<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$rec#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 7 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %800 = insertvalue {i64, i1} undef, i64 undef, 0 
   %801 = insertvalue {i64, i1} %800, i1 0, 1 
   ret {i64, i1} %801 
 if.then1:
-  %786 = add   i64 %"$rec#0", -7 
+  %786 = add   i64 %"$rec##0", -7 
   %787 = inttoptr i64 %786 to i16* 
   %788 = getelementptr  i16, i16* %787, i64 0 
   %789 = load  i16, i16* %788 
-  %"4$tmp$3#0" = icmp eq i16 %789, 9 
-  br i1 %"4$tmp$3#0", label %if.then2, label %if.else2 
+  %"4$tmp$3##0" = icmp eq i16 %789, 9 
+  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
 if.else1:
   %798 = insertvalue {i64, i1} undef, i64 undef, 0 
   %799 = insertvalue {i64, i1} %798, i1 0, 1 
   ret {i64, i1} %799 
 if.then2:
-  %790 = add   i64 %"$rec#0", 1 
+  %790 = add   i64 %"$rec##0", 1 
   %791 = inttoptr i64 %790 to i64* 
   %792 = getelementptr  i64, i64* %791, i64 0 
   %793 = load  i64, i64* %792 
@@ -4733,27 +4733,27 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f10<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f10<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$rec#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 7 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
-  %823 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %823 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %824 = insertvalue {i64, i1} %823, i1 0, 1 
   ret {i64, i1} %824 
 if.then1:
-  %802 = add   i64 %"$rec#0", -7 
+  %802 = add   i64 %"$rec##0", -7 
   %803 = inttoptr i64 %802 to i16* 
   %804 = getelementptr  i16, i16* %803, i64 0 
   %805 = load  i16, i16* %804 
-  %"4$tmp$3#0" = icmp eq i16 %805, 9 
-  br i1 %"4$tmp$3#0", label %if.then2, label %if.else2 
+  %"4$tmp$3##0" = icmp eq i16 %805, 9 
+  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
 if.else1:
-  %821 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %821 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %822 = insertvalue {i64, i1} %821, i1 0, 1 
   ret {i64, i1} %822 
 if.then2:
@@ -4761,7 +4761,7 @@ if.then2:
   %807 = tail call ccc  i8*  @wybe_malloc(i32  %806)  
   %808 = ptrtoint i8* %807 to i64 
   %809 = add   i64 %808, 7 
-  %810 = sub   i64 %"$rec#0", 7 
+  %810 = sub   i64 %"$rec##0", 7 
   %811 = inttoptr i64 %808 to i8* 
   %812 = inttoptr i64 %810 to i8* 
   %813 = trunc i64 16 to i32  
@@ -4769,42 +4769,42 @@ if.then2:
   %814 = add   i64 %809, 1 
   %815 = inttoptr i64 %814 to i64* 
   %816 = getelementptr  i64, i64* %815, i64 0 
-  store  i64 %"$field#0", i64* %816 
+  store  i64 %"$field##0", i64* %816 
   %817 = insertvalue {i64, i1} undef, i64 %809, 0 
   %818 = insertvalue {i64, i1} %817, i1 1, 1 
   ret {i64, i1} %818 
 if.else2:
-  %819 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %819 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %820 = insertvalue {i64, i1} %819, i1 0, 1 
   ret {i64, i1} %820 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f11<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f11<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$rec#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 7 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %839 = insertvalue {i64, i1} undef, i64 undef, 0 
   %840 = insertvalue {i64, i1} %839, i1 0, 1 
   ret {i64, i1} %840 
 if.then1:
-  %825 = add   i64 %"$rec#0", -7 
+  %825 = add   i64 %"$rec##0", -7 
   %826 = inttoptr i64 %825 to i16* 
   %827 = getelementptr  i16, i16* %826, i64 0 
   %828 = load  i16, i16* %827 
-  %"4$tmp$3#0" = icmp eq i16 %828, 10 
-  br i1 %"4$tmp$3#0", label %if.then2, label %if.else2 
+  %"4$tmp$3##0" = icmp eq i16 %828, 10 
+  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
 if.else1:
   %837 = insertvalue {i64, i1} undef, i64 undef, 0 
   %838 = insertvalue {i64, i1} %837, i1 0, 1 
   ret {i64, i1} %838 
 if.then2:
-  %829 = add   i64 %"$rec#0", 1 
+  %829 = add   i64 %"$rec##0", 1 
   %830 = inttoptr i64 %829 to i64* 
   %831 = getelementptr  i64, i64* %830, i64 0 
   %832 = load  i64, i64* %831 
@@ -4818,27 +4818,27 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f11<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f11<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$rec#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 7 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
-  %862 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %862 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %863 = insertvalue {i64, i1} %862, i1 0, 1 
   ret {i64, i1} %863 
 if.then1:
-  %841 = add   i64 %"$rec#0", -7 
+  %841 = add   i64 %"$rec##0", -7 
   %842 = inttoptr i64 %841 to i16* 
   %843 = getelementptr  i16, i16* %842, i64 0 
   %844 = load  i16, i16* %843 
-  %"4$tmp$3#0" = icmp eq i16 %844, 10 
-  br i1 %"4$tmp$3#0", label %if.then2, label %if.else2 
+  %"4$tmp$3##0" = icmp eq i16 %844, 10 
+  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
 if.else1:
-  %860 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %860 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %861 = insertvalue {i64, i1} %860, i1 0, 1 
   ret {i64, i1} %861 
 if.then2:
@@ -4846,7 +4846,7 @@ if.then2:
   %846 = tail call ccc  i8*  @wybe_malloc(i32  %845)  
   %847 = ptrtoint i8* %846 to i64 
   %848 = add   i64 %847, 7 
-  %849 = sub   i64 %"$rec#0", 7 
+  %849 = sub   i64 %"$rec##0", 7 
   %850 = inttoptr i64 %847 to i8* 
   %851 = inttoptr i64 %849 to i8* 
   %852 = trunc i64 16 to i32  
@@ -4854,42 +4854,42 @@ if.then2:
   %853 = add   i64 %848, 1 
   %854 = inttoptr i64 %853 to i64* 
   %855 = getelementptr  i64, i64* %854, i64 0 
-  store  i64 %"$field#0", i64* %855 
+  store  i64 %"$field##0", i64* %855 
   %856 = insertvalue {i64, i1} undef, i64 %848, 0 
   %857 = insertvalue {i64, i1} %856, i1 1, 1 
   ret {i64, i1} %857 
 if.else2:
-  %858 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %858 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %859 = insertvalue {i64, i1} %858, i1 0, 1 
   ret {i64, i1} %859 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f12<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f12<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$rec#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 7 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %878 = insertvalue {i64, i1} undef, i64 undef, 0 
   %879 = insertvalue {i64, i1} %878, i1 0, 1 
   ret {i64, i1} %879 
 if.then1:
-  %864 = add   i64 %"$rec#0", -7 
+  %864 = add   i64 %"$rec##0", -7 
   %865 = inttoptr i64 %864 to i16* 
   %866 = getelementptr  i16, i16* %865, i64 0 
   %867 = load  i16, i16* %866 
-  %"4$tmp$3#0" = icmp eq i16 %867, 11 
-  br i1 %"4$tmp$3#0", label %if.then2, label %if.else2 
+  %"4$tmp$3##0" = icmp eq i16 %867, 11 
+  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
 if.else1:
   %876 = insertvalue {i64, i1} undef, i64 undef, 0 
   %877 = insertvalue {i64, i1} %876, i1 0, 1 
   ret {i64, i1} %877 
 if.then2:
-  %868 = add   i64 %"$rec#0", 1 
+  %868 = add   i64 %"$rec##0", 1 
   %869 = inttoptr i64 %868 to i64* 
   %870 = getelementptr  i64, i64* %869, i64 0 
   %871 = load  i64, i64* %870 
@@ -4903,27 +4903,27 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f12<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f12<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$rec#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 7 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
-  %901 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %901 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %902 = insertvalue {i64, i1} %901, i1 0, 1 
   ret {i64, i1} %902 
 if.then1:
-  %880 = add   i64 %"$rec#0", -7 
+  %880 = add   i64 %"$rec##0", -7 
   %881 = inttoptr i64 %880 to i16* 
   %882 = getelementptr  i16, i16* %881, i64 0 
   %883 = load  i16, i16* %882 
-  %"4$tmp$3#0" = icmp eq i16 %883, 11 
-  br i1 %"4$tmp$3#0", label %if.then2, label %if.else2 
+  %"4$tmp$3##0" = icmp eq i16 %883, 11 
+  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
 if.else1:
-  %899 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %899 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %900 = insertvalue {i64, i1} %899, i1 0, 1 
   ret {i64, i1} %900 
 if.then2:
@@ -4931,7 +4931,7 @@ if.then2:
   %885 = tail call ccc  i8*  @wybe_malloc(i32  %884)  
   %886 = ptrtoint i8* %885 to i64 
   %887 = add   i64 %886, 7 
-  %888 = sub   i64 %"$rec#0", 7 
+  %888 = sub   i64 %"$rec##0", 7 
   %889 = inttoptr i64 %886 to i8* 
   %890 = inttoptr i64 %888 to i8* 
   %891 = trunc i64 16 to i32  
@@ -4939,42 +4939,42 @@ if.then2:
   %892 = add   i64 %887, 1 
   %893 = inttoptr i64 %892 to i64* 
   %894 = getelementptr  i64, i64* %893, i64 0 
-  store  i64 %"$field#0", i64* %894 
+  store  i64 %"$field##0", i64* %894 
   %895 = insertvalue {i64, i1} undef, i64 %887, 0 
   %896 = insertvalue {i64, i1} %895, i1 1, 1 
   ret {i64, i1} %896 
 if.else2:
-  %897 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %897 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %898 = insertvalue {i64, i1} %897, i1 0, 1 
   ret {i64, i1} %898 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f13<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f13<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$rec#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 7 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %917 = insertvalue {i64, i1} undef, i64 undef, 0 
   %918 = insertvalue {i64, i1} %917, i1 0, 1 
   ret {i64, i1} %918 
 if.then1:
-  %903 = add   i64 %"$rec#0", -7 
+  %903 = add   i64 %"$rec##0", -7 
   %904 = inttoptr i64 %903 to i16* 
   %905 = getelementptr  i16, i16* %904, i64 0 
   %906 = load  i16, i16* %905 
-  %"4$tmp$3#0" = icmp eq i16 %906, 12 
-  br i1 %"4$tmp$3#0", label %if.then2, label %if.else2 
+  %"4$tmp$3##0" = icmp eq i16 %906, 12 
+  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
 if.else1:
   %915 = insertvalue {i64, i1} undef, i64 undef, 0 
   %916 = insertvalue {i64, i1} %915, i1 0, 1 
   ret {i64, i1} %916 
 if.then2:
-  %907 = add   i64 %"$rec#0", 1 
+  %907 = add   i64 %"$rec##0", 1 
   %908 = inttoptr i64 %907 to i64* 
   %909 = getelementptr  i64, i64* %908, i64 0 
   %910 = load  i64, i64* %909 
@@ -4988,27 +4988,27 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f13<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f13<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$rec#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 7 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
-  %940 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %940 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %941 = insertvalue {i64, i1} %940, i1 0, 1 
   ret {i64, i1} %941 
 if.then1:
-  %919 = add   i64 %"$rec#0", -7 
+  %919 = add   i64 %"$rec##0", -7 
   %920 = inttoptr i64 %919 to i16* 
   %921 = getelementptr  i16, i16* %920, i64 0 
   %922 = load  i16, i16* %921 
-  %"4$tmp$3#0" = icmp eq i16 %922, 12 
-  br i1 %"4$tmp$3#0", label %if.then2, label %if.else2 
+  %"4$tmp$3##0" = icmp eq i16 %922, 12 
+  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
 if.else1:
-  %938 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %938 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %939 = insertvalue {i64, i1} %938, i1 0, 1 
   ret {i64, i1} %939 
 if.then2:
@@ -5016,7 +5016,7 @@ if.then2:
   %924 = tail call ccc  i8*  @wybe_malloc(i32  %923)  
   %925 = ptrtoint i8* %924 to i64 
   %926 = add   i64 %925, 7 
-  %927 = sub   i64 %"$rec#0", 7 
+  %927 = sub   i64 %"$rec##0", 7 
   %928 = inttoptr i64 %925 to i8* 
   %929 = inttoptr i64 %927 to i8* 
   %930 = trunc i64 16 to i32  
@@ -5024,42 +5024,42 @@ if.then2:
   %931 = add   i64 %926, 1 
   %932 = inttoptr i64 %931 to i64* 
   %933 = getelementptr  i64, i64* %932, i64 0 
-  store  i64 %"$field#0", i64* %933 
+  store  i64 %"$field##0", i64* %933 
   %934 = insertvalue {i64, i1} undef, i64 %926, 0 
   %935 = insertvalue {i64, i1} %934, i1 1, 1 
   ret {i64, i1} %935 
 if.else2:
-  %936 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %936 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %937 = insertvalue {i64, i1} %936, i1 0, 1 
   ret {i64, i1} %937 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f14<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f14<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$rec#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 7 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %956 = insertvalue {i64, i1} undef, i64 undef, 0 
   %957 = insertvalue {i64, i1} %956, i1 0, 1 
   ret {i64, i1} %957 
 if.then1:
-  %942 = add   i64 %"$rec#0", -7 
+  %942 = add   i64 %"$rec##0", -7 
   %943 = inttoptr i64 %942 to i16* 
   %944 = getelementptr  i16, i16* %943, i64 0 
   %945 = load  i16, i16* %944 
-  %"4$tmp$3#0" = icmp eq i16 %945, 13 
-  br i1 %"4$tmp$3#0", label %if.then2, label %if.else2 
+  %"4$tmp$3##0" = icmp eq i16 %945, 13 
+  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
 if.else1:
   %954 = insertvalue {i64, i1} undef, i64 undef, 0 
   %955 = insertvalue {i64, i1} %954, i1 0, 1 
   ret {i64, i1} %955 
 if.then2:
-  %946 = add   i64 %"$rec#0", 1 
+  %946 = add   i64 %"$rec##0", 1 
   %947 = inttoptr i64 %946 to i64* 
   %948 = getelementptr  i64, i64* %947, i64 0 
   %949 = load  i64, i64* %948 
@@ -5073,27 +5073,27 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f14<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f14<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$rec#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 7 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
-  %979 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %979 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %980 = insertvalue {i64, i1} %979, i1 0, 1 
   ret {i64, i1} %980 
 if.then1:
-  %958 = add   i64 %"$rec#0", -7 
+  %958 = add   i64 %"$rec##0", -7 
   %959 = inttoptr i64 %958 to i16* 
   %960 = getelementptr  i16, i16* %959, i64 0 
   %961 = load  i16, i16* %960 
-  %"4$tmp$3#0" = icmp eq i16 %961, 13 
-  br i1 %"4$tmp$3#0", label %if.then2, label %if.else2 
+  %"4$tmp$3##0" = icmp eq i16 %961, 13 
+  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
 if.else1:
-  %977 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %977 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %978 = insertvalue {i64, i1} %977, i1 0, 1 
   ret {i64, i1} %978 
 if.then2:
@@ -5101,7 +5101,7 @@ if.then2:
   %963 = tail call ccc  i8*  @wybe_malloc(i32  %962)  
   %964 = ptrtoint i8* %963 to i64 
   %965 = add   i64 %964, 7 
-  %966 = sub   i64 %"$rec#0", 7 
+  %966 = sub   i64 %"$rec##0", 7 
   %967 = inttoptr i64 %964 to i8* 
   %968 = inttoptr i64 %966 to i8* 
   %969 = trunc i64 16 to i32  
@@ -5109,42 +5109,42 @@ if.then2:
   %970 = add   i64 %965, 1 
   %971 = inttoptr i64 %970 to i64* 
   %972 = getelementptr  i64, i64* %971, i64 0 
-  store  i64 %"$field#0", i64* %972 
+  store  i64 %"$field##0", i64* %972 
   %973 = insertvalue {i64, i1} undef, i64 %965, 0 
   %974 = insertvalue {i64, i1} %973, i1 1, 1 
   ret {i64, i1} %974 
 if.else2:
-  %975 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %975 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %976 = insertvalue {i64, i1} %975, i1 0, 1 
   ret {i64, i1} %976 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f15<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f15<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$rec#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 7 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %995 = insertvalue {i64, i1} undef, i64 undef, 0 
   %996 = insertvalue {i64, i1} %995, i1 0, 1 
   ret {i64, i1} %996 
 if.then1:
-  %981 = add   i64 %"$rec#0", -7 
+  %981 = add   i64 %"$rec##0", -7 
   %982 = inttoptr i64 %981 to i16* 
   %983 = getelementptr  i16, i16* %982, i64 0 
   %984 = load  i16, i16* %983 
-  %"4$tmp$3#0" = icmp eq i16 %984, 14 
-  br i1 %"4$tmp$3#0", label %if.then2, label %if.else2 
+  %"4$tmp$3##0" = icmp eq i16 %984, 14 
+  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
 if.else1:
   %993 = insertvalue {i64, i1} undef, i64 undef, 0 
   %994 = insertvalue {i64, i1} %993, i1 0, 1 
   ret {i64, i1} %994 
 if.then2:
-  %985 = add   i64 %"$rec#0", 1 
+  %985 = add   i64 %"$rec##0", 1 
   %986 = inttoptr i64 %985 to i64* 
   %987 = getelementptr  i64, i64* %986, i64 0 
   %988 = load  i64, i64* %987 
@@ -5158,27 +5158,27 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f15<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f15<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$rec#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 7 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
-  %1018 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %1018 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %1019 = insertvalue {i64, i1} %1018, i1 0, 1 
   ret {i64, i1} %1019 
 if.then1:
-  %997 = add   i64 %"$rec#0", -7 
+  %997 = add   i64 %"$rec##0", -7 
   %998 = inttoptr i64 %997 to i16* 
   %999 = getelementptr  i16, i16* %998, i64 0 
   %1000 = load  i16, i16* %999 
-  %"4$tmp$3#0" = icmp eq i16 %1000, 14 
-  br i1 %"4$tmp$3#0", label %if.then2, label %if.else2 
+  %"4$tmp$3##0" = icmp eq i16 %1000, 14 
+  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
 if.else1:
-  %1016 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %1016 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %1017 = insertvalue {i64, i1} %1016, i1 0, 1 
   ret {i64, i1} %1017 
 if.then2:
@@ -5186,7 +5186,7 @@ if.then2:
   %1002 = tail call ccc  i8*  @wybe_malloc(i32  %1001)  
   %1003 = ptrtoint i8* %1002 to i64 
   %1004 = add   i64 %1003, 7 
-  %1005 = sub   i64 %"$rec#0", 7 
+  %1005 = sub   i64 %"$rec##0", 7 
   %1006 = inttoptr i64 %1003 to i8* 
   %1007 = inttoptr i64 %1005 to i8* 
   %1008 = trunc i64 16 to i32  
@@ -5194,42 +5194,42 @@ if.then2:
   %1009 = add   i64 %1004, 1 
   %1010 = inttoptr i64 %1009 to i64* 
   %1011 = getelementptr  i64, i64* %1010, i64 0 
-  store  i64 %"$field#0", i64* %1011 
+  store  i64 %"$field##0", i64* %1011 
   %1012 = insertvalue {i64, i1} undef, i64 %1004, 0 
   %1013 = insertvalue {i64, i1} %1012, i1 1, 1 
   ret {i64, i1} %1013 
 if.else2:
-  %1014 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %1014 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %1015 = insertvalue {i64, i1} %1014, i1 0, 1 
   ret {i64, i1} %1015 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f16<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f16<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$rec#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 7 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %1034 = insertvalue {i64, i1} undef, i64 undef, 0 
   %1035 = insertvalue {i64, i1} %1034, i1 0, 1 
   ret {i64, i1} %1035 
 if.then1:
-  %1020 = add   i64 %"$rec#0", -7 
+  %1020 = add   i64 %"$rec##0", -7 
   %1021 = inttoptr i64 %1020 to i16* 
   %1022 = getelementptr  i16, i16* %1021, i64 0 
   %1023 = load  i16, i16* %1022 
-  %"4$tmp$3#0" = icmp eq i16 %1023, 15 
-  br i1 %"4$tmp$3#0", label %if.then2, label %if.else2 
+  %"4$tmp$3##0" = icmp eq i16 %1023, 15 
+  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
 if.else1:
   %1032 = insertvalue {i64, i1} undef, i64 undef, 0 
   %1033 = insertvalue {i64, i1} %1032, i1 0, 1 
   ret {i64, i1} %1033 
 if.then2:
-  %1024 = add   i64 %"$rec#0", 1 
+  %1024 = add   i64 %"$rec##0", 1 
   %1025 = inttoptr i64 %1024 to i64* 
   %1026 = getelementptr  i64, i64* %1025, i64 0 
   %1027 = load  i64, i64* %1026 
@@ -5243,27 +5243,27 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f16<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f16<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$rec#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 7 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
-  %1057 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %1057 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %1058 = insertvalue {i64, i1} %1057, i1 0, 1 
   ret {i64, i1} %1058 
 if.then1:
-  %1036 = add   i64 %"$rec#0", -7 
+  %1036 = add   i64 %"$rec##0", -7 
   %1037 = inttoptr i64 %1036 to i16* 
   %1038 = getelementptr  i16, i16* %1037, i64 0 
   %1039 = load  i16, i16* %1038 
-  %"4$tmp$3#0" = icmp eq i16 %1039, 15 
-  br i1 %"4$tmp$3#0", label %if.then2, label %if.else2 
+  %"4$tmp$3##0" = icmp eq i16 %1039, 15 
+  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
 if.else1:
-  %1055 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %1055 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %1056 = insertvalue {i64, i1} %1055, i1 0, 1 
   ret {i64, i1} %1056 
 if.then2:
@@ -5271,7 +5271,7 @@ if.then2:
   %1041 = tail call ccc  i8*  @wybe_malloc(i32  %1040)  
   %1042 = ptrtoint i8* %1041 to i64 
   %1043 = add   i64 %1042, 7 
-  %1044 = sub   i64 %"$rec#0", 7 
+  %1044 = sub   i64 %"$rec##0", 7 
   %1045 = inttoptr i64 %1042 to i8* 
   %1046 = inttoptr i64 %1044 to i8* 
   %1047 = trunc i64 16 to i32  
@@ -5279,42 +5279,42 @@ if.then2:
   %1048 = add   i64 %1043, 1 
   %1049 = inttoptr i64 %1048 to i64* 
   %1050 = getelementptr  i64, i64* %1049, i64 0 
-  store  i64 %"$field#0", i64* %1050 
+  store  i64 %"$field##0", i64* %1050 
   %1051 = insertvalue {i64, i1} undef, i64 %1043, 0 
   %1052 = insertvalue {i64, i1} %1051, i1 1, 1 
   ret {i64, i1} %1052 
 if.else2:
-  %1053 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %1053 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %1054 = insertvalue {i64, i1} %1053, i1 0, 1 
   ret {i64, i1} %1054 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f17<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f17<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$rec#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 7 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %1073 = insertvalue {i64, i1} undef, i64 undef, 0 
   %1074 = insertvalue {i64, i1} %1073, i1 0, 1 
   ret {i64, i1} %1074 
 if.then1:
-  %1059 = add   i64 %"$rec#0", -7 
+  %1059 = add   i64 %"$rec##0", -7 
   %1060 = inttoptr i64 %1059 to i16* 
   %1061 = getelementptr  i16, i16* %1060, i64 0 
   %1062 = load  i16, i16* %1061 
-  %"4$tmp$3#0" = icmp eq i16 %1062, 16 
-  br i1 %"4$tmp$3#0", label %if.then2, label %if.else2 
+  %"4$tmp$3##0" = icmp eq i16 %1062, 16 
+  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
 if.else1:
   %1071 = insertvalue {i64, i1} undef, i64 undef, 0 
   %1072 = insertvalue {i64, i1} %1071, i1 0, 1 
   ret {i64, i1} %1072 
 if.then2:
-  %1063 = add   i64 %"$rec#0", 1 
+  %1063 = add   i64 %"$rec##0", 1 
   %1064 = inttoptr i64 %1063 to i64* 
   %1065 = getelementptr  i64, i64* %1064, i64 0 
   %1066 = load  i64, i64* %1065 
@@ -5328,27 +5328,27 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f17<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f17<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp uge i64 %"$rec#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 7 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 7 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
-  %1096 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %1096 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %1097 = insertvalue {i64, i1} %1096, i1 0, 1 
   ret {i64, i1} %1097 
 if.then1:
-  %1075 = add   i64 %"$rec#0", -7 
+  %1075 = add   i64 %"$rec##0", -7 
   %1076 = inttoptr i64 %1075 to i16* 
   %1077 = getelementptr  i16, i16* %1076, i64 0 
   %1078 = load  i16, i16* %1077 
-  %"4$tmp$3#0" = icmp eq i16 %1078, 16 
-  br i1 %"4$tmp$3#0", label %if.then2, label %if.else2 
+  %"4$tmp$3##0" = icmp eq i16 %1078, 16 
+  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
 if.else1:
-  %1094 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %1094 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %1095 = insertvalue {i64, i1} %1094, i1 0, 1 
   ret {i64, i1} %1095 
 if.then2:
@@ -5356,7 +5356,7 @@ if.then2:
   %1080 = tail call ccc  i8*  @wybe_malloc(i32  %1079)  
   %1081 = ptrtoint i8* %1080 to i64 
   %1082 = add   i64 %1081, 7 
-  %1083 = sub   i64 %"$rec#0", 7 
+  %1083 = sub   i64 %"$rec##0", 7 
   %1084 = inttoptr i64 %1081 to i8* 
   %1085 = inttoptr i64 %1083 to i8* 
   %1086 = trunc i64 16 to i32  
@@ -5364,12 +5364,12 @@ if.then2:
   %1087 = add   i64 %1082, 1 
   %1088 = inttoptr i64 %1087 to i64* 
   %1089 = getelementptr  i64, i64* %1088, i64 0 
-  store  i64 %"$field#0", i64* %1089 
+  store  i64 %"$field##0", i64* %1089 
   %1090 = insertvalue {i64, i1} undef, i64 %1082, 0 
   %1091 = insertvalue {i64, i1} %1090, i1 1, 1 
   ret {i64, i1} %1091 
 if.else2:
-  %1092 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %1092 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %1093 = insertvalue {i64, i1} %1092, i1 0, 1 
   ret {i64, i1} %1093 
 }
@@ -5393,11 +5393,11 @@ entry:
 }
 
 
-define external fastcc  i1 @"multictr.complicated.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"multictr.complicated.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = tail call fastcc  i1  @"multictr.complicated.=<0>"(i64  %"$left#0", i64  %"$right#0")  
-  %"1$$$#0" = xor i1 %"1$tmp$0#0", 1 
-  ret i1 %"1$$$#0" 
+  %"1$tmp$0##0" = tail call fastcc  i1  @"multictr.complicated.=<0>"(i64  %"$left##0", i64  %"$right##0")  
+  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
+  ret i1 %"1$$$##0" 
 }
 --------------------------------------------------
  Module multictr.length
@@ -5417,47 +5417,47 @@ entry:
 
 = > public {inline} (1 calls)
 0: multictr.length.=<0>
-=($left#0:multictr.length, $right#0:multictr.length, ?$$#0:wybe.bool):
+=($left##0:multictr.length, $right##0:multictr.length, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(~$left#0:multictr.length, ~$right#0:multictr.length, ?$$#0:wybe.bool)
+    foreign llvm icmp_eq(~$left##0:multictr.length, ~$right##0:multictr.length, ?$$##0:wybe.bool)
 
 
 metres > public {inline} (0 calls)
 0: multictr.length.metres<0>
-metres(value#0:wybe.float, ?$#2:multictr.length):
+metres(value##0:wybe.float, ?$##2:multictr.length):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(~value#0:multictr.length, ?$#2:multictr.length)
+    foreign llvm move(~value##0:multictr.length, ?$##2:multictr.length)
 metres > public {inline} (0 calls)
 1: multictr.length.metres<1>
-metres(?value#0:wybe.float, $#0:multictr.length):
+metres(?value##0:wybe.float, $##0:multictr.length):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm cast(~$#0:multictr.length, ?value#0:wybe.float)
+    foreign lpvm cast(~$##0:multictr.length, ?value##0:wybe.float)
 
 
 value > public {inline} (0 calls)
 0: multictr.length.value<0>
-value($rec#0:multictr.length, ?$#0:wybe.float):
+value($rec##0:multictr.length, ?$##0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm cast(~$rec#0:multictr.length, ?$#0:wybe.float)
+    foreign lpvm cast(~$rec##0:multictr.length, ?$##0:wybe.float)
 value > public {inline} (0 calls)
 1: multictr.length.value<1>
-value([$rec#0:multictr.length], ?$rec#2:multictr.length, $field#0:wybe.float):
+value([$rec##0:multictr.length], ?$rec##2:multictr.length, $field##0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(~$field#0:multictr.length, ?$rec#2:multictr.length)
+    foreign llvm move(~$field##0:multictr.length, ?$rec##2:multictr.length)
 
 
 ~= > public {inline} (0 calls)
 0: multictr.length.~=<0>
-~=($left#0:multictr.length, $right#0:multictr.length, ?$$#0:wybe.bool):
+~=($left##0:multictr.length, $right##0:multictr.length, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(~$left#0:multictr.length, ~$right#0:multictr.length, ?tmp$0#0:wybe.bool)
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    foreign llvm icmp_eq(~$left##0:multictr.length, ~$right##0:multictr.length, ?tmp$0##0:wybe.bool)
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
   LLVM code       :
 
@@ -5473,46 +5473,46 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"multictr.length.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"multictr.length.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$$$#0" = icmp eq i64 %"$left#0", %"$right#0" 
-  ret i1 %"1$$$#0" 
+  %"1$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
+  ret i1 %"1$$$##0" 
 }
 
 
-define external fastcc  i64 @"multictr.length.metres<0>"(double  %"value#0")    {
+define external fastcc  i64 @"multictr.length.metres<0>"(double  %"value##0")    {
 entry:
-  %1 = bitcast double %"value#0" to i64 
+  %1 = bitcast double %"value##0" to i64 
   ret i64 %1 
 }
 
 
-define external fastcc  double @"multictr.length.metres<1>"(i64  %"$#0")    {
+define external fastcc  double @"multictr.length.metres<1>"(i64  %"$##0")    {
 entry:
-  %2 = bitcast i64 %"$#0" to double 
+  %2 = bitcast i64 %"$##0" to double 
   ret double %2 
 }
 
 
-define external fastcc  double @"multictr.length.value<0>"(i64  %"$rec#0")    {
+define external fastcc  double @"multictr.length.value<0>"(i64  %"$rec##0")    {
 entry:
-  %3 = bitcast i64 %"$rec#0" to double 
+  %3 = bitcast i64 %"$rec##0" to double 
   ret double %3 
 }
 
 
-define external fastcc  i64 @"multictr.length.value<1>"(double  %"$field#0")    {
+define external fastcc  i64 @"multictr.length.value<1>"(double  %"$field##0")    {
 entry:
-  %4 = bitcast double %"$field#0" to i64 
+  %4 = bitcast double %"$field##0" to i64 
   ret i64 %4 
 }
 
 
-define external fastcc  i1 @"multictr.length.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"multictr.length.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = icmp eq i64 %"$left#0", %"$right#0" 
-  %"1$$$#0" = xor i1 %"1$tmp$0#0", 1 
-  ret i1 %"1$$$#0" 
+  %"1$tmp$0##0" = icmp eq i64 %"$left##0", %"$right##0" 
+  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
+  ret i1 %"1$$$##0" 
 }
 --------------------------------------------------
  Module multictr.maybe_int
@@ -5533,99 +5533,99 @@ entry:
 
 = > public (1 calls)
 0: multictr.maybe_int.=<0>
-=($left#0:multictr.maybe_int, $right#0:multictr.maybe_int, ?$$#0:wybe.bool):
+=($left##0:multictr.maybe_int, $right##0:multictr.maybe_int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left#0:multictr.maybe_int, ~$right#0:multictr.maybe_int, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~$left##0:multictr.maybe_int, ~$right##0:multictr.maybe_int, ?$$##0:wybe.bool)
 
     1:
-        foreign lpvm access(~$left#0:multictr.maybe_int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$left$value#0:wybe.int)
-        foreign llvm icmp_ne($right#0:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.bool)
-        case ~tmp$8#0:wybe.bool of
+        foreign lpvm access(~$left##0:multictr.maybe_int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$left$value##0:wybe.int)
+        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.bool)
+        case ~tmp$8##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign lpvm access(~$right#0:multictr.maybe_int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$right$value#0:wybe.int)
-            foreign llvm icmp_eq(~$left$value#0:wybe.int, ~$right$value#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+            foreign lpvm access(~$right##0:multictr.maybe_int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$right$value##0:wybe.int)
+            foreign llvm icmp_eq(~$left$value##0:wybe.int, ~$right$value##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 
 just > public {inline} (0 calls)
 0: multictr.maybe_int.just<0>
-just(value#0:wybe.int, ?$#0:multictr.maybe_int):
+just(value##0:wybe.int, ?$##0:multictr.maybe_int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr.maybe_int)
-    foreign lpvm mutate(~$rec#0:multictr.maybe_int, ?$#0:multictr.maybe_int, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~value#0:wybe.int)
+    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr.maybe_int)
+    foreign lpvm mutate(~$rec##0:multictr.maybe_int, ?$##0:multictr.maybe_int, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~value##0:wybe.int)
 just > public {inline} (8 calls)
 1: multictr.maybe_int.just<1>
-just(?value#0:wybe.int, $#0:multictr.maybe_int, ?$$#0:wybe.bool):
+just(?value##0:wybe.int, $##0:multictr.maybe_int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?value#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?value##0:wybe.int)
 
     1:
-        foreign lpvm access(~$#0:multictr.maybe_int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?value#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$##0:multictr.maybe_int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?value##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 nothing > public {inline} (0 calls)
 0: multictr.maybe_int.nothing<0>
-nothing(?$#0:multictr.maybe_int):
+nothing(?$##0:multictr.maybe_int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:multictr.maybe_int, ?$#0:multictr.maybe_int)
+    foreign llvm move(0:multictr.maybe_int, ?$##0:multictr.maybe_int)
 
 
 value > public {inline} (0 calls)
 0: multictr.maybe_int.value<0>
-value($rec#0:multictr.maybe_int, ?$#0:wybe.int, ?$$#0:wybe.bool):
+value($rec##0:multictr.maybe_int, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec#0:multictr.maybe_int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:multictr.maybe_int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 value > public {inline} (0 calls)
 1: multictr.maybe_int.value<1>
-value($rec#0:multictr.maybe_int, ?$rec#1:multictr.maybe_int, $field#0:wybe.int, ?$$#0:wybe.bool):
+value($rec##0:multictr.maybe_int, ?$rec##1:multictr.maybe_int, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multictr.maybe_int, ?$rec#1:multictr.maybe_int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multictr.maybe_int, ?$rec##1:multictr.maybe_int)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec#0:multictr.maybe_int, ?$rec#1:multictr.maybe_int, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm {noalias} mutate(~$rec##0:multictr.maybe_int, ?$rec##1:multictr.maybe_int, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: multictr.maybe_int.~=<0>
-~=($left#0:multictr.maybe_int, $right#0:multictr.maybe_int, ?$$#0:wybe.bool):
+~=($left##0:multictr.maybe_int, $right##0:multictr.maybe_int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    multictr.maybe_int.=<0>(~$left#0:multictr.maybe_int, ~$right#0:multictr.maybe_int, ?tmp$0#0:wybe.bool) #0
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    multictr.maybe_int.=<0>(~$left##0:multictr.maybe_int, ~$right##0:multictr.maybe_int, ?tmp$0##0:wybe.bool) #0
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
   LLVM code       :
 
@@ -5641,48 +5641,48 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"multictr.maybe_int.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"multictr.maybe_int.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$left#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %"2$tmp$8#0" = icmp ne i64 %"$right#0", 0 
-  br i1 %"2$tmp$8#0", label %if.then1, label %if.else1 
+  %"2$tmp$8##0" = icmp ne i64 %"$right##0", 0 
+  br i1 %"2$tmp$8##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = icmp eq i64 %"$left#0", %"$right#0" 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
+  ret i1 %"3$$$##0" 
 if.then1:
-  %4 = inttoptr i64 %"$right#0" to i64* 
+  %4 = inttoptr i64 %"$right##0" to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
   %6 = load  i64, i64* %5 
-  %"4$$$#0" = icmp eq i64 %3, %6 
-  ret i1 %"4$$$#0" 
+  %"4$$$##0" = icmp eq i64 %3, %6 
+  ret i1 %"4$$$##0" 
 if.else1:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"multictr.maybe_int.just<0>"(i64  %"value#0")    {
+define external fastcc  i64 @"multictr.maybe_int.just<0>"(i64  %"value##0")    {
 entry:
   %7 = trunc i64 8 to i32  
   %8 = tail call ccc  i8*  @wybe_malloc(i32  %7)  
   %9 = ptrtoint i8* %8 to i64 
   %10 = inttoptr i64 %9 to i64* 
   %11 = getelementptr  i64, i64* %10, i64 0 
-  store  i64 %"value#0", i64* %11 
+  store  i64 %"value##0", i64* %11 
   ret i64 %9 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.maybe_int.just<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"multictr.maybe_int.just<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %12 = inttoptr i64 %"$#0" to i64* 
+  %12 = inttoptr i64 %"$##0" to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
   %15 = insertvalue {i64, i1} undef, i64 %14, 0 
@@ -5701,12 +5701,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.maybe_int.value<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"multictr.maybe_int.value<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %19 = inttoptr i64 %"$rec#0" to i64* 
+  %19 = inttoptr i64 %"$rec##0" to i64* 
   %20 = getelementptr  i64, i64* %19, i64 0 
   %21 = load  i64, i64* %20 
   %22 = insertvalue {i64, i1} undef, i64 %21, 0 
@@ -5719,36 +5719,36 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.maybe_int.value<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"multictr.maybe_int.value<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %26 = trunc i64 8 to i32  
   %27 = tail call ccc  i8*  @wybe_malloc(i32  %26)  
   %28 = ptrtoint i8* %27 to i64 
   %29 = inttoptr i64 %28 to i8* 
-  %30 = inttoptr i64 %"$rec#0" to i8* 
+  %30 = inttoptr i64 %"$rec##0" to i8* 
   %31 = trunc i64 8 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %29, i8*  %30, i32  %31, i32  8, i1  0)  
   %32 = inttoptr i64 %28 to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
-  store  i64 %"$field#0", i64* %33 
+  store  i64 %"$field##0", i64* %33 
   %34 = insertvalue {i64, i1} undef, i64 %28, 0 
   %35 = insertvalue {i64, i1} %34, i1 1, 1 
   ret {i64, i1} %35 
 if.else:
-  %36 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %36 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %37 = insertvalue {i64, i1} %36, i1 0, 1 
   ret {i64, i1} %37 
 }
 
 
-define external fastcc  i1 @"multictr.maybe_int.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"multictr.maybe_int.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = tail call fastcc  i1  @"multictr.maybe_int.=<0>"(i64  %"$left#0", i64  %"$right#0")  
-  %"1$$$#0" = xor i1 %"1$tmp$0#0", 1 
-  ret i1 %"1$$$#0" 
+  %"1$tmp$0##0" = tail call fastcc  i1  @"multictr.maybe_int.=<0>"(i64  %"$left##0", i64  %"$right##0")  
+  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
+  ret i1 %"1$$$##0" 
 }
 --------------------------------------------------
  Module multictr.number
@@ -5772,173 +5772,173 @@ entry:
 
 = > public (1 calls)
 0: multictr.number.=<0>
-=($left#0:multictr.number, $right#0:multictr.number, ?$$#0:wybe.bool):
+=($left##0:multictr.number, $right##0:multictr.number, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($left#0:wybe.int, 1:wybe.int, ?tmp$8#0:wybe.int)
-    foreign llvm icmp_eq(tmp$8#0:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.bool)
-    case ~tmp$9#0:wybe.bool of
+    foreign llvm and($left##0:wybe.int, 1:wybe.int, ?tmp$8##0:wybe.int)
+    foreign llvm icmp_eq(tmp$8##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
+    case ~tmp$9##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~tmp$8#0:wybe.int, 1:wybe.int, ?tmp$12#0:wybe.bool)
-        case ~tmp$12#0:wybe.bool of
+        foreign llvm icmp_eq(~tmp$8##0:wybe.int, 1:wybe.int, ?tmp$12##0:wybe.bool)
+        case ~tmp$12##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign lpvm access(~$left#0:multictr.number, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$left$float_value#0:wybe.float)
-            foreign llvm and($right#0:wybe.int, 1:wybe.int, ?tmp$14#0:wybe.int)
-            foreign llvm icmp_eq(~tmp$14#0:wybe.int, 1:wybe.int, ?tmp$15#0:wybe.bool)
-            case ~tmp$15#0:wybe.bool of
+            foreign lpvm access(~$left##0:multictr.number, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$left$float_value##0:wybe.float)
+            foreign llvm and($right##0:wybe.int, 1:wybe.int, ?tmp$14##0:wybe.int)
+            foreign llvm icmp_eq(~tmp$14##0:wybe.int, 1:wybe.int, ?tmp$15##0:wybe.bool)
+            case ~tmp$15##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                foreign lpvm access(~$right#0:multictr.number, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$right$float_value#0:wybe.float)
-                foreign llvm fcmp_eq(~$left$float_value#0:wybe.float, ~$right$float_value#0:wybe.float, ?$$#0:wybe.bool) @float:nn:nn
+                foreign lpvm access(~$right##0:multictr.number, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$right$float_value##0:wybe.float)
+                foreign llvm fcmp_eq(~$left$float_value##0:wybe.float, ~$right$float_value##0:wybe.float, ?$$##0:wybe.bool) @float:nn:nn
 
 
 
     1:
-        foreign lpvm access(~$left#0:multictr.number, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$left$int_value#0:wybe.int)
-        foreign llvm and($right#0:wybe.int, 1:wybe.int, ?tmp$11#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$11#0:wybe.int, 0:wybe.int, ?tmp$12#0:wybe.bool)
-        case ~tmp$12#0:wybe.bool of
+        foreign lpvm access(~$left##0:multictr.number, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$left$int_value##0:wybe.int)
+        foreign llvm and($right##0:wybe.int, 1:wybe.int, ?tmp$11##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$11##0:wybe.int, 0:wybe.int, ?tmp$12##0:wybe.bool)
+        case ~tmp$12##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign lpvm access(~$right#0:multictr.number, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$right$int_value#0:wybe.int)
-            foreign llvm icmp_eq(~$left$int_value#0:wybe.int, ~$right$int_value#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+            foreign lpvm access(~$right##0:multictr.number, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$right$int_value##0:wybe.int)
+            foreign llvm icmp_eq(~$left$int_value##0:wybe.int, ~$right$int_value##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 
 float > public {inline} (0 calls)
 0: multictr.number.float<0>
-float(float_value#0:wybe.float, ?$#0:multictr.number):
+float(float_value##0:wybe.float, ?$##0:multictr.number):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr.number)
-    foreign lpvm mutate(~$rec#0:multictr.number, ?$rec#1:multictr.number, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~float_value#0:wybe.float)
-    foreign llvm or(~$rec#1:multictr.number, 1:wybe.int, ?$#0:multictr.number)
+    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr.number)
+    foreign lpvm mutate(~$rec##0:multictr.number, ?$rec##1:multictr.number, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~float_value##0:wybe.float)
+    foreign llvm or(~$rec##1:multictr.number, 1:wybe.int, ?$##0:multictr.number)
 float > public {inline} (5 calls)
 1: multictr.number.float<1>
-float(?float_value#0:wybe.float, $#0:multictr.number, ?$$#0:wybe.bool):
+float(?float_value##0:wybe.float, $##0:multictr.number, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($#0:wybe.int, 1:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 1:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.float, ?float_value#0:wybe.float)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.float, ?float_value##0:wybe.float)
 
     1:
-        foreign lpvm access(~$#0:multictr.number, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?float_value#0:wybe.float)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$##0:multictr.number, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?float_value##0:wybe.float)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 float_value > public {inline} (0 calls)
 0: multictr.number.float_value<0>
-float_value($rec#0:multictr.number, ?$#0:wybe.float, ?$$#0:wybe.bool):
+float_value($rec##0:multictr.number, ?$##0:wybe.float, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec#0:wybe.int, 1:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 1:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($rec##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.float, ?$#0:wybe.float)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.float, ?$##0:wybe.float)
 
     1:
-        foreign lpvm access(~$rec#0:multictr.number, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$#0:wybe.float)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:multictr.number, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$##0:wybe.float)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 float_value > public {inline} (0 calls)
 1: multictr.number.float_value<1>
-float_value($rec#0:multictr.number, ?$rec#1:multictr.number, $field#0:wybe.float, ?$$#0:wybe.bool):
+float_value($rec##0:multictr.number, ?$rec##1:multictr.number, $field##0:wybe.float, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec#0:wybe.int, 1:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 1:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($rec##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multictr.number, ?$rec#1:multictr.number)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multictr.number, ?$rec##1:multictr.number)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec#0:multictr.number, ?$rec#1:multictr.number, -1:wybe.int, 0:wybe.int, 8:wybe.int, 1:wybe.int, ~$field#0:wybe.float)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm {noalias} mutate(~$rec##0:multictr.number, ?$rec##1:multictr.number, -1:wybe.int, 0:wybe.int, 8:wybe.int, 1:wybe.int, ~$field##0:wybe.float)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 int > public {inline} (0 calls)
 0: multictr.number.int<0>
-int(int_value#0:wybe.int, ?$#0:multictr.number):
+int(int_value##0:wybe.int, ?$##0:multictr.number):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr.number)
-    foreign lpvm mutate(~$rec#0:multictr.number, ?$#0:multictr.number, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~int_value#0:wybe.int)
+    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr.number)
+    foreign lpvm mutate(~$rec##0:multictr.number, ?$##0:multictr.number, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~int_value##0:wybe.int)
 int > public {inline} (10 calls)
 1: multictr.number.int<1>
-int(?int_value#0:wybe.int, $#0:multictr.number, ?$$#0:wybe.bool):
+int(?int_value##0:wybe.int, $##0:multictr.number, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($#0:wybe.int, 1:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?int_value#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?int_value##0:wybe.int)
 
     1:
-        foreign lpvm access(~$#0:multictr.number, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?int_value#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$##0:multictr.number, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?int_value##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 int_value > public {inline} (0 calls)
 0: multictr.number.int_value<0>
-int_value($rec#0:multictr.number, ?$#0:wybe.int, ?$$#0:wybe.bool):
+int_value($rec##0:multictr.number, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec#0:wybe.int, 1:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($rec##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec#0:multictr.number, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:multictr.number, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 int_value > public {inline} (0 calls)
 1: multictr.number.int_value<1>
-int_value($rec#0:multictr.number, ?$rec#1:multictr.number, $field#0:wybe.int, ?$$#0:wybe.bool):
+int_value($rec##0:multictr.number, ?$rec##1:multictr.number, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec#0:wybe.int, 1:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($rec##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multictr.number, ?$rec#1:multictr.number)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multictr.number, ?$rec##1:multictr.number)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec#0:multictr.number, ?$rec#1:multictr.number, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm {noalias} mutate(~$rec##0:multictr.number, ?$rec##1:multictr.number, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: multictr.number.~=<0>
-~=($left#0:multictr.number, $right#0:multictr.number, ?$$#0:wybe.bool):
+~=($left##0:multictr.number, $right##0:multictr.number, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    multictr.number.=<0>(~$left#0:multictr.number, ~$right#0:multictr.number, ?tmp$0#0:wybe.bool) #0
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    multictr.number.=<0>(~$left##0:multictr.number, ~$right##0:multictr.number, ?tmp$0##0:wybe.bool) #0
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
   LLVM code       :
 
@@ -5954,71 +5954,71 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"multictr.number.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"multictr.number.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$8#0" = and i64 %"$left#0", 1 
-  %"1$tmp$9#0" = icmp eq i64 %"1$tmp$8#0", 0 
-  br i1 %"1$tmp$9#0", label %if.then, label %if.else 
+  %"1$tmp$8##0" = and i64 %"$left##0", 1 
+  %"1$tmp$9##0" = icmp eq i64 %"1$tmp$8##0", 0 
+  br i1 %"1$tmp$9##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %"2$tmp$11#0" = and i64 %"$right#0", 1 
-  %"2$tmp$12#0" = icmp eq i64 %"2$tmp$11#0", 0 
-  br i1 %"2$tmp$12#0", label %if.then1, label %if.else1 
+  %"2$tmp$11##0" = and i64 %"$right##0", 1 
+  %"2$tmp$12##0" = icmp eq i64 %"2$tmp$11##0", 0 
+  br i1 %"2$tmp$12##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$tmp$12#0" = icmp eq i64 %"1$tmp$8#0", 1 
-  br i1 %"3$tmp$12#0", label %if.then2, label %if.else2 
+  %"3$tmp$12##0" = icmp eq i64 %"1$tmp$8##0", 1 
+  br i1 %"3$tmp$12##0", label %if.then2, label %if.else2 
 if.then1:
-  %4 = inttoptr i64 %"$right#0" to i64* 
+  %4 = inttoptr i64 %"$right##0" to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
   %6 = load  i64, i64* %5 
-  %"4$$$#0" = icmp eq i64 %3, %6 
-  ret i1 %"4$$$#0" 
+  %"4$$$##0" = icmp eq i64 %3, %6 
+  ret i1 %"4$$$##0" 
 if.else1:
   ret i1 0 
 if.then2:
-  %7 = add   i64 %"$left#0", -1 
+  %7 = add   i64 %"$left##0", -1 
   %8 = inttoptr i64 %7 to double* 
   %9 = getelementptr  double, double* %8, i64 0 
   %10 = load  double, double* %9 
-  %"6$tmp$14#0" = and i64 %"$right#0", 1 
-  %"6$tmp$15#0" = icmp eq i64 %"6$tmp$14#0", 1 
-  br i1 %"6$tmp$15#0", label %if.then3, label %if.else3 
+  %"6$tmp$14##0" = and i64 %"$right##0", 1 
+  %"6$tmp$15##0" = icmp eq i64 %"6$tmp$14##0", 1 
+  br i1 %"6$tmp$15##0", label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %11 = add   i64 %"$right#0", -1 
+  %11 = add   i64 %"$right##0", -1 
   %12 = inttoptr i64 %11 to double* 
   %13 = getelementptr  double, double* %12, i64 0 
   %14 = load  double, double* %13 
-  %"8$$$#0" = fcmp oeq double %10, %14 
-  ret i1 %"8$$$#0" 
+  %"8$$$##0" = fcmp oeq double %10, %14 
+  ret i1 %"8$$$##0" 
 if.else3:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"multictr.number.float<0>"(double  %"float_value#0")    {
+define external fastcc  i64 @"multictr.number.float<0>"(double  %"float_value##0")    {
 entry:
   %15 = trunc i64 8 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to double* 
   %19 = getelementptr  double, double* %18, i64 0 
-  store  double %"float_value#0", double* %19 
-  %"1$$#0" = or i64 %17, 1 
-  ret i64 %"1$$#0" 
+  store  double %"float_value##0", double* %19 
+  %"1$$##0" = or i64 %17, 1 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  {double, i1} @"multictr.number.float<1>"(i64  %"$#0")    {
+define external fastcc  {double, i1} @"multictr.number.float<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$#0", 1 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 1 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$##0", 1 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 1 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %20 = add   i64 %"$#0", -1 
+  %20 = add   i64 %"$##0", -1 
   %21 = inttoptr i64 %20 to double* 
   %22 = getelementptr  double, double* %21, i64 0 
   %23 = load  double, double* %22 
@@ -6032,13 +6032,13 @@ if.else:
 }
 
 
-define external fastcc  {double, i1} @"multictr.number.float_value<0>"(i64  %"$rec#0")    {
+define external fastcc  {double, i1} @"multictr.number.float_value<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$rec#0", 1 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 1 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$rec##0", 1 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 1 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %28 = add   i64 %"$rec#0", -1 
+  %28 = add   i64 %"$rec##0", -1 
   %29 = inttoptr i64 %28 to double* 
   %30 = getelementptr  double, double* %29, i64 0 
   %31 = load  double, double* %30 
@@ -6052,17 +6052,17 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.number.float_value<1>"(i64  %"$rec#0", double  %"$field#0")    {
+define external fastcc  {i64, i1} @"multictr.number.float_value<1>"(i64  %"$rec##0", double  %"$field##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$rec#0", 1 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 1 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$rec##0", 1 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 1 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %36 = trunc i64 8 to i32  
   %37 = tail call ccc  i8*  @wybe_malloc(i32  %36)  
   %38 = ptrtoint i8* %37 to i64 
   %39 = add   i64 %38, 1 
-  %40 = sub   i64 %"$rec#0", 1 
+  %40 = sub   i64 %"$rec##0", 1 
   %41 = inttoptr i64 %38 to i8* 
   %42 = inttoptr i64 %40 to i8* 
   %43 = trunc i64 8 to i32  
@@ -6070,36 +6070,36 @@ if.then:
   %44 = add   i64 %39, -1 
   %45 = inttoptr i64 %44 to double* 
   %46 = getelementptr  double, double* %45, i64 0 
-  store  double %"$field#0", double* %46 
+  store  double %"$field##0", double* %46 
   %47 = insertvalue {i64, i1} undef, i64 %39, 0 
   %48 = insertvalue {i64, i1} %47, i1 1, 1 
   ret {i64, i1} %48 
 if.else:
-  %49 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %49 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %50 = insertvalue {i64, i1} %49, i1 0, 1 
   ret {i64, i1} %50 
 }
 
 
-define external fastcc  i64 @"multictr.number.int<0>"(i64  %"int_value#0")    {
+define external fastcc  i64 @"multictr.number.int<0>"(i64  %"int_value##0")    {
 entry:
   %51 = trunc i64 8 to i32  
   %52 = tail call ccc  i8*  @wybe_malloc(i32  %51)  
   %53 = ptrtoint i8* %52 to i64 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"int_value#0", i64* %55 
+  store  i64 %"int_value##0", i64* %55 
   ret i64 %53 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.number.int<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"multictr.number.int<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$#0", 1 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$##0", 1 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %56 = inttoptr i64 %"$#0" to i64* 
+  %56 = inttoptr i64 %"$##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
   %59 = insertvalue {i64, i1} undef, i64 %58, 0 
@@ -6112,13 +6112,13 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.number.int_value<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"multictr.number.int_value<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$rec#0", 1 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$rec##0", 1 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %63 = inttoptr i64 %"$rec#0" to i64* 
+  %63 = inttoptr i64 %"$rec##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
   %66 = insertvalue {i64, i1} undef, i64 %65, 0 
@@ -6131,37 +6131,37 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.number.int_value<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"multictr.number.int_value<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$rec#0", 1 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$rec##0", 1 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %70 = trunc i64 8 to i32  
   %71 = tail call ccc  i8*  @wybe_malloc(i32  %70)  
   %72 = ptrtoint i8* %71 to i64 
   %73 = inttoptr i64 %72 to i8* 
-  %74 = inttoptr i64 %"$rec#0" to i8* 
+  %74 = inttoptr i64 %"$rec##0" to i8* 
   %75 = trunc i64 8 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %73, i8*  %74, i32  %75, i32  8, i1  0)  
   %76 = inttoptr i64 %72 to i64* 
   %77 = getelementptr  i64, i64* %76, i64 0 
-  store  i64 %"$field#0", i64* %77 
+  store  i64 %"$field##0", i64* %77 
   %78 = insertvalue {i64, i1} undef, i64 %72, 0 
   %79 = insertvalue {i64, i1} %78, i1 1, 1 
   ret {i64, i1} %79 
 if.else:
-  %80 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %80 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %81 = insertvalue {i64, i1} %80, i1 0, 1 
   ret {i64, i1} %81 
 }
 
 
-define external fastcc  i1 @"multictr.number.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"multictr.number.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = tail call fastcc  i1  @"multictr.number.=<0>"(i64  %"$left#0", i64  %"$right#0")  
-  %"1$$$#0" = xor i1 %"1$tmp$0#0", 1 
-  ret i1 %"1$$$#0" 
+  %"1$tmp$0##0" = tail call fastcc  i1  @"multictr.number.=<0>"(i64  %"$left##0", i64  %"$right##0")  
+  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
+  ret i1 %"1$$$##0" 
 }
 --------------------------------------------------
  Module multictr.perhaps
@@ -6181,47 +6181,47 @@ entry:
 
 = > public {inline} (1 calls)
 0: multictr.perhaps.=<0>
-=($left#0:multictr.perhaps, $right#0:multictr.perhaps, ?$$#0:wybe.bool):
+=($left##0:multictr.perhaps, $right##0:multictr.perhaps, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(~$left#0:multictr.perhaps, ~$right#0:multictr.perhaps, ?$$#0:wybe.bool)
+    foreign llvm icmp_eq(~$left##0:multictr.perhaps, ~$right##0:multictr.perhaps, ?$$##0:wybe.bool)
 
 
 content > public {inline} (0 calls)
 0: multictr.perhaps.content<0>
-content($rec#0:multictr.perhaps, ?$#0:multictr.maybe_int):
+content($rec##0:multictr.perhaps, ?$##0:multictr.maybe_int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm cast(~$rec#0:multictr.perhaps, ?$#0:multictr.maybe_int)
+    foreign lpvm cast(~$rec##0:multictr.perhaps, ?$##0:multictr.maybe_int)
 content > public {inline} (0 calls)
 1: multictr.perhaps.content<1>
-content([$rec#0:multictr.perhaps], ?$rec#2:multictr.perhaps, $field#0:multictr.maybe_int):
+content([$rec##0:multictr.perhaps], ?$rec##2:multictr.perhaps, $field##0:multictr.maybe_int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(~$field#0:multictr.perhaps, ?$rec#2:multictr.perhaps)
+    foreign llvm move(~$field##0:multictr.perhaps, ?$rec##2:multictr.perhaps)
 
 
 perhaps > public {inline} (0 calls)
 0: multictr.perhaps.perhaps<0>
-perhaps(content#0:multictr.maybe_int, ?$#2:multictr.perhaps):
+perhaps(content##0:multictr.maybe_int, ?$##2:multictr.perhaps):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(~content#0:multictr.perhaps, ?$#2:multictr.perhaps)
+    foreign llvm move(~content##0:multictr.perhaps, ?$##2:multictr.perhaps)
 perhaps > public {inline} (0 calls)
 1: multictr.perhaps.perhaps<1>
-perhaps(?content#0:multictr.maybe_int, $#0:multictr.perhaps):
+perhaps(?content##0:multictr.maybe_int, $##0:multictr.perhaps):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm cast(~$#0:multictr.perhaps, ?content#0:multictr.maybe_int)
+    foreign lpvm cast(~$##0:multictr.perhaps, ?content##0:multictr.maybe_int)
 
 
 ~= > public {inline} (0 calls)
 0: multictr.perhaps.~=<0>
-~=($left#0:multictr.perhaps, $right#0:multictr.perhaps, ?$$#0:wybe.bool):
+~=($left##0:multictr.perhaps, $right##0:multictr.perhaps, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(~$left#0:multictr.perhaps, ~$right#0:multictr.perhaps, ?tmp$0#0:wybe.bool)
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    foreign llvm icmp_eq(~$left##0:multictr.perhaps, ~$right##0:multictr.perhaps, ?tmp$0##0:wybe.bool)
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
   LLVM code       :
 
@@ -6237,42 +6237,42 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"multictr.perhaps.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"multictr.perhaps.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$$$#0" = icmp eq i64 %"$left#0", %"$right#0" 
-  ret i1 %"1$$$#0" 
+  %"1$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
+  ret i1 %"1$$$##0" 
 }
 
 
-define external fastcc  i64 @"multictr.perhaps.content<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"multictr.perhaps.content<0>"(i64  %"$rec##0")    {
 entry:
-  ret i64 %"$rec#0" 
+  ret i64 %"$rec##0" 
 }
 
 
-define external fastcc  i64 @"multictr.perhaps.content<1>"(i64  %"$field#0")    {
+define external fastcc  i64 @"multictr.perhaps.content<1>"(i64  %"$field##0")    {
 entry:
-  ret i64 %"$field#0" 
+  ret i64 %"$field##0" 
 }
 
 
-define external fastcc  i64 @"multictr.perhaps.perhaps<0>"(i64  %"content#0")    {
+define external fastcc  i64 @"multictr.perhaps.perhaps<0>"(i64  %"content##0")    {
 entry:
-  ret i64 %"content#0" 
+  ret i64 %"content##0" 
 }
 
 
-define external fastcc  i64 @"multictr.perhaps.perhaps<1>"(i64  %"$#0")    {
+define external fastcc  i64 @"multictr.perhaps.perhaps<1>"(i64  %"$##0")    {
 entry:
-  ret i64 %"$#0" 
+  ret i64 %"$##0" 
 }
 
 
-define external fastcc  i1 @"multictr.perhaps.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"multictr.perhaps.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = icmp eq i64 %"$left#0", %"$right#0" 
-  %"1$$$#0" = xor i1 %"1$tmp$0#0", 1 
-  ret i1 %"1$$$#0" 
+  %"1$tmp$0##0" = icmp eq i64 %"$left##0", %"$right##0" 
+  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
+  ret i1 %"1$$$##0" 
 }
 --------------------------------------------------
  Module multictr.rank
@@ -6301,123 +6301,123 @@ entry:
 
 = > public {inline} (1 calls)
 0: multictr.rank.=<0>
-=($left#0:multictr.rank, $right#0:multictr.rank, ?$$#0:wybe.bool):
+=($left##0:multictr.rank, $right##0:multictr.rank, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(~$left#0:multictr.rank, ~$right#0:multictr.rank, ?$$#0:wybe.bool)
+    foreign llvm icmp_eq(~$left##0:multictr.rank, ~$right##0:multictr.rank, ?$$##0:wybe.bool)
 
 
 ace > public {inline} (0 calls)
 0: multictr.rank.ace<0>
-ace(?$#0:multictr.rank):
+ace(?$##0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(12:multictr.rank, ?$#0:multictr.rank)
+    foreign llvm move(12:multictr.rank, ?$##0:multictr.rank)
 
 
 jack > public {inline} (0 calls)
 0: multictr.rank.jack<0>
-jack(?$#0:multictr.rank):
+jack(?$##0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(9:multictr.rank, ?$#0:multictr.rank)
+    foreign llvm move(9:multictr.rank, ?$##0:multictr.rank)
 
 
 king > public {inline} (0 calls)
 0: multictr.rank.king<0>
-king(?$#0:multictr.rank):
+king(?$##0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(11:multictr.rank, ?$#0:multictr.rank)
+    foreign llvm move(11:multictr.rank, ?$##0:multictr.rank)
 
 
 queen > public {inline} (0 calls)
 0: multictr.rank.queen<0>
-queen(?$#0:multictr.rank):
+queen(?$##0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(10:multictr.rank, ?$#0:multictr.rank)
+    foreign llvm move(10:multictr.rank, ?$##0:multictr.rank)
 
 
 r10 > public {inline} (0 calls)
 0: multictr.rank.r10<0>
-r10(?$#0:multictr.rank):
+r10(?$##0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(8:multictr.rank, ?$#0:multictr.rank)
+    foreign llvm move(8:multictr.rank, ?$##0:multictr.rank)
 
 
 r2 > public {inline} (0 calls)
 0: multictr.rank.r2<0>
-r2(?$#0:multictr.rank):
+r2(?$##0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:multictr.rank, ?$#0:multictr.rank)
+    foreign llvm move(0:multictr.rank, ?$##0:multictr.rank)
 
 
 r3 > public {inline} (0 calls)
 0: multictr.rank.r3<0>
-r3(?$#0:multictr.rank):
+r3(?$##0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(1:multictr.rank, ?$#0:multictr.rank)
+    foreign llvm move(1:multictr.rank, ?$##0:multictr.rank)
 
 
 r4 > public {inline} (0 calls)
 0: multictr.rank.r4<0>
-r4(?$#0:multictr.rank):
+r4(?$##0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(2:multictr.rank, ?$#0:multictr.rank)
+    foreign llvm move(2:multictr.rank, ?$##0:multictr.rank)
 
 
 r5 > public {inline} (0 calls)
 0: multictr.rank.r5<0>
-r5(?$#0:multictr.rank):
+r5(?$##0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(3:multictr.rank, ?$#0:multictr.rank)
+    foreign llvm move(3:multictr.rank, ?$##0:multictr.rank)
 
 
 r6 > public {inline} (0 calls)
 0: multictr.rank.r6<0>
-r6(?$#0:multictr.rank):
+r6(?$##0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(4:multictr.rank, ?$#0:multictr.rank)
+    foreign llvm move(4:multictr.rank, ?$##0:multictr.rank)
 
 
 r7 > public {inline} (0 calls)
 0: multictr.rank.r7<0>
-r7(?$#0:multictr.rank):
+r7(?$##0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(5:multictr.rank, ?$#0:multictr.rank)
+    foreign llvm move(5:multictr.rank, ?$##0:multictr.rank)
 
 
 r8 > public {inline} (0 calls)
 0: multictr.rank.r8<0>
-r8(?$#0:multictr.rank):
+r8(?$##0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(6:multictr.rank, ?$#0:multictr.rank)
+    foreign llvm move(6:multictr.rank, ?$##0:multictr.rank)
 
 
 r9 > public {inline} (0 calls)
 0: multictr.rank.r9<0>
-r9(?$#0:multictr.rank):
+r9(?$##0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(7:multictr.rank, ?$#0:multictr.rank)
+    foreign llvm move(7:multictr.rank, ?$##0:multictr.rank)
 
 
 ~= > public {inline} (0 calls)
 0: multictr.rank.~=<0>
-~=($left#0:multictr.rank, $right#0:multictr.rank, ?$$#0:wybe.bool):
+~=($left##0:multictr.rank, $right##0:multictr.rank, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(~$left#0:multictr.rank, ~$right#0:multictr.rank, ?tmp$0#0:wybe.bool)
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    foreign llvm icmp_eq(~$left##0:multictr.rank, ~$right##0:multictr.rank, ?tmp$0##0:wybe.bool)
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
   LLVM code       :
 
@@ -6433,10 +6433,10 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"multictr.rank.=<0>"(i4  %"$left#0", i4  %"$right#0")    {
+define external fastcc  i1 @"multictr.rank.=<0>"(i4  %"$left##0", i4  %"$right##0")    {
 entry:
-  %"1$$$#0" = icmp eq i4 %"$left#0", %"$right#0" 
-  ret i1 %"1$$$#0" 
+  %"1$$$##0" = icmp eq i4 %"$left##0", %"$right##0" 
+  ret i1 %"1$$$##0" 
 }
 
 
@@ -6518,11 +6518,11 @@ entry:
 }
 
 
-define external fastcc  i1 @"multictr.rank.~=<0>"(i4  %"$left#0", i4  %"$right#0")    {
+define external fastcc  i1 @"multictr.rank.~=<0>"(i4  %"$left##0", i4  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = icmp eq i4 %"$left#0", %"$right#0" 
-  %"1$$$#0" = xor i1 %"1$tmp$0#0", 1 
-  ret i1 %"1$$$#0" 
+  %"1$tmp$0##0" = icmp eq i4 %"$left##0", %"$right##0" 
+  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
+  ret i1 %"1$$$##0" 
 }
 --------------------------------------------------
  Module multictr.simple
@@ -6549,71 +6549,71 @@ entry:
 
 = > public (1 calls)
 0: multictr.simple.=<0>
-=($left#0:multictr.simple, $right#0:multictr.simple, ?$$#0:wybe.bool):
+=($left##0:multictr.simple, $right##0:multictr.simple, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left#0:multictr.simple, ~$right#0:multictr.simple, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~$left##0:multictr.simple, ~$right##0:multictr.simple, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm and($left#0:wybe.int, 1:wybe.int, ?tmp$11#0:wybe.int)
-        foreign llvm icmp_eq(tmp$11#0:wybe.int, 0:wybe.int, ?tmp$12#0:wybe.bool)
-        case ~tmp$12#0:wybe.bool of
+        foreign llvm and($left##0:wybe.int, 1:wybe.int, ?tmp$11##0:wybe.int)
+        foreign llvm icmp_eq(tmp$11##0:wybe.int, 0:wybe.int, ?tmp$12##0:wybe.bool)
+        case ~tmp$12##0:wybe.bool of
         0:
-            foreign llvm icmp_eq(~tmp$11#0:wybe.int, 1:wybe.int, ?tmp$16#0:wybe.bool)
-            case ~tmp$16#0:wybe.bool of
+            foreign llvm icmp_eq(~tmp$11##0:wybe.int, 1:wybe.int, ?tmp$16##0:wybe.bool)
+            case ~tmp$16##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                foreign lpvm access($left#0:multictr.simple, -1:wybe.int, 16:wybe.int, 1:wybe.int, ?$left$two_field1#0:wybe.int)
-                foreign lpvm access(~$left#0:multictr.simple, 7:wybe.int, 16:wybe.int, 1:wybe.int, ?$left$two_field2#0:wybe.int)
-                foreign llvm icmp_ne($right#0:wybe.int, 0:wybe.int, ?tmp$18#0:wybe.bool)
-                case ~tmp$18#0:wybe.bool of
+                foreign lpvm access($left##0:multictr.simple, -1:wybe.int, 16:wybe.int, 1:wybe.int, ?$left$two_field1##0:wybe.int)
+                foreign lpvm access(~$left##0:multictr.simple, 7:wybe.int, 16:wybe.int, 1:wybe.int, ?$left$two_field2##0:wybe.int)
+                foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$18##0:wybe.bool)
+                case ~tmp$18##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                 1:
-                    foreign llvm and($right#0:wybe.int, 1:wybe.int, ?tmp$19#0:wybe.int)
-                    foreign llvm icmp_eq(~tmp$19#0:wybe.int, 1:wybe.int, ?tmp$20#0:wybe.bool)
-                    case ~tmp$20#0:wybe.bool of
+                    foreign llvm and($right##0:wybe.int, 1:wybe.int, ?tmp$19##0:wybe.int)
+                    foreign llvm icmp_eq(~tmp$19##0:wybe.int, 1:wybe.int, ?tmp$20##0:wybe.bool)
+                    case ~tmp$20##0:wybe.bool of
                     0:
-                        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                     1:
-                        foreign lpvm access($right#0:multictr.simple, -1:wybe.int, 16:wybe.int, 1:wybe.int, ?$right$two_field1#0:wybe.int)
-                        foreign lpvm access(~$right#0:multictr.simple, 7:wybe.int, 16:wybe.int, 1:wybe.int, ?$right$two_field2#0:wybe.int)
-                        foreign llvm icmp_eq(~$left$two_field1#0:wybe.int, ~$right$two_field1#0:wybe.int, ?tmp$5#0:wybe.bool) @int:nn:nn
-                        case ~tmp$5#0:wybe.bool of
+                        foreign lpvm access($right##0:multictr.simple, -1:wybe.int, 16:wybe.int, 1:wybe.int, ?$right$two_field1##0:wybe.int)
+                        foreign lpvm access(~$right##0:multictr.simple, 7:wybe.int, 16:wybe.int, 1:wybe.int, ?$right$two_field2##0:wybe.int)
+                        foreign llvm icmp_eq(~$left$two_field1##0:wybe.int, ~$right$two_field1##0:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
+                        case ~tmp$5##0:wybe.bool of
                         0:
-                            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                         1:
-                            foreign llvm icmp_eq(~$left$two_field2#0:wybe.int, ~$right$two_field2#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+                            foreign llvm icmp_eq(~$left$two_field2##0:wybe.int, ~$right$two_field2##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 
 
         1:
-            foreign lpvm access(~$left#0:multictr.simple, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$left$one_field#0:wybe.int)
-            foreign llvm icmp_ne($right#0:wybe.int, 0:wybe.int, ?tmp$14#0:wybe.bool)
-            case ~tmp$14#0:wybe.bool of
+            foreign lpvm access(~$left##0:multictr.simple, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$left$one_field##0:wybe.int)
+            foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$14##0:wybe.bool)
+            case ~tmp$14##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                foreign llvm and($right#0:wybe.int, 1:wybe.int, ?tmp$15#0:wybe.int)
-                foreign llvm icmp_eq(~tmp$15#0:wybe.int, 0:wybe.int, ?tmp$16#0:wybe.bool)
-                case ~tmp$16#0:wybe.bool of
+                foreign llvm and($right##0:wybe.int, 1:wybe.int, ?tmp$15##0:wybe.int)
+                foreign llvm icmp_eq(~tmp$15##0:wybe.int, 0:wybe.int, ?tmp$16##0:wybe.bool)
+                case ~tmp$16##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                 1:
-                    foreign lpvm access(~$right#0:multictr.simple, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$right$one_field#0:wybe.int)
-                    foreign llvm icmp_eq(~$left$one_field#0:wybe.int, ~$right$one_field#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+                    foreign lpvm access(~$right##0:multictr.simple, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$right$one_field##0:wybe.int)
+                    foreign llvm icmp_eq(~$left$one_field##0:wybe.int, ~$right$one_field##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
@@ -6622,240 +6622,240 @@ entry:
 
 one > public {inline} (0 calls)
 0: multictr.simple.one<0>
-one(one_field#0:wybe.int, ?$#0:multictr.simple):
+one(one_field##0:wybe.int, ?$##0:multictr.simple):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr.simple)
-    foreign lpvm mutate(~$rec#0:multictr.simple, ?$#0:multictr.simple, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~one_field#0:wybe.int)
+    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr.simple)
+    foreign lpvm mutate(~$rec##0:multictr.simple, ?$##0:multictr.simple, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~one_field##0:wybe.int)
 one > public {inline} (11 calls)
 1: multictr.simple.one<1>
-one(?one_field#0:wybe.int, $#0:multictr.simple, ?$$#0:wybe.bool):
+one(?one_field##0:wybe.int, $##0:multictr.simple, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?one_field#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?one_field##0:wybe.int)
 
     1:
-        foreign llvm and($#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?one_field#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?one_field##0:wybe.int)
 
         1:
-            foreign lpvm access(~$#0:multictr.simple, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?one_field#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm access(~$##0:multictr.simple, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?one_field##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 one_field > public {inline} (0 calls)
 0: multictr.simple.one_field<0>
-one_field($rec#0:multictr.simple, ?$#0:wybe.int, ?$$#0:wybe.bool):
+one_field($rec##0:multictr.simple, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
         1:
-            foreign lpvm access(~$rec#0:multictr.simple, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm access(~$rec##0:multictr.simple, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 one_field > public {inline} (0 calls)
 1: multictr.simple.one_field<1>
-one_field($rec#0:multictr.simple, ?$rec#1:multictr.simple, $field#0:wybe.int, ?$$#0:wybe.bool):
+one_field($rec##0:multictr.simple, ?$rec##1:multictr.simple, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multictr.simple, ?$rec#1:multictr.simple)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multictr.simple, ?$rec##1:multictr.simple)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(~$rec#0:multictr.simple, ?$rec#1:multictr.simple)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(~$rec##0:multictr.simple, ?$rec##1:multictr.simple)
 
         1:
-            foreign lpvm {noalias} mutate(~$rec#0:multictr.simple, ?$rec#1:multictr.simple, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm {noalias} mutate(~$rec##0:multictr.simple, ?$rec##1:multictr.simple, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 two > public {inline} (0 calls)
 0: multictr.simple.two<0>
-two(two_field1#0:wybe.int, two_field2#0:wybe.int, ?$#0:multictr.simple):
+two(two_field1##0:wybe.int, two_field2##0:wybe.int, ?$##0:multictr.simple):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:multictr.simple)
-    foreign lpvm mutate(~$rec#0:multictr.simple, ?$rec#1:multictr.simple, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~two_field1#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:multictr.simple, ?$rec#2:multictr.simple, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~two_field2#0:wybe.int)
-    foreign llvm or(~$rec#2:multictr.simple, 1:wybe.int, ?$#0:multictr.simple)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:multictr.simple)
+    foreign lpvm mutate(~$rec##0:multictr.simple, ?$rec##1:multictr.simple, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~two_field1##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:multictr.simple, ?$rec##2:multictr.simple, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~two_field2##0:wybe.int)
+    foreign llvm or(~$rec##2:multictr.simple, 1:wybe.int, ?$##0:multictr.simple)
 two > public {inline} (7 calls)
 1: multictr.simple.two<1>
-two(?two_field1#0:wybe.int, ?two_field2#0:wybe.int, $#0:multictr.simple, ?$$#0:wybe.bool):
+two(?two_field1##0:wybe.int, ?two_field2##0:wybe.int, $##0:multictr.simple, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?two_field1#0:wybe.int)
-        foreign llvm move(undef:wybe.int, ?two_field2#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?two_field1##0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?two_field2##0:wybe.int)
 
     1:
-        foreign llvm and($#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 1:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?two_field1#0:wybe.int)
-            foreign llvm move(undef:wybe.int, ?two_field2#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?two_field1##0:wybe.int)
+            foreign llvm move(undef:wybe.int, ?two_field2##0:wybe.int)
 
         1:
-            foreign lpvm access($#0:multictr.simple, -1:wybe.int, 16:wybe.int, 1:wybe.int, ?two_field1#0:wybe.int)
-            foreign lpvm access(~$#0:multictr.simple, 7:wybe.int, 16:wybe.int, 1:wybe.int, ?two_field2#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm access($##0:multictr.simple, -1:wybe.int, 16:wybe.int, 1:wybe.int, ?two_field1##0:wybe.int)
+            foreign lpvm access(~$##0:multictr.simple, 7:wybe.int, 16:wybe.int, 1:wybe.int, ?two_field2##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 two_field1 > public {inline} (0 calls)
 0: multictr.simple.two_field1<0>
-two_field1($rec#0:multictr.simple, ?$#0:wybe.int, ?$$#0:wybe.bool):
+two_field1($rec##0:multictr.simple, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 1:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
         1:
-            foreign lpvm access(~$rec#0:multictr.simple, -1:wybe.int, 16:wybe.int, 1:wybe.int, ?$#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm access(~$rec##0:multictr.simple, -1:wybe.int, 16:wybe.int, 1:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 two_field1 > public {inline} (0 calls)
 1: multictr.simple.two_field1<1>
-two_field1($rec#0:multictr.simple, ?$rec#1:multictr.simple, $field#0:wybe.int, ?$$#0:wybe.bool):
+two_field1($rec##0:multictr.simple, ?$rec##1:multictr.simple, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multictr.simple, ?$rec#1:multictr.simple)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multictr.simple, ?$rec##1:multictr.simple)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 1:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(~$rec#0:multictr.simple, ?$rec#1:multictr.simple)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(~$rec##0:multictr.simple, ?$rec##1:multictr.simple)
 
         1:
-            foreign lpvm {noalias} mutate(~$rec#0:multictr.simple, ?$rec#1:multictr.simple, -1:wybe.int, 0:wybe.int, 16:wybe.int, 1:wybe.int, ~$field#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm {noalias} mutate(~$rec##0:multictr.simple, ?$rec##1:multictr.simple, -1:wybe.int, 0:wybe.int, 16:wybe.int, 1:wybe.int, ~$field##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 two_field2 > public {inline} (0 calls)
 0: multictr.simple.two_field2<0>
-two_field2($rec#0:multictr.simple, ?$#0:wybe.int, ?$$#0:wybe.bool):
+two_field2($rec##0:multictr.simple, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 1:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
         1:
-            foreign lpvm access(~$rec#0:multictr.simple, 7:wybe.int, 16:wybe.int, 1:wybe.int, ?$#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm access(~$rec##0:multictr.simple, 7:wybe.int, 16:wybe.int, 1:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 two_field2 > public {inline} (0 calls)
 1: multictr.simple.two_field2<1>
-two_field2($rec#0:multictr.simple, ?$rec#1:multictr.simple, $field#0:wybe.int, ?$$#0:wybe.bool):
+two_field2($rec##0:multictr.simple, ?$rec##1:multictr.simple, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multictr.simple, ?$rec#1:multictr.simple)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multictr.simple, ?$rec##1:multictr.simple)
 
     1:
-        foreign llvm and($rec#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2#0:wybe.int, 1:wybe.int, ?tmp$1#0:wybe.bool)
-        case ~tmp$1#0:wybe.bool of
+        foreign llvm and($rec##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.bool)
+        case ~tmp$1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(~$rec#0:multictr.simple, ?$rec#1:multictr.simple)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(~$rec##0:multictr.simple, ?$rec##1:multictr.simple)
 
         1:
-            foreign lpvm {noalias} mutate(~$rec#0:multictr.simple, ?$rec#1:multictr.simple, 7:wybe.int, 0:wybe.int, 16:wybe.int, 1:wybe.int, ~$field#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm {noalias} mutate(~$rec##0:multictr.simple, ?$rec##1:multictr.simple, 7:wybe.int, 0:wybe.int, 16:wybe.int, 1:wybe.int, ~$field##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 zero > public {inline} (0 calls)
 0: multictr.simple.zero<0>
-zero(?$#0:multictr.simple):
+zero(?$##0:multictr.simple):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:multictr.simple, ?$#0:multictr.simple)
+    foreign llvm move(0:multictr.simple, ?$##0:multictr.simple)
 
 
 ~= > public {inline} (0 calls)
 0: multictr.simple.~=<0>
-~=($left#0:multictr.simple, $right#0:multictr.simple, ?$$#0:wybe.bool):
+~=($left##0:multictr.simple, $right##0:multictr.simple, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    multictr.simple.=<0>(~$left#0:multictr.simple, ~$right#0:multictr.simple, ?tmp$0#0:wybe.bool) #0
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    multictr.simple.=<0>(~$left##0:multictr.simple, ~$right##0:multictr.simple, ?tmp$0##0:wybe.bool) #0
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
   LLVM code       :
 
@@ -6871,106 +6871,106 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"multictr.simple.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"multictr.simple.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$left#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$11#0" = and i64 %"$left#0", 1 
-  %"2$tmp$12#0" = icmp eq i64 %"2$tmp$11#0", 0 
-  br i1 %"2$tmp$12#0", label %if.then1, label %if.else1 
+  %"2$tmp$11##0" = and i64 %"$left##0", 1 
+  %"2$tmp$12##0" = icmp eq i64 %"2$tmp$11##0", 0 
+  br i1 %"2$tmp$12##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = icmp eq i64 %"$left#0", %"$right#0" 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
+  ret i1 %"3$$$##0" 
 if.then1:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %"4$tmp$14#0" = icmp ne i64 %"$right#0", 0 
-  br i1 %"4$tmp$14#0", label %if.then2, label %if.else2 
+  %"4$tmp$14##0" = icmp ne i64 %"$right##0", 0 
+  br i1 %"4$tmp$14##0", label %if.then2, label %if.else2 
 if.else1:
-  %"5$tmp$16#0" = icmp eq i64 %"2$tmp$11#0", 1 
-  br i1 %"5$tmp$16#0", label %if.then4, label %if.else4 
+  %"5$tmp$16##0" = icmp eq i64 %"2$tmp$11##0", 1 
+  br i1 %"5$tmp$16##0", label %if.then4, label %if.else4 
 if.then2:
-  %"6$tmp$15#0" = and i64 %"$right#0", 1 
-  %"6$tmp$16#0" = icmp eq i64 %"6$tmp$15#0", 0 
-  br i1 %"6$tmp$16#0", label %if.then3, label %if.else3 
+  %"6$tmp$15##0" = and i64 %"$right##0", 1 
+  %"6$tmp$16##0" = icmp eq i64 %"6$tmp$15##0", 0 
+  br i1 %"6$tmp$16##0", label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %4 = inttoptr i64 %"$right#0" to i64* 
+  %4 = inttoptr i64 %"$right##0" to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
   %6 = load  i64, i64* %5 
-  %"8$$$#0" = icmp eq i64 %3, %6 
-  ret i1 %"8$$$#0" 
+  %"8$$$##0" = icmp eq i64 %3, %6 
+  ret i1 %"8$$$##0" 
 if.else3:
   ret i1 0 
 if.then4:
-  %7 = add   i64 %"$left#0", -1 
+  %7 = add   i64 %"$left##0", -1 
   %8 = inttoptr i64 %7 to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$left#0", 7 
+  %11 = add   i64 %"$left##0", 7 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"10$tmp$18#0" = icmp ne i64 %"$right#0", 0 
-  br i1 %"10$tmp$18#0", label %if.then5, label %if.else5 
+  %"10$tmp$18##0" = icmp ne i64 %"$right##0", 0 
+  br i1 %"10$tmp$18##0", label %if.then5, label %if.else5 
 if.else4:
   ret i1 0 
 if.then5:
-  %"12$tmp$19#0" = and i64 %"$right#0", 1 
-  %"12$tmp$20#0" = icmp eq i64 %"12$tmp$19#0", 1 
-  br i1 %"12$tmp$20#0", label %if.then6, label %if.else6 
+  %"12$tmp$19##0" = and i64 %"$right##0", 1 
+  %"12$tmp$20##0" = icmp eq i64 %"12$tmp$19##0", 1 
+  br i1 %"12$tmp$20##0", label %if.then6, label %if.else6 
 if.else5:
   ret i1 0 
 if.then6:
-  %15 = add   i64 %"$right#0", -1 
+  %15 = add   i64 %"$right##0", -1 
   %16 = inttoptr i64 %15 to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
-  %19 = add   i64 %"$right#0", 7 
+  %19 = add   i64 %"$right##0", 7 
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %"14$tmp$5#0" = icmp eq i64 %10, %18 
-  br i1 %"14$tmp$5#0", label %if.then7, label %if.else7 
+  %"14$tmp$5##0" = icmp eq i64 %10, %18 
+  br i1 %"14$tmp$5##0", label %if.then7, label %if.else7 
 if.else6:
   ret i1 0 
 if.then7:
-  %"16$$$#0" = icmp eq i64 %14, %22 
-  ret i1 %"16$$$#0" 
+  %"16$$$##0" = icmp eq i64 %14, %22 
+  ret i1 %"16$$$##0" 
 if.else7:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"multictr.simple.one<0>"(i64  %"one_field#0")    {
+define external fastcc  i64 @"multictr.simple.one<0>"(i64  %"one_field##0")    {
 entry:
   %23 = trunc i64 8 to i32  
   %24 = tail call ccc  i8*  @wybe_malloc(i32  %23)  
   %25 = ptrtoint i8* %24 to i64 
   %26 = inttoptr i64 %25 to i64* 
   %27 = getelementptr  i64, i64* %26, i64 0 
-  store  i64 %"one_field#0", i64* %27 
+  store  i64 %"one_field##0", i64* %27 
   ret i64 %25 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.simple.one<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"multictr.simple.one<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$#0", 1 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 0 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$##0", 1 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 0 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %35 = insertvalue {i64, i1} undef, i64 undef, 0 
   %36 = insertvalue {i64, i1} %35, i1 0, 1 
   ret {i64, i1} %36 
 if.then1:
-  %28 = inttoptr i64 %"$#0" to i64* 
+  %28 = inttoptr i64 %"$##0" to i64* 
   %29 = getelementptr  i64, i64* %28, i64 0 
   %30 = load  i64, i64* %29 
   %31 = insertvalue {i64, i1} undef, i64 %30, 0 
@@ -6983,20 +6983,20 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.simple.one_field<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"multictr.simple.one_field<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 1 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 0 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 1 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 0 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %44 = insertvalue {i64, i1} undef, i64 undef, 0 
   %45 = insertvalue {i64, i1} %44, i1 0, 1 
   ret {i64, i1} %45 
 if.then1:
-  %37 = inttoptr i64 %"$rec#0" to i64* 
+  %37 = inttoptr i64 %"$rec##0" to i64* 
   %38 = getelementptr  i64, i64* %37, i64 0 
   %39 = load  i64, i64* %38 
   %40 = insertvalue {i64, i1} undef, i64 %39, 0 
@@ -7009,16 +7009,16 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.simple.one_field<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"multictr.simple.one_field<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 1 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 0 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 1 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 0 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
-  %58 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %58 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %59 = insertvalue {i64, i1} %58, i1 0, 1 
   ret {i64, i1} %59 
 if.then1:
@@ -7026,58 +7026,58 @@ if.then1:
   %47 = tail call ccc  i8*  @wybe_malloc(i32  %46)  
   %48 = ptrtoint i8* %47 to i64 
   %49 = inttoptr i64 %48 to i8* 
-  %50 = inttoptr i64 %"$rec#0" to i8* 
+  %50 = inttoptr i64 %"$rec##0" to i8* 
   %51 = trunc i64 8 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %49, i8*  %50, i32  %51, i32  8, i1  0)  
   %52 = inttoptr i64 %48 to i64* 
   %53 = getelementptr  i64, i64* %52, i64 0 
-  store  i64 %"$field#0", i64* %53 
+  store  i64 %"$field##0", i64* %53 
   %54 = insertvalue {i64, i1} undef, i64 %48, 0 
   %55 = insertvalue {i64, i1} %54, i1 1, 1 
   ret {i64, i1} %55 
 if.else1:
-  %56 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %56 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %57 = insertvalue {i64, i1} %56, i1 0, 1 
   ret {i64, i1} %57 
 }
 
 
-define external fastcc  i64 @"multictr.simple.two<0>"(i64  %"two_field1#0", i64  %"two_field2#0")    {
+define external fastcc  i64 @"multictr.simple.two<0>"(i64  %"two_field1##0", i64  %"two_field2##0")    {
 entry:
   %60 = trunc i64 16 to i32  
   %61 = tail call ccc  i8*  @wybe_malloc(i32  %60)  
   %62 = ptrtoint i8* %61 to i64 
   %63 = inttoptr i64 %62 to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
-  store  i64 %"two_field1#0", i64* %64 
+  store  i64 %"two_field1##0", i64* %64 
   %65 = add   i64 %62, 8 
   %66 = inttoptr i64 %65 to i64* 
   %67 = getelementptr  i64, i64* %66, i64 0 
-  store  i64 %"two_field2#0", i64* %67 
-  %"1$$#0" = or i64 %62, 1 
-  ret i64 %"1$$#0" 
+  store  i64 %"two_field2##0", i64* %67 
+  %"1$$##0" = or i64 %62, 1 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  {i64, i64, i1} @"multictr.simple.two<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64, i1} @"multictr.simple.two<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$#0", 1 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 1 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$##0", 1 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 1 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %82 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
   %83 = insertvalue {i64, i64, i1} %82, i64 undef, 1 
   %84 = insertvalue {i64, i64, i1} %83, i1 0, 2 
   ret {i64, i64, i1} %84 
 if.then1:
-  %68 = add   i64 %"$#0", -1 
+  %68 = add   i64 %"$##0", -1 
   %69 = inttoptr i64 %68 to i64* 
   %70 = getelementptr  i64, i64* %69, i64 0 
   %71 = load  i64, i64* %70 
-  %72 = add   i64 %"$#0", 7 
+  %72 = add   i64 %"$##0", 7 
   %73 = inttoptr i64 %72 to i64* 
   %74 = getelementptr  i64, i64* %73, i64 0 
   %75 = load  i64, i64* %74 
@@ -7093,20 +7093,20 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.simple.two_field1<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"multictr.simple.two_field1<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 1 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 1 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 1 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 1 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %93 = insertvalue {i64, i1} undef, i64 undef, 0 
   %94 = insertvalue {i64, i1} %93, i1 0, 1 
   ret {i64, i1} %94 
 if.then1:
-  %85 = add   i64 %"$rec#0", -1 
+  %85 = add   i64 %"$rec##0", -1 
   %86 = inttoptr i64 %85 to i64* 
   %87 = getelementptr  i64, i64* %86, i64 0 
   %88 = load  i64, i64* %87 
@@ -7120,16 +7120,16 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.simple.two_field1<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"multictr.simple.two_field1<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 1 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 1 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 1 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 1 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
-  %110 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %110 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %111 = insertvalue {i64, i1} %110, i1 0, 1 
   ret {i64, i1} %111 
 if.then1:
@@ -7137,7 +7137,7 @@ if.then1:
   %96 = tail call ccc  i8*  @wybe_malloc(i32  %95)  
   %97 = ptrtoint i8* %96 to i64 
   %98 = add   i64 %97, 1 
-  %99 = sub   i64 %"$rec#0", 1 
+  %99 = sub   i64 %"$rec##0", 1 
   %100 = inttoptr i64 %97 to i8* 
   %101 = inttoptr i64 %99 to i8* 
   %102 = trunc i64 16 to i32  
@@ -7145,31 +7145,31 @@ if.then1:
   %103 = add   i64 %98, -1 
   %104 = inttoptr i64 %103 to i64* 
   %105 = getelementptr  i64, i64* %104, i64 0 
-  store  i64 %"$field#0", i64* %105 
+  store  i64 %"$field##0", i64* %105 
   %106 = insertvalue {i64, i1} undef, i64 %98, 0 
   %107 = insertvalue {i64, i1} %106, i1 1, 1 
   ret {i64, i1} %107 
 if.else1:
-  %108 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %108 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %109 = insertvalue {i64, i1} %108, i1 0, 1 
   ret {i64, i1} %109 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.simple.two_field2<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"multictr.simple.two_field2<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 1 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 1 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 1 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 1 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
   %120 = insertvalue {i64, i1} undef, i64 undef, 0 
   %121 = insertvalue {i64, i1} %120, i1 0, 1 
   ret {i64, i1} %121 
 if.then1:
-  %112 = add   i64 %"$rec#0", 7 
+  %112 = add   i64 %"$rec##0", 7 
   %113 = inttoptr i64 %112 to i64* 
   %114 = getelementptr  i64, i64* %113, i64 0 
   %115 = load  i64, i64* %114 
@@ -7183,16 +7183,16 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.simple.two_field2<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"multictr.simple.two_field2<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = and i64 %"$rec#0", 1 
-  %"2$tmp$1#0" = icmp eq i64 %"2$tmp$2#0", 1 
-  br i1 %"2$tmp$1#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = and i64 %"$rec##0", 1 
+  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 1 
+  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
 if.else:
-  %137 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %137 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %138 = insertvalue {i64, i1} %137, i1 0, 1 
   ret {i64, i1} %138 
 if.then1:
@@ -7200,7 +7200,7 @@ if.then1:
   %123 = tail call ccc  i8*  @wybe_malloc(i32  %122)  
   %124 = ptrtoint i8* %123 to i64 
   %125 = add   i64 %124, 1 
-  %126 = sub   i64 %"$rec#0", 1 
+  %126 = sub   i64 %"$rec##0", 1 
   %127 = inttoptr i64 %124 to i8* 
   %128 = inttoptr i64 %126 to i8* 
   %129 = trunc i64 16 to i32  
@@ -7208,12 +7208,12 @@ if.then1:
   %130 = add   i64 %125, 7 
   %131 = inttoptr i64 %130 to i64* 
   %132 = getelementptr  i64, i64* %131, i64 0 
-  store  i64 %"$field#0", i64* %132 
+  store  i64 %"$field##0", i64* %132 
   %133 = insertvalue {i64, i1} undef, i64 %125, 0 
   %134 = insertvalue {i64, i1} %133, i1 1, 1 
   ret {i64, i1} %134 
 if.else1:
-  %135 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %135 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %136 = insertvalue {i64, i1} %135, i1 0, 1 
   ret {i64, i1} %136 
 }
@@ -7225,11 +7225,11 @@ entry:
 }
 
 
-define external fastcc  i1 @"multictr.simple.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"multictr.simple.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = tail call fastcc  i1  @"multictr.simple.=<0>"(i64  %"$left#0", i64  %"$right#0")  
-  %"1$$$#0" = xor i1 %"1$tmp$0#0", 1 
-  ret i1 %"1$$$#0" 
+  %"1$tmp$0##0" = tail call fastcc  i1  @"multictr.simple.=<0>"(i64  %"$left##0", i64  %"$right##0")  
+  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
+  ret i1 %"1$$$##0" 
 }
 --------------------------------------------------
  Module multictr.suit
@@ -7249,51 +7249,51 @@ entry:
 
 = > public {inline} (1 calls)
 0: multictr.suit.=<0>
-=($left#0:multictr.suit, $right#0:multictr.suit, ?$$#0:wybe.bool):
+=($left##0:multictr.suit, $right##0:multictr.suit, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(~$left#0:multictr.suit, ~$right#0:multictr.suit, ?$$#0:wybe.bool)
+    foreign llvm icmp_eq(~$left##0:multictr.suit, ~$right##0:multictr.suit, ?$$##0:wybe.bool)
 
 
 clubs > public {inline} (0 calls)
 0: multictr.suit.clubs<0>
-clubs(?$#0:multictr.suit):
+clubs(?$##0:multictr.suit):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:multictr.suit, ?$#0:multictr.suit)
+    foreign llvm move(0:multictr.suit, ?$##0:multictr.suit)
 
 
 diamonds > public {inline} (0 calls)
 0: multictr.suit.diamonds<0>
-diamonds(?$#0:multictr.suit):
+diamonds(?$##0:multictr.suit):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(1:multictr.suit, ?$#0:multictr.suit)
+    foreign llvm move(1:multictr.suit, ?$##0:multictr.suit)
 
 
 hearts > public {inline} (0 calls)
 0: multictr.suit.hearts<0>
-hearts(?$#0:multictr.suit):
+hearts(?$##0:multictr.suit):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(2:multictr.suit, ?$#0:multictr.suit)
+    foreign llvm move(2:multictr.suit, ?$##0:multictr.suit)
 
 
 spades > public {inline} (0 calls)
 0: multictr.suit.spades<0>
-spades(?$#0:multictr.suit):
+spades(?$##0:multictr.suit):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(3:multictr.suit, ?$#0:multictr.suit)
+    foreign llvm move(3:multictr.suit, ?$##0:multictr.suit)
 
 
 ~= > public {inline} (0 calls)
 0: multictr.suit.~=<0>
-~=($left#0:multictr.suit, $right#0:multictr.suit, ?$$#0:wybe.bool):
+~=($left##0:multictr.suit, $right##0:multictr.suit, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(~$left#0:multictr.suit, ~$right#0:multictr.suit, ?tmp$0#0:wybe.bool)
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    foreign llvm icmp_eq(~$left##0:multictr.suit, ~$right##0:multictr.suit, ?tmp$0##0:wybe.bool)
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
   LLVM code       :
 
@@ -7309,10 +7309,10 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"multictr.suit.=<0>"(i2  %"$left#0", i2  %"$right#0")    {
+define external fastcc  i1 @"multictr.suit.=<0>"(i2  %"$left##0", i2  %"$right##0")    {
 entry:
-  %"1$$$#0" = icmp eq i2 %"$left#0", %"$right#0" 
-  ret i1 %"1$$$#0" 
+  %"1$$$##0" = icmp eq i2 %"$left##0", %"$right##0" 
+  ret i1 %"1$$$##0" 
 }
 
 
@@ -7340,11 +7340,11 @@ entry:
 }
 
 
-define external fastcc  i1 @"multictr.suit.~=<0>"(i2  %"$left#0", i2  %"$right#0")    {
+define external fastcc  i1 @"multictr.suit.~=<0>"(i2  %"$left##0", i2  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = icmp eq i2 %"$left#0", %"$right#0" 
-  %"1$$$#0" = xor i1 %"1$tmp$0#0", 1 
-  ret i1 %"1$$$#0" 
+  %"1$tmp$0##0" = icmp eq i2 %"$left##0", %"$right##0" 
+  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
+  ret i1 %"1$$$##0" 
 }
 --------------------------------------------------
  Module multictr.unit
@@ -7361,26 +7361,26 @@ entry:
 
 = > public {inline} (1 calls)
 0: multictr.unit.=<0>
-=([$left#0:multictr.unit], [$right#0:multictr.unit], ?$$#0:wybe.bool):
+=([$left##0:multictr.unit], [$right##0:multictr.unit], ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+    foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 unit > public {inline} (0 calls)
 0: multictr.unit.unit<0>
-unit(?$#0:multictr.unit):
+unit(?$##0:multictr.unit):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:multictr.unit, ?$#0:multictr.unit)
+    foreign llvm move(0:multictr.unit, ?$##0:multictr.unit)
 
 
 ~= > public {inline} (0 calls)
 0: multictr.unit.~=<0>
-~=([$left#0:multictr.unit], [$right#0:multictr.unit], ?$$#0:wybe.bool):
+~=([$left##0:multictr.unit], [$right##0:multictr.unit], ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
   LLVM code       :
 

--- a/test-cases/final-dump/multictr.exp
+++ b/test-cases/final-dump/multictr.exp
@@ -248,8 +248,8 @@ rank($rec#0:multictr.card, ?$rec#2:multictr.card, $field#0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(~$rec#0:multictr.card, -61:multictr.card, ?$rec#1:multictr.card)
-    foreign llvm shl(~$field#0:multictr.card, 2:multictr.card, ?$tmp#0:multictr.card)
-    foreign llvm or(~$rec#1:multictr.card, ~$tmp#0:multictr.card, ?$rec#2:multictr.card)
+    foreign llvm shl(~$field#0:multictr.card, 2:multictr.card, ?$temp#0:multictr.card)
+    foreign llvm or(~$rec#1:multictr.card, ~$temp#0:multictr.card, ?$rec#2:multictr.card)
 
 
 suit > public {inline} (0 calls)
@@ -333,8 +333,8 @@ define external fastcc  i6 @"multictr.card.rank<1>"(i6  %"$rec#0", i4  %"$field#
 entry:
   %"1$$rec#1" = and i6 %"$rec#0", -61 
   %8 = zext i4 %"$field#0" to i6  
-  %"1$$tmp#0" = shl   i6 %8, 2 
-  %"1$$rec#2" = or i6 %"1$$rec#1", %"1$$tmp#0" 
+  %"1$$temp#0" = shl   i6 %8, 2 
+  %"1$$rec#2" = or i6 %"1$$rec#1", %"1$$temp#0" 
   ret i6 %"1$$rec#2" 
 }
 

--- a/test-cases/final-dump/multictr.exp
+++ b/test-cases/final-dump/multictr.exp
@@ -209,72 +209,72 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 = > public {inline} (1 calls)
 0: multictr.card.=<0>
-=($left##0:multictr.card, $right##0:multictr.card, ?$$##0:wybe.bool):
+=(#left##0:multictr.card, #right##0:multictr.card, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(~$left##0:multictr.card, ~$right##0:multictr.card, ?$$##0:wybe.bool)
+    foreign llvm icmp_eq(~#left##0:multictr.card, ~#right##0:multictr.card, ?####0:wybe.bool)
 
 
 card > public {inline} (0 calls)
 0: multictr.card.card<0>
-card(suit##0:multictr.suit, rank##0:multictr.rank, ?$##3:multictr.card):
+card(suit##0:multictr.suit, rank##0:multictr.rank, ?###3:multictr.card):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm shl(~rank##0:multictr.card, 2:multictr.card, ?$temp##1:multictr.card)
-    foreign llvm or(~$temp##1:multictr.card, ~suit##0:multictr.card, ?$##3:multictr.card)
+    foreign llvm shl(~rank##0:multictr.card, 2:multictr.card, ?#temp##1:multictr.card)
+    foreign llvm or(~#temp##1:multictr.card, ~suit##0:multictr.card, ?###3:multictr.card)
 card > public {inline} (0 calls)
 1: multictr.card.card<1>
-card(?suit##0:multictr.suit, ?rank##0:multictr.rank, $##0:multictr.card):
+card(?suit##0:multictr.suit, ?rank##0:multictr.rank, ###0:multictr.card):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($##0:multictr.card, 3:multictr.card, ?$temp2##0:multictr.card)
-    foreign lpvm cast(~$temp2##0:multictr.card, ?suit##0:multictr.suit)
-    foreign llvm lshr(~$##0:multictr.card, 2:multictr.card, ?$temp##1:multictr.card)
-    foreign llvm and(~$temp##1:multictr.card, 15:multictr.card, ?$temp2##1:multictr.card)
-    foreign lpvm cast(~$temp2##1:multictr.card, ?rank##0:multictr.rank)
+    foreign llvm and(###0:multictr.card, 3:multictr.card, ?#temp2##0:multictr.card)
+    foreign lpvm cast(~#temp2##0:multictr.card, ?suit##0:multictr.suit)
+    foreign llvm lshr(~###0:multictr.card, 2:multictr.card, ?#temp##1:multictr.card)
+    foreign llvm and(~#temp##1:multictr.card, 15:multictr.card, ?#temp2##1:multictr.card)
+    foreign lpvm cast(~#temp2##1:multictr.card, ?rank##0:multictr.rank)
 
 
 rank > public {inline} (0 calls)
 0: multictr.card.rank<0>
-rank($rec##0:multictr.card, ?$##0:multictr.rank):
+rank(#rec##0:multictr.card, ?###0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm lshr(~$rec##0:multictr.card, 2:multictr.card, ?$rec##1:multictr.card)
-    foreign llvm and(~$rec##1:multictr.card, 15:multictr.card, ?$field##0:multictr.card)
-    foreign lpvm cast(~$field##0:multictr.card, ?$##0:multictr.rank)
+    foreign llvm lshr(~#rec##0:multictr.card, 2:multictr.card, ?#rec##1:multictr.card)
+    foreign llvm and(~#rec##1:multictr.card, 15:multictr.card, ?#field##0:multictr.card)
+    foreign lpvm cast(~#field##0:multictr.card, ?###0:multictr.rank)
 rank > public {inline} (0 calls)
 1: multictr.card.rank<1>
-rank($rec##0:multictr.card, ?$rec##2:multictr.card, $field##0:multictr.rank):
+rank(#rec##0:multictr.card, ?#rec##2:multictr.card, #field##0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and(~$rec##0:multictr.card, -61:multictr.card, ?$rec##1:multictr.card)
-    foreign llvm shl(~$field##0:multictr.card, 2:multictr.card, ?$temp##0:multictr.card)
-    foreign llvm or(~$rec##1:multictr.card, ~$temp##0:multictr.card, ?$rec##2:multictr.card)
+    foreign llvm and(~#rec##0:multictr.card, -61:multictr.card, ?#rec##1:multictr.card)
+    foreign llvm shl(~#field##0:multictr.card, 2:multictr.card, ?#temp##0:multictr.card)
+    foreign llvm or(~#rec##1:multictr.card, ~#temp##0:multictr.card, ?#rec##2:multictr.card)
 
 
 suit > public {inline} (0 calls)
 0: multictr.card.suit<0>
-suit($rec##0:multictr.card, ?$##0:multictr.suit):
+suit(#rec##0:multictr.card, ?###0:multictr.suit):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and(~$rec##0:multictr.card, 3:multictr.card, ?$field##0:multictr.card)
-    foreign lpvm cast(~$field##0:multictr.card, ?$##0:multictr.suit)
+    foreign llvm and(~#rec##0:multictr.card, 3:multictr.card, ?#field##0:multictr.card)
+    foreign lpvm cast(~#field##0:multictr.card, ?###0:multictr.suit)
 suit > public {inline} (0 calls)
 1: multictr.card.suit<1>
-suit($rec##0:multictr.card, ?$rec##2:multictr.card, $field##0:multictr.suit):
+suit(#rec##0:multictr.card, ?#rec##2:multictr.card, #field##0:multictr.suit):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and(~$rec##0:multictr.card, -4:multictr.card, ?$rec##1:multictr.card)
-    foreign llvm or(~$field##0:multictr.card, ~$rec##1:multictr.card, ?$rec##2:multictr.card)
+    foreign llvm and(~#rec##0:multictr.card, -4:multictr.card, ?#rec##1:multictr.card)
+    foreign llvm or(~#field##0:multictr.card, ~#rec##1:multictr.card, ?#rec##2:multictr.card)
 
 
 ~= > public {inline} (0 calls)
 0: multictr.card.~=<0>
-~=($left##0:multictr.card, $right##0:multictr.card, ?$$##0:wybe.bool):
+~=(#left##0:multictr.card, #right##0:multictr.card, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(~$left##0:multictr.card, ~$right##0:multictr.card, ?tmp$0##0:wybe.bool)
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    foreign llvm icmp_eq(~#left##0:multictr.card, ~#right##0:multictr.card, ?tmp#0##0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
   LLVM code       :
 
@@ -290,77 +290,77 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"multictr.card.=<0>"(i6  %"$left##0", i6  %"$right##0")    {
+define external fastcc  i1 @"multictr.card.=<0>"(i6  %"#left##0", i6  %"#right##0")    {
 entry:
-  %"1$$$##0" = icmp eq i6 %"$left##0", %"$right##0" 
-  ret i1 %"1$$$##0" 
+  %"1#####0" = icmp eq i6 %"#left##0", %"#right##0" 
+  ret i1 %"1#####0" 
 }
 
 
 define external fastcc  i6 @"multictr.card.card<0>"(i2  %"suit##0", i4  %"rank##0")    {
 entry:
   %1 = zext i4 %"rank##0" to i6  
-  %"1$$temp##1" = shl   i6 %1, 2 
+  %"1##temp##1" = shl   i6 %1, 2 
   %2 = zext i2 %"suit##0" to i6  
-  %"1$$##3" = or i6 %"1$$temp##1", %2 
-  ret i6 %"1$$##3" 
+  %"1####3" = or i6 %"1##temp##1", %2 
+  ret i6 %"1####3" 
 }
 
 
-define external fastcc  {i2, i4} @"multictr.card.card<1>"(i6  %"$##0")    {
+define external fastcc  {i2, i4} @"multictr.card.card<1>"(i6  %"###0")    {
 entry:
-  %"1$$temp2##0" = and i6 %"$##0", 3 
-  %3 = trunc i6 %"1$$temp2##0" to i2  
-  %"1$$temp##1" = lshr  i6 %"$##0", 2 
-  %"1$$temp2##1" = and i6 %"1$$temp##1", 15 
-  %4 = trunc i6 %"1$$temp2##1" to i4  
+  %"1##temp2##0" = and i6 %"###0", 3 
+  %3 = trunc i6 %"1##temp2##0" to i2  
+  %"1##temp##1" = lshr  i6 %"###0", 2 
+  %"1##temp2##1" = and i6 %"1##temp##1", 15 
+  %4 = trunc i6 %"1##temp2##1" to i4  
   %5 = insertvalue {i2, i4} undef, i2 %3, 0 
   %6 = insertvalue {i2, i4} %5, i4 %4, 1 
   ret {i2, i4} %6 
 }
 
 
-define external fastcc  i4 @"multictr.card.rank<0>"(i6  %"$rec##0")    {
+define external fastcc  i4 @"multictr.card.rank<0>"(i6  %"#rec##0")    {
 entry:
-  %"1$$rec##1" = lshr  i6 %"$rec##0", 2 
-  %"1$$field##0" = and i6 %"1$$rec##1", 15 
-  %7 = trunc i6 %"1$$field##0" to i4  
+  %"1##rec##1" = lshr  i6 %"#rec##0", 2 
+  %"1##field##0" = and i6 %"1##rec##1", 15 
+  %7 = trunc i6 %"1##field##0" to i4  
   ret i4 %7 
 }
 
 
-define external fastcc  i6 @"multictr.card.rank<1>"(i6  %"$rec##0", i4  %"$field##0")    {
+define external fastcc  i6 @"multictr.card.rank<1>"(i6  %"#rec##0", i4  %"#field##0")    {
 entry:
-  %"1$$rec##1" = and i6 %"$rec##0", -61 
-  %8 = zext i4 %"$field##0" to i6  
-  %"1$$temp##0" = shl   i6 %8, 2 
-  %"1$$rec##2" = or i6 %"1$$rec##1", %"1$$temp##0" 
-  ret i6 %"1$$rec##2" 
+  %"1##rec##1" = and i6 %"#rec##0", -61 
+  %8 = zext i4 %"#field##0" to i6  
+  %"1##temp##0" = shl   i6 %8, 2 
+  %"1##rec##2" = or i6 %"1##rec##1", %"1##temp##0" 
+  ret i6 %"1##rec##2" 
 }
 
 
-define external fastcc  i2 @"multictr.card.suit<0>"(i6  %"$rec##0")    {
+define external fastcc  i2 @"multictr.card.suit<0>"(i6  %"#rec##0")    {
 entry:
-  %"1$$field##0" = and i6 %"$rec##0", 3 
-  %9 = trunc i6 %"1$$field##0" to i2  
+  %"1##field##0" = and i6 %"#rec##0", 3 
+  %9 = trunc i6 %"1##field##0" to i2  
   ret i2 %9 
 }
 
 
-define external fastcc  i6 @"multictr.card.suit<1>"(i6  %"$rec##0", i2  %"$field##0")    {
+define external fastcc  i6 @"multictr.card.suit<1>"(i6  %"#rec##0", i2  %"#field##0")    {
 entry:
-  %"1$$rec##1" = and i6 %"$rec##0", -4 
-  %10 = zext i2 %"$field##0" to i6  
-  %"1$$rec##2" = or i6 %10, %"1$$rec##1" 
-  ret i6 %"1$$rec##2" 
+  %"1##rec##1" = and i6 %"#rec##0", -4 
+  %10 = zext i2 %"#field##0" to i6  
+  %"1##rec##2" = or i6 %10, %"1##rec##1" 
+  ret i6 %"1##rec##2" 
 }
 
 
-define external fastcc  i1 @"multictr.card.~=<0>"(i6  %"$left##0", i6  %"$right##0")    {
+define external fastcc  i1 @"multictr.card.~=<0>"(i6  %"#left##0", i6  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = icmp eq i6 %"$left##0", %"$right##0" 
-  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
-  ret i1 %"1$$$##0" 
+  %"1#tmp#0##0" = icmp eq i6 %"#left##0", %"#right##0" 
+  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1#####0" 
 }
 --------------------------------------------------
  Module multictr.complicated
@@ -448,361 +448,361 @@ entry:
 
 = > public (1 calls)
 0: multictr.complicated.=<0>
-=($left##0:multictr.complicated, $right##0:multictr.complicated, ?$$##0:wybe.bool):
+=(#left##0:multictr.complicated, #right##0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($left##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#left##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left##0:multictr.complicated, ~$right##0:multictr.complicated, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:multictr.complicated, ~#right##0:multictr.complicated, ?####0:wybe.bool)
 
     1:
-        foreign llvm and($left##0:wybe.int, 7:wybe.int, ?tmp$55##0:wybe.int)
-        foreign llvm icmp_eq(tmp$55##0:wybe.int, 0:wybe.int, ?tmp$56##0:wybe.bool)
-        case ~tmp$56##0:wybe.bool of
+        foreign llvm and(#left##0:wybe.int, 7:wybe.int, ?tmp#55##0:wybe.int)
+        foreign llvm icmp_eq(tmp#55##0:wybe.int, 0:wybe.int, ?tmp#56##0:wybe.bool)
+        case ~tmp#56##0:wybe.bool of
         0:
-            foreign llvm icmp_eq(tmp$55##0:wybe.int, 1:wybe.int, ?tmp$60##0:wybe.bool)
-            case ~tmp$60##0:wybe.bool of
+            foreign llvm icmp_eq(tmp#55##0:wybe.int, 1:wybe.int, ?tmp#60##0:wybe.bool)
+            case ~tmp#60##0:wybe.bool of
             0:
-                foreign llvm icmp_eq(tmp$55##0:wybe.int, 2:wybe.int, ?tmp$64##0:wybe.bool)
-                case ~tmp$64##0:wybe.bool of
+                foreign llvm icmp_eq(tmp#55##0:wybe.int, 2:wybe.int, ?tmp#64##0:wybe.bool)
+                case ~tmp#64##0:wybe.bool of
                 0:
-                    foreign llvm icmp_eq(tmp$55##0:wybe.int, 3:wybe.int, ?tmp$68##0:wybe.bool)
-                    case ~tmp$68##0:wybe.bool of
+                    foreign llvm icmp_eq(tmp#55##0:wybe.int, 3:wybe.int, ?tmp#68##0:wybe.bool)
+                    case ~tmp#68##0:wybe.bool of
                     0:
-                        foreign llvm icmp_eq(tmp$55##0:wybe.int, 4:wybe.int, ?tmp$72##0:wybe.bool)
-                        case ~tmp$72##0:wybe.bool of
+                        foreign llvm icmp_eq(tmp#55##0:wybe.int, 4:wybe.int, ?tmp#72##0:wybe.bool)
+                        case ~tmp#72##0:wybe.bool of
                         0:
-                            foreign llvm icmp_eq(tmp$55##0:wybe.int, 5:wybe.int, ?tmp$76##0:wybe.bool)
-                            case ~tmp$76##0:wybe.bool of
+                            foreign llvm icmp_eq(tmp#55##0:wybe.int, 5:wybe.int, ?tmp#76##0:wybe.bool)
+                            case ~tmp#76##0:wybe.bool of
                             0:
-                                foreign llvm icmp_eq(tmp$55##0:wybe.int, 6:wybe.int, ?tmp$80##0:wybe.bool)
-                                case ~tmp$80##0:wybe.bool of
+                                foreign llvm icmp_eq(tmp#55##0:wybe.int, 6:wybe.int, ?tmp#80##0:wybe.bool)
+                                case ~tmp#80##0:wybe.bool of
                                 0:
-                                    foreign llvm icmp_eq(~tmp$55##0:wybe.int, 7:wybe.int, ?tmp$84##0:wybe.bool)
-                                    case ~tmp$84##0:wybe.bool of
+                                    foreign llvm icmp_eq(~tmp#55##0:wybe.int, 7:wybe.int, ?tmp#84##0:wybe.bool)
+                                    case ~tmp#84##0:wybe.bool of
                                     0:
-                                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                     1:
-                                        foreign lpvm access($left##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp$85##0:16 bit unsigned)
-                                        foreign llvm icmp_eq(tmp$85##0:16 bit unsigned, 7:16 bit unsigned, ?tmp$86##0:wybe.bool)
-                                        case ~tmp$86##0:wybe.bool of
+                                        foreign lpvm access(#left##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#85##0:16 bit unsigned)
+                                        foreign llvm icmp_eq(tmp#85##0:16 bit unsigned, 7:16 bit unsigned, ?tmp#86##0:wybe.bool)
+                                        case ~tmp#86##0:wybe.bool of
                                         0:
-                                            foreign llvm icmp_eq(tmp$85##0:16 bit unsigned, 8:16 bit unsigned, ?tmp$92##0:wybe.bool)
-                                            case ~tmp$92##0:wybe.bool of
+                                            foreign llvm icmp_eq(tmp#85##0:16 bit unsigned, 8:16 bit unsigned, ?tmp#92##0:wybe.bool)
+                                            case ~tmp#92##0:wybe.bool of
                                             0:
-                                                foreign llvm icmp_eq(tmp$85##0:16 bit unsigned, 9:16 bit unsigned, ?tmp$98##0:wybe.bool)
-                                                case ~tmp$98##0:wybe.bool of
+                                                foreign llvm icmp_eq(tmp#85##0:16 bit unsigned, 9:16 bit unsigned, ?tmp#98##0:wybe.bool)
+                                                case ~tmp#98##0:wybe.bool of
                                                 0:
-                                                    foreign llvm icmp_eq(tmp$85##0:16 bit unsigned, 10:16 bit unsigned, ?tmp$104##0:wybe.bool)
-                                                    case ~tmp$104##0:wybe.bool of
+                                                    foreign llvm icmp_eq(tmp#85##0:16 bit unsigned, 10:16 bit unsigned, ?tmp#104##0:wybe.bool)
+                                                    case ~tmp#104##0:wybe.bool of
                                                     0:
-                                                        foreign llvm icmp_eq(tmp$85##0:16 bit unsigned, 11:16 bit unsigned, ?tmp$110##0:wybe.bool)
-                                                        case ~tmp$110##0:wybe.bool of
+                                                        foreign llvm icmp_eq(tmp#85##0:16 bit unsigned, 11:16 bit unsigned, ?tmp#110##0:wybe.bool)
+                                                        case ~tmp#110##0:wybe.bool of
                                                         0:
-                                                            foreign llvm icmp_eq(tmp$85##0:16 bit unsigned, 12:16 bit unsigned, ?tmp$116##0:wybe.bool)
-                                                            case ~tmp$116##0:wybe.bool of
+                                                            foreign llvm icmp_eq(tmp#85##0:16 bit unsigned, 12:16 bit unsigned, ?tmp#116##0:wybe.bool)
+                                                            case ~tmp#116##0:wybe.bool of
                                                             0:
-                                                                foreign llvm icmp_eq(tmp$85##0:16 bit unsigned, 13:16 bit unsigned, ?tmp$122##0:wybe.bool)
-                                                                case ~tmp$122##0:wybe.bool of
+                                                                foreign llvm icmp_eq(tmp#85##0:16 bit unsigned, 13:16 bit unsigned, ?tmp#122##0:wybe.bool)
+                                                                case ~tmp#122##0:wybe.bool of
                                                                 0:
-                                                                    foreign llvm icmp_eq(tmp$85##0:16 bit unsigned, 14:16 bit unsigned, ?tmp$128##0:wybe.bool)
-                                                                    case ~tmp$128##0:wybe.bool of
+                                                                    foreign llvm icmp_eq(tmp#85##0:16 bit unsigned, 14:16 bit unsigned, ?tmp#128##0:wybe.bool)
+                                                                    case ~tmp#128##0:wybe.bool of
                                                                     0:
-                                                                        foreign llvm icmp_eq(tmp$85##0:16 bit unsigned, 15:16 bit unsigned, ?tmp$134##0:wybe.bool)
-                                                                        case ~tmp$134##0:wybe.bool of
+                                                                        foreign llvm icmp_eq(tmp#85##0:16 bit unsigned, 15:16 bit unsigned, ?tmp#134##0:wybe.bool)
+                                                                        case ~tmp#134##0:wybe.bool of
                                                                         0:
-                                                                            foreign llvm icmp_eq(~tmp$85##0:16 bit unsigned, 16:16 bit unsigned, ?tmp$140##0:wybe.bool)
-                                                                            case ~tmp$140##0:wybe.bool of
+                                                                            foreign llvm icmp_eq(~tmp#85##0:16 bit unsigned, 16:16 bit unsigned, ?tmp#140##0:wybe.bool)
+                                                                            case ~tmp#140##0:wybe.bool of
                                                                             0:
-                                                                                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                                                                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                                                             1:
-                                                                                foreign lpvm access(~$left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$left$f17##0:wybe.int)
-                                                                                foreign llvm icmp_uge($right##0:wybe.int, 4:wybe.int, ?tmp$142##0:wybe.bool)
-                                                                                case ~tmp$142##0:wybe.bool of
+                                                                                foreign lpvm access(~#left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#left#f17##0:wybe.int)
+                                                                                foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#142##0:wybe.bool)
+                                                                                case ~tmp#142##0:wybe.bool of
                                                                                 0:
-                                                                                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                                                                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                                                                 1:
-                                                                                    foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$143##0:wybe.int)
-                                                                                    foreign llvm icmp_eq(~tmp$143##0:wybe.int, 7:wybe.int, ?tmp$144##0:wybe.bool)
-                                                                                    case ~tmp$144##0:wybe.bool of
+                                                                                    foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#143##0:wybe.int)
+                                                                                    foreign llvm icmp_eq(~tmp#143##0:wybe.int, 7:wybe.int, ?tmp#144##0:wybe.bool)
+                                                                                    case ~tmp#144##0:wybe.bool of
                                                                                     0:
-                                                                                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                                                                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                                                                     1:
-                                                                                        foreign lpvm access($right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp$145##0:16 bit unsigned)
-                                                                                        foreign llvm icmp_eq(~tmp$145##0:16 bit unsigned, 16:16 bit unsigned, ?tmp$146##0:wybe.bool)
-                                                                                        case ~tmp$146##0:wybe.bool of
+                                                                                        foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#145##0:16 bit unsigned)
+                                                                                        foreign llvm icmp_eq(~tmp#145##0:16 bit unsigned, 16:16 bit unsigned, ?tmp#146##0:wybe.bool)
+                                                                                        case ~tmp#146##0:wybe.bool of
                                                                                         0:
-                                                                                            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                                                                            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                                                                         1:
-                                                                                            foreign lpvm access(~$right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$right$f17##0:wybe.int)
-                                                                                            foreign llvm icmp_eq(~$left$f17##0:wybe.int, ~$right$f17##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+                                                                                            foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f17##0:wybe.int)
+                                                                                            foreign llvm icmp_eq(~#left#f17##0:wybe.int, ~#right#f17##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 
 
                                                                         1:
-                                                                            foreign lpvm access(~$left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$left$f16##0:wybe.int)
-                                                                            foreign llvm icmp_uge($right##0:wybe.int, 4:wybe.int, ?tmp$136##0:wybe.bool)
-                                                                            case ~tmp$136##0:wybe.bool of
+                                                                            foreign lpvm access(~#left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#left#f16##0:wybe.int)
+                                                                            foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#136##0:wybe.bool)
+                                                                            case ~tmp#136##0:wybe.bool of
                                                                             0:
-                                                                                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                                                                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                                                             1:
-                                                                                foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$137##0:wybe.int)
-                                                                                foreign llvm icmp_eq(~tmp$137##0:wybe.int, 7:wybe.int, ?tmp$138##0:wybe.bool)
-                                                                                case ~tmp$138##0:wybe.bool of
+                                                                                foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#137##0:wybe.int)
+                                                                                foreign llvm icmp_eq(~tmp#137##0:wybe.int, 7:wybe.int, ?tmp#138##0:wybe.bool)
+                                                                                case ~tmp#138##0:wybe.bool of
                                                                                 0:
-                                                                                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                                                                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                                                                 1:
-                                                                                    foreign lpvm access($right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp$139##0:16 bit unsigned)
-                                                                                    foreign llvm icmp_eq(~tmp$139##0:16 bit unsigned, 15:16 bit unsigned, ?tmp$140##0:wybe.bool)
-                                                                                    case ~tmp$140##0:wybe.bool of
+                                                                                    foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#139##0:16 bit unsigned)
+                                                                                    foreign llvm icmp_eq(~tmp#139##0:16 bit unsigned, 15:16 bit unsigned, ?tmp#140##0:wybe.bool)
+                                                                                    case ~tmp#140##0:wybe.bool of
                                                                                     0:
-                                                                                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                                                                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                                                                     1:
-                                                                                        foreign lpvm access(~$right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$right$f16##0:wybe.int)
-                                                                                        foreign llvm icmp_eq(~$left$f16##0:wybe.int, ~$right$f16##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+                                                                                        foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f16##0:wybe.int)
+                                                                                        foreign llvm icmp_eq(~#left#f16##0:wybe.int, ~#right#f16##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 
 
                                                                     1:
-                                                                        foreign lpvm access(~$left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$left$f15##0:wybe.int)
-                                                                        foreign llvm icmp_uge($right##0:wybe.int, 4:wybe.int, ?tmp$130##0:wybe.bool)
-                                                                        case ~tmp$130##0:wybe.bool of
+                                                                        foreign lpvm access(~#left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#left#f15##0:wybe.int)
+                                                                        foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#130##0:wybe.bool)
+                                                                        case ~tmp#130##0:wybe.bool of
                                                                         0:
-                                                                            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                                                            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                                                         1:
-                                                                            foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$131##0:wybe.int)
-                                                                            foreign llvm icmp_eq(~tmp$131##0:wybe.int, 7:wybe.int, ?tmp$132##0:wybe.bool)
-                                                                            case ~tmp$132##0:wybe.bool of
+                                                                            foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#131##0:wybe.int)
+                                                                            foreign llvm icmp_eq(~tmp#131##0:wybe.int, 7:wybe.int, ?tmp#132##0:wybe.bool)
+                                                                            case ~tmp#132##0:wybe.bool of
                                                                             0:
-                                                                                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                                                                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                                                             1:
-                                                                                foreign lpvm access($right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp$133##0:16 bit unsigned)
-                                                                                foreign llvm icmp_eq(~tmp$133##0:16 bit unsigned, 14:16 bit unsigned, ?tmp$134##0:wybe.bool)
-                                                                                case ~tmp$134##0:wybe.bool of
+                                                                                foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#133##0:16 bit unsigned)
+                                                                                foreign llvm icmp_eq(~tmp#133##0:16 bit unsigned, 14:16 bit unsigned, ?tmp#134##0:wybe.bool)
+                                                                                case ~tmp#134##0:wybe.bool of
                                                                                 0:
-                                                                                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                                                                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                                                                 1:
-                                                                                    foreign lpvm access(~$right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$right$f15##0:wybe.int)
-                                                                                    foreign llvm icmp_eq(~$left$f15##0:wybe.int, ~$right$f15##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+                                                                                    foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f15##0:wybe.int)
+                                                                                    foreign llvm icmp_eq(~#left#f15##0:wybe.int, ~#right#f15##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 
 
                                                                 1:
-                                                                    foreign lpvm access(~$left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$left$f14##0:wybe.int)
-                                                                    foreign llvm icmp_uge($right##0:wybe.int, 4:wybe.int, ?tmp$124##0:wybe.bool)
-                                                                    case ~tmp$124##0:wybe.bool of
+                                                                    foreign lpvm access(~#left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#left#f14##0:wybe.int)
+                                                                    foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#124##0:wybe.bool)
+                                                                    case ~tmp#124##0:wybe.bool of
                                                                     0:
-                                                                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                                                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                                                     1:
-                                                                        foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$125##0:wybe.int)
-                                                                        foreign llvm icmp_eq(~tmp$125##0:wybe.int, 7:wybe.int, ?tmp$126##0:wybe.bool)
-                                                                        case ~tmp$126##0:wybe.bool of
+                                                                        foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#125##0:wybe.int)
+                                                                        foreign llvm icmp_eq(~tmp#125##0:wybe.int, 7:wybe.int, ?tmp#126##0:wybe.bool)
+                                                                        case ~tmp#126##0:wybe.bool of
                                                                         0:
-                                                                            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                                                            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                                                         1:
-                                                                            foreign lpvm access($right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp$127##0:16 bit unsigned)
-                                                                            foreign llvm icmp_eq(~tmp$127##0:16 bit unsigned, 13:16 bit unsigned, ?tmp$128##0:wybe.bool)
-                                                                            case ~tmp$128##0:wybe.bool of
+                                                                            foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#127##0:16 bit unsigned)
+                                                                            foreign llvm icmp_eq(~tmp#127##0:16 bit unsigned, 13:16 bit unsigned, ?tmp#128##0:wybe.bool)
+                                                                            case ~tmp#128##0:wybe.bool of
                                                                             0:
-                                                                                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                                                                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                                                             1:
-                                                                                foreign lpvm access(~$right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$right$f14##0:wybe.int)
-                                                                                foreign llvm icmp_eq(~$left$f14##0:wybe.int, ~$right$f14##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+                                                                                foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f14##0:wybe.int)
+                                                                                foreign llvm icmp_eq(~#left#f14##0:wybe.int, ~#right#f14##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 
 
                                                             1:
-                                                                foreign lpvm access(~$left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$left$f13##0:wybe.int)
-                                                                foreign llvm icmp_uge($right##0:wybe.int, 4:wybe.int, ?tmp$118##0:wybe.bool)
-                                                                case ~tmp$118##0:wybe.bool of
+                                                                foreign lpvm access(~#left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#left#f13##0:wybe.int)
+                                                                foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#118##0:wybe.bool)
+                                                                case ~tmp#118##0:wybe.bool of
                                                                 0:
-                                                                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                                                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                                                 1:
-                                                                    foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$119##0:wybe.int)
-                                                                    foreign llvm icmp_eq(~tmp$119##0:wybe.int, 7:wybe.int, ?tmp$120##0:wybe.bool)
-                                                                    case ~tmp$120##0:wybe.bool of
+                                                                    foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#119##0:wybe.int)
+                                                                    foreign llvm icmp_eq(~tmp#119##0:wybe.int, 7:wybe.int, ?tmp#120##0:wybe.bool)
+                                                                    case ~tmp#120##0:wybe.bool of
                                                                     0:
-                                                                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                                                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                                                     1:
-                                                                        foreign lpvm access($right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp$121##0:16 bit unsigned)
-                                                                        foreign llvm icmp_eq(~tmp$121##0:16 bit unsigned, 12:16 bit unsigned, ?tmp$122##0:wybe.bool)
-                                                                        case ~tmp$122##0:wybe.bool of
+                                                                        foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#121##0:16 bit unsigned)
+                                                                        foreign llvm icmp_eq(~tmp#121##0:16 bit unsigned, 12:16 bit unsigned, ?tmp#122##0:wybe.bool)
+                                                                        case ~tmp#122##0:wybe.bool of
                                                                         0:
-                                                                            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                                                            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                                                         1:
-                                                                            foreign lpvm access(~$right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$right$f13##0:wybe.int)
-                                                                            foreign llvm icmp_eq(~$left$f13##0:wybe.int, ~$right$f13##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+                                                                            foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f13##0:wybe.int)
+                                                                            foreign llvm icmp_eq(~#left#f13##0:wybe.int, ~#right#f13##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 
 
                                                         1:
-                                                            foreign lpvm access(~$left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$left$f12##0:wybe.int)
-                                                            foreign llvm icmp_uge($right##0:wybe.int, 4:wybe.int, ?tmp$112##0:wybe.bool)
-                                                            case ~tmp$112##0:wybe.bool of
+                                                            foreign lpvm access(~#left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#left#f12##0:wybe.int)
+                                                            foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#112##0:wybe.bool)
+                                                            case ~tmp#112##0:wybe.bool of
                                                             0:
-                                                                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                                                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                                             1:
-                                                                foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$113##0:wybe.int)
-                                                                foreign llvm icmp_eq(~tmp$113##0:wybe.int, 7:wybe.int, ?tmp$114##0:wybe.bool)
-                                                                case ~tmp$114##0:wybe.bool of
+                                                                foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#113##0:wybe.int)
+                                                                foreign llvm icmp_eq(~tmp#113##0:wybe.int, 7:wybe.int, ?tmp#114##0:wybe.bool)
+                                                                case ~tmp#114##0:wybe.bool of
                                                                 0:
-                                                                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                                                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                                                 1:
-                                                                    foreign lpvm access($right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp$115##0:16 bit unsigned)
-                                                                    foreign llvm icmp_eq(~tmp$115##0:16 bit unsigned, 11:16 bit unsigned, ?tmp$116##0:wybe.bool)
-                                                                    case ~tmp$116##0:wybe.bool of
+                                                                    foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#115##0:16 bit unsigned)
+                                                                    foreign llvm icmp_eq(~tmp#115##0:16 bit unsigned, 11:16 bit unsigned, ?tmp#116##0:wybe.bool)
+                                                                    case ~tmp#116##0:wybe.bool of
                                                                     0:
-                                                                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                                                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                                                     1:
-                                                                        foreign lpvm access(~$right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$right$f12##0:wybe.int)
-                                                                        foreign llvm icmp_eq(~$left$f12##0:wybe.int, ~$right$f12##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+                                                                        foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f12##0:wybe.int)
+                                                                        foreign llvm icmp_eq(~#left#f12##0:wybe.int, ~#right#f12##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 
 
                                                     1:
-                                                        foreign lpvm access(~$left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$left$f11##0:wybe.int)
-                                                        foreign llvm icmp_uge($right##0:wybe.int, 4:wybe.int, ?tmp$106##0:wybe.bool)
-                                                        case ~tmp$106##0:wybe.bool of
+                                                        foreign lpvm access(~#left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#left#f11##0:wybe.int)
+                                                        foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#106##0:wybe.bool)
+                                                        case ~tmp#106##0:wybe.bool of
                                                         0:
-                                                            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                                            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                                         1:
-                                                            foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$107##0:wybe.int)
-                                                            foreign llvm icmp_eq(~tmp$107##0:wybe.int, 7:wybe.int, ?tmp$108##0:wybe.bool)
-                                                            case ~tmp$108##0:wybe.bool of
+                                                            foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#107##0:wybe.int)
+                                                            foreign llvm icmp_eq(~tmp#107##0:wybe.int, 7:wybe.int, ?tmp#108##0:wybe.bool)
+                                                            case ~tmp#108##0:wybe.bool of
                                                             0:
-                                                                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                                                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                                             1:
-                                                                foreign lpvm access($right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp$109##0:16 bit unsigned)
-                                                                foreign llvm icmp_eq(~tmp$109##0:16 bit unsigned, 10:16 bit unsigned, ?tmp$110##0:wybe.bool)
-                                                                case ~tmp$110##0:wybe.bool of
+                                                                foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#109##0:16 bit unsigned)
+                                                                foreign llvm icmp_eq(~tmp#109##0:16 bit unsigned, 10:16 bit unsigned, ?tmp#110##0:wybe.bool)
+                                                                case ~tmp#110##0:wybe.bool of
                                                                 0:
-                                                                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                                                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                                                 1:
-                                                                    foreign lpvm access(~$right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$right$f11##0:wybe.int)
-                                                                    foreign llvm icmp_eq(~$left$f11##0:wybe.int, ~$right$f11##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+                                                                    foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f11##0:wybe.int)
+                                                                    foreign llvm icmp_eq(~#left#f11##0:wybe.int, ~#right#f11##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 
 
                                                 1:
-                                                    foreign lpvm access(~$left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$left$f10##0:wybe.int)
-                                                    foreign llvm icmp_uge($right##0:wybe.int, 4:wybe.int, ?tmp$100##0:wybe.bool)
-                                                    case ~tmp$100##0:wybe.bool of
+                                                    foreign lpvm access(~#left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#left#f10##0:wybe.int)
+                                                    foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#100##0:wybe.bool)
+                                                    case ~tmp#100##0:wybe.bool of
                                                     0:
-                                                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                                     1:
-                                                        foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$101##0:wybe.int)
-                                                        foreign llvm icmp_eq(~tmp$101##0:wybe.int, 7:wybe.int, ?tmp$102##0:wybe.bool)
-                                                        case ~tmp$102##0:wybe.bool of
+                                                        foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#101##0:wybe.int)
+                                                        foreign llvm icmp_eq(~tmp#101##0:wybe.int, 7:wybe.int, ?tmp#102##0:wybe.bool)
+                                                        case ~tmp#102##0:wybe.bool of
                                                         0:
-                                                            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                                            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                                         1:
-                                                            foreign lpvm access($right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp$103##0:16 bit unsigned)
-                                                            foreign llvm icmp_eq(~tmp$103##0:16 bit unsigned, 9:16 bit unsigned, ?tmp$104##0:wybe.bool)
-                                                            case ~tmp$104##0:wybe.bool of
+                                                            foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#103##0:16 bit unsigned)
+                                                            foreign llvm icmp_eq(~tmp#103##0:16 bit unsigned, 9:16 bit unsigned, ?tmp#104##0:wybe.bool)
+                                                            case ~tmp#104##0:wybe.bool of
                                                             0:
-                                                                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                                                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                                             1:
-                                                                foreign lpvm access(~$right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$right$f10##0:wybe.int)
-                                                                foreign llvm icmp_eq(~$left$f10##0:wybe.int, ~$right$f10##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+                                                                foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f10##0:wybe.int)
+                                                                foreign llvm icmp_eq(~#left#f10##0:wybe.int, ~#right#f10##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 
 
                                             1:
-                                                foreign lpvm access(~$left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$left$f09##0:wybe.int)
-                                                foreign llvm icmp_uge($right##0:wybe.int, 4:wybe.int, ?tmp$94##0:wybe.bool)
-                                                case ~tmp$94##0:wybe.bool of
+                                                foreign lpvm access(~#left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#left#f09##0:wybe.int)
+                                                foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#94##0:wybe.bool)
+                                                case ~tmp#94##0:wybe.bool of
                                                 0:
-                                                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                                 1:
-                                                    foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$95##0:wybe.int)
-                                                    foreign llvm icmp_eq(~tmp$95##0:wybe.int, 7:wybe.int, ?tmp$96##0:wybe.bool)
-                                                    case ~tmp$96##0:wybe.bool of
+                                                    foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#95##0:wybe.int)
+                                                    foreign llvm icmp_eq(~tmp#95##0:wybe.int, 7:wybe.int, ?tmp#96##0:wybe.bool)
+                                                    case ~tmp#96##0:wybe.bool of
                                                     0:
-                                                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                                     1:
-                                                        foreign lpvm access($right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp$97##0:16 bit unsigned)
-                                                        foreign llvm icmp_eq(~tmp$97##0:16 bit unsigned, 8:16 bit unsigned, ?tmp$98##0:wybe.bool)
-                                                        case ~tmp$98##0:wybe.bool of
+                                                        foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#97##0:16 bit unsigned)
+                                                        foreign llvm icmp_eq(~tmp#97##0:16 bit unsigned, 8:16 bit unsigned, ?tmp#98##0:wybe.bool)
+                                                        case ~tmp#98##0:wybe.bool of
                                                         0:
-                                                            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                                            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                                         1:
-                                                            foreign lpvm access(~$right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$right$f09##0:wybe.int)
-                                                            foreign llvm icmp_eq(~$left$f09##0:wybe.int, ~$right$f09##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+                                                            foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f09##0:wybe.int)
+                                                            foreign llvm icmp_eq(~#left#f09##0:wybe.int, ~#right#f09##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 
 
                                         1:
-                                            foreign lpvm access(~$left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$left$f08##0:wybe.int)
-                                            foreign llvm icmp_uge($right##0:wybe.int, 4:wybe.int, ?tmp$88##0:wybe.bool)
-                                            case ~tmp$88##0:wybe.bool of
+                                            foreign lpvm access(~#left##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#left#f08##0:wybe.int)
+                                            foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#88##0:wybe.bool)
+                                            case ~tmp#88##0:wybe.bool of
                                             0:
-                                                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                             1:
-                                                foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$89##0:wybe.int)
-                                                foreign llvm icmp_eq(~tmp$89##0:wybe.int, 7:wybe.int, ?tmp$90##0:wybe.bool)
-                                                case ~tmp$90##0:wybe.bool of
+                                                foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#89##0:wybe.int)
+                                                foreign llvm icmp_eq(~tmp#89##0:wybe.int, 7:wybe.int, ?tmp#90##0:wybe.bool)
+                                                case ~tmp#90##0:wybe.bool of
                                                 0:
-                                                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                                 1:
-                                                    foreign lpvm access($right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp$91##0:16 bit unsigned)
-                                                    foreign llvm icmp_eq(~tmp$91##0:16 bit unsigned, 7:16 bit unsigned, ?tmp$92##0:wybe.bool)
-                                                    case ~tmp$92##0:wybe.bool of
+                                                    foreign lpvm access(#right##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?tmp#91##0:16 bit unsigned)
+                                                    foreign llvm icmp_eq(~tmp#91##0:16 bit unsigned, 7:16 bit unsigned, ?tmp#92##0:wybe.bool)
+                                                    case ~tmp#92##0:wybe.bool of
                                                     0:
-                                                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                                     1:
-                                                        foreign lpvm access(~$right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$right$f08##0:wybe.int)
-                                                        foreign llvm icmp_eq(~$left$f08##0:wybe.int, ~$right$f08##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+                                                        foreign lpvm access(~#right##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?#right#f08##0:wybe.int)
+                                                        foreign llvm icmp_eq(~#left#f08##0:wybe.int, ~#right#f08##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
@@ -810,148 +810,148 @@ entry:
 
 
                                 1:
-                                    foreign lpvm access(~$left##0:multictr.complicated, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?$left$f07##0:wybe.int)
-                                    foreign llvm icmp_uge($right##0:wybe.int, 4:wybe.int, ?tmp$82##0:wybe.bool)
-                                    case ~tmp$82##0:wybe.bool of
+                                    foreign lpvm access(~#left##0:multictr.complicated, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?#left#f07##0:wybe.int)
+                                    foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#82##0:wybe.bool)
+                                    case ~tmp#82##0:wybe.bool of
                                     0:
-                                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                     1:
-                                        foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$83##0:wybe.int)
-                                        foreign llvm icmp_eq(~tmp$83##0:wybe.int, 6:wybe.int, ?tmp$84##0:wybe.bool)
-                                        case ~tmp$84##0:wybe.bool of
+                                        foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#83##0:wybe.int)
+                                        foreign llvm icmp_eq(~tmp#83##0:wybe.int, 6:wybe.int, ?tmp#84##0:wybe.bool)
+                                        case ~tmp#84##0:wybe.bool of
                                         0:
-                                            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                         1:
-                                            foreign lpvm access(~$right##0:multictr.complicated, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?$right$f07##0:wybe.int)
-                                            foreign llvm icmp_eq(~$left$f07##0:wybe.int, ~$right$f07##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+                                            foreign lpvm access(~#right##0:multictr.complicated, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?#right#f07##0:wybe.int)
+                                            foreign llvm icmp_eq(~#left#f07##0:wybe.int, ~#right#f07##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 
                             1:
-                                foreign lpvm access(~$left##0:multictr.complicated, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?$left$f06##0:wybe.int)
-                                foreign llvm icmp_uge($right##0:wybe.int, 4:wybe.int, ?tmp$78##0:wybe.bool)
-                                case ~tmp$78##0:wybe.bool of
+                                foreign lpvm access(~#left##0:multictr.complicated, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?#left#f06##0:wybe.int)
+                                foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#78##0:wybe.bool)
+                                case ~tmp#78##0:wybe.bool of
                                 0:
-                                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                 1:
-                                    foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$79##0:wybe.int)
-                                    foreign llvm icmp_eq(~tmp$79##0:wybe.int, 5:wybe.int, ?tmp$80##0:wybe.bool)
-                                    case ~tmp$80##0:wybe.bool of
+                                    foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#79##0:wybe.int)
+                                    foreign llvm icmp_eq(~tmp#79##0:wybe.int, 5:wybe.int, ?tmp#80##0:wybe.bool)
+                                    case ~tmp#80##0:wybe.bool of
                                     0:
-                                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                     1:
-                                        foreign lpvm access(~$right##0:multictr.complicated, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?$right$f06##0:wybe.int)
-                                        foreign llvm icmp_eq(~$left$f06##0:wybe.int, ~$right$f06##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+                                        foreign lpvm access(~#right##0:multictr.complicated, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?#right#f06##0:wybe.int)
+                                        foreign llvm icmp_eq(~#left#f06##0:wybe.int, ~#right#f06##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 
                         1:
-                            foreign lpvm access(~$left##0:multictr.complicated, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?$left$f05##0:wybe.int)
-                            foreign llvm icmp_uge($right##0:wybe.int, 4:wybe.int, ?tmp$74##0:wybe.bool)
-                            case ~tmp$74##0:wybe.bool of
+                            foreign lpvm access(~#left##0:multictr.complicated, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?#left#f05##0:wybe.int)
+                            foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#74##0:wybe.bool)
+                            case ~tmp#74##0:wybe.bool of
                             0:
-                                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                             1:
-                                foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$75##0:wybe.int)
-                                foreign llvm icmp_eq(~tmp$75##0:wybe.int, 4:wybe.int, ?tmp$76##0:wybe.bool)
-                                case ~tmp$76##0:wybe.bool of
+                                foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#75##0:wybe.int)
+                                foreign llvm icmp_eq(~tmp#75##0:wybe.int, 4:wybe.int, ?tmp#76##0:wybe.bool)
+                                case ~tmp#76##0:wybe.bool of
                                 0:
-                                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                 1:
-                                    foreign lpvm access(~$right##0:multictr.complicated, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?$right$f05##0:wybe.int)
-                                    foreign llvm icmp_eq(~$left$f05##0:wybe.int, ~$right$f05##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+                                    foreign lpvm access(~#right##0:multictr.complicated, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?#right#f05##0:wybe.int)
+                                    foreign llvm icmp_eq(~#left#f05##0:wybe.int, ~#right#f05##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 
                     1:
-                        foreign lpvm access(~$left##0:multictr.complicated, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?$left$f04##0:wybe.int)
-                        foreign llvm icmp_uge($right##0:wybe.int, 4:wybe.int, ?tmp$70##0:wybe.bool)
-                        case ~tmp$70##0:wybe.bool of
+                        foreign lpvm access(~#left##0:multictr.complicated, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?#left#f04##0:wybe.int)
+                        foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#70##0:wybe.bool)
+                        case ~tmp#70##0:wybe.bool of
                         0:
-                            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                         1:
-                            foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$71##0:wybe.int)
-                            foreign llvm icmp_eq(~tmp$71##0:wybe.int, 3:wybe.int, ?tmp$72##0:wybe.bool)
-                            case ~tmp$72##0:wybe.bool of
+                            foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#71##0:wybe.int)
+                            foreign llvm icmp_eq(~tmp#71##0:wybe.int, 3:wybe.int, ?tmp#72##0:wybe.bool)
+                            case ~tmp#72##0:wybe.bool of
                             0:
-                                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                             1:
-                                foreign lpvm access(~$right##0:multictr.complicated, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?$right$f04##0:wybe.int)
-                                foreign llvm icmp_eq(~$left$f04##0:wybe.int, ~$right$f04##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+                                foreign lpvm access(~#right##0:multictr.complicated, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?#right#f04##0:wybe.int)
+                                foreign llvm icmp_eq(~#left#f04##0:wybe.int, ~#right#f04##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 
                 1:
-                    foreign lpvm access(~$left##0:multictr.complicated, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$left$f03##0:wybe.int)
-                    foreign llvm icmp_uge($right##0:wybe.int, 4:wybe.int, ?tmp$66##0:wybe.bool)
-                    case ~tmp$66##0:wybe.bool of
+                    foreign lpvm access(~#left##0:multictr.complicated, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#left#f03##0:wybe.int)
+                    foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#66##0:wybe.bool)
+                    case ~tmp#66##0:wybe.bool of
                     0:
-                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                     1:
-                        foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$67##0:wybe.int)
-                        foreign llvm icmp_eq(~tmp$67##0:wybe.int, 2:wybe.int, ?tmp$68##0:wybe.bool)
-                        case ~tmp$68##0:wybe.bool of
+                        foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#67##0:wybe.int)
+                        foreign llvm icmp_eq(~tmp#67##0:wybe.int, 2:wybe.int, ?tmp#68##0:wybe.bool)
+                        case ~tmp#68##0:wybe.bool of
                         0:
-                            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                         1:
-                            foreign lpvm access(~$right##0:multictr.complicated, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$right$f03##0:wybe.int)
-                            foreign llvm icmp_eq(~$left$f03##0:wybe.int, ~$right$f03##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+                            foreign lpvm access(~#right##0:multictr.complicated, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#right#f03##0:wybe.int)
+                            foreign llvm icmp_eq(~#left#f03##0:wybe.int, ~#right#f03##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 
             1:
-                foreign lpvm access(~$left##0:multictr.complicated, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$left$f02##0:wybe.int)
-                foreign llvm icmp_uge($right##0:wybe.int, 4:wybe.int, ?tmp$62##0:wybe.bool)
-                case ~tmp$62##0:wybe.bool of
+                foreign lpvm access(~#left##0:multictr.complicated, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#left#f02##0:wybe.int)
+                foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#62##0:wybe.bool)
+                case ~tmp#62##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                 1:
-                    foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$63##0:wybe.int)
-                    foreign llvm icmp_eq(~tmp$63##0:wybe.int, 1:wybe.int, ?tmp$64##0:wybe.bool)
-                    case ~tmp$64##0:wybe.bool of
+                    foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#63##0:wybe.int)
+                    foreign llvm icmp_eq(~tmp#63##0:wybe.int, 1:wybe.int, ?tmp#64##0:wybe.bool)
+                    case ~tmp#64##0:wybe.bool of
                     0:
-                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                     1:
-                        foreign lpvm access(~$right##0:multictr.complicated, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$right$f02##0:wybe.int)
-                        foreign llvm icmp_eq(~$left$f02##0:wybe.int, ~$right$f02##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+                        foreign lpvm access(~#right##0:multictr.complicated, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#right#f02##0:wybe.int)
+                        foreign llvm icmp_eq(~#left#f02##0:wybe.int, ~#right#f02##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 
         1:
-            foreign lpvm access(~$left##0:multictr.complicated, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$left$f01##0:wybe.int)
-            foreign llvm icmp_uge($right##0:wybe.int, 4:wybe.int, ?tmp$58##0:wybe.bool)
-            case ~tmp$58##0:wybe.bool of
+            foreign lpvm access(~#left##0:multictr.complicated, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#left#f01##0:wybe.int)
+            foreign llvm icmp_uge(#right##0:wybe.int, 4:wybe.int, ?tmp#58##0:wybe.bool)
+            case ~tmp#58##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
             1:
-                foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$59##0:wybe.int)
-                foreign llvm icmp_eq(~tmp$59##0:wybe.int, 0:wybe.int, ?tmp$60##0:wybe.bool)
-                case ~tmp$60##0:wybe.bool of
+                foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#59##0:wybe.int)
+                foreign llvm icmp_eq(~tmp#59##0:wybe.int, 0:wybe.int, ?tmp#60##0:wybe.bool)
+                case ~tmp#60##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                 1:
-                    foreign lpvm access(~$right##0:multictr.complicated, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$right$f01##0:wybe.int)
-                    foreign llvm icmp_eq(~$left$f01##0:wybe.int, ~$right$f01##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+                    foreign lpvm access(~#right##0:multictr.complicated, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#right#f01##0:wybe.int)
+                    foreign llvm icmp_eq(~#left#f01##0:wybe.int, ~#right#f01##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
@@ -960,288 +960,288 @@ entry:
 
 autumn > public {inline} (0 calls)
 0: multictr.complicated.autumn<0>
-autumn(?$##0:multictr.complicated):
+autumn(?###0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(3:multictr.complicated, ?$##0:multictr.complicated)
+    foreign llvm move(3:multictr.complicated, ?###0:multictr.complicated)
 
 
 c01 > public {inline} (0 calls)
 0: multictr.complicated.c01<0>
-c01(f01##0:wybe.int, ?$##0:multictr.complicated):
+c01(f01##0:wybe.int, ?###0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr.complicated)
-    foreign lpvm mutate(~$rec##0:multictr.complicated, ?$##0:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f01##0:wybe.int)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated)
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?###0:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f01##0:wybe.int)
 c01 > public {inline} (40 calls)
 1: multictr.complicated.c01<1>
-c01(?f01##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
+c01(?f01##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(###0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f01##0:wybe.int)
 
     1:
-        foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?f01##0:wybe.int)
 
         1:
-            foreign lpvm access(~$##0:multictr.complicated, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?f01##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm access(~###0:multictr.complicated, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?f01##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 c02 > public {inline} (0 calls)
 0: multictr.complicated.c02<0>
-c02(f02##0:wybe.int, ?$##0:multictr.complicated):
+c02(f02##0:wybe.int, ?###0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr.complicated)
-    foreign lpvm mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f02##0:wybe.int)
-    foreign llvm or(~$rec##1:multictr.complicated, 1:wybe.int, ?$##0:multictr.complicated)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated)
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f02##0:wybe.int)
+    foreign llvm or(~#rec##1:multictr.complicated, 1:wybe.int, ?###0:multictr.complicated)
 c02 > public {inline} (35 calls)
 1: multictr.complicated.c02<1>
-c02(?f02##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
+c02(?f02##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(###0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f02##0:wybe.int)
 
     1:
-        foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?f02##0:wybe.int)
 
         1:
-            foreign lpvm access(~$##0:multictr.complicated, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?f02##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm access(~###0:multictr.complicated, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?f02##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 c03 > public {inline} (0 calls)
 0: multictr.complicated.c03<0>
-c03(f03##0:wybe.int, ?$##0:multictr.complicated):
+c03(f03##0:wybe.int, ?###0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr.complicated)
-    foreign lpvm mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f03##0:wybe.int)
-    foreign llvm or(~$rec##1:multictr.complicated, 2:wybe.int, ?$##0:multictr.complicated)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated)
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f03##0:wybe.int)
+    foreign llvm or(~#rec##1:multictr.complicated, 2:wybe.int, ?###0:multictr.complicated)
 c03 > public {inline} (33 calls)
 1: multictr.complicated.c03<1>
-c03(?f03##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
+c03(?f03##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(###0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f03##0:wybe.int)
 
     1:
-        foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 2:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 2:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?f03##0:wybe.int)
 
         1:
-            foreign lpvm access(~$##0:multictr.complicated, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?f03##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm access(~###0:multictr.complicated, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?f03##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 c04 > public {inline} (0 calls)
 0: multictr.complicated.c04<0>
-c04(f04##0:wybe.int, ?$##0:multictr.complicated):
+c04(f04##0:wybe.int, ?###0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr.complicated)
-    foreign lpvm mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f04##0:wybe.int)
-    foreign llvm or(~$rec##1:multictr.complicated, 3:wybe.int, ?$##0:multictr.complicated)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated)
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f04##0:wybe.int)
+    foreign llvm or(~#rec##1:multictr.complicated, 3:wybe.int, ?###0:multictr.complicated)
 c04 > public {inline} (31 calls)
 1: multictr.complicated.c04<1>
-c04(?f04##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
+c04(?f04##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(###0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f04##0:wybe.int)
 
     1:
-        foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 3:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 3:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?f04##0:wybe.int)
 
         1:
-            foreign lpvm access(~$##0:multictr.complicated, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?f04##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm access(~###0:multictr.complicated, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?f04##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 c05 > public {inline} (0 calls)
 0: multictr.complicated.c05<0>
-c05(f05##0:wybe.int, ?$##0:multictr.complicated):
+c05(f05##0:wybe.int, ?###0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr.complicated)
-    foreign lpvm mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f05##0:wybe.int)
-    foreign llvm or(~$rec##1:multictr.complicated, 4:wybe.int, ?$##0:multictr.complicated)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated)
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f05##0:wybe.int)
+    foreign llvm or(~#rec##1:multictr.complicated, 4:wybe.int, ?###0:multictr.complicated)
 c05 > public {inline} (29 calls)
 1: multictr.complicated.c05<1>
-c05(?f05##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
+c05(?f05##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(###0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f05##0:wybe.int)
 
     1:
-        foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 4:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 4:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?f05##0:wybe.int)
 
         1:
-            foreign lpvm access(~$##0:multictr.complicated, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?f05##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm access(~###0:multictr.complicated, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?f05##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 c06 > public {inline} (0 calls)
 0: multictr.complicated.c06<0>
-c06(f06##0:wybe.int, ?$##0:multictr.complicated):
+c06(f06##0:wybe.int, ?###0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr.complicated)
-    foreign lpvm mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f06##0:wybe.int)
-    foreign llvm or(~$rec##1:multictr.complicated, 5:wybe.int, ?$##0:multictr.complicated)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated)
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f06##0:wybe.int)
+    foreign llvm or(~#rec##1:multictr.complicated, 5:wybe.int, ?###0:multictr.complicated)
 c06 > public {inline} (27 calls)
 1: multictr.complicated.c06<1>
-c06(?f06##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
+c06(?f06##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(###0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f06##0:wybe.int)
 
     1:
-        foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 5:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 5:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?f06##0:wybe.int)
 
         1:
-            foreign lpvm access(~$##0:multictr.complicated, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?f06##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm access(~###0:multictr.complicated, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?f06##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 c07 > public {inline} (0 calls)
 0: multictr.complicated.c07<0>
-c07(f07##0:wybe.int, ?$##0:multictr.complicated):
+c07(f07##0:wybe.int, ?###0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr.complicated)
-    foreign lpvm mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f07##0:wybe.int)
-    foreign llvm or(~$rec##1:multictr.complicated, 6:wybe.int, ?$##0:multictr.complicated)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.complicated)
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f07##0:wybe.int)
+    foreign llvm or(~#rec##1:multictr.complicated, 6:wybe.int, ?###0:multictr.complicated)
 c07 > public {inline} (25 calls)
 1: multictr.complicated.c07<1>
-c07(?f07##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
+c07(?f07##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(###0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f07##0:wybe.int)
 
     1:
-        foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 6:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 6:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?f07##0:wybe.int)
 
         1:
-            foreign lpvm access(~$##0:multictr.complicated, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?f07##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm access(~###0:multictr.complicated, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?f07##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 c08 > public {inline} (0 calls)
 0: multictr.complicated.c08<0>
-c08(f08##0:wybe.int, ?$##0:multictr.complicated):
+c08(f08##0:wybe.int, ?###0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:multictr.complicated)
-    foreign lpvm mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 7:wybe.int)
-    foreign lpvm mutate(~$rec##1:multictr.complicated, ?$rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f08##0:wybe.int)
-    foreign llvm or(~$rec##2:multictr.complicated, 7:wybe.int, ?$##0:multictr.complicated)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated)
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 7:wybe.int)
+    foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f08##0:wybe.int)
+    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?###0:multictr.complicated)
 c08 > public {inline} (23 calls)
 1: multictr.complicated.c08<1>
-c08(?f08##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
+c08(?f08##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(###0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f08##0:wybe.int)
 
     1:
-        foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?f08##0:wybe.int)
 
         1:
-            foreign lpvm access($##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 7:16 bit unsigned, ?tmp$3##0:wybe.bool)
-            case ~tmp$3##0:wybe.bool of
+            foreign lpvm access(###0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 7:16 bit unsigned, ?tmp#3##0:wybe.bool)
+            case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
                 foreign llvm move(undef:wybe.int, ?f08##0:wybe.int)
 
             1:
-                foreign lpvm access(~$##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f08##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+                foreign lpvm access(~###0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f08##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
@@ -1249,43 +1249,43 @@ c08(?f08##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
 
 c09 > public {inline} (0 calls)
 0: multictr.complicated.c09<0>
-c09(f09##0:wybe.int, ?$##0:multictr.complicated):
+c09(f09##0:wybe.int, ?###0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:multictr.complicated)
-    foreign lpvm mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 8:wybe.int)
-    foreign lpvm mutate(~$rec##1:multictr.complicated, ?$rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f09##0:wybe.int)
-    foreign llvm or(~$rec##2:multictr.complicated, 7:wybe.int, ?$##0:multictr.complicated)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated)
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 8:wybe.int)
+    foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f09##0:wybe.int)
+    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?###0:multictr.complicated)
 c09 > public {inline} (21 calls)
 1: multictr.complicated.c09<1>
-c09(?f09##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
+c09(?f09##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(###0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f09##0:wybe.int)
 
     1:
-        foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?f09##0:wybe.int)
 
         1:
-            foreign lpvm access($##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 8:16 bit unsigned, ?tmp$3##0:wybe.bool)
-            case ~tmp$3##0:wybe.bool of
+            foreign lpvm access(###0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 8:16 bit unsigned, ?tmp#3##0:wybe.bool)
+            case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
                 foreign llvm move(undef:wybe.int, ?f09##0:wybe.int)
 
             1:
-                foreign lpvm access(~$##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f09##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+                foreign lpvm access(~###0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f09##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
@@ -1293,43 +1293,43 @@ c09(?f09##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
 
 c10 > public {inline} (0 calls)
 0: multictr.complicated.c10<0>
-c10(f10##0:wybe.int, ?$##0:multictr.complicated):
+c10(f10##0:wybe.int, ?###0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:multictr.complicated)
-    foreign lpvm mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 9:wybe.int)
-    foreign lpvm mutate(~$rec##1:multictr.complicated, ?$rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f10##0:wybe.int)
-    foreign llvm or(~$rec##2:multictr.complicated, 7:wybe.int, ?$##0:multictr.complicated)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated)
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 9:wybe.int)
+    foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f10##0:wybe.int)
+    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?###0:multictr.complicated)
 c10 > public {inline} (19 calls)
 1: multictr.complicated.c10<1>
-c10(?f10##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
+c10(?f10##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(###0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f10##0:wybe.int)
 
     1:
-        foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?f10##0:wybe.int)
 
         1:
-            foreign lpvm access($##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 9:16 bit unsigned, ?tmp$3##0:wybe.bool)
-            case ~tmp$3##0:wybe.bool of
+            foreign lpvm access(###0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 9:16 bit unsigned, ?tmp#3##0:wybe.bool)
+            case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
                 foreign llvm move(undef:wybe.int, ?f10##0:wybe.int)
 
             1:
-                foreign lpvm access(~$##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f10##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+                foreign lpvm access(~###0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f10##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
@@ -1337,43 +1337,43 @@ c10(?f10##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
 
 c11 > public {inline} (0 calls)
 0: multictr.complicated.c11<0>
-c11(f11##0:wybe.int, ?$##0:multictr.complicated):
+c11(f11##0:wybe.int, ?###0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:multictr.complicated)
-    foreign lpvm mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    foreign lpvm mutate(~$rec##1:multictr.complicated, ?$rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f11##0:wybe.int)
-    foreign llvm or(~$rec##2:multictr.complicated, 7:wybe.int, ?$##0:multictr.complicated)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated)
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f11##0:wybe.int)
+    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?###0:multictr.complicated)
 c11 > public {inline} (17 calls)
 1: multictr.complicated.c11<1>
-c11(?f11##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
+c11(?f11##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(###0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f11##0:wybe.int)
 
     1:
-        foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?f11##0:wybe.int)
 
         1:
-            foreign lpvm access($##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 10:16 bit unsigned, ?tmp$3##0:wybe.bool)
-            case ~tmp$3##0:wybe.bool of
+            foreign lpvm access(###0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 10:16 bit unsigned, ?tmp#3##0:wybe.bool)
+            case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
                 foreign llvm move(undef:wybe.int, ?f11##0:wybe.int)
 
             1:
-                foreign lpvm access(~$##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f11##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+                foreign lpvm access(~###0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f11##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
@@ -1381,43 +1381,43 @@ c11(?f11##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
 
 c12 > public {inline} (0 calls)
 0: multictr.complicated.c12<0>
-c12(f12##0:wybe.int, ?$##0:multictr.complicated):
+c12(f12##0:wybe.int, ?###0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:multictr.complicated)
-    foreign lpvm mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 11:wybe.int)
-    foreign lpvm mutate(~$rec##1:multictr.complicated, ?$rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f12##0:wybe.int)
-    foreign llvm or(~$rec##2:multictr.complicated, 7:wybe.int, ?$##0:multictr.complicated)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated)
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 11:wybe.int)
+    foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f12##0:wybe.int)
+    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?###0:multictr.complicated)
 c12 > public {inline} (15 calls)
 1: multictr.complicated.c12<1>
-c12(?f12##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
+c12(?f12##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(###0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f12##0:wybe.int)
 
     1:
-        foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?f12##0:wybe.int)
 
         1:
-            foreign lpvm access($##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 11:16 bit unsigned, ?tmp$3##0:wybe.bool)
-            case ~tmp$3##0:wybe.bool of
+            foreign lpvm access(###0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 11:16 bit unsigned, ?tmp#3##0:wybe.bool)
+            case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
                 foreign llvm move(undef:wybe.int, ?f12##0:wybe.int)
 
             1:
-                foreign lpvm access(~$##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f12##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+                foreign lpvm access(~###0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f12##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
@@ -1425,43 +1425,43 @@ c12(?f12##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
 
 c13 > public {inline} (0 calls)
 0: multictr.complicated.c13<0>
-c13(f13##0:wybe.int, ?$##0:multictr.complicated):
+c13(f13##0:wybe.int, ?###0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:multictr.complicated)
-    foreign lpvm mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 12:wybe.int)
-    foreign lpvm mutate(~$rec##1:multictr.complicated, ?$rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f13##0:wybe.int)
-    foreign llvm or(~$rec##2:multictr.complicated, 7:wybe.int, ?$##0:multictr.complicated)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated)
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 12:wybe.int)
+    foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f13##0:wybe.int)
+    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?###0:multictr.complicated)
 c13 > public {inline} (13 calls)
 1: multictr.complicated.c13<1>
-c13(?f13##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
+c13(?f13##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(###0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f13##0:wybe.int)
 
     1:
-        foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?f13##0:wybe.int)
 
         1:
-            foreign lpvm access($##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 12:16 bit unsigned, ?tmp$3##0:wybe.bool)
-            case ~tmp$3##0:wybe.bool of
+            foreign lpvm access(###0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 12:16 bit unsigned, ?tmp#3##0:wybe.bool)
+            case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
                 foreign llvm move(undef:wybe.int, ?f13##0:wybe.int)
 
             1:
-                foreign lpvm access(~$##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f13##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+                foreign lpvm access(~###0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f13##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
@@ -1469,43 +1469,43 @@ c13(?f13##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
 
 c14 > public {inline} (0 calls)
 0: multictr.complicated.c14<0>
-c14(f14##0:wybe.int, ?$##0:multictr.complicated):
+c14(f14##0:wybe.int, ?###0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:multictr.complicated)
-    foreign lpvm mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 13:wybe.int)
-    foreign lpvm mutate(~$rec##1:multictr.complicated, ?$rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f14##0:wybe.int)
-    foreign llvm or(~$rec##2:multictr.complicated, 7:wybe.int, ?$##0:multictr.complicated)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated)
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 13:wybe.int)
+    foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f14##0:wybe.int)
+    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?###0:multictr.complicated)
 c14 > public {inline} (11 calls)
 1: multictr.complicated.c14<1>
-c14(?f14##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
+c14(?f14##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(###0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f14##0:wybe.int)
 
     1:
-        foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?f14##0:wybe.int)
 
         1:
-            foreign lpvm access($##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 13:16 bit unsigned, ?tmp$3##0:wybe.bool)
-            case ~tmp$3##0:wybe.bool of
+            foreign lpvm access(###0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 13:16 bit unsigned, ?tmp#3##0:wybe.bool)
+            case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
                 foreign llvm move(undef:wybe.int, ?f14##0:wybe.int)
 
             1:
-                foreign lpvm access(~$##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f14##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+                foreign lpvm access(~###0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f14##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
@@ -1513,43 +1513,43 @@ c14(?f14##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
 
 c15 > public {inline} (0 calls)
 0: multictr.complicated.c15<0>
-c15(f15##0:wybe.int, ?$##0:multictr.complicated):
+c15(f15##0:wybe.int, ?###0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:multictr.complicated)
-    foreign lpvm mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 14:wybe.int)
-    foreign lpvm mutate(~$rec##1:multictr.complicated, ?$rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f15##0:wybe.int)
-    foreign llvm or(~$rec##2:multictr.complicated, 7:wybe.int, ?$##0:multictr.complicated)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated)
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 14:wybe.int)
+    foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f15##0:wybe.int)
+    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?###0:multictr.complicated)
 c15 > public {inline} (9 calls)
 1: multictr.complicated.c15<1>
-c15(?f15##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
+c15(?f15##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(###0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f15##0:wybe.int)
 
     1:
-        foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?f15##0:wybe.int)
 
         1:
-            foreign lpvm access($##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 14:16 bit unsigned, ?tmp$3##0:wybe.bool)
-            case ~tmp$3##0:wybe.bool of
+            foreign lpvm access(###0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 14:16 bit unsigned, ?tmp#3##0:wybe.bool)
+            case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
                 foreign llvm move(undef:wybe.int, ?f15##0:wybe.int)
 
             1:
-                foreign lpvm access(~$##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f15##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+                foreign lpvm access(~###0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f15##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
@@ -1557,43 +1557,43 @@ c15(?f15##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
 
 c16 > public {inline} (0 calls)
 0: multictr.complicated.c16<0>
-c16(f16##0:wybe.int, ?$##0:multictr.complicated):
+c16(f16##0:wybe.int, ?###0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:multictr.complicated)
-    foreign lpvm mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 15:wybe.int)
-    foreign lpvm mutate(~$rec##1:multictr.complicated, ?$rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f16##0:wybe.int)
-    foreign llvm or(~$rec##2:multictr.complicated, 7:wybe.int, ?$##0:multictr.complicated)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated)
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 15:wybe.int)
+    foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f16##0:wybe.int)
+    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?###0:multictr.complicated)
 c16 > public {inline} (7 calls)
 1: multictr.complicated.c16<1>
-c16(?f16##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
+c16(?f16##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(###0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f16##0:wybe.int)
 
     1:
-        foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?f16##0:wybe.int)
 
         1:
-            foreign lpvm access($##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 15:16 bit unsigned, ?tmp$3##0:wybe.bool)
-            case ~tmp$3##0:wybe.bool of
+            foreign lpvm access(###0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 15:16 bit unsigned, ?tmp#3##0:wybe.bool)
+            case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
                 foreign llvm move(undef:wybe.int, ?f16##0:wybe.int)
 
             1:
-                foreign lpvm access(~$##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f16##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+                foreign lpvm access(~###0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f16##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
@@ -1601,43 +1601,43 @@ c16(?f16##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
 
 c17 > public {inline} (0 calls)
 0: multictr.complicated.c17<0>
-c17(f17##0:wybe.int, ?$##0:multictr.complicated):
+c17(f17##0:wybe.int, ?###0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:multictr.complicated)
-    foreign lpvm mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 16:wybe.int)
-    foreign lpvm mutate(~$rec##1:multictr.complicated, ?$rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f17##0:wybe.int)
-    foreign llvm or(~$rec##2:multictr.complicated, 7:wybe.int, ?$##0:multictr.complicated)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.complicated)
+    foreign lpvm mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 16:wybe.int)
+    foreign lpvm mutate(~#rec##1:multictr.complicated, ?#rec##2:multictr.complicated, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~f17##0:wybe.int)
+    foreign llvm or(~#rec##2:multictr.complicated, 7:wybe.int, ?###0:multictr.complicated)
 c17 > public {inline} (5 calls)
 1: multictr.complicated.c17<1>
-c17(?f17##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
+c17(?f17##0:wybe.int, ###0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(###0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f17##0:wybe.int)
 
     1:
-        foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?f17##0:wybe.int)
 
         1:
-            foreign lpvm access($##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 16:16 bit unsigned, ?tmp$3##0:wybe.bool)
-            case ~tmp$3##0:wybe.bool of
+            foreign lpvm access(###0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 16:16 bit unsigned, ?tmp#3##0:wybe.bool)
+            case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
                 foreign llvm move(undef:wybe.int, ?f17##0:wybe.int)
 
             1:
-                foreign lpvm access(~$##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f17##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+                foreign lpvm access(~###0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?f17##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
@@ -1645,417 +1645,417 @@ c17(?f17##0:wybe.int, $##0:multictr.complicated, ?$$##0:wybe.bool):
 
 f01 > public {inline} (0 calls)
 0: multictr.complicated.f01<0>
-f01($rec##0:multictr.complicated, ?$##0:wybe.int, ?$$##0:wybe.bool):
+f01(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
         1:
-            foreign lpvm access(~$rec##0:multictr.complicated, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm access(~#rec##0:multictr.complicated, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?###0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 f01 > public {inline} (0 calls)
 1: multictr.complicated.f01<1>
-f01($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.int, ?$$##0:wybe.bool):
+f01(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
-            foreign lpvm {noalias} mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 f02 > public {inline} (0 calls)
 0: multictr.complicated.f02<0>
-f02($rec##0:multictr.complicated, ?$##0:wybe.int, ?$$##0:wybe.bool):
+f02(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
         1:
-            foreign lpvm access(~$rec##0:multictr.complicated, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm access(~#rec##0:multictr.complicated, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?###0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 f02 > public {inline} (0 calls)
 1: multictr.complicated.f02<1>
-f02($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.int, ?$$##0:wybe.bool):
+f02(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
-            foreign lpvm {noalias} mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, -1:wybe.int, 0:wybe.int, 8:wybe.int, 1:wybe.int, ~$field##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, -1:wybe.int, 0:wybe.int, 8:wybe.int, 1:wybe.int, ~#field##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 f03 > public {inline} (0 calls)
 0: multictr.complicated.f03<0>
-f03($rec##0:multictr.complicated, ?$##0:wybe.int, ?$$##0:wybe.bool):
+f03(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 2:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 2:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
         1:
-            foreign lpvm access(~$rec##0:multictr.complicated, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm access(~#rec##0:multictr.complicated, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?###0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 f03 > public {inline} (0 calls)
 1: multictr.complicated.f03<1>
-f03($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.int, ?$$##0:wybe.bool):
+f03(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 2:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 2:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
-            foreign lpvm {noalias} mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, -2:wybe.int, 0:wybe.int, 8:wybe.int, 2:wybe.int, ~$field##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, -2:wybe.int, 0:wybe.int, 8:wybe.int, 2:wybe.int, ~#field##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 f04 > public {inline} (0 calls)
 0: multictr.complicated.f04<0>
-f04($rec##0:multictr.complicated, ?$##0:wybe.int, ?$$##0:wybe.bool):
+f04(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 3:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 3:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
         1:
-            foreign lpvm access(~$rec##0:multictr.complicated, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?$##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm access(~#rec##0:multictr.complicated, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?###0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 f04 > public {inline} (0 calls)
 1: multictr.complicated.f04<1>
-f04($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.int, ?$$##0:wybe.bool):
+f04(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 3:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 3:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
-            foreign lpvm {noalias} mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, -3:wybe.int, 0:wybe.int, 8:wybe.int, 3:wybe.int, ~$field##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, -3:wybe.int, 0:wybe.int, 8:wybe.int, 3:wybe.int, ~#field##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 f05 > public {inline} (0 calls)
 0: multictr.complicated.f05<0>
-f05($rec##0:multictr.complicated, ?$##0:wybe.int, ?$$##0:wybe.bool):
+f05(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 4:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 4:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
         1:
-            foreign lpvm access(~$rec##0:multictr.complicated, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?$##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm access(~#rec##0:multictr.complicated, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?###0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 f05 > public {inline} (0 calls)
 1: multictr.complicated.f05<1>
-f05($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.int, ?$$##0:wybe.bool):
+f05(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 4:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 4:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
-            foreign lpvm {noalias} mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, -4:wybe.int, 0:wybe.int, 8:wybe.int, 4:wybe.int, ~$field##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, -4:wybe.int, 0:wybe.int, 8:wybe.int, 4:wybe.int, ~#field##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 f06 > public {inline} (0 calls)
 0: multictr.complicated.f06<0>
-f06($rec##0:multictr.complicated, ?$##0:wybe.int, ?$$##0:wybe.bool):
+f06(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 5:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 5:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
         1:
-            foreign lpvm access(~$rec##0:multictr.complicated, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?$##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm access(~#rec##0:multictr.complicated, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?###0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 f06 > public {inline} (0 calls)
 1: multictr.complicated.f06<1>
-f06($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.int, ?$$##0:wybe.bool):
+f06(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 5:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 5:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
-            foreign lpvm {noalias} mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, -5:wybe.int, 0:wybe.int, 8:wybe.int, 5:wybe.int, ~$field##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, -5:wybe.int, 0:wybe.int, 8:wybe.int, 5:wybe.int, ~#field##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 f07 > public {inline} (0 calls)
 0: multictr.complicated.f07<0>
-f07($rec##0:multictr.complicated, ?$##0:wybe.int, ?$$##0:wybe.bool):
+f07(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 6:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 6:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
         1:
-            foreign lpvm access(~$rec##0:multictr.complicated, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?$##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm access(~#rec##0:multictr.complicated, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?###0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 f07 > public {inline} (0 calls)
 1: multictr.complicated.f07<1>
-f07($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.int, ?$$##0:wybe.bool):
+f07(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 6:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 6:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
-            foreign lpvm {noalias} mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, -6:wybe.int, 0:wybe.int, 8:wybe.int, 6:wybe.int, ~$field##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, -6:wybe.int, 0:wybe.int, 8:wybe.int, 6:wybe.int, ~#field##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 f08 > public {inline} (0 calls)
 0: multictr.complicated.f08<0>
-f08($rec##0:multictr.complicated, ?$##0:wybe.int, ?$$##0:wybe.bool):
+f08(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
         1:
-            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 7:16 bit unsigned, ?tmp$3##0:wybe.bool)
-            case ~tmp$3##0:wybe.bool of
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 7:16 bit unsigned, ?tmp#3##0:wybe.bool)
+            case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
             1:
-                foreign lpvm access(~$rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?###0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 f08 > public {inline} (0 calls)
 1: multictr.complicated.f08<1>
-f08($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.int, ?$$##0:wybe.bool):
+f08(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
-            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 7:16 bit unsigned, ?tmp$3##0:wybe.bool)
-            case ~tmp$3##0:wybe.bool of
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 7:16 bit unsigned, ?tmp#3##0:wybe.bool)
+            case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-                foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
             1:
-                foreign lpvm {noalias} mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~$field##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+                foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
@@ -2063,67 +2063,67 @@ f08($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.
 
 f09 > public {inline} (0 calls)
 0: multictr.complicated.f09<0>
-f09($rec##0:multictr.complicated, ?$##0:wybe.int, ?$$##0:wybe.bool):
+f09(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
         1:
-            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 8:16 bit unsigned, ?tmp$3##0:wybe.bool)
-            case ~tmp$3##0:wybe.bool of
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 8:16 bit unsigned, ?tmp#3##0:wybe.bool)
+            case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
             1:
-                foreign lpvm access(~$rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?###0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 f09 > public {inline} (0 calls)
 1: multictr.complicated.f09<1>
-f09($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.int, ?$$##0:wybe.bool):
+f09(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
-            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 8:16 bit unsigned, ?tmp$3##0:wybe.bool)
-            case ~tmp$3##0:wybe.bool of
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 8:16 bit unsigned, ?tmp#3##0:wybe.bool)
+            case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-                foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
             1:
-                foreign lpvm {noalias} mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~$field##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+                foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
@@ -2131,67 +2131,67 @@ f09($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.
 
 f10 > public {inline} (0 calls)
 0: multictr.complicated.f10<0>
-f10($rec##0:multictr.complicated, ?$##0:wybe.int, ?$$##0:wybe.bool):
+f10(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
         1:
-            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 9:16 bit unsigned, ?tmp$3##0:wybe.bool)
-            case ~tmp$3##0:wybe.bool of
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 9:16 bit unsigned, ?tmp#3##0:wybe.bool)
+            case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
             1:
-                foreign lpvm access(~$rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?###0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 f10 > public {inline} (0 calls)
 1: multictr.complicated.f10<1>
-f10($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.int, ?$$##0:wybe.bool):
+f10(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
-            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 9:16 bit unsigned, ?tmp$3##0:wybe.bool)
-            case ~tmp$3##0:wybe.bool of
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 9:16 bit unsigned, ?tmp#3##0:wybe.bool)
+            case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-                foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
             1:
-                foreign lpvm {noalias} mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~$field##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+                foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
@@ -2199,67 +2199,67 @@ f10($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.
 
 f11 > public {inline} (0 calls)
 0: multictr.complicated.f11<0>
-f11($rec##0:multictr.complicated, ?$##0:wybe.int, ?$$##0:wybe.bool):
+f11(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
         1:
-            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 10:16 bit unsigned, ?tmp$3##0:wybe.bool)
-            case ~tmp$3##0:wybe.bool of
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 10:16 bit unsigned, ?tmp#3##0:wybe.bool)
+            case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
             1:
-                foreign lpvm access(~$rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?###0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 f11 > public {inline} (0 calls)
 1: multictr.complicated.f11<1>
-f11($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.int, ?$$##0:wybe.bool):
+f11(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
-            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 10:16 bit unsigned, ?tmp$3##0:wybe.bool)
-            case ~tmp$3##0:wybe.bool of
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 10:16 bit unsigned, ?tmp#3##0:wybe.bool)
+            case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-                foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
             1:
-                foreign lpvm {noalias} mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~$field##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+                foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
@@ -2267,67 +2267,67 @@ f11($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.
 
 f12 > public {inline} (0 calls)
 0: multictr.complicated.f12<0>
-f12($rec##0:multictr.complicated, ?$##0:wybe.int, ?$$##0:wybe.bool):
+f12(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
         1:
-            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 11:16 bit unsigned, ?tmp$3##0:wybe.bool)
-            case ~tmp$3##0:wybe.bool of
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 11:16 bit unsigned, ?tmp#3##0:wybe.bool)
+            case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
             1:
-                foreign lpvm access(~$rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?###0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 f12 > public {inline} (0 calls)
 1: multictr.complicated.f12<1>
-f12($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.int, ?$$##0:wybe.bool):
+f12(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
-            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 11:16 bit unsigned, ?tmp$3##0:wybe.bool)
-            case ~tmp$3##0:wybe.bool of
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 11:16 bit unsigned, ?tmp#3##0:wybe.bool)
+            case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-                foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
             1:
-                foreign lpvm {noalias} mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~$field##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+                foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
@@ -2335,67 +2335,67 @@ f12($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.
 
 f13 > public {inline} (0 calls)
 0: multictr.complicated.f13<0>
-f13($rec##0:multictr.complicated, ?$##0:wybe.int, ?$$##0:wybe.bool):
+f13(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
         1:
-            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 12:16 bit unsigned, ?tmp$3##0:wybe.bool)
-            case ~tmp$3##0:wybe.bool of
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 12:16 bit unsigned, ?tmp#3##0:wybe.bool)
+            case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
             1:
-                foreign lpvm access(~$rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?###0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 f13 > public {inline} (0 calls)
 1: multictr.complicated.f13<1>
-f13($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.int, ?$$##0:wybe.bool):
+f13(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
-            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 12:16 bit unsigned, ?tmp$3##0:wybe.bool)
-            case ~tmp$3##0:wybe.bool of
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 12:16 bit unsigned, ?tmp#3##0:wybe.bool)
+            case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-                foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
             1:
-                foreign lpvm {noalias} mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~$field##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+                foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
@@ -2403,67 +2403,67 @@ f13($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.
 
 f14 > public {inline} (0 calls)
 0: multictr.complicated.f14<0>
-f14($rec##0:multictr.complicated, ?$##0:wybe.int, ?$$##0:wybe.bool):
+f14(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
         1:
-            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 13:16 bit unsigned, ?tmp$3##0:wybe.bool)
-            case ~tmp$3##0:wybe.bool of
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 13:16 bit unsigned, ?tmp#3##0:wybe.bool)
+            case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
             1:
-                foreign lpvm access(~$rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?###0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 f14 > public {inline} (0 calls)
 1: multictr.complicated.f14<1>
-f14($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.int, ?$$##0:wybe.bool):
+f14(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
-            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 13:16 bit unsigned, ?tmp$3##0:wybe.bool)
-            case ~tmp$3##0:wybe.bool of
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 13:16 bit unsigned, ?tmp#3##0:wybe.bool)
+            case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-                foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
             1:
-                foreign lpvm {noalias} mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~$field##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+                foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
@@ -2471,67 +2471,67 @@ f14($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.
 
 f15 > public {inline} (0 calls)
 0: multictr.complicated.f15<0>
-f15($rec##0:multictr.complicated, ?$##0:wybe.int, ?$$##0:wybe.bool):
+f15(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
         1:
-            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 14:16 bit unsigned, ?tmp$3##0:wybe.bool)
-            case ~tmp$3##0:wybe.bool of
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 14:16 bit unsigned, ?tmp#3##0:wybe.bool)
+            case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
             1:
-                foreign lpvm access(~$rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?###0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 f15 > public {inline} (0 calls)
 1: multictr.complicated.f15<1>
-f15($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.int, ?$$##0:wybe.bool):
+f15(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
-            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 14:16 bit unsigned, ?tmp$3##0:wybe.bool)
-            case ~tmp$3##0:wybe.bool of
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 14:16 bit unsigned, ?tmp#3##0:wybe.bool)
+            case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-                foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
             1:
-                foreign lpvm {noalias} mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~$field##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+                foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
@@ -2539,67 +2539,67 @@ f15($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.
 
 f16 > public {inline} (0 calls)
 0: multictr.complicated.f16<0>
-f16($rec##0:multictr.complicated, ?$##0:wybe.int, ?$$##0:wybe.bool):
+f16(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
         1:
-            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 15:16 bit unsigned, ?tmp$3##0:wybe.bool)
-            case ~tmp$3##0:wybe.bool of
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 15:16 bit unsigned, ?tmp#3##0:wybe.bool)
+            case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
             1:
-                foreign lpvm access(~$rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?###0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 f16 > public {inline} (0 calls)
 1: multictr.complicated.f16<1>
-f16($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.int, ?$$##0:wybe.bool):
+f16(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
-            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 15:16 bit unsigned, ?tmp$3##0:wybe.bool)
-            case ~tmp$3##0:wybe.bool of
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 15:16 bit unsigned, ?tmp#3##0:wybe.bool)
+            case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-                foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
             1:
-                foreign lpvm {noalias} mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~$field##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+                foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
@@ -2607,67 +2607,67 @@ f16($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.
 
 f17 > public {inline} (0 calls)
 0: multictr.complicated.f17<0>
-f17($rec##0:multictr.complicated, ?$##0:wybe.int, ?$$##0:wybe.bool):
+f17(#rec##0:multictr.complicated, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
         1:
-            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 16:16 bit unsigned, ?tmp$3##0:wybe.bool)
-            case ~tmp$3##0:wybe.bool of
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 16:16 bit unsigned, ?tmp#3##0:wybe.bool)
+            case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-                foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
             1:
-                foreign lpvm access(~$rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?$##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+                foreign lpvm access(~#rec##0:multictr.complicated, 1:wybe.int, 16:wybe.int, 7:wybe.int, ?###0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 f17 > public {inline} (0 calls)
 1: multictr.complicated.f17<1>
-f17($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.int, ?$$##0:wybe.bool):
+f17(#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_uge($rec##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_uge(#rec##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
         1:
-            foreign lpvm access($rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?$tag##0:16 bit unsigned)
-            foreign llvm icmp_eq(~$tag##0:16 bit unsigned, 16:16 bit unsigned, ?tmp$3##0:wybe.bool)
-            case ~tmp$3##0:wybe.bool of
+            foreign lpvm access(#rec##0:multictr.complicated, -7:wybe.int, 16:wybe.int, 7:wybe.int, ?#tag##0:16 bit unsigned)
+            foreign llvm icmp_eq(~#tag##0:16 bit unsigned, 16:16 bit unsigned, ?tmp#3##0:wybe.bool)
+            case ~tmp#3##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-                foreign llvm move(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated)
 
             1:
-                foreign lpvm {noalias} mutate(~$rec##0:multictr.complicated, ?$rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~$field##0:wybe.int)
-                foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+                foreign lpvm {noalias} mutate(~#rec##0:multictr.complicated, ?#rec##1:multictr.complicated, 1:wybe.int, 0:wybe.int, 16:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
+                foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
@@ -2675,35 +2675,35 @@ f17($rec##0:multictr.complicated, ?$rec##1:multictr.complicated, $field##0:wybe.
 
 spring > public {inline} (0 calls)
 0: multictr.complicated.spring<0>
-spring(?$##0:multictr.complicated):
+spring(?###0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(1:multictr.complicated, ?$##0:multictr.complicated)
+    foreign llvm move(1:multictr.complicated, ?###0:multictr.complicated)
 
 
 summer > public {inline} (0 calls)
 0: multictr.complicated.summer<0>
-summer(?$##0:multictr.complicated):
+summer(?###0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(2:multictr.complicated, ?$##0:multictr.complicated)
+    foreign llvm move(2:multictr.complicated, ?###0:multictr.complicated)
 
 
 winter > public {inline} (0 calls)
 0: multictr.complicated.winter<0>
-winter(?$##0:multictr.complicated):
+winter(?###0:multictr.complicated):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:multictr.complicated, ?$##0:multictr.complicated)
+    foreign llvm move(0:multictr.complicated, ?###0:multictr.complicated)
 
 
 ~= > public {inline} (0 calls)
 0: multictr.complicated.~=<0>
-~=($left##0:multictr.complicated, $right##0:multictr.complicated, ?$$##0:wybe.bool):
+~=(#left##0:multictr.complicated, #right##0:multictr.complicated, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    multictr.complicated.=<0>(~$left##0:multictr.complicated, ~$right##0:multictr.complicated, ?tmp$0##0:wybe.bool) #0
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    multictr.complicated.=<0>(~#left##0:multictr.complicated, ~#right##0:multictr.complicated, ?tmp#0##0:wybe.bool) #0
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
   LLVM code       :
 
@@ -2719,536 +2719,536 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"multictr.complicated.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"multictr.complicated.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$left##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#left##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$55##0" = and i64 %"$left##0", 7 
-  %"2$tmp$56##0" = icmp eq i64 %"2$tmp$55##0", 0 
-  br i1 %"2$tmp$56##0", label %if.then1, label %if.else1 
+  %"2#tmp#55##0" = and i64 %"#left##0", 7 
+  %"2#tmp#56##0" = icmp eq i64 %"2#tmp#55##0", 0 
+  br i1 %"2#tmp#56##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3#####0" 
 if.then1:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %"4$tmp$58##0" = icmp uge i64 %"$right##0", 4 
-  br i1 %"4$tmp$58##0", label %if.then2, label %if.else2 
+  %"4#tmp#58##0" = icmp uge i64 %"#right##0", 4 
+  br i1 %"4#tmp#58##0", label %if.then2, label %if.else2 
 if.else1:
-  %"5$tmp$60##0" = icmp eq i64 %"2$tmp$55##0", 1 
-  br i1 %"5$tmp$60##0", label %if.then4, label %if.else4 
+  %"5#tmp#60##0" = icmp eq i64 %"2#tmp#55##0", 1 
+  br i1 %"5#tmp#60##0", label %if.then4, label %if.else4 
 if.then2:
-  %"6$tmp$59##0" = and i64 %"$right##0", 7 
-  %"6$tmp$60##0" = icmp eq i64 %"6$tmp$59##0", 0 
-  br i1 %"6$tmp$60##0", label %if.then3, label %if.else3 
+  %"6#tmp#59##0" = and i64 %"#right##0", 7 
+  %"6#tmp#60##0" = icmp eq i64 %"6#tmp#59##0", 0 
+  br i1 %"6#tmp#60##0", label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %4 = inttoptr i64 %"$right##0" to i64* 
+  %4 = inttoptr i64 %"#right##0" to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
   %6 = load  i64, i64* %5 
-  %"8$$$##0" = icmp eq i64 %3, %6 
-  ret i1 %"8$$$##0" 
+  %"8#####0" = icmp eq i64 %3, %6 
+  ret i1 %"8#####0" 
 if.else3:
   ret i1 0 
 if.then4:
-  %7 = add   i64 %"$left##0", -1 
+  %7 = add   i64 %"#left##0", -1 
   %8 = inttoptr i64 %7 to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %"10$tmp$62##0" = icmp uge i64 %"$right##0", 4 
-  br i1 %"10$tmp$62##0", label %if.then5, label %if.else5 
+  %"10#tmp#62##0" = icmp uge i64 %"#right##0", 4 
+  br i1 %"10#tmp#62##0", label %if.then5, label %if.else5 
 if.else4:
-  %"11$tmp$64##0" = icmp eq i64 %"2$tmp$55##0", 2 
-  br i1 %"11$tmp$64##0", label %if.then7, label %if.else7 
+  %"11#tmp#64##0" = icmp eq i64 %"2#tmp#55##0", 2 
+  br i1 %"11#tmp#64##0", label %if.then7, label %if.else7 
 if.then5:
-  %"12$tmp$63##0" = and i64 %"$right##0", 7 
-  %"12$tmp$64##0" = icmp eq i64 %"12$tmp$63##0", 1 
-  br i1 %"12$tmp$64##0", label %if.then6, label %if.else6 
+  %"12#tmp#63##0" = and i64 %"#right##0", 7 
+  %"12#tmp#64##0" = icmp eq i64 %"12#tmp#63##0", 1 
+  br i1 %"12#tmp#64##0", label %if.then6, label %if.else6 
 if.else5:
   ret i1 0 
 if.then6:
-  %11 = add   i64 %"$right##0", -1 
+  %11 = add   i64 %"#right##0", -1 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"14$$$##0" = icmp eq i64 %10, %14 
-  ret i1 %"14$$$##0" 
+  %"14#####0" = icmp eq i64 %10, %14 
+  ret i1 %"14#####0" 
 if.else6:
   ret i1 0 
 if.then7:
-  %15 = add   i64 %"$left##0", -2 
+  %15 = add   i64 %"#left##0", -2 
   %16 = inttoptr i64 %15 to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
-  %"16$tmp$66##0" = icmp uge i64 %"$right##0", 4 
-  br i1 %"16$tmp$66##0", label %if.then8, label %if.else8 
+  %"16#tmp#66##0" = icmp uge i64 %"#right##0", 4 
+  br i1 %"16#tmp#66##0", label %if.then8, label %if.else8 
 if.else7:
-  %"17$tmp$68##0" = icmp eq i64 %"2$tmp$55##0", 3 
-  br i1 %"17$tmp$68##0", label %if.then10, label %if.else10 
+  %"17#tmp#68##0" = icmp eq i64 %"2#tmp#55##0", 3 
+  br i1 %"17#tmp#68##0", label %if.then10, label %if.else10 
 if.then8:
-  %"18$tmp$67##0" = and i64 %"$right##0", 7 
-  %"18$tmp$68##0" = icmp eq i64 %"18$tmp$67##0", 2 
-  br i1 %"18$tmp$68##0", label %if.then9, label %if.else9 
+  %"18#tmp#67##0" = and i64 %"#right##0", 7 
+  %"18#tmp#68##0" = icmp eq i64 %"18#tmp#67##0", 2 
+  br i1 %"18#tmp#68##0", label %if.then9, label %if.else9 
 if.else8:
   ret i1 0 
 if.then9:
-  %19 = add   i64 %"$right##0", -2 
+  %19 = add   i64 %"#right##0", -2 
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %"20$$$##0" = icmp eq i64 %18, %22 
-  ret i1 %"20$$$##0" 
+  %"20#####0" = icmp eq i64 %18, %22 
+  ret i1 %"20#####0" 
 if.else9:
   ret i1 0 
 if.then10:
-  %23 = add   i64 %"$left##0", -3 
+  %23 = add   i64 %"#left##0", -3 
   %24 = inttoptr i64 %23 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
   %26 = load  i64, i64* %25 
-  %"22$tmp$70##0" = icmp uge i64 %"$right##0", 4 
-  br i1 %"22$tmp$70##0", label %if.then11, label %if.else11 
+  %"22#tmp#70##0" = icmp uge i64 %"#right##0", 4 
+  br i1 %"22#tmp#70##0", label %if.then11, label %if.else11 
 if.else10:
-  %"23$tmp$72##0" = icmp eq i64 %"2$tmp$55##0", 4 
-  br i1 %"23$tmp$72##0", label %if.then13, label %if.else13 
+  %"23#tmp#72##0" = icmp eq i64 %"2#tmp#55##0", 4 
+  br i1 %"23#tmp#72##0", label %if.then13, label %if.else13 
 if.then11:
-  %"24$tmp$71##0" = and i64 %"$right##0", 7 
-  %"24$tmp$72##0" = icmp eq i64 %"24$tmp$71##0", 3 
-  br i1 %"24$tmp$72##0", label %if.then12, label %if.else12 
+  %"24#tmp#71##0" = and i64 %"#right##0", 7 
+  %"24#tmp#72##0" = icmp eq i64 %"24#tmp#71##0", 3 
+  br i1 %"24#tmp#72##0", label %if.then12, label %if.else12 
 if.else11:
   ret i1 0 
 if.then12:
-  %27 = add   i64 %"$right##0", -3 
+  %27 = add   i64 %"#right##0", -3 
   %28 = inttoptr i64 %27 to i64* 
   %29 = getelementptr  i64, i64* %28, i64 0 
   %30 = load  i64, i64* %29 
-  %"26$$$##0" = icmp eq i64 %26, %30 
-  ret i1 %"26$$$##0" 
+  %"26#####0" = icmp eq i64 %26, %30 
+  ret i1 %"26#####0" 
 if.else12:
   ret i1 0 
 if.then13:
-  %31 = add   i64 %"$left##0", -4 
+  %31 = add   i64 %"#left##0", -4 
   %32 = inttoptr i64 %31 to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
-  %"28$tmp$74##0" = icmp uge i64 %"$right##0", 4 
-  br i1 %"28$tmp$74##0", label %if.then14, label %if.else14 
+  %"28#tmp#74##0" = icmp uge i64 %"#right##0", 4 
+  br i1 %"28#tmp#74##0", label %if.then14, label %if.else14 
 if.else13:
-  %"29$tmp$76##0" = icmp eq i64 %"2$tmp$55##0", 5 
-  br i1 %"29$tmp$76##0", label %if.then16, label %if.else16 
+  %"29#tmp#76##0" = icmp eq i64 %"2#tmp#55##0", 5 
+  br i1 %"29#tmp#76##0", label %if.then16, label %if.else16 
 if.then14:
-  %"30$tmp$75##0" = and i64 %"$right##0", 7 
-  %"30$tmp$76##0" = icmp eq i64 %"30$tmp$75##0", 4 
-  br i1 %"30$tmp$76##0", label %if.then15, label %if.else15 
+  %"30#tmp#75##0" = and i64 %"#right##0", 7 
+  %"30#tmp#76##0" = icmp eq i64 %"30#tmp#75##0", 4 
+  br i1 %"30#tmp#76##0", label %if.then15, label %if.else15 
 if.else14:
   ret i1 0 
 if.then15:
-  %35 = add   i64 %"$right##0", -4 
+  %35 = add   i64 %"#right##0", -4 
   %36 = inttoptr i64 %35 to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
-  %"32$$$##0" = icmp eq i64 %34, %38 
-  ret i1 %"32$$$##0" 
+  %"32#####0" = icmp eq i64 %34, %38 
+  ret i1 %"32#####0" 
 if.else15:
   ret i1 0 
 if.then16:
-  %39 = add   i64 %"$left##0", -5 
+  %39 = add   i64 %"#left##0", -5 
   %40 = inttoptr i64 %39 to i64* 
   %41 = getelementptr  i64, i64* %40, i64 0 
   %42 = load  i64, i64* %41 
-  %"34$tmp$78##0" = icmp uge i64 %"$right##0", 4 
-  br i1 %"34$tmp$78##0", label %if.then17, label %if.else17 
+  %"34#tmp#78##0" = icmp uge i64 %"#right##0", 4 
+  br i1 %"34#tmp#78##0", label %if.then17, label %if.else17 
 if.else16:
-  %"35$tmp$80##0" = icmp eq i64 %"2$tmp$55##0", 6 
-  br i1 %"35$tmp$80##0", label %if.then19, label %if.else19 
+  %"35#tmp#80##0" = icmp eq i64 %"2#tmp#55##0", 6 
+  br i1 %"35#tmp#80##0", label %if.then19, label %if.else19 
 if.then17:
-  %"36$tmp$79##0" = and i64 %"$right##0", 7 
-  %"36$tmp$80##0" = icmp eq i64 %"36$tmp$79##0", 5 
-  br i1 %"36$tmp$80##0", label %if.then18, label %if.else18 
+  %"36#tmp#79##0" = and i64 %"#right##0", 7 
+  %"36#tmp#80##0" = icmp eq i64 %"36#tmp#79##0", 5 
+  br i1 %"36#tmp#80##0", label %if.then18, label %if.else18 
 if.else17:
   ret i1 0 
 if.then18:
-  %43 = add   i64 %"$right##0", -5 
+  %43 = add   i64 %"#right##0", -5 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
-  %"38$$$##0" = icmp eq i64 %42, %46 
-  ret i1 %"38$$$##0" 
+  %"38#####0" = icmp eq i64 %42, %46 
+  ret i1 %"38#####0" 
 if.else18:
   ret i1 0 
 if.then19:
-  %47 = add   i64 %"$left##0", -6 
+  %47 = add   i64 %"#left##0", -6 
   %48 = inttoptr i64 %47 to i64* 
   %49 = getelementptr  i64, i64* %48, i64 0 
   %50 = load  i64, i64* %49 
-  %"40$tmp$82##0" = icmp uge i64 %"$right##0", 4 
-  br i1 %"40$tmp$82##0", label %if.then20, label %if.else20 
+  %"40#tmp#82##0" = icmp uge i64 %"#right##0", 4 
+  br i1 %"40#tmp#82##0", label %if.then20, label %if.else20 
 if.else19:
-  %"41$tmp$84##0" = icmp eq i64 %"2$tmp$55##0", 7 
-  br i1 %"41$tmp$84##0", label %if.then22, label %if.else22 
+  %"41#tmp#84##0" = icmp eq i64 %"2#tmp#55##0", 7 
+  br i1 %"41#tmp#84##0", label %if.then22, label %if.else22 
 if.then20:
-  %"42$tmp$83##0" = and i64 %"$right##0", 7 
-  %"42$tmp$84##0" = icmp eq i64 %"42$tmp$83##0", 6 
-  br i1 %"42$tmp$84##0", label %if.then21, label %if.else21 
+  %"42#tmp#83##0" = and i64 %"#right##0", 7 
+  %"42#tmp#84##0" = icmp eq i64 %"42#tmp#83##0", 6 
+  br i1 %"42#tmp#84##0", label %if.then21, label %if.else21 
 if.else20:
   ret i1 0 
 if.then21:
-  %51 = add   i64 %"$right##0", -6 
+  %51 = add   i64 %"#right##0", -6 
   %52 = inttoptr i64 %51 to i64* 
   %53 = getelementptr  i64, i64* %52, i64 0 
   %54 = load  i64, i64* %53 
-  %"44$$$##0" = icmp eq i64 %50, %54 
-  ret i1 %"44$$$##0" 
+  %"44#####0" = icmp eq i64 %50, %54 
+  ret i1 %"44#####0" 
 if.else21:
   ret i1 0 
 if.then22:
-  %55 = add   i64 %"$left##0", -7 
+  %55 = add   i64 %"#left##0", -7 
   %56 = inttoptr i64 %55 to i16* 
   %57 = getelementptr  i16, i16* %56, i64 0 
   %58 = load  i16, i16* %57 
-  %"46$tmp$86##0" = icmp eq i16 %58, 7 
-  br i1 %"46$tmp$86##0", label %if.then23, label %if.else23 
+  %"46#tmp#86##0" = icmp eq i16 %58, 7 
+  br i1 %"46#tmp#86##0", label %if.then23, label %if.else23 
 if.else22:
   ret i1 0 
 if.then23:
-  %59 = add   i64 %"$left##0", 1 
+  %59 = add   i64 %"#left##0", 1 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %"48$tmp$88##0" = icmp uge i64 %"$right##0", 4 
-  br i1 %"48$tmp$88##0", label %if.then24, label %if.else24 
+  %"48#tmp#88##0" = icmp uge i64 %"#right##0", 4 
+  br i1 %"48#tmp#88##0", label %if.then24, label %if.else24 
 if.else23:
-  %"49$tmp$92##0" = icmp eq i16 %58, 8 
-  br i1 %"49$tmp$92##0", label %if.then27, label %if.else27 
+  %"49#tmp#92##0" = icmp eq i16 %58, 8 
+  br i1 %"49#tmp#92##0", label %if.then27, label %if.else27 
 if.then24:
-  %"50$tmp$89##0" = and i64 %"$right##0", 7 
-  %"50$tmp$90##0" = icmp eq i64 %"50$tmp$89##0", 7 
-  br i1 %"50$tmp$90##0", label %if.then25, label %if.else25 
+  %"50#tmp#89##0" = and i64 %"#right##0", 7 
+  %"50#tmp#90##0" = icmp eq i64 %"50#tmp#89##0", 7 
+  br i1 %"50#tmp#90##0", label %if.then25, label %if.else25 
 if.else24:
   ret i1 0 
 if.then25:
-  %63 = add   i64 %"$right##0", -7 
+  %63 = add   i64 %"#right##0", -7 
   %64 = inttoptr i64 %63 to i16* 
   %65 = getelementptr  i16, i16* %64, i64 0 
   %66 = load  i16, i16* %65 
-  %"52$tmp$92##0" = icmp eq i16 %66, 7 
-  br i1 %"52$tmp$92##0", label %if.then26, label %if.else26 
+  %"52#tmp#92##0" = icmp eq i16 %66, 7 
+  br i1 %"52#tmp#92##0", label %if.then26, label %if.else26 
 if.else25:
   ret i1 0 
 if.then26:
-  %67 = add   i64 %"$right##0", 1 
+  %67 = add   i64 %"#right##0", 1 
   %68 = inttoptr i64 %67 to i64* 
   %69 = getelementptr  i64, i64* %68, i64 0 
   %70 = load  i64, i64* %69 
-  %"54$$$##0" = icmp eq i64 %62, %70 
-  ret i1 %"54$$$##0" 
+  %"54#####0" = icmp eq i64 %62, %70 
+  ret i1 %"54#####0" 
 if.else26:
   ret i1 0 
 if.then27:
-  %71 = add   i64 %"$left##0", 1 
+  %71 = add   i64 %"#left##0", 1 
   %72 = inttoptr i64 %71 to i64* 
   %73 = getelementptr  i64, i64* %72, i64 0 
   %74 = load  i64, i64* %73 
-  %"56$tmp$94##0" = icmp uge i64 %"$right##0", 4 
-  br i1 %"56$tmp$94##0", label %if.then28, label %if.else28 
+  %"56#tmp#94##0" = icmp uge i64 %"#right##0", 4 
+  br i1 %"56#tmp#94##0", label %if.then28, label %if.else28 
 if.else27:
-  %"57$tmp$98##0" = icmp eq i16 %58, 9 
-  br i1 %"57$tmp$98##0", label %if.then31, label %if.else31 
+  %"57#tmp#98##0" = icmp eq i16 %58, 9 
+  br i1 %"57#tmp#98##0", label %if.then31, label %if.else31 
 if.then28:
-  %"58$tmp$95##0" = and i64 %"$right##0", 7 
-  %"58$tmp$96##0" = icmp eq i64 %"58$tmp$95##0", 7 
-  br i1 %"58$tmp$96##0", label %if.then29, label %if.else29 
+  %"58#tmp#95##0" = and i64 %"#right##0", 7 
+  %"58#tmp#96##0" = icmp eq i64 %"58#tmp#95##0", 7 
+  br i1 %"58#tmp#96##0", label %if.then29, label %if.else29 
 if.else28:
   ret i1 0 
 if.then29:
-  %75 = add   i64 %"$right##0", -7 
+  %75 = add   i64 %"#right##0", -7 
   %76 = inttoptr i64 %75 to i16* 
   %77 = getelementptr  i16, i16* %76, i64 0 
   %78 = load  i16, i16* %77 
-  %"60$tmp$98##0" = icmp eq i16 %78, 8 
-  br i1 %"60$tmp$98##0", label %if.then30, label %if.else30 
+  %"60#tmp#98##0" = icmp eq i16 %78, 8 
+  br i1 %"60#tmp#98##0", label %if.then30, label %if.else30 
 if.else29:
   ret i1 0 
 if.then30:
-  %79 = add   i64 %"$right##0", 1 
+  %79 = add   i64 %"#right##0", 1 
   %80 = inttoptr i64 %79 to i64* 
   %81 = getelementptr  i64, i64* %80, i64 0 
   %82 = load  i64, i64* %81 
-  %"62$$$##0" = icmp eq i64 %74, %82 
-  ret i1 %"62$$$##0" 
+  %"62#####0" = icmp eq i64 %74, %82 
+  ret i1 %"62#####0" 
 if.else30:
   ret i1 0 
 if.then31:
-  %83 = add   i64 %"$left##0", 1 
+  %83 = add   i64 %"#left##0", 1 
   %84 = inttoptr i64 %83 to i64* 
   %85 = getelementptr  i64, i64* %84, i64 0 
   %86 = load  i64, i64* %85 
-  %"64$tmp$100##0" = icmp uge i64 %"$right##0", 4 
-  br i1 %"64$tmp$100##0", label %if.then32, label %if.else32 
+  %"64#tmp#100##0" = icmp uge i64 %"#right##0", 4 
+  br i1 %"64#tmp#100##0", label %if.then32, label %if.else32 
 if.else31:
-  %"65$tmp$104##0" = icmp eq i16 %58, 10 
-  br i1 %"65$tmp$104##0", label %if.then35, label %if.else35 
+  %"65#tmp#104##0" = icmp eq i16 %58, 10 
+  br i1 %"65#tmp#104##0", label %if.then35, label %if.else35 
 if.then32:
-  %"66$tmp$101##0" = and i64 %"$right##0", 7 
-  %"66$tmp$102##0" = icmp eq i64 %"66$tmp$101##0", 7 
-  br i1 %"66$tmp$102##0", label %if.then33, label %if.else33 
+  %"66#tmp#101##0" = and i64 %"#right##0", 7 
+  %"66#tmp#102##0" = icmp eq i64 %"66#tmp#101##0", 7 
+  br i1 %"66#tmp#102##0", label %if.then33, label %if.else33 
 if.else32:
   ret i1 0 
 if.then33:
-  %87 = add   i64 %"$right##0", -7 
+  %87 = add   i64 %"#right##0", -7 
   %88 = inttoptr i64 %87 to i16* 
   %89 = getelementptr  i16, i16* %88, i64 0 
   %90 = load  i16, i16* %89 
-  %"68$tmp$104##0" = icmp eq i16 %90, 9 
-  br i1 %"68$tmp$104##0", label %if.then34, label %if.else34 
+  %"68#tmp#104##0" = icmp eq i16 %90, 9 
+  br i1 %"68#tmp#104##0", label %if.then34, label %if.else34 
 if.else33:
   ret i1 0 
 if.then34:
-  %91 = add   i64 %"$right##0", 1 
+  %91 = add   i64 %"#right##0", 1 
   %92 = inttoptr i64 %91 to i64* 
   %93 = getelementptr  i64, i64* %92, i64 0 
   %94 = load  i64, i64* %93 
-  %"70$$$##0" = icmp eq i64 %86, %94 
-  ret i1 %"70$$$##0" 
+  %"70#####0" = icmp eq i64 %86, %94 
+  ret i1 %"70#####0" 
 if.else34:
   ret i1 0 
 if.then35:
-  %95 = add   i64 %"$left##0", 1 
+  %95 = add   i64 %"#left##0", 1 
   %96 = inttoptr i64 %95 to i64* 
   %97 = getelementptr  i64, i64* %96, i64 0 
   %98 = load  i64, i64* %97 
-  %"72$tmp$106##0" = icmp uge i64 %"$right##0", 4 
-  br i1 %"72$tmp$106##0", label %if.then36, label %if.else36 
+  %"72#tmp#106##0" = icmp uge i64 %"#right##0", 4 
+  br i1 %"72#tmp#106##0", label %if.then36, label %if.else36 
 if.else35:
-  %"73$tmp$110##0" = icmp eq i16 %58, 11 
-  br i1 %"73$tmp$110##0", label %if.then39, label %if.else39 
+  %"73#tmp#110##0" = icmp eq i16 %58, 11 
+  br i1 %"73#tmp#110##0", label %if.then39, label %if.else39 
 if.then36:
-  %"74$tmp$107##0" = and i64 %"$right##0", 7 
-  %"74$tmp$108##0" = icmp eq i64 %"74$tmp$107##0", 7 
-  br i1 %"74$tmp$108##0", label %if.then37, label %if.else37 
+  %"74#tmp#107##0" = and i64 %"#right##0", 7 
+  %"74#tmp#108##0" = icmp eq i64 %"74#tmp#107##0", 7 
+  br i1 %"74#tmp#108##0", label %if.then37, label %if.else37 
 if.else36:
   ret i1 0 
 if.then37:
-  %99 = add   i64 %"$right##0", -7 
+  %99 = add   i64 %"#right##0", -7 
   %100 = inttoptr i64 %99 to i16* 
   %101 = getelementptr  i16, i16* %100, i64 0 
   %102 = load  i16, i16* %101 
-  %"76$tmp$110##0" = icmp eq i16 %102, 10 
-  br i1 %"76$tmp$110##0", label %if.then38, label %if.else38 
+  %"76#tmp#110##0" = icmp eq i16 %102, 10 
+  br i1 %"76#tmp#110##0", label %if.then38, label %if.else38 
 if.else37:
   ret i1 0 
 if.then38:
-  %103 = add   i64 %"$right##0", 1 
+  %103 = add   i64 %"#right##0", 1 
   %104 = inttoptr i64 %103 to i64* 
   %105 = getelementptr  i64, i64* %104, i64 0 
   %106 = load  i64, i64* %105 
-  %"78$$$##0" = icmp eq i64 %98, %106 
-  ret i1 %"78$$$##0" 
+  %"78#####0" = icmp eq i64 %98, %106 
+  ret i1 %"78#####0" 
 if.else38:
   ret i1 0 
 if.then39:
-  %107 = add   i64 %"$left##0", 1 
+  %107 = add   i64 %"#left##0", 1 
   %108 = inttoptr i64 %107 to i64* 
   %109 = getelementptr  i64, i64* %108, i64 0 
   %110 = load  i64, i64* %109 
-  %"80$tmp$112##0" = icmp uge i64 %"$right##0", 4 
-  br i1 %"80$tmp$112##0", label %if.then40, label %if.else40 
+  %"80#tmp#112##0" = icmp uge i64 %"#right##0", 4 
+  br i1 %"80#tmp#112##0", label %if.then40, label %if.else40 
 if.else39:
-  %"81$tmp$116##0" = icmp eq i16 %58, 12 
-  br i1 %"81$tmp$116##0", label %if.then43, label %if.else43 
+  %"81#tmp#116##0" = icmp eq i16 %58, 12 
+  br i1 %"81#tmp#116##0", label %if.then43, label %if.else43 
 if.then40:
-  %"82$tmp$113##0" = and i64 %"$right##0", 7 
-  %"82$tmp$114##0" = icmp eq i64 %"82$tmp$113##0", 7 
-  br i1 %"82$tmp$114##0", label %if.then41, label %if.else41 
+  %"82#tmp#113##0" = and i64 %"#right##0", 7 
+  %"82#tmp#114##0" = icmp eq i64 %"82#tmp#113##0", 7 
+  br i1 %"82#tmp#114##0", label %if.then41, label %if.else41 
 if.else40:
   ret i1 0 
 if.then41:
-  %111 = add   i64 %"$right##0", -7 
+  %111 = add   i64 %"#right##0", -7 
   %112 = inttoptr i64 %111 to i16* 
   %113 = getelementptr  i16, i16* %112, i64 0 
   %114 = load  i16, i16* %113 
-  %"84$tmp$116##0" = icmp eq i16 %114, 11 
-  br i1 %"84$tmp$116##0", label %if.then42, label %if.else42 
+  %"84#tmp#116##0" = icmp eq i16 %114, 11 
+  br i1 %"84#tmp#116##0", label %if.then42, label %if.else42 
 if.else41:
   ret i1 0 
 if.then42:
-  %115 = add   i64 %"$right##0", 1 
+  %115 = add   i64 %"#right##0", 1 
   %116 = inttoptr i64 %115 to i64* 
   %117 = getelementptr  i64, i64* %116, i64 0 
   %118 = load  i64, i64* %117 
-  %"86$$$##0" = icmp eq i64 %110, %118 
-  ret i1 %"86$$$##0" 
+  %"86#####0" = icmp eq i64 %110, %118 
+  ret i1 %"86#####0" 
 if.else42:
   ret i1 0 
 if.then43:
-  %119 = add   i64 %"$left##0", 1 
+  %119 = add   i64 %"#left##0", 1 
   %120 = inttoptr i64 %119 to i64* 
   %121 = getelementptr  i64, i64* %120, i64 0 
   %122 = load  i64, i64* %121 
-  %"88$tmp$118##0" = icmp uge i64 %"$right##0", 4 
-  br i1 %"88$tmp$118##0", label %if.then44, label %if.else44 
+  %"88#tmp#118##0" = icmp uge i64 %"#right##0", 4 
+  br i1 %"88#tmp#118##0", label %if.then44, label %if.else44 
 if.else43:
-  %"89$tmp$122##0" = icmp eq i16 %58, 13 
-  br i1 %"89$tmp$122##0", label %if.then47, label %if.else47 
+  %"89#tmp#122##0" = icmp eq i16 %58, 13 
+  br i1 %"89#tmp#122##0", label %if.then47, label %if.else47 
 if.then44:
-  %"90$tmp$119##0" = and i64 %"$right##0", 7 
-  %"90$tmp$120##0" = icmp eq i64 %"90$tmp$119##0", 7 
-  br i1 %"90$tmp$120##0", label %if.then45, label %if.else45 
+  %"90#tmp#119##0" = and i64 %"#right##0", 7 
+  %"90#tmp#120##0" = icmp eq i64 %"90#tmp#119##0", 7 
+  br i1 %"90#tmp#120##0", label %if.then45, label %if.else45 
 if.else44:
   ret i1 0 
 if.then45:
-  %123 = add   i64 %"$right##0", -7 
+  %123 = add   i64 %"#right##0", -7 
   %124 = inttoptr i64 %123 to i16* 
   %125 = getelementptr  i16, i16* %124, i64 0 
   %126 = load  i16, i16* %125 
-  %"92$tmp$122##0" = icmp eq i16 %126, 12 
-  br i1 %"92$tmp$122##0", label %if.then46, label %if.else46 
+  %"92#tmp#122##0" = icmp eq i16 %126, 12 
+  br i1 %"92#tmp#122##0", label %if.then46, label %if.else46 
 if.else45:
   ret i1 0 
 if.then46:
-  %127 = add   i64 %"$right##0", 1 
+  %127 = add   i64 %"#right##0", 1 
   %128 = inttoptr i64 %127 to i64* 
   %129 = getelementptr  i64, i64* %128, i64 0 
   %130 = load  i64, i64* %129 
-  %"94$$$##0" = icmp eq i64 %122, %130 
-  ret i1 %"94$$$##0" 
+  %"94#####0" = icmp eq i64 %122, %130 
+  ret i1 %"94#####0" 
 if.else46:
   ret i1 0 
 if.then47:
-  %131 = add   i64 %"$left##0", 1 
+  %131 = add   i64 %"#left##0", 1 
   %132 = inttoptr i64 %131 to i64* 
   %133 = getelementptr  i64, i64* %132, i64 0 
   %134 = load  i64, i64* %133 
-  %"96$tmp$124##0" = icmp uge i64 %"$right##0", 4 
-  br i1 %"96$tmp$124##0", label %if.then48, label %if.else48 
+  %"96#tmp#124##0" = icmp uge i64 %"#right##0", 4 
+  br i1 %"96#tmp#124##0", label %if.then48, label %if.else48 
 if.else47:
-  %"97$tmp$128##0" = icmp eq i16 %58, 14 
-  br i1 %"97$tmp$128##0", label %if.then51, label %if.else51 
+  %"97#tmp#128##0" = icmp eq i16 %58, 14 
+  br i1 %"97#tmp#128##0", label %if.then51, label %if.else51 
 if.then48:
-  %"98$tmp$125##0" = and i64 %"$right##0", 7 
-  %"98$tmp$126##0" = icmp eq i64 %"98$tmp$125##0", 7 
-  br i1 %"98$tmp$126##0", label %if.then49, label %if.else49 
+  %"98#tmp#125##0" = and i64 %"#right##0", 7 
+  %"98#tmp#126##0" = icmp eq i64 %"98#tmp#125##0", 7 
+  br i1 %"98#tmp#126##0", label %if.then49, label %if.else49 
 if.else48:
   ret i1 0 
 if.then49:
-  %135 = add   i64 %"$right##0", -7 
+  %135 = add   i64 %"#right##0", -7 
   %136 = inttoptr i64 %135 to i16* 
   %137 = getelementptr  i16, i16* %136, i64 0 
   %138 = load  i16, i16* %137 
-  %"100$tmp$128##0" = icmp eq i16 %138, 13 
-  br i1 %"100$tmp$128##0", label %if.then50, label %if.else50 
+  %"100#tmp#128##0" = icmp eq i16 %138, 13 
+  br i1 %"100#tmp#128##0", label %if.then50, label %if.else50 
 if.else49:
   ret i1 0 
 if.then50:
-  %139 = add   i64 %"$right##0", 1 
+  %139 = add   i64 %"#right##0", 1 
   %140 = inttoptr i64 %139 to i64* 
   %141 = getelementptr  i64, i64* %140, i64 0 
   %142 = load  i64, i64* %141 
-  %"102$$$##0" = icmp eq i64 %134, %142 
-  ret i1 %"102$$$##0" 
+  %"102#####0" = icmp eq i64 %134, %142 
+  ret i1 %"102#####0" 
 if.else50:
   ret i1 0 
 if.then51:
-  %143 = add   i64 %"$left##0", 1 
+  %143 = add   i64 %"#left##0", 1 
   %144 = inttoptr i64 %143 to i64* 
   %145 = getelementptr  i64, i64* %144, i64 0 
   %146 = load  i64, i64* %145 
-  %"104$tmp$130##0" = icmp uge i64 %"$right##0", 4 
-  br i1 %"104$tmp$130##0", label %if.then52, label %if.else52 
+  %"104#tmp#130##0" = icmp uge i64 %"#right##0", 4 
+  br i1 %"104#tmp#130##0", label %if.then52, label %if.else52 
 if.else51:
-  %"105$tmp$134##0" = icmp eq i16 %58, 15 
-  br i1 %"105$tmp$134##0", label %if.then55, label %if.else55 
+  %"105#tmp#134##0" = icmp eq i16 %58, 15 
+  br i1 %"105#tmp#134##0", label %if.then55, label %if.else55 
 if.then52:
-  %"106$tmp$131##0" = and i64 %"$right##0", 7 
-  %"106$tmp$132##0" = icmp eq i64 %"106$tmp$131##0", 7 
-  br i1 %"106$tmp$132##0", label %if.then53, label %if.else53 
+  %"106#tmp#131##0" = and i64 %"#right##0", 7 
+  %"106#tmp#132##0" = icmp eq i64 %"106#tmp#131##0", 7 
+  br i1 %"106#tmp#132##0", label %if.then53, label %if.else53 
 if.else52:
   ret i1 0 
 if.then53:
-  %147 = add   i64 %"$right##0", -7 
+  %147 = add   i64 %"#right##0", -7 
   %148 = inttoptr i64 %147 to i16* 
   %149 = getelementptr  i16, i16* %148, i64 0 
   %150 = load  i16, i16* %149 
-  %"108$tmp$134##0" = icmp eq i16 %150, 14 
-  br i1 %"108$tmp$134##0", label %if.then54, label %if.else54 
+  %"108#tmp#134##0" = icmp eq i16 %150, 14 
+  br i1 %"108#tmp#134##0", label %if.then54, label %if.else54 
 if.else53:
   ret i1 0 
 if.then54:
-  %151 = add   i64 %"$right##0", 1 
+  %151 = add   i64 %"#right##0", 1 
   %152 = inttoptr i64 %151 to i64* 
   %153 = getelementptr  i64, i64* %152, i64 0 
   %154 = load  i64, i64* %153 
-  %"110$$$##0" = icmp eq i64 %146, %154 
-  ret i1 %"110$$$##0" 
+  %"110#####0" = icmp eq i64 %146, %154 
+  ret i1 %"110#####0" 
 if.else54:
   ret i1 0 
 if.then55:
-  %155 = add   i64 %"$left##0", 1 
+  %155 = add   i64 %"#left##0", 1 
   %156 = inttoptr i64 %155 to i64* 
   %157 = getelementptr  i64, i64* %156, i64 0 
   %158 = load  i64, i64* %157 
-  %"112$tmp$136##0" = icmp uge i64 %"$right##0", 4 
-  br i1 %"112$tmp$136##0", label %if.then56, label %if.else56 
+  %"112#tmp#136##0" = icmp uge i64 %"#right##0", 4 
+  br i1 %"112#tmp#136##0", label %if.then56, label %if.else56 
 if.else55:
-  %"113$tmp$140##0" = icmp eq i16 %58, 16 
-  br i1 %"113$tmp$140##0", label %if.then59, label %if.else59 
+  %"113#tmp#140##0" = icmp eq i16 %58, 16 
+  br i1 %"113#tmp#140##0", label %if.then59, label %if.else59 
 if.then56:
-  %"114$tmp$137##0" = and i64 %"$right##0", 7 
-  %"114$tmp$138##0" = icmp eq i64 %"114$tmp$137##0", 7 
-  br i1 %"114$tmp$138##0", label %if.then57, label %if.else57 
+  %"114#tmp#137##0" = and i64 %"#right##0", 7 
+  %"114#tmp#138##0" = icmp eq i64 %"114#tmp#137##0", 7 
+  br i1 %"114#tmp#138##0", label %if.then57, label %if.else57 
 if.else56:
   ret i1 0 
 if.then57:
-  %159 = add   i64 %"$right##0", -7 
+  %159 = add   i64 %"#right##0", -7 
   %160 = inttoptr i64 %159 to i16* 
   %161 = getelementptr  i16, i16* %160, i64 0 
   %162 = load  i16, i16* %161 
-  %"116$tmp$140##0" = icmp eq i16 %162, 15 
-  br i1 %"116$tmp$140##0", label %if.then58, label %if.else58 
+  %"116#tmp#140##0" = icmp eq i16 %162, 15 
+  br i1 %"116#tmp#140##0", label %if.then58, label %if.else58 
 if.else57:
   ret i1 0 
 if.then58:
-  %163 = add   i64 %"$right##0", 1 
+  %163 = add   i64 %"#right##0", 1 
   %164 = inttoptr i64 %163 to i64* 
   %165 = getelementptr  i64, i64* %164, i64 0 
   %166 = load  i64, i64* %165 
-  %"118$$$##0" = icmp eq i64 %158, %166 
-  ret i1 %"118$$$##0" 
+  %"118#####0" = icmp eq i64 %158, %166 
+  ret i1 %"118#####0" 
 if.else58:
   ret i1 0 
 if.then59:
-  %167 = add   i64 %"$left##0", 1 
+  %167 = add   i64 %"#left##0", 1 
   %168 = inttoptr i64 %167 to i64* 
   %169 = getelementptr  i64, i64* %168, i64 0 
   %170 = load  i64, i64* %169 
-  %"120$tmp$142##0" = icmp uge i64 %"$right##0", 4 
-  br i1 %"120$tmp$142##0", label %if.then60, label %if.else60 
+  %"120#tmp#142##0" = icmp uge i64 %"#right##0", 4 
+  br i1 %"120#tmp#142##0", label %if.then60, label %if.else60 
 if.else59:
   ret i1 0 
 if.then60:
-  %"122$tmp$143##0" = and i64 %"$right##0", 7 
-  %"122$tmp$144##0" = icmp eq i64 %"122$tmp$143##0", 7 
-  br i1 %"122$tmp$144##0", label %if.then61, label %if.else61 
+  %"122#tmp#143##0" = and i64 %"#right##0", 7 
+  %"122#tmp#144##0" = icmp eq i64 %"122#tmp#143##0", 7 
+  br i1 %"122#tmp#144##0", label %if.then61, label %if.else61 
 if.else60:
   ret i1 0 
 if.then61:
-  %171 = add   i64 %"$right##0", -7 
+  %171 = add   i64 %"#right##0", -7 
   %172 = inttoptr i64 %171 to i16* 
   %173 = getelementptr  i16, i16* %172, i64 0 
   %174 = load  i16, i16* %173 
-  %"124$tmp$146##0" = icmp eq i16 %174, 16 
-  br i1 %"124$tmp$146##0", label %if.then62, label %if.else62 
+  %"124#tmp#146##0" = icmp eq i16 %174, 16 
+  br i1 %"124#tmp#146##0", label %if.then62, label %if.else62 
 if.else61:
   ret i1 0 
 if.then62:
-  %175 = add   i64 %"$right##0", 1 
+  %175 = add   i64 %"#right##0", 1 
   %176 = inttoptr i64 %175 to i64* 
   %177 = getelementptr  i64, i64* %176, i64 0 
   %178 = load  i64, i64* %177 
-  %"126$$$##0" = icmp eq i64 %170, %178 
-  ret i1 %"126$$$##0" 
+  %"126#####0" = icmp eq i64 %170, %178 
+  ret i1 %"126#####0" 
 if.else62:
   ret i1 0 
 }
@@ -3272,20 +3272,20 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c01<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c01<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"###0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 0 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"###0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 0 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %191 = insertvalue {i64, i1} undef, i64 undef, 0 
   %192 = insertvalue {i64, i1} %191, i1 0, 1 
   ret {i64, i1} %192 
 if.then1:
-  %184 = inttoptr i64 %"$##0" to i64* 
+  %184 = inttoptr i64 %"###0" to i64* 
   %185 = getelementptr  i64, i64* %184, i64 0 
   %186 = load  i64, i64* %185 
   %187 = insertvalue {i64, i1} undef, i64 %186, 0 
@@ -3306,25 +3306,25 @@ entry:
   %196 = inttoptr i64 %195 to i64* 
   %197 = getelementptr  i64, i64* %196, i64 0 
   store  i64 %"f02##0", i64* %197 
-  %"1$$##0" = or i64 %195, 1 
-  ret i64 %"1$$##0" 
+  %"1####0" = or i64 %195, 1 
+  ret i64 %"1####0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c02<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c02<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"###0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 1 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"###0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 1 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %206 = insertvalue {i64, i1} undef, i64 undef, 0 
   %207 = insertvalue {i64, i1} %206, i1 0, 1 
   ret {i64, i1} %207 
 if.then1:
-  %198 = add   i64 %"$##0", -1 
+  %198 = add   i64 %"###0", -1 
   %199 = inttoptr i64 %198 to i64* 
   %200 = getelementptr  i64, i64* %199, i64 0 
   %201 = load  i64, i64* %200 
@@ -3346,25 +3346,25 @@ entry:
   %211 = inttoptr i64 %210 to i64* 
   %212 = getelementptr  i64, i64* %211, i64 0 
   store  i64 %"f03##0", i64* %212 
-  %"1$$##0" = or i64 %210, 2 
-  ret i64 %"1$$##0" 
+  %"1####0" = or i64 %210, 2 
+  ret i64 %"1####0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c03<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c03<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"###0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 2 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"###0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 2 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %221 = insertvalue {i64, i1} undef, i64 undef, 0 
   %222 = insertvalue {i64, i1} %221, i1 0, 1 
   ret {i64, i1} %222 
 if.then1:
-  %213 = add   i64 %"$##0", -2 
+  %213 = add   i64 %"###0", -2 
   %214 = inttoptr i64 %213 to i64* 
   %215 = getelementptr  i64, i64* %214, i64 0 
   %216 = load  i64, i64* %215 
@@ -3386,25 +3386,25 @@ entry:
   %226 = inttoptr i64 %225 to i64* 
   %227 = getelementptr  i64, i64* %226, i64 0 
   store  i64 %"f04##0", i64* %227 
-  %"1$$##0" = or i64 %225, 3 
-  ret i64 %"1$$##0" 
+  %"1####0" = or i64 %225, 3 
+  ret i64 %"1####0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c04<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c04<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"###0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 3 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"###0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 3 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %236 = insertvalue {i64, i1} undef, i64 undef, 0 
   %237 = insertvalue {i64, i1} %236, i1 0, 1 
   ret {i64, i1} %237 
 if.then1:
-  %228 = add   i64 %"$##0", -3 
+  %228 = add   i64 %"###0", -3 
   %229 = inttoptr i64 %228 to i64* 
   %230 = getelementptr  i64, i64* %229, i64 0 
   %231 = load  i64, i64* %230 
@@ -3426,25 +3426,25 @@ entry:
   %241 = inttoptr i64 %240 to i64* 
   %242 = getelementptr  i64, i64* %241, i64 0 
   store  i64 %"f05##0", i64* %242 
-  %"1$$##0" = or i64 %240, 4 
-  ret i64 %"1$$##0" 
+  %"1####0" = or i64 %240, 4 
+  ret i64 %"1####0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c05<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c05<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"###0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 4 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"###0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 4 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %251 = insertvalue {i64, i1} undef, i64 undef, 0 
   %252 = insertvalue {i64, i1} %251, i1 0, 1 
   ret {i64, i1} %252 
 if.then1:
-  %243 = add   i64 %"$##0", -4 
+  %243 = add   i64 %"###0", -4 
   %244 = inttoptr i64 %243 to i64* 
   %245 = getelementptr  i64, i64* %244, i64 0 
   %246 = load  i64, i64* %245 
@@ -3466,25 +3466,25 @@ entry:
   %256 = inttoptr i64 %255 to i64* 
   %257 = getelementptr  i64, i64* %256, i64 0 
   store  i64 %"f06##0", i64* %257 
-  %"1$$##0" = or i64 %255, 5 
-  ret i64 %"1$$##0" 
+  %"1####0" = or i64 %255, 5 
+  ret i64 %"1####0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c06<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c06<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"###0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 5 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"###0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 5 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %266 = insertvalue {i64, i1} undef, i64 undef, 0 
   %267 = insertvalue {i64, i1} %266, i1 0, 1 
   ret {i64, i1} %267 
 if.then1:
-  %258 = add   i64 %"$##0", -5 
+  %258 = add   i64 %"###0", -5 
   %259 = inttoptr i64 %258 to i64* 
   %260 = getelementptr  i64, i64* %259, i64 0 
   %261 = load  i64, i64* %260 
@@ -3506,25 +3506,25 @@ entry:
   %271 = inttoptr i64 %270 to i64* 
   %272 = getelementptr  i64, i64* %271, i64 0 
   store  i64 %"f07##0", i64* %272 
-  %"1$$##0" = or i64 %270, 6 
-  ret i64 %"1$$##0" 
+  %"1####0" = or i64 %270, 6 
+  ret i64 %"1####0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c07<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c07<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"###0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 6 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"###0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 6 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %281 = insertvalue {i64, i1} undef, i64 undef, 0 
   %282 = insertvalue {i64, i1} %281, i1 0, 1 
   ret {i64, i1} %282 
 if.then1:
-  %273 = add   i64 %"$##0", -6 
+  %273 = add   i64 %"###0", -6 
   %274 = inttoptr i64 %273 to i64* 
   %275 = getelementptr  i64, i64* %274, i64 0 
   %276 = load  i64, i64* %275 
@@ -3550,36 +3550,36 @@ entry:
   %289 = inttoptr i64 %288 to i64* 
   %290 = getelementptr  i64, i64* %289, i64 0 
   store  i64 %"f08##0", i64* %290 
-  %"1$$##0" = or i64 %285, 7 
-  ret i64 %"1$$##0" 
+  %"1####0" = or i64 %285, 7 
+  ret i64 %"1####0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c08<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c08<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"###0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"###0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %305 = insertvalue {i64, i1} undef, i64 undef, 0 
   %306 = insertvalue {i64, i1} %305, i1 0, 1 
   ret {i64, i1} %306 
 if.then1:
-  %291 = add   i64 %"$##0", -7 
+  %291 = add   i64 %"###0", -7 
   %292 = inttoptr i64 %291 to i16* 
   %293 = getelementptr  i16, i16* %292, i64 0 
   %294 = load  i16, i16* %293 
-  %"4$tmp$3##0" = icmp eq i16 %294, 7 
-  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
+  %"4#tmp#3##0" = icmp eq i16 %294, 7 
+  br i1 %"4#tmp#3##0", label %if.then2, label %if.else2 
 if.else1:
   %303 = insertvalue {i64, i1} undef, i64 undef, 0 
   %304 = insertvalue {i64, i1} %303, i1 0, 1 
   ret {i64, i1} %304 
 if.then2:
-  %295 = add   i64 %"$##0", 1 
+  %295 = add   i64 %"###0", 1 
   %296 = inttoptr i64 %295 to i64* 
   %297 = getelementptr  i64, i64* %296, i64 0 
   %298 = load  i64, i64* %297 
@@ -3605,36 +3605,36 @@ entry:
   %313 = inttoptr i64 %312 to i64* 
   %314 = getelementptr  i64, i64* %313, i64 0 
   store  i64 %"f09##0", i64* %314 
-  %"1$$##0" = or i64 %309, 7 
-  ret i64 %"1$$##0" 
+  %"1####0" = or i64 %309, 7 
+  ret i64 %"1####0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c09<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c09<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"###0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"###0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %329 = insertvalue {i64, i1} undef, i64 undef, 0 
   %330 = insertvalue {i64, i1} %329, i1 0, 1 
   ret {i64, i1} %330 
 if.then1:
-  %315 = add   i64 %"$##0", -7 
+  %315 = add   i64 %"###0", -7 
   %316 = inttoptr i64 %315 to i16* 
   %317 = getelementptr  i16, i16* %316, i64 0 
   %318 = load  i16, i16* %317 
-  %"4$tmp$3##0" = icmp eq i16 %318, 8 
-  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
+  %"4#tmp#3##0" = icmp eq i16 %318, 8 
+  br i1 %"4#tmp#3##0", label %if.then2, label %if.else2 
 if.else1:
   %327 = insertvalue {i64, i1} undef, i64 undef, 0 
   %328 = insertvalue {i64, i1} %327, i1 0, 1 
   ret {i64, i1} %328 
 if.then2:
-  %319 = add   i64 %"$##0", 1 
+  %319 = add   i64 %"###0", 1 
   %320 = inttoptr i64 %319 to i64* 
   %321 = getelementptr  i64, i64* %320, i64 0 
   %322 = load  i64, i64* %321 
@@ -3660,36 +3660,36 @@ entry:
   %337 = inttoptr i64 %336 to i64* 
   %338 = getelementptr  i64, i64* %337, i64 0 
   store  i64 %"f10##0", i64* %338 
-  %"1$$##0" = or i64 %333, 7 
-  ret i64 %"1$$##0" 
+  %"1####0" = or i64 %333, 7 
+  ret i64 %"1####0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c10<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c10<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"###0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"###0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %353 = insertvalue {i64, i1} undef, i64 undef, 0 
   %354 = insertvalue {i64, i1} %353, i1 0, 1 
   ret {i64, i1} %354 
 if.then1:
-  %339 = add   i64 %"$##0", -7 
+  %339 = add   i64 %"###0", -7 
   %340 = inttoptr i64 %339 to i16* 
   %341 = getelementptr  i16, i16* %340, i64 0 
   %342 = load  i16, i16* %341 
-  %"4$tmp$3##0" = icmp eq i16 %342, 9 
-  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
+  %"4#tmp#3##0" = icmp eq i16 %342, 9 
+  br i1 %"4#tmp#3##0", label %if.then2, label %if.else2 
 if.else1:
   %351 = insertvalue {i64, i1} undef, i64 undef, 0 
   %352 = insertvalue {i64, i1} %351, i1 0, 1 
   ret {i64, i1} %352 
 if.then2:
-  %343 = add   i64 %"$##0", 1 
+  %343 = add   i64 %"###0", 1 
   %344 = inttoptr i64 %343 to i64* 
   %345 = getelementptr  i64, i64* %344, i64 0 
   %346 = load  i64, i64* %345 
@@ -3715,36 +3715,36 @@ entry:
   %361 = inttoptr i64 %360 to i64* 
   %362 = getelementptr  i64, i64* %361, i64 0 
   store  i64 %"f11##0", i64* %362 
-  %"1$$##0" = or i64 %357, 7 
-  ret i64 %"1$$##0" 
+  %"1####0" = or i64 %357, 7 
+  ret i64 %"1####0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c11<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c11<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"###0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"###0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %377 = insertvalue {i64, i1} undef, i64 undef, 0 
   %378 = insertvalue {i64, i1} %377, i1 0, 1 
   ret {i64, i1} %378 
 if.then1:
-  %363 = add   i64 %"$##0", -7 
+  %363 = add   i64 %"###0", -7 
   %364 = inttoptr i64 %363 to i16* 
   %365 = getelementptr  i16, i16* %364, i64 0 
   %366 = load  i16, i16* %365 
-  %"4$tmp$3##0" = icmp eq i16 %366, 10 
-  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
+  %"4#tmp#3##0" = icmp eq i16 %366, 10 
+  br i1 %"4#tmp#3##0", label %if.then2, label %if.else2 
 if.else1:
   %375 = insertvalue {i64, i1} undef, i64 undef, 0 
   %376 = insertvalue {i64, i1} %375, i1 0, 1 
   ret {i64, i1} %376 
 if.then2:
-  %367 = add   i64 %"$##0", 1 
+  %367 = add   i64 %"###0", 1 
   %368 = inttoptr i64 %367 to i64* 
   %369 = getelementptr  i64, i64* %368, i64 0 
   %370 = load  i64, i64* %369 
@@ -3770,36 +3770,36 @@ entry:
   %385 = inttoptr i64 %384 to i64* 
   %386 = getelementptr  i64, i64* %385, i64 0 
   store  i64 %"f12##0", i64* %386 
-  %"1$$##0" = or i64 %381, 7 
-  ret i64 %"1$$##0" 
+  %"1####0" = or i64 %381, 7 
+  ret i64 %"1####0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c12<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c12<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"###0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"###0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %401 = insertvalue {i64, i1} undef, i64 undef, 0 
   %402 = insertvalue {i64, i1} %401, i1 0, 1 
   ret {i64, i1} %402 
 if.then1:
-  %387 = add   i64 %"$##0", -7 
+  %387 = add   i64 %"###0", -7 
   %388 = inttoptr i64 %387 to i16* 
   %389 = getelementptr  i16, i16* %388, i64 0 
   %390 = load  i16, i16* %389 
-  %"4$tmp$3##0" = icmp eq i16 %390, 11 
-  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
+  %"4#tmp#3##0" = icmp eq i16 %390, 11 
+  br i1 %"4#tmp#3##0", label %if.then2, label %if.else2 
 if.else1:
   %399 = insertvalue {i64, i1} undef, i64 undef, 0 
   %400 = insertvalue {i64, i1} %399, i1 0, 1 
   ret {i64, i1} %400 
 if.then2:
-  %391 = add   i64 %"$##0", 1 
+  %391 = add   i64 %"###0", 1 
   %392 = inttoptr i64 %391 to i64* 
   %393 = getelementptr  i64, i64* %392, i64 0 
   %394 = load  i64, i64* %393 
@@ -3825,36 +3825,36 @@ entry:
   %409 = inttoptr i64 %408 to i64* 
   %410 = getelementptr  i64, i64* %409, i64 0 
   store  i64 %"f13##0", i64* %410 
-  %"1$$##0" = or i64 %405, 7 
-  ret i64 %"1$$##0" 
+  %"1####0" = or i64 %405, 7 
+  ret i64 %"1####0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c13<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c13<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"###0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"###0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %425 = insertvalue {i64, i1} undef, i64 undef, 0 
   %426 = insertvalue {i64, i1} %425, i1 0, 1 
   ret {i64, i1} %426 
 if.then1:
-  %411 = add   i64 %"$##0", -7 
+  %411 = add   i64 %"###0", -7 
   %412 = inttoptr i64 %411 to i16* 
   %413 = getelementptr  i16, i16* %412, i64 0 
   %414 = load  i16, i16* %413 
-  %"4$tmp$3##0" = icmp eq i16 %414, 12 
-  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
+  %"4#tmp#3##0" = icmp eq i16 %414, 12 
+  br i1 %"4#tmp#3##0", label %if.then2, label %if.else2 
 if.else1:
   %423 = insertvalue {i64, i1} undef, i64 undef, 0 
   %424 = insertvalue {i64, i1} %423, i1 0, 1 
   ret {i64, i1} %424 
 if.then2:
-  %415 = add   i64 %"$##0", 1 
+  %415 = add   i64 %"###0", 1 
   %416 = inttoptr i64 %415 to i64* 
   %417 = getelementptr  i64, i64* %416, i64 0 
   %418 = load  i64, i64* %417 
@@ -3880,36 +3880,36 @@ entry:
   %433 = inttoptr i64 %432 to i64* 
   %434 = getelementptr  i64, i64* %433, i64 0 
   store  i64 %"f14##0", i64* %434 
-  %"1$$##0" = or i64 %429, 7 
-  ret i64 %"1$$##0" 
+  %"1####0" = or i64 %429, 7 
+  ret i64 %"1####0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c14<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c14<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"###0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"###0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %449 = insertvalue {i64, i1} undef, i64 undef, 0 
   %450 = insertvalue {i64, i1} %449, i1 0, 1 
   ret {i64, i1} %450 
 if.then1:
-  %435 = add   i64 %"$##0", -7 
+  %435 = add   i64 %"###0", -7 
   %436 = inttoptr i64 %435 to i16* 
   %437 = getelementptr  i16, i16* %436, i64 0 
   %438 = load  i16, i16* %437 
-  %"4$tmp$3##0" = icmp eq i16 %438, 13 
-  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
+  %"4#tmp#3##0" = icmp eq i16 %438, 13 
+  br i1 %"4#tmp#3##0", label %if.then2, label %if.else2 
 if.else1:
   %447 = insertvalue {i64, i1} undef, i64 undef, 0 
   %448 = insertvalue {i64, i1} %447, i1 0, 1 
   ret {i64, i1} %448 
 if.then2:
-  %439 = add   i64 %"$##0", 1 
+  %439 = add   i64 %"###0", 1 
   %440 = inttoptr i64 %439 to i64* 
   %441 = getelementptr  i64, i64* %440, i64 0 
   %442 = load  i64, i64* %441 
@@ -3935,36 +3935,36 @@ entry:
   %457 = inttoptr i64 %456 to i64* 
   %458 = getelementptr  i64, i64* %457, i64 0 
   store  i64 %"f15##0", i64* %458 
-  %"1$$##0" = or i64 %453, 7 
-  ret i64 %"1$$##0" 
+  %"1####0" = or i64 %453, 7 
+  ret i64 %"1####0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c15<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c15<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"###0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"###0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %473 = insertvalue {i64, i1} undef, i64 undef, 0 
   %474 = insertvalue {i64, i1} %473, i1 0, 1 
   ret {i64, i1} %474 
 if.then1:
-  %459 = add   i64 %"$##0", -7 
+  %459 = add   i64 %"###0", -7 
   %460 = inttoptr i64 %459 to i16* 
   %461 = getelementptr  i16, i16* %460, i64 0 
   %462 = load  i16, i16* %461 
-  %"4$tmp$3##0" = icmp eq i16 %462, 14 
-  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
+  %"4#tmp#3##0" = icmp eq i16 %462, 14 
+  br i1 %"4#tmp#3##0", label %if.then2, label %if.else2 
 if.else1:
   %471 = insertvalue {i64, i1} undef, i64 undef, 0 
   %472 = insertvalue {i64, i1} %471, i1 0, 1 
   ret {i64, i1} %472 
 if.then2:
-  %463 = add   i64 %"$##0", 1 
+  %463 = add   i64 %"###0", 1 
   %464 = inttoptr i64 %463 to i64* 
   %465 = getelementptr  i64, i64* %464, i64 0 
   %466 = load  i64, i64* %465 
@@ -3990,36 +3990,36 @@ entry:
   %481 = inttoptr i64 %480 to i64* 
   %482 = getelementptr  i64, i64* %481, i64 0 
   store  i64 %"f16##0", i64* %482 
-  %"1$$##0" = or i64 %477, 7 
-  ret i64 %"1$$##0" 
+  %"1####0" = or i64 %477, 7 
+  ret i64 %"1####0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c16<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c16<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"###0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"###0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %497 = insertvalue {i64, i1} undef, i64 undef, 0 
   %498 = insertvalue {i64, i1} %497, i1 0, 1 
   ret {i64, i1} %498 
 if.then1:
-  %483 = add   i64 %"$##0", -7 
+  %483 = add   i64 %"###0", -7 
   %484 = inttoptr i64 %483 to i16* 
   %485 = getelementptr  i16, i16* %484, i64 0 
   %486 = load  i16, i16* %485 
-  %"4$tmp$3##0" = icmp eq i16 %486, 15 
-  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
+  %"4#tmp#3##0" = icmp eq i16 %486, 15 
+  br i1 %"4#tmp#3##0", label %if.then2, label %if.else2 
 if.else1:
   %495 = insertvalue {i64, i1} undef, i64 undef, 0 
   %496 = insertvalue {i64, i1} %495, i1 0, 1 
   ret {i64, i1} %496 
 if.then2:
-  %487 = add   i64 %"$##0", 1 
+  %487 = add   i64 %"###0", 1 
   %488 = inttoptr i64 %487 to i64* 
   %489 = getelementptr  i64, i64* %488, i64 0 
   %490 = load  i64, i64* %489 
@@ -4045,36 +4045,36 @@ entry:
   %505 = inttoptr i64 %504 to i64* 
   %506 = getelementptr  i64, i64* %505, i64 0 
   store  i64 %"f17##0", i64* %506 
-  %"1$$##0" = or i64 %501, 7 
-  ret i64 %"1$$##0" 
+  %"1####0" = or i64 %501, 7 
+  ret i64 %"1####0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.c17<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.c17<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"###0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"###0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %521 = insertvalue {i64, i1} undef, i64 undef, 0 
   %522 = insertvalue {i64, i1} %521, i1 0, 1 
   ret {i64, i1} %522 
 if.then1:
-  %507 = add   i64 %"$##0", -7 
+  %507 = add   i64 %"###0", -7 
   %508 = inttoptr i64 %507 to i16* 
   %509 = getelementptr  i16, i16* %508, i64 0 
   %510 = load  i16, i16* %509 
-  %"4$tmp$3##0" = icmp eq i16 %510, 16 
-  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
+  %"4#tmp#3##0" = icmp eq i16 %510, 16 
+  br i1 %"4#tmp#3##0", label %if.then2, label %if.else2 
 if.else1:
   %519 = insertvalue {i64, i1} undef, i64 undef, 0 
   %520 = insertvalue {i64, i1} %519, i1 0, 1 
   ret {i64, i1} %520 
 if.then2:
-  %511 = add   i64 %"$##0", 1 
+  %511 = add   i64 %"###0", 1 
   %512 = inttoptr i64 %511 to i64* 
   %513 = getelementptr  i64, i64* %512, i64 0 
   %514 = load  i64, i64* %513 
@@ -4088,20 +4088,20 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f01<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f01<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#rec##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 0 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 0 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %530 = insertvalue {i64, i1} undef, i64 undef, 0 
   %531 = insertvalue {i64, i1} %530, i1 0, 1 
   ret {i64, i1} %531 
 if.then1:
-  %523 = inttoptr i64 %"$rec##0" to i64* 
+  %523 = inttoptr i64 %"#rec##0" to i64* 
   %524 = getelementptr  i64, i64* %523, i64 0 
   %525 = load  i64, i64* %524 
   %526 = insertvalue {i64, i1} undef, i64 %525, 0 
@@ -4114,16 +4114,16 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f01<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f01<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#rec##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 0 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 0 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
-  %544 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %544 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %545 = insertvalue {i64, i1} %544, i1 0, 1 
   ret {i64, i1} %545 
 if.then1:
@@ -4131,36 +4131,36 @@ if.then1:
   %533 = tail call ccc  i8*  @wybe_malloc(i32  %532)  
   %534 = ptrtoint i8* %533 to i64 
   %535 = inttoptr i64 %534 to i8* 
-  %536 = inttoptr i64 %"$rec##0" to i8* 
+  %536 = inttoptr i64 %"#rec##0" to i8* 
   %537 = trunc i64 8 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %535, i8*  %536, i32  %537, i32  8, i1  0)  
   %538 = inttoptr i64 %534 to i64* 
   %539 = getelementptr  i64, i64* %538, i64 0 
-  store  i64 %"$field##0", i64* %539 
+  store  i64 %"#field##0", i64* %539 
   %540 = insertvalue {i64, i1} undef, i64 %534, 0 
   %541 = insertvalue {i64, i1} %540, i1 1, 1 
   ret {i64, i1} %541 
 if.else1:
-  %542 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %542 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %543 = insertvalue {i64, i1} %542, i1 0, 1 
   ret {i64, i1} %543 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f02<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f02<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#rec##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 1 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 1 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %554 = insertvalue {i64, i1} undef, i64 undef, 0 
   %555 = insertvalue {i64, i1} %554, i1 0, 1 
   ret {i64, i1} %555 
 if.then1:
-  %546 = add   i64 %"$rec##0", -1 
+  %546 = add   i64 %"#rec##0", -1 
   %547 = inttoptr i64 %546 to i64* 
   %548 = getelementptr  i64, i64* %547, i64 0 
   %549 = load  i64, i64* %548 
@@ -4174,16 +4174,16 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f02<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f02<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#rec##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 1 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 1 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
-  %571 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %571 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %572 = insertvalue {i64, i1} %571, i1 0, 1 
   ret {i64, i1} %572 
 if.then1:
@@ -4191,7 +4191,7 @@ if.then1:
   %557 = tail call ccc  i8*  @wybe_malloc(i32  %556)  
   %558 = ptrtoint i8* %557 to i64 
   %559 = add   i64 %558, 1 
-  %560 = sub   i64 %"$rec##0", 1 
+  %560 = sub   i64 %"#rec##0", 1 
   %561 = inttoptr i64 %558 to i8* 
   %562 = inttoptr i64 %560 to i8* 
   %563 = trunc i64 8 to i32  
@@ -4199,31 +4199,31 @@ if.then1:
   %564 = add   i64 %559, -1 
   %565 = inttoptr i64 %564 to i64* 
   %566 = getelementptr  i64, i64* %565, i64 0 
-  store  i64 %"$field##0", i64* %566 
+  store  i64 %"#field##0", i64* %566 
   %567 = insertvalue {i64, i1} undef, i64 %559, 0 
   %568 = insertvalue {i64, i1} %567, i1 1, 1 
   ret {i64, i1} %568 
 if.else1:
-  %569 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %569 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %570 = insertvalue {i64, i1} %569, i1 0, 1 
   ret {i64, i1} %570 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f03<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f03<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#rec##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 2 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 2 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %581 = insertvalue {i64, i1} undef, i64 undef, 0 
   %582 = insertvalue {i64, i1} %581, i1 0, 1 
   ret {i64, i1} %582 
 if.then1:
-  %573 = add   i64 %"$rec##0", -2 
+  %573 = add   i64 %"#rec##0", -2 
   %574 = inttoptr i64 %573 to i64* 
   %575 = getelementptr  i64, i64* %574, i64 0 
   %576 = load  i64, i64* %575 
@@ -4237,16 +4237,16 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f03<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f03<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#rec##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 2 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 2 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
-  %598 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %598 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %599 = insertvalue {i64, i1} %598, i1 0, 1 
   ret {i64, i1} %599 
 if.then1:
@@ -4254,7 +4254,7 @@ if.then1:
   %584 = tail call ccc  i8*  @wybe_malloc(i32  %583)  
   %585 = ptrtoint i8* %584 to i64 
   %586 = add   i64 %585, 2 
-  %587 = sub   i64 %"$rec##0", 2 
+  %587 = sub   i64 %"#rec##0", 2 
   %588 = inttoptr i64 %585 to i8* 
   %589 = inttoptr i64 %587 to i8* 
   %590 = trunc i64 8 to i32  
@@ -4262,31 +4262,31 @@ if.then1:
   %591 = add   i64 %586, -2 
   %592 = inttoptr i64 %591 to i64* 
   %593 = getelementptr  i64, i64* %592, i64 0 
-  store  i64 %"$field##0", i64* %593 
+  store  i64 %"#field##0", i64* %593 
   %594 = insertvalue {i64, i1} undef, i64 %586, 0 
   %595 = insertvalue {i64, i1} %594, i1 1, 1 
   ret {i64, i1} %595 
 if.else1:
-  %596 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %596 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %597 = insertvalue {i64, i1} %596, i1 0, 1 
   ret {i64, i1} %597 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f04<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f04<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#rec##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 3 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 3 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %608 = insertvalue {i64, i1} undef, i64 undef, 0 
   %609 = insertvalue {i64, i1} %608, i1 0, 1 
   ret {i64, i1} %609 
 if.then1:
-  %600 = add   i64 %"$rec##0", -3 
+  %600 = add   i64 %"#rec##0", -3 
   %601 = inttoptr i64 %600 to i64* 
   %602 = getelementptr  i64, i64* %601, i64 0 
   %603 = load  i64, i64* %602 
@@ -4300,16 +4300,16 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f04<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f04<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#rec##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 3 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 3 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
-  %625 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %625 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %626 = insertvalue {i64, i1} %625, i1 0, 1 
   ret {i64, i1} %626 
 if.then1:
@@ -4317,7 +4317,7 @@ if.then1:
   %611 = tail call ccc  i8*  @wybe_malloc(i32  %610)  
   %612 = ptrtoint i8* %611 to i64 
   %613 = add   i64 %612, 3 
-  %614 = sub   i64 %"$rec##0", 3 
+  %614 = sub   i64 %"#rec##0", 3 
   %615 = inttoptr i64 %612 to i8* 
   %616 = inttoptr i64 %614 to i8* 
   %617 = trunc i64 8 to i32  
@@ -4325,31 +4325,31 @@ if.then1:
   %618 = add   i64 %613, -3 
   %619 = inttoptr i64 %618 to i64* 
   %620 = getelementptr  i64, i64* %619, i64 0 
-  store  i64 %"$field##0", i64* %620 
+  store  i64 %"#field##0", i64* %620 
   %621 = insertvalue {i64, i1} undef, i64 %613, 0 
   %622 = insertvalue {i64, i1} %621, i1 1, 1 
   ret {i64, i1} %622 
 if.else1:
-  %623 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %623 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %624 = insertvalue {i64, i1} %623, i1 0, 1 
   ret {i64, i1} %624 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f05<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f05<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#rec##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 4 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 4 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %635 = insertvalue {i64, i1} undef, i64 undef, 0 
   %636 = insertvalue {i64, i1} %635, i1 0, 1 
   ret {i64, i1} %636 
 if.then1:
-  %627 = add   i64 %"$rec##0", -4 
+  %627 = add   i64 %"#rec##0", -4 
   %628 = inttoptr i64 %627 to i64* 
   %629 = getelementptr  i64, i64* %628, i64 0 
   %630 = load  i64, i64* %629 
@@ -4363,16 +4363,16 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f05<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f05<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#rec##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 4 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 4 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
-  %652 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %652 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %653 = insertvalue {i64, i1} %652, i1 0, 1 
   ret {i64, i1} %653 
 if.then1:
@@ -4380,7 +4380,7 @@ if.then1:
   %638 = tail call ccc  i8*  @wybe_malloc(i32  %637)  
   %639 = ptrtoint i8* %638 to i64 
   %640 = add   i64 %639, 4 
-  %641 = sub   i64 %"$rec##0", 4 
+  %641 = sub   i64 %"#rec##0", 4 
   %642 = inttoptr i64 %639 to i8* 
   %643 = inttoptr i64 %641 to i8* 
   %644 = trunc i64 8 to i32  
@@ -4388,31 +4388,31 @@ if.then1:
   %645 = add   i64 %640, -4 
   %646 = inttoptr i64 %645 to i64* 
   %647 = getelementptr  i64, i64* %646, i64 0 
-  store  i64 %"$field##0", i64* %647 
+  store  i64 %"#field##0", i64* %647 
   %648 = insertvalue {i64, i1} undef, i64 %640, 0 
   %649 = insertvalue {i64, i1} %648, i1 1, 1 
   ret {i64, i1} %649 
 if.else1:
-  %650 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %650 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %651 = insertvalue {i64, i1} %650, i1 0, 1 
   ret {i64, i1} %651 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f06<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f06<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#rec##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 5 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 5 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %662 = insertvalue {i64, i1} undef, i64 undef, 0 
   %663 = insertvalue {i64, i1} %662, i1 0, 1 
   ret {i64, i1} %663 
 if.then1:
-  %654 = add   i64 %"$rec##0", -5 
+  %654 = add   i64 %"#rec##0", -5 
   %655 = inttoptr i64 %654 to i64* 
   %656 = getelementptr  i64, i64* %655, i64 0 
   %657 = load  i64, i64* %656 
@@ -4426,16 +4426,16 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f06<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f06<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#rec##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 5 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 5 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
-  %679 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %679 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %680 = insertvalue {i64, i1} %679, i1 0, 1 
   ret {i64, i1} %680 
 if.then1:
@@ -4443,7 +4443,7 @@ if.then1:
   %665 = tail call ccc  i8*  @wybe_malloc(i32  %664)  
   %666 = ptrtoint i8* %665 to i64 
   %667 = add   i64 %666, 5 
-  %668 = sub   i64 %"$rec##0", 5 
+  %668 = sub   i64 %"#rec##0", 5 
   %669 = inttoptr i64 %666 to i8* 
   %670 = inttoptr i64 %668 to i8* 
   %671 = trunc i64 8 to i32  
@@ -4451,31 +4451,31 @@ if.then1:
   %672 = add   i64 %667, -5 
   %673 = inttoptr i64 %672 to i64* 
   %674 = getelementptr  i64, i64* %673, i64 0 
-  store  i64 %"$field##0", i64* %674 
+  store  i64 %"#field##0", i64* %674 
   %675 = insertvalue {i64, i1} undef, i64 %667, 0 
   %676 = insertvalue {i64, i1} %675, i1 1, 1 
   ret {i64, i1} %676 
 if.else1:
-  %677 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %677 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %678 = insertvalue {i64, i1} %677, i1 0, 1 
   ret {i64, i1} %678 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f07<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f07<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#rec##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 6 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 6 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %689 = insertvalue {i64, i1} undef, i64 undef, 0 
   %690 = insertvalue {i64, i1} %689, i1 0, 1 
   ret {i64, i1} %690 
 if.then1:
-  %681 = add   i64 %"$rec##0", -6 
+  %681 = add   i64 %"#rec##0", -6 
   %682 = inttoptr i64 %681 to i64* 
   %683 = getelementptr  i64, i64* %682, i64 0 
   %684 = load  i64, i64* %683 
@@ -4489,16 +4489,16 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f07<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f07<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#rec##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 6 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 6 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
-  %706 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %706 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %707 = insertvalue {i64, i1} %706, i1 0, 1 
   ret {i64, i1} %707 
 if.then1:
@@ -4506,7 +4506,7 @@ if.then1:
   %692 = tail call ccc  i8*  @wybe_malloc(i32  %691)  
   %693 = ptrtoint i8* %692 to i64 
   %694 = add   i64 %693, 6 
-  %695 = sub   i64 %"$rec##0", 6 
+  %695 = sub   i64 %"#rec##0", 6 
   %696 = inttoptr i64 %693 to i8* 
   %697 = inttoptr i64 %695 to i8* 
   %698 = trunc i64 8 to i32  
@@ -4514,42 +4514,42 @@ if.then1:
   %699 = add   i64 %694, -6 
   %700 = inttoptr i64 %699 to i64* 
   %701 = getelementptr  i64, i64* %700, i64 0 
-  store  i64 %"$field##0", i64* %701 
+  store  i64 %"#field##0", i64* %701 
   %702 = insertvalue {i64, i1} undef, i64 %694, 0 
   %703 = insertvalue {i64, i1} %702, i1 1, 1 
   ret {i64, i1} %703 
 if.else1:
-  %704 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %704 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %705 = insertvalue {i64, i1} %704, i1 0, 1 
   ret {i64, i1} %705 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f08<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f08<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#rec##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %722 = insertvalue {i64, i1} undef, i64 undef, 0 
   %723 = insertvalue {i64, i1} %722, i1 0, 1 
   ret {i64, i1} %723 
 if.then1:
-  %708 = add   i64 %"$rec##0", -7 
+  %708 = add   i64 %"#rec##0", -7 
   %709 = inttoptr i64 %708 to i16* 
   %710 = getelementptr  i16, i16* %709, i64 0 
   %711 = load  i16, i16* %710 
-  %"4$tmp$3##0" = icmp eq i16 %711, 7 
-  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
+  %"4#tmp#3##0" = icmp eq i16 %711, 7 
+  br i1 %"4#tmp#3##0", label %if.then2, label %if.else2 
 if.else1:
   %720 = insertvalue {i64, i1} undef, i64 undef, 0 
   %721 = insertvalue {i64, i1} %720, i1 0, 1 
   ret {i64, i1} %721 
 if.then2:
-  %712 = add   i64 %"$rec##0", 1 
+  %712 = add   i64 %"#rec##0", 1 
   %713 = inttoptr i64 %712 to i64* 
   %714 = getelementptr  i64, i64* %713, i64 0 
   %715 = load  i64, i64* %714 
@@ -4563,27 +4563,27 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f08<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f08<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#rec##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
-  %745 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %745 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %746 = insertvalue {i64, i1} %745, i1 0, 1 
   ret {i64, i1} %746 
 if.then1:
-  %724 = add   i64 %"$rec##0", -7 
+  %724 = add   i64 %"#rec##0", -7 
   %725 = inttoptr i64 %724 to i16* 
   %726 = getelementptr  i16, i16* %725, i64 0 
   %727 = load  i16, i16* %726 
-  %"4$tmp$3##0" = icmp eq i16 %727, 7 
-  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
+  %"4#tmp#3##0" = icmp eq i16 %727, 7 
+  br i1 %"4#tmp#3##0", label %if.then2, label %if.else2 
 if.else1:
-  %743 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %743 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %744 = insertvalue {i64, i1} %743, i1 0, 1 
   ret {i64, i1} %744 
 if.then2:
@@ -4591,7 +4591,7 @@ if.then2:
   %729 = tail call ccc  i8*  @wybe_malloc(i32  %728)  
   %730 = ptrtoint i8* %729 to i64 
   %731 = add   i64 %730, 7 
-  %732 = sub   i64 %"$rec##0", 7 
+  %732 = sub   i64 %"#rec##0", 7 
   %733 = inttoptr i64 %730 to i8* 
   %734 = inttoptr i64 %732 to i8* 
   %735 = trunc i64 16 to i32  
@@ -4599,42 +4599,42 @@ if.then2:
   %736 = add   i64 %731, 1 
   %737 = inttoptr i64 %736 to i64* 
   %738 = getelementptr  i64, i64* %737, i64 0 
-  store  i64 %"$field##0", i64* %738 
+  store  i64 %"#field##0", i64* %738 
   %739 = insertvalue {i64, i1} undef, i64 %731, 0 
   %740 = insertvalue {i64, i1} %739, i1 1, 1 
   ret {i64, i1} %740 
 if.else2:
-  %741 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %741 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %742 = insertvalue {i64, i1} %741, i1 0, 1 
   ret {i64, i1} %742 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f09<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f09<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#rec##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %761 = insertvalue {i64, i1} undef, i64 undef, 0 
   %762 = insertvalue {i64, i1} %761, i1 0, 1 
   ret {i64, i1} %762 
 if.then1:
-  %747 = add   i64 %"$rec##0", -7 
+  %747 = add   i64 %"#rec##0", -7 
   %748 = inttoptr i64 %747 to i16* 
   %749 = getelementptr  i16, i16* %748, i64 0 
   %750 = load  i16, i16* %749 
-  %"4$tmp$3##0" = icmp eq i16 %750, 8 
-  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
+  %"4#tmp#3##0" = icmp eq i16 %750, 8 
+  br i1 %"4#tmp#3##0", label %if.then2, label %if.else2 
 if.else1:
   %759 = insertvalue {i64, i1} undef, i64 undef, 0 
   %760 = insertvalue {i64, i1} %759, i1 0, 1 
   ret {i64, i1} %760 
 if.then2:
-  %751 = add   i64 %"$rec##0", 1 
+  %751 = add   i64 %"#rec##0", 1 
   %752 = inttoptr i64 %751 to i64* 
   %753 = getelementptr  i64, i64* %752, i64 0 
   %754 = load  i64, i64* %753 
@@ -4648,27 +4648,27 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f09<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f09<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#rec##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
-  %784 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %784 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %785 = insertvalue {i64, i1} %784, i1 0, 1 
   ret {i64, i1} %785 
 if.then1:
-  %763 = add   i64 %"$rec##0", -7 
+  %763 = add   i64 %"#rec##0", -7 
   %764 = inttoptr i64 %763 to i16* 
   %765 = getelementptr  i16, i16* %764, i64 0 
   %766 = load  i16, i16* %765 
-  %"4$tmp$3##0" = icmp eq i16 %766, 8 
-  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
+  %"4#tmp#3##0" = icmp eq i16 %766, 8 
+  br i1 %"4#tmp#3##0", label %if.then2, label %if.else2 
 if.else1:
-  %782 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %782 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %783 = insertvalue {i64, i1} %782, i1 0, 1 
   ret {i64, i1} %783 
 if.then2:
@@ -4676,7 +4676,7 @@ if.then2:
   %768 = tail call ccc  i8*  @wybe_malloc(i32  %767)  
   %769 = ptrtoint i8* %768 to i64 
   %770 = add   i64 %769, 7 
-  %771 = sub   i64 %"$rec##0", 7 
+  %771 = sub   i64 %"#rec##0", 7 
   %772 = inttoptr i64 %769 to i8* 
   %773 = inttoptr i64 %771 to i8* 
   %774 = trunc i64 16 to i32  
@@ -4684,42 +4684,42 @@ if.then2:
   %775 = add   i64 %770, 1 
   %776 = inttoptr i64 %775 to i64* 
   %777 = getelementptr  i64, i64* %776, i64 0 
-  store  i64 %"$field##0", i64* %777 
+  store  i64 %"#field##0", i64* %777 
   %778 = insertvalue {i64, i1} undef, i64 %770, 0 
   %779 = insertvalue {i64, i1} %778, i1 1, 1 
   ret {i64, i1} %779 
 if.else2:
-  %780 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %780 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %781 = insertvalue {i64, i1} %780, i1 0, 1 
   ret {i64, i1} %781 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f10<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f10<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#rec##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %800 = insertvalue {i64, i1} undef, i64 undef, 0 
   %801 = insertvalue {i64, i1} %800, i1 0, 1 
   ret {i64, i1} %801 
 if.then1:
-  %786 = add   i64 %"$rec##0", -7 
+  %786 = add   i64 %"#rec##0", -7 
   %787 = inttoptr i64 %786 to i16* 
   %788 = getelementptr  i16, i16* %787, i64 0 
   %789 = load  i16, i16* %788 
-  %"4$tmp$3##0" = icmp eq i16 %789, 9 
-  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
+  %"4#tmp#3##0" = icmp eq i16 %789, 9 
+  br i1 %"4#tmp#3##0", label %if.then2, label %if.else2 
 if.else1:
   %798 = insertvalue {i64, i1} undef, i64 undef, 0 
   %799 = insertvalue {i64, i1} %798, i1 0, 1 
   ret {i64, i1} %799 
 if.then2:
-  %790 = add   i64 %"$rec##0", 1 
+  %790 = add   i64 %"#rec##0", 1 
   %791 = inttoptr i64 %790 to i64* 
   %792 = getelementptr  i64, i64* %791, i64 0 
   %793 = load  i64, i64* %792 
@@ -4733,27 +4733,27 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f10<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f10<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#rec##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
-  %823 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %823 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %824 = insertvalue {i64, i1} %823, i1 0, 1 
   ret {i64, i1} %824 
 if.then1:
-  %802 = add   i64 %"$rec##0", -7 
+  %802 = add   i64 %"#rec##0", -7 
   %803 = inttoptr i64 %802 to i16* 
   %804 = getelementptr  i16, i16* %803, i64 0 
   %805 = load  i16, i16* %804 
-  %"4$tmp$3##0" = icmp eq i16 %805, 9 
-  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
+  %"4#tmp#3##0" = icmp eq i16 %805, 9 
+  br i1 %"4#tmp#3##0", label %if.then2, label %if.else2 
 if.else1:
-  %821 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %821 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %822 = insertvalue {i64, i1} %821, i1 0, 1 
   ret {i64, i1} %822 
 if.then2:
@@ -4761,7 +4761,7 @@ if.then2:
   %807 = tail call ccc  i8*  @wybe_malloc(i32  %806)  
   %808 = ptrtoint i8* %807 to i64 
   %809 = add   i64 %808, 7 
-  %810 = sub   i64 %"$rec##0", 7 
+  %810 = sub   i64 %"#rec##0", 7 
   %811 = inttoptr i64 %808 to i8* 
   %812 = inttoptr i64 %810 to i8* 
   %813 = trunc i64 16 to i32  
@@ -4769,42 +4769,42 @@ if.then2:
   %814 = add   i64 %809, 1 
   %815 = inttoptr i64 %814 to i64* 
   %816 = getelementptr  i64, i64* %815, i64 0 
-  store  i64 %"$field##0", i64* %816 
+  store  i64 %"#field##0", i64* %816 
   %817 = insertvalue {i64, i1} undef, i64 %809, 0 
   %818 = insertvalue {i64, i1} %817, i1 1, 1 
   ret {i64, i1} %818 
 if.else2:
-  %819 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %819 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %820 = insertvalue {i64, i1} %819, i1 0, 1 
   ret {i64, i1} %820 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f11<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f11<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#rec##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %839 = insertvalue {i64, i1} undef, i64 undef, 0 
   %840 = insertvalue {i64, i1} %839, i1 0, 1 
   ret {i64, i1} %840 
 if.then1:
-  %825 = add   i64 %"$rec##0", -7 
+  %825 = add   i64 %"#rec##0", -7 
   %826 = inttoptr i64 %825 to i16* 
   %827 = getelementptr  i16, i16* %826, i64 0 
   %828 = load  i16, i16* %827 
-  %"4$tmp$3##0" = icmp eq i16 %828, 10 
-  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
+  %"4#tmp#3##0" = icmp eq i16 %828, 10 
+  br i1 %"4#tmp#3##0", label %if.then2, label %if.else2 
 if.else1:
   %837 = insertvalue {i64, i1} undef, i64 undef, 0 
   %838 = insertvalue {i64, i1} %837, i1 0, 1 
   ret {i64, i1} %838 
 if.then2:
-  %829 = add   i64 %"$rec##0", 1 
+  %829 = add   i64 %"#rec##0", 1 
   %830 = inttoptr i64 %829 to i64* 
   %831 = getelementptr  i64, i64* %830, i64 0 
   %832 = load  i64, i64* %831 
@@ -4818,27 +4818,27 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f11<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f11<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#rec##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
-  %862 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %862 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %863 = insertvalue {i64, i1} %862, i1 0, 1 
   ret {i64, i1} %863 
 if.then1:
-  %841 = add   i64 %"$rec##0", -7 
+  %841 = add   i64 %"#rec##0", -7 
   %842 = inttoptr i64 %841 to i16* 
   %843 = getelementptr  i16, i16* %842, i64 0 
   %844 = load  i16, i16* %843 
-  %"4$tmp$3##0" = icmp eq i16 %844, 10 
-  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
+  %"4#tmp#3##0" = icmp eq i16 %844, 10 
+  br i1 %"4#tmp#3##0", label %if.then2, label %if.else2 
 if.else1:
-  %860 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %860 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %861 = insertvalue {i64, i1} %860, i1 0, 1 
   ret {i64, i1} %861 
 if.then2:
@@ -4846,7 +4846,7 @@ if.then2:
   %846 = tail call ccc  i8*  @wybe_malloc(i32  %845)  
   %847 = ptrtoint i8* %846 to i64 
   %848 = add   i64 %847, 7 
-  %849 = sub   i64 %"$rec##0", 7 
+  %849 = sub   i64 %"#rec##0", 7 
   %850 = inttoptr i64 %847 to i8* 
   %851 = inttoptr i64 %849 to i8* 
   %852 = trunc i64 16 to i32  
@@ -4854,42 +4854,42 @@ if.then2:
   %853 = add   i64 %848, 1 
   %854 = inttoptr i64 %853 to i64* 
   %855 = getelementptr  i64, i64* %854, i64 0 
-  store  i64 %"$field##0", i64* %855 
+  store  i64 %"#field##0", i64* %855 
   %856 = insertvalue {i64, i1} undef, i64 %848, 0 
   %857 = insertvalue {i64, i1} %856, i1 1, 1 
   ret {i64, i1} %857 
 if.else2:
-  %858 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %858 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %859 = insertvalue {i64, i1} %858, i1 0, 1 
   ret {i64, i1} %859 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f12<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f12<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#rec##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %878 = insertvalue {i64, i1} undef, i64 undef, 0 
   %879 = insertvalue {i64, i1} %878, i1 0, 1 
   ret {i64, i1} %879 
 if.then1:
-  %864 = add   i64 %"$rec##0", -7 
+  %864 = add   i64 %"#rec##0", -7 
   %865 = inttoptr i64 %864 to i16* 
   %866 = getelementptr  i16, i16* %865, i64 0 
   %867 = load  i16, i16* %866 
-  %"4$tmp$3##0" = icmp eq i16 %867, 11 
-  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
+  %"4#tmp#3##0" = icmp eq i16 %867, 11 
+  br i1 %"4#tmp#3##0", label %if.then2, label %if.else2 
 if.else1:
   %876 = insertvalue {i64, i1} undef, i64 undef, 0 
   %877 = insertvalue {i64, i1} %876, i1 0, 1 
   ret {i64, i1} %877 
 if.then2:
-  %868 = add   i64 %"$rec##0", 1 
+  %868 = add   i64 %"#rec##0", 1 
   %869 = inttoptr i64 %868 to i64* 
   %870 = getelementptr  i64, i64* %869, i64 0 
   %871 = load  i64, i64* %870 
@@ -4903,27 +4903,27 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f12<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f12<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#rec##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
-  %901 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %901 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %902 = insertvalue {i64, i1} %901, i1 0, 1 
   ret {i64, i1} %902 
 if.then1:
-  %880 = add   i64 %"$rec##0", -7 
+  %880 = add   i64 %"#rec##0", -7 
   %881 = inttoptr i64 %880 to i16* 
   %882 = getelementptr  i16, i16* %881, i64 0 
   %883 = load  i16, i16* %882 
-  %"4$tmp$3##0" = icmp eq i16 %883, 11 
-  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
+  %"4#tmp#3##0" = icmp eq i16 %883, 11 
+  br i1 %"4#tmp#3##0", label %if.then2, label %if.else2 
 if.else1:
-  %899 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %899 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %900 = insertvalue {i64, i1} %899, i1 0, 1 
   ret {i64, i1} %900 
 if.then2:
@@ -4931,7 +4931,7 @@ if.then2:
   %885 = tail call ccc  i8*  @wybe_malloc(i32  %884)  
   %886 = ptrtoint i8* %885 to i64 
   %887 = add   i64 %886, 7 
-  %888 = sub   i64 %"$rec##0", 7 
+  %888 = sub   i64 %"#rec##0", 7 
   %889 = inttoptr i64 %886 to i8* 
   %890 = inttoptr i64 %888 to i8* 
   %891 = trunc i64 16 to i32  
@@ -4939,42 +4939,42 @@ if.then2:
   %892 = add   i64 %887, 1 
   %893 = inttoptr i64 %892 to i64* 
   %894 = getelementptr  i64, i64* %893, i64 0 
-  store  i64 %"$field##0", i64* %894 
+  store  i64 %"#field##0", i64* %894 
   %895 = insertvalue {i64, i1} undef, i64 %887, 0 
   %896 = insertvalue {i64, i1} %895, i1 1, 1 
   ret {i64, i1} %896 
 if.else2:
-  %897 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %897 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %898 = insertvalue {i64, i1} %897, i1 0, 1 
   ret {i64, i1} %898 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f13<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f13<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#rec##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %917 = insertvalue {i64, i1} undef, i64 undef, 0 
   %918 = insertvalue {i64, i1} %917, i1 0, 1 
   ret {i64, i1} %918 
 if.then1:
-  %903 = add   i64 %"$rec##0", -7 
+  %903 = add   i64 %"#rec##0", -7 
   %904 = inttoptr i64 %903 to i16* 
   %905 = getelementptr  i16, i16* %904, i64 0 
   %906 = load  i16, i16* %905 
-  %"4$tmp$3##0" = icmp eq i16 %906, 12 
-  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
+  %"4#tmp#3##0" = icmp eq i16 %906, 12 
+  br i1 %"4#tmp#3##0", label %if.then2, label %if.else2 
 if.else1:
   %915 = insertvalue {i64, i1} undef, i64 undef, 0 
   %916 = insertvalue {i64, i1} %915, i1 0, 1 
   ret {i64, i1} %916 
 if.then2:
-  %907 = add   i64 %"$rec##0", 1 
+  %907 = add   i64 %"#rec##0", 1 
   %908 = inttoptr i64 %907 to i64* 
   %909 = getelementptr  i64, i64* %908, i64 0 
   %910 = load  i64, i64* %909 
@@ -4988,27 +4988,27 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f13<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f13<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#rec##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
-  %940 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %940 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %941 = insertvalue {i64, i1} %940, i1 0, 1 
   ret {i64, i1} %941 
 if.then1:
-  %919 = add   i64 %"$rec##0", -7 
+  %919 = add   i64 %"#rec##0", -7 
   %920 = inttoptr i64 %919 to i16* 
   %921 = getelementptr  i16, i16* %920, i64 0 
   %922 = load  i16, i16* %921 
-  %"4$tmp$3##0" = icmp eq i16 %922, 12 
-  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
+  %"4#tmp#3##0" = icmp eq i16 %922, 12 
+  br i1 %"4#tmp#3##0", label %if.then2, label %if.else2 
 if.else1:
-  %938 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %938 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %939 = insertvalue {i64, i1} %938, i1 0, 1 
   ret {i64, i1} %939 
 if.then2:
@@ -5016,7 +5016,7 @@ if.then2:
   %924 = tail call ccc  i8*  @wybe_malloc(i32  %923)  
   %925 = ptrtoint i8* %924 to i64 
   %926 = add   i64 %925, 7 
-  %927 = sub   i64 %"$rec##0", 7 
+  %927 = sub   i64 %"#rec##0", 7 
   %928 = inttoptr i64 %925 to i8* 
   %929 = inttoptr i64 %927 to i8* 
   %930 = trunc i64 16 to i32  
@@ -5024,42 +5024,42 @@ if.then2:
   %931 = add   i64 %926, 1 
   %932 = inttoptr i64 %931 to i64* 
   %933 = getelementptr  i64, i64* %932, i64 0 
-  store  i64 %"$field##0", i64* %933 
+  store  i64 %"#field##0", i64* %933 
   %934 = insertvalue {i64, i1} undef, i64 %926, 0 
   %935 = insertvalue {i64, i1} %934, i1 1, 1 
   ret {i64, i1} %935 
 if.else2:
-  %936 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %936 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %937 = insertvalue {i64, i1} %936, i1 0, 1 
   ret {i64, i1} %937 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f14<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f14<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#rec##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %956 = insertvalue {i64, i1} undef, i64 undef, 0 
   %957 = insertvalue {i64, i1} %956, i1 0, 1 
   ret {i64, i1} %957 
 if.then1:
-  %942 = add   i64 %"$rec##0", -7 
+  %942 = add   i64 %"#rec##0", -7 
   %943 = inttoptr i64 %942 to i16* 
   %944 = getelementptr  i16, i16* %943, i64 0 
   %945 = load  i16, i16* %944 
-  %"4$tmp$3##0" = icmp eq i16 %945, 13 
-  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
+  %"4#tmp#3##0" = icmp eq i16 %945, 13 
+  br i1 %"4#tmp#3##0", label %if.then2, label %if.else2 
 if.else1:
   %954 = insertvalue {i64, i1} undef, i64 undef, 0 
   %955 = insertvalue {i64, i1} %954, i1 0, 1 
   ret {i64, i1} %955 
 if.then2:
-  %946 = add   i64 %"$rec##0", 1 
+  %946 = add   i64 %"#rec##0", 1 
   %947 = inttoptr i64 %946 to i64* 
   %948 = getelementptr  i64, i64* %947, i64 0 
   %949 = load  i64, i64* %948 
@@ -5073,27 +5073,27 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f14<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f14<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#rec##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
-  %979 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %979 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %980 = insertvalue {i64, i1} %979, i1 0, 1 
   ret {i64, i1} %980 
 if.then1:
-  %958 = add   i64 %"$rec##0", -7 
+  %958 = add   i64 %"#rec##0", -7 
   %959 = inttoptr i64 %958 to i16* 
   %960 = getelementptr  i16, i16* %959, i64 0 
   %961 = load  i16, i16* %960 
-  %"4$tmp$3##0" = icmp eq i16 %961, 13 
-  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
+  %"4#tmp#3##0" = icmp eq i16 %961, 13 
+  br i1 %"4#tmp#3##0", label %if.then2, label %if.else2 
 if.else1:
-  %977 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %977 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %978 = insertvalue {i64, i1} %977, i1 0, 1 
   ret {i64, i1} %978 
 if.then2:
@@ -5101,7 +5101,7 @@ if.then2:
   %963 = tail call ccc  i8*  @wybe_malloc(i32  %962)  
   %964 = ptrtoint i8* %963 to i64 
   %965 = add   i64 %964, 7 
-  %966 = sub   i64 %"$rec##0", 7 
+  %966 = sub   i64 %"#rec##0", 7 
   %967 = inttoptr i64 %964 to i8* 
   %968 = inttoptr i64 %966 to i8* 
   %969 = trunc i64 16 to i32  
@@ -5109,42 +5109,42 @@ if.then2:
   %970 = add   i64 %965, 1 
   %971 = inttoptr i64 %970 to i64* 
   %972 = getelementptr  i64, i64* %971, i64 0 
-  store  i64 %"$field##0", i64* %972 
+  store  i64 %"#field##0", i64* %972 
   %973 = insertvalue {i64, i1} undef, i64 %965, 0 
   %974 = insertvalue {i64, i1} %973, i1 1, 1 
   ret {i64, i1} %974 
 if.else2:
-  %975 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %975 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %976 = insertvalue {i64, i1} %975, i1 0, 1 
   ret {i64, i1} %976 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f15<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f15<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#rec##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %995 = insertvalue {i64, i1} undef, i64 undef, 0 
   %996 = insertvalue {i64, i1} %995, i1 0, 1 
   ret {i64, i1} %996 
 if.then1:
-  %981 = add   i64 %"$rec##0", -7 
+  %981 = add   i64 %"#rec##0", -7 
   %982 = inttoptr i64 %981 to i16* 
   %983 = getelementptr  i16, i16* %982, i64 0 
   %984 = load  i16, i16* %983 
-  %"4$tmp$3##0" = icmp eq i16 %984, 14 
-  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
+  %"4#tmp#3##0" = icmp eq i16 %984, 14 
+  br i1 %"4#tmp#3##0", label %if.then2, label %if.else2 
 if.else1:
   %993 = insertvalue {i64, i1} undef, i64 undef, 0 
   %994 = insertvalue {i64, i1} %993, i1 0, 1 
   ret {i64, i1} %994 
 if.then2:
-  %985 = add   i64 %"$rec##0", 1 
+  %985 = add   i64 %"#rec##0", 1 
   %986 = inttoptr i64 %985 to i64* 
   %987 = getelementptr  i64, i64* %986, i64 0 
   %988 = load  i64, i64* %987 
@@ -5158,27 +5158,27 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f15<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f15<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#rec##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
-  %1018 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %1018 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %1019 = insertvalue {i64, i1} %1018, i1 0, 1 
   ret {i64, i1} %1019 
 if.then1:
-  %997 = add   i64 %"$rec##0", -7 
+  %997 = add   i64 %"#rec##0", -7 
   %998 = inttoptr i64 %997 to i16* 
   %999 = getelementptr  i16, i16* %998, i64 0 
   %1000 = load  i16, i16* %999 
-  %"4$tmp$3##0" = icmp eq i16 %1000, 14 
-  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
+  %"4#tmp#3##0" = icmp eq i16 %1000, 14 
+  br i1 %"4#tmp#3##0", label %if.then2, label %if.else2 
 if.else1:
-  %1016 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %1016 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %1017 = insertvalue {i64, i1} %1016, i1 0, 1 
   ret {i64, i1} %1017 
 if.then2:
@@ -5186,7 +5186,7 @@ if.then2:
   %1002 = tail call ccc  i8*  @wybe_malloc(i32  %1001)  
   %1003 = ptrtoint i8* %1002 to i64 
   %1004 = add   i64 %1003, 7 
-  %1005 = sub   i64 %"$rec##0", 7 
+  %1005 = sub   i64 %"#rec##0", 7 
   %1006 = inttoptr i64 %1003 to i8* 
   %1007 = inttoptr i64 %1005 to i8* 
   %1008 = trunc i64 16 to i32  
@@ -5194,42 +5194,42 @@ if.then2:
   %1009 = add   i64 %1004, 1 
   %1010 = inttoptr i64 %1009 to i64* 
   %1011 = getelementptr  i64, i64* %1010, i64 0 
-  store  i64 %"$field##0", i64* %1011 
+  store  i64 %"#field##0", i64* %1011 
   %1012 = insertvalue {i64, i1} undef, i64 %1004, 0 
   %1013 = insertvalue {i64, i1} %1012, i1 1, 1 
   ret {i64, i1} %1013 
 if.else2:
-  %1014 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %1014 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %1015 = insertvalue {i64, i1} %1014, i1 0, 1 
   ret {i64, i1} %1015 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f16<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f16<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#rec##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %1034 = insertvalue {i64, i1} undef, i64 undef, 0 
   %1035 = insertvalue {i64, i1} %1034, i1 0, 1 
   ret {i64, i1} %1035 
 if.then1:
-  %1020 = add   i64 %"$rec##0", -7 
+  %1020 = add   i64 %"#rec##0", -7 
   %1021 = inttoptr i64 %1020 to i16* 
   %1022 = getelementptr  i16, i16* %1021, i64 0 
   %1023 = load  i16, i16* %1022 
-  %"4$tmp$3##0" = icmp eq i16 %1023, 15 
-  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
+  %"4#tmp#3##0" = icmp eq i16 %1023, 15 
+  br i1 %"4#tmp#3##0", label %if.then2, label %if.else2 
 if.else1:
   %1032 = insertvalue {i64, i1} undef, i64 undef, 0 
   %1033 = insertvalue {i64, i1} %1032, i1 0, 1 
   ret {i64, i1} %1033 
 if.then2:
-  %1024 = add   i64 %"$rec##0", 1 
+  %1024 = add   i64 %"#rec##0", 1 
   %1025 = inttoptr i64 %1024 to i64* 
   %1026 = getelementptr  i64, i64* %1025, i64 0 
   %1027 = load  i64, i64* %1026 
@@ -5243,27 +5243,27 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f16<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f16<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#rec##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
-  %1057 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %1057 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %1058 = insertvalue {i64, i1} %1057, i1 0, 1 
   ret {i64, i1} %1058 
 if.then1:
-  %1036 = add   i64 %"$rec##0", -7 
+  %1036 = add   i64 %"#rec##0", -7 
   %1037 = inttoptr i64 %1036 to i16* 
   %1038 = getelementptr  i16, i16* %1037, i64 0 
   %1039 = load  i16, i16* %1038 
-  %"4$tmp$3##0" = icmp eq i16 %1039, 15 
-  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
+  %"4#tmp#3##0" = icmp eq i16 %1039, 15 
+  br i1 %"4#tmp#3##0", label %if.then2, label %if.else2 
 if.else1:
-  %1055 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %1055 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %1056 = insertvalue {i64, i1} %1055, i1 0, 1 
   ret {i64, i1} %1056 
 if.then2:
@@ -5271,7 +5271,7 @@ if.then2:
   %1041 = tail call ccc  i8*  @wybe_malloc(i32  %1040)  
   %1042 = ptrtoint i8* %1041 to i64 
   %1043 = add   i64 %1042, 7 
-  %1044 = sub   i64 %"$rec##0", 7 
+  %1044 = sub   i64 %"#rec##0", 7 
   %1045 = inttoptr i64 %1042 to i8* 
   %1046 = inttoptr i64 %1044 to i8* 
   %1047 = trunc i64 16 to i32  
@@ -5279,42 +5279,42 @@ if.then2:
   %1048 = add   i64 %1043, 1 
   %1049 = inttoptr i64 %1048 to i64* 
   %1050 = getelementptr  i64, i64* %1049, i64 0 
-  store  i64 %"$field##0", i64* %1050 
+  store  i64 %"#field##0", i64* %1050 
   %1051 = insertvalue {i64, i1} undef, i64 %1043, 0 
   %1052 = insertvalue {i64, i1} %1051, i1 1, 1 
   ret {i64, i1} %1052 
 if.else2:
-  %1053 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %1053 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %1054 = insertvalue {i64, i1} %1053, i1 0, 1 
   ret {i64, i1} %1054 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f17<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f17<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#rec##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %1073 = insertvalue {i64, i1} undef, i64 undef, 0 
   %1074 = insertvalue {i64, i1} %1073, i1 0, 1 
   ret {i64, i1} %1074 
 if.then1:
-  %1059 = add   i64 %"$rec##0", -7 
+  %1059 = add   i64 %"#rec##0", -7 
   %1060 = inttoptr i64 %1059 to i16* 
   %1061 = getelementptr  i16, i16* %1060, i64 0 
   %1062 = load  i16, i16* %1061 
-  %"4$tmp$3##0" = icmp eq i16 %1062, 16 
-  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
+  %"4#tmp#3##0" = icmp eq i16 %1062, 16 
+  br i1 %"4#tmp#3##0", label %if.then2, label %if.else2 
 if.else1:
   %1071 = insertvalue {i64, i1} undef, i64 undef, 0 
   %1072 = insertvalue {i64, i1} %1071, i1 0, 1 
   ret {i64, i1} %1072 
 if.then2:
-  %1063 = add   i64 %"$rec##0", 1 
+  %1063 = add   i64 %"#rec##0", 1 
   %1064 = inttoptr i64 %1063 to i64* 
   %1065 = getelementptr  i64, i64* %1064, i64 0 
   %1066 = load  i64, i64* %1065 
@@ -5328,27 +5328,27 @@ if.else2:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.complicated.f17<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"multictr.complicated.f17<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp uge i64 %"$rec##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp uge i64 %"#rec##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 7 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 7 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 7 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 7 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
-  %1096 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %1096 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %1097 = insertvalue {i64, i1} %1096, i1 0, 1 
   ret {i64, i1} %1097 
 if.then1:
-  %1075 = add   i64 %"$rec##0", -7 
+  %1075 = add   i64 %"#rec##0", -7 
   %1076 = inttoptr i64 %1075 to i16* 
   %1077 = getelementptr  i16, i16* %1076, i64 0 
   %1078 = load  i16, i16* %1077 
-  %"4$tmp$3##0" = icmp eq i16 %1078, 16 
-  br i1 %"4$tmp$3##0", label %if.then2, label %if.else2 
+  %"4#tmp#3##0" = icmp eq i16 %1078, 16 
+  br i1 %"4#tmp#3##0", label %if.then2, label %if.else2 
 if.else1:
-  %1094 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %1094 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %1095 = insertvalue {i64, i1} %1094, i1 0, 1 
   ret {i64, i1} %1095 
 if.then2:
@@ -5356,7 +5356,7 @@ if.then2:
   %1080 = tail call ccc  i8*  @wybe_malloc(i32  %1079)  
   %1081 = ptrtoint i8* %1080 to i64 
   %1082 = add   i64 %1081, 7 
-  %1083 = sub   i64 %"$rec##0", 7 
+  %1083 = sub   i64 %"#rec##0", 7 
   %1084 = inttoptr i64 %1081 to i8* 
   %1085 = inttoptr i64 %1083 to i8* 
   %1086 = trunc i64 16 to i32  
@@ -5364,12 +5364,12 @@ if.then2:
   %1087 = add   i64 %1082, 1 
   %1088 = inttoptr i64 %1087 to i64* 
   %1089 = getelementptr  i64, i64* %1088, i64 0 
-  store  i64 %"$field##0", i64* %1089 
+  store  i64 %"#field##0", i64* %1089 
   %1090 = insertvalue {i64, i1} undef, i64 %1082, 0 
   %1091 = insertvalue {i64, i1} %1090, i1 1, 1 
   ret {i64, i1} %1091 
 if.else2:
-  %1092 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %1092 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %1093 = insertvalue {i64, i1} %1092, i1 0, 1 
   ret {i64, i1} %1093 
 }
@@ -5393,11 +5393,11 @@ entry:
 }
 
 
-define external fastcc  i1 @"multictr.complicated.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"multictr.complicated.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = tail call fastcc  i1  @"multictr.complicated.=<0>"(i64  %"$left##0", i64  %"$right##0")  
-  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
-  ret i1 %"1$$$##0" 
+  %"1#tmp#0##0" = tail call fastcc  i1  @"multictr.complicated.=<0>"(i64  %"#left##0", i64  %"#right##0")  
+  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1#####0" 
 }
 --------------------------------------------------
  Module multictr.length
@@ -5417,47 +5417,47 @@ entry:
 
 = > public {inline} (1 calls)
 0: multictr.length.=<0>
-=($left##0:multictr.length, $right##0:multictr.length, ?$$##0:wybe.bool):
+=(#left##0:multictr.length, #right##0:multictr.length, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(~$left##0:multictr.length, ~$right##0:multictr.length, ?$$##0:wybe.bool)
+    foreign llvm icmp_eq(~#left##0:multictr.length, ~#right##0:multictr.length, ?####0:wybe.bool)
 
 
 metres > public {inline} (0 calls)
 0: multictr.length.metres<0>
-metres(value##0:wybe.float, ?$##2:multictr.length):
+metres(value##0:wybe.float, ?###2:multictr.length):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(~value##0:multictr.length, ?$##2:multictr.length)
+    foreign llvm move(~value##0:multictr.length, ?###2:multictr.length)
 metres > public {inline} (0 calls)
 1: multictr.length.metres<1>
-metres(?value##0:wybe.float, $##0:multictr.length):
+metres(?value##0:wybe.float, ###0:multictr.length):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm cast(~$##0:multictr.length, ?value##0:wybe.float)
+    foreign lpvm cast(~###0:multictr.length, ?value##0:wybe.float)
 
 
 value > public {inline} (0 calls)
 0: multictr.length.value<0>
-value($rec##0:multictr.length, ?$##0:wybe.float):
+value(#rec##0:multictr.length, ?###0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm cast(~$rec##0:multictr.length, ?$##0:wybe.float)
+    foreign lpvm cast(~#rec##0:multictr.length, ?###0:wybe.float)
 value > public {inline} (0 calls)
 1: multictr.length.value<1>
-value([$rec##0:multictr.length], ?$rec##2:multictr.length, $field##0:wybe.float):
+value([#rec##0:multictr.length], ?#rec##2:multictr.length, #field##0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(~$field##0:multictr.length, ?$rec##2:multictr.length)
+    foreign llvm move(~#field##0:multictr.length, ?#rec##2:multictr.length)
 
 
 ~= > public {inline} (0 calls)
 0: multictr.length.~=<0>
-~=($left##0:multictr.length, $right##0:multictr.length, ?$$##0:wybe.bool):
+~=(#left##0:multictr.length, #right##0:multictr.length, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(~$left##0:multictr.length, ~$right##0:multictr.length, ?tmp$0##0:wybe.bool)
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    foreign llvm icmp_eq(~#left##0:multictr.length, ~#right##0:multictr.length, ?tmp#0##0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
   LLVM code       :
 
@@ -5473,10 +5473,10 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"multictr.length.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"multictr.length.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
-  ret i1 %"1$$$##0" 
+  %"1#####0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"1#####0" 
 }
 
 
@@ -5487,32 +5487,32 @@ entry:
 }
 
 
-define external fastcc  double @"multictr.length.metres<1>"(i64  %"$##0")    {
+define external fastcc  double @"multictr.length.metres<1>"(i64  %"###0")    {
 entry:
-  %2 = bitcast i64 %"$##0" to double 
+  %2 = bitcast i64 %"###0" to double 
   ret double %2 
 }
 
 
-define external fastcc  double @"multictr.length.value<0>"(i64  %"$rec##0")    {
+define external fastcc  double @"multictr.length.value<0>"(i64  %"#rec##0")    {
 entry:
-  %3 = bitcast i64 %"$rec##0" to double 
+  %3 = bitcast i64 %"#rec##0" to double 
   ret double %3 
 }
 
 
-define external fastcc  i64 @"multictr.length.value<1>"(double  %"$field##0")    {
+define external fastcc  i64 @"multictr.length.value<1>"(double  %"#field##0")    {
 entry:
-  %4 = bitcast double %"$field##0" to i64 
+  %4 = bitcast double %"#field##0" to i64 
   ret i64 %4 
 }
 
 
-define external fastcc  i1 @"multictr.length.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"multictr.length.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = icmp eq i64 %"$left##0", %"$right##0" 
-  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
-  ret i1 %"1$$$##0" 
+  %"1#tmp#0##0" = icmp eq i64 %"#left##0", %"#right##0" 
+  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1#####0" 
 }
 --------------------------------------------------
  Module multictr.maybe_int
@@ -5533,99 +5533,99 @@ entry:
 
 = > public (1 calls)
 0: multictr.maybe_int.=<0>
-=($left##0:multictr.maybe_int, $right##0:multictr.maybe_int, ?$$##0:wybe.bool):
+=(#left##0:multictr.maybe_int, #right##0:multictr.maybe_int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left##0:multictr.maybe_int, ~$right##0:multictr.maybe_int, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:multictr.maybe_int, ~#right##0:multictr.maybe_int, ?####0:wybe.bool)
 
     1:
-        foreign lpvm access(~$left##0:multictr.maybe_int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$left$value##0:wybe.int)
-        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.bool)
-        case ~tmp$8##0:wybe.bool of
+        foreign lpvm access(~#left##0:multictr.maybe_int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#left#value##0:wybe.int)
+        foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool)
+        case ~tmp#8##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign lpvm access(~$right##0:multictr.maybe_int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$right$value##0:wybe.int)
-            foreign llvm icmp_eq(~$left$value##0:wybe.int, ~$right$value##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+            foreign lpvm access(~#right##0:multictr.maybe_int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#right#value##0:wybe.int)
+            foreign llvm icmp_eq(~#left#value##0:wybe.int, ~#right#value##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 
 just > public {inline} (0 calls)
 0: multictr.maybe_int.just<0>
-just(value##0:wybe.int, ?$##0:multictr.maybe_int):
+just(value##0:wybe.int, ?###0:multictr.maybe_int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr.maybe_int)
-    foreign lpvm mutate(~$rec##0:multictr.maybe_int, ?$##0:multictr.maybe_int, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~value##0:wybe.int)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.maybe_int)
+    foreign lpvm mutate(~#rec##0:multictr.maybe_int, ?###0:multictr.maybe_int, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~value##0:wybe.int)
 just > public {inline} (8 calls)
 1: multictr.maybe_int.just<1>
-just(?value##0:wybe.int, $##0:multictr.maybe_int, ?$$##0:wybe.bool):
+just(?value##0:wybe.int, ###0:multictr.maybe_int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?value##0:wybe.int)
 
     1:
-        foreign lpvm access(~$##0:multictr.maybe_int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?value##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~###0:multictr.maybe_int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?value##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 nothing > public {inline} (0 calls)
 0: multictr.maybe_int.nothing<0>
-nothing(?$##0:multictr.maybe_int):
+nothing(?###0:multictr.maybe_int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:multictr.maybe_int, ?$##0:multictr.maybe_int)
+    foreign llvm move(0:multictr.maybe_int, ?###0:multictr.maybe_int)
 
 
 value > public {inline} (0 calls)
 0: multictr.maybe_int.value<0>
-value($rec##0:multictr.maybe_int, ?$##0:wybe.int, ?$$##0:wybe.bool):
+value(#rec##0:multictr.maybe_int, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec##0:multictr.maybe_int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:multictr.maybe_int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 value > public {inline} (0 calls)
 1: multictr.maybe_int.value<1>
-value($rec##0:multictr.maybe_int, ?$rec##1:multictr.maybe_int, $field##0:wybe.int, ?$$##0:wybe.bool):
+value(#rec##0:multictr.maybe_int, ?#rec##1:multictr.maybe_int, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multictr.maybe_int, ?$rec##1:multictr.maybe_int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multictr.maybe_int, ?#rec##1:multictr.maybe_int)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec##0:multictr.maybe_int, ?$rec##1:multictr.maybe_int, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm {noalias} mutate(~#rec##0:multictr.maybe_int, ?#rec##1:multictr.maybe_int, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: multictr.maybe_int.~=<0>
-~=($left##0:multictr.maybe_int, $right##0:multictr.maybe_int, ?$$##0:wybe.bool):
+~=(#left##0:multictr.maybe_int, #right##0:multictr.maybe_int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    multictr.maybe_int.=<0>(~$left##0:multictr.maybe_int, ~$right##0:multictr.maybe_int, ?tmp$0##0:wybe.bool) #0
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    multictr.maybe_int.=<0>(~#left##0:multictr.maybe_int, ~#right##0:multictr.maybe_int, ?tmp#0##0:wybe.bool) #0
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
   LLVM code       :
 
@@ -5641,25 +5641,25 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"multictr.maybe_int.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"multictr.maybe_int.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#left##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %"2$tmp$8##0" = icmp ne i64 %"$right##0", 0 
-  br i1 %"2$tmp$8##0", label %if.then1, label %if.else1 
+  %"2#tmp#8##0" = icmp ne i64 %"#right##0", 0 
+  br i1 %"2#tmp#8##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3#####0" 
 if.then1:
-  %4 = inttoptr i64 %"$right##0" to i64* 
+  %4 = inttoptr i64 %"#right##0" to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
   %6 = load  i64, i64* %5 
-  %"4$$$##0" = icmp eq i64 %3, %6 
-  ret i1 %"4$$$##0" 
+  %"4#####0" = icmp eq i64 %3, %6 
+  ret i1 %"4#####0" 
 if.else1:
   ret i1 0 
 }
@@ -5677,12 +5677,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.maybe_int.just<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"multictr.maybe_int.just<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %12 = inttoptr i64 %"$##0" to i64* 
+  %12 = inttoptr i64 %"###0" to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
   %15 = insertvalue {i64, i1} undef, i64 %14, 0 
@@ -5701,12 +5701,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.maybe_int.value<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"multictr.maybe_int.value<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %19 = inttoptr i64 %"$rec##0" to i64* 
+  %19 = inttoptr i64 %"#rec##0" to i64* 
   %20 = getelementptr  i64, i64* %19, i64 0 
   %21 = load  i64, i64* %20 
   %22 = insertvalue {i64, i1} undef, i64 %21, 0 
@@ -5719,36 +5719,36 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.maybe_int.value<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"multictr.maybe_int.value<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %26 = trunc i64 8 to i32  
   %27 = tail call ccc  i8*  @wybe_malloc(i32  %26)  
   %28 = ptrtoint i8* %27 to i64 
   %29 = inttoptr i64 %28 to i8* 
-  %30 = inttoptr i64 %"$rec##0" to i8* 
+  %30 = inttoptr i64 %"#rec##0" to i8* 
   %31 = trunc i64 8 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %29, i8*  %30, i32  %31, i32  8, i1  0)  
   %32 = inttoptr i64 %28 to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
-  store  i64 %"$field##0", i64* %33 
+  store  i64 %"#field##0", i64* %33 
   %34 = insertvalue {i64, i1} undef, i64 %28, 0 
   %35 = insertvalue {i64, i1} %34, i1 1, 1 
   ret {i64, i1} %35 
 if.else:
-  %36 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %36 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %37 = insertvalue {i64, i1} %36, i1 0, 1 
   ret {i64, i1} %37 
 }
 
 
-define external fastcc  i1 @"multictr.maybe_int.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"multictr.maybe_int.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = tail call fastcc  i1  @"multictr.maybe_int.=<0>"(i64  %"$left##0", i64  %"$right##0")  
-  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
-  ret i1 %"1$$$##0" 
+  %"1#tmp#0##0" = tail call fastcc  i1  @"multictr.maybe_int.=<0>"(i64  %"#left##0", i64  %"#right##0")  
+  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1#####0" 
 }
 --------------------------------------------------
  Module multictr.number
@@ -5772,173 +5772,173 @@ entry:
 
 = > public (1 calls)
 0: multictr.number.=<0>
-=($left##0:multictr.number, $right##0:multictr.number, ?$$##0:wybe.bool):
+=(#left##0:multictr.number, #right##0:multictr.number, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($left##0:wybe.int, 1:wybe.int, ?tmp$8##0:wybe.int)
-    foreign llvm icmp_eq(tmp$8##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
-    case ~tmp$9##0:wybe.bool of
+    foreign llvm and(#left##0:wybe.int, 1:wybe.int, ?tmp#8##0:wybe.int)
+    foreign llvm icmp_eq(tmp#8##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
+    case ~tmp#9##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~tmp$8##0:wybe.int, 1:wybe.int, ?tmp$12##0:wybe.bool)
-        case ~tmp$12##0:wybe.bool of
+        foreign llvm icmp_eq(~tmp#8##0:wybe.int, 1:wybe.int, ?tmp#12##0:wybe.bool)
+        case ~tmp#12##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign lpvm access(~$left##0:multictr.number, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$left$float_value##0:wybe.float)
-            foreign llvm and($right##0:wybe.int, 1:wybe.int, ?tmp$14##0:wybe.int)
-            foreign llvm icmp_eq(~tmp$14##0:wybe.int, 1:wybe.int, ?tmp$15##0:wybe.bool)
-            case ~tmp$15##0:wybe.bool of
+            foreign lpvm access(~#left##0:multictr.number, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#left#float_value##0:wybe.float)
+            foreign llvm and(#right##0:wybe.int, 1:wybe.int, ?tmp#14##0:wybe.int)
+            foreign llvm icmp_eq(~tmp#14##0:wybe.int, 1:wybe.int, ?tmp#15##0:wybe.bool)
+            case ~tmp#15##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
             1:
-                foreign lpvm access(~$right##0:multictr.number, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$right$float_value##0:wybe.float)
-                foreign llvm fcmp_eq(~$left$float_value##0:wybe.float, ~$right$float_value##0:wybe.float, ?$$##0:wybe.bool) @float:nn:nn
+                foreign lpvm access(~#right##0:multictr.number, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#right#float_value##0:wybe.float)
+                foreign llvm fcmp_eq(~#left#float_value##0:wybe.float, ~#right#float_value##0:wybe.float, ?####0:wybe.bool) @float:nn:nn
 
 
 
     1:
-        foreign lpvm access(~$left##0:multictr.number, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$left$int_value##0:wybe.int)
-        foreign llvm and($right##0:wybe.int, 1:wybe.int, ?tmp$11##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$11##0:wybe.int, 0:wybe.int, ?tmp$12##0:wybe.bool)
-        case ~tmp$12##0:wybe.bool of
+        foreign lpvm access(~#left##0:multictr.number, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#left#int_value##0:wybe.int)
+        foreign llvm and(#right##0:wybe.int, 1:wybe.int, ?tmp#11##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#11##0:wybe.int, 0:wybe.int, ?tmp#12##0:wybe.bool)
+        case ~tmp#12##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign lpvm access(~$right##0:multictr.number, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$right$int_value##0:wybe.int)
-            foreign llvm icmp_eq(~$left$int_value##0:wybe.int, ~$right$int_value##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+            foreign lpvm access(~#right##0:multictr.number, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#right#int_value##0:wybe.int)
+            foreign llvm icmp_eq(~#left#int_value##0:wybe.int, ~#right#int_value##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 
 float > public {inline} (0 calls)
 0: multictr.number.float<0>
-float(float_value##0:wybe.float, ?$##0:multictr.number):
+float(float_value##0:wybe.float, ?###0:multictr.number):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr.number)
-    foreign lpvm mutate(~$rec##0:multictr.number, ?$rec##1:multictr.number, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~float_value##0:wybe.float)
-    foreign llvm or(~$rec##1:multictr.number, 1:wybe.int, ?$##0:multictr.number)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.number)
+    foreign lpvm mutate(~#rec##0:multictr.number, ?#rec##1:multictr.number, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~float_value##0:wybe.float)
+    foreign llvm or(~#rec##1:multictr.number, 1:wybe.int, ?###0:multictr.number)
 float > public {inline} (5 calls)
 1: multictr.number.float<1>
-float(?float_value##0:wybe.float, $##0:multictr.number, ?$$##0:wybe.bool):
+float(?float_value##0:wybe.float, ###0:multictr.number, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(###0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.float, ?float_value##0:wybe.float)
 
     1:
-        foreign lpvm access(~$##0:multictr.number, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?float_value##0:wybe.float)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~###0:multictr.number, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?float_value##0:wybe.float)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 float_value > public {inline} (0 calls)
 0: multictr.number.float_value<0>
-float_value($rec##0:multictr.number, ?$##0:wybe.float, ?$$##0:wybe.bool):
+float_value(#rec##0:multictr.number, ?###0:wybe.float, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(#rec##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.float, ?$##0:wybe.float)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.float, ?###0:wybe.float)
 
     1:
-        foreign lpvm access(~$rec##0:multictr.number, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$##0:wybe.float)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:multictr.number, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?###0:wybe.float)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 float_value > public {inline} (0 calls)
 1: multictr.number.float_value<1>
-float_value($rec##0:multictr.number, ?$rec##1:multictr.number, $field##0:wybe.float, ?$$##0:wybe.bool):
+float_value(#rec##0:multictr.number, ?#rec##1:multictr.number, #field##0:wybe.float, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(#rec##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multictr.number, ?$rec##1:multictr.number)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multictr.number, ?#rec##1:multictr.number)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec##0:multictr.number, ?$rec##1:multictr.number, -1:wybe.int, 0:wybe.int, 8:wybe.int, 1:wybe.int, ~$field##0:wybe.float)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm {noalias} mutate(~#rec##0:multictr.number, ?#rec##1:multictr.number, -1:wybe.int, 0:wybe.int, 8:wybe.int, 1:wybe.int, ~#field##0:wybe.float)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 int > public {inline} (0 calls)
 0: multictr.number.int<0>
-int(int_value##0:wybe.int, ?$##0:multictr.number):
+int(int_value##0:wybe.int, ?###0:multictr.number):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr.number)
-    foreign lpvm mutate(~$rec##0:multictr.number, ?$##0:multictr.number, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~int_value##0:wybe.int)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.number)
+    foreign lpvm mutate(~#rec##0:multictr.number, ?###0:multictr.number, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~int_value##0:wybe.int)
 int > public {inline} (10 calls)
 1: multictr.number.int<1>
-int(?int_value##0:wybe.int, $##0:multictr.number, ?$$##0:wybe.bool):
+int(?int_value##0:wybe.int, ###0:multictr.number, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(###0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?int_value##0:wybe.int)
 
     1:
-        foreign lpvm access(~$##0:multictr.number, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?int_value##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~###0:multictr.number, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?int_value##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 int_value > public {inline} (0 calls)
 0: multictr.number.int_value<0>
-int_value($rec##0:multictr.number, ?$##0:wybe.int, ?$$##0:wybe.bool):
+int_value(#rec##0:multictr.number, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(#rec##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec##0:multictr.number, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:multictr.number, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 int_value > public {inline} (0 calls)
 1: multictr.number.int_value<1>
-int_value($rec##0:multictr.number, ?$rec##1:multictr.number, $field##0:wybe.int, ?$$##0:wybe.bool):
+int_value(#rec##0:multictr.number, ?#rec##1:multictr.number, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(#rec##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multictr.number, ?$rec##1:multictr.number)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multictr.number, ?#rec##1:multictr.number)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec##0:multictr.number, ?$rec##1:multictr.number, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm {noalias} mutate(~#rec##0:multictr.number, ?#rec##1:multictr.number, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: multictr.number.~=<0>
-~=($left##0:multictr.number, $right##0:multictr.number, ?$$##0:wybe.bool):
+~=(#left##0:multictr.number, #right##0:multictr.number, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    multictr.number.=<0>(~$left##0:multictr.number, ~$right##0:multictr.number, ?tmp$0##0:wybe.bool) #0
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    multictr.number.=<0>(~#left##0:multictr.number, ~#right##0:multictr.number, ?tmp#0##0:wybe.bool) #0
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
   LLVM code       :
 
@@ -5954,46 +5954,46 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"multictr.number.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"multictr.number.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$8##0" = and i64 %"$left##0", 1 
-  %"1$tmp$9##0" = icmp eq i64 %"1$tmp$8##0", 0 
-  br i1 %"1$tmp$9##0", label %if.then, label %if.else 
+  %"1#tmp#8##0" = and i64 %"#left##0", 1 
+  %"1#tmp#9##0" = icmp eq i64 %"1#tmp#8##0", 0 
+  br i1 %"1#tmp#9##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %"2$tmp$11##0" = and i64 %"$right##0", 1 
-  %"2$tmp$12##0" = icmp eq i64 %"2$tmp$11##0", 0 
-  br i1 %"2$tmp$12##0", label %if.then1, label %if.else1 
+  %"2#tmp#11##0" = and i64 %"#right##0", 1 
+  %"2#tmp#12##0" = icmp eq i64 %"2#tmp#11##0", 0 
+  br i1 %"2#tmp#12##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$tmp$12##0" = icmp eq i64 %"1$tmp$8##0", 1 
-  br i1 %"3$tmp$12##0", label %if.then2, label %if.else2 
+  %"3#tmp#12##0" = icmp eq i64 %"1#tmp#8##0", 1 
+  br i1 %"3#tmp#12##0", label %if.then2, label %if.else2 
 if.then1:
-  %4 = inttoptr i64 %"$right##0" to i64* 
+  %4 = inttoptr i64 %"#right##0" to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
   %6 = load  i64, i64* %5 
-  %"4$$$##0" = icmp eq i64 %3, %6 
-  ret i1 %"4$$$##0" 
+  %"4#####0" = icmp eq i64 %3, %6 
+  ret i1 %"4#####0" 
 if.else1:
   ret i1 0 
 if.then2:
-  %7 = add   i64 %"$left##0", -1 
+  %7 = add   i64 %"#left##0", -1 
   %8 = inttoptr i64 %7 to double* 
   %9 = getelementptr  double, double* %8, i64 0 
   %10 = load  double, double* %9 
-  %"6$tmp$14##0" = and i64 %"$right##0", 1 
-  %"6$tmp$15##0" = icmp eq i64 %"6$tmp$14##0", 1 
-  br i1 %"6$tmp$15##0", label %if.then3, label %if.else3 
+  %"6#tmp#14##0" = and i64 %"#right##0", 1 
+  %"6#tmp#15##0" = icmp eq i64 %"6#tmp#14##0", 1 
+  br i1 %"6#tmp#15##0", label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %11 = add   i64 %"$right##0", -1 
+  %11 = add   i64 %"#right##0", -1 
   %12 = inttoptr i64 %11 to double* 
   %13 = getelementptr  double, double* %12, i64 0 
   %14 = load  double, double* %13 
-  %"8$$$##0" = fcmp oeq double %10, %14 
-  ret i1 %"8$$$##0" 
+  %"8#####0" = fcmp oeq double %10, %14 
+  ret i1 %"8#####0" 
 if.else3:
   ret i1 0 
 }
@@ -6007,18 +6007,18 @@ entry:
   %18 = inttoptr i64 %17 to double* 
   %19 = getelementptr  double, double* %18, i64 0 
   store  double %"float_value##0", double* %19 
-  %"1$$##0" = or i64 %17, 1 
-  ret i64 %"1$$##0" 
+  %"1####0" = or i64 %17, 1 
+  ret i64 %"1####0" 
 }
 
 
-define external fastcc  {double, i1} @"multictr.number.float<1>"(i64  %"$##0")    {
+define external fastcc  {double, i1} @"multictr.number.float<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$##0", 1 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 1 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"###0", 1 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 1 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %20 = add   i64 %"$##0", -1 
+  %20 = add   i64 %"###0", -1 
   %21 = inttoptr i64 %20 to double* 
   %22 = getelementptr  double, double* %21, i64 0 
   %23 = load  double, double* %22 
@@ -6032,13 +6032,13 @@ if.else:
 }
 
 
-define external fastcc  {double, i1} @"multictr.number.float_value<0>"(i64  %"$rec##0")    {
+define external fastcc  {double, i1} @"multictr.number.float_value<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$rec##0", 1 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 1 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"#rec##0", 1 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 1 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %28 = add   i64 %"$rec##0", -1 
+  %28 = add   i64 %"#rec##0", -1 
   %29 = inttoptr i64 %28 to double* 
   %30 = getelementptr  double, double* %29, i64 0 
   %31 = load  double, double* %30 
@@ -6052,17 +6052,17 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.number.float_value<1>"(i64  %"$rec##0", double  %"$field##0")    {
+define external fastcc  {i64, i1} @"multictr.number.float_value<1>"(i64  %"#rec##0", double  %"#field##0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$rec##0", 1 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 1 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"#rec##0", 1 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 1 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %36 = trunc i64 8 to i32  
   %37 = tail call ccc  i8*  @wybe_malloc(i32  %36)  
   %38 = ptrtoint i8* %37 to i64 
   %39 = add   i64 %38, 1 
-  %40 = sub   i64 %"$rec##0", 1 
+  %40 = sub   i64 %"#rec##0", 1 
   %41 = inttoptr i64 %38 to i8* 
   %42 = inttoptr i64 %40 to i8* 
   %43 = trunc i64 8 to i32  
@@ -6070,12 +6070,12 @@ if.then:
   %44 = add   i64 %39, -1 
   %45 = inttoptr i64 %44 to double* 
   %46 = getelementptr  double, double* %45, i64 0 
-  store  double %"$field##0", double* %46 
+  store  double %"#field##0", double* %46 
   %47 = insertvalue {i64, i1} undef, i64 %39, 0 
   %48 = insertvalue {i64, i1} %47, i1 1, 1 
   ret {i64, i1} %48 
 if.else:
-  %49 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %49 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %50 = insertvalue {i64, i1} %49, i1 0, 1 
   ret {i64, i1} %50 
 }
@@ -6093,13 +6093,13 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.number.int<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"multictr.number.int<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$##0", 1 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"###0", 1 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %56 = inttoptr i64 %"$##0" to i64* 
+  %56 = inttoptr i64 %"###0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
   %59 = insertvalue {i64, i1} undef, i64 %58, 0 
@@ -6112,13 +6112,13 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.number.int_value<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"multictr.number.int_value<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$rec##0", 1 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"#rec##0", 1 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %63 = inttoptr i64 %"$rec##0" to i64* 
+  %63 = inttoptr i64 %"#rec##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
   %66 = insertvalue {i64, i1} undef, i64 %65, 0 
@@ -6131,37 +6131,37 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.number.int_value<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"multictr.number.int_value<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$rec##0", 1 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"#rec##0", 1 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %70 = trunc i64 8 to i32  
   %71 = tail call ccc  i8*  @wybe_malloc(i32  %70)  
   %72 = ptrtoint i8* %71 to i64 
   %73 = inttoptr i64 %72 to i8* 
-  %74 = inttoptr i64 %"$rec##0" to i8* 
+  %74 = inttoptr i64 %"#rec##0" to i8* 
   %75 = trunc i64 8 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %73, i8*  %74, i32  %75, i32  8, i1  0)  
   %76 = inttoptr i64 %72 to i64* 
   %77 = getelementptr  i64, i64* %76, i64 0 
-  store  i64 %"$field##0", i64* %77 
+  store  i64 %"#field##0", i64* %77 
   %78 = insertvalue {i64, i1} undef, i64 %72, 0 
   %79 = insertvalue {i64, i1} %78, i1 1, 1 
   ret {i64, i1} %79 
 if.else:
-  %80 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %80 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %81 = insertvalue {i64, i1} %80, i1 0, 1 
   ret {i64, i1} %81 
 }
 
 
-define external fastcc  i1 @"multictr.number.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"multictr.number.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = tail call fastcc  i1  @"multictr.number.=<0>"(i64  %"$left##0", i64  %"$right##0")  
-  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
-  ret i1 %"1$$$##0" 
+  %"1#tmp#0##0" = tail call fastcc  i1  @"multictr.number.=<0>"(i64  %"#left##0", i64  %"#right##0")  
+  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1#####0" 
 }
 --------------------------------------------------
  Module multictr.perhaps
@@ -6181,47 +6181,47 @@ entry:
 
 = > public {inline} (1 calls)
 0: multictr.perhaps.=<0>
-=($left##0:multictr.perhaps, $right##0:multictr.perhaps, ?$$##0:wybe.bool):
+=(#left##0:multictr.perhaps, #right##0:multictr.perhaps, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(~$left##0:multictr.perhaps, ~$right##0:multictr.perhaps, ?$$##0:wybe.bool)
+    foreign llvm icmp_eq(~#left##0:multictr.perhaps, ~#right##0:multictr.perhaps, ?####0:wybe.bool)
 
 
 content > public {inline} (0 calls)
 0: multictr.perhaps.content<0>
-content($rec##0:multictr.perhaps, ?$##0:multictr.maybe_int):
+content(#rec##0:multictr.perhaps, ?###0:multictr.maybe_int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm cast(~$rec##0:multictr.perhaps, ?$##0:multictr.maybe_int)
+    foreign lpvm cast(~#rec##0:multictr.perhaps, ?###0:multictr.maybe_int)
 content > public {inline} (0 calls)
 1: multictr.perhaps.content<1>
-content([$rec##0:multictr.perhaps], ?$rec##2:multictr.perhaps, $field##0:multictr.maybe_int):
+content([#rec##0:multictr.perhaps], ?#rec##2:multictr.perhaps, #field##0:multictr.maybe_int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(~$field##0:multictr.perhaps, ?$rec##2:multictr.perhaps)
+    foreign llvm move(~#field##0:multictr.perhaps, ?#rec##2:multictr.perhaps)
 
 
 perhaps > public {inline} (0 calls)
 0: multictr.perhaps.perhaps<0>
-perhaps(content##0:multictr.maybe_int, ?$##2:multictr.perhaps):
+perhaps(content##0:multictr.maybe_int, ?###2:multictr.perhaps):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(~content##0:multictr.perhaps, ?$##2:multictr.perhaps)
+    foreign llvm move(~content##0:multictr.perhaps, ?###2:multictr.perhaps)
 perhaps > public {inline} (0 calls)
 1: multictr.perhaps.perhaps<1>
-perhaps(?content##0:multictr.maybe_int, $##0:multictr.perhaps):
+perhaps(?content##0:multictr.maybe_int, ###0:multictr.perhaps):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm cast(~$##0:multictr.perhaps, ?content##0:multictr.maybe_int)
+    foreign lpvm cast(~###0:multictr.perhaps, ?content##0:multictr.maybe_int)
 
 
 ~= > public {inline} (0 calls)
 0: multictr.perhaps.~=<0>
-~=($left##0:multictr.perhaps, $right##0:multictr.perhaps, ?$$##0:wybe.bool):
+~=(#left##0:multictr.perhaps, #right##0:multictr.perhaps, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(~$left##0:multictr.perhaps, ~$right##0:multictr.perhaps, ?tmp$0##0:wybe.bool)
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    foreign llvm icmp_eq(~#left##0:multictr.perhaps, ~#right##0:multictr.perhaps, ?tmp#0##0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
   LLVM code       :
 
@@ -6237,22 +6237,22 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"multictr.perhaps.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"multictr.perhaps.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
-  ret i1 %"1$$$##0" 
+  %"1#####0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"1#####0" 
 }
 
 
-define external fastcc  i64 @"multictr.perhaps.content<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"multictr.perhaps.content<0>"(i64  %"#rec##0")    {
 entry:
-  ret i64 %"$rec##0" 
+  ret i64 %"#rec##0" 
 }
 
 
-define external fastcc  i64 @"multictr.perhaps.content<1>"(i64  %"$field##0")    {
+define external fastcc  i64 @"multictr.perhaps.content<1>"(i64  %"#field##0")    {
 entry:
-  ret i64 %"$field##0" 
+  ret i64 %"#field##0" 
 }
 
 
@@ -6262,17 +6262,17 @@ entry:
 }
 
 
-define external fastcc  i64 @"multictr.perhaps.perhaps<1>"(i64  %"$##0")    {
+define external fastcc  i64 @"multictr.perhaps.perhaps<1>"(i64  %"###0")    {
 entry:
-  ret i64 %"$##0" 
+  ret i64 %"###0" 
 }
 
 
-define external fastcc  i1 @"multictr.perhaps.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"multictr.perhaps.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = icmp eq i64 %"$left##0", %"$right##0" 
-  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
-  ret i1 %"1$$$##0" 
+  %"1#tmp#0##0" = icmp eq i64 %"#left##0", %"#right##0" 
+  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1#####0" 
 }
 --------------------------------------------------
  Module multictr.rank
@@ -6301,123 +6301,123 @@ entry:
 
 = > public {inline} (1 calls)
 0: multictr.rank.=<0>
-=($left##0:multictr.rank, $right##0:multictr.rank, ?$$##0:wybe.bool):
+=(#left##0:multictr.rank, #right##0:multictr.rank, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(~$left##0:multictr.rank, ~$right##0:multictr.rank, ?$$##0:wybe.bool)
+    foreign llvm icmp_eq(~#left##0:multictr.rank, ~#right##0:multictr.rank, ?####0:wybe.bool)
 
 
 ace > public {inline} (0 calls)
 0: multictr.rank.ace<0>
-ace(?$##0:multictr.rank):
+ace(?###0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(12:multictr.rank, ?$##0:multictr.rank)
+    foreign llvm move(12:multictr.rank, ?###0:multictr.rank)
 
 
 jack > public {inline} (0 calls)
 0: multictr.rank.jack<0>
-jack(?$##0:multictr.rank):
+jack(?###0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(9:multictr.rank, ?$##0:multictr.rank)
+    foreign llvm move(9:multictr.rank, ?###0:multictr.rank)
 
 
 king > public {inline} (0 calls)
 0: multictr.rank.king<0>
-king(?$##0:multictr.rank):
+king(?###0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(11:multictr.rank, ?$##0:multictr.rank)
+    foreign llvm move(11:multictr.rank, ?###0:multictr.rank)
 
 
 queen > public {inline} (0 calls)
 0: multictr.rank.queen<0>
-queen(?$##0:multictr.rank):
+queen(?###0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(10:multictr.rank, ?$##0:multictr.rank)
+    foreign llvm move(10:multictr.rank, ?###0:multictr.rank)
 
 
 r10 > public {inline} (0 calls)
 0: multictr.rank.r10<0>
-r10(?$##0:multictr.rank):
+r10(?###0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(8:multictr.rank, ?$##0:multictr.rank)
+    foreign llvm move(8:multictr.rank, ?###0:multictr.rank)
 
 
 r2 > public {inline} (0 calls)
 0: multictr.rank.r2<0>
-r2(?$##0:multictr.rank):
+r2(?###0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:multictr.rank, ?$##0:multictr.rank)
+    foreign llvm move(0:multictr.rank, ?###0:multictr.rank)
 
 
 r3 > public {inline} (0 calls)
 0: multictr.rank.r3<0>
-r3(?$##0:multictr.rank):
+r3(?###0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(1:multictr.rank, ?$##0:multictr.rank)
+    foreign llvm move(1:multictr.rank, ?###0:multictr.rank)
 
 
 r4 > public {inline} (0 calls)
 0: multictr.rank.r4<0>
-r4(?$##0:multictr.rank):
+r4(?###0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(2:multictr.rank, ?$##0:multictr.rank)
+    foreign llvm move(2:multictr.rank, ?###0:multictr.rank)
 
 
 r5 > public {inline} (0 calls)
 0: multictr.rank.r5<0>
-r5(?$##0:multictr.rank):
+r5(?###0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(3:multictr.rank, ?$##0:multictr.rank)
+    foreign llvm move(3:multictr.rank, ?###0:multictr.rank)
 
 
 r6 > public {inline} (0 calls)
 0: multictr.rank.r6<0>
-r6(?$##0:multictr.rank):
+r6(?###0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(4:multictr.rank, ?$##0:multictr.rank)
+    foreign llvm move(4:multictr.rank, ?###0:multictr.rank)
 
 
 r7 > public {inline} (0 calls)
 0: multictr.rank.r7<0>
-r7(?$##0:multictr.rank):
+r7(?###0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(5:multictr.rank, ?$##0:multictr.rank)
+    foreign llvm move(5:multictr.rank, ?###0:multictr.rank)
 
 
 r8 > public {inline} (0 calls)
 0: multictr.rank.r8<0>
-r8(?$##0:multictr.rank):
+r8(?###0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(6:multictr.rank, ?$##0:multictr.rank)
+    foreign llvm move(6:multictr.rank, ?###0:multictr.rank)
 
 
 r9 > public {inline} (0 calls)
 0: multictr.rank.r9<0>
-r9(?$##0:multictr.rank):
+r9(?###0:multictr.rank):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(7:multictr.rank, ?$##0:multictr.rank)
+    foreign llvm move(7:multictr.rank, ?###0:multictr.rank)
 
 
 ~= > public {inline} (0 calls)
 0: multictr.rank.~=<0>
-~=($left##0:multictr.rank, $right##0:multictr.rank, ?$$##0:wybe.bool):
+~=(#left##0:multictr.rank, #right##0:multictr.rank, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(~$left##0:multictr.rank, ~$right##0:multictr.rank, ?tmp$0##0:wybe.bool)
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    foreign llvm icmp_eq(~#left##0:multictr.rank, ~#right##0:multictr.rank, ?tmp#0##0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
   LLVM code       :
 
@@ -6433,10 +6433,10 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"multictr.rank.=<0>"(i4  %"$left##0", i4  %"$right##0")    {
+define external fastcc  i1 @"multictr.rank.=<0>"(i4  %"#left##0", i4  %"#right##0")    {
 entry:
-  %"1$$$##0" = icmp eq i4 %"$left##0", %"$right##0" 
-  ret i1 %"1$$$##0" 
+  %"1#####0" = icmp eq i4 %"#left##0", %"#right##0" 
+  ret i1 %"1#####0" 
 }
 
 
@@ -6518,11 +6518,11 @@ entry:
 }
 
 
-define external fastcc  i1 @"multictr.rank.~=<0>"(i4  %"$left##0", i4  %"$right##0")    {
+define external fastcc  i1 @"multictr.rank.~=<0>"(i4  %"#left##0", i4  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = icmp eq i4 %"$left##0", %"$right##0" 
-  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
-  ret i1 %"1$$$##0" 
+  %"1#tmp#0##0" = icmp eq i4 %"#left##0", %"#right##0" 
+  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1#####0" 
 }
 --------------------------------------------------
  Module multictr.simple
@@ -6549,71 +6549,71 @@ entry:
 
 = > public (1 calls)
 0: multictr.simple.=<0>
-=($left##0:multictr.simple, $right##0:multictr.simple, ?$$##0:wybe.bool):
+=(#left##0:multictr.simple, #right##0:multictr.simple, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left##0:multictr.simple, ~$right##0:multictr.simple, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:multictr.simple, ~#right##0:multictr.simple, ?####0:wybe.bool)
 
     1:
-        foreign llvm and($left##0:wybe.int, 1:wybe.int, ?tmp$11##0:wybe.int)
-        foreign llvm icmp_eq(tmp$11##0:wybe.int, 0:wybe.int, ?tmp$12##0:wybe.bool)
-        case ~tmp$12##0:wybe.bool of
+        foreign llvm and(#left##0:wybe.int, 1:wybe.int, ?tmp#11##0:wybe.int)
+        foreign llvm icmp_eq(tmp#11##0:wybe.int, 0:wybe.int, ?tmp#12##0:wybe.bool)
+        case ~tmp#12##0:wybe.bool of
         0:
-            foreign llvm icmp_eq(~tmp$11##0:wybe.int, 1:wybe.int, ?tmp$16##0:wybe.bool)
-            case ~tmp$16##0:wybe.bool of
+            foreign llvm icmp_eq(~tmp#11##0:wybe.int, 1:wybe.int, ?tmp#16##0:wybe.bool)
+            case ~tmp#16##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
             1:
-                foreign lpvm access($left##0:multictr.simple, -1:wybe.int, 16:wybe.int, 1:wybe.int, ?$left$two_field1##0:wybe.int)
-                foreign lpvm access(~$left##0:multictr.simple, 7:wybe.int, 16:wybe.int, 1:wybe.int, ?$left$two_field2##0:wybe.int)
-                foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$18##0:wybe.bool)
-                case ~tmp$18##0:wybe.bool of
+                foreign lpvm access(#left##0:multictr.simple, -1:wybe.int, 16:wybe.int, 1:wybe.int, ?#left#two_field1##0:wybe.int)
+                foreign lpvm access(~#left##0:multictr.simple, 7:wybe.int, 16:wybe.int, 1:wybe.int, ?#left#two_field2##0:wybe.int)
+                foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#18##0:wybe.bool)
+                case ~tmp#18##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                 1:
-                    foreign llvm and($right##0:wybe.int, 1:wybe.int, ?tmp$19##0:wybe.int)
-                    foreign llvm icmp_eq(~tmp$19##0:wybe.int, 1:wybe.int, ?tmp$20##0:wybe.bool)
-                    case ~tmp$20##0:wybe.bool of
+                    foreign llvm and(#right##0:wybe.int, 1:wybe.int, ?tmp#19##0:wybe.int)
+                    foreign llvm icmp_eq(~tmp#19##0:wybe.int, 1:wybe.int, ?tmp#20##0:wybe.bool)
+                    case ~tmp#20##0:wybe.bool of
                     0:
-                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                     1:
-                        foreign lpvm access($right##0:multictr.simple, -1:wybe.int, 16:wybe.int, 1:wybe.int, ?$right$two_field1##0:wybe.int)
-                        foreign lpvm access(~$right##0:multictr.simple, 7:wybe.int, 16:wybe.int, 1:wybe.int, ?$right$two_field2##0:wybe.int)
-                        foreign llvm icmp_eq(~$left$two_field1##0:wybe.int, ~$right$two_field1##0:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
-                        case ~tmp$5##0:wybe.bool of
+                        foreign lpvm access(#right##0:multictr.simple, -1:wybe.int, 16:wybe.int, 1:wybe.int, ?#right#two_field1##0:wybe.int)
+                        foreign lpvm access(~#right##0:multictr.simple, 7:wybe.int, 16:wybe.int, 1:wybe.int, ?#right#two_field2##0:wybe.int)
+                        foreign llvm icmp_eq(~#left#two_field1##0:wybe.int, ~#right#two_field1##0:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
+                        case ~tmp#5##0:wybe.bool of
                         0:
-                            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                         1:
-                            foreign llvm icmp_eq(~$left$two_field2##0:wybe.int, ~$right$two_field2##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+                            foreign llvm icmp_eq(~#left#two_field2##0:wybe.int, ~#right#two_field2##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 
 
         1:
-            foreign lpvm access(~$left##0:multictr.simple, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$left$one_field##0:wybe.int)
-            foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$14##0:wybe.bool)
-            case ~tmp$14##0:wybe.bool of
+            foreign lpvm access(~#left##0:multictr.simple, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#left#one_field##0:wybe.int)
+            foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#14##0:wybe.bool)
+            case ~tmp#14##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
             1:
-                foreign llvm and($right##0:wybe.int, 1:wybe.int, ?tmp$15##0:wybe.int)
-                foreign llvm icmp_eq(~tmp$15##0:wybe.int, 0:wybe.int, ?tmp$16##0:wybe.bool)
-                case ~tmp$16##0:wybe.bool of
+                foreign llvm and(#right##0:wybe.int, 1:wybe.int, ?tmp#15##0:wybe.int)
+                foreign llvm icmp_eq(~tmp#15##0:wybe.int, 0:wybe.int, ?tmp#16##0:wybe.bool)
+                case ~tmp#16##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                 1:
-                    foreign lpvm access(~$right##0:multictr.simple, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$right$one_field##0:wybe.int)
-                    foreign llvm icmp_eq(~$left$one_field##0:wybe.int, ~$right$one_field##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+                    foreign lpvm access(~#right##0:multictr.simple, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#right#one_field##0:wybe.int)
+                    foreign llvm icmp_eq(~#left#one_field##0:wybe.int, ~#right#one_field##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
@@ -6622,240 +6622,240 @@ entry:
 
 one > public {inline} (0 calls)
 0: multictr.simple.one<0>
-one(one_field##0:wybe.int, ?$##0:multictr.simple):
+one(one_field##0:wybe.int, ?###0:multictr.simple):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr.simple)
-    foreign lpvm mutate(~$rec##0:multictr.simple, ?$##0:multictr.simple, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~one_field##0:wybe.int)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr.simple)
+    foreign lpvm mutate(~#rec##0:multictr.simple, ?###0:multictr.simple, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~one_field##0:wybe.int)
 one > public {inline} (11 calls)
 1: multictr.simple.one<1>
-one(?one_field##0:wybe.int, $##0:multictr.simple, ?$$##0:wybe.bool):
+one(?one_field##0:wybe.int, ###0:multictr.simple, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?one_field##0:wybe.int)
 
     1:
-        foreign llvm and($##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(###0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?one_field##0:wybe.int)
 
         1:
-            foreign lpvm access(~$##0:multictr.simple, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?one_field##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm access(~###0:multictr.simple, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?one_field##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 one_field > public {inline} (0 calls)
 0: multictr.simple.one_field<0>
-one_field($rec##0:multictr.simple, ?$##0:wybe.int, ?$$##0:wybe.bool):
+one_field(#rec##0:multictr.simple, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
         1:
-            foreign lpvm access(~$rec##0:multictr.simple, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm access(~#rec##0:multictr.simple, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?###0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 one_field > public {inline} (0 calls)
 1: multictr.simple.one_field<1>
-one_field($rec##0:multictr.simple, ?$rec##1:multictr.simple, $field##0:wybe.int, ?$$##0:wybe.bool):
+one_field(#rec##0:multictr.simple, ?#rec##1:multictr.simple, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multictr.simple, ?$rec##1:multictr.simple)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multictr.simple, ?#rec##1:multictr.simple)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(~$rec##0:multictr.simple, ?$rec##1:multictr.simple)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(~#rec##0:multictr.simple, ?#rec##1:multictr.simple)
 
         1:
-            foreign lpvm {noalias} mutate(~$rec##0:multictr.simple, ?$rec##1:multictr.simple, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm {noalias} mutate(~#rec##0:multictr.simple, ?#rec##1:multictr.simple, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 two > public {inline} (0 calls)
 0: multictr.simple.two<0>
-two(two_field1##0:wybe.int, two_field2##0:wybe.int, ?$##0:multictr.simple):
+two(two_field1##0:wybe.int, two_field2##0:wybe.int, ?###0:multictr.simple):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:multictr.simple)
-    foreign lpvm mutate(~$rec##0:multictr.simple, ?$rec##1:multictr.simple, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~two_field1##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:multictr.simple, ?$rec##2:multictr.simple, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~two_field2##0:wybe.int)
-    foreign llvm or(~$rec##2:multictr.simple, 1:wybe.int, ?$##0:multictr.simple)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:multictr.simple)
+    foreign lpvm mutate(~#rec##0:multictr.simple, ?#rec##1:multictr.simple, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~two_field1##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:multictr.simple, ?#rec##2:multictr.simple, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~two_field2##0:wybe.int)
+    foreign llvm or(~#rec##2:multictr.simple, 1:wybe.int, ?###0:multictr.simple)
 two > public {inline} (7 calls)
 1: multictr.simple.two<1>
-two(?two_field1##0:wybe.int, ?two_field2##0:wybe.int, $##0:multictr.simple, ?$$##0:wybe.bool):
+two(?two_field1##0:wybe.int, ?two_field2##0:wybe.int, ###0:multictr.simple, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?two_field1##0:wybe.int)
         foreign llvm move(undef:wybe.int, ?two_field2##0:wybe.int)
 
     1:
-        foreign llvm and($##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(###0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?two_field1##0:wybe.int)
             foreign llvm move(undef:wybe.int, ?two_field2##0:wybe.int)
 
         1:
-            foreign lpvm access($##0:multictr.simple, -1:wybe.int, 16:wybe.int, 1:wybe.int, ?two_field1##0:wybe.int)
-            foreign lpvm access(~$##0:multictr.simple, 7:wybe.int, 16:wybe.int, 1:wybe.int, ?two_field2##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm access(###0:multictr.simple, -1:wybe.int, 16:wybe.int, 1:wybe.int, ?two_field1##0:wybe.int)
+            foreign lpvm access(~###0:multictr.simple, 7:wybe.int, 16:wybe.int, 1:wybe.int, ?two_field2##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 two_field1 > public {inline} (0 calls)
 0: multictr.simple.two_field1<0>
-two_field1($rec##0:multictr.simple, ?$##0:wybe.int, ?$$##0:wybe.bool):
+two_field1(#rec##0:multictr.simple, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
         1:
-            foreign lpvm access(~$rec##0:multictr.simple, -1:wybe.int, 16:wybe.int, 1:wybe.int, ?$##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm access(~#rec##0:multictr.simple, -1:wybe.int, 16:wybe.int, 1:wybe.int, ?###0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 two_field1 > public {inline} (0 calls)
 1: multictr.simple.two_field1<1>
-two_field1($rec##0:multictr.simple, ?$rec##1:multictr.simple, $field##0:wybe.int, ?$$##0:wybe.bool):
+two_field1(#rec##0:multictr.simple, ?#rec##1:multictr.simple, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multictr.simple, ?$rec##1:multictr.simple)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multictr.simple, ?#rec##1:multictr.simple)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(~$rec##0:multictr.simple, ?$rec##1:multictr.simple)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(~#rec##0:multictr.simple, ?#rec##1:multictr.simple)
 
         1:
-            foreign lpvm {noalias} mutate(~$rec##0:multictr.simple, ?$rec##1:multictr.simple, -1:wybe.int, 0:wybe.int, 16:wybe.int, 1:wybe.int, ~$field##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm {noalias} mutate(~#rec##0:multictr.simple, ?#rec##1:multictr.simple, -1:wybe.int, 0:wybe.int, 16:wybe.int, 1:wybe.int, ~#field##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 two_field2 > public {inline} (0 calls)
 0: multictr.simple.two_field2<0>
-two_field2($rec##0:multictr.simple, ?$##0:wybe.int, ?$$##0:wybe.bool):
+two_field2(#rec##0:multictr.simple, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
         1:
-            foreign lpvm access(~$rec##0:multictr.simple, 7:wybe.int, 16:wybe.int, 1:wybe.int, ?$##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm access(~#rec##0:multictr.simple, 7:wybe.int, 16:wybe.int, 1:wybe.int, ?###0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 two_field2 > public {inline} (0 calls)
 1: multictr.simple.two_field2<1>
-two_field2($rec##0:multictr.simple, ?$rec##1:multictr.simple, $field##0:wybe.int, ?$$##0:wybe.bool):
+two_field2(#rec##0:multictr.simple, ?#rec##1:multictr.simple, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multictr.simple, ?$rec##1:multictr.simple)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multictr.simple, ?#rec##1:multictr.simple)
 
     1:
-        foreign llvm and($rec##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$2##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.bool)
-        case ~tmp$1##0:wybe.bool of
+        foreign llvm and(#rec##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#2##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.bool)
+        case ~tmp#1##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-            foreign llvm move(~$rec##0:multictr.simple, ?$rec##1:multictr.simple)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(~#rec##0:multictr.simple, ?#rec##1:multictr.simple)
 
         1:
-            foreign lpvm {noalias} mutate(~$rec##0:multictr.simple, ?$rec##1:multictr.simple, 7:wybe.int, 0:wybe.int, 16:wybe.int, 1:wybe.int, ~$field##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign lpvm {noalias} mutate(~#rec##0:multictr.simple, ?#rec##1:multictr.simple, 7:wybe.int, 0:wybe.int, 16:wybe.int, 1:wybe.int, ~#field##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 zero > public {inline} (0 calls)
 0: multictr.simple.zero<0>
-zero(?$##0:multictr.simple):
+zero(?###0:multictr.simple):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:multictr.simple, ?$##0:multictr.simple)
+    foreign llvm move(0:multictr.simple, ?###0:multictr.simple)
 
 
 ~= > public {inline} (0 calls)
 0: multictr.simple.~=<0>
-~=($left##0:multictr.simple, $right##0:multictr.simple, ?$$##0:wybe.bool):
+~=(#left##0:multictr.simple, #right##0:multictr.simple, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    multictr.simple.=<0>(~$left##0:multictr.simple, ~$right##0:multictr.simple, ?tmp$0##0:wybe.bool) #0
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    multictr.simple.=<0>(~#left##0:multictr.simple, ~#right##0:multictr.simple, ?tmp#0##0:wybe.bool) #0
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
   LLVM code       :
 
@@ -6871,75 +6871,75 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"multictr.simple.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"multictr.simple.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#left##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$11##0" = and i64 %"$left##0", 1 
-  %"2$tmp$12##0" = icmp eq i64 %"2$tmp$11##0", 0 
-  br i1 %"2$tmp$12##0", label %if.then1, label %if.else1 
+  %"2#tmp#11##0" = and i64 %"#left##0", 1 
+  %"2#tmp#12##0" = icmp eq i64 %"2#tmp#11##0", 0 
+  br i1 %"2#tmp#12##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3#####0" 
 if.then1:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %"4$tmp$14##0" = icmp ne i64 %"$right##0", 0 
-  br i1 %"4$tmp$14##0", label %if.then2, label %if.else2 
+  %"4#tmp#14##0" = icmp ne i64 %"#right##0", 0 
+  br i1 %"4#tmp#14##0", label %if.then2, label %if.else2 
 if.else1:
-  %"5$tmp$16##0" = icmp eq i64 %"2$tmp$11##0", 1 
-  br i1 %"5$tmp$16##0", label %if.then4, label %if.else4 
+  %"5#tmp#16##0" = icmp eq i64 %"2#tmp#11##0", 1 
+  br i1 %"5#tmp#16##0", label %if.then4, label %if.else4 
 if.then2:
-  %"6$tmp$15##0" = and i64 %"$right##0", 1 
-  %"6$tmp$16##0" = icmp eq i64 %"6$tmp$15##0", 0 
-  br i1 %"6$tmp$16##0", label %if.then3, label %if.else3 
+  %"6#tmp#15##0" = and i64 %"#right##0", 1 
+  %"6#tmp#16##0" = icmp eq i64 %"6#tmp#15##0", 0 
+  br i1 %"6#tmp#16##0", label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %4 = inttoptr i64 %"$right##0" to i64* 
+  %4 = inttoptr i64 %"#right##0" to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
   %6 = load  i64, i64* %5 
-  %"8$$$##0" = icmp eq i64 %3, %6 
-  ret i1 %"8$$$##0" 
+  %"8#####0" = icmp eq i64 %3, %6 
+  ret i1 %"8#####0" 
 if.else3:
   ret i1 0 
 if.then4:
-  %7 = add   i64 %"$left##0", -1 
+  %7 = add   i64 %"#left##0", -1 
   %8 = inttoptr i64 %7 to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$left##0", 7 
+  %11 = add   i64 %"#left##0", 7 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"10$tmp$18##0" = icmp ne i64 %"$right##0", 0 
-  br i1 %"10$tmp$18##0", label %if.then5, label %if.else5 
+  %"10#tmp#18##0" = icmp ne i64 %"#right##0", 0 
+  br i1 %"10#tmp#18##0", label %if.then5, label %if.else5 
 if.else4:
   ret i1 0 
 if.then5:
-  %"12$tmp$19##0" = and i64 %"$right##0", 1 
-  %"12$tmp$20##0" = icmp eq i64 %"12$tmp$19##0", 1 
-  br i1 %"12$tmp$20##0", label %if.then6, label %if.else6 
+  %"12#tmp#19##0" = and i64 %"#right##0", 1 
+  %"12#tmp#20##0" = icmp eq i64 %"12#tmp#19##0", 1 
+  br i1 %"12#tmp#20##0", label %if.then6, label %if.else6 
 if.else5:
   ret i1 0 
 if.then6:
-  %15 = add   i64 %"$right##0", -1 
+  %15 = add   i64 %"#right##0", -1 
   %16 = inttoptr i64 %15 to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
-  %19 = add   i64 %"$right##0", 7 
+  %19 = add   i64 %"#right##0", 7 
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %"14$tmp$5##0" = icmp eq i64 %10, %18 
-  br i1 %"14$tmp$5##0", label %if.then7, label %if.else7 
+  %"14#tmp#5##0" = icmp eq i64 %10, %18 
+  br i1 %"14#tmp#5##0", label %if.then7, label %if.else7 
 if.else6:
   ret i1 0 
 if.then7:
-  %"16$$$##0" = icmp eq i64 %14, %22 
-  ret i1 %"16$$$##0" 
+  %"16#####0" = icmp eq i64 %14, %22 
+  ret i1 %"16#####0" 
 if.else7:
   ret i1 0 
 }
@@ -6957,20 +6957,20 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.simple.one<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"multictr.simple.one<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$##0", 1 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 0 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"###0", 1 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 0 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %35 = insertvalue {i64, i1} undef, i64 undef, 0 
   %36 = insertvalue {i64, i1} %35, i1 0, 1 
   ret {i64, i1} %36 
 if.then1:
-  %28 = inttoptr i64 %"$##0" to i64* 
+  %28 = inttoptr i64 %"###0" to i64* 
   %29 = getelementptr  i64, i64* %28, i64 0 
   %30 = load  i64, i64* %29 
   %31 = insertvalue {i64, i1} undef, i64 %30, 0 
@@ -6983,20 +6983,20 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.simple.one_field<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"multictr.simple.one_field<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 1 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 0 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 1 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 0 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %44 = insertvalue {i64, i1} undef, i64 undef, 0 
   %45 = insertvalue {i64, i1} %44, i1 0, 1 
   ret {i64, i1} %45 
 if.then1:
-  %37 = inttoptr i64 %"$rec##0" to i64* 
+  %37 = inttoptr i64 %"#rec##0" to i64* 
   %38 = getelementptr  i64, i64* %37, i64 0 
   %39 = load  i64, i64* %38 
   %40 = insertvalue {i64, i1} undef, i64 %39, 0 
@@ -7009,16 +7009,16 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.simple.one_field<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"multictr.simple.one_field<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 1 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 0 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 1 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 0 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
-  %58 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %58 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %59 = insertvalue {i64, i1} %58, i1 0, 1 
   ret {i64, i1} %59 
 if.then1:
@@ -7026,17 +7026,17 @@ if.then1:
   %47 = tail call ccc  i8*  @wybe_malloc(i32  %46)  
   %48 = ptrtoint i8* %47 to i64 
   %49 = inttoptr i64 %48 to i8* 
-  %50 = inttoptr i64 %"$rec##0" to i8* 
+  %50 = inttoptr i64 %"#rec##0" to i8* 
   %51 = trunc i64 8 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %49, i8*  %50, i32  %51, i32  8, i1  0)  
   %52 = inttoptr i64 %48 to i64* 
   %53 = getelementptr  i64, i64* %52, i64 0 
-  store  i64 %"$field##0", i64* %53 
+  store  i64 %"#field##0", i64* %53 
   %54 = insertvalue {i64, i1} undef, i64 %48, 0 
   %55 = insertvalue {i64, i1} %54, i1 1, 1 
   ret {i64, i1} %55 
 if.else1:
-  %56 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %56 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %57 = insertvalue {i64, i1} %56, i1 0, 1 
   ret {i64, i1} %57 
 }
@@ -7054,30 +7054,30 @@ entry:
   %66 = inttoptr i64 %65 to i64* 
   %67 = getelementptr  i64, i64* %66, i64 0 
   store  i64 %"two_field2##0", i64* %67 
-  %"1$$##0" = or i64 %62, 1 
-  ret i64 %"1$$##0" 
+  %"1####0" = or i64 %62, 1 
+  ret i64 %"1####0" 
 }
 
 
-define external fastcc  {i64, i64, i1} @"multictr.simple.two<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64, i1} @"multictr.simple.two<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$##0", 1 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 1 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"###0", 1 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 1 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %82 = insertvalue {i64, i64, i1} undef, i64 undef, 0 
   %83 = insertvalue {i64, i64, i1} %82, i64 undef, 1 
   %84 = insertvalue {i64, i64, i1} %83, i1 0, 2 
   ret {i64, i64, i1} %84 
 if.then1:
-  %68 = add   i64 %"$##0", -1 
+  %68 = add   i64 %"###0", -1 
   %69 = inttoptr i64 %68 to i64* 
   %70 = getelementptr  i64, i64* %69, i64 0 
   %71 = load  i64, i64* %70 
-  %72 = add   i64 %"$##0", 7 
+  %72 = add   i64 %"###0", 7 
   %73 = inttoptr i64 %72 to i64* 
   %74 = getelementptr  i64, i64* %73, i64 0 
   %75 = load  i64, i64* %74 
@@ -7093,20 +7093,20 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.simple.two_field1<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"multictr.simple.two_field1<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 1 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 1 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 1 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 1 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %93 = insertvalue {i64, i1} undef, i64 undef, 0 
   %94 = insertvalue {i64, i1} %93, i1 0, 1 
   ret {i64, i1} %94 
 if.then1:
-  %85 = add   i64 %"$rec##0", -1 
+  %85 = add   i64 %"#rec##0", -1 
   %86 = inttoptr i64 %85 to i64* 
   %87 = getelementptr  i64, i64* %86, i64 0 
   %88 = load  i64, i64* %87 
@@ -7120,16 +7120,16 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.simple.two_field1<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"multictr.simple.two_field1<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 1 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 1 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 1 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 1 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
-  %110 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %110 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %111 = insertvalue {i64, i1} %110, i1 0, 1 
   ret {i64, i1} %111 
 if.then1:
@@ -7137,7 +7137,7 @@ if.then1:
   %96 = tail call ccc  i8*  @wybe_malloc(i32  %95)  
   %97 = ptrtoint i8* %96 to i64 
   %98 = add   i64 %97, 1 
-  %99 = sub   i64 %"$rec##0", 1 
+  %99 = sub   i64 %"#rec##0", 1 
   %100 = inttoptr i64 %97 to i8* 
   %101 = inttoptr i64 %99 to i8* 
   %102 = trunc i64 16 to i32  
@@ -7145,31 +7145,31 @@ if.then1:
   %103 = add   i64 %98, -1 
   %104 = inttoptr i64 %103 to i64* 
   %105 = getelementptr  i64, i64* %104, i64 0 
-  store  i64 %"$field##0", i64* %105 
+  store  i64 %"#field##0", i64* %105 
   %106 = insertvalue {i64, i1} undef, i64 %98, 0 
   %107 = insertvalue {i64, i1} %106, i1 1, 1 
   ret {i64, i1} %107 
 if.else1:
-  %108 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %108 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %109 = insertvalue {i64, i1} %108, i1 0, 1 
   ret {i64, i1} %109 
 }
 
 
-define external fastcc  {i64, i1} @"multictr.simple.two_field2<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"multictr.simple.two_field2<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 1 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 1 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 1 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 1 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
   %120 = insertvalue {i64, i1} undef, i64 undef, 0 
   %121 = insertvalue {i64, i1} %120, i1 0, 1 
   ret {i64, i1} %121 
 if.then1:
-  %112 = add   i64 %"$rec##0", 7 
+  %112 = add   i64 %"#rec##0", 7 
   %113 = inttoptr i64 %112 to i64* 
   %114 = getelementptr  i64, i64* %113, i64 0 
   %115 = load  i64, i64* %114 
@@ -7183,16 +7183,16 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"multictr.simple.two_field2<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"multictr.simple.two_field2<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = and i64 %"$rec##0", 1 
-  %"2$tmp$1##0" = icmp eq i64 %"2$tmp$2##0", 1 
-  br i1 %"2$tmp$1##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = and i64 %"#rec##0", 1 
+  %"2#tmp#1##0" = icmp eq i64 %"2#tmp#2##0", 1 
+  br i1 %"2#tmp#1##0", label %if.then1, label %if.else1 
 if.else:
-  %137 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %137 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %138 = insertvalue {i64, i1} %137, i1 0, 1 
   ret {i64, i1} %138 
 if.then1:
@@ -7200,7 +7200,7 @@ if.then1:
   %123 = tail call ccc  i8*  @wybe_malloc(i32  %122)  
   %124 = ptrtoint i8* %123 to i64 
   %125 = add   i64 %124, 1 
-  %126 = sub   i64 %"$rec##0", 1 
+  %126 = sub   i64 %"#rec##0", 1 
   %127 = inttoptr i64 %124 to i8* 
   %128 = inttoptr i64 %126 to i8* 
   %129 = trunc i64 16 to i32  
@@ -7208,12 +7208,12 @@ if.then1:
   %130 = add   i64 %125, 7 
   %131 = inttoptr i64 %130 to i64* 
   %132 = getelementptr  i64, i64* %131, i64 0 
-  store  i64 %"$field##0", i64* %132 
+  store  i64 %"#field##0", i64* %132 
   %133 = insertvalue {i64, i1} undef, i64 %125, 0 
   %134 = insertvalue {i64, i1} %133, i1 1, 1 
   ret {i64, i1} %134 
 if.else1:
-  %135 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %135 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %136 = insertvalue {i64, i1} %135, i1 0, 1 
   ret {i64, i1} %136 
 }
@@ -7225,11 +7225,11 @@ entry:
 }
 
 
-define external fastcc  i1 @"multictr.simple.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"multictr.simple.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = tail call fastcc  i1  @"multictr.simple.=<0>"(i64  %"$left##0", i64  %"$right##0")  
-  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
-  ret i1 %"1$$$##0" 
+  %"1#tmp#0##0" = tail call fastcc  i1  @"multictr.simple.=<0>"(i64  %"#left##0", i64  %"#right##0")  
+  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1#####0" 
 }
 --------------------------------------------------
  Module multictr.suit
@@ -7249,51 +7249,51 @@ entry:
 
 = > public {inline} (1 calls)
 0: multictr.suit.=<0>
-=($left##0:multictr.suit, $right##0:multictr.suit, ?$$##0:wybe.bool):
+=(#left##0:multictr.suit, #right##0:multictr.suit, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(~$left##0:multictr.suit, ~$right##0:multictr.suit, ?$$##0:wybe.bool)
+    foreign llvm icmp_eq(~#left##0:multictr.suit, ~#right##0:multictr.suit, ?####0:wybe.bool)
 
 
 clubs > public {inline} (0 calls)
 0: multictr.suit.clubs<0>
-clubs(?$##0:multictr.suit):
+clubs(?###0:multictr.suit):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:multictr.suit, ?$##0:multictr.suit)
+    foreign llvm move(0:multictr.suit, ?###0:multictr.suit)
 
 
 diamonds > public {inline} (0 calls)
 0: multictr.suit.diamonds<0>
-diamonds(?$##0:multictr.suit):
+diamonds(?###0:multictr.suit):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(1:multictr.suit, ?$##0:multictr.suit)
+    foreign llvm move(1:multictr.suit, ?###0:multictr.suit)
 
 
 hearts > public {inline} (0 calls)
 0: multictr.suit.hearts<0>
-hearts(?$##0:multictr.suit):
+hearts(?###0:multictr.suit):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(2:multictr.suit, ?$##0:multictr.suit)
+    foreign llvm move(2:multictr.suit, ?###0:multictr.suit)
 
 
 spades > public {inline} (0 calls)
 0: multictr.suit.spades<0>
-spades(?$##0:multictr.suit):
+spades(?###0:multictr.suit):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(3:multictr.suit, ?$##0:multictr.suit)
+    foreign llvm move(3:multictr.suit, ?###0:multictr.suit)
 
 
 ~= > public {inline} (0 calls)
 0: multictr.suit.~=<0>
-~=($left##0:multictr.suit, $right##0:multictr.suit, ?$$##0:wybe.bool):
+~=(#left##0:multictr.suit, #right##0:multictr.suit, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(~$left##0:multictr.suit, ~$right##0:multictr.suit, ?tmp$0##0:wybe.bool)
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    foreign llvm icmp_eq(~#left##0:multictr.suit, ~#right##0:multictr.suit, ?tmp#0##0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
   LLVM code       :
 
@@ -7309,10 +7309,10 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"multictr.suit.=<0>"(i2  %"$left##0", i2  %"$right##0")    {
+define external fastcc  i1 @"multictr.suit.=<0>"(i2  %"#left##0", i2  %"#right##0")    {
 entry:
-  %"1$$$##0" = icmp eq i2 %"$left##0", %"$right##0" 
-  ret i1 %"1$$$##0" 
+  %"1#####0" = icmp eq i2 %"#left##0", %"#right##0" 
+  ret i1 %"1#####0" 
 }
 
 
@@ -7340,11 +7340,11 @@ entry:
 }
 
 
-define external fastcc  i1 @"multictr.suit.~=<0>"(i2  %"$left##0", i2  %"$right##0")    {
+define external fastcc  i1 @"multictr.suit.~=<0>"(i2  %"#left##0", i2  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = icmp eq i2 %"$left##0", %"$right##0" 
-  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
-  ret i1 %"1$$$##0" 
+  %"1#tmp#0##0" = icmp eq i2 %"#left##0", %"#right##0" 
+  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1#####0" 
 }
 --------------------------------------------------
  Module multictr.unit
@@ -7361,26 +7361,26 @@ entry:
 
 = > public {inline} (1 calls)
 0: multictr.unit.=<0>
-=([$left##0:multictr.unit], [$right##0:multictr.unit], ?$$##0:wybe.bool):
+=([#left##0:multictr.unit], [#right##0:multictr.unit], ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+    foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 unit > public {inline} (0 calls)
 0: multictr.unit.unit<0>
-unit(?$##0:multictr.unit):
+unit(?###0:multictr.unit):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:multictr.unit, ?$##0:multictr.unit)
+    foreign llvm move(0:multictr.unit, ?###0:multictr.unit)
 
 
 ~= > public {inline} (0 calls)
 0: multictr.unit.~=<0>
-~=([$left##0:multictr.unit], [$right##0:multictr.unit], ?$$##0:wybe.bool):
+~=([#left##0:multictr.unit], [#right##0:multictr.unit], ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
   LLVM code       :
 

--- a/test-cases/final-dump/multictr2.exp
+++ b/test-cases/final-dump/multictr2.exp
@@ -51,104 +51,104 @@ AFTER EVERYTHING:
 
 print_t > public (0 calls)
 0: multictr2.print_t<0>
-print_t(x#0:multictr2.t, io#0:wybe.phantom, ?io#8:wybe.phantom):
+print_t(x##0:multictr2.t, io##0:wybe.phantom, ?io##8:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and(x#0:wybe.int, 7:wybe.int, ?tmp$9#0:wybe.int)
-    foreign llvm icmp_eq(tmp$9#0:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.bool)
-    case ~tmp$10#0:wybe.bool of
+    foreign llvm and(x##0:wybe.int, 7:wybe.int, ?tmp$9##0:wybe.int)
+    foreign llvm icmp_eq(tmp$9##0:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.bool)
+    case ~tmp$10##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(tmp$9#0:wybe.int, 1:wybe.int, ?tmp$13#0:wybe.bool)
-        case ~tmp$13#0:wybe.bool of
+        foreign llvm icmp_eq(tmp$9##0:wybe.int, 1:wybe.int, ?tmp$13##0:wybe.bool)
+        case ~tmp$13##0:wybe.bool of
         0:
-            foreign llvm icmp_eq(tmp$9#0:wybe.int, 2:wybe.int, ?tmp$16#0:wybe.bool)
-            case ~tmp$16#0:wybe.bool of
+            foreign llvm icmp_eq(tmp$9##0:wybe.int, 2:wybe.int, ?tmp$16##0:wybe.bool)
+            case ~tmp$16##0:wybe.bool of
             0:
-                foreign llvm icmp_eq(tmp$9#0:wybe.int, 3:wybe.int, ?tmp$19#0:wybe.bool)
-                case ~tmp$19#0:wybe.bool of
+                foreign llvm icmp_eq(tmp$9##0:wybe.int, 3:wybe.int, ?tmp$19##0:wybe.bool)
+                case ~tmp$19##0:wybe.bool of
                 0:
-                    foreign llvm icmp_eq(tmp$9#0:wybe.int, 4:wybe.int, ?tmp$22#0:wybe.bool)
-                    case ~tmp$22#0:wybe.bool of
+                    foreign llvm icmp_eq(tmp$9##0:wybe.int, 4:wybe.int, ?tmp$22##0:wybe.bool)
+                    case ~tmp$22##0:wybe.bool of
                     0:
-                        foreign llvm icmp_eq(tmp$9#0:wybe.int, 5:wybe.int, ?tmp$25#0:wybe.bool)
-                        case ~tmp$25#0:wybe.bool of
+                        foreign llvm icmp_eq(tmp$9##0:wybe.int, 5:wybe.int, ?tmp$25##0:wybe.bool)
+                        case ~tmp$25##0:wybe.bool of
                         0:
-                            foreign llvm icmp_eq(tmp$9#0:wybe.int, 6:wybe.int, ?tmp$28#0:wybe.bool)
-                            case ~tmp$28#0:wybe.bool of
+                            foreign llvm icmp_eq(tmp$9##0:wybe.int, 6:wybe.int, ?tmp$28##0:wybe.bool)
+                            case ~tmp$28##0:wybe.bool of
                             0:
-                                foreign llvm icmp_eq(~tmp$9#0:wybe.int, 7:wybe.int, ?tmp$31#0:wybe.bool)
-                                case ~tmp$31#0:wybe.bool of
+                                foreign llvm icmp_eq(~tmp$9##0:wybe.int, 7:wybe.int, ?tmp$31##0:wybe.bool)
+                                case ~tmp$31##0:wybe.bool of
                                 0:
-                                    foreign c putchar('\n':wybe.char, ~#io#0:wybe.phantom, ?#io#8:wybe.phantom) @io:nn:nn
+                                    foreign c putchar('\n':wybe.char, ~#io##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
 
                                 1:
-                                    foreign lpvm access(x#0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?a#7:wybe.int)
-                                    foreign lpvm access(x#0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?b#0:wybe.int)
-                                    foreign lpvm access(~x#0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?c#0:wybe.float)
-                                    foreign c print_string("c08(":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-                                    foreign c print_int(~a#7:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-                                    foreign c print_string(", ":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-                                    foreign c print_int(~b#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-                                    foreign c print_string(", ":wybe.string, ~#io#4:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-                                    foreign c print_float(~c#0:wybe.float, ~#io#5:wybe.phantom, ?#io#6:wybe.phantom) @io:nn:nn
-                                    foreign c print_string(")":wybe.string, ~#io#6:wybe.phantom, ?#io#7:wybe.phantom) @io:nn:nn
-                                    foreign c putchar('\n':wybe.char, ~#io#7:wybe.phantom, ?#io#8:wybe.phantom) @io:nn:nn
+                                    foreign lpvm access(x##0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?a##7:wybe.int)
+                                    foreign lpvm access(x##0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?b##0:wybe.int)
+                                    foreign lpvm access(~x##0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?c##0:wybe.float)
+                                    foreign c print_string("c08(":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+                                    foreign c print_int(~a##7:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+                                    foreign c print_string(", ":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+                                    foreign c print_int(~b##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+                                    foreign c print_string(", ":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+                                    foreign c print_float(~c##0:wybe.float, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+                                    foreign c print_string(")":wybe.string, ~#io##6:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
+                                    foreign c putchar('\n':wybe.char, ~#io##7:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
 
 
                             1:
-                                foreign lpvm access(~x#0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?a#6:wybe.int)
-                                foreign c print_string("c07(":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-                                foreign c print_int(~a#6:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-                                foreign c print_string(")":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-                                foreign c putchar('\n':wybe.char, ~#io#3:wybe.phantom, ?#io#8:wybe.phantom) @io:nn:nn
+                                foreign lpvm access(~x##0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?a##6:wybe.int)
+                                foreign c print_string("c07(":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+                                foreign c print_int(~a##6:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+                                foreign c print_string(")":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+                                foreign c putchar('\n':wybe.char, ~#io##3:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
 
 
                         1:
-                            foreign lpvm access(~x#0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?a#5:wybe.int)
-                            foreign c print_string("c06(":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-                            foreign c print_int(~a#5:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-                            foreign c print_string(")":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-                            foreign c putchar('\n':wybe.char, ~#io#3:wybe.phantom, ?#io#8:wybe.phantom) @io:nn:nn
+                            foreign lpvm access(~x##0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?a##5:wybe.int)
+                            foreign c print_string("c06(":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+                            foreign c print_int(~a##5:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+                            foreign c print_string(")":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+                            foreign c putchar('\n':wybe.char, ~#io##3:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
 
 
                     1:
-                        foreign lpvm access(~x#0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?a#4:wybe.int)
-                        foreign c print_string("c05(":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-                        foreign c print_int(~a#4:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-                        foreign c print_string(")":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-                        foreign c putchar('\n':wybe.char, ~#io#3:wybe.phantom, ?#io#8:wybe.phantom) @io:nn:nn
+                        foreign lpvm access(~x##0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?a##4:wybe.int)
+                        foreign c print_string("c05(":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+                        foreign c print_int(~a##4:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+                        foreign c print_string(")":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+                        foreign c putchar('\n':wybe.char, ~#io##3:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
 
 
                 1:
-                    foreign lpvm access(~x#0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?a#3:wybe.int)
-                    foreign c print_string("c04(":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-                    foreign c print_int(~a#3:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-                    foreign c print_string(")":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-                    foreign c putchar('\n':wybe.char, ~#io#3:wybe.phantom, ?#io#8:wybe.phantom) @io:nn:nn
+                    foreign lpvm access(~x##0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?a##3:wybe.int)
+                    foreign c print_string("c04(":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+                    foreign c print_int(~a##3:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+                    foreign c print_string(")":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+                    foreign c putchar('\n':wybe.char, ~#io##3:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
 
 
             1:
-                foreign lpvm access(~x#0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?a#2:wybe.int)
-                foreign c print_string("c03(":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-                foreign c print_int(~a#2:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-                foreign c print_string(")":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-                foreign c putchar('\n':wybe.char, ~#io#3:wybe.phantom, ?#io#8:wybe.phantom) @io:nn:nn
+                foreign lpvm access(~x##0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?a##2:wybe.int)
+                foreign c print_string("c03(":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+                foreign c print_int(~a##2:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+                foreign c print_string(")":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+                foreign c putchar('\n':wybe.char, ~#io##3:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
 
 
         1:
-            foreign lpvm access(~x#0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?a#1:wybe.int)
-            foreign c print_string("c03(":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-            foreign c print_int(~a#1:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-            foreign c print_string(")":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-            foreign c putchar('\n':wybe.char, ~#io#3:wybe.phantom, ?#io#8:wybe.phantom) @io:nn:nn
+            foreign lpvm access(~x##0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?a##1:wybe.int)
+            foreign c print_string("c03(":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+            foreign c print_int(~a##1:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+            foreign c print_string(")":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+            foreign c putchar('\n':wybe.char, ~#io##3:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
 
 
     1:
-        foreign lpvm access(~x#0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a#0:wybe.int)
-        foreign c print_string("c01(":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        foreign c print_int(~a#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-        foreign c print_string(")":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~#io#3:wybe.phantom, ?#io#8:wybe.phantom) @io:nn:nn
+        foreign lpvm access(~x##0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?a##0:wybe.int)
+        foreign c print_string("c01(":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        foreign c print_int(~a##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+        foreign c print_string(")":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~#io##3:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
 
 
   LLVM code       :
@@ -231,13 +231,13 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"multictr2.print_t<0>"(i64  %"x#0")    {
+define external fastcc  void @"multictr2.print_t<0>"(i64  %"x##0")    {
 entry:
-  %"1$tmp$9#0" = and i64 %"x#0", 7 
-  %"1$tmp$10#0" = icmp eq i64 %"1$tmp$9#0", 0 
-  br i1 %"1$tmp$10#0", label %if.then, label %if.else 
+  %"1$tmp$9##0" = and i64 %"x##0", 7 
+  %"1$tmp$10##0" = icmp eq i64 %"1$tmp$9##0", 0 
+  br i1 %"1$tmp$10##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"x#0" to i64* 
+  %1 = inttoptr i64 %"x##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
   %5 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @multictr2.4, i32 0, i32 0) to i64 
@@ -248,10 +248,10 @@ if.then:
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else:
-  %"3$tmp$13#0" = icmp eq i64 %"1$tmp$9#0", 1 
-  br i1 %"3$tmp$13#0", label %if.then1, label %if.else1 
+  %"3$tmp$13##0" = icmp eq i64 %"1$tmp$9##0", 1 
+  br i1 %"3$tmp$13##0", label %if.then1, label %if.else1 
 if.then1:
-  %8 = add   i64 %"x#0", -1 
+  %8 = add   i64 %"x##0", -1 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
@@ -263,10 +263,10 @@ if.then1:
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else1:
-  %"5$tmp$16#0" = icmp eq i64 %"1$tmp$9#0", 2 
-  br i1 %"5$tmp$16#0", label %if.then2, label %if.else2 
+  %"5$tmp$16##0" = icmp eq i64 %"1$tmp$9##0", 2 
+  br i1 %"5$tmp$16##0", label %if.then2, label %if.else2 
 if.then2:
-  %16 = add   i64 %"x#0", -2 
+  %16 = add   i64 %"x##0", -2 
   %17 = inttoptr i64 %16 to i64* 
   %18 = getelementptr  i64, i64* %17, i64 0 
   %19 = load  i64, i64* %18 
@@ -278,10 +278,10 @@ if.then2:
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else2:
-  %"7$tmp$19#0" = icmp eq i64 %"1$tmp$9#0", 3 
-  br i1 %"7$tmp$19#0", label %if.then3, label %if.else3 
+  %"7$tmp$19##0" = icmp eq i64 %"1$tmp$9##0", 3 
+  br i1 %"7$tmp$19##0", label %if.then3, label %if.else3 
 if.then3:
-  %24 = add   i64 %"x#0", -3 
+  %24 = add   i64 %"x##0", -3 
   %25 = inttoptr i64 %24 to i64* 
   %26 = getelementptr  i64, i64* %25, i64 0 
   %27 = load  i64, i64* %26 
@@ -293,10 +293,10 @@ if.then3:
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else3:
-  %"9$tmp$22#0" = icmp eq i64 %"1$tmp$9#0", 4 
-  br i1 %"9$tmp$22#0", label %if.then4, label %if.else4 
+  %"9$tmp$22##0" = icmp eq i64 %"1$tmp$9##0", 4 
+  br i1 %"9$tmp$22##0", label %if.then4, label %if.else4 
 if.then4:
-  %32 = add   i64 %"x#0", -4 
+  %32 = add   i64 %"x##0", -4 
   %33 = inttoptr i64 %32 to i64* 
   %34 = getelementptr  i64, i64* %33, i64 0 
   %35 = load  i64, i64* %34 
@@ -308,10 +308,10 @@ if.then4:
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else4:
-  %"11$tmp$25#0" = icmp eq i64 %"1$tmp$9#0", 5 
-  br i1 %"11$tmp$25#0", label %if.then5, label %if.else5 
+  %"11$tmp$25##0" = icmp eq i64 %"1$tmp$9##0", 5 
+  br i1 %"11$tmp$25##0", label %if.then5, label %if.else5 
 if.then5:
-  %40 = add   i64 %"x#0", -5 
+  %40 = add   i64 %"x##0", -5 
   %41 = inttoptr i64 %40 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
   %43 = load  i64, i64* %42 
@@ -323,10 +323,10 @@ if.then5:
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else5:
-  %"13$tmp$28#0" = icmp eq i64 %"1$tmp$9#0", 6 
-  br i1 %"13$tmp$28#0", label %if.then6, label %if.else6 
+  %"13$tmp$28##0" = icmp eq i64 %"1$tmp$9##0", 6 
+  br i1 %"13$tmp$28##0", label %if.then6, label %if.else6 
 if.then6:
-  %48 = add   i64 %"x#0", -6 
+  %48 = add   i64 %"x##0", -6 
   %49 = inttoptr i64 %48 to i64* 
   %50 = getelementptr  i64, i64* %49, i64 0 
   %51 = load  i64, i64* %50 
@@ -338,18 +338,18 @@ if.then6:
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else6:
-  %"15$tmp$31#0" = icmp eq i64 %"1$tmp$9#0", 7 
-  br i1 %"15$tmp$31#0", label %if.then7, label %if.else7 
+  %"15$tmp$31##0" = icmp eq i64 %"1$tmp$9##0", 7 
+  br i1 %"15$tmp$31##0", label %if.then7, label %if.else7 
 if.then7:
-  %56 = add   i64 %"x#0", -7 
+  %56 = add   i64 %"x##0", -7 
   %57 = inttoptr i64 %56 to i64* 
   %58 = getelementptr  i64, i64* %57, i64 0 
   %59 = load  i64, i64* %58 
-  %60 = add   i64 %"x#0", 1 
+  %60 = add   i64 %"x##0", 1 
   %61 = inttoptr i64 %60 to i64* 
   %62 = getelementptr  i64, i64* %61, i64 0 
   %63 = load  i64, i64* %62 
-  %64 = add   i64 %"x#0", 9 
+  %64 = add   i64 %"x##0", 9 
   %65 = inttoptr i64 %64 to double* 
   %66 = getelementptr  double, double* %65, i64 0 
   %67 = load  double, double* %66 
@@ -420,727 +420,727 @@ if.else7:
 
 = > public (1 calls)
 0: multictr2.t.=<0>
-=($left#0:multictr2.t, $right#0:multictr2.t, ?$$#0:wybe.bool):
+=($left##0:multictr2.t, $right##0:multictr2.t, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($left#0:wybe.int, 7:wybe.int, ?tmp$28#0:wybe.int)
-    foreign llvm icmp_eq(tmp$28#0:wybe.int, 0:wybe.int, ?tmp$29#0:wybe.bool)
-    case ~tmp$29#0:wybe.bool of
+    foreign llvm and($left##0:wybe.int, 7:wybe.int, ?tmp$28##0:wybe.int)
+    foreign llvm icmp_eq(tmp$28##0:wybe.int, 0:wybe.int, ?tmp$29##0:wybe.bool)
+    case ~tmp$29##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(tmp$28#0:wybe.int, 1:wybe.int, ?tmp$32#0:wybe.bool)
-        case ~tmp$32#0:wybe.bool of
+        foreign llvm icmp_eq(tmp$28##0:wybe.int, 1:wybe.int, ?tmp$32##0:wybe.bool)
+        case ~tmp$32##0:wybe.bool of
         0:
-            foreign llvm icmp_eq(tmp$28#0:wybe.int, 2:wybe.int, ?tmp$35#0:wybe.bool)
-            case ~tmp$35#0:wybe.bool of
+            foreign llvm icmp_eq(tmp$28##0:wybe.int, 2:wybe.int, ?tmp$35##0:wybe.bool)
+            case ~tmp$35##0:wybe.bool of
             0:
-                foreign llvm icmp_eq(tmp$28#0:wybe.int, 3:wybe.int, ?tmp$38#0:wybe.bool)
-                case ~tmp$38#0:wybe.bool of
+                foreign llvm icmp_eq(tmp$28##0:wybe.int, 3:wybe.int, ?tmp$38##0:wybe.bool)
+                case ~tmp$38##0:wybe.bool of
                 0:
-                    foreign llvm icmp_eq(tmp$28#0:wybe.int, 4:wybe.int, ?tmp$41#0:wybe.bool)
-                    case ~tmp$41#0:wybe.bool of
+                    foreign llvm icmp_eq(tmp$28##0:wybe.int, 4:wybe.int, ?tmp$41##0:wybe.bool)
+                    case ~tmp$41##0:wybe.bool of
                     0:
-                        foreign llvm icmp_eq(tmp$28#0:wybe.int, 5:wybe.int, ?tmp$44#0:wybe.bool)
-                        case ~tmp$44#0:wybe.bool of
+                        foreign llvm icmp_eq(tmp$28##0:wybe.int, 5:wybe.int, ?tmp$44##0:wybe.bool)
+                        case ~tmp$44##0:wybe.bool of
                         0:
-                            foreign llvm icmp_eq(tmp$28#0:wybe.int, 6:wybe.int, ?tmp$47#0:wybe.bool)
-                            case ~tmp$47#0:wybe.bool of
+                            foreign llvm icmp_eq(tmp$28##0:wybe.int, 6:wybe.int, ?tmp$47##0:wybe.bool)
+                            case ~tmp$47##0:wybe.bool of
                             0:
-                                foreign llvm icmp_eq(~tmp$28#0:wybe.int, 7:wybe.int, ?tmp$50#0:wybe.bool)
-                                case ~tmp$50#0:wybe.bool of
+                                foreign llvm icmp_eq(~tmp$28##0:wybe.int, 7:wybe.int, ?tmp$50##0:wybe.bool)
+                                case ~tmp$50##0:wybe.bool of
                                 0:
-                                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                 1:
-                                    foreign lpvm access($left#0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?$left$f08_a#0:wybe.int)
-                                    foreign lpvm access($left#0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?$left$f08_b#0:wybe.int)
-                                    foreign lpvm access(~$left#0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?$left$f08_c#0:wybe.float)
-                                    foreign llvm and($right#0:wybe.int, 7:wybe.int, ?tmp$52#0:wybe.int)
-                                    foreign llvm icmp_eq(~tmp$52#0:wybe.int, 7:wybe.int, ?tmp$53#0:wybe.bool)
-                                    case ~tmp$53#0:wybe.bool of
+                                    foreign lpvm access($left##0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?$left$f08_a##0:wybe.int)
+                                    foreign lpvm access($left##0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?$left$f08_b##0:wybe.int)
+                                    foreign lpvm access(~$left##0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?$left$f08_c##0:wybe.float)
+                                    foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$52##0:wybe.int)
+                                    foreign llvm icmp_eq(~tmp$52##0:wybe.int, 7:wybe.int, ?tmp$53##0:wybe.bool)
+                                    case ~tmp$53##0:wybe.bool of
                                     0:
-                                        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                     1:
-                                        foreign lpvm access($right#0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?$right$f08_a#0:wybe.int)
-                                        foreign lpvm access($right#0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?$right$f08_b#0:wybe.int)
-                                        foreign lpvm access(~$right#0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?$right$f08_c#0:wybe.float)
-                                        foreign llvm icmp_eq(~$left$f08_a#0:wybe.int, ~$right$f08_a#0:wybe.int, ?tmp$16#0:wybe.bool) @int:nn:nn
-                                        case ~tmp$16#0:wybe.bool of
+                                        foreign lpvm access($right##0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?$right$f08_a##0:wybe.int)
+                                        foreign lpvm access($right##0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?$right$f08_b##0:wybe.int)
+                                        foreign lpvm access(~$right##0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?$right$f08_c##0:wybe.float)
+                                        foreign llvm icmp_eq(~$left$f08_a##0:wybe.int, ~$right$f08_a##0:wybe.int, ?tmp$16##0:wybe.bool) @int:nn:nn
+                                        case ~tmp$16##0:wybe.bool of
                                         0:
-                                            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                         1:
-                                            foreign llvm icmp_eq(~$left$f08_b#0:wybe.int, ~$right$f08_b#0:wybe.int, ?tmp$17#0:wybe.bool) @int:nn:nn
-                                            case ~tmp$17#0:wybe.bool of
+                                            foreign llvm icmp_eq(~$left$f08_b##0:wybe.int, ~$right$f08_b##0:wybe.int, ?tmp$17##0:wybe.bool) @int:nn:nn
+                                            case ~tmp$17##0:wybe.bool of
                                             0:
-                                                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                             1:
-                                                foreign llvm fcmp_eq(~$left$f08_c#0:wybe.float, ~$right$f08_c#0:wybe.float, ?$$#0:wybe.bool) @float:nn:nn
+                                                foreign llvm fcmp_eq(~$left$f08_c##0:wybe.float, ~$right$f08_c##0:wybe.float, ?$$##0:wybe.bool) @float:nn:nn
 
 
 
 
 
                             1:
-                                foreign lpvm access(~$left#0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?$left$f07#0:wybe.int)
-                                foreign llvm and($right#0:wybe.int, 7:wybe.int, ?tmp$49#0:wybe.int)
-                                foreign llvm icmp_eq(~tmp$49#0:wybe.int, 6:wybe.int, ?tmp$50#0:wybe.bool)
-                                case ~tmp$50#0:wybe.bool of
+                                foreign lpvm access(~$left##0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?$left$f07##0:wybe.int)
+                                foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$49##0:wybe.int)
+                                foreign llvm icmp_eq(~tmp$49##0:wybe.int, 6:wybe.int, ?tmp$50##0:wybe.bool)
+                                case ~tmp$50##0:wybe.bool of
                                 0:
-                                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                                 1:
-                                    foreign lpvm access(~$right#0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?$right$f07#0:wybe.int)
-                                    foreign llvm icmp_eq(~$left$f07#0:wybe.int, ~$right$f07#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+                                    foreign lpvm access(~$right##0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?$right$f07##0:wybe.int)
+                                    foreign llvm icmp_eq(~$left$f07##0:wybe.int, ~$right$f07##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
                         1:
-                            foreign lpvm access(~$left#0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?$left$f06#0:wybe.int)
-                            foreign llvm and($right#0:wybe.int, 7:wybe.int, ?tmp$46#0:wybe.int)
-                            foreign llvm icmp_eq(~tmp$46#0:wybe.int, 5:wybe.int, ?tmp$47#0:wybe.bool)
-                            case ~tmp$47#0:wybe.bool of
+                            foreign lpvm access(~$left##0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?$left$f06##0:wybe.int)
+                            foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$46##0:wybe.int)
+                            foreign llvm icmp_eq(~tmp$46##0:wybe.int, 5:wybe.int, ?tmp$47##0:wybe.bool)
+                            case ~tmp$47##0:wybe.bool of
                             0:
-                                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                             1:
-                                foreign lpvm access(~$right#0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?$right$f06#0:wybe.int)
-                                foreign llvm icmp_eq(~$left$f06#0:wybe.int, ~$right$f06#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+                                foreign lpvm access(~$right##0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?$right$f06##0:wybe.int)
+                                foreign llvm icmp_eq(~$left$f06##0:wybe.int, ~$right$f06##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
                     1:
-                        foreign lpvm access(~$left#0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?$left$f05#0:wybe.int)
-                        foreign llvm and($right#0:wybe.int, 7:wybe.int, ?tmp$43#0:wybe.int)
-                        foreign llvm icmp_eq(~tmp$43#0:wybe.int, 4:wybe.int, ?tmp$44#0:wybe.bool)
-                        case ~tmp$44#0:wybe.bool of
+                        foreign lpvm access(~$left##0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?$left$f05##0:wybe.int)
+                        foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$43##0:wybe.int)
+                        foreign llvm icmp_eq(~tmp$43##0:wybe.int, 4:wybe.int, ?tmp$44##0:wybe.bool)
+                        case ~tmp$44##0:wybe.bool of
                         0:
-                            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                         1:
-                            foreign lpvm access(~$right#0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?$right$f05#0:wybe.int)
-                            foreign llvm icmp_eq(~$left$f05#0:wybe.int, ~$right$f05#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+                            foreign lpvm access(~$right##0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?$right$f05##0:wybe.int)
+                            foreign llvm icmp_eq(~$left$f05##0:wybe.int, ~$right$f05##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
                 1:
-                    foreign lpvm access(~$left#0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?$left$f04#0:wybe.int)
-                    foreign llvm and($right#0:wybe.int, 7:wybe.int, ?tmp$40#0:wybe.int)
-                    foreign llvm icmp_eq(~tmp$40#0:wybe.int, 3:wybe.int, ?tmp$41#0:wybe.bool)
-                    case ~tmp$41#0:wybe.bool of
+                    foreign lpvm access(~$left##0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?$left$f04##0:wybe.int)
+                    foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$40##0:wybe.int)
+                    foreign llvm icmp_eq(~tmp$40##0:wybe.int, 3:wybe.int, ?tmp$41##0:wybe.bool)
+                    case ~tmp$41##0:wybe.bool of
                     0:
-                        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                     1:
-                        foreign lpvm access(~$right#0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?$right$f04#0:wybe.int)
-                        foreign llvm icmp_eq(~$left$f04#0:wybe.int, ~$right$f04#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+                        foreign lpvm access(~$right##0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?$right$f04##0:wybe.int)
+                        foreign llvm icmp_eq(~$left$f04##0:wybe.int, ~$right$f04##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
             1:
-                foreign lpvm access(~$left#0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$left$f03#0:wybe.int)
-                foreign llvm and($right#0:wybe.int, 7:wybe.int, ?tmp$37#0:wybe.int)
-                foreign llvm icmp_eq(~tmp$37#0:wybe.int, 2:wybe.int, ?tmp$38#0:wybe.bool)
-                case ~tmp$38#0:wybe.bool of
+                foreign lpvm access(~$left##0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$left$f03##0:wybe.int)
+                foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$37##0:wybe.int)
+                foreign llvm icmp_eq(~tmp$37##0:wybe.int, 2:wybe.int, ?tmp$38##0:wybe.bool)
+                case ~tmp$38##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                 1:
-                    foreign lpvm access(~$right#0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$right$f03#0:wybe.int)
-                    foreign llvm icmp_eq(~$left$f03#0:wybe.int, ~$right$f03#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+                    foreign lpvm access(~$right##0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$right$f03##0:wybe.int)
+                    foreign llvm icmp_eq(~$left$f03##0:wybe.int, ~$right$f03##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
         1:
-            foreign lpvm access(~$left#0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$left$f02#0:wybe.int)
-            foreign llvm and($right#0:wybe.int, 7:wybe.int, ?tmp$34#0:wybe.int)
-            foreign llvm icmp_eq(~tmp$34#0:wybe.int, 1:wybe.int, ?tmp$35#0:wybe.bool)
-            case ~tmp$35#0:wybe.bool of
+            foreign lpvm access(~$left##0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$left$f02##0:wybe.int)
+            foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$34##0:wybe.int)
+            foreign llvm icmp_eq(~tmp$34##0:wybe.int, 1:wybe.int, ?tmp$35##0:wybe.bool)
+            case ~tmp$35##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                foreign lpvm access(~$right#0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$right$f02#0:wybe.int)
-                foreign llvm icmp_eq(~$left$f02#0:wybe.int, ~$right$f02#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+                foreign lpvm access(~$right##0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$right$f02##0:wybe.int)
+                foreign llvm icmp_eq(~$left$f02##0:wybe.int, ~$right$f02##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
     1:
-        foreign lpvm access(~$left#0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$left$f01#0:wybe.int)
-        foreign llvm and($right#0:wybe.int, 7:wybe.int, ?tmp$31#0:wybe.int)
-        foreign llvm icmp_eq(~tmp$31#0:wybe.int, 0:wybe.int, ?tmp$32#0:wybe.bool)
-        case ~tmp$32#0:wybe.bool of
+        foreign lpvm access(~$left##0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$left$f01##0:wybe.int)
+        foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$31##0:wybe.int)
+        foreign llvm icmp_eq(~tmp$31##0:wybe.int, 0:wybe.int, ?tmp$32##0:wybe.bool)
+        case ~tmp$32##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign lpvm access(~$right#0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$right$f01#0:wybe.int)
-            foreign llvm icmp_eq(~$left$f01#0:wybe.int, ~$right$f01#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+            foreign lpvm access(~$right##0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$right$f01##0:wybe.int)
+            foreign llvm icmp_eq(~$left$f01##0:wybe.int, ~$right$f01##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 
 c01 > public {inline} (0 calls)
 0: multictr2.t.c01<0>
-c01(f01#0:wybe.int, ?$#0:multictr2.t):
+c01(f01##0:wybe.int, ?$##0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr2.t)
-    foreign lpvm mutate(~$rec#0:multictr2.t, ?$#0:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f01#0:wybe.int)
+    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr2.t)
+    foreign lpvm mutate(~$rec##0:multictr2.t, ?$##0:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f01##0:wybe.int)
 c01 > public {inline} (24 calls)
 1: multictr2.t.c01<1>
-c01(?f01#0:wybe.int, $#0:multictr2.t, ?$$#0:wybe.bool):
+c01(?f01##0:wybe.int, $##0:multictr2.t, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?f01#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?f01##0:wybe.int)
 
     1:
-        foreign lpvm access(~$#0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?f01#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$##0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?f01##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 c02 > public {inline} (0 calls)
 0: multictr2.t.c02<0>
-c02(f02#0:wybe.int, ?$#0:multictr2.t):
+c02(f02##0:wybe.int, ?$##0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr2.t)
-    foreign lpvm mutate(~$rec#0:multictr2.t, ?$rec#1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f02#0:wybe.int)
-    foreign llvm or(~$rec#1:multictr2.t, 1:wybe.int, ?$#0:multictr2.t)
+    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr2.t)
+    foreign lpvm mutate(~$rec##0:multictr2.t, ?$rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f02##0:wybe.int)
+    foreign llvm or(~$rec##1:multictr2.t, 1:wybe.int, ?$##0:multictr2.t)
 c02 > public {inline} (19 calls)
 1: multictr2.t.c02<1>
-c02(?f02#0:wybe.int, $#0:multictr2.t, ?$$#0:wybe.bool):
+c02(?f02##0:wybe.int, $##0:multictr2.t, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 1:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?f02#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?f02##0:wybe.int)
 
     1:
-        foreign lpvm access(~$#0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?f02#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$##0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?f02##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 c03 > public {inline} (0 calls)
 0: multictr2.t.c03<0>
-c03(f03#0:wybe.int, ?$#0:multictr2.t):
+c03(f03##0:wybe.int, ?$##0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr2.t)
-    foreign lpvm mutate(~$rec#0:multictr2.t, ?$rec#1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f03#0:wybe.int)
-    foreign llvm or(~$rec#1:multictr2.t, 2:wybe.int, ?$#0:multictr2.t)
+    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr2.t)
+    foreign lpvm mutate(~$rec##0:multictr2.t, ?$rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f03##0:wybe.int)
+    foreign llvm or(~$rec##1:multictr2.t, 2:wybe.int, ?$##0:multictr2.t)
 c03 > public {inline} (17 calls)
 1: multictr2.t.c03<1>
-c03(?f03#0:wybe.int, $#0:multictr2.t, ?$$#0:wybe.bool):
+c03(?f03##0:wybe.int, $##0:multictr2.t, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 2:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 2:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?f03#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?f03##0:wybe.int)
 
     1:
-        foreign lpvm access(~$#0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?f03#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$##0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?f03##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 c04 > public {inline} (0 calls)
 0: multictr2.t.c04<0>
-c04(f04#0:wybe.int, ?$#0:multictr2.t):
+c04(f04##0:wybe.int, ?$##0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr2.t)
-    foreign lpvm mutate(~$rec#0:multictr2.t, ?$rec#1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f04#0:wybe.int)
-    foreign llvm or(~$rec#1:multictr2.t, 3:wybe.int, ?$#0:multictr2.t)
+    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr2.t)
+    foreign lpvm mutate(~$rec##0:multictr2.t, ?$rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f04##0:wybe.int)
+    foreign llvm or(~$rec##1:multictr2.t, 3:wybe.int, ?$##0:multictr2.t)
 c04 > public {inline} (15 calls)
 1: multictr2.t.c04<1>
-c04(?f04#0:wybe.int, $#0:multictr2.t, ?$$#0:wybe.bool):
+c04(?f04##0:wybe.int, $##0:multictr2.t, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 3:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 3:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?f04#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?f04##0:wybe.int)
 
     1:
-        foreign lpvm access(~$#0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?f04#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$##0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?f04##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 c05 > public {inline} (0 calls)
 0: multictr2.t.c05<0>
-c05(f05#0:wybe.int, ?$#0:multictr2.t):
+c05(f05##0:wybe.int, ?$##0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr2.t)
-    foreign lpvm mutate(~$rec#0:multictr2.t, ?$rec#1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f05#0:wybe.int)
-    foreign llvm or(~$rec#1:multictr2.t, 4:wybe.int, ?$#0:multictr2.t)
+    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr2.t)
+    foreign lpvm mutate(~$rec##0:multictr2.t, ?$rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f05##0:wybe.int)
+    foreign llvm or(~$rec##1:multictr2.t, 4:wybe.int, ?$##0:multictr2.t)
 c05 > public {inline} (13 calls)
 1: multictr2.t.c05<1>
-c05(?f05#0:wybe.int, $#0:multictr2.t, ?$$#0:wybe.bool):
+c05(?f05##0:wybe.int, $##0:multictr2.t, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?f05#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?f05##0:wybe.int)
 
     1:
-        foreign lpvm access(~$#0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?f05#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$##0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?f05##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 c06 > public {inline} (0 calls)
 0: multictr2.t.c06<0>
-c06(f06#0:wybe.int, ?$#0:multictr2.t):
+c06(f06##0:wybe.int, ?$##0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr2.t)
-    foreign lpvm mutate(~$rec#0:multictr2.t, ?$rec#1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f06#0:wybe.int)
-    foreign llvm or(~$rec#1:multictr2.t, 5:wybe.int, ?$#0:multictr2.t)
+    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr2.t)
+    foreign lpvm mutate(~$rec##0:multictr2.t, ?$rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f06##0:wybe.int)
+    foreign llvm or(~$rec##1:multictr2.t, 5:wybe.int, ?$##0:multictr2.t)
 c06 > public {inline} (11 calls)
 1: multictr2.t.c06<1>
-c06(?f06#0:wybe.int, $#0:multictr2.t, ?$$#0:wybe.bool):
+c06(?f06##0:wybe.int, $##0:multictr2.t, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 5:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 5:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?f06#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?f06##0:wybe.int)
 
     1:
-        foreign lpvm access(~$#0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?f06#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$##0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?f06##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 c07 > public {inline} (0 calls)
 0: multictr2.t.c07<0>
-c07(f07#0:wybe.int, ?$#0:multictr2.t):
+c07(f07##0:wybe.int, ?$##0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec#0:multictr2.t)
-    foreign lpvm mutate(~$rec#0:multictr2.t, ?$rec#1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f07#0:wybe.int)
-    foreign llvm or(~$rec#1:multictr2.t, 6:wybe.int, ?$#0:multictr2.t)
+    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr2.t)
+    foreign lpvm mutate(~$rec##0:multictr2.t, ?$rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f07##0:wybe.int)
+    foreign llvm or(~$rec##1:multictr2.t, 6:wybe.int, ?$##0:multictr2.t)
 c07 > public {inline} (9 calls)
 1: multictr2.t.c07<1>
-c07(?f07#0:wybe.int, $#0:multictr2.t, ?$$#0:wybe.bool):
+c07(?f07##0:wybe.int, $##0:multictr2.t, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 6:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 6:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?f07#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?f07##0:wybe.int)
 
     1:
-        foreign lpvm access(~$#0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?f07#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$##0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?f07##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 c08 > public {inline} (0 calls)
 0: multictr2.t.c08<0>
-c08(f08_a#0:wybe.int, f08_b#0:wybe.int, f08_c#0:wybe.float, ?$#0:multictr2.t):
+c08(f08_a##0:wybe.int, f08_b##0:wybe.int, f08_c##0:wybe.float, ?$##0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?$rec#0:multictr2.t)
-    foreign lpvm mutate(~$rec#0:multictr2.t, ?$rec#1:multictr2.t, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~f08_a#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:multictr2.t, ?$rec#2:multictr2.t, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~f08_b#0:wybe.int)
-    foreign lpvm mutate(~$rec#2:multictr2.t, ?$rec#3:multictr2.t, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~f08_c#0:wybe.float)
-    foreign llvm or(~$rec#3:multictr2.t, 7:wybe.int, ?$#0:multictr2.t)
+    foreign lpvm alloc(24:wybe.int, ?$rec##0:multictr2.t)
+    foreign lpvm mutate(~$rec##0:multictr2.t, ?$rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~f08_a##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:multictr2.t, ?$rec##2:multictr2.t, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~f08_b##0:wybe.int)
+    foreign lpvm mutate(~$rec##2:multictr2.t, ?$rec##3:multictr2.t, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~f08_c##0:wybe.float)
+    foreign llvm or(~$rec##3:multictr2.t, 7:wybe.int, ?$##0:multictr2.t)
 c08 > public {inline} (9 calls)
 1: multictr2.t.c08<1>
-c08(?f08_a#0:wybe.int, ?f08_b#0:wybe.int, ?f08_c#0:wybe.float, $#0:multictr2.t, ?$$#0:wybe.bool):
+c08(?f08_a##0:wybe.int, ?f08_b##0:wybe.int, ?f08_c##0:wybe.float, $##0:multictr2.t, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 7:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 7:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?f08_a#0:wybe.int)
-        foreign llvm move(undef:wybe.int, ?f08_b#0:wybe.int)
-        foreign llvm move(undef:wybe.float, ?f08_c#0:wybe.float)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?f08_a##0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?f08_b##0:wybe.int)
+        foreign llvm move(undef:wybe.float, ?f08_c##0:wybe.float)
 
     1:
-        foreign lpvm access($#0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?f08_a#0:wybe.int)
-        foreign lpvm access($#0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?f08_b#0:wybe.int)
-        foreign lpvm access(~$#0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?f08_c#0:wybe.float)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access($##0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?f08_a##0:wybe.int)
+        foreign lpvm access($##0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?f08_b##0:wybe.int)
+        foreign lpvm access(~$##0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?f08_c##0:wybe.float)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 f01 > public {inline} (0 calls)
 0: multictr2.t.f01<0>
-f01($rec#0:multictr2.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
+f01($rec##0:multictr2.t, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec#0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 f01 > public {inline} (0 calls)
 1: multictr2.t.f01<1>
-f01($rec#0:multictr2.t, ?$rec#1:multictr2.t, $field#0:wybe.int, ?$$#0:wybe.bool):
+f01($rec##0:multictr2.t, ?$rec##1:multictr2.t, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multictr2.t, ?$rec#1:multictr2.t)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multictr2.t, ?$rec##1:multictr2.t)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec#0:multictr2.t, ?$rec#1:multictr2.t, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm {noalias} mutate(~$rec##0:multictr2.t, ?$rec##1:multictr2.t, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 f02 > public {inline} (0 calls)
 0: multictr2.t.f02<0>
-f02($rec#0:multictr2.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
+f02($rec##0:multictr2.t, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 1:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec#0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 f02 > public {inline} (0 calls)
 1: multictr2.t.f02<1>
-f02($rec#0:multictr2.t, ?$rec#1:multictr2.t, $field#0:wybe.int, ?$$#0:wybe.bool):
+f02($rec##0:multictr2.t, ?$rec##1:multictr2.t, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 1:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multictr2.t, ?$rec#1:multictr2.t)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multictr2.t, ?$rec##1:multictr2.t)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec#0:multictr2.t, ?$rec#1:multictr2.t, -1:wybe.int, 0:wybe.int, 8:wybe.int, 1:wybe.int, ~$field#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm {noalias} mutate(~$rec##0:multictr2.t, ?$rec##1:multictr2.t, -1:wybe.int, 0:wybe.int, 8:wybe.int, 1:wybe.int, ~$field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 f03 > public {inline} (0 calls)
 0: multictr2.t.f03<0>
-f03($rec#0:multictr2.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
+f03($rec##0:multictr2.t, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 2:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 2:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec#0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 f03 > public {inline} (0 calls)
 1: multictr2.t.f03<1>
-f03($rec#0:multictr2.t, ?$rec#1:multictr2.t, $field#0:wybe.int, ?$$#0:wybe.bool):
+f03($rec##0:multictr2.t, ?$rec##1:multictr2.t, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 2:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 2:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multictr2.t, ?$rec#1:multictr2.t)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multictr2.t, ?$rec##1:multictr2.t)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec#0:multictr2.t, ?$rec#1:multictr2.t, -2:wybe.int, 0:wybe.int, 8:wybe.int, 2:wybe.int, ~$field#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm {noalias} mutate(~$rec##0:multictr2.t, ?$rec##1:multictr2.t, -2:wybe.int, 0:wybe.int, 8:wybe.int, 2:wybe.int, ~$field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 f04 > public {inline} (0 calls)
 0: multictr2.t.f04<0>
-f04($rec#0:multictr2.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
+f04($rec##0:multictr2.t, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 3:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 3:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec#0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?$#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 f04 > public {inline} (0 calls)
 1: multictr2.t.f04<1>
-f04($rec#0:multictr2.t, ?$rec#1:multictr2.t, $field#0:wybe.int, ?$$#0:wybe.bool):
+f04($rec##0:multictr2.t, ?$rec##1:multictr2.t, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 3:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 3:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multictr2.t, ?$rec#1:multictr2.t)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multictr2.t, ?$rec##1:multictr2.t)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec#0:multictr2.t, ?$rec#1:multictr2.t, -3:wybe.int, 0:wybe.int, 8:wybe.int, 3:wybe.int, ~$field#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm {noalias} mutate(~$rec##0:multictr2.t, ?$rec##1:multictr2.t, -3:wybe.int, 0:wybe.int, 8:wybe.int, 3:wybe.int, ~$field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 f05 > public {inline} (0 calls)
 0: multictr2.t.f05<0>
-f05($rec#0:multictr2.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
+f05($rec##0:multictr2.t, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec#0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?$#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 f05 > public {inline} (0 calls)
 1: multictr2.t.f05<1>
-f05($rec#0:multictr2.t, ?$rec#1:multictr2.t, $field#0:wybe.int, ?$$#0:wybe.bool):
+f05($rec##0:multictr2.t, ?$rec##1:multictr2.t, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 4:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multictr2.t, ?$rec#1:multictr2.t)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multictr2.t, ?$rec##1:multictr2.t)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec#0:multictr2.t, ?$rec#1:multictr2.t, -4:wybe.int, 0:wybe.int, 8:wybe.int, 4:wybe.int, ~$field#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm {noalias} mutate(~$rec##0:multictr2.t, ?$rec##1:multictr2.t, -4:wybe.int, 0:wybe.int, 8:wybe.int, 4:wybe.int, ~$field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 f06 > public {inline} (0 calls)
 0: multictr2.t.f06<0>
-f06($rec#0:multictr2.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
+f06($rec##0:multictr2.t, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 5:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 5:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec#0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?$#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 f06 > public {inline} (0 calls)
 1: multictr2.t.f06<1>
-f06($rec#0:multictr2.t, ?$rec#1:multictr2.t, $field#0:wybe.int, ?$$#0:wybe.bool):
+f06($rec##0:multictr2.t, ?$rec##1:multictr2.t, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 5:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 5:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multictr2.t, ?$rec#1:multictr2.t)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multictr2.t, ?$rec##1:multictr2.t)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec#0:multictr2.t, ?$rec#1:multictr2.t, -5:wybe.int, 0:wybe.int, 8:wybe.int, 5:wybe.int, ~$field#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm {noalias} mutate(~$rec##0:multictr2.t, ?$rec##1:multictr2.t, -5:wybe.int, 0:wybe.int, 8:wybe.int, 5:wybe.int, ~$field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 f07 > public {inline} (0 calls)
 0: multictr2.t.f07<0>
-f07($rec#0:multictr2.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
+f07($rec##0:multictr2.t, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 6:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 6:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec#0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?$#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 f07 > public {inline} (0 calls)
 1: multictr2.t.f07<1>
-f07($rec#0:multictr2.t, ?$rec#1:multictr2.t, $field#0:wybe.int, ?$$#0:wybe.bool):
+f07($rec##0:multictr2.t, ?$rec##1:multictr2.t, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 6:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 6:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multictr2.t, ?$rec#1:multictr2.t)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multictr2.t, ?$rec##1:multictr2.t)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec#0:multictr2.t, ?$rec#1:multictr2.t, -6:wybe.int, 0:wybe.int, 8:wybe.int, 6:wybe.int, ~$field#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm {noalias} mutate(~$rec##0:multictr2.t, ?$rec##1:multictr2.t, -6:wybe.int, 0:wybe.int, 8:wybe.int, 6:wybe.int, ~$field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 f08_a > public {inline} (0 calls)
 0: multictr2.t.f08_a<0>
-f08_a($rec#0:multictr2.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
+f08_a($rec##0:multictr2.t, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 7:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 7:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec#0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?$#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 f08_a > public {inline} (0 calls)
 1: multictr2.t.f08_a<1>
-f08_a($rec#0:multictr2.t, ?$rec#1:multictr2.t, $field#0:wybe.int, ?$$#0:wybe.bool):
+f08_a($rec##0:multictr2.t, ?$rec##1:multictr2.t, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 7:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 7:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multictr2.t, ?$rec#1:multictr2.t)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multictr2.t, ?$rec##1:multictr2.t)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec#0:multictr2.t, ?$rec#1:multictr2.t, -7:wybe.int, 0:wybe.int, 24:wybe.int, 7:wybe.int, ~$field#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm {noalias} mutate(~$rec##0:multictr2.t, ?$rec##1:multictr2.t, -7:wybe.int, 0:wybe.int, 24:wybe.int, 7:wybe.int, ~$field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 f08_b > public {inline} (0 calls)
 0: multictr2.t.f08_b<0>
-f08_b($rec#0:multictr2.t, ?$#0:wybe.int, ?$$#0:wybe.bool):
+f08_b($rec##0:multictr2.t, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 7:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 7:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec#0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?$#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 f08_b > public {inline} (0 calls)
 1: multictr2.t.f08_b<1>
-f08_b($rec#0:multictr2.t, ?$rec#1:multictr2.t, $field#0:wybe.int, ?$$#0:wybe.bool):
+f08_b($rec##0:multictr2.t, ?$rec##1:multictr2.t, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 7:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 7:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multictr2.t, ?$rec#1:multictr2.t)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multictr2.t, ?$rec##1:multictr2.t)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec#0:multictr2.t, ?$rec#1:multictr2.t, 1:wybe.int, 0:wybe.int, 24:wybe.int, 7:wybe.int, ~$field#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm {noalias} mutate(~$rec##0:multictr2.t, ?$rec##1:multictr2.t, 1:wybe.int, 0:wybe.int, 24:wybe.int, 7:wybe.int, ~$field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 f08_c > public {inline} (0 calls)
 0: multictr2.t.f08_c<0>
-f08_c($rec#0:multictr2.t, ?$#0:wybe.float, ?$$#0:wybe.bool):
+f08_c($rec##0:multictr2.t, ?$##0:wybe.float, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 7:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 7:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.float, ?$#0:wybe.float)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.float, ?$##0:wybe.float)
 
     1:
-        foreign lpvm access(~$rec#0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?$#0:wybe.float)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?$##0:wybe.float)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 f08_c > public {inline} (0 calls)
 1: multictr2.t.f08_c<1>
-f08_c($rec#0:multictr2.t, ?$rec#1:multictr2.t, $field#0:wybe.float, ?$$#0:wybe.bool):
+f08_c($rec##0:multictr2.t, ?$rec##1:multictr2.t, $field##0:wybe.float, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec#0:wybe.int, 7:wybe.int, ?tmp$1#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 7:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 7:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:multictr2.t, ?$rec#1:multictr2.t)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:multictr2.t, ?$rec##1:multictr2.t)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec#0:multictr2.t, ?$rec#1:multictr2.t, 9:wybe.int, 0:wybe.int, 24:wybe.int, 7:wybe.int, ~$field#0:wybe.float)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm {noalias} mutate(~$rec##0:multictr2.t, ?$rec##1:multictr2.t, 9:wybe.int, 0:wybe.int, 24:wybe.int, 7:wybe.int, ~$field##0:wybe.float)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: multictr2.t.~=<0>
-~=($left#0:multictr2.t, $right#0:multictr2.t, ?$$#0:wybe.bool):
+~=($left##0:multictr2.t, $right##0:multictr2.t, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    multictr2.t.=<0>(~$left#0:multictr2.t, ~$right#0:multictr2.t, ?tmp$0#0:wybe.bool) #0
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    multictr2.t.=<0>(~$left##0:multictr2.t, ~$right##0:multictr2.t, ?tmp$0##0:wybe.bool) #0
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
   LLVM code       :
 
@@ -1156,216 +1156,216 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"multictr2.t.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"multictr2.t.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$28#0" = and i64 %"$left#0", 7 
-  %"1$tmp$29#0" = icmp eq i64 %"1$tmp$28#0", 0 
-  br i1 %"1$tmp$29#0", label %if.then, label %if.else 
+  %"1$tmp$28##0" = and i64 %"$left##0", 7 
+  %"1$tmp$29##0" = icmp eq i64 %"1$tmp$28##0", 0 
+  br i1 %"1$tmp$29##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %"2$tmp$31#0" = and i64 %"$right#0", 7 
-  %"2$tmp$32#0" = icmp eq i64 %"2$tmp$31#0", 0 
-  br i1 %"2$tmp$32#0", label %if.then1, label %if.else1 
+  %"2$tmp$31##0" = and i64 %"$right##0", 7 
+  %"2$tmp$32##0" = icmp eq i64 %"2$tmp$31##0", 0 
+  br i1 %"2$tmp$32##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$tmp$32#0" = icmp eq i64 %"1$tmp$28#0", 1 
-  br i1 %"3$tmp$32#0", label %if.then2, label %if.else2 
+  %"3$tmp$32##0" = icmp eq i64 %"1$tmp$28##0", 1 
+  br i1 %"3$tmp$32##0", label %if.then2, label %if.else2 
 if.then1:
-  %4 = inttoptr i64 %"$right#0" to i64* 
+  %4 = inttoptr i64 %"$right##0" to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
   %6 = load  i64, i64* %5 
-  %"4$$$#0" = icmp eq i64 %3, %6 
-  ret i1 %"4$$$#0" 
+  %"4$$$##0" = icmp eq i64 %3, %6 
+  ret i1 %"4$$$##0" 
 if.else1:
   ret i1 0 
 if.then2:
-  %7 = add   i64 %"$left#0", -1 
+  %7 = add   i64 %"$left##0", -1 
   %8 = inttoptr i64 %7 to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %"6$tmp$34#0" = and i64 %"$right#0", 7 
-  %"6$tmp$35#0" = icmp eq i64 %"6$tmp$34#0", 1 
-  br i1 %"6$tmp$35#0", label %if.then3, label %if.else3 
+  %"6$tmp$34##0" = and i64 %"$right##0", 7 
+  %"6$tmp$35##0" = icmp eq i64 %"6$tmp$34##0", 1 
+  br i1 %"6$tmp$35##0", label %if.then3, label %if.else3 
 if.else2:
-  %"7$tmp$35#0" = icmp eq i64 %"1$tmp$28#0", 2 
-  br i1 %"7$tmp$35#0", label %if.then4, label %if.else4 
+  %"7$tmp$35##0" = icmp eq i64 %"1$tmp$28##0", 2 
+  br i1 %"7$tmp$35##0", label %if.then4, label %if.else4 
 if.then3:
-  %11 = add   i64 %"$right#0", -1 
+  %11 = add   i64 %"$right##0", -1 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"8$$$#0" = icmp eq i64 %10, %14 
-  ret i1 %"8$$$#0" 
+  %"8$$$##0" = icmp eq i64 %10, %14 
+  ret i1 %"8$$$##0" 
 if.else3:
   ret i1 0 
 if.then4:
-  %15 = add   i64 %"$left#0", -2 
+  %15 = add   i64 %"$left##0", -2 
   %16 = inttoptr i64 %15 to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
-  %"10$tmp$37#0" = and i64 %"$right#0", 7 
-  %"10$tmp$38#0" = icmp eq i64 %"10$tmp$37#0", 2 
-  br i1 %"10$tmp$38#0", label %if.then5, label %if.else5 
+  %"10$tmp$37##0" = and i64 %"$right##0", 7 
+  %"10$tmp$38##0" = icmp eq i64 %"10$tmp$37##0", 2 
+  br i1 %"10$tmp$38##0", label %if.then5, label %if.else5 
 if.else4:
-  %"11$tmp$38#0" = icmp eq i64 %"1$tmp$28#0", 3 
-  br i1 %"11$tmp$38#0", label %if.then6, label %if.else6 
+  %"11$tmp$38##0" = icmp eq i64 %"1$tmp$28##0", 3 
+  br i1 %"11$tmp$38##0", label %if.then6, label %if.else6 
 if.then5:
-  %19 = add   i64 %"$right#0", -2 
+  %19 = add   i64 %"$right##0", -2 
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %"12$$$#0" = icmp eq i64 %18, %22 
-  ret i1 %"12$$$#0" 
+  %"12$$$##0" = icmp eq i64 %18, %22 
+  ret i1 %"12$$$##0" 
 if.else5:
   ret i1 0 
 if.then6:
-  %23 = add   i64 %"$left#0", -3 
+  %23 = add   i64 %"$left##0", -3 
   %24 = inttoptr i64 %23 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
   %26 = load  i64, i64* %25 
-  %"14$tmp$40#0" = and i64 %"$right#0", 7 
-  %"14$tmp$41#0" = icmp eq i64 %"14$tmp$40#0", 3 
-  br i1 %"14$tmp$41#0", label %if.then7, label %if.else7 
+  %"14$tmp$40##0" = and i64 %"$right##0", 7 
+  %"14$tmp$41##0" = icmp eq i64 %"14$tmp$40##0", 3 
+  br i1 %"14$tmp$41##0", label %if.then7, label %if.else7 
 if.else6:
-  %"15$tmp$41#0" = icmp eq i64 %"1$tmp$28#0", 4 
-  br i1 %"15$tmp$41#0", label %if.then8, label %if.else8 
+  %"15$tmp$41##0" = icmp eq i64 %"1$tmp$28##0", 4 
+  br i1 %"15$tmp$41##0", label %if.then8, label %if.else8 
 if.then7:
-  %27 = add   i64 %"$right#0", -3 
+  %27 = add   i64 %"$right##0", -3 
   %28 = inttoptr i64 %27 to i64* 
   %29 = getelementptr  i64, i64* %28, i64 0 
   %30 = load  i64, i64* %29 
-  %"16$$$#0" = icmp eq i64 %26, %30 
-  ret i1 %"16$$$#0" 
+  %"16$$$##0" = icmp eq i64 %26, %30 
+  ret i1 %"16$$$##0" 
 if.else7:
   ret i1 0 
 if.then8:
-  %31 = add   i64 %"$left#0", -4 
+  %31 = add   i64 %"$left##0", -4 
   %32 = inttoptr i64 %31 to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
-  %"18$tmp$43#0" = and i64 %"$right#0", 7 
-  %"18$tmp$44#0" = icmp eq i64 %"18$tmp$43#0", 4 
-  br i1 %"18$tmp$44#0", label %if.then9, label %if.else9 
+  %"18$tmp$43##0" = and i64 %"$right##0", 7 
+  %"18$tmp$44##0" = icmp eq i64 %"18$tmp$43##0", 4 
+  br i1 %"18$tmp$44##0", label %if.then9, label %if.else9 
 if.else8:
-  %"19$tmp$44#0" = icmp eq i64 %"1$tmp$28#0", 5 
-  br i1 %"19$tmp$44#0", label %if.then10, label %if.else10 
+  %"19$tmp$44##0" = icmp eq i64 %"1$tmp$28##0", 5 
+  br i1 %"19$tmp$44##0", label %if.then10, label %if.else10 
 if.then9:
-  %35 = add   i64 %"$right#0", -4 
+  %35 = add   i64 %"$right##0", -4 
   %36 = inttoptr i64 %35 to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
-  %"20$$$#0" = icmp eq i64 %34, %38 
-  ret i1 %"20$$$#0" 
+  %"20$$$##0" = icmp eq i64 %34, %38 
+  ret i1 %"20$$$##0" 
 if.else9:
   ret i1 0 
 if.then10:
-  %39 = add   i64 %"$left#0", -5 
+  %39 = add   i64 %"$left##0", -5 
   %40 = inttoptr i64 %39 to i64* 
   %41 = getelementptr  i64, i64* %40, i64 0 
   %42 = load  i64, i64* %41 
-  %"22$tmp$46#0" = and i64 %"$right#0", 7 
-  %"22$tmp$47#0" = icmp eq i64 %"22$tmp$46#0", 5 
-  br i1 %"22$tmp$47#0", label %if.then11, label %if.else11 
+  %"22$tmp$46##0" = and i64 %"$right##0", 7 
+  %"22$tmp$47##0" = icmp eq i64 %"22$tmp$46##0", 5 
+  br i1 %"22$tmp$47##0", label %if.then11, label %if.else11 
 if.else10:
-  %"23$tmp$47#0" = icmp eq i64 %"1$tmp$28#0", 6 
-  br i1 %"23$tmp$47#0", label %if.then12, label %if.else12 
+  %"23$tmp$47##0" = icmp eq i64 %"1$tmp$28##0", 6 
+  br i1 %"23$tmp$47##0", label %if.then12, label %if.else12 
 if.then11:
-  %43 = add   i64 %"$right#0", -5 
+  %43 = add   i64 %"$right##0", -5 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
-  %"24$$$#0" = icmp eq i64 %42, %46 
-  ret i1 %"24$$$#0" 
+  %"24$$$##0" = icmp eq i64 %42, %46 
+  ret i1 %"24$$$##0" 
 if.else11:
   ret i1 0 
 if.then12:
-  %47 = add   i64 %"$left#0", -6 
+  %47 = add   i64 %"$left##0", -6 
   %48 = inttoptr i64 %47 to i64* 
   %49 = getelementptr  i64, i64* %48, i64 0 
   %50 = load  i64, i64* %49 
-  %"26$tmp$49#0" = and i64 %"$right#0", 7 
-  %"26$tmp$50#0" = icmp eq i64 %"26$tmp$49#0", 6 
-  br i1 %"26$tmp$50#0", label %if.then13, label %if.else13 
+  %"26$tmp$49##0" = and i64 %"$right##0", 7 
+  %"26$tmp$50##0" = icmp eq i64 %"26$tmp$49##0", 6 
+  br i1 %"26$tmp$50##0", label %if.then13, label %if.else13 
 if.else12:
-  %"27$tmp$50#0" = icmp eq i64 %"1$tmp$28#0", 7 
-  br i1 %"27$tmp$50#0", label %if.then14, label %if.else14 
+  %"27$tmp$50##0" = icmp eq i64 %"1$tmp$28##0", 7 
+  br i1 %"27$tmp$50##0", label %if.then14, label %if.else14 
 if.then13:
-  %51 = add   i64 %"$right#0", -6 
+  %51 = add   i64 %"$right##0", -6 
   %52 = inttoptr i64 %51 to i64* 
   %53 = getelementptr  i64, i64* %52, i64 0 
   %54 = load  i64, i64* %53 
-  %"28$$$#0" = icmp eq i64 %50, %54 
-  ret i1 %"28$$$#0" 
+  %"28$$$##0" = icmp eq i64 %50, %54 
+  ret i1 %"28$$$##0" 
 if.else13:
   ret i1 0 
 if.then14:
-  %55 = add   i64 %"$left#0", -7 
+  %55 = add   i64 %"$left##0", -7 
   %56 = inttoptr i64 %55 to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 1 
+  %59 = add   i64 %"$left##0", 1 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = add   i64 %"$left#0", 9 
+  %63 = add   i64 %"$left##0", 9 
   %64 = inttoptr i64 %63 to double* 
   %65 = getelementptr  double, double* %64, i64 0 
   %66 = load  double, double* %65 
-  %"30$tmp$52#0" = and i64 %"$right#0", 7 
-  %"30$tmp$53#0" = icmp eq i64 %"30$tmp$52#0", 7 
-  br i1 %"30$tmp$53#0", label %if.then15, label %if.else15 
+  %"30$tmp$52##0" = and i64 %"$right##0", 7 
+  %"30$tmp$53##0" = icmp eq i64 %"30$tmp$52##0", 7 
+  br i1 %"30$tmp$53##0", label %if.then15, label %if.else15 
 if.else14:
   ret i1 0 
 if.then15:
-  %67 = add   i64 %"$right#0", -7 
+  %67 = add   i64 %"$right##0", -7 
   %68 = inttoptr i64 %67 to i64* 
   %69 = getelementptr  i64, i64* %68, i64 0 
   %70 = load  i64, i64* %69 
-  %71 = add   i64 %"$right#0", 1 
+  %71 = add   i64 %"$right##0", 1 
   %72 = inttoptr i64 %71 to i64* 
   %73 = getelementptr  i64, i64* %72, i64 0 
   %74 = load  i64, i64* %73 
-  %75 = add   i64 %"$right#0", 9 
+  %75 = add   i64 %"$right##0", 9 
   %76 = inttoptr i64 %75 to double* 
   %77 = getelementptr  double, double* %76, i64 0 
   %78 = load  double, double* %77 
-  %"32$tmp$16#0" = icmp eq i64 %58, %70 
-  br i1 %"32$tmp$16#0", label %if.then16, label %if.else16 
+  %"32$tmp$16##0" = icmp eq i64 %58, %70 
+  br i1 %"32$tmp$16##0", label %if.then16, label %if.else16 
 if.else15:
   ret i1 0 
 if.then16:
-  %"34$tmp$17#0" = icmp eq i64 %62, %74 
-  br i1 %"34$tmp$17#0", label %if.then17, label %if.else17 
+  %"34$tmp$17##0" = icmp eq i64 %62, %74 
+  br i1 %"34$tmp$17##0", label %if.then17, label %if.else17 
 if.else16:
   ret i1 0 
 if.then17:
-  %"36$$$#0" = fcmp oeq double %66, %78 
-  ret i1 %"36$$$#0" 
+  %"36$$$##0" = fcmp oeq double %66, %78 
+  ret i1 %"36$$$##0" 
 if.else17:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"multictr2.t.c01<0>"(i64  %"f01#0")    {
+define external fastcc  i64 @"multictr2.t.c01<0>"(i64  %"f01##0")    {
 entry:
   %79 = trunc i64 8 to i32  
   %80 = tail call ccc  i8*  @wybe_malloc(i32  %79)  
   %81 = ptrtoint i8* %80 to i64 
   %82 = inttoptr i64 %81 to i64* 
   %83 = getelementptr  i64, i64* %82, i64 0 
-  store  i64 %"f01#0", i64* %83 
+  store  i64 %"f01##0", i64* %83 
   ret i64 %81 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.c01<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"multictr2.t.c01<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$#0", 7 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$##0", 7 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %84 = inttoptr i64 %"$#0" to i64* 
+  %84 = inttoptr i64 %"$##0" to i64* 
   %85 = getelementptr  i64, i64* %84, i64 0 
   %86 = load  i64, i64* %85 
   %87 = insertvalue {i64, i1} undef, i64 %86, 0 
@@ -1378,26 +1378,26 @@ if.else:
 }
 
 
-define external fastcc  i64 @"multictr2.t.c02<0>"(i64  %"f02#0")    {
+define external fastcc  i64 @"multictr2.t.c02<0>"(i64  %"f02##0")    {
 entry:
   %91 = trunc i64 8 to i32  
   %92 = tail call ccc  i8*  @wybe_malloc(i32  %91)  
   %93 = ptrtoint i8* %92 to i64 
   %94 = inttoptr i64 %93 to i64* 
   %95 = getelementptr  i64, i64* %94, i64 0 
-  store  i64 %"f02#0", i64* %95 
-  %"1$$#0" = or i64 %93, 1 
-  ret i64 %"1$$#0" 
+  store  i64 %"f02##0", i64* %95 
+  %"1$$##0" = or i64 %93, 1 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.c02<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"multictr2.t.c02<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$#0", 7 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 1 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$##0", 7 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 1 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %96 = add   i64 %"$#0", -1 
+  %96 = add   i64 %"$##0", -1 
   %97 = inttoptr i64 %96 to i64* 
   %98 = getelementptr  i64, i64* %97, i64 0 
   %99 = load  i64, i64* %98 
@@ -1411,26 +1411,26 @@ if.else:
 }
 
 
-define external fastcc  i64 @"multictr2.t.c03<0>"(i64  %"f03#0")    {
+define external fastcc  i64 @"multictr2.t.c03<0>"(i64  %"f03##0")    {
 entry:
   %104 = trunc i64 8 to i32  
   %105 = tail call ccc  i8*  @wybe_malloc(i32  %104)  
   %106 = ptrtoint i8* %105 to i64 
   %107 = inttoptr i64 %106 to i64* 
   %108 = getelementptr  i64, i64* %107, i64 0 
-  store  i64 %"f03#0", i64* %108 
-  %"1$$#0" = or i64 %106, 2 
-  ret i64 %"1$$#0" 
+  store  i64 %"f03##0", i64* %108 
+  %"1$$##0" = or i64 %106, 2 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.c03<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"multictr2.t.c03<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$#0", 7 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 2 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$##0", 7 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 2 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %109 = add   i64 %"$#0", -2 
+  %109 = add   i64 %"$##0", -2 
   %110 = inttoptr i64 %109 to i64* 
   %111 = getelementptr  i64, i64* %110, i64 0 
   %112 = load  i64, i64* %111 
@@ -1444,26 +1444,26 @@ if.else:
 }
 
 
-define external fastcc  i64 @"multictr2.t.c04<0>"(i64  %"f04#0")    {
+define external fastcc  i64 @"multictr2.t.c04<0>"(i64  %"f04##0")    {
 entry:
   %117 = trunc i64 8 to i32  
   %118 = tail call ccc  i8*  @wybe_malloc(i32  %117)  
   %119 = ptrtoint i8* %118 to i64 
   %120 = inttoptr i64 %119 to i64* 
   %121 = getelementptr  i64, i64* %120, i64 0 
-  store  i64 %"f04#0", i64* %121 
-  %"1$$#0" = or i64 %119, 3 
-  ret i64 %"1$$#0" 
+  store  i64 %"f04##0", i64* %121 
+  %"1$$##0" = or i64 %119, 3 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.c04<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"multictr2.t.c04<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$#0", 7 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 3 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$##0", 7 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 3 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %122 = add   i64 %"$#0", -3 
+  %122 = add   i64 %"$##0", -3 
   %123 = inttoptr i64 %122 to i64* 
   %124 = getelementptr  i64, i64* %123, i64 0 
   %125 = load  i64, i64* %124 
@@ -1477,26 +1477,26 @@ if.else:
 }
 
 
-define external fastcc  i64 @"multictr2.t.c05<0>"(i64  %"f05#0")    {
+define external fastcc  i64 @"multictr2.t.c05<0>"(i64  %"f05##0")    {
 entry:
   %130 = trunc i64 8 to i32  
   %131 = tail call ccc  i8*  @wybe_malloc(i32  %130)  
   %132 = ptrtoint i8* %131 to i64 
   %133 = inttoptr i64 %132 to i64* 
   %134 = getelementptr  i64, i64* %133, i64 0 
-  store  i64 %"f05#0", i64* %134 
-  %"1$$#0" = or i64 %132, 4 
-  ret i64 %"1$$#0" 
+  store  i64 %"f05##0", i64* %134 
+  %"1$$##0" = or i64 %132, 4 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.c05<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"multictr2.t.c05<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$#0", 7 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$##0", 7 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %135 = add   i64 %"$#0", -4 
+  %135 = add   i64 %"$##0", -4 
   %136 = inttoptr i64 %135 to i64* 
   %137 = getelementptr  i64, i64* %136, i64 0 
   %138 = load  i64, i64* %137 
@@ -1510,26 +1510,26 @@ if.else:
 }
 
 
-define external fastcc  i64 @"multictr2.t.c06<0>"(i64  %"f06#0")    {
+define external fastcc  i64 @"multictr2.t.c06<0>"(i64  %"f06##0")    {
 entry:
   %143 = trunc i64 8 to i32  
   %144 = tail call ccc  i8*  @wybe_malloc(i32  %143)  
   %145 = ptrtoint i8* %144 to i64 
   %146 = inttoptr i64 %145 to i64* 
   %147 = getelementptr  i64, i64* %146, i64 0 
-  store  i64 %"f06#0", i64* %147 
-  %"1$$#0" = or i64 %145, 5 
-  ret i64 %"1$$#0" 
+  store  i64 %"f06##0", i64* %147 
+  %"1$$##0" = or i64 %145, 5 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.c06<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"multictr2.t.c06<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$#0", 7 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 5 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$##0", 7 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 5 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %148 = add   i64 %"$#0", -5 
+  %148 = add   i64 %"$##0", -5 
   %149 = inttoptr i64 %148 to i64* 
   %150 = getelementptr  i64, i64* %149, i64 0 
   %151 = load  i64, i64* %150 
@@ -1543,26 +1543,26 @@ if.else:
 }
 
 
-define external fastcc  i64 @"multictr2.t.c07<0>"(i64  %"f07#0")    {
+define external fastcc  i64 @"multictr2.t.c07<0>"(i64  %"f07##0")    {
 entry:
   %156 = trunc i64 8 to i32  
   %157 = tail call ccc  i8*  @wybe_malloc(i32  %156)  
   %158 = ptrtoint i8* %157 to i64 
   %159 = inttoptr i64 %158 to i64* 
   %160 = getelementptr  i64, i64* %159, i64 0 
-  store  i64 %"f07#0", i64* %160 
-  %"1$$#0" = or i64 %158, 6 
-  ret i64 %"1$$#0" 
+  store  i64 %"f07##0", i64* %160 
+  %"1$$##0" = or i64 %158, 6 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.c07<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i1} @"multictr2.t.c07<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$#0", 7 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 6 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$##0", 7 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 6 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %161 = add   i64 %"$#0", -6 
+  %161 = add   i64 %"$##0", -6 
   %162 = inttoptr i64 %161 to i64* 
   %163 = getelementptr  i64, i64* %162, i64 0 
   %164 = load  i64, i64* %163 
@@ -1576,42 +1576,42 @@ if.else:
 }
 
 
-define external fastcc  i64 @"multictr2.t.c08<0>"(i64  %"f08_a#0", i64  %"f08_b#0", double  %"f08_c#0")    {
+define external fastcc  i64 @"multictr2.t.c08<0>"(i64  %"f08_a##0", i64  %"f08_b##0", double  %"f08_c##0")    {
 entry:
   %169 = trunc i64 24 to i32  
   %170 = tail call ccc  i8*  @wybe_malloc(i32  %169)  
   %171 = ptrtoint i8* %170 to i64 
   %172 = inttoptr i64 %171 to i64* 
   %173 = getelementptr  i64, i64* %172, i64 0 
-  store  i64 %"f08_a#0", i64* %173 
+  store  i64 %"f08_a##0", i64* %173 
   %174 = add   i64 %171, 8 
   %175 = inttoptr i64 %174 to i64* 
   %176 = getelementptr  i64, i64* %175, i64 0 
-  store  i64 %"f08_b#0", i64* %176 
+  store  i64 %"f08_b##0", i64* %176 
   %177 = add   i64 %171, 16 
   %178 = inttoptr i64 %177 to double* 
   %179 = getelementptr  double, double* %178, i64 0 
-  store  double %"f08_c#0", double* %179 
-  %"1$$#0" = or i64 %171, 7 
-  ret i64 %"1$$#0" 
+  store  double %"f08_c##0", double* %179 
+  %"1$$##0" = or i64 %171, 7 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  {i64, i64, double, i1} @"multictr2.t.c08<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64, double, i1} @"multictr2.t.c08<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$#0", 7 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 7 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$##0", 7 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 7 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %180 = add   i64 %"$#0", -7 
+  %180 = add   i64 %"$##0", -7 
   %181 = inttoptr i64 %180 to i64* 
   %182 = getelementptr  i64, i64* %181, i64 0 
   %183 = load  i64, i64* %182 
-  %184 = add   i64 %"$#0", 1 
+  %184 = add   i64 %"$##0", 1 
   %185 = inttoptr i64 %184 to i64* 
   %186 = getelementptr  i64, i64* %185, i64 0 
   %187 = load  i64, i64* %186 
-  %188 = add   i64 %"$#0", 9 
+  %188 = add   i64 %"$##0", 9 
   %189 = inttoptr i64 %188 to double* 
   %190 = getelementptr  double, double* %189, i64 0 
   %191 = load  double, double* %190 
@@ -1629,13 +1629,13 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f01<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f01<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$rec#0", 7 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %200 = inttoptr i64 %"$rec#0" to i64* 
+  %200 = inttoptr i64 %"$rec##0" to i64* 
   %201 = getelementptr  i64, i64* %200, i64 0 
   %202 = load  i64, i64* %201 
   %203 = insertvalue {i64, i1} undef, i64 %202, 0 
@@ -1648,39 +1648,39 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f01<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f01<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$rec#0", 7 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %207 = trunc i64 8 to i32  
   %208 = tail call ccc  i8*  @wybe_malloc(i32  %207)  
   %209 = ptrtoint i8* %208 to i64 
   %210 = inttoptr i64 %209 to i8* 
-  %211 = inttoptr i64 %"$rec#0" to i8* 
+  %211 = inttoptr i64 %"$rec##0" to i8* 
   %212 = trunc i64 8 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %210, i8*  %211, i32  %212, i32  8, i1  0)  
   %213 = inttoptr i64 %209 to i64* 
   %214 = getelementptr  i64, i64* %213, i64 0 
-  store  i64 %"$field#0", i64* %214 
+  store  i64 %"$field##0", i64* %214 
   %215 = insertvalue {i64, i1} undef, i64 %209, 0 
   %216 = insertvalue {i64, i1} %215, i1 1, 1 
   ret {i64, i1} %216 
 if.else:
-  %217 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %217 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %218 = insertvalue {i64, i1} %217, i1 0, 1 
   ret {i64, i1} %218 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f02<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f02<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$rec#0", 7 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 1 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 1 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %219 = add   i64 %"$rec#0", -1 
+  %219 = add   i64 %"$rec##0", -1 
   %220 = inttoptr i64 %219 to i64* 
   %221 = getelementptr  i64, i64* %220, i64 0 
   %222 = load  i64, i64* %221 
@@ -1694,17 +1694,17 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f02<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f02<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$rec#0", 7 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 1 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 1 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %227 = trunc i64 8 to i32  
   %228 = tail call ccc  i8*  @wybe_malloc(i32  %227)  
   %229 = ptrtoint i8* %228 to i64 
   %230 = add   i64 %229, 1 
-  %231 = sub   i64 %"$rec#0", 1 
+  %231 = sub   i64 %"$rec##0", 1 
   %232 = inttoptr i64 %229 to i8* 
   %233 = inttoptr i64 %231 to i8* 
   %234 = trunc i64 8 to i32  
@@ -1712,24 +1712,24 @@ if.then:
   %235 = add   i64 %230, -1 
   %236 = inttoptr i64 %235 to i64* 
   %237 = getelementptr  i64, i64* %236, i64 0 
-  store  i64 %"$field#0", i64* %237 
+  store  i64 %"$field##0", i64* %237 
   %238 = insertvalue {i64, i1} undef, i64 %230, 0 
   %239 = insertvalue {i64, i1} %238, i1 1, 1 
   ret {i64, i1} %239 
 if.else:
-  %240 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %240 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %241 = insertvalue {i64, i1} %240, i1 0, 1 
   ret {i64, i1} %241 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f03<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f03<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$rec#0", 7 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 2 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 2 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %242 = add   i64 %"$rec#0", -2 
+  %242 = add   i64 %"$rec##0", -2 
   %243 = inttoptr i64 %242 to i64* 
   %244 = getelementptr  i64, i64* %243, i64 0 
   %245 = load  i64, i64* %244 
@@ -1743,17 +1743,17 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f03<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f03<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$rec#0", 7 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 2 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 2 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %250 = trunc i64 8 to i32  
   %251 = tail call ccc  i8*  @wybe_malloc(i32  %250)  
   %252 = ptrtoint i8* %251 to i64 
   %253 = add   i64 %252, 2 
-  %254 = sub   i64 %"$rec#0", 2 
+  %254 = sub   i64 %"$rec##0", 2 
   %255 = inttoptr i64 %252 to i8* 
   %256 = inttoptr i64 %254 to i8* 
   %257 = trunc i64 8 to i32  
@@ -1761,24 +1761,24 @@ if.then:
   %258 = add   i64 %253, -2 
   %259 = inttoptr i64 %258 to i64* 
   %260 = getelementptr  i64, i64* %259, i64 0 
-  store  i64 %"$field#0", i64* %260 
+  store  i64 %"$field##0", i64* %260 
   %261 = insertvalue {i64, i1} undef, i64 %253, 0 
   %262 = insertvalue {i64, i1} %261, i1 1, 1 
   ret {i64, i1} %262 
 if.else:
-  %263 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %263 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %264 = insertvalue {i64, i1} %263, i1 0, 1 
   ret {i64, i1} %264 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f04<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f04<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$rec#0", 7 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 3 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 3 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %265 = add   i64 %"$rec#0", -3 
+  %265 = add   i64 %"$rec##0", -3 
   %266 = inttoptr i64 %265 to i64* 
   %267 = getelementptr  i64, i64* %266, i64 0 
   %268 = load  i64, i64* %267 
@@ -1792,17 +1792,17 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f04<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f04<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$rec#0", 7 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 3 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 3 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %273 = trunc i64 8 to i32  
   %274 = tail call ccc  i8*  @wybe_malloc(i32  %273)  
   %275 = ptrtoint i8* %274 to i64 
   %276 = add   i64 %275, 3 
-  %277 = sub   i64 %"$rec#0", 3 
+  %277 = sub   i64 %"$rec##0", 3 
   %278 = inttoptr i64 %275 to i8* 
   %279 = inttoptr i64 %277 to i8* 
   %280 = trunc i64 8 to i32  
@@ -1810,24 +1810,24 @@ if.then:
   %281 = add   i64 %276, -3 
   %282 = inttoptr i64 %281 to i64* 
   %283 = getelementptr  i64, i64* %282, i64 0 
-  store  i64 %"$field#0", i64* %283 
+  store  i64 %"$field##0", i64* %283 
   %284 = insertvalue {i64, i1} undef, i64 %276, 0 
   %285 = insertvalue {i64, i1} %284, i1 1, 1 
   ret {i64, i1} %285 
 if.else:
-  %286 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %286 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %287 = insertvalue {i64, i1} %286, i1 0, 1 
   ret {i64, i1} %287 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f05<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f05<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$rec#0", 7 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %288 = add   i64 %"$rec#0", -4 
+  %288 = add   i64 %"$rec##0", -4 
   %289 = inttoptr i64 %288 to i64* 
   %290 = getelementptr  i64, i64* %289, i64 0 
   %291 = load  i64, i64* %290 
@@ -1841,17 +1841,17 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f05<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f05<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$rec#0", 7 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 4 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 4 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %296 = trunc i64 8 to i32  
   %297 = tail call ccc  i8*  @wybe_malloc(i32  %296)  
   %298 = ptrtoint i8* %297 to i64 
   %299 = add   i64 %298, 4 
-  %300 = sub   i64 %"$rec#0", 4 
+  %300 = sub   i64 %"$rec##0", 4 
   %301 = inttoptr i64 %298 to i8* 
   %302 = inttoptr i64 %300 to i8* 
   %303 = trunc i64 8 to i32  
@@ -1859,24 +1859,24 @@ if.then:
   %304 = add   i64 %299, -4 
   %305 = inttoptr i64 %304 to i64* 
   %306 = getelementptr  i64, i64* %305, i64 0 
-  store  i64 %"$field#0", i64* %306 
+  store  i64 %"$field##0", i64* %306 
   %307 = insertvalue {i64, i1} undef, i64 %299, 0 
   %308 = insertvalue {i64, i1} %307, i1 1, 1 
   ret {i64, i1} %308 
 if.else:
-  %309 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %309 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %310 = insertvalue {i64, i1} %309, i1 0, 1 
   ret {i64, i1} %310 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f06<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f06<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$rec#0", 7 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 5 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 5 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %311 = add   i64 %"$rec#0", -5 
+  %311 = add   i64 %"$rec##0", -5 
   %312 = inttoptr i64 %311 to i64* 
   %313 = getelementptr  i64, i64* %312, i64 0 
   %314 = load  i64, i64* %313 
@@ -1890,17 +1890,17 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f06<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f06<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$rec#0", 7 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 5 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 5 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %319 = trunc i64 8 to i32  
   %320 = tail call ccc  i8*  @wybe_malloc(i32  %319)  
   %321 = ptrtoint i8* %320 to i64 
   %322 = add   i64 %321, 5 
-  %323 = sub   i64 %"$rec#0", 5 
+  %323 = sub   i64 %"$rec##0", 5 
   %324 = inttoptr i64 %321 to i8* 
   %325 = inttoptr i64 %323 to i8* 
   %326 = trunc i64 8 to i32  
@@ -1908,24 +1908,24 @@ if.then:
   %327 = add   i64 %322, -5 
   %328 = inttoptr i64 %327 to i64* 
   %329 = getelementptr  i64, i64* %328, i64 0 
-  store  i64 %"$field#0", i64* %329 
+  store  i64 %"$field##0", i64* %329 
   %330 = insertvalue {i64, i1} undef, i64 %322, 0 
   %331 = insertvalue {i64, i1} %330, i1 1, 1 
   ret {i64, i1} %331 
 if.else:
-  %332 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %332 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %333 = insertvalue {i64, i1} %332, i1 0, 1 
   ret {i64, i1} %333 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f07<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f07<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$rec#0", 7 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 6 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 6 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %334 = add   i64 %"$rec#0", -6 
+  %334 = add   i64 %"$rec##0", -6 
   %335 = inttoptr i64 %334 to i64* 
   %336 = getelementptr  i64, i64* %335, i64 0 
   %337 = load  i64, i64* %336 
@@ -1939,17 +1939,17 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f07<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f07<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$rec#0", 7 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 6 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 6 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %342 = trunc i64 8 to i32  
   %343 = tail call ccc  i8*  @wybe_malloc(i32  %342)  
   %344 = ptrtoint i8* %343 to i64 
   %345 = add   i64 %344, 6 
-  %346 = sub   i64 %"$rec#0", 6 
+  %346 = sub   i64 %"$rec##0", 6 
   %347 = inttoptr i64 %344 to i8* 
   %348 = inttoptr i64 %346 to i8* 
   %349 = trunc i64 8 to i32  
@@ -1957,24 +1957,24 @@ if.then:
   %350 = add   i64 %345, -6 
   %351 = inttoptr i64 %350 to i64* 
   %352 = getelementptr  i64, i64* %351, i64 0 
-  store  i64 %"$field#0", i64* %352 
+  store  i64 %"$field##0", i64* %352 
   %353 = insertvalue {i64, i1} undef, i64 %345, 0 
   %354 = insertvalue {i64, i1} %353, i1 1, 1 
   ret {i64, i1} %354 
 if.else:
-  %355 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %355 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %356 = insertvalue {i64, i1} %355, i1 0, 1 
   ret {i64, i1} %356 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f08_a<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f08_a<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$rec#0", 7 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 7 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 7 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %357 = add   i64 %"$rec#0", -7 
+  %357 = add   i64 %"$rec##0", -7 
   %358 = inttoptr i64 %357 to i64* 
   %359 = getelementptr  i64, i64* %358, i64 0 
   %360 = load  i64, i64* %359 
@@ -1988,17 +1988,17 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f08_a<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f08_a<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$rec#0", 7 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 7 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 7 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %365 = trunc i64 24 to i32  
   %366 = tail call ccc  i8*  @wybe_malloc(i32  %365)  
   %367 = ptrtoint i8* %366 to i64 
   %368 = add   i64 %367, 7 
-  %369 = sub   i64 %"$rec#0", 7 
+  %369 = sub   i64 %"$rec##0", 7 
   %370 = inttoptr i64 %367 to i8* 
   %371 = inttoptr i64 %369 to i8* 
   %372 = trunc i64 24 to i32  
@@ -2006,24 +2006,24 @@ if.then:
   %373 = add   i64 %368, -7 
   %374 = inttoptr i64 %373 to i64* 
   %375 = getelementptr  i64, i64* %374, i64 0 
-  store  i64 %"$field#0", i64* %375 
+  store  i64 %"$field##0", i64* %375 
   %376 = insertvalue {i64, i1} undef, i64 %368, 0 
   %377 = insertvalue {i64, i1} %376, i1 1, 1 
   ret {i64, i1} %377 
 if.else:
-  %378 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %378 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %379 = insertvalue {i64, i1} %378, i1 0, 1 
   ret {i64, i1} %379 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f08_b<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f08_b<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$rec#0", 7 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 7 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 7 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %380 = add   i64 %"$rec#0", 1 
+  %380 = add   i64 %"$rec##0", 1 
   %381 = inttoptr i64 %380 to i64* 
   %382 = getelementptr  i64, i64* %381, i64 0 
   %383 = load  i64, i64* %382 
@@ -2037,17 +2037,17 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f08_b<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f08_b<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$rec#0", 7 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 7 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 7 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %388 = trunc i64 24 to i32  
   %389 = tail call ccc  i8*  @wybe_malloc(i32  %388)  
   %390 = ptrtoint i8* %389 to i64 
   %391 = add   i64 %390, 7 
-  %392 = sub   i64 %"$rec#0", 7 
+  %392 = sub   i64 %"$rec##0", 7 
   %393 = inttoptr i64 %390 to i8* 
   %394 = inttoptr i64 %392 to i8* 
   %395 = trunc i64 24 to i32  
@@ -2055,24 +2055,24 @@ if.then:
   %396 = add   i64 %391, 1 
   %397 = inttoptr i64 %396 to i64* 
   %398 = getelementptr  i64, i64* %397, i64 0 
-  store  i64 %"$field#0", i64* %398 
+  store  i64 %"$field##0", i64* %398 
   %399 = insertvalue {i64, i1} undef, i64 %391, 0 
   %400 = insertvalue {i64, i1} %399, i1 1, 1 
   ret {i64, i1} %400 
 if.else:
-  %401 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %401 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %402 = insertvalue {i64, i1} %401, i1 0, 1 
   ret {i64, i1} %402 
 }
 
 
-define external fastcc  {double, i1} @"multictr2.t.f08_c<0>"(i64  %"$rec#0")    {
+define external fastcc  {double, i1} @"multictr2.t.f08_c<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$rec#0", 7 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 7 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 7 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %403 = add   i64 %"$rec#0", 9 
+  %403 = add   i64 %"$rec##0", 9 
   %404 = inttoptr i64 %403 to double* 
   %405 = getelementptr  double, double* %404, i64 0 
   %406 = load  double, double* %405 
@@ -2086,17 +2086,17 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f08_c<1>"(i64  %"$rec#0", double  %"$field#0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f08_c<1>"(i64  %"$rec##0", double  %"$field##0")    {
 entry:
-  %"1$tmp$1#0" = and i64 %"$rec#0", 7 
-  %"1$tmp$0#0" = icmp eq i64 %"1$tmp$1#0", 7 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
+  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 7 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %411 = trunc i64 24 to i32  
   %412 = tail call ccc  i8*  @wybe_malloc(i32  %411)  
   %413 = ptrtoint i8* %412 to i64 
   %414 = add   i64 %413, 7 
-  %415 = sub   i64 %"$rec#0", 7 
+  %415 = sub   i64 %"$rec##0", 7 
   %416 = inttoptr i64 %413 to i8* 
   %417 = inttoptr i64 %415 to i8* 
   %418 = trunc i64 24 to i32  
@@ -2104,20 +2104,20 @@ if.then:
   %419 = add   i64 %414, 9 
   %420 = inttoptr i64 %419 to double* 
   %421 = getelementptr  double, double* %420, i64 0 
-  store  double %"$field#0", double* %421 
+  store  double %"$field##0", double* %421 
   %422 = insertvalue {i64, i1} undef, i64 %414, 0 
   %423 = insertvalue {i64, i1} %422, i1 1, 1 
   ret {i64, i1} %423 
 if.else:
-  %424 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %424 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %425 = insertvalue {i64, i1} %424, i1 0, 1 
   ret {i64, i1} %425 
 }
 
 
-define external fastcc  i1 @"multictr2.t.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"multictr2.t.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = tail call fastcc  i1  @"multictr2.t.=<0>"(i64  %"$left#0", i64  %"$right#0")  
-  %"1$$$#0" = xor i1 %"1$tmp$0#0", 1 
-  ret i1 %"1$$$#0" 
+  %"1$tmp$0##0" = tail call fastcc  i1  @"multictr2.t.=<0>"(i64  %"$left##0", i64  %"$right##0")  
+  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
+  ret i1 %"1$$$##0" 
 }

--- a/test-cases/final-dump/multictr2.exp
+++ b/test-cases/final-dump/multictr2.exp
@@ -54,30 +54,30 @@ print_t > public (0 calls)
 print_t(x##0:multictr2.t, io##0:wybe.phantom, ?io##8:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and(x##0:wybe.int, 7:wybe.int, ?tmp$9##0:wybe.int)
-    foreign llvm icmp_eq(tmp$9##0:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.bool)
-    case ~tmp$10##0:wybe.bool of
+    foreign llvm and(x##0:wybe.int, 7:wybe.int, ?tmp#9##0:wybe.int)
+    foreign llvm icmp_eq(tmp#9##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
+    case ~tmp#10##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(tmp$9##0:wybe.int, 1:wybe.int, ?tmp$13##0:wybe.bool)
-        case ~tmp$13##0:wybe.bool of
+        foreign llvm icmp_eq(tmp#9##0:wybe.int, 1:wybe.int, ?tmp#13##0:wybe.bool)
+        case ~tmp#13##0:wybe.bool of
         0:
-            foreign llvm icmp_eq(tmp$9##0:wybe.int, 2:wybe.int, ?tmp$16##0:wybe.bool)
-            case ~tmp$16##0:wybe.bool of
+            foreign llvm icmp_eq(tmp#9##0:wybe.int, 2:wybe.int, ?tmp#16##0:wybe.bool)
+            case ~tmp#16##0:wybe.bool of
             0:
-                foreign llvm icmp_eq(tmp$9##0:wybe.int, 3:wybe.int, ?tmp$19##0:wybe.bool)
-                case ~tmp$19##0:wybe.bool of
+                foreign llvm icmp_eq(tmp#9##0:wybe.int, 3:wybe.int, ?tmp#19##0:wybe.bool)
+                case ~tmp#19##0:wybe.bool of
                 0:
-                    foreign llvm icmp_eq(tmp$9##0:wybe.int, 4:wybe.int, ?tmp$22##0:wybe.bool)
-                    case ~tmp$22##0:wybe.bool of
+                    foreign llvm icmp_eq(tmp#9##0:wybe.int, 4:wybe.int, ?tmp#22##0:wybe.bool)
+                    case ~tmp#22##0:wybe.bool of
                     0:
-                        foreign llvm icmp_eq(tmp$9##0:wybe.int, 5:wybe.int, ?tmp$25##0:wybe.bool)
-                        case ~tmp$25##0:wybe.bool of
+                        foreign llvm icmp_eq(tmp#9##0:wybe.int, 5:wybe.int, ?tmp#25##0:wybe.bool)
+                        case ~tmp#25##0:wybe.bool of
                         0:
-                            foreign llvm icmp_eq(tmp$9##0:wybe.int, 6:wybe.int, ?tmp$28##0:wybe.bool)
-                            case ~tmp$28##0:wybe.bool of
+                            foreign llvm icmp_eq(tmp#9##0:wybe.int, 6:wybe.int, ?tmp#28##0:wybe.bool)
+                            case ~tmp#28##0:wybe.bool of
                             0:
-                                foreign llvm icmp_eq(~tmp$9##0:wybe.int, 7:wybe.int, ?tmp$31##0:wybe.bool)
-                                case ~tmp$31##0:wybe.bool of
+                                foreign llvm icmp_eq(~tmp#9##0:wybe.int, 7:wybe.int, ?tmp#31##0:wybe.bool)
+                                case ~tmp#31##0:wybe.bool of
                                 0:
                                     foreign c putchar('\n':wybe.char, ~#io##0:wybe.phantom, ?#io##8:wybe.phantom) @io:nn:nn
 
@@ -233,9 +233,9 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"multictr2.print_t<0>"(i64  %"x##0")    {
 entry:
-  %"1$tmp$9##0" = and i64 %"x##0", 7 
-  %"1$tmp$10##0" = icmp eq i64 %"1$tmp$9##0", 0 
-  br i1 %"1$tmp$10##0", label %if.then, label %if.else 
+  %"1#tmp#9##0" = and i64 %"x##0", 7 
+  %"1#tmp#10##0" = icmp eq i64 %"1#tmp#9##0", 0 
+  br i1 %"1#tmp#10##0", label %if.then, label %if.else 
 if.then:
   %1 = inttoptr i64 %"x##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
@@ -248,8 +248,8 @@ if.then:
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else:
-  %"3$tmp$13##0" = icmp eq i64 %"1$tmp$9##0", 1 
-  br i1 %"3$tmp$13##0", label %if.then1, label %if.else1 
+  %"3#tmp#13##0" = icmp eq i64 %"1#tmp#9##0", 1 
+  br i1 %"3#tmp#13##0", label %if.then1, label %if.else1 
 if.then1:
   %8 = add   i64 %"x##0", -1 
   %9 = inttoptr i64 %8 to i64* 
@@ -263,8 +263,8 @@ if.then1:
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else1:
-  %"5$tmp$16##0" = icmp eq i64 %"1$tmp$9##0", 2 
-  br i1 %"5$tmp$16##0", label %if.then2, label %if.else2 
+  %"5#tmp#16##0" = icmp eq i64 %"1#tmp#9##0", 2 
+  br i1 %"5#tmp#16##0", label %if.then2, label %if.else2 
 if.then2:
   %16 = add   i64 %"x##0", -2 
   %17 = inttoptr i64 %16 to i64* 
@@ -278,8 +278,8 @@ if.then2:
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else2:
-  %"7$tmp$19##0" = icmp eq i64 %"1$tmp$9##0", 3 
-  br i1 %"7$tmp$19##0", label %if.then3, label %if.else3 
+  %"7#tmp#19##0" = icmp eq i64 %"1#tmp#9##0", 3 
+  br i1 %"7#tmp#19##0", label %if.then3, label %if.else3 
 if.then3:
   %24 = add   i64 %"x##0", -3 
   %25 = inttoptr i64 %24 to i64* 
@@ -293,8 +293,8 @@ if.then3:
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else3:
-  %"9$tmp$22##0" = icmp eq i64 %"1$tmp$9##0", 4 
-  br i1 %"9$tmp$22##0", label %if.then4, label %if.else4 
+  %"9#tmp#22##0" = icmp eq i64 %"1#tmp#9##0", 4 
+  br i1 %"9#tmp#22##0", label %if.then4, label %if.else4 
 if.then4:
   %32 = add   i64 %"x##0", -4 
   %33 = inttoptr i64 %32 to i64* 
@@ -308,8 +308,8 @@ if.then4:
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else4:
-  %"11$tmp$25##0" = icmp eq i64 %"1$tmp$9##0", 5 
-  br i1 %"11$tmp$25##0", label %if.then5, label %if.else5 
+  %"11#tmp#25##0" = icmp eq i64 %"1#tmp#9##0", 5 
+  br i1 %"11#tmp#25##0", label %if.then5, label %if.else5 
 if.then5:
   %40 = add   i64 %"x##0", -5 
   %41 = inttoptr i64 %40 to i64* 
@@ -323,8 +323,8 @@ if.then5:
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else5:
-  %"13$tmp$28##0" = icmp eq i64 %"1$tmp$9##0", 6 
-  br i1 %"13$tmp$28##0", label %if.then6, label %if.else6 
+  %"13#tmp#28##0" = icmp eq i64 %"1#tmp#9##0", 6 
+  br i1 %"13#tmp#28##0", label %if.then6, label %if.else6 
 if.then6:
   %48 = add   i64 %"x##0", -6 
   %49 = inttoptr i64 %48 to i64* 
@@ -338,8 +338,8 @@ if.then6:
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else6:
-  %"15$tmp$31##0" = icmp eq i64 %"1$tmp$9##0", 7 
-  br i1 %"15$tmp$31##0", label %if.then7, label %if.else7 
+  %"15#tmp#31##0" = icmp eq i64 %"1#tmp#9##0", 7 
+  br i1 %"15#tmp#31##0", label %if.then7, label %if.else7 
 if.then7:
   %56 = add   i64 %"x##0", -7 
   %57 = inttoptr i64 %56 to i64* 
@@ -420,727 +420,727 @@ if.else7:
 
 = > public (1 calls)
 0: multictr2.t.=<0>
-=($left##0:multictr2.t, $right##0:multictr2.t, ?$$##0:wybe.bool):
+=(#left##0:multictr2.t, #right##0:multictr2.t, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($left##0:wybe.int, 7:wybe.int, ?tmp$28##0:wybe.int)
-    foreign llvm icmp_eq(tmp$28##0:wybe.int, 0:wybe.int, ?tmp$29##0:wybe.bool)
-    case ~tmp$29##0:wybe.bool of
+    foreign llvm and(#left##0:wybe.int, 7:wybe.int, ?tmp#28##0:wybe.int)
+    foreign llvm icmp_eq(tmp#28##0:wybe.int, 0:wybe.int, ?tmp#29##0:wybe.bool)
+    case ~tmp#29##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(tmp$28##0:wybe.int, 1:wybe.int, ?tmp$32##0:wybe.bool)
-        case ~tmp$32##0:wybe.bool of
+        foreign llvm icmp_eq(tmp#28##0:wybe.int, 1:wybe.int, ?tmp#32##0:wybe.bool)
+        case ~tmp#32##0:wybe.bool of
         0:
-            foreign llvm icmp_eq(tmp$28##0:wybe.int, 2:wybe.int, ?tmp$35##0:wybe.bool)
-            case ~tmp$35##0:wybe.bool of
+            foreign llvm icmp_eq(tmp#28##0:wybe.int, 2:wybe.int, ?tmp#35##0:wybe.bool)
+            case ~tmp#35##0:wybe.bool of
             0:
-                foreign llvm icmp_eq(tmp$28##0:wybe.int, 3:wybe.int, ?tmp$38##0:wybe.bool)
-                case ~tmp$38##0:wybe.bool of
+                foreign llvm icmp_eq(tmp#28##0:wybe.int, 3:wybe.int, ?tmp#38##0:wybe.bool)
+                case ~tmp#38##0:wybe.bool of
                 0:
-                    foreign llvm icmp_eq(tmp$28##0:wybe.int, 4:wybe.int, ?tmp$41##0:wybe.bool)
-                    case ~tmp$41##0:wybe.bool of
+                    foreign llvm icmp_eq(tmp#28##0:wybe.int, 4:wybe.int, ?tmp#41##0:wybe.bool)
+                    case ~tmp#41##0:wybe.bool of
                     0:
-                        foreign llvm icmp_eq(tmp$28##0:wybe.int, 5:wybe.int, ?tmp$44##0:wybe.bool)
-                        case ~tmp$44##0:wybe.bool of
+                        foreign llvm icmp_eq(tmp#28##0:wybe.int, 5:wybe.int, ?tmp#44##0:wybe.bool)
+                        case ~tmp#44##0:wybe.bool of
                         0:
-                            foreign llvm icmp_eq(tmp$28##0:wybe.int, 6:wybe.int, ?tmp$47##0:wybe.bool)
-                            case ~tmp$47##0:wybe.bool of
+                            foreign llvm icmp_eq(tmp#28##0:wybe.int, 6:wybe.int, ?tmp#47##0:wybe.bool)
+                            case ~tmp#47##0:wybe.bool of
                             0:
-                                foreign llvm icmp_eq(~tmp$28##0:wybe.int, 7:wybe.int, ?tmp$50##0:wybe.bool)
-                                case ~tmp$50##0:wybe.bool of
+                                foreign llvm icmp_eq(~tmp#28##0:wybe.int, 7:wybe.int, ?tmp#50##0:wybe.bool)
+                                case ~tmp#50##0:wybe.bool of
                                 0:
-                                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                 1:
-                                    foreign lpvm access($left##0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?$left$f08_a##0:wybe.int)
-                                    foreign lpvm access($left##0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?$left$f08_b##0:wybe.int)
-                                    foreign lpvm access(~$left##0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?$left$f08_c##0:wybe.float)
-                                    foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$52##0:wybe.int)
-                                    foreign llvm icmp_eq(~tmp$52##0:wybe.int, 7:wybe.int, ?tmp$53##0:wybe.bool)
-                                    case ~tmp$53##0:wybe.bool of
+                                    foreign lpvm access(#left##0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?#left#f08_a##0:wybe.int)
+                                    foreign lpvm access(#left##0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?#left#f08_b##0:wybe.int)
+                                    foreign lpvm access(~#left##0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?#left#f08_c##0:wybe.float)
+                                    foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#52##0:wybe.int)
+                                    foreign llvm icmp_eq(~tmp#52##0:wybe.int, 7:wybe.int, ?tmp#53##0:wybe.bool)
+                                    case ~tmp#53##0:wybe.bool of
                                     0:
-                                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                     1:
-                                        foreign lpvm access($right##0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?$right$f08_a##0:wybe.int)
-                                        foreign lpvm access($right##0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?$right$f08_b##0:wybe.int)
-                                        foreign lpvm access(~$right##0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?$right$f08_c##0:wybe.float)
-                                        foreign llvm icmp_eq(~$left$f08_a##0:wybe.int, ~$right$f08_a##0:wybe.int, ?tmp$16##0:wybe.bool) @int:nn:nn
-                                        case ~tmp$16##0:wybe.bool of
+                                        foreign lpvm access(#right##0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?#right#f08_a##0:wybe.int)
+                                        foreign lpvm access(#right##0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?#right#f08_b##0:wybe.int)
+                                        foreign lpvm access(~#right##0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?#right#f08_c##0:wybe.float)
+                                        foreign llvm icmp_eq(~#left#f08_a##0:wybe.int, ~#right#f08_a##0:wybe.int, ?tmp#16##0:wybe.bool) @int:nn:nn
+                                        case ~tmp#16##0:wybe.bool of
                                         0:
-                                            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                         1:
-                                            foreign llvm icmp_eq(~$left$f08_b##0:wybe.int, ~$right$f08_b##0:wybe.int, ?tmp$17##0:wybe.bool) @int:nn:nn
-                                            case ~tmp$17##0:wybe.bool of
+                                            foreign llvm icmp_eq(~#left#f08_b##0:wybe.int, ~#right#f08_b##0:wybe.int, ?tmp#17##0:wybe.bool) @int:nn:nn
+                                            case ~tmp#17##0:wybe.bool of
                                             0:
-                                                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                             1:
-                                                foreign llvm fcmp_eq(~$left$f08_c##0:wybe.float, ~$right$f08_c##0:wybe.float, ?$$##0:wybe.bool) @float:nn:nn
+                                                foreign llvm fcmp_eq(~#left#f08_c##0:wybe.float, ~#right#f08_c##0:wybe.float, ?####0:wybe.bool) @float:nn:nn
 
 
 
 
 
                             1:
-                                foreign lpvm access(~$left##0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?$left$f07##0:wybe.int)
-                                foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$49##0:wybe.int)
-                                foreign llvm icmp_eq(~tmp$49##0:wybe.int, 6:wybe.int, ?tmp$50##0:wybe.bool)
-                                case ~tmp$50##0:wybe.bool of
+                                foreign lpvm access(~#left##0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?#left#f07##0:wybe.int)
+                                foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#49##0:wybe.int)
+                                foreign llvm icmp_eq(~tmp#49##0:wybe.int, 6:wybe.int, ?tmp#50##0:wybe.bool)
+                                case ~tmp#50##0:wybe.bool of
                                 0:
-                                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                                 1:
-                                    foreign lpvm access(~$right##0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?$right$f07##0:wybe.int)
-                                    foreign llvm icmp_eq(~$left$f07##0:wybe.int, ~$right$f07##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+                                    foreign lpvm access(~#right##0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?#right#f07##0:wybe.int)
+                                    foreign llvm icmp_eq(~#left#f07##0:wybe.int, ~#right#f07##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
                         1:
-                            foreign lpvm access(~$left##0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?$left$f06##0:wybe.int)
-                            foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$46##0:wybe.int)
-                            foreign llvm icmp_eq(~tmp$46##0:wybe.int, 5:wybe.int, ?tmp$47##0:wybe.bool)
-                            case ~tmp$47##0:wybe.bool of
+                            foreign lpvm access(~#left##0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?#left#f06##0:wybe.int)
+                            foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#46##0:wybe.int)
+                            foreign llvm icmp_eq(~tmp#46##0:wybe.int, 5:wybe.int, ?tmp#47##0:wybe.bool)
+                            case ~tmp#47##0:wybe.bool of
                             0:
-                                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                             1:
-                                foreign lpvm access(~$right##0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?$right$f06##0:wybe.int)
-                                foreign llvm icmp_eq(~$left$f06##0:wybe.int, ~$right$f06##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+                                foreign lpvm access(~#right##0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?#right#f06##0:wybe.int)
+                                foreign llvm icmp_eq(~#left#f06##0:wybe.int, ~#right#f06##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
                     1:
-                        foreign lpvm access(~$left##0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?$left$f05##0:wybe.int)
-                        foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$43##0:wybe.int)
-                        foreign llvm icmp_eq(~tmp$43##0:wybe.int, 4:wybe.int, ?tmp$44##0:wybe.bool)
-                        case ~tmp$44##0:wybe.bool of
+                        foreign lpvm access(~#left##0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?#left#f05##0:wybe.int)
+                        foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#43##0:wybe.int)
+                        foreign llvm icmp_eq(~tmp#43##0:wybe.int, 4:wybe.int, ?tmp#44##0:wybe.bool)
+                        case ~tmp#44##0:wybe.bool of
                         0:
-                            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                         1:
-                            foreign lpvm access(~$right##0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?$right$f05##0:wybe.int)
-                            foreign llvm icmp_eq(~$left$f05##0:wybe.int, ~$right$f05##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+                            foreign lpvm access(~#right##0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?#right#f05##0:wybe.int)
+                            foreign llvm icmp_eq(~#left#f05##0:wybe.int, ~#right#f05##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
                 1:
-                    foreign lpvm access(~$left##0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?$left$f04##0:wybe.int)
-                    foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$40##0:wybe.int)
-                    foreign llvm icmp_eq(~tmp$40##0:wybe.int, 3:wybe.int, ?tmp$41##0:wybe.bool)
-                    case ~tmp$41##0:wybe.bool of
+                    foreign lpvm access(~#left##0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?#left#f04##0:wybe.int)
+                    foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#40##0:wybe.int)
+                    foreign llvm icmp_eq(~tmp#40##0:wybe.int, 3:wybe.int, ?tmp#41##0:wybe.bool)
+                    case ~tmp#41##0:wybe.bool of
                     0:
-                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                     1:
-                        foreign lpvm access(~$right##0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?$right$f04##0:wybe.int)
-                        foreign llvm icmp_eq(~$left$f04##0:wybe.int, ~$right$f04##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+                        foreign lpvm access(~#right##0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?#right#f04##0:wybe.int)
+                        foreign llvm icmp_eq(~#left#f04##0:wybe.int, ~#right#f04##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
             1:
-                foreign lpvm access(~$left##0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$left$f03##0:wybe.int)
-                foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$37##0:wybe.int)
-                foreign llvm icmp_eq(~tmp$37##0:wybe.int, 2:wybe.int, ?tmp$38##0:wybe.bool)
-                case ~tmp$38##0:wybe.bool of
+                foreign lpvm access(~#left##0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#left#f03##0:wybe.int)
+                foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#37##0:wybe.int)
+                foreign llvm icmp_eq(~tmp#37##0:wybe.int, 2:wybe.int, ?tmp#38##0:wybe.bool)
+                case ~tmp#38##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                 1:
-                    foreign lpvm access(~$right##0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$right$f03##0:wybe.int)
-                    foreign llvm icmp_eq(~$left$f03##0:wybe.int, ~$right$f03##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+                    foreign lpvm access(~#right##0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#right#f03##0:wybe.int)
+                    foreign llvm icmp_eq(~#left#f03##0:wybe.int, ~#right#f03##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
         1:
-            foreign lpvm access(~$left##0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$left$f02##0:wybe.int)
-            foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$34##0:wybe.int)
-            foreign llvm icmp_eq(~tmp$34##0:wybe.int, 1:wybe.int, ?tmp$35##0:wybe.bool)
-            case ~tmp$35##0:wybe.bool of
+            foreign lpvm access(~#left##0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#left#f02##0:wybe.int)
+            foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#34##0:wybe.int)
+            foreign llvm icmp_eq(~tmp#34##0:wybe.int, 1:wybe.int, ?tmp#35##0:wybe.bool)
+            case ~tmp#35##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
             1:
-                foreign lpvm access(~$right##0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$right$f02##0:wybe.int)
-                foreign llvm icmp_eq(~$left$f02##0:wybe.int, ~$right$f02##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+                foreign lpvm access(~#right##0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#right#f02##0:wybe.int)
+                foreign llvm icmp_eq(~#left#f02##0:wybe.int, ~#right#f02##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
     1:
-        foreign lpvm access(~$left##0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$left$f01##0:wybe.int)
-        foreign llvm and($right##0:wybe.int, 7:wybe.int, ?tmp$31##0:wybe.int)
-        foreign llvm icmp_eq(~tmp$31##0:wybe.int, 0:wybe.int, ?tmp$32##0:wybe.bool)
-        case ~tmp$32##0:wybe.bool of
+        foreign lpvm access(~#left##0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#left#f01##0:wybe.int)
+        foreign llvm and(#right##0:wybe.int, 7:wybe.int, ?tmp#31##0:wybe.int)
+        foreign llvm icmp_eq(~tmp#31##0:wybe.int, 0:wybe.int, ?tmp#32##0:wybe.bool)
+        case ~tmp#32##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign lpvm access(~$right##0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$right$f01##0:wybe.int)
-            foreign llvm icmp_eq(~$left$f01##0:wybe.int, ~$right$f01##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+            foreign lpvm access(~#right##0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#right#f01##0:wybe.int)
+            foreign llvm icmp_eq(~#left#f01##0:wybe.int, ~#right#f01##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 
 c01 > public {inline} (0 calls)
 0: multictr2.t.c01<0>
-c01(f01##0:wybe.int, ?$##0:multictr2.t):
+c01(f01##0:wybe.int, ?###0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr2.t)
-    foreign lpvm mutate(~$rec##0:multictr2.t, ?$##0:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f01##0:wybe.int)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t)
+    foreign lpvm mutate(~#rec##0:multictr2.t, ?###0:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f01##0:wybe.int)
 c01 > public {inline} (24 calls)
 1: multictr2.t.c01<1>
-c01(?f01##0:wybe.int, $##0:multictr2.t, ?$$##0:wybe.bool):
+c01(?f01##0:wybe.int, ###0:multictr2.t, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f01##0:wybe.int)
 
     1:
-        foreign lpvm access(~$##0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?f01##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~###0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?f01##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 c02 > public {inline} (0 calls)
 0: multictr2.t.c02<0>
-c02(f02##0:wybe.int, ?$##0:multictr2.t):
+c02(f02##0:wybe.int, ?###0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr2.t)
-    foreign lpvm mutate(~$rec##0:multictr2.t, ?$rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f02##0:wybe.int)
-    foreign llvm or(~$rec##1:multictr2.t, 1:wybe.int, ?$##0:multictr2.t)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t)
+    foreign lpvm mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f02##0:wybe.int)
+    foreign llvm or(~#rec##1:multictr2.t, 1:wybe.int, ?###0:multictr2.t)
 c02 > public {inline} (19 calls)
 1: multictr2.t.c02<1>
-c02(?f02##0:wybe.int, $##0:multictr2.t, ?$$##0:wybe.bool):
+c02(?f02##0:wybe.int, ###0:multictr2.t, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f02##0:wybe.int)
 
     1:
-        foreign lpvm access(~$##0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?f02##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~###0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?f02##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 c03 > public {inline} (0 calls)
 0: multictr2.t.c03<0>
-c03(f03##0:wybe.int, ?$##0:multictr2.t):
+c03(f03##0:wybe.int, ?###0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr2.t)
-    foreign lpvm mutate(~$rec##0:multictr2.t, ?$rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f03##0:wybe.int)
-    foreign llvm or(~$rec##1:multictr2.t, 2:wybe.int, ?$##0:multictr2.t)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t)
+    foreign lpvm mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f03##0:wybe.int)
+    foreign llvm or(~#rec##1:multictr2.t, 2:wybe.int, ?###0:multictr2.t)
 c03 > public {inline} (17 calls)
 1: multictr2.t.c03<1>
-c03(?f03##0:wybe.int, $##0:multictr2.t, ?$$##0:wybe.bool):
+c03(?f03##0:wybe.int, ###0:multictr2.t, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 2:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 2:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f03##0:wybe.int)
 
     1:
-        foreign lpvm access(~$##0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?f03##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~###0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?f03##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 c04 > public {inline} (0 calls)
 0: multictr2.t.c04<0>
-c04(f04##0:wybe.int, ?$##0:multictr2.t):
+c04(f04##0:wybe.int, ?###0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr2.t)
-    foreign lpvm mutate(~$rec##0:multictr2.t, ?$rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f04##0:wybe.int)
-    foreign llvm or(~$rec##1:multictr2.t, 3:wybe.int, ?$##0:multictr2.t)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t)
+    foreign lpvm mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f04##0:wybe.int)
+    foreign llvm or(~#rec##1:multictr2.t, 3:wybe.int, ?###0:multictr2.t)
 c04 > public {inline} (15 calls)
 1: multictr2.t.c04<1>
-c04(?f04##0:wybe.int, $##0:multictr2.t, ?$$##0:wybe.bool):
+c04(?f04##0:wybe.int, ###0:multictr2.t, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 3:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 3:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f04##0:wybe.int)
 
     1:
-        foreign lpvm access(~$##0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?f04##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~###0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?f04##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 c05 > public {inline} (0 calls)
 0: multictr2.t.c05<0>
-c05(f05##0:wybe.int, ?$##0:multictr2.t):
+c05(f05##0:wybe.int, ?###0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr2.t)
-    foreign lpvm mutate(~$rec##0:multictr2.t, ?$rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f05##0:wybe.int)
-    foreign llvm or(~$rec##1:multictr2.t, 4:wybe.int, ?$##0:multictr2.t)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t)
+    foreign lpvm mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f05##0:wybe.int)
+    foreign llvm or(~#rec##1:multictr2.t, 4:wybe.int, ?###0:multictr2.t)
 c05 > public {inline} (13 calls)
 1: multictr2.t.c05<1>
-c05(?f05##0:wybe.int, $##0:multictr2.t, ?$$##0:wybe.bool):
+c05(?f05##0:wybe.int, ###0:multictr2.t, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f05##0:wybe.int)
 
     1:
-        foreign lpvm access(~$##0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?f05##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~###0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?f05##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 c06 > public {inline} (0 calls)
 0: multictr2.t.c06<0>
-c06(f06##0:wybe.int, ?$##0:multictr2.t):
+c06(f06##0:wybe.int, ?###0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr2.t)
-    foreign lpvm mutate(~$rec##0:multictr2.t, ?$rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f06##0:wybe.int)
-    foreign llvm or(~$rec##1:multictr2.t, 5:wybe.int, ?$##0:multictr2.t)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t)
+    foreign lpvm mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f06##0:wybe.int)
+    foreign llvm or(~#rec##1:multictr2.t, 5:wybe.int, ?###0:multictr2.t)
 c06 > public {inline} (11 calls)
 1: multictr2.t.c06<1>
-c06(?f06##0:wybe.int, $##0:multictr2.t, ?$$##0:wybe.bool):
+c06(?f06##0:wybe.int, ###0:multictr2.t, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 5:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 5:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f06##0:wybe.int)
 
     1:
-        foreign lpvm access(~$##0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?f06##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~###0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?f06##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 c07 > public {inline} (0 calls)
 0: multictr2.t.c07<0>
-c07(f07##0:wybe.int, ?$##0:multictr2.t):
+c07(f07##0:wybe.int, ?###0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?$rec##0:multictr2.t)
-    foreign lpvm mutate(~$rec##0:multictr2.t, ?$rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f07##0:wybe.int)
-    foreign llvm or(~$rec##1:multictr2.t, 6:wybe.int, ?$##0:multictr2.t)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t)
+    foreign lpvm mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f07##0:wybe.int)
+    foreign llvm or(~#rec##1:multictr2.t, 6:wybe.int, ?###0:multictr2.t)
 c07 > public {inline} (9 calls)
 1: multictr2.t.c07<1>
-c07(?f07##0:wybe.int, $##0:multictr2.t, ?$$##0:wybe.bool):
+c07(?f07##0:wybe.int, ###0:multictr2.t, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 6:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 6:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f07##0:wybe.int)
 
     1:
-        foreign lpvm access(~$##0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?f07##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~###0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?f07##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 c08 > public {inline} (0 calls)
 0: multictr2.t.c08<0>
-c08(f08_a##0:wybe.int, f08_b##0:wybe.int, f08_c##0:wybe.float, ?$##0:multictr2.t):
+c08(f08_a##0:wybe.int, f08_b##0:wybe.int, f08_c##0:wybe.float, ?###0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?$rec##0:multictr2.t)
-    foreign lpvm mutate(~$rec##0:multictr2.t, ?$rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~f08_a##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:multictr2.t, ?$rec##2:multictr2.t, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~f08_b##0:wybe.int)
-    foreign lpvm mutate(~$rec##2:multictr2.t, ?$rec##3:multictr2.t, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~f08_c##0:wybe.float)
-    foreign llvm or(~$rec##3:multictr2.t, 7:wybe.int, ?$##0:multictr2.t)
+    foreign lpvm alloc(24:wybe.int, ?#rec##0:multictr2.t)
+    foreign lpvm mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~f08_a##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:multictr2.t, ?#rec##2:multictr2.t, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~f08_b##0:wybe.int)
+    foreign lpvm mutate(~#rec##2:multictr2.t, ?#rec##3:multictr2.t, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~f08_c##0:wybe.float)
+    foreign llvm or(~#rec##3:multictr2.t, 7:wybe.int, ?###0:multictr2.t)
 c08 > public {inline} (9 calls)
 1: multictr2.t.c08<1>
-c08(?f08_a##0:wybe.int, ?f08_b##0:wybe.int, ?f08_c##0:wybe.float, $##0:multictr2.t, ?$$##0:wybe.bool):
+c08(?f08_a##0:wybe.int, ?f08_b##0:wybe.int, ?f08_c##0:wybe.float, ###0:multictr2.t, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 7:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 7:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f08_a##0:wybe.int)
         foreign llvm move(undef:wybe.int, ?f08_b##0:wybe.int)
         foreign llvm move(undef:wybe.float, ?f08_c##0:wybe.float)
 
     1:
-        foreign lpvm access($##0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?f08_a##0:wybe.int)
-        foreign lpvm access($##0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?f08_b##0:wybe.int)
-        foreign lpvm access(~$##0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?f08_c##0:wybe.float)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(###0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?f08_a##0:wybe.int)
+        foreign lpvm access(###0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?f08_b##0:wybe.int)
+        foreign lpvm access(~###0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?f08_c##0:wybe.float)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 f01 > public {inline} (0 calls)
 0: multictr2.t.f01<0>
-f01($rec##0:multictr2.t, ?$##0:wybe.int, ?$$##0:wybe.bool):
+f01(#rec##0:multictr2.t, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec##0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?$##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 f01 > public {inline} (0 calls)
 1: multictr2.t.f01<1>
-f01($rec##0:multictr2.t, ?$rec##1:multictr2.t, $field##0:wybe.int, ?$$##0:wybe.bool):
+f01(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multictr2.t, ?$rec##1:multictr2.t)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multictr2.t, ?#rec##1:multictr2.t)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec##0:multictr2.t, ?$rec##1:multictr2.t, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 f02 > public {inline} (0 calls)
 0: multictr2.t.f02<0>
-f02($rec##0:multictr2.t, ?$##0:wybe.int, ?$$##0:wybe.bool):
+f02(#rec##0:multictr2.t, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec##0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?$##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?###0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 f02 > public {inline} (0 calls)
 1: multictr2.t.f02<1>
-f02($rec##0:multictr2.t, ?$rec##1:multictr2.t, $field##0:wybe.int, ?$$##0:wybe.bool):
+f02(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multictr2.t, ?$rec##1:multictr2.t)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multictr2.t, ?#rec##1:multictr2.t)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec##0:multictr2.t, ?$rec##1:multictr2.t, -1:wybe.int, 0:wybe.int, 8:wybe.int, 1:wybe.int, ~$field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, -1:wybe.int, 0:wybe.int, 8:wybe.int, 1:wybe.int, ~#field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 f03 > public {inline} (0 calls)
 0: multictr2.t.f03<0>
-f03($rec##0:multictr2.t, ?$##0:wybe.int, ?$$##0:wybe.bool):
+f03(#rec##0:multictr2.t, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 2:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 2:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec##0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?$##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?###0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 f03 > public {inline} (0 calls)
 1: multictr2.t.f03<1>
-f03($rec##0:multictr2.t, ?$rec##1:multictr2.t, $field##0:wybe.int, ?$$##0:wybe.bool):
+f03(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 2:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 2:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multictr2.t, ?$rec##1:multictr2.t)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multictr2.t, ?#rec##1:multictr2.t)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec##0:multictr2.t, ?$rec##1:multictr2.t, -2:wybe.int, 0:wybe.int, 8:wybe.int, 2:wybe.int, ~$field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, -2:wybe.int, 0:wybe.int, 8:wybe.int, 2:wybe.int, ~#field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 f04 > public {inline} (0 calls)
 0: multictr2.t.f04<0>
-f04($rec##0:multictr2.t, ?$##0:wybe.int, ?$$##0:wybe.bool):
+f04(#rec##0:multictr2.t, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 3:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 3:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec##0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?$##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?###0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 f04 > public {inline} (0 calls)
 1: multictr2.t.f04<1>
-f04($rec##0:multictr2.t, ?$rec##1:multictr2.t, $field##0:wybe.int, ?$$##0:wybe.bool):
+f04(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 3:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 3:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multictr2.t, ?$rec##1:multictr2.t)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multictr2.t, ?#rec##1:multictr2.t)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec##0:multictr2.t, ?$rec##1:multictr2.t, -3:wybe.int, 0:wybe.int, 8:wybe.int, 3:wybe.int, ~$field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, -3:wybe.int, 0:wybe.int, 8:wybe.int, 3:wybe.int, ~#field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 f05 > public {inline} (0 calls)
 0: multictr2.t.f05<0>
-f05($rec##0:multictr2.t, ?$##0:wybe.int, ?$$##0:wybe.bool):
+f05(#rec##0:multictr2.t, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec##0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?$##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?###0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 f05 > public {inline} (0 calls)
 1: multictr2.t.f05<1>
-f05($rec##0:multictr2.t, ?$rec##1:multictr2.t, $field##0:wybe.int, ?$$##0:wybe.bool):
+f05(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 4:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multictr2.t, ?$rec##1:multictr2.t)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multictr2.t, ?#rec##1:multictr2.t)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec##0:multictr2.t, ?$rec##1:multictr2.t, -4:wybe.int, 0:wybe.int, 8:wybe.int, 4:wybe.int, ~$field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, -4:wybe.int, 0:wybe.int, 8:wybe.int, 4:wybe.int, ~#field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 f06 > public {inline} (0 calls)
 0: multictr2.t.f06<0>
-f06($rec##0:multictr2.t, ?$##0:wybe.int, ?$$##0:wybe.bool):
+f06(#rec##0:multictr2.t, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 5:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 5:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec##0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?$##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?###0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 f06 > public {inline} (0 calls)
 1: multictr2.t.f06<1>
-f06($rec##0:multictr2.t, ?$rec##1:multictr2.t, $field##0:wybe.int, ?$$##0:wybe.bool):
+f06(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 5:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 5:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multictr2.t, ?$rec##1:multictr2.t)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multictr2.t, ?#rec##1:multictr2.t)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec##0:multictr2.t, ?$rec##1:multictr2.t, -5:wybe.int, 0:wybe.int, 8:wybe.int, 5:wybe.int, ~$field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, -5:wybe.int, 0:wybe.int, 8:wybe.int, 5:wybe.int, ~#field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 f07 > public {inline} (0 calls)
 0: multictr2.t.f07<0>
-f07($rec##0:multictr2.t, ?$##0:wybe.int, ?$$##0:wybe.bool):
+f07(#rec##0:multictr2.t, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 6:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 6:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec##0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?$##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?###0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 f07 > public {inline} (0 calls)
 1: multictr2.t.f07<1>
-f07($rec##0:multictr2.t, ?$rec##1:multictr2.t, $field##0:wybe.int, ?$$##0:wybe.bool):
+f07(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 6:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 6:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multictr2.t, ?$rec##1:multictr2.t)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multictr2.t, ?#rec##1:multictr2.t)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec##0:multictr2.t, ?$rec##1:multictr2.t, -6:wybe.int, 0:wybe.int, 8:wybe.int, 6:wybe.int, ~$field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, -6:wybe.int, 0:wybe.int, 8:wybe.int, 6:wybe.int, ~#field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 f08_a > public {inline} (0 calls)
 0: multictr2.t.f08_a<0>
-f08_a($rec##0:multictr2.t, ?$##0:wybe.int, ?$$##0:wybe.bool):
+f08_a(#rec##0:multictr2.t, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 7:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 7:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec##0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?$##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?###0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 f08_a > public {inline} (0 calls)
 1: multictr2.t.f08_a<1>
-f08_a($rec##0:multictr2.t, ?$rec##1:multictr2.t, $field##0:wybe.int, ?$$##0:wybe.bool):
+f08_a(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 7:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 7:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multictr2.t, ?$rec##1:multictr2.t)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multictr2.t, ?#rec##1:multictr2.t)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec##0:multictr2.t, ?$rec##1:multictr2.t, -7:wybe.int, 0:wybe.int, 24:wybe.int, 7:wybe.int, ~$field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, -7:wybe.int, 0:wybe.int, 24:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 f08_b > public {inline} (0 calls)
 0: multictr2.t.f08_b<0>
-f08_b($rec##0:multictr2.t, ?$##0:wybe.int, ?$$##0:wybe.bool):
+f08_b(#rec##0:multictr2.t, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 7:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 7:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec##0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?$##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?###0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 f08_b > public {inline} (0 calls)
 1: multictr2.t.f08_b<1>
-f08_b($rec##0:multictr2.t, ?$rec##1:multictr2.t, $field##0:wybe.int, ?$$##0:wybe.bool):
+f08_b(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 7:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 7:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multictr2.t, ?$rec##1:multictr2.t)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multictr2.t, ?#rec##1:multictr2.t)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec##0:multictr2.t, ?$rec##1:multictr2.t, 1:wybe.int, 0:wybe.int, 24:wybe.int, 7:wybe.int, ~$field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 1:wybe.int, 0:wybe.int, 24:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 f08_c > public {inline} (0 calls)
 0: multictr2.t.f08_c<0>
-f08_c($rec##0:multictr2.t, ?$##0:wybe.float, ?$$##0:wybe.bool):
+f08_c(#rec##0:multictr2.t, ?###0:wybe.float, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 7:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 7:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.float, ?$##0:wybe.float)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.float, ?###0:wybe.float)
 
     1:
-        foreign lpvm access(~$rec##0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?$##0:wybe.float)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?###0:wybe.float)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 f08_c > public {inline} (0 calls)
 1: multictr2.t.f08_c<1>
-f08_c($rec##0:multictr2.t, ?$rec##1:multictr2.t, $field##0:wybe.float, ?$$##0:wybe.bool):
+f08_c(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.float, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and($rec##0:wybe.int, 7:wybe.int, ?tmp$1##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 7:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 7:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:multictr2.t, ?$rec##1:multictr2.t)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:multictr2.t, ?#rec##1:multictr2.t)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec##0:multictr2.t, ?$rec##1:multictr2.t, 9:wybe.int, 0:wybe.int, 24:wybe.int, 7:wybe.int, ~$field##0:wybe.float)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 9:wybe.int, 0:wybe.int, 24:wybe.int, 7:wybe.int, ~#field##0:wybe.float)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: multictr2.t.~=<0>
-~=($left##0:multictr2.t, $right##0:multictr2.t, ?$$##0:wybe.bool):
+~=(#left##0:multictr2.t, #right##0:multictr2.t, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    multictr2.t.=<0>(~$left##0:multictr2.t, ~$right##0:multictr2.t, ?tmp$0##0:wybe.bool) #0
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    multictr2.t.=<0>(~#left##0:multictr2.t, ~#right##0:multictr2.t, ?tmp#0##0:wybe.bool) #0
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
   LLVM code       :
 
@@ -1156,192 +1156,192 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"multictr2.t.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"multictr2.t.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$28##0" = and i64 %"$left##0", 7 
-  %"1$tmp$29##0" = icmp eq i64 %"1$tmp$28##0", 0 
-  br i1 %"1$tmp$29##0", label %if.then, label %if.else 
+  %"1#tmp#28##0" = and i64 %"#left##0", 7 
+  %"1#tmp#29##0" = icmp eq i64 %"1#tmp#28##0", 0 
+  br i1 %"1#tmp#29##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %"2$tmp$31##0" = and i64 %"$right##0", 7 
-  %"2$tmp$32##0" = icmp eq i64 %"2$tmp$31##0", 0 
-  br i1 %"2$tmp$32##0", label %if.then1, label %if.else1 
+  %"2#tmp#31##0" = and i64 %"#right##0", 7 
+  %"2#tmp#32##0" = icmp eq i64 %"2#tmp#31##0", 0 
+  br i1 %"2#tmp#32##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$tmp$32##0" = icmp eq i64 %"1$tmp$28##0", 1 
-  br i1 %"3$tmp$32##0", label %if.then2, label %if.else2 
+  %"3#tmp#32##0" = icmp eq i64 %"1#tmp#28##0", 1 
+  br i1 %"3#tmp#32##0", label %if.then2, label %if.else2 
 if.then1:
-  %4 = inttoptr i64 %"$right##0" to i64* 
+  %4 = inttoptr i64 %"#right##0" to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
   %6 = load  i64, i64* %5 
-  %"4$$$##0" = icmp eq i64 %3, %6 
-  ret i1 %"4$$$##0" 
+  %"4#####0" = icmp eq i64 %3, %6 
+  ret i1 %"4#####0" 
 if.else1:
   ret i1 0 
 if.then2:
-  %7 = add   i64 %"$left##0", -1 
+  %7 = add   i64 %"#left##0", -1 
   %8 = inttoptr i64 %7 to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %"6$tmp$34##0" = and i64 %"$right##0", 7 
-  %"6$tmp$35##0" = icmp eq i64 %"6$tmp$34##0", 1 
-  br i1 %"6$tmp$35##0", label %if.then3, label %if.else3 
+  %"6#tmp#34##0" = and i64 %"#right##0", 7 
+  %"6#tmp#35##0" = icmp eq i64 %"6#tmp#34##0", 1 
+  br i1 %"6#tmp#35##0", label %if.then3, label %if.else3 
 if.else2:
-  %"7$tmp$35##0" = icmp eq i64 %"1$tmp$28##0", 2 
-  br i1 %"7$tmp$35##0", label %if.then4, label %if.else4 
+  %"7#tmp#35##0" = icmp eq i64 %"1#tmp#28##0", 2 
+  br i1 %"7#tmp#35##0", label %if.then4, label %if.else4 
 if.then3:
-  %11 = add   i64 %"$right##0", -1 
+  %11 = add   i64 %"#right##0", -1 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"8$$$##0" = icmp eq i64 %10, %14 
-  ret i1 %"8$$$##0" 
+  %"8#####0" = icmp eq i64 %10, %14 
+  ret i1 %"8#####0" 
 if.else3:
   ret i1 0 
 if.then4:
-  %15 = add   i64 %"$left##0", -2 
+  %15 = add   i64 %"#left##0", -2 
   %16 = inttoptr i64 %15 to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
-  %"10$tmp$37##0" = and i64 %"$right##0", 7 
-  %"10$tmp$38##0" = icmp eq i64 %"10$tmp$37##0", 2 
-  br i1 %"10$tmp$38##0", label %if.then5, label %if.else5 
+  %"10#tmp#37##0" = and i64 %"#right##0", 7 
+  %"10#tmp#38##0" = icmp eq i64 %"10#tmp#37##0", 2 
+  br i1 %"10#tmp#38##0", label %if.then5, label %if.else5 
 if.else4:
-  %"11$tmp$38##0" = icmp eq i64 %"1$tmp$28##0", 3 
-  br i1 %"11$tmp$38##0", label %if.then6, label %if.else6 
+  %"11#tmp#38##0" = icmp eq i64 %"1#tmp#28##0", 3 
+  br i1 %"11#tmp#38##0", label %if.then6, label %if.else6 
 if.then5:
-  %19 = add   i64 %"$right##0", -2 
+  %19 = add   i64 %"#right##0", -2 
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %"12$$$##0" = icmp eq i64 %18, %22 
-  ret i1 %"12$$$##0" 
+  %"12#####0" = icmp eq i64 %18, %22 
+  ret i1 %"12#####0" 
 if.else5:
   ret i1 0 
 if.then6:
-  %23 = add   i64 %"$left##0", -3 
+  %23 = add   i64 %"#left##0", -3 
   %24 = inttoptr i64 %23 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
   %26 = load  i64, i64* %25 
-  %"14$tmp$40##0" = and i64 %"$right##0", 7 
-  %"14$tmp$41##0" = icmp eq i64 %"14$tmp$40##0", 3 
-  br i1 %"14$tmp$41##0", label %if.then7, label %if.else7 
+  %"14#tmp#40##0" = and i64 %"#right##0", 7 
+  %"14#tmp#41##0" = icmp eq i64 %"14#tmp#40##0", 3 
+  br i1 %"14#tmp#41##0", label %if.then7, label %if.else7 
 if.else6:
-  %"15$tmp$41##0" = icmp eq i64 %"1$tmp$28##0", 4 
-  br i1 %"15$tmp$41##0", label %if.then8, label %if.else8 
+  %"15#tmp#41##0" = icmp eq i64 %"1#tmp#28##0", 4 
+  br i1 %"15#tmp#41##0", label %if.then8, label %if.else8 
 if.then7:
-  %27 = add   i64 %"$right##0", -3 
+  %27 = add   i64 %"#right##0", -3 
   %28 = inttoptr i64 %27 to i64* 
   %29 = getelementptr  i64, i64* %28, i64 0 
   %30 = load  i64, i64* %29 
-  %"16$$$##0" = icmp eq i64 %26, %30 
-  ret i1 %"16$$$##0" 
+  %"16#####0" = icmp eq i64 %26, %30 
+  ret i1 %"16#####0" 
 if.else7:
   ret i1 0 
 if.then8:
-  %31 = add   i64 %"$left##0", -4 
+  %31 = add   i64 %"#left##0", -4 
   %32 = inttoptr i64 %31 to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
-  %"18$tmp$43##0" = and i64 %"$right##0", 7 
-  %"18$tmp$44##0" = icmp eq i64 %"18$tmp$43##0", 4 
-  br i1 %"18$tmp$44##0", label %if.then9, label %if.else9 
+  %"18#tmp#43##0" = and i64 %"#right##0", 7 
+  %"18#tmp#44##0" = icmp eq i64 %"18#tmp#43##0", 4 
+  br i1 %"18#tmp#44##0", label %if.then9, label %if.else9 
 if.else8:
-  %"19$tmp$44##0" = icmp eq i64 %"1$tmp$28##0", 5 
-  br i1 %"19$tmp$44##0", label %if.then10, label %if.else10 
+  %"19#tmp#44##0" = icmp eq i64 %"1#tmp#28##0", 5 
+  br i1 %"19#tmp#44##0", label %if.then10, label %if.else10 
 if.then9:
-  %35 = add   i64 %"$right##0", -4 
+  %35 = add   i64 %"#right##0", -4 
   %36 = inttoptr i64 %35 to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
-  %"20$$$##0" = icmp eq i64 %34, %38 
-  ret i1 %"20$$$##0" 
+  %"20#####0" = icmp eq i64 %34, %38 
+  ret i1 %"20#####0" 
 if.else9:
   ret i1 0 
 if.then10:
-  %39 = add   i64 %"$left##0", -5 
+  %39 = add   i64 %"#left##0", -5 
   %40 = inttoptr i64 %39 to i64* 
   %41 = getelementptr  i64, i64* %40, i64 0 
   %42 = load  i64, i64* %41 
-  %"22$tmp$46##0" = and i64 %"$right##0", 7 
-  %"22$tmp$47##0" = icmp eq i64 %"22$tmp$46##0", 5 
-  br i1 %"22$tmp$47##0", label %if.then11, label %if.else11 
+  %"22#tmp#46##0" = and i64 %"#right##0", 7 
+  %"22#tmp#47##0" = icmp eq i64 %"22#tmp#46##0", 5 
+  br i1 %"22#tmp#47##0", label %if.then11, label %if.else11 
 if.else10:
-  %"23$tmp$47##0" = icmp eq i64 %"1$tmp$28##0", 6 
-  br i1 %"23$tmp$47##0", label %if.then12, label %if.else12 
+  %"23#tmp#47##0" = icmp eq i64 %"1#tmp#28##0", 6 
+  br i1 %"23#tmp#47##0", label %if.then12, label %if.else12 
 if.then11:
-  %43 = add   i64 %"$right##0", -5 
+  %43 = add   i64 %"#right##0", -5 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
-  %"24$$$##0" = icmp eq i64 %42, %46 
-  ret i1 %"24$$$##0" 
+  %"24#####0" = icmp eq i64 %42, %46 
+  ret i1 %"24#####0" 
 if.else11:
   ret i1 0 
 if.then12:
-  %47 = add   i64 %"$left##0", -6 
+  %47 = add   i64 %"#left##0", -6 
   %48 = inttoptr i64 %47 to i64* 
   %49 = getelementptr  i64, i64* %48, i64 0 
   %50 = load  i64, i64* %49 
-  %"26$tmp$49##0" = and i64 %"$right##0", 7 
-  %"26$tmp$50##0" = icmp eq i64 %"26$tmp$49##0", 6 
-  br i1 %"26$tmp$50##0", label %if.then13, label %if.else13 
+  %"26#tmp#49##0" = and i64 %"#right##0", 7 
+  %"26#tmp#50##0" = icmp eq i64 %"26#tmp#49##0", 6 
+  br i1 %"26#tmp#50##0", label %if.then13, label %if.else13 
 if.else12:
-  %"27$tmp$50##0" = icmp eq i64 %"1$tmp$28##0", 7 
-  br i1 %"27$tmp$50##0", label %if.then14, label %if.else14 
+  %"27#tmp#50##0" = icmp eq i64 %"1#tmp#28##0", 7 
+  br i1 %"27#tmp#50##0", label %if.then14, label %if.else14 
 if.then13:
-  %51 = add   i64 %"$right##0", -6 
+  %51 = add   i64 %"#right##0", -6 
   %52 = inttoptr i64 %51 to i64* 
   %53 = getelementptr  i64, i64* %52, i64 0 
   %54 = load  i64, i64* %53 
-  %"28$$$##0" = icmp eq i64 %50, %54 
-  ret i1 %"28$$$##0" 
+  %"28#####0" = icmp eq i64 %50, %54 
+  ret i1 %"28#####0" 
 if.else13:
   ret i1 0 
 if.then14:
-  %55 = add   i64 %"$left##0", -7 
+  %55 = add   i64 %"#left##0", -7 
   %56 = inttoptr i64 %55 to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 1 
+  %59 = add   i64 %"#left##0", 1 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = add   i64 %"$left##0", 9 
+  %63 = add   i64 %"#left##0", 9 
   %64 = inttoptr i64 %63 to double* 
   %65 = getelementptr  double, double* %64, i64 0 
   %66 = load  double, double* %65 
-  %"30$tmp$52##0" = and i64 %"$right##0", 7 
-  %"30$tmp$53##0" = icmp eq i64 %"30$tmp$52##0", 7 
-  br i1 %"30$tmp$53##0", label %if.then15, label %if.else15 
+  %"30#tmp#52##0" = and i64 %"#right##0", 7 
+  %"30#tmp#53##0" = icmp eq i64 %"30#tmp#52##0", 7 
+  br i1 %"30#tmp#53##0", label %if.then15, label %if.else15 
 if.else14:
   ret i1 0 
 if.then15:
-  %67 = add   i64 %"$right##0", -7 
+  %67 = add   i64 %"#right##0", -7 
   %68 = inttoptr i64 %67 to i64* 
   %69 = getelementptr  i64, i64* %68, i64 0 
   %70 = load  i64, i64* %69 
-  %71 = add   i64 %"$right##0", 1 
+  %71 = add   i64 %"#right##0", 1 
   %72 = inttoptr i64 %71 to i64* 
   %73 = getelementptr  i64, i64* %72, i64 0 
   %74 = load  i64, i64* %73 
-  %75 = add   i64 %"$right##0", 9 
+  %75 = add   i64 %"#right##0", 9 
   %76 = inttoptr i64 %75 to double* 
   %77 = getelementptr  double, double* %76, i64 0 
   %78 = load  double, double* %77 
-  %"32$tmp$16##0" = icmp eq i64 %58, %70 
-  br i1 %"32$tmp$16##0", label %if.then16, label %if.else16 
+  %"32#tmp#16##0" = icmp eq i64 %58, %70 
+  br i1 %"32#tmp#16##0", label %if.then16, label %if.else16 
 if.else15:
   ret i1 0 
 if.then16:
-  %"34$tmp$17##0" = icmp eq i64 %62, %74 
-  br i1 %"34$tmp$17##0", label %if.then17, label %if.else17 
+  %"34#tmp#17##0" = icmp eq i64 %62, %74 
+  br i1 %"34#tmp#17##0", label %if.then17, label %if.else17 
 if.else16:
   ret i1 0 
 if.then17:
-  %"36$$$##0" = fcmp oeq double %66, %78 
-  ret i1 %"36$$$##0" 
+  %"36#####0" = fcmp oeq double %66, %78 
+  ret i1 %"36#####0" 
 if.else17:
   ret i1 0 
 }
@@ -1359,13 +1359,13 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.c01<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.c01<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$##0", 7 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"###0", 7 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %84 = inttoptr i64 %"$##0" to i64* 
+  %84 = inttoptr i64 %"###0" to i64* 
   %85 = getelementptr  i64, i64* %84, i64 0 
   %86 = load  i64, i64* %85 
   %87 = insertvalue {i64, i1} undef, i64 %86, 0 
@@ -1386,18 +1386,18 @@ entry:
   %94 = inttoptr i64 %93 to i64* 
   %95 = getelementptr  i64, i64* %94, i64 0 
   store  i64 %"f02##0", i64* %95 
-  %"1$$##0" = or i64 %93, 1 
-  ret i64 %"1$$##0" 
+  %"1####0" = or i64 %93, 1 
+  ret i64 %"1####0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.c02<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.c02<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$##0", 7 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 1 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"###0", 7 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 1 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %96 = add   i64 %"$##0", -1 
+  %96 = add   i64 %"###0", -1 
   %97 = inttoptr i64 %96 to i64* 
   %98 = getelementptr  i64, i64* %97, i64 0 
   %99 = load  i64, i64* %98 
@@ -1419,18 +1419,18 @@ entry:
   %107 = inttoptr i64 %106 to i64* 
   %108 = getelementptr  i64, i64* %107, i64 0 
   store  i64 %"f03##0", i64* %108 
-  %"1$$##0" = or i64 %106, 2 
-  ret i64 %"1$$##0" 
+  %"1####0" = or i64 %106, 2 
+  ret i64 %"1####0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.c03<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.c03<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$##0", 7 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 2 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"###0", 7 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 2 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %109 = add   i64 %"$##0", -2 
+  %109 = add   i64 %"###0", -2 
   %110 = inttoptr i64 %109 to i64* 
   %111 = getelementptr  i64, i64* %110, i64 0 
   %112 = load  i64, i64* %111 
@@ -1452,18 +1452,18 @@ entry:
   %120 = inttoptr i64 %119 to i64* 
   %121 = getelementptr  i64, i64* %120, i64 0 
   store  i64 %"f04##0", i64* %121 
-  %"1$$##0" = or i64 %119, 3 
-  ret i64 %"1$$##0" 
+  %"1####0" = or i64 %119, 3 
+  ret i64 %"1####0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.c04<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.c04<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$##0", 7 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 3 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"###0", 7 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 3 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %122 = add   i64 %"$##0", -3 
+  %122 = add   i64 %"###0", -3 
   %123 = inttoptr i64 %122 to i64* 
   %124 = getelementptr  i64, i64* %123, i64 0 
   %125 = load  i64, i64* %124 
@@ -1485,18 +1485,18 @@ entry:
   %133 = inttoptr i64 %132 to i64* 
   %134 = getelementptr  i64, i64* %133, i64 0 
   store  i64 %"f05##0", i64* %134 
-  %"1$$##0" = or i64 %132, 4 
-  ret i64 %"1$$##0" 
+  %"1####0" = or i64 %132, 4 
+  ret i64 %"1####0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.c05<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.c05<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$##0", 7 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"###0", 7 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %135 = add   i64 %"$##0", -4 
+  %135 = add   i64 %"###0", -4 
   %136 = inttoptr i64 %135 to i64* 
   %137 = getelementptr  i64, i64* %136, i64 0 
   %138 = load  i64, i64* %137 
@@ -1518,18 +1518,18 @@ entry:
   %146 = inttoptr i64 %145 to i64* 
   %147 = getelementptr  i64, i64* %146, i64 0 
   store  i64 %"f06##0", i64* %147 
-  %"1$$##0" = or i64 %145, 5 
-  ret i64 %"1$$##0" 
+  %"1####0" = or i64 %145, 5 
+  ret i64 %"1####0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.c06<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.c06<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$##0", 7 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 5 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"###0", 7 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 5 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %148 = add   i64 %"$##0", -5 
+  %148 = add   i64 %"###0", -5 
   %149 = inttoptr i64 %148 to i64* 
   %150 = getelementptr  i64, i64* %149, i64 0 
   %151 = load  i64, i64* %150 
@@ -1551,18 +1551,18 @@ entry:
   %159 = inttoptr i64 %158 to i64* 
   %160 = getelementptr  i64, i64* %159, i64 0 
   store  i64 %"f07##0", i64* %160 
-  %"1$$##0" = or i64 %158, 6 
-  ret i64 %"1$$##0" 
+  %"1####0" = or i64 %158, 6 
+  ret i64 %"1####0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.c07<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.c07<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$##0", 7 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 6 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"###0", 7 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 6 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %161 = add   i64 %"$##0", -6 
+  %161 = add   i64 %"###0", -6 
   %162 = inttoptr i64 %161 to i64* 
   %163 = getelementptr  i64, i64* %162, i64 0 
   %164 = load  i64, i64* %163 
@@ -1592,26 +1592,26 @@ entry:
   %178 = inttoptr i64 %177 to double* 
   %179 = getelementptr  double, double* %178, i64 0 
   store  double %"f08_c##0", double* %179 
-  %"1$$##0" = or i64 %171, 7 
-  ret i64 %"1$$##0" 
+  %"1####0" = or i64 %171, 7 
+  ret i64 %"1####0" 
 }
 
 
-define external fastcc  {i64, i64, double, i1} @"multictr2.t.c08<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64, double, i1} @"multictr2.t.c08<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$##0", 7 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 7 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"###0", 7 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 7 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %180 = add   i64 %"$##0", -7 
+  %180 = add   i64 %"###0", -7 
   %181 = inttoptr i64 %180 to i64* 
   %182 = getelementptr  i64, i64* %181, i64 0 
   %183 = load  i64, i64* %182 
-  %184 = add   i64 %"$##0", 1 
+  %184 = add   i64 %"###0", 1 
   %185 = inttoptr i64 %184 to i64* 
   %186 = getelementptr  i64, i64* %185, i64 0 
   %187 = load  i64, i64* %186 
-  %188 = add   i64 %"$##0", 9 
+  %188 = add   i64 %"###0", 9 
   %189 = inttoptr i64 %188 to double* 
   %190 = getelementptr  double, double* %189, i64 0 
   %191 = load  double, double* %190 
@@ -1629,13 +1629,13 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f01<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f01<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"#rec##0", 7 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %200 = inttoptr i64 %"$rec##0" to i64* 
+  %200 = inttoptr i64 %"#rec##0" to i64* 
   %201 = getelementptr  i64, i64* %200, i64 0 
   %202 = load  i64, i64* %201 
   %203 = insertvalue {i64, i1} undef, i64 %202, 0 
@@ -1648,39 +1648,39 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f01<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f01<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"#rec##0", 7 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %207 = trunc i64 8 to i32  
   %208 = tail call ccc  i8*  @wybe_malloc(i32  %207)  
   %209 = ptrtoint i8* %208 to i64 
   %210 = inttoptr i64 %209 to i8* 
-  %211 = inttoptr i64 %"$rec##0" to i8* 
+  %211 = inttoptr i64 %"#rec##0" to i8* 
   %212 = trunc i64 8 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %210, i8*  %211, i32  %212, i32  8, i1  0)  
   %213 = inttoptr i64 %209 to i64* 
   %214 = getelementptr  i64, i64* %213, i64 0 
-  store  i64 %"$field##0", i64* %214 
+  store  i64 %"#field##0", i64* %214 
   %215 = insertvalue {i64, i1} undef, i64 %209, 0 
   %216 = insertvalue {i64, i1} %215, i1 1, 1 
   ret {i64, i1} %216 
 if.else:
-  %217 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %217 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %218 = insertvalue {i64, i1} %217, i1 0, 1 
   ret {i64, i1} %218 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f02<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f02<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 1 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"#rec##0", 7 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 1 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %219 = add   i64 %"$rec##0", -1 
+  %219 = add   i64 %"#rec##0", -1 
   %220 = inttoptr i64 %219 to i64* 
   %221 = getelementptr  i64, i64* %220, i64 0 
   %222 = load  i64, i64* %221 
@@ -1694,17 +1694,17 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f02<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f02<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 1 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"#rec##0", 7 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 1 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %227 = trunc i64 8 to i32  
   %228 = tail call ccc  i8*  @wybe_malloc(i32  %227)  
   %229 = ptrtoint i8* %228 to i64 
   %230 = add   i64 %229, 1 
-  %231 = sub   i64 %"$rec##0", 1 
+  %231 = sub   i64 %"#rec##0", 1 
   %232 = inttoptr i64 %229 to i8* 
   %233 = inttoptr i64 %231 to i8* 
   %234 = trunc i64 8 to i32  
@@ -1712,24 +1712,24 @@ if.then:
   %235 = add   i64 %230, -1 
   %236 = inttoptr i64 %235 to i64* 
   %237 = getelementptr  i64, i64* %236, i64 0 
-  store  i64 %"$field##0", i64* %237 
+  store  i64 %"#field##0", i64* %237 
   %238 = insertvalue {i64, i1} undef, i64 %230, 0 
   %239 = insertvalue {i64, i1} %238, i1 1, 1 
   ret {i64, i1} %239 
 if.else:
-  %240 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %240 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %241 = insertvalue {i64, i1} %240, i1 0, 1 
   ret {i64, i1} %241 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f03<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f03<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 2 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"#rec##0", 7 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 2 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %242 = add   i64 %"$rec##0", -2 
+  %242 = add   i64 %"#rec##0", -2 
   %243 = inttoptr i64 %242 to i64* 
   %244 = getelementptr  i64, i64* %243, i64 0 
   %245 = load  i64, i64* %244 
@@ -1743,17 +1743,17 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f03<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f03<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 2 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"#rec##0", 7 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 2 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %250 = trunc i64 8 to i32  
   %251 = tail call ccc  i8*  @wybe_malloc(i32  %250)  
   %252 = ptrtoint i8* %251 to i64 
   %253 = add   i64 %252, 2 
-  %254 = sub   i64 %"$rec##0", 2 
+  %254 = sub   i64 %"#rec##0", 2 
   %255 = inttoptr i64 %252 to i8* 
   %256 = inttoptr i64 %254 to i8* 
   %257 = trunc i64 8 to i32  
@@ -1761,24 +1761,24 @@ if.then:
   %258 = add   i64 %253, -2 
   %259 = inttoptr i64 %258 to i64* 
   %260 = getelementptr  i64, i64* %259, i64 0 
-  store  i64 %"$field##0", i64* %260 
+  store  i64 %"#field##0", i64* %260 
   %261 = insertvalue {i64, i1} undef, i64 %253, 0 
   %262 = insertvalue {i64, i1} %261, i1 1, 1 
   ret {i64, i1} %262 
 if.else:
-  %263 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %263 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %264 = insertvalue {i64, i1} %263, i1 0, 1 
   ret {i64, i1} %264 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f04<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f04<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 3 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"#rec##0", 7 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 3 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %265 = add   i64 %"$rec##0", -3 
+  %265 = add   i64 %"#rec##0", -3 
   %266 = inttoptr i64 %265 to i64* 
   %267 = getelementptr  i64, i64* %266, i64 0 
   %268 = load  i64, i64* %267 
@@ -1792,17 +1792,17 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f04<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f04<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 3 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"#rec##0", 7 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 3 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %273 = trunc i64 8 to i32  
   %274 = tail call ccc  i8*  @wybe_malloc(i32  %273)  
   %275 = ptrtoint i8* %274 to i64 
   %276 = add   i64 %275, 3 
-  %277 = sub   i64 %"$rec##0", 3 
+  %277 = sub   i64 %"#rec##0", 3 
   %278 = inttoptr i64 %275 to i8* 
   %279 = inttoptr i64 %277 to i8* 
   %280 = trunc i64 8 to i32  
@@ -1810,24 +1810,24 @@ if.then:
   %281 = add   i64 %276, -3 
   %282 = inttoptr i64 %281 to i64* 
   %283 = getelementptr  i64, i64* %282, i64 0 
-  store  i64 %"$field##0", i64* %283 
+  store  i64 %"#field##0", i64* %283 
   %284 = insertvalue {i64, i1} undef, i64 %276, 0 
   %285 = insertvalue {i64, i1} %284, i1 1, 1 
   ret {i64, i1} %285 
 if.else:
-  %286 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %286 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %287 = insertvalue {i64, i1} %286, i1 0, 1 
   ret {i64, i1} %287 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f05<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f05<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"#rec##0", 7 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %288 = add   i64 %"$rec##0", -4 
+  %288 = add   i64 %"#rec##0", -4 
   %289 = inttoptr i64 %288 to i64* 
   %290 = getelementptr  i64, i64* %289, i64 0 
   %291 = load  i64, i64* %290 
@@ -1841,17 +1841,17 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f05<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f05<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 4 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"#rec##0", 7 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 4 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %296 = trunc i64 8 to i32  
   %297 = tail call ccc  i8*  @wybe_malloc(i32  %296)  
   %298 = ptrtoint i8* %297 to i64 
   %299 = add   i64 %298, 4 
-  %300 = sub   i64 %"$rec##0", 4 
+  %300 = sub   i64 %"#rec##0", 4 
   %301 = inttoptr i64 %298 to i8* 
   %302 = inttoptr i64 %300 to i8* 
   %303 = trunc i64 8 to i32  
@@ -1859,24 +1859,24 @@ if.then:
   %304 = add   i64 %299, -4 
   %305 = inttoptr i64 %304 to i64* 
   %306 = getelementptr  i64, i64* %305, i64 0 
-  store  i64 %"$field##0", i64* %306 
+  store  i64 %"#field##0", i64* %306 
   %307 = insertvalue {i64, i1} undef, i64 %299, 0 
   %308 = insertvalue {i64, i1} %307, i1 1, 1 
   ret {i64, i1} %308 
 if.else:
-  %309 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %309 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %310 = insertvalue {i64, i1} %309, i1 0, 1 
   ret {i64, i1} %310 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f06<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f06<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 5 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"#rec##0", 7 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 5 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %311 = add   i64 %"$rec##0", -5 
+  %311 = add   i64 %"#rec##0", -5 
   %312 = inttoptr i64 %311 to i64* 
   %313 = getelementptr  i64, i64* %312, i64 0 
   %314 = load  i64, i64* %313 
@@ -1890,17 +1890,17 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f06<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f06<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 5 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"#rec##0", 7 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 5 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %319 = trunc i64 8 to i32  
   %320 = tail call ccc  i8*  @wybe_malloc(i32  %319)  
   %321 = ptrtoint i8* %320 to i64 
   %322 = add   i64 %321, 5 
-  %323 = sub   i64 %"$rec##0", 5 
+  %323 = sub   i64 %"#rec##0", 5 
   %324 = inttoptr i64 %321 to i8* 
   %325 = inttoptr i64 %323 to i8* 
   %326 = trunc i64 8 to i32  
@@ -1908,24 +1908,24 @@ if.then:
   %327 = add   i64 %322, -5 
   %328 = inttoptr i64 %327 to i64* 
   %329 = getelementptr  i64, i64* %328, i64 0 
-  store  i64 %"$field##0", i64* %329 
+  store  i64 %"#field##0", i64* %329 
   %330 = insertvalue {i64, i1} undef, i64 %322, 0 
   %331 = insertvalue {i64, i1} %330, i1 1, 1 
   ret {i64, i1} %331 
 if.else:
-  %332 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %332 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %333 = insertvalue {i64, i1} %332, i1 0, 1 
   ret {i64, i1} %333 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f07<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f07<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 6 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"#rec##0", 7 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 6 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %334 = add   i64 %"$rec##0", -6 
+  %334 = add   i64 %"#rec##0", -6 
   %335 = inttoptr i64 %334 to i64* 
   %336 = getelementptr  i64, i64* %335, i64 0 
   %337 = load  i64, i64* %336 
@@ -1939,17 +1939,17 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f07<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f07<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 6 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"#rec##0", 7 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 6 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %342 = trunc i64 8 to i32  
   %343 = tail call ccc  i8*  @wybe_malloc(i32  %342)  
   %344 = ptrtoint i8* %343 to i64 
   %345 = add   i64 %344, 6 
-  %346 = sub   i64 %"$rec##0", 6 
+  %346 = sub   i64 %"#rec##0", 6 
   %347 = inttoptr i64 %344 to i8* 
   %348 = inttoptr i64 %346 to i8* 
   %349 = trunc i64 8 to i32  
@@ -1957,24 +1957,24 @@ if.then:
   %350 = add   i64 %345, -6 
   %351 = inttoptr i64 %350 to i64* 
   %352 = getelementptr  i64, i64* %351, i64 0 
-  store  i64 %"$field##0", i64* %352 
+  store  i64 %"#field##0", i64* %352 
   %353 = insertvalue {i64, i1} undef, i64 %345, 0 
   %354 = insertvalue {i64, i1} %353, i1 1, 1 
   ret {i64, i1} %354 
 if.else:
-  %355 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %355 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %356 = insertvalue {i64, i1} %355, i1 0, 1 
   ret {i64, i1} %356 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f08_a<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f08_a<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 7 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"#rec##0", 7 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 7 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %357 = add   i64 %"$rec##0", -7 
+  %357 = add   i64 %"#rec##0", -7 
   %358 = inttoptr i64 %357 to i64* 
   %359 = getelementptr  i64, i64* %358, i64 0 
   %360 = load  i64, i64* %359 
@@ -1988,17 +1988,17 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f08_a<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f08_a<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 7 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"#rec##0", 7 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 7 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %365 = trunc i64 24 to i32  
   %366 = tail call ccc  i8*  @wybe_malloc(i32  %365)  
   %367 = ptrtoint i8* %366 to i64 
   %368 = add   i64 %367, 7 
-  %369 = sub   i64 %"$rec##0", 7 
+  %369 = sub   i64 %"#rec##0", 7 
   %370 = inttoptr i64 %367 to i8* 
   %371 = inttoptr i64 %369 to i8* 
   %372 = trunc i64 24 to i32  
@@ -2006,24 +2006,24 @@ if.then:
   %373 = add   i64 %368, -7 
   %374 = inttoptr i64 %373 to i64* 
   %375 = getelementptr  i64, i64* %374, i64 0 
-  store  i64 %"$field##0", i64* %375 
+  store  i64 %"#field##0", i64* %375 
   %376 = insertvalue {i64, i1} undef, i64 %368, 0 
   %377 = insertvalue {i64, i1} %376, i1 1, 1 
   ret {i64, i1} %377 
 if.else:
-  %378 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %378 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %379 = insertvalue {i64, i1} %378, i1 0, 1 
   ret {i64, i1} %379 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f08_b<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f08_b<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 7 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"#rec##0", 7 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 7 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %380 = add   i64 %"$rec##0", 1 
+  %380 = add   i64 %"#rec##0", 1 
   %381 = inttoptr i64 %380 to i64* 
   %382 = getelementptr  i64, i64* %381, i64 0 
   %383 = load  i64, i64* %382 
@@ -2037,17 +2037,17 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f08_b<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f08_b<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 7 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"#rec##0", 7 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 7 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %388 = trunc i64 24 to i32  
   %389 = tail call ccc  i8*  @wybe_malloc(i32  %388)  
   %390 = ptrtoint i8* %389 to i64 
   %391 = add   i64 %390, 7 
-  %392 = sub   i64 %"$rec##0", 7 
+  %392 = sub   i64 %"#rec##0", 7 
   %393 = inttoptr i64 %390 to i8* 
   %394 = inttoptr i64 %392 to i8* 
   %395 = trunc i64 24 to i32  
@@ -2055,24 +2055,24 @@ if.then:
   %396 = add   i64 %391, 1 
   %397 = inttoptr i64 %396 to i64* 
   %398 = getelementptr  i64, i64* %397, i64 0 
-  store  i64 %"$field##0", i64* %398 
+  store  i64 %"#field##0", i64* %398 
   %399 = insertvalue {i64, i1} undef, i64 %391, 0 
   %400 = insertvalue {i64, i1} %399, i1 1, 1 
   ret {i64, i1} %400 
 if.else:
-  %401 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %401 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %402 = insertvalue {i64, i1} %401, i1 0, 1 
   ret {i64, i1} %402 
 }
 
 
-define external fastcc  {double, i1} @"multictr2.t.f08_c<0>"(i64  %"$rec##0")    {
+define external fastcc  {double, i1} @"multictr2.t.f08_c<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 7 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"#rec##0", 7 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 7 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %403 = add   i64 %"$rec##0", 9 
+  %403 = add   i64 %"#rec##0", 9 
   %404 = inttoptr i64 %403 to double* 
   %405 = getelementptr  double, double* %404, i64 0 
   %406 = load  double, double* %405 
@@ -2086,17 +2086,17 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.f08_c<1>"(i64  %"$rec##0", double  %"$field##0")    {
+define external fastcc  {i64, i1} @"multictr2.t.f08_c<1>"(i64  %"#rec##0", double  %"#field##0")    {
 entry:
-  %"1$tmp$1##0" = and i64 %"$rec##0", 7 
-  %"1$tmp$0##0" = icmp eq i64 %"1$tmp$1##0", 7 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = and i64 %"#rec##0", 7 
+  %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 7 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %411 = trunc i64 24 to i32  
   %412 = tail call ccc  i8*  @wybe_malloc(i32  %411)  
   %413 = ptrtoint i8* %412 to i64 
   %414 = add   i64 %413, 7 
-  %415 = sub   i64 %"$rec##0", 7 
+  %415 = sub   i64 %"#rec##0", 7 
   %416 = inttoptr i64 %413 to i8* 
   %417 = inttoptr i64 %415 to i8* 
   %418 = trunc i64 24 to i32  
@@ -2104,20 +2104,20 @@ if.then:
   %419 = add   i64 %414, 9 
   %420 = inttoptr i64 %419 to double* 
   %421 = getelementptr  double, double* %420, i64 0 
-  store  double %"$field##0", double* %421 
+  store  double %"#field##0", double* %421 
   %422 = insertvalue {i64, i1} undef, i64 %414, 0 
   %423 = insertvalue {i64, i1} %422, i1 1, 1 
   ret {i64, i1} %423 
 if.else:
-  %424 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %424 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %425 = insertvalue {i64, i1} %424, i1 0, 1 
   ret {i64, i1} %425 
 }
 
 
-define external fastcc  i1 @"multictr2.t.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"multictr2.t.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = tail call fastcc  i1  @"multictr2.t.=<0>"(i64  %"$left##0", i64  %"$right##0")  
-  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
-  ret i1 %"1$$$##0" 
+  %"1#tmp#0##0" = tail call fastcc  i1  @"multictr2.t.=<0>"(i64  %"#left##0", i64  %"#right##0")  
+  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1#####0" 
 }

--- a/test-cases/final-dump/multictr2.exp
+++ b/test-cases/final-dump/multictr2.exp
@@ -420,7 +420,7 @@ if.else7:
 
 = > public (1 calls)
 0: multictr2.t.=<0>
-=(#left##0:multictr2.t, #right##0:multictr2.t, ?####0:wybe.bool):
+=(#left##0:multictr2.t, #right##0:multictr2.t, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#left##0:wybe.int, 7:wybe.int, ?tmp#28##0:wybe.int)
@@ -448,7 +448,7 @@ if.else7:
                                 foreign llvm icmp_eq(~tmp#28##0:wybe.int, 7:wybe.int, ?tmp#50##0:wybe.bool)
                                 case ~tmp#50##0:wybe.bool of
                                 0:
-                                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                 1:
                                     foreign lpvm access(#left##0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?#left#f08_a##0:wybe.int)
@@ -458,7 +458,7 @@ if.else7:
                                     foreign llvm icmp_eq(~tmp#52##0:wybe.int, 7:wybe.int, ?tmp#53##0:wybe.bool)
                                     case ~tmp#53##0:wybe.bool of
                                     0:
-                                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                     1:
                                         foreign lpvm access(#right##0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?#right#f08_a##0:wybe.int)
@@ -467,16 +467,16 @@ if.else7:
                                         foreign llvm icmp_eq(~#left#f08_a##0:wybe.int, ~#right#f08_a##0:wybe.int, ?tmp#16##0:wybe.bool) @int:nn:nn
                                         case ~tmp#16##0:wybe.bool of
                                         0:
-                                            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                         1:
                                             foreign llvm icmp_eq(~#left#f08_b##0:wybe.int, ~#right#f08_b##0:wybe.int, ?tmp#17##0:wybe.bool) @int:nn:nn
                                             case ~tmp#17##0:wybe.bool of
                                             0:
-                                                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                             1:
-                                                foreign llvm fcmp_eq(~#left#f08_c##0:wybe.float, ~#right#f08_c##0:wybe.float, ?####0:wybe.bool) @float:nn:nn
+                                                foreign llvm fcmp_eq(~#left#f08_c##0:wybe.float, ~#right#f08_c##0:wybe.float, ?#success##0:wybe.bool) @float:nn:nn
 
 
 
@@ -488,11 +488,11 @@ if.else7:
                                 foreign llvm icmp_eq(~tmp#49##0:wybe.int, 6:wybe.int, ?tmp#50##0:wybe.bool)
                                 case ~tmp#50##0:wybe.bool of
                                 0:
-                                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                                 1:
                                     foreign lpvm access(~#right##0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?#right#f07##0:wybe.int)
-                                    foreign llvm icmp_eq(~#left#f07##0:wybe.int, ~#right#f07##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+                                    foreign llvm icmp_eq(~#left#f07##0:wybe.int, ~#right#f07##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -502,11 +502,11 @@ if.else7:
                             foreign llvm icmp_eq(~tmp#46##0:wybe.int, 5:wybe.int, ?tmp#47##0:wybe.bool)
                             case ~tmp#47##0:wybe.bool of
                             0:
-                                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                             1:
                                 foreign lpvm access(~#right##0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?#right#f06##0:wybe.int)
-                                foreign llvm icmp_eq(~#left#f06##0:wybe.int, ~#right#f06##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+                                foreign llvm icmp_eq(~#left#f06##0:wybe.int, ~#right#f06##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -516,11 +516,11 @@ if.else7:
                         foreign llvm icmp_eq(~tmp#43##0:wybe.int, 4:wybe.int, ?tmp#44##0:wybe.bool)
                         case ~tmp#44##0:wybe.bool of
                         0:
-                            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                         1:
                             foreign lpvm access(~#right##0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?#right#f05##0:wybe.int)
-                            foreign llvm icmp_eq(~#left#f05##0:wybe.int, ~#right#f05##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+                            foreign llvm icmp_eq(~#left#f05##0:wybe.int, ~#right#f05##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -530,11 +530,11 @@ if.else7:
                     foreign llvm icmp_eq(~tmp#40##0:wybe.int, 3:wybe.int, ?tmp#41##0:wybe.bool)
                     case ~tmp#41##0:wybe.bool of
                     0:
-                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                     1:
                         foreign lpvm access(~#right##0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?#right#f04##0:wybe.int)
-                        foreign llvm icmp_eq(~#left#f04##0:wybe.int, ~#right#f04##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+                        foreign llvm icmp_eq(~#left#f04##0:wybe.int, ~#right#f04##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -544,11 +544,11 @@ if.else7:
                 foreign llvm icmp_eq(~tmp#37##0:wybe.int, 2:wybe.int, ?tmp#38##0:wybe.bool)
                 case ~tmp#38##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                 1:
                     foreign lpvm access(~#right##0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#right#f03##0:wybe.int)
-                    foreign llvm icmp_eq(~#left#f03##0:wybe.int, ~#right#f03##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+                    foreign llvm icmp_eq(~#left#f03##0:wybe.int, ~#right#f03##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -558,11 +558,11 @@ if.else7:
             foreign llvm icmp_eq(~tmp#34##0:wybe.int, 1:wybe.int, ?tmp#35##0:wybe.bool)
             case ~tmp#35##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
                 foreign lpvm access(~#right##0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#right#f02##0:wybe.int)
-                foreign llvm icmp_eq(~#left#f02##0:wybe.int, ~#right#f02##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+                foreign llvm icmp_eq(~#left#f02##0:wybe.int, ~#right#f02##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -572,11 +572,11 @@ if.else7:
         foreign llvm icmp_eq(~tmp#31##0:wybe.int, 0:wybe.int, ?tmp#32##0:wybe.bool)
         case ~tmp#32##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign lpvm access(~#right##0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#right#f01##0:wybe.int)
-            foreign llvm icmp_eq(~#left#f01##0:wybe.int, ~#right#f01##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+            foreign llvm icmp_eq(~#left#f01##0:wybe.int, ~#right#f01##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -590,19 +590,19 @@ c01(f01##0:wybe.int, ?#result##0:multictr2.t):
     foreign lpvm mutate(~#rec##0:multictr2.t, ?#result##0:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f01##0:wybe.int)
 c01 > public {inline} (24 calls)
 1: multictr2.t.c01<1>
-c01(?f01##0:wybe.int, #result##0:multictr2.t, ?####0:wybe.bool):
+c01(?f01##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#result##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f01##0:wybe.int)
 
     1:
         foreign lpvm access(~#result##0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?f01##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -616,19 +616,19 @@ c02(f02##0:wybe.int, ?#result##0:multictr2.t):
     foreign llvm or(~#rec##1:multictr2.t, 1:wybe.int, ?#result##0:multictr2.t)
 c02 > public {inline} (19 calls)
 1: multictr2.t.c02<1>
-c02(?f02##0:wybe.int, #result##0:multictr2.t, ?####0:wybe.bool):
+c02(?f02##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#result##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f02##0:wybe.int)
 
     1:
         foreign lpvm access(~#result##0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?f02##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -642,19 +642,19 @@ c03(f03##0:wybe.int, ?#result##0:multictr2.t):
     foreign llvm or(~#rec##1:multictr2.t, 2:wybe.int, ?#result##0:multictr2.t)
 c03 > public {inline} (17 calls)
 1: multictr2.t.c03<1>
-c03(?f03##0:wybe.int, #result##0:multictr2.t, ?####0:wybe.bool):
+c03(?f03##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#result##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 2:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f03##0:wybe.int)
 
     1:
         foreign lpvm access(~#result##0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?f03##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -668,19 +668,19 @@ c04(f04##0:wybe.int, ?#result##0:multictr2.t):
     foreign llvm or(~#rec##1:multictr2.t, 3:wybe.int, ?#result##0:multictr2.t)
 c04 > public {inline} (15 calls)
 1: multictr2.t.c04<1>
-c04(?f04##0:wybe.int, #result##0:multictr2.t, ?####0:wybe.bool):
+c04(?f04##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#result##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 3:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f04##0:wybe.int)
 
     1:
         foreign lpvm access(~#result##0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?f04##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -694,19 +694,19 @@ c05(f05##0:wybe.int, ?#result##0:multictr2.t):
     foreign llvm or(~#rec##1:multictr2.t, 4:wybe.int, ?#result##0:multictr2.t)
 c05 > public {inline} (13 calls)
 1: multictr2.t.c05<1>
-c05(?f05##0:wybe.int, #result##0:multictr2.t, ?####0:wybe.bool):
+c05(?f05##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#result##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f05##0:wybe.int)
 
     1:
         foreign lpvm access(~#result##0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?f05##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -720,19 +720,19 @@ c06(f06##0:wybe.int, ?#result##0:multictr2.t):
     foreign llvm or(~#rec##1:multictr2.t, 5:wybe.int, ?#result##0:multictr2.t)
 c06 > public {inline} (11 calls)
 1: multictr2.t.c06<1>
-c06(?f06##0:wybe.int, #result##0:multictr2.t, ?####0:wybe.bool):
+c06(?f06##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#result##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 5:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f06##0:wybe.int)
 
     1:
         foreign lpvm access(~#result##0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?f06##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -746,19 +746,19 @@ c07(f07##0:wybe.int, ?#result##0:multictr2.t):
     foreign llvm or(~#rec##1:multictr2.t, 6:wybe.int, ?#result##0:multictr2.t)
 c07 > public {inline} (9 calls)
 1: multictr2.t.c07<1>
-c07(?f07##0:wybe.int, #result##0:multictr2.t, ?####0:wybe.bool):
+c07(?f07##0:wybe.int, #result##0:multictr2.t, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#result##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 6:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f07##0:wybe.int)
 
     1:
         foreign lpvm access(~#result##0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?f07##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -774,14 +774,14 @@ c08(f08_a##0:wybe.int, f08_b##0:wybe.int, f08_c##0:wybe.float, ?#result##0:multi
     foreign llvm or(~#rec##3:multictr2.t, 7:wybe.int, ?#result##0:multictr2.t)
 c08 > public {inline} (9 calls)
 1: multictr2.t.c08<1>
-c08(?f08_a##0:wybe.int, ?f08_b##0:wybe.int, ?f08_c##0:wybe.float, #result##0:multictr2.t, ?####0:wybe.bool):
+c08(?f08_a##0:wybe.int, ?f08_b##0:wybe.int, ?f08_c##0:wybe.float, #result##0:multictr2.t, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#result##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 7:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?f08_a##0:wybe.int)
         foreign llvm move(undef:wybe.int, ?f08_b##0:wybe.int)
         foreign llvm move(undef:wybe.float, ?f08_c##0:wybe.float)
@@ -790,357 +790,357 @@ c08(?f08_a##0:wybe.int, ?f08_b##0:wybe.int, ?f08_c##0:wybe.float, #result##0:mul
         foreign lpvm access(#result##0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?f08_a##0:wybe.int)
         foreign lpvm access(#result##0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?f08_b##0:wybe.int)
         foreign lpvm access(~#result##0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?f08_c##0:wybe.float)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 f01 > public {inline} (0 calls)
 0: multictr2.t.f01<0>
-f01(#rec##0:multictr2.t, ?#result##0:wybe.int, ?####0:wybe.bool):
+f01(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign lpvm access(~#rec##0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 f01 > public {inline} (0 calls)
 1: multictr2.t.f01<1>
-f01(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?####0:wybe.bool):
+f01(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multictr2.t, ?#rec##1:multictr2.t)
 
     1:
         foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 0:wybe.int, 8:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 f02 > public {inline} (0 calls)
 0: multictr2.t.f02<0>
-f02(#rec##0:multictr2.t, ?#result##0:wybe.int, ?####0:wybe.bool):
+f02(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign lpvm access(~#rec##0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#result##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 f02 > public {inline} (0 calls)
 1: multictr2.t.f02<1>
-f02(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?####0:wybe.bool):
+f02(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multictr2.t, ?#rec##1:multictr2.t)
 
     1:
         foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, -1:wybe.int, 0:wybe.int, 8:wybe.int, 1:wybe.int, ~#field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 f03 > public {inline} (0 calls)
 0: multictr2.t.f03<0>
-f03(#rec##0:multictr2.t, ?#result##0:wybe.int, ?####0:wybe.bool):
+f03(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 2:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign lpvm access(~#rec##0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#result##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 f03 > public {inline} (0 calls)
 1: multictr2.t.f03<1>
-f03(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?####0:wybe.bool):
+f03(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 2:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multictr2.t, ?#rec##1:multictr2.t)
 
     1:
         foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, -2:wybe.int, 0:wybe.int, 8:wybe.int, 2:wybe.int, ~#field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 f04 > public {inline} (0 calls)
 0: multictr2.t.f04<0>
-f04(#rec##0:multictr2.t, ?#result##0:wybe.int, ?####0:wybe.bool):
+f04(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 3:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign lpvm access(~#rec##0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?#result##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 f04 > public {inline} (0 calls)
 1: multictr2.t.f04<1>
-f04(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?####0:wybe.bool):
+f04(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 3:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multictr2.t, ?#rec##1:multictr2.t)
 
     1:
         foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, -3:wybe.int, 0:wybe.int, 8:wybe.int, 3:wybe.int, ~#field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 f05 > public {inline} (0 calls)
 0: multictr2.t.f05<0>
-f05(#rec##0:multictr2.t, ?#result##0:wybe.int, ?####0:wybe.bool):
+f05(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign lpvm access(~#rec##0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?#result##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 f05 > public {inline} (0 calls)
 1: multictr2.t.f05<1>
-f05(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?####0:wybe.bool):
+f05(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multictr2.t, ?#rec##1:multictr2.t)
 
     1:
         foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, -4:wybe.int, 0:wybe.int, 8:wybe.int, 4:wybe.int, ~#field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 f06 > public {inline} (0 calls)
 0: multictr2.t.f06<0>
-f06(#rec##0:multictr2.t, ?#result##0:wybe.int, ?####0:wybe.bool):
+f06(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 5:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign lpvm access(~#rec##0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?#result##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 f06 > public {inline} (0 calls)
 1: multictr2.t.f06<1>
-f06(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?####0:wybe.bool):
+f06(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 5:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multictr2.t, ?#rec##1:multictr2.t)
 
     1:
         foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, -5:wybe.int, 0:wybe.int, 8:wybe.int, 5:wybe.int, ~#field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 f07 > public {inline} (0 calls)
 0: multictr2.t.f07<0>
-f07(#rec##0:multictr2.t, ?#result##0:wybe.int, ?####0:wybe.bool):
+f07(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 6:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign lpvm access(~#rec##0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?#result##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 f07 > public {inline} (0 calls)
 1: multictr2.t.f07<1>
-f07(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?####0:wybe.bool):
+f07(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 6:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multictr2.t, ?#rec##1:multictr2.t)
 
     1:
         foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, -6:wybe.int, 0:wybe.int, 8:wybe.int, 6:wybe.int, ~#field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 f08_a > public {inline} (0 calls)
 0: multictr2.t.f08_a<0>
-f08_a(#rec##0:multictr2.t, ?#result##0:wybe.int, ?####0:wybe.bool):
+f08_a(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 7:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign lpvm access(~#rec##0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 f08_a > public {inline} (0 calls)
 1: multictr2.t.f08_a<1>
-f08_a(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?####0:wybe.bool):
+f08_a(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 7:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multictr2.t, ?#rec##1:multictr2.t)
 
     1:
         foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, -7:wybe.int, 0:wybe.int, 24:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 f08_b > public {inline} (0 calls)
 0: multictr2.t.f08_b<0>
-f08_b(#rec##0:multictr2.t, ?#result##0:wybe.int, ?####0:wybe.bool):
+f08_b(#rec##0:multictr2.t, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 7:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign lpvm access(~#rec##0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 f08_b > public {inline} (0 calls)
 1: multictr2.t.f08_b<1>
-f08_b(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?####0:wybe.bool):
+f08_b(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 7:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multictr2.t, ?#rec##1:multictr2.t)
 
     1:
         foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 1:wybe.int, 0:wybe.int, 24:wybe.int, 7:wybe.int, ~#field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 f08_c > public {inline} (0 calls)
 0: multictr2.t.f08_c<0>
-f08_c(#rec##0:multictr2.t, ?#result##0:wybe.float, ?####0:wybe.bool):
+f08_c(#rec##0:multictr2.t, ?#result##0:wybe.float, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 7:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.float, ?#result##0:wybe.float)
 
     1:
         foreign lpvm access(~#rec##0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?#result##0:wybe.float)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 f08_c > public {inline} (0 calls)
 1: multictr2.t.f08_c<1>
-f08_c(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.float, ?####0:wybe.bool):
+f08_c(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.float, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 7:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:multictr2.t, ?#rec##1:multictr2.t)
 
     1:
         foreign lpvm {noalias} mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 9:wybe.int, 0:wybe.int, 24:wybe.int, 7:wybe.int, ~#field##0:wybe.float)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: multictr2.t.~=<0>
-~=(#left##0:multictr2.t, #right##0:multictr2.t, ?####0:wybe.bool):
+~=(#left##0:multictr2.t, #right##0:multictr2.t, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     multictr2.t.=<0>(~#left##0:multictr2.t, ~#right##0:multictr2.t, ?tmp#0##0:wybe.bool) #0
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 
@@ -1175,8 +1175,8 @@ if.then1:
   %4 = inttoptr i64 %"#right##0" to i64* 
   %5 = getelementptr  i64, i64* %4, i64 0 
   %6 = load  i64, i64* %5 
-  %"4#####0" = icmp eq i64 %3, %6 
-  ret i1 %"4#####0" 
+  %"4##success##0" = icmp eq i64 %3, %6 
+  ret i1 %"4##success##0" 
 if.else1:
   ret i1 0 
 if.then2:
@@ -1195,8 +1195,8 @@ if.then3:
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"8#####0" = icmp eq i64 %10, %14 
-  ret i1 %"8#####0" 
+  %"8##success##0" = icmp eq i64 %10, %14 
+  ret i1 %"8##success##0" 
 if.else3:
   ret i1 0 
 if.then4:
@@ -1215,8 +1215,8 @@ if.then5:
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %"12#####0" = icmp eq i64 %18, %22 
-  ret i1 %"12#####0" 
+  %"12##success##0" = icmp eq i64 %18, %22 
+  ret i1 %"12##success##0" 
 if.else5:
   ret i1 0 
 if.then6:
@@ -1235,8 +1235,8 @@ if.then7:
   %28 = inttoptr i64 %27 to i64* 
   %29 = getelementptr  i64, i64* %28, i64 0 
   %30 = load  i64, i64* %29 
-  %"16#####0" = icmp eq i64 %26, %30 
-  ret i1 %"16#####0" 
+  %"16##success##0" = icmp eq i64 %26, %30 
+  ret i1 %"16##success##0" 
 if.else7:
   ret i1 0 
 if.then8:
@@ -1255,8 +1255,8 @@ if.then9:
   %36 = inttoptr i64 %35 to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
-  %"20#####0" = icmp eq i64 %34, %38 
-  ret i1 %"20#####0" 
+  %"20##success##0" = icmp eq i64 %34, %38 
+  ret i1 %"20##success##0" 
 if.else9:
   ret i1 0 
 if.then10:
@@ -1275,8 +1275,8 @@ if.then11:
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
-  %"24#####0" = icmp eq i64 %42, %46 
-  ret i1 %"24#####0" 
+  %"24##success##0" = icmp eq i64 %42, %46 
+  ret i1 %"24##success##0" 
 if.else11:
   ret i1 0 
 if.then12:
@@ -1295,8 +1295,8 @@ if.then13:
   %52 = inttoptr i64 %51 to i64* 
   %53 = getelementptr  i64, i64* %52, i64 0 
   %54 = load  i64, i64* %53 
-  %"28#####0" = icmp eq i64 %50, %54 
-  ret i1 %"28#####0" 
+  %"28##success##0" = icmp eq i64 %50, %54 
+  ret i1 %"28##success##0" 
 if.else13:
   ret i1 0 
 if.then14:
@@ -1340,8 +1340,8 @@ if.then16:
 if.else16:
   ret i1 0 
 if.then17:
-  %"36#####0" = fcmp oeq double %66, %78 
-  ret i1 %"36#####0" 
+  %"36##success##0" = fcmp oeq double %66, %78 
+  ret i1 %"36##success##0" 
 if.else17:
   ret i1 0 
 }
@@ -2118,6 +2118,6 @@ if.else:
 define external fastcc  i1 @"multictr2.t.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %"1#tmp#0##0" = tail call fastcc  i1  @"multictr2.t.=<0>"(i64  %"#left##0", i64  %"#right##0")  
-  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
-  ret i1 %"1#####0" 
+  %"1##success##0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1##success##0" 
 }

--- a/test-cases/final-dump/multictr2.exp
+++ b/test-cases/final-dump/multictr2.exp
@@ -583,17 +583,17 @@ if.else7:
 
 c01 > public {inline} (0 calls)
 0: multictr2.t.c01<0>
-c01(f01##0:wybe.int, ?###0:multictr2.t):
+c01(f01##0:wybe.int, ?#result##0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t)
-    foreign lpvm mutate(~#rec##0:multictr2.t, ?###0:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f01##0:wybe.int)
+    foreign lpvm mutate(~#rec##0:multictr2.t, ?#result##0:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f01##0:wybe.int)
 c01 > public {inline} (24 calls)
 1: multictr2.t.c01<1>
-c01(?f01##0:wybe.int, ###0:multictr2.t, ?####0:wybe.bool):
+c01(?f01##0:wybe.int, #result##0:multictr2.t, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm and(#result##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
@@ -601,25 +601,25 @@ c01(?f01##0:wybe.int, ###0:multictr2.t, ?####0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?f01##0:wybe.int)
 
     1:
-        foreign lpvm access(~###0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?f01##0:wybe.int)
+        foreign lpvm access(~#result##0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?f01##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 c02 > public {inline} (0 calls)
 0: multictr2.t.c02<0>
-c02(f02##0:wybe.int, ?###0:multictr2.t):
+c02(f02##0:wybe.int, ?#result##0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t)
     foreign lpvm mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f02##0:wybe.int)
-    foreign llvm or(~#rec##1:multictr2.t, 1:wybe.int, ?###0:multictr2.t)
+    foreign llvm or(~#rec##1:multictr2.t, 1:wybe.int, ?#result##0:multictr2.t)
 c02 > public {inline} (19 calls)
 1: multictr2.t.c02<1>
-c02(?f02##0:wybe.int, ###0:multictr2.t, ?####0:wybe.bool):
+c02(?f02##0:wybe.int, #result##0:multictr2.t, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm and(#result##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
@@ -627,25 +627,25 @@ c02(?f02##0:wybe.int, ###0:multictr2.t, ?####0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?f02##0:wybe.int)
 
     1:
-        foreign lpvm access(~###0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?f02##0:wybe.int)
+        foreign lpvm access(~#result##0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?f02##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 c03 > public {inline} (0 calls)
 0: multictr2.t.c03<0>
-c03(f03##0:wybe.int, ?###0:multictr2.t):
+c03(f03##0:wybe.int, ?#result##0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t)
     foreign lpvm mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f03##0:wybe.int)
-    foreign llvm or(~#rec##1:multictr2.t, 2:wybe.int, ?###0:multictr2.t)
+    foreign llvm or(~#rec##1:multictr2.t, 2:wybe.int, ?#result##0:multictr2.t)
 c03 > public {inline} (17 calls)
 1: multictr2.t.c03<1>
-c03(?f03##0:wybe.int, ###0:multictr2.t, ?####0:wybe.bool):
+c03(?f03##0:wybe.int, #result##0:multictr2.t, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm and(#result##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 2:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
@@ -653,25 +653,25 @@ c03(?f03##0:wybe.int, ###0:multictr2.t, ?####0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?f03##0:wybe.int)
 
     1:
-        foreign lpvm access(~###0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?f03##0:wybe.int)
+        foreign lpvm access(~#result##0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?f03##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 c04 > public {inline} (0 calls)
 0: multictr2.t.c04<0>
-c04(f04##0:wybe.int, ?###0:multictr2.t):
+c04(f04##0:wybe.int, ?#result##0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t)
     foreign lpvm mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f04##0:wybe.int)
-    foreign llvm or(~#rec##1:multictr2.t, 3:wybe.int, ?###0:multictr2.t)
+    foreign llvm or(~#rec##1:multictr2.t, 3:wybe.int, ?#result##0:multictr2.t)
 c04 > public {inline} (15 calls)
 1: multictr2.t.c04<1>
-c04(?f04##0:wybe.int, ###0:multictr2.t, ?####0:wybe.bool):
+c04(?f04##0:wybe.int, #result##0:multictr2.t, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm and(#result##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 3:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
@@ -679,25 +679,25 @@ c04(?f04##0:wybe.int, ###0:multictr2.t, ?####0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?f04##0:wybe.int)
 
     1:
-        foreign lpvm access(~###0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?f04##0:wybe.int)
+        foreign lpvm access(~#result##0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?f04##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 c05 > public {inline} (0 calls)
 0: multictr2.t.c05<0>
-c05(f05##0:wybe.int, ?###0:multictr2.t):
+c05(f05##0:wybe.int, ?#result##0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t)
     foreign lpvm mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f05##0:wybe.int)
-    foreign llvm or(~#rec##1:multictr2.t, 4:wybe.int, ?###0:multictr2.t)
+    foreign llvm or(~#rec##1:multictr2.t, 4:wybe.int, ?#result##0:multictr2.t)
 c05 > public {inline} (13 calls)
 1: multictr2.t.c05<1>
-c05(?f05##0:wybe.int, ###0:multictr2.t, ?####0:wybe.bool):
+c05(?f05##0:wybe.int, #result##0:multictr2.t, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm and(#result##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 4:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
@@ -705,25 +705,25 @@ c05(?f05##0:wybe.int, ###0:multictr2.t, ?####0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?f05##0:wybe.int)
 
     1:
-        foreign lpvm access(~###0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?f05##0:wybe.int)
+        foreign lpvm access(~#result##0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?f05##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 c06 > public {inline} (0 calls)
 0: multictr2.t.c06<0>
-c06(f06##0:wybe.int, ?###0:multictr2.t):
+c06(f06##0:wybe.int, ?#result##0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t)
     foreign lpvm mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f06##0:wybe.int)
-    foreign llvm or(~#rec##1:multictr2.t, 5:wybe.int, ?###0:multictr2.t)
+    foreign llvm or(~#rec##1:multictr2.t, 5:wybe.int, ?#result##0:multictr2.t)
 c06 > public {inline} (11 calls)
 1: multictr2.t.c06<1>
-c06(?f06##0:wybe.int, ###0:multictr2.t, ?####0:wybe.bool):
+c06(?f06##0:wybe.int, #result##0:multictr2.t, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm and(#result##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 5:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
@@ -731,25 +731,25 @@ c06(?f06##0:wybe.int, ###0:multictr2.t, ?####0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?f06##0:wybe.int)
 
     1:
-        foreign lpvm access(~###0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?f06##0:wybe.int)
+        foreign lpvm access(~#result##0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?f06##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 c07 > public {inline} (0 calls)
 0: multictr2.t.c07<0>
-c07(f07##0:wybe.int, ?###0:multictr2.t):
+c07(f07##0:wybe.int, ?#result##0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?#rec##0:multictr2.t)
     foreign lpvm mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~f07##0:wybe.int)
-    foreign llvm or(~#rec##1:multictr2.t, 6:wybe.int, ?###0:multictr2.t)
+    foreign llvm or(~#rec##1:multictr2.t, 6:wybe.int, ?#result##0:multictr2.t)
 c07 > public {inline} (9 calls)
 1: multictr2.t.c07<1>
-c07(?f07##0:wybe.int, ###0:multictr2.t, ?####0:wybe.bool):
+c07(?f07##0:wybe.int, #result##0:multictr2.t, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm and(#result##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 6:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
@@ -757,27 +757,27 @@ c07(?f07##0:wybe.int, ###0:multictr2.t, ?####0:wybe.bool):
         foreign llvm move(undef:wybe.int, ?f07##0:wybe.int)
 
     1:
-        foreign lpvm access(~###0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?f07##0:wybe.int)
+        foreign lpvm access(~#result##0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?f07##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 c08 > public {inline} (0 calls)
 0: multictr2.t.c08<0>
-c08(f08_a##0:wybe.int, f08_b##0:wybe.int, f08_c##0:wybe.float, ?###0:multictr2.t):
+c08(f08_a##0:wybe.int, f08_b##0:wybe.int, f08_c##0:wybe.float, ?#result##0:multictr2.t):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(24:wybe.int, ?#rec##0:multictr2.t)
     foreign lpvm mutate(~#rec##0:multictr2.t, ?#rec##1:multictr2.t, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~f08_a##0:wybe.int)
     foreign lpvm mutate(~#rec##1:multictr2.t, ?#rec##2:multictr2.t, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~f08_b##0:wybe.int)
     foreign lpvm mutate(~#rec##2:multictr2.t, ?#rec##3:multictr2.t, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~f08_c##0:wybe.float)
-    foreign llvm or(~#rec##3:multictr2.t, 7:wybe.int, ?###0:multictr2.t)
+    foreign llvm or(~#rec##3:multictr2.t, 7:wybe.int, ?#result##0:multictr2.t)
 c08 > public {inline} (9 calls)
 1: multictr2.t.c08<1>
-c08(?f08_a##0:wybe.int, ?f08_b##0:wybe.int, ?f08_c##0:wybe.float, ###0:multictr2.t, ?####0:wybe.bool):
+c08(?f08_a##0:wybe.int, ?f08_b##0:wybe.int, ?f08_c##0:wybe.float, #result##0:multictr2.t, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm and(###0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
+    foreign llvm and(#result##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
     foreign llvm icmp_eq(~tmp#1##0:wybe.int, 7:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
@@ -787,16 +787,16 @@ c08(?f08_a##0:wybe.int, ?f08_b##0:wybe.int, ?f08_c##0:wybe.float, ###0:multictr2
         foreign llvm move(undef:wybe.float, ?f08_c##0:wybe.float)
 
     1:
-        foreign lpvm access(###0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?f08_a##0:wybe.int)
-        foreign lpvm access(###0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?f08_b##0:wybe.int)
-        foreign lpvm access(~###0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?f08_c##0:wybe.float)
+        foreign lpvm access(#result##0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?f08_a##0:wybe.int)
+        foreign lpvm access(#result##0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?f08_b##0:wybe.int)
+        foreign lpvm access(~#result##0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?f08_c##0:wybe.float)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 f01 > public {inline} (0 calls)
 0: multictr2.t.f01<0>
-f01(#rec##0:multictr2.t, ?###0:wybe.int, ?####0:wybe.bool):
+f01(#rec##0:multictr2.t, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
@@ -804,10 +804,10 @@ f01(#rec##0:multictr2.t, ?###0:wybe.int, ?####0:wybe.bool):
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign lpvm access(~#rec##0:multictr2.t, 0:wybe.int, 8:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 f01 > public {inline} (0 calls)
@@ -830,7 +830,7 @@ f01(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?####0:wybe.b
 
 f02 > public {inline} (0 calls)
 0: multictr2.t.f02<0>
-f02(#rec##0:multictr2.t, ?###0:wybe.int, ?####0:wybe.bool):
+f02(#rec##0:multictr2.t, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
@@ -838,10 +838,10 @@ f02(#rec##0:multictr2.t, ?###0:wybe.int, ?####0:wybe.bool):
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?###0:wybe.int)
+        foreign lpvm access(~#rec##0:multictr2.t, -1:wybe.int, 8:wybe.int, 1:wybe.int, ?#result##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 f02 > public {inline} (0 calls)
@@ -864,7 +864,7 @@ f02(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?####0:wybe.b
 
 f03 > public {inline} (0 calls)
 0: multictr2.t.f03<0>
-f03(#rec##0:multictr2.t, ?###0:wybe.int, ?####0:wybe.bool):
+f03(#rec##0:multictr2.t, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
@@ -872,10 +872,10 @@ f03(#rec##0:multictr2.t, ?###0:wybe.int, ?####0:wybe.bool):
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?###0:wybe.int)
+        foreign lpvm access(~#rec##0:multictr2.t, -2:wybe.int, 8:wybe.int, 2:wybe.int, ?#result##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 f03 > public {inline} (0 calls)
@@ -898,7 +898,7 @@ f03(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?####0:wybe.b
 
 f04 > public {inline} (0 calls)
 0: multictr2.t.f04<0>
-f04(#rec##0:multictr2.t, ?###0:wybe.int, ?####0:wybe.bool):
+f04(#rec##0:multictr2.t, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
@@ -906,10 +906,10 @@ f04(#rec##0:multictr2.t, ?###0:wybe.int, ?####0:wybe.bool):
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?###0:wybe.int)
+        foreign lpvm access(~#rec##0:multictr2.t, -3:wybe.int, 8:wybe.int, 3:wybe.int, ?#result##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 f04 > public {inline} (0 calls)
@@ -932,7 +932,7 @@ f04(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?####0:wybe.b
 
 f05 > public {inline} (0 calls)
 0: multictr2.t.f05<0>
-f05(#rec##0:multictr2.t, ?###0:wybe.int, ?####0:wybe.bool):
+f05(#rec##0:multictr2.t, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
@@ -940,10 +940,10 @@ f05(#rec##0:multictr2.t, ?###0:wybe.int, ?####0:wybe.bool):
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?###0:wybe.int)
+        foreign lpvm access(~#rec##0:multictr2.t, -4:wybe.int, 8:wybe.int, 4:wybe.int, ?#result##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 f05 > public {inline} (0 calls)
@@ -966,7 +966,7 @@ f05(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?####0:wybe.b
 
 f06 > public {inline} (0 calls)
 0: multictr2.t.f06<0>
-f06(#rec##0:multictr2.t, ?###0:wybe.int, ?####0:wybe.bool):
+f06(#rec##0:multictr2.t, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
@@ -974,10 +974,10 @@ f06(#rec##0:multictr2.t, ?###0:wybe.int, ?####0:wybe.bool):
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?###0:wybe.int)
+        foreign lpvm access(~#rec##0:multictr2.t, -5:wybe.int, 8:wybe.int, 5:wybe.int, ?#result##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 f06 > public {inline} (0 calls)
@@ -1000,7 +1000,7 @@ f06(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?####0:wybe.b
 
 f07 > public {inline} (0 calls)
 0: multictr2.t.f07<0>
-f07(#rec##0:multictr2.t, ?###0:wybe.int, ?####0:wybe.bool):
+f07(#rec##0:multictr2.t, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
@@ -1008,10 +1008,10 @@ f07(#rec##0:multictr2.t, ?###0:wybe.int, ?####0:wybe.bool):
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?###0:wybe.int)
+        foreign lpvm access(~#rec##0:multictr2.t, -6:wybe.int, 8:wybe.int, 6:wybe.int, ?#result##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 f07 > public {inline} (0 calls)
@@ -1034,7 +1034,7 @@ f07(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?####0:wybe.b
 
 f08_a > public {inline} (0 calls)
 0: multictr2.t.f08_a<0>
-f08_a(#rec##0:multictr2.t, ?###0:wybe.int, ?####0:wybe.bool):
+f08_a(#rec##0:multictr2.t, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
@@ -1042,10 +1042,10 @@ f08_a(#rec##0:multictr2.t, ?###0:wybe.int, ?####0:wybe.bool):
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?###0:wybe.int)
+        foreign lpvm access(~#rec##0:multictr2.t, -7:wybe.int, 24:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 f08_a > public {inline} (0 calls)
@@ -1068,7 +1068,7 @@ f08_a(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?####0:wybe
 
 f08_b > public {inline} (0 calls)
 0: multictr2.t.f08_b<0>
-f08_b(#rec##0:multictr2.t, ?###0:wybe.int, ?####0:wybe.bool):
+f08_b(#rec##0:multictr2.t, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
@@ -1076,10 +1076,10 @@ f08_b(#rec##0:multictr2.t, ?###0:wybe.int, ?####0:wybe.bool):
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?###0:wybe.int)
+        foreign lpvm access(~#rec##0:multictr2.t, 1:wybe.int, 24:wybe.int, 7:wybe.int, ?#result##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 f08_b > public {inline} (0 calls)
@@ -1102,7 +1102,7 @@ f08_b(#rec##0:multictr2.t, ?#rec##1:multictr2.t, #field##0:wybe.int, ?####0:wybe
 
 f08_c > public {inline} (0 calls)
 0: multictr2.t.f08_c<0>
-f08_c(#rec##0:multictr2.t, ?###0:wybe.float, ?####0:wybe.bool):
+f08_c(#rec##0:multictr2.t, ?#result##0:wybe.float, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 7:wybe.int, ?tmp#1##0:wybe.int)
@@ -1110,10 +1110,10 @@ f08_c(#rec##0:multictr2.t, ?###0:wybe.float, ?####0:wybe.bool):
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.float, ?###0:wybe.float)
+        foreign llvm move(undef:wybe.float, ?#result##0:wybe.float)
 
     1:
-        foreign lpvm access(~#rec##0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?###0:wybe.float)
+        foreign lpvm access(~#rec##0:multictr2.t, 9:wybe.int, 24:wybe.int, 7:wybe.int, ?#result##0:wybe.float)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 f08_c > public {inline} (0 calls)
@@ -1359,13 +1359,13 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.c01<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"multictr2.t.c01<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#1##0" = and i64 %"###0", 7 
+  %"1#tmp#1##0" = and i64 %"#result##0", 7 
   %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %84 = inttoptr i64 %"###0" to i64* 
+  %84 = inttoptr i64 %"#result##0" to i64* 
   %85 = getelementptr  i64, i64* %84, i64 0 
   %86 = load  i64, i64* %85 
   %87 = insertvalue {i64, i1} undef, i64 %86, 0 
@@ -1386,18 +1386,18 @@ entry:
   %94 = inttoptr i64 %93 to i64* 
   %95 = getelementptr  i64, i64* %94, i64 0 
   store  i64 %"f02##0", i64* %95 
-  %"1####0" = or i64 %93, 1 
-  ret i64 %"1####0" 
+  %"1##result##0" = or i64 %93, 1 
+  ret i64 %"1##result##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.c02<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"multictr2.t.c02<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#1##0" = and i64 %"###0", 7 
+  %"1#tmp#1##0" = and i64 %"#result##0", 7 
   %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 1 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %96 = add   i64 %"###0", -1 
+  %96 = add   i64 %"#result##0", -1 
   %97 = inttoptr i64 %96 to i64* 
   %98 = getelementptr  i64, i64* %97, i64 0 
   %99 = load  i64, i64* %98 
@@ -1419,18 +1419,18 @@ entry:
   %107 = inttoptr i64 %106 to i64* 
   %108 = getelementptr  i64, i64* %107, i64 0 
   store  i64 %"f03##0", i64* %108 
-  %"1####0" = or i64 %106, 2 
-  ret i64 %"1####0" 
+  %"1##result##0" = or i64 %106, 2 
+  ret i64 %"1##result##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.c03<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"multictr2.t.c03<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#1##0" = and i64 %"###0", 7 
+  %"1#tmp#1##0" = and i64 %"#result##0", 7 
   %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 2 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %109 = add   i64 %"###0", -2 
+  %109 = add   i64 %"#result##0", -2 
   %110 = inttoptr i64 %109 to i64* 
   %111 = getelementptr  i64, i64* %110, i64 0 
   %112 = load  i64, i64* %111 
@@ -1452,18 +1452,18 @@ entry:
   %120 = inttoptr i64 %119 to i64* 
   %121 = getelementptr  i64, i64* %120, i64 0 
   store  i64 %"f04##0", i64* %121 
-  %"1####0" = or i64 %119, 3 
-  ret i64 %"1####0" 
+  %"1##result##0" = or i64 %119, 3 
+  ret i64 %"1##result##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.c04<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"multictr2.t.c04<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#1##0" = and i64 %"###0", 7 
+  %"1#tmp#1##0" = and i64 %"#result##0", 7 
   %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 3 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %122 = add   i64 %"###0", -3 
+  %122 = add   i64 %"#result##0", -3 
   %123 = inttoptr i64 %122 to i64* 
   %124 = getelementptr  i64, i64* %123, i64 0 
   %125 = load  i64, i64* %124 
@@ -1485,18 +1485,18 @@ entry:
   %133 = inttoptr i64 %132 to i64* 
   %134 = getelementptr  i64, i64* %133, i64 0 
   store  i64 %"f05##0", i64* %134 
-  %"1####0" = or i64 %132, 4 
-  ret i64 %"1####0" 
+  %"1##result##0" = or i64 %132, 4 
+  ret i64 %"1##result##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.c05<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"multictr2.t.c05<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#1##0" = and i64 %"###0", 7 
+  %"1#tmp#1##0" = and i64 %"#result##0", 7 
   %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 4 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %135 = add   i64 %"###0", -4 
+  %135 = add   i64 %"#result##0", -4 
   %136 = inttoptr i64 %135 to i64* 
   %137 = getelementptr  i64, i64* %136, i64 0 
   %138 = load  i64, i64* %137 
@@ -1518,18 +1518,18 @@ entry:
   %146 = inttoptr i64 %145 to i64* 
   %147 = getelementptr  i64, i64* %146, i64 0 
   store  i64 %"f06##0", i64* %147 
-  %"1####0" = or i64 %145, 5 
-  ret i64 %"1####0" 
+  %"1##result##0" = or i64 %145, 5 
+  ret i64 %"1##result##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.c06<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"multictr2.t.c06<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#1##0" = and i64 %"###0", 7 
+  %"1#tmp#1##0" = and i64 %"#result##0", 7 
   %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 5 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %148 = add   i64 %"###0", -5 
+  %148 = add   i64 %"#result##0", -5 
   %149 = inttoptr i64 %148 to i64* 
   %150 = getelementptr  i64, i64* %149, i64 0 
   %151 = load  i64, i64* %150 
@@ -1551,18 +1551,18 @@ entry:
   %159 = inttoptr i64 %158 to i64* 
   %160 = getelementptr  i64, i64* %159, i64 0 
   store  i64 %"f07##0", i64* %160 
-  %"1####0" = or i64 %158, 6 
-  ret i64 %"1####0" 
+  %"1##result##0" = or i64 %158, 6 
+  ret i64 %"1##result##0" 
 }
 
 
-define external fastcc  {i64, i1} @"multictr2.t.c07<1>"(i64  %"###0")    {
+define external fastcc  {i64, i1} @"multictr2.t.c07<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#1##0" = and i64 %"###0", 7 
+  %"1#tmp#1##0" = and i64 %"#result##0", 7 
   %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 6 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %161 = add   i64 %"###0", -6 
+  %161 = add   i64 %"#result##0", -6 
   %162 = inttoptr i64 %161 to i64* 
   %163 = getelementptr  i64, i64* %162, i64 0 
   %164 = load  i64, i64* %163 
@@ -1592,26 +1592,26 @@ entry:
   %178 = inttoptr i64 %177 to double* 
   %179 = getelementptr  double, double* %178, i64 0 
   store  double %"f08_c##0", double* %179 
-  %"1####0" = or i64 %171, 7 
-  ret i64 %"1####0" 
+  %"1##result##0" = or i64 %171, 7 
+  ret i64 %"1##result##0" 
 }
 
 
-define external fastcc  {i64, i64, double, i1} @"multictr2.t.c08<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64, double, i1} @"multictr2.t.c08<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#1##0" = and i64 %"###0", 7 
+  %"1#tmp#1##0" = and i64 %"#result##0", 7 
   %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 7 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %180 = add   i64 %"###0", -7 
+  %180 = add   i64 %"#result##0", -7 
   %181 = inttoptr i64 %180 to i64* 
   %182 = getelementptr  i64, i64* %181, i64 0 
   %183 = load  i64, i64* %182 
-  %184 = add   i64 %"###0", 1 
+  %184 = add   i64 %"#result##0", 1 
   %185 = inttoptr i64 %184 to i64* 
   %186 = getelementptr  i64, i64* %185, i64 0 
   %187 = load  i64, i64* %186 
-  %188 = add   i64 %"###0", 9 
+  %188 = add   i64 %"#result##0", 9 
   %189 = inttoptr i64 %188 to double* 
   %190 = getelementptr  double, double* %189, i64 0 
   %191 = load  double, double* %190 

--- a/test-cases/final-dump/mutual_type.exp
+++ b/test-cases/final-dump/mutual_type.exp
@@ -46,13 +46,13 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 = > public (1 calls)
 0: mutual_type.a.=<0>
-=(#left##0:mutual_type.a, #right##0:mutual_type.a, ?####0:wybe.bool):
+=(#left##0:mutual_type.a, #right##0:mutual_type.a, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~#left##0:mutual_type.a, ~#right##0:mutual_type.a, ?####0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:mutual_type.a, ~#right##0:mutual_type.a, ?#success##0:wybe.bool)
 
     1:
         foreign lpvm access(#left##0:mutual_type.a, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#ahead##0:wybe.int)
@@ -60,7 +60,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
         case ~tmp#9##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign lpvm access(#right##0:mutual_type.a, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#ahead##0:wybe.int)
@@ -68,10 +68,10 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
             foreign llvm icmp_eq(~#left#ahead##0:wybe.int, ~#right#ahead##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
             case ~tmp#4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
-                mutual_type.b.=<0>(~#left#atail##0:mutual_type.b, ~#right#atail##0:mutual_type.b, ?####0:wybe.bool) #3
+                mutual_type.b.=<0>(~#left#atail##0:mutual_type.b, ~#right#atail##0:mutual_type.b, ?#success##0:wybe.bool) #3
 
 
 
@@ -87,84 +87,84 @@ a(ahead##0:wybe.int, atail##0:mutual_type.b, ?#result##0:mutual_type.a):
     foreign lpvm mutate(~#rec##1:mutual_type.a, ?#result##0:mutual_type.a, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~atail##0:mutual_type.b)
 a > public {inline} (12 calls)
 1: mutual_type.a.a<1>
-a(?ahead##0:wybe.int, ?atail##0:mutual_type.b, #result##0:mutual_type.a, ?####0:wybe.bool):
+a(?ahead##0:wybe.int, ?atail##0:mutual_type.b, #result##0:mutual_type.a, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?ahead##0:wybe.int)
         foreign llvm move(undef:mutual_type.b, ?atail##0:mutual_type.b)
 
     1:
         foreign lpvm access(#result##0:mutual_type.a, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ahead##0:wybe.int)
         foreign lpvm access(~#result##0:mutual_type.a, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?atail##0:mutual_type.b)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 ahead > public {inline} (0 calls)
 0: mutual_type.a.ahead<0>
-ahead(#rec##0:mutual_type.a, ?#result##0:wybe.int, ?####0:wybe.bool):
+ahead(#rec##0:mutual_type.a, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign lpvm access(~#rec##0:mutual_type.a, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 ahead > public {inline} (0 calls)
 1: mutual_type.a.ahead<1>
-ahead(#rec##0:mutual_type.a, ?#rec##1:mutual_type.a, #field##0:wybe.int, ?####0:wybe.bool):
+ahead(#rec##0:mutual_type.a, ?#rec##1:mutual_type.a, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:mutual_type.a, ?#rec##1:mutual_type.a)
 
     1:
         foreign lpvm mutate(~#rec##0:mutual_type.a, ?#rec##1:mutual_type.a, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 atail > public {inline} (0 calls)
 0: mutual_type.a.atail<0>
-atail(#rec##0:mutual_type.a, ?#result##0:mutual_type.b, ?####0:wybe.bool):
+atail(#rec##0:mutual_type.a, ?#result##0:mutual_type.b, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:mutual_type.b, ?#result##0:mutual_type.b)
 
     1:
         foreign lpvm access(~#rec##0:mutual_type.a, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:mutual_type.b)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 atail > public {inline} (0 calls)
 1: mutual_type.a.atail<1>
-atail(#rec##0:mutual_type.a, ?#rec##1:mutual_type.a, #field##0:mutual_type.b, ?####0:wybe.bool):
+atail(#rec##0:mutual_type.a, ?#rec##1:mutual_type.a, #field##0:mutual_type.b, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:mutual_type.a, ?#rec##1:mutual_type.a)
 
     1:
         foreign lpvm {noalias} mutate(~#rec##0:mutual_type.a, ?#rec##1:mutual_type.a, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:mutual_type.b)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -178,11 +178,11 @@ no_a(?#result##0:mutual_type.a):
 
 ~= > public {inline} (0 calls)
 0: mutual_type.a.~=<0>
-~=(#left##0:mutual_type.a, #right##0:mutual_type.a, ?####0:wybe.bool):
+~=(#left##0:mutual_type.a, #right##0:mutual_type.a, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     mutual_type.a.=<0>(~#left##0:mutual_type.a, ~#right##0:mutual_type.a, ?tmp#0##0:wybe.bool) #0
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 
@@ -213,8 +213,8 @@ if.then:
   %"2#tmp#9##0" = icmp ne i64 %"#right##0", 0 
   br i1 %"2#tmp#9##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %"3#####0" 
+  %"3##success##0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3##success##0" 
 if.then1:
   %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
@@ -228,8 +228,8 @@ if.then1:
 if.else1:
   ret i1 0 
 if.then2:
-  %"6#####0" = tail call fastcc  i1  @"mutual_type.b.=<0>"(i64  %7, i64  %14)  
-  ret i1 %"6#####0" 
+  %"6##success##0" = tail call fastcc  i1  @"mutual_type.b.=<0>"(i64  %7, i64  %14)  
+  ret i1 %"6##success##0" 
 if.else2:
   ret i1 0 
 }
@@ -372,8 +372,8 @@ entry:
 define external fastcc  i1 @"mutual_type.a.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %"1#tmp#0##0" = tail call fastcc  i1  @"mutual_type.a.=<0>"(i64  %"#left##0", i64  %"#right##0")  
-  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
-  ret i1 %"1#####0" 
+  %"1##success##0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1##success##0" 
 }
 --------------------------------------------------
  Module mutual_type.b
@@ -396,13 +396,13 @@ entry:
 
 = > public (1 calls)
 0: mutual_type.b.=<0>
-=(#left##0:mutual_type.b, #right##0:mutual_type.b, ?####0:wybe.bool):
+=(#left##0:mutual_type.b, #right##0:mutual_type.b, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~#left##0:mutual_type.b, ~#right##0:mutual_type.b, ?####0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:mutual_type.b, ~#right##0:mutual_type.b, ?#success##0:wybe.bool)
 
     1:
         foreign lpvm access(#left##0:mutual_type.b, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#bhead##0:wybe.int)
@@ -410,7 +410,7 @@ entry:
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
         case ~tmp#9##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign lpvm access(#right##0:mutual_type.b, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#bhead##0:wybe.int)
@@ -418,10 +418,10 @@ entry:
             foreign llvm icmp_eq(~#left#bhead##0:wybe.int, ~#right#bhead##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
             case ~tmp#4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
-                mutual_type.a.=<0>(~#left#btail##0:mutual_type.a, ~#right#btail##0:mutual_type.a, ?####0:wybe.bool) #3
+                mutual_type.a.=<0>(~#left#btail##0:mutual_type.a, ~#right#btail##0:mutual_type.a, ?#success##0:wybe.bool) #3
 
 
 
@@ -437,84 +437,84 @@ b(bhead##0:wybe.int, btail##0:mutual_type.a, ?#result##0:mutual_type.b):
     foreign lpvm mutate(~#rec##1:mutual_type.b, ?#result##0:mutual_type.b, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~btail##0:mutual_type.a)
 b > public {inline} (12 calls)
 1: mutual_type.b.b<1>
-b(?bhead##0:wybe.int, ?btail##0:mutual_type.a, #result##0:mutual_type.b, ?####0:wybe.bool):
+b(?bhead##0:wybe.int, ?btail##0:mutual_type.a, #result##0:mutual_type.b, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?bhead##0:wybe.int)
         foreign llvm move(undef:mutual_type.a, ?btail##0:mutual_type.a)
 
     1:
         foreign lpvm access(#result##0:mutual_type.b, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?bhead##0:wybe.int)
         foreign lpvm access(~#result##0:mutual_type.b, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?btail##0:mutual_type.a)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 bhead > public {inline} (0 calls)
 0: mutual_type.b.bhead<0>
-bhead(#rec##0:mutual_type.b, ?#result##0:wybe.int, ?####0:wybe.bool):
+bhead(#rec##0:mutual_type.b, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign lpvm access(~#rec##0:mutual_type.b, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 bhead > public {inline} (0 calls)
 1: mutual_type.b.bhead<1>
-bhead(#rec##0:mutual_type.b, ?#rec##1:mutual_type.b, #field##0:wybe.int, ?####0:wybe.bool):
+bhead(#rec##0:mutual_type.b, ?#rec##1:mutual_type.b, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:mutual_type.b, ?#rec##1:mutual_type.b)
 
     1:
         foreign lpvm mutate(~#rec##0:mutual_type.b, ?#rec##1:mutual_type.b, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 btail > public {inline} (0 calls)
 0: mutual_type.b.btail<0>
-btail(#rec##0:mutual_type.b, ?#result##0:mutual_type.a, ?####0:wybe.bool):
+btail(#rec##0:mutual_type.b, ?#result##0:mutual_type.a, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:mutual_type.a, ?#result##0:mutual_type.a)
 
     1:
         foreign lpvm access(~#rec##0:mutual_type.b, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:mutual_type.a)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 btail > public {inline} (0 calls)
 1: mutual_type.b.btail<1>
-btail(#rec##0:mutual_type.b, ?#rec##1:mutual_type.b, #field##0:mutual_type.a, ?####0:wybe.bool):
+btail(#rec##0:mutual_type.b, ?#rec##1:mutual_type.b, #field##0:mutual_type.a, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:mutual_type.b, ?#rec##1:mutual_type.b)
 
     1:
         foreign lpvm {noalias} mutate(~#rec##0:mutual_type.b, ?#rec##1:mutual_type.b, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:mutual_type.a)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -528,11 +528,11 @@ no_b(?#result##0:mutual_type.b):
 
 ~= > public {inline} (0 calls)
 0: mutual_type.b.~=<0>
-~=(#left##0:mutual_type.b, #right##0:mutual_type.b, ?####0:wybe.bool):
+~=(#left##0:mutual_type.b, #right##0:mutual_type.b, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     mutual_type.b.=<0>(~#left##0:mutual_type.b, ~#right##0:mutual_type.b, ?tmp#0##0:wybe.bool) #0
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 
@@ -563,8 +563,8 @@ if.then:
   %"2#tmp#9##0" = icmp ne i64 %"#right##0", 0 
   br i1 %"2#tmp#9##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %"3#####0" 
+  %"3##success##0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3##success##0" 
 if.then1:
   %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
@@ -578,8 +578,8 @@ if.then1:
 if.else1:
   ret i1 0 
 if.then2:
-  %"6#####0" = tail call fastcc  i1  @"mutual_type.a.=<0>"(i64  %7, i64  %14)  
-  ret i1 %"6#####0" 
+  %"6##success##0" = tail call fastcc  i1  @"mutual_type.a.=<0>"(i64  %7, i64  %14)  
+  ret i1 %"6##success##0" 
 if.else2:
   ret i1 0 
 }
@@ -722,6 +722,6 @@ entry:
 define external fastcc  i1 @"mutual_type.b.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %"1#tmp#0##0" = tail call fastcc  i1  @"mutual_type.b.=<0>"(i64  %"#left##0", i64  %"#right##0")  
-  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
-  ret i1 %"1#####0" 
+  %"1##success##0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1##success##0" 
 }

--- a/test-cases/final-dump/mutual_type.exp
+++ b/test-cases/final-dump/mutual_type.exp
@@ -46,32 +46,32 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 = > public (1 calls)
 0: mutual_type.a.=<0>
-=($left##0:mutual_type.a, $right##0:mutual_type.a, ?$$##0:wybe.bool):
+=(#left##0:mutual_type.a, #right##0:mutual_type.a, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left##0:mutual_type.a, ~$right##0:mutual_type.a, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:mutual_type.a, ~#right##0:mutual_type.a, ?####0:wybe.bool)
 
     1:
-        foreign lpvm access($left##0:mutual_type.a, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$ahead##0:wybe.int)
-        foreign lpvm access(~$left##0:mutual_type.a, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$atail##0:mutual_type.b)
-        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
-        case ~tmp$9##0:wybe.bool of
+        foreign lpvm access(#left##0:mutual_type.a, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#ahead##0:wybe.int)
+        foreign lpvm access(~#left##0:mutual_type.a, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#atail##0:mutual_type.b)
+        foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
+        case ~tmp#9##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign lpvm access($right##0:mutual_type.a, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$ahead##0:wybe.int)
-            foreign lpvm access(~$right##0:mutual_type.a, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$atail##0:mutual_type.b)
-            foreign llvm icmp_eq(~$left$ahead##0:wybe.int, ~$right$ahead##0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
-            case ~tmp$4##0:wybe.bool of
+            foreign lpvm access(#right##0:mutual_type.a, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#ahead##0:wybe.int)
+            foreign lpvm access(~#right##0:mutual_type.a, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#atail##0:mutual_type.b)
+            foreign llvm icmp_eq(~#left#ahead##0:wybe.int, ~#right#ahead##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
+            case ~tmp#4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
             1:
-                mutual_type.b.=<0>(~$left$atail##0:mutual_type.b, ~$right$atail##0:mutual_type.b, ?$$##0:wybe.bool) #3
+                mutual_type.b.=<0>(~#left#atail##0:mutual_type.b, ~#right#atail##0:mutual_type.b, ?####0:wybe.bool) #3
 
 
 
@@ -79,110 +79,110 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 a > public {inline} (0 calls)
 0: mutual_type.a.a<0>
-a(ahead##0:wybe.int, atail##0:mutual_type.b, ?$##0:mutual_type.a):
+a(ahead##0:wybe.int, atail##0:mutual_type.b, ?###0:mutual_type.a):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:mutual_type.a)
-    foreign lpvm mutate(~$rec##0:mutual_type.a, ?$rec##1:mutual_type.a, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~ahead##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:mutual_type.a, ?$##0:mutual_type.a, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~atail##0:mutual_type.b)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:mutual_type.a)
+    foreign lpvm mutate(~#rec##0:mutual_type.a, ?#rec##1:mutual_type.a, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~ahead##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:mutual_type.a, ?###0:mutual_type.a, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~atail##0:mutual_type.b)
 a > public {inline} (12 calls)
 1: mutual_type.a.a<1>
-a(?ahead##0:wybe.int, ?atail##0:mutual_type.b, $##0:mutual_type.a, ?$$##0:wybe.bool):
+a(?ahead##0:wybe.int, ?atail##0:mutual_type.b, ###0:mutual_type.a, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?ahead##0:wybe.int)
         foreign llvm move(undef:mutual_type.b, ?atail##0:mutual_type.b)
 
     1:
-        foreign lpvm access($##0:mutual_type.a, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ahead##0:wybe.int)
-        foreign lpvm access(~$##0:mutual_type.a, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?atail##0:mutual_type.b)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(###0:mutual_type.a, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ahead##0:wybe.int)
+        foreign lpvm access(~###0:mutual_type.a, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?atail##0:mutual_type.b)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 ahead > public {inline} (0 calls)
 0: mutual_type.a.ahead<0>
-ahead($rec##0:mutual_type.a, ?$##0:wybe.int, ?$$##0:wybe.bool):
+ahead(#rec##0:mutual_type.a, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec##0:mutual_type.a, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:mutual_type.a, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 ahead > public {inline} (0 calls)
 1: mutual_type.a.ahead<1>
-ahead($rec##0:mutual_type.a, ?$rec##1:mutual_type.a, $field##0:wybe.int, ?$$##0:wybe.bool):
+ahead(#rec##0:mutual_type.a, ?#rec##1:mutual_type.a, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:mutual_type.a, ?$rec##1:mutual_type.a)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:mutual_type.a, ?#rec##1:mutual_type.a)
 
     1:
-        foreign lpvm mutate(~$rec##0:mutual_type.a, ?$rec##1:mutual_type.a, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~#rec##0:mutual_type.a, ?#rec##1:mutual_type.a, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 atail > public {inline} (0 calls)
 0: mutual_type.a.atail<0>
-atail($rec##0:mutual_type.a, ?$##0:mutual_type.b, ?$$##0:wybe.bool):
+atail(#rec##0:mutual_type.a, ?###0:mutual_type.b, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:mutual_type.b, ?$##0:mutual_type.b)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:mutual_type.b, ?###0:mutual_type.b)
 
     1:
-        foreign lpvm access(~$rec##0:mutual_type.a, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:mutual_type.b)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:mutual_type.a, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:mutual_type.b)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 atail > public {inline} (0 calls)
 1: mutual_type.a.atail<1>
-atail($rec##0:mutual_type.a, ?$rec##1:mutual_type.a, $field##0:mutual_type.b, ?$$##0:wybe.bool):
+atail(#rec##0:mutual_type.a, ?#rec##1:mutual_type.a, #field##0:mutual_type.b, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:mutual_type.a, ?$rec##1:mutual_type.a)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:mutual_type.a, ?#rec##1:mutual_type.a)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec##0:mutual_type.a, ?$rec##1:mutual_type.a, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:mutual_type.b)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm {noalias} mutate(~#rec##0:mutual_type.a, ?#rec##1:mutual_type.a, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:mutual_type.b)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 no_a > public {inline} (0 calls)
 0: mutual_type.a.no_a<0>
-no_a(?$##0:mutual_type.a):
+no_a(?###0:mutual_type.a):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:mutual_type.a, ?$##0:mutual_type.a)
+    foreign llvm move(0:mutual_type.a, ?###0:mutual_type.a)
 
 
 ~= > public {inline} (0 calls)
 0: mutual_type.a.~=<0>
-~=($left##0:mutual_type.a, $right##0:mutual_type.a, ?$$##0:wybe.bool):
+~=(#left##0:mutual_type.a, #right##0:mutual_type.a, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    mutual_type.a.=<0>(~$left##0:mutual_type.a, ~$right##0:mutual_type.a, ?tmp$0##0:wybe.bool) #0
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    mutual_type.a.=<0>(~#left##0:mutual_type.a, ~#right##0:mutual_type.a, ?tmp#0##0:wybe.bool) #0
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
   LLVM code       :
 
@@ -198,38 +198,38 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"mutual_type.a.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"mutual_type.a.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#left##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %"2$tmp$9##0" = icmp ne i64 %"$right##0", 0 
-  br i1 %"2$tmp$9##0", label %if.then1, label %if.else1 
+  %"2#tmp#9##0" = icmp ne i64 %"#right##0", 0 
+  br i1 %"2#tmp#9##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3#####0" 
 if.then1:
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"4$tmp$4##0" = icmp eq i64 %3, %10 
-  br i1 %"4$tmp$4##0", label %if.then2, label %if.else2 
+  %"4#tmp#4##0" = icmp eq i64 %3, %10 
+  br i1 %"4#tmp#4##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$$$##0" = tail call fastcc  i1  @"mutual_type.b.=<0>"(i64  %7, i64  %14)  
-  ret i1 %"6$$$##0" 
+  %"6#####0" = tail call fastcc  i1  @"mutual_type.b.=<0>"(i64  %7, i64  %14)  
+  ret i1 %"6#####0" 
 if.else2:
   ret i1 0 
 }
@@ -251,15 +251,15 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"mutual_type.a.a<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64, i1} @"mutual_type.a.a<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -275,12 +275,12 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mutual_type.a.ahead<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"mutual_type.a.ahead<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %36 = inttoptr i64 %"$rec##0" to i64* 
+  %36 = inttoptr i64 %"#rec##0" to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
   %39 = insertvalue {i64, i1} undef, i64 %38, 0 
@@ -293,37 +293,37 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mutual_type.a.ahead<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"mutual_type.a.ahead<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %43 = trunc i64 16 to i32  
   %44 = tail call ccc  i8*  @wybe_malloc(i32  %43)  
   %45 = ptrtoint i8* %44 to i64 
   %46 = inttoptr i64 %45 to i8* 
-  %47 = inttoptr i64 %"$rec##0" to i8* 
+  %47 = inttoptr i64 %"#rec##0" to i8* 
   %48 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %46, i8*  %47, i32  %48, i32  8, i1  0)  
   %49 = inttoptr i64 %45 to i64* 
   %50 = getelementptr  i64, i64* %49, i64 0 
-  store  i64 %"$field##0", i64* %50 
+  store  i64 %"#field##0", i64* %50 
   %51 = insertvalue {i64, i1} undef, i64 %45, 0 
   %52 = insertvalue {i64, i1} %51, i1 1, 1 
   ret {i64, i1} %52 
 if.else:
-  %53 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %53 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %54 = insertvalue {i64, i1} %53, i1 0, 1 
   ret {i64, i1} %54 
 }
 
 
-define external fastcc  {i64, i1} @"mutual_type.a.atail<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"mutual_type.a.atail<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %55 = add   i64 %"$rec##0", 8 
+  %55 = add   i64 %"#rec##0", 8 
   %56 = inttoptr i64 %55 to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
@@ -337,27 +337,27 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mutual_type.a.atail<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"mutual_type.a.atail<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %63 = trunc i64 16 to i32  
   %64 = tail call ccc  i8*  @wybe_malloc(i32  %63)  
   %65 = ptrtoint i8* %64 to i64 
   %66 = inttoptr i64 %65 to i8* 
-  %67 = inttoptr i64 %"$rec##0" to i8* 
+  %67 = inttoptr i64 %"#rec##0" to i8* 
   %68 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %66, i8*  %67, i32  %68, i32  8, i1  0)  
   %69 = add   i64 %65, 8 
   %70 = inttoptr i64 %69 to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
-  store  i64 %"$field##0", i64* %71 
+  store  i64 %"#field##0", i64* %71 
   %72 = insertvalue {i64, i1} undef, i64 %65, 0 
   %73 = insertvalue {i64, i1} %72, i1 1, 1 
   ret {i64, i1} %73 
 if.else:
-  %74 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %74 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %75 = insertvalue {i64, i1} %74, i1 0, 1 
   ret {i64, i1} %75 
 }
@@ -369,11 +369,11 @@ entry:
 }
 
 
-define external fastcc  i1 @"mutual_type.a.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"mutual_type.a.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = tail call fastcc  i1  @"mutual_type.a.=<0>"(i64  %"$left##0", i64  %"$right##0")  
-  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
-  ret i1 %"1$$$##0" 
+  %"1#tmp#0##0" = tail call fastcc  i1  @"mutual_type.a.=<0>"(i64  %"#left##0", i64  %"#right##0")  
+  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1#####0" 
 }
 --------------------------------------------------
  Module mutual_type.b
@@ -396,32 +396,32 @@ entry:
 
 = > public (1 calls)
 0: mutual_type.b.=<0>
-=($left##0:mutual_type.b, $right##0:mutual_type.b, ?$$##0:wybe.bool):
+=(#left##0:mutual_type.b, #right##0:mutual_type.b, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left##0:mutual_type.b, ~$right##0:mutual_type.b, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:mutual_type.b, ~#right##0:mutual_type.b, ?####0:wybe.bool)
 
     1:
-        foreign lpvm access($left##0:mutual_type.b, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$bhead##0:wybe.int)
-        foreign lpvm access(~$left##0:mutual_type.b, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$btail##0:mutual_type.a)
-        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
-        case ~tmp$9##0:wybe.bool of
+        foreign lpvm access(#left##0:mutual_type.b, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#bhead##0:wybe.int)
+        foreign lpvm access(~#left##0:mutual_type.b, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#btail##0:mutual_type.a)
+        foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
+        case ~tmp#9##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign lpvm access($right##0:mutual_type.b, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$bhead##0:wybe.int)
-            foreign lpvm access(~$right##0:mutual_type.b, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$btail##0:mutual_type.a)
-            foreign llvm icmp_eq(~$left$bhead##0:wybe.int, ~$right$bhead##0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
-            case ~tmp$4##0:wybe.bool of
+            foreign lpvm access(#right##0:mutual_type.b, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#bhead##0:wybe.int)
+            foreign lpvm access(~#right##0:mutual_type.b, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#btail##0:mutual_type.a)
+            foreign llvm icmp_eq(~#left#bhead##0:wybe.int, ~#right#bhead##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
+            case ~tmp#4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
             1:
-                mutual_type.a.=<0>(~$left$btail##0:mutual_type.a, ~$right$btail##0:mutual_type.a, ?$$##0:wybe.bool) #3
+                mutual_type.a.=<0>(~#left#btail##0:mutual_type.a, ~#right#btail##0:mutual_type.a, ?####0:wybe.bool) #3
 
 
 
@@ -429,110 +429,110 @@ entry:
 
 b > public {inline} (0 calls)
 0: mutual_type.b.b<0>
-b(bhead##0:wybe.int, btail##0:mutual_type.a, ?$##0:mutual_type.b):
+b(bhead##0:wybe.int, btail##0:mutual_type.a, ?###0:mutual_type.b):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:mutual_type.b)
-    foreign lpvm mutate(~$rec##0:mutual_type.b, ?$rec##1:mutual_type.b, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~bhead##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:mutual_type.b, ?$##0:mutual_type.b, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~btail##0:mutual_type.a)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:mutual_type.b)
+    foreign lpvm mutate(~#rec##0:mutual_type.b, ?#rec##1:mutual_type.b, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~bhead##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:mutual_type.b, ?###0:mutual_type.b, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~btail##0:mutual_type.a)
 b > public {inline} (12 calls)
 1: mutual_type.b.b<1>
-b(?bhead##0:wybe.int, ?btail##0:mutual_type.a, $##0:mutual_type.b, ?$$##0:wybe.bool):
+b(?bhead##0:wybe.int, ?btail##0:mutual_type.a, ###0:mutual_type.b, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?bhead##0:wybe.int)
         foreign llvm move(undef:mutual_type.a, ?btail##0:mutual_type.a)
 
     1:
-        foreign lpvm access($##0:mutual_type.b, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?bhead##0:wybe.int)
-        foreign lpvm access(~$##0:mutual_type.b, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?btail##0:mutual_type.a)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(###0:mutual_type.b, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?bhead##0:wybe.int)
+        foreign lpvm access(~###0:mutual_type.b, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?btail##0:mutual_type.a)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 bhead > public {inline} (0 calls)
 0: mutual_type.b.bhead<0>
-bhead($rec##0:mutual_type.b, ?$##0:wybe.int, ?$$##0:wybe.bool):
+bhead(#rec##0:mutual_type.b, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec##0:mutual_type.b, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:mutual_type.b, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 bhead > public {inline} (0 calls)
 1: mutual_type.b.bhead<1>
-bhead($rec##0:mutual_type.b, ?$rec##1:mutual_type.b, $field##0:wybe.int, ?$$##0:wybe.bool):
+bhead(#rec##0:mutual_type.b, ?#rec##1:mutual_type.b, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:mutual_type.b, ?$rec##1:mutual_type.b)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:mutual_type.b, ?#rec##1:mutual_type.b)
 
     1:
-        foreign lpvm mutate(~$rec##0:mutual_type.b, ?$rec##1:mutual_type.b, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~#rec##0:mutual_type.b, ?#rec##1:mutual_type.b, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 btail > public {inline} (0 calls)
 0: mutual_type.b.btail<0>
-btail($rec##0:mutual_type.b, ?$##0:mutual_type.a, ?$$##0:wybe.bool):
+btail(#rec##0:mutual_type.b, ?###0:mutual_type.a, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:mutual_type.a, ?$##0:mutual_type.a)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:mutual_type.a, ?###0:mutual_type.a)
 
     1:
-        foreign lpvm access(~$rec##0:mutual_type.b, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:mutual_type.a)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:mutual_type.b, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:mutual_type.a)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 btail > public {inline} (0 calls)
 1: mutual_type.b.btail<1>
-btail($rec##0:mutual_type.b, ?$rec##1:mutual_type.b, $field##0:mutual_type.a, ?$$##0:wybe.bool):
+btail(#rec##0:mutual_type.b, ?#rec##1:mutual_type.b, #field##0:mutual_type.a, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:mutual_type.b, ?$rec##1:mutual_type.b)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:mutual_type.b, ?#rec##1:mutual_type.b)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec##0:mutual_type.b, ?$rec##1:mutual_type.b, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:mutual_type.a)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm {noalias} mutate(~#rec##0:mutual_type.b, ?#rec##1:mutual_type.b, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:mutual_type.a)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 no_b > public {inline} (0 calls)
 0: mutual_type.b.no_b<0>
-no_b(?$##0:mutual_type.b):
+no_b(?###0:mutual_type.b):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:mutual_type.b, ?$##0:mutual_type.b)
+    foreign llvm move(0:mutual_type.b, ?###0:mutual_type.b)
 
 
 ~= > public {inline} (0 calls)
 0: mutual_type.b.~=<0>
-~=($left##0:mutual_type.b, $right##0:mutual_type.b, ?$$##0:wybe.bool):
+~=(#left##0:mutual_type.b, #right##0:mutual_type.b, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    mutual_type.b.=<0>(~$left##0:mutual_type.b, ~$right##0:mutual_type.b, ?tmp$0##0:wybe.bool) #0
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    mutual_type.b.=<0>(~#left##0:mutual_type.b, ~#right##0:mutual_type.b, ?tmp#0##0:wybe.bool) #0
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
   LLVM code       :
 
@@ -548,38 +548,38 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"mutual_type.b.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"mutual_type.b.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#left##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %"2$tmp$9##0" = icmp ne i64 %"$right##0", 0 
-  br i1 %"2$tmp$9##0", label %if.then1, label %if.else1 
+  %"2#tmp#9##0" = icmp ne i64 %"#right##0", 0 
+  br i1 %"2#tmp#9##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3#####0" 
 if.then1:
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"4$tmp$4##0" = icmp eq i64 %3, %10 
-  br i1 %"4$tmp$4##0", label %if.then2, label %if.else2 
+  %"4#tmp#4##0" = icmp eq i64 %3, %10 
+  br i1 %"4#tmp#4##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$$$##0" = tail call fastcc  i1  @"mutual_type.a.=<0>"(i64  %7, i64  %14)  
-  ret i1 %"6$$$##0" 
+  %"6#####0" = tail call fastcc  i1  @"mutual_type.a.=<0>"(i64  %7, i64  %14)  
+  ret i1 %"6#####0" 
 if.else2:
   ret i1 0 
 }
@@ -601,15 +601,15 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"mutual_type.b.b<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64, i1} @"mutual_type.b.b<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -625,12 +625,12 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mutual_type.b.bhead<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"mutual_type.b.bhead<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %36 = inttoptr i64 %"$rec##0" to i64* 
+  %36 = inttoptr i64 %"#rec##0" to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
   %39 = insertvalue {i64, i1} undef, i64 %38, 0 
@@ -643,37 +643,37 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mutual_type.b.bhead<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"mutual_type.b.bhead<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %43 = trunc i64 16 to i32  
   %44 = tail call ccc  i8*  @wybe_malloc(i32  %43)  
   %45 = ptrtoint i8* %44 to i64 
   %46 = inttoptr i64 %45 to i8* 
-  %47 = inttoptr i64 %"$rec##0" to i8* 
+  %47 = inttoptr i64 %"#rec##0" to i8* 
   %48 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %46, i8*  %47, i32  %48, i32  8, i1  0)  
   %49 = inttoptr i64 %45 to i64* 
   %50 = getelementptr  i64, i64* %49, i64 0 
-  store  i64 %"$field##0", i64* %50 
+  store  i64 %"#field##0", i64* %50 
   %51 = insertvalue {i64, i1} undef, i64 %45, 0 
   %52 = insertvalue {i64, i1} %51, i1 1, 1 
   ret {i64, i1} %52 
 if.else:
-  %53 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %53 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %54 = insertvalue {i64, i1} %53, i1 0, 1 
   ret {i64, i1} %54 
 }
 
 
-define external fastcc  {i64, i1} @"mutual_type.b.btail<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"mutual_type.b.btail<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %55 = add   i64 %"$rec##0", 8 
+  %55 = add   i64 %"#rec##0", 8 
   %56 = inttoptr i64 %55 to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
@@ -687,27 +687,27 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mutual_type.b.btail<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"mutual_type.b.btail<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %63 = trunc i64 16 to i32  
   %64 = tail call ccc  i8*  @wybe_malloc(i32  %63)  
   %65 = ptrtoint i8* %64 to i64 
   %66 = inttoptr i64 %65 to i8* 
-  %67 = inttoptr i64 %"$rec##0" to i8* 
+  %67 = inttoptr i64 %"#rec##0" to i8* 
   %68 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %66, i8*  %67, i32  %68, i32  8, i1  0)  
   %69 = add   i64 %65, 8 
   %70 = inttoptr i64 %69 to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
-  store  i64 %"$field##0", i64* %71 
+  store  i64 %"#field##0", i64* %71 
   %72 = insertvalue {i64, i1} undef, i64 %65, 0 
   %73 = insertvalue {i64, i1} %72, i1 1, 1 
   ret {i64, i1} %73 
 if.else:
-  %74 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %74 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %75 = insertvalue {i64, i1} %74, i1 0, 1 
   ret {i64, i1} %75 
 }
@@ -719,9 +719,9 @@ entry:
 }
 
 
-define external fastcc  i1 @"mutual_type.b.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"mutual_type.b.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = tail call fastcc  i1  @"mutual_type.b.=<0>"(i64  %"$left##0", i64  %"$right##0")  
-  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
-  ret i1 %"1$$$##0" 
+  %"1#tmp#0##0" = tail call fastcc  i1  @"mutual_type.b.=<0>"(i64  %"#left##0", i64  %"#right##0")  
+  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1#####0" 
 }

--- a/test-cases/final-dump/mutual_type.exp
+++ b/test-cases/final-dump/mutual_type.exp
@@ -79,18 +79,18 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 a > public {inline} (0 calls)
 0: mutual_type.a.a<0>
-a(ahead##0:wybe.int, atail##0:mutual_type.b, ?###0:mutual_type.a):
+a(ahead##0:wybe.int, atail##0:mutual_type.b, ?#result##0:mutual_type.a):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:mutual_type.a)
     foreign lpvm mutate(~#rec##0:mutual_type.a, ?#rec##1:mutual_type.a, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~ahead##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:mutual_type.a, ?###0:mutual_type.a, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~atail##0:mutual_type.b)
+    foreign lpvm mutate(~#rec##1:mutual_type.a, ?#result##0:mutual_type.a, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~atail##0:mutual_type.b)
 a > public {inline} (12 calls)
 1: mutual_type.a.a<1>
-a(?ahead##0:wybe.int, ?atail##0:mutual_type.b, ###0:mutual_type.a, ?####0:wybe.bool):
+a(?ahead##0:wybe.int, ?atail##0:mutual_type.b, #result##0:mutual_type.a, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
@@ -98,25 +98,25 @@ a(?ahead##0:wybe.int, ?atail##0:mutual_type.b, ###0:mutual_type.a, ?####0:wybe.b
         foreign llvm move(undef:mutual_type.b, ?atail##0:mutual_type.b)
 
     1:
-        foreign lpvm access(###0:mutual_type.a, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ahead##0:wybe.int)
-        foreign lpvm access(~###0:mutual_type.a, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?atail##0:mutual_type.b)
+        foreign lpvm access(#result##0:mutual_type.a, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ahead##0:wybe.int)
+        foreign lpvm access(~#result##0:mutual_type.a, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?atail##0:mutual_type.b)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 ahead > public {inline} (0 calls)
 0: mutual_type.a.ahead<0>
-ahead(#rec##0:mutual_type.a, ?###0:wybe.int, ?####0:wybe.bool):
+ahead(#rec##0:mutual_type.a, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:mutual_type.a, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign lpvm access(~#rec##0:mutual_type.a, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 ahead > public {inline} (0 calls)
@@ -138,17 +138,17 @@ ahead(#rec##0:mutual_type.a, ?#rec##1:mutual_type.a, #field##0:wybe.int, ?####0:
 
 atail > public {inline} (0 calls)
 0: mutual_type.a.atail<0>
-atail(#rec##0:mutual_type.a, ?###0:mutual_type.b, ?####0:wybe.bool):
+atail(#rec##0:mutual_type.a, ?#result##0:mutual_type.b, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:mutual_type.b, ?###0:mutual_type.b)
+        foreign llvm move(undef:mutual_type.b, ?#result##0:mutual_type.b)
 
     1:
-        foreign lpvm access(~#rec##0:mutual_type.a, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:mutual_type.b)
+        foreign lpvm access(~#rec##0:mutual_type.a, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:mutual_type.b)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 atail > public {inline} (0 calls)
@@ -170,10 +170,10 @@ atail(#rec##0:mutual_type.a, ?#rec##1:mutual_type.a, #field##0:mutual_type.b, ?#
 
 no_a > public {inline} (0 calls)
 0: mutual_type.a.no_a<0>
-no_a(?###0:mutual_type.a):
+no_a(?#result##0:mutual_type.a):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:mutual_type.a, ?###0:mutual_type.a)
+    foreign llvm move(0:mutual_type.a, ?#result##0:mutual_type.a)
 
 
 ~= > public {inline} (0 calls)
@@ -251,15 +251,15 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"mutual_type.a.a<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64, i1} @"mutual_type.a.a<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  %"1#tmp#0##0" = icmp ne i64 %"#result##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -429,18 +429,18 @@ entry:
 
 b > public {inline} (0 calls)
 0: mutual_type.b.b<0>
-b(bhead##0:wybe.int, btail##0:mutual_type.a, ?###0:mutual_type.b):
+b(bhead##0:wybe.int, btail##0:mutual_type.a, ?#result##0:mutual_type.b):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:mutual_type.b)
     foreign lpvm mutate(~#rec##0:mutual_type.b, ?#rec##1:mutual_type.b, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~bhead##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:mutual_type.b, ?###0:mutual_type.b, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~btail##0:mutual_type.a)
+    foreign lpvm mutate(~#rec##1:mutual_type.b, ?#result##0:mutual_type.b, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~btail##0:mutual_type.a)
 b > public {inline} (12 calls)
 1: mutual_type.b.b<1>
-b(?bhead##0:wybe.int, ?btail##0:mutual_type.a, ###0:mutual_type.b, ?####0:wybe.bool):
+b(?bhead##0:wybe.int, ?btail##0:mutual_type.a, #result##0:mutual_type.b, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
@@ -448,25 +448,25 @@ b(?bhead##0:wybe.int, ?btail##0:mutual_type.a, ###0:mutual_type.b, ?####0:wybe.b
         foreign llvm move(undef:mutual_type.a, ?btail##0:mutual_type.a)
 
     1:
-        foreign lpvm access(###0:mutual_type.b, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?bhead##0:wybe.int)
-        foreign lpvm access(~###0:mutual_type.b, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?btail##0:mutual_type.a)
+        foreign lpvm access(#result##0:mutual_type.b, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?bhead##0:wybe.int)
+        foreign lpvm access(~#result##0:mutual_type.b, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?btail##0:mutual_type.a)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 bhead > public {inline} (0 calls)
 0: mutual_type.b.bhead<0>
-bhead(#rec##0:mutual_type.b, ?###0:wybe.int, ?####0:wybe.bool):
+bhead(#rec##0:mutual_type.b, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:mutual_type.b, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign lpvm access(~#rec##0:mutual_type.b, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 bhead > public {inline} (0 calls)
@@ -488,17 +488,17 @@ bhead(#rec##0:mutual_type.b, ?#rec##1:mutual_type.b, #field##0:wybe.int, ?####0:
 
 btail > public {inline} (0 calls)
 0: mutual_type.b.btail<0>
-btail(#rec##0:mutual_type.b, ?###0:mutual_type.a, ?####0:wybe.bool):
+btail(#rec##0:mutual_type.b, ?#result##0:mutual_type.a, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:mutual_type.a, ?###0:mutual_type.a)
+        foreign llvm move(undef:mutual_type.a, ?#result##0:mutual_type.a)
 
     1:
-        foreign lpvm access(~#rec##0:mutual_type.b, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:mutual_type.a)
+        foreign lpvm access(~#rec##0:mutual_type.b, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:mutual_type.a)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 btail > public {inline} (0 calls)
@@ -520,10 +520,10 @@ btail(#rec##0:mutual_type.b, ?#rec##1:mutual_type.b, #field##0:mutual_type.a, ?#
 
 no_b > public {inline} (0 calls)
 0: mutual_type.b.no_b<0>
-no_b(?###0:mutual_type.b):
+no_b(?#result##0:mutual_type.b):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:mutual_type.b, ?###0:mutual_type.b)
+    foreign llvm move(0:mutual_type.b, ?#result##0:mutual_type.b)
 
 
 ~= > public {inline} (0 calls)
@@ -601,15 +601,15 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"mutual_type.b.b<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64, i1} @"mutual_type.b.b<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  %"1#tmp#0##0" = icmp ne i64 %"#result##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 

--- a/test-cases/final-dump/mutual_type.exp
+++ b/test-cases/final-dump/mutual_type.exp
@@ -46,32 +46,32 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 = > public (1 calls)
 0: mutual_type.a.=<0>
-=($left#0:mutual_type.a, $right#0:mutual_type.a, ?$$#0:wybe.bool):
+=($left##0:mutual_type.a, $right##0:mutual_type.a, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left#0:mutual_type.a, ~$right#0:mutual_type.a, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~$left##0:mutual_type.a, ~$right##0:mutual_type.a, ?$$##0:wybe.bool)
 
     1:
-        foreign lpvm access($left#0:mutual_type.a, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$ahead#0:wybe.int)
-        foreign lpvm access(~$left#0:mutual_type.a, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$atail#0:mutual_type.b)
-        foreign llvm icmp_ne($right#0:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.bool)
-        case ~tmp$9#0:wybe.bool of
+        foreign lpvm access($left##0:mutual_type.a, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$ahead##0:wybe.int)
+        foreign lpvm access(~$left##0:mutual_type.a, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$atail##0:mutual_type.b)
+        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
+        case ~tmp$9##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign lpvm access($right#0:mutual_type.a, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$ahead#0:wybe.int)
-            foreign lpvm access(~$right#0:mutual_type.a, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$atail#0:mutual_type.b)
-            foreign llvm icmp_eq(~$left$ahead#0:wybe.int, ~$right$ahead#0:wybe.int, ?tmp$4#0:wybe.bool) @int:nn:nn
-            case ~tmp$4#0:wybe.bool of
+            foreign lpvm access($right##0:mutual_type.a, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$ahead##0:wybe.int)
+            foreign lpvm access(~$right##0:mutual_type.a, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$atail##0:mutual_type.b)
+            foreign llvm icmp_eq(~$left$ahead##0:wybe.int, ~$right$ahead##0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
+            case ~tmp$4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                mutual_type.b.=<0>(~$left$atail#0:mutual_type.b, ~$right$atail#0:mutual_type.b, ?$$#0:wybe.bool) #3
+                mutual_type.b.=<0>(~$left$atail##0:mutual_type.b, ~$right$atail##0:mutual_type.b, ?$$##0:wybe.bool) #3
 
 
 
@@ -79,110 +79,110 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 a > public {inline} (0 calls)
 0: mutual_type.a.a<0>
-a(ahead#0:wybe.int, atail#0:mutual_type.b, ?$#0:mutual_type.a):
+a(ahead##0:wybe.int, atail##0:mutual_type.b, ?$##0:mutual_type.a):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:mutual_type.a)
-    foreign lpvm mutate(~$rec#0:mutual_type.a, ?$rec#1:mutual_type.a, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~ahead#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:mutual_type.a, ?$#0:mutual_type.a, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~atail#0:mutual_type.b)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:mutual_type.a)
+    foreign lpvm mutate(~$rec##0:mutual_type.a, ?$rec##1:mutual_type.a, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~ahead##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:mutual_type.a, ?$##0:mutual_type.a, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~atail##0:mutual_type.b)
 a > public {inline} (12 calls)
 1: mutual_type.a.a<1>
-a(?ahead#0:wybe.int, ?atail#0:mutual_type.b, $#0:mutual_type.a, ?$$#0:wybe.bool):
+a(?ahead##0:wybe.int, ?atail##0:mutual_type.b, $##0:mutual_type.a, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?ahead#0:wybe.int)
-        foreign llvm move(undef:mutual_type.b, ?atail#0:mutual_type.b)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?ahead##0:wybe.int)
+        foreign llvm move(undef:mutual_type.b, ?atail##0:mutual_type.b)
 
     1:
-        foreign lpvm access($#0:mutual_type.a, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ahead#0:wybe.int)
-        foreign lpvm access(~$#0:mutual_type.a, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?atail#0:mutual_type.b)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access($##0:mutual_type.a, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ahead##0:wybe.int)
+        foreign lpvm access(~$##0:mutual_type.a, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?atail##0:mutual_type.b)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 ahead > public {inline} (0 calls)
 0: mutual_type.a.ahead<0>
-ahead($rec#0:mutual_type.a, ?$#0:wybe.int, ?$$#0:wybe.bool):
+ahead($rec##0:mutual_type.a, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec#0:mutual_type.a, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:mutual_type.a, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 ahead > public {inline} (0 calls)
 1: mutual_type.a.ahead<1>
-ahead($rec#0:mutual_type.a, ?$rec#1:mutual_type.a, $field#0:wybe.int, ?$$#0:wybe.bool):
+ahead($rec##0:mutual_type.a, ?$rec##1:mutual_type.a, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:mutual_type.a, ?$rec#1:mutual_type.a)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:mutual_type.a, ?$rec##1:mutual_type.a)
 
     1:
-        foreign lpvm mutate(~$rec#0:mutual_type.a, ?$rec#1:mutual_type.a, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~$rec##0:mutual_type.a, ?$rec##1:mutual_type.a, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 atail > public {inline} (0 calls)
 0: mutual_type.a.atail<0>
-atail($rec#0:mutual_type.a, ?$#0:mutual_type.b, ?$$#0:wybe.bool):
+atail($rec##0:mutual_type.a, ?$##0:mutual_type.b, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:mutual_type.b, ?$#0:mutual_type.b)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:mutual_type.b, ?$##0:mutual_type.b)
 
     1:
-        foreign lpvm access(~$rec#0:mutual_type.a, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:mutual_type.b)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:mutual_type.a, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:mutual_type.b)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 atail > public {inline} (0 calls)
 1: mutual_type.a.atail<1>
-atail($rec#0:mutual_type.a, ?$rec#1:mutual_type.a, $field#0:mutual_type.b, ?$$#0:wybe.bool):
+atail($rec##0:mutual_type.a, ?$rec##1:mutual_type.a, $field##0:mutual_type.b, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:mutual_type.a, ?$rec#1:mutual_type.a)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:mutual_type.a, ?$rec##1:mutual_type.a)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec#0:mutual_type.a, ?$rec#1:mutual_type.a, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:mutual_type.b)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm {noalias} mutate(~$rec##0:mutual_type.a, ?$rec##1:mutual_type.a, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:mutual_type.b)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 no_a > public {inline} (0 calls)
 0: mutual_type.a.no_a<0>
-no_a(?$#0:mutual_type.a):
+no_a(?$##0:mutual_type.a):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:mutual_type.a, ?$#0:mutual_type.a)
+    foreign llvm move(0:mutual_type.a, ?$##0:mutual_type.a)
 
 
 ~= > public {inline} (0 calls)
 0: mutual_type.a.~=<0>
-~=($left#0:mutual_type.a, $right#0:mutual_type.a, ?$$#0:wybe.bool):
+~=($left##0:mutual_type.a, $right##0:mutual_type.a, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    mutual_type.a.=<0>(~$left#0:mutual_type.a, ~$right#0:mutual_type.a, ?tmp$0#0:wybe.bool) #0
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    mutual_type.a.=<0>(~$left##0:mutual_type.a, ~$right##0:mutual_type.a, ?tmp$0##0:wybe.bool) #0
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
   LLVM code       :
 
@@ -198,68 +198,68 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"mutual_type.a.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"mutual_type.a.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$left#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %"2$tmp$9#0" = icmp ne i64 %"$right#0", 0 
-  br i1 %"2$tmp$9#0", label %if.then1, label %if.else1 
+  %"2$tmp$9##0" = icmp ne i64 %"$right##0", 0 
+  br i1 %"2$tmp$9##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = icmp eq i64 %"$left#0", %"$right#0" 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
+  ret i1 %"3$$$##0" 
 if.then1:
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"4$tmp$4#0" = icmp eq i64 %3, %10 
-  br i1 %"4$tmp$4#0", label %if.then2, label %if.else2 
+  %"4$tmp$4##0" = icmp eq i64 %3, %10 
+  br i1 %"4$tmp$4##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$$$#0" = tail call fastcc  i1  @"mutual_type.b.=<0>"(i64  %7, i64  %14)  
-  ret i1 %"6$$$#0" 
+  %"6$$$##0" = tail call fastcc  i1  @"mutual_type.b.=<0>"(i64  %7, i64  %14)  
+  ret i1 %"6$$$##0" 
 if.else2:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"mutual_type.a.a<0>"(i64  %"ahead#0", i64  %"atail#0")    {
+define external fastcc  i64 @"mutual_type.a.a<0>"(i64  %"ahead##0", i64  %"atail##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"ahead#0", i64* %19 
+  store  i64 %"ahead##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"atail#0", i64* %22 
+  store  i64 %"atail##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64, i1} @"mutual_type.a.a<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64, i1} @"mutual_type.a.a<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -275,12 +275,12 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mutual_type.a.ahead<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"mutual_type.a.ahead<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %36 = inttoptr i64 %"$rec#0" to i64* 
+  %36 = inttoptr i64 %"$rec##0" to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
   %39 = insertvalue {i64, i1} undef, i64 %38, 0 
@@ -293,37 +293,37 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mutual_type.a.ahead<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"mutual_type.a.ahead<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %43 = trunc i64 16 to i32  
   %44 = tail call ccc  i8*  @wybe_malloc(i32  %43)  
   %45 = ptrtoint i8* %44 to i64 
   %46 = inttoptr i64 %45 to i8* 
-  %47 = inttoptr i64 %"$rec#0" to i8* 
+  %47 = inttoptr i64 %"$rec##0" to i8* 
   %48 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %46, i8*  %47, i32  %48, i32  8, i1  0)  
   %49 = inttoptr i64 %45 to i64* 
   %50 = getelementptr  i64, i64* %49, i64 0 
-  store  i64 %"$field#0", i64* %50 
+  store  i64 %"$field##0", i64* %50 
   %51 = insertvalue {i64, i1} undef, i64 %45, 0 
   %52 = insertvalue {i64, i1} %51, i1 1, 1 
   ret {i64, i1} %52 
 if.else:
-  %53 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %53 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %54 = insertvalue {i64, i1} %53, i1 0, 1 
   ret {i64, i1} %54 
 }
 
 
-define external fastcc  {i64, i1} @"mutual_type.a.atail<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"mutual_type.a.atail<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %55 = add   i64 %"$rec#0", 8 
+  %55 = add   i64 %"$rec##0", 8 
   %56 = inttoptr i64 %55 to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
@@ -337,27 +337,27 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mutual_type.a.atail<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"mutual_type.a.atail<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %63 = trunc i64 16 to i32  
   %64 = tail call ccc  i8*  @wybe_malloc(i32  %63)  
   %65 = ptrtoint i8* %64 to i64 
   %66 = inttoptr i64 %65 to i8* 
-  %67 = inttoptr i64 %"$rec#0" to i8* 
+  %67 = inttoptr i64 %"$rec##0" to i8* 
   %68 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %66, i8*  %67, i32  %68, i32  8, i1  0)  
   %69 = add   i64 %65, 8 
   %70 = inttoptr i64 %69 to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
-  store  i64 %"$field#0", i64* %71 
+  store  i64 %"$field##0", i64* %71 
   %72 = insertvalue {i64, i1} undef, i64 %65, 0 
   %73 = insertvalue {i64, i1} %72, i1 1, 1 
   ret {i64, i1} %73 
 if.else:
-  %74 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %74 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %75 = insertvalue {i64, i1} %74, i1 0, 1 
   ret {i64, i1} %75 
 }
@@ -369,11 +369,11 @@ entry:
 }
 
 
-define external fastcc  i1 @"mutual_type.a.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"mutual_type.a.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = tail call fastcc  i1  @"mutual_type.a.=<0>"(i64  %"$left#0", i64  %"$right#0")  
-  %"1$$$#0" = xor i1 %"1$tmp$0#0", 1 
-  ret i1 %"1$$$#0" 
+  %"1$tmp$0##0" = tail call fastcc  i1  @"mutual_type.a.=<0>"(i64  %"$left##0", i64  %"$right##0")  
+  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
+  ret i1 %"1$$$##0" 
 }
 --------------------------------------------------
  Module mutual_type.b
@@ -396,32 +396,32 @@ entry:
 
 = > public (1 calls)
 0: mutual_type.b.=<0>
-=($left#0:mutual_type.b, $right#0:mutual_type.b, ?$$#0:wybe.bool):
+=($left##0:mutual_type.b, $right##0:mutual_type.b, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left#0:mutual_type.b, ~$right#0:mutual_type.b, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~$left##0:mutual_type.b, ~$right##0:mutual_type.b, ?$$##0:wybe.bool)
 
     1:
-        foreign lpvm access($left#0:mutual_type.b, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$bhead#0:wybe.int)
-        foreign lpvm access(~$left#0:mutual_type.b, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$btail#0:mutual_type.a)
-        foreign llvm icmp_ne($right#0:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.bool)
-        case ~tmp$9#0:wybe.bool of
+        foreign lpvm access($left##0:mutual_type.b, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$bhead##0:wybe.int)
+        foreign lpvm access(~$left##0:mutual_type.b, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$btail##0:mutual_type.a)
+        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
+        case ~tmp$9##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign lpvm access($right#0:mutual_type.b, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$bhead#0:wybe.int)
-            foreign lpvm access(~$right#0:mutual_type.b, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$btail#0:mutual_type.a)
-            foreign llvm icmp_eq(~$left$bhead#0:wybe.int, ~$right$bhead#0:wybe.int, ?tmp$4#0:wybe.bool) @int:nn:nn
-            case ~tmp$4#0:wybe.bool of
+            foreign lpvm access($right##0:mutual_type.b, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$bhead##0:wybe.int)
+            foreign lpvm access(~$right##0:mutual_type.b, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$btail##0:mutual_type.a)
+            foreign llvm icmp_eq(~$left$bhead##0:wybe.int, ~$right$bhead##0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
+            case ~tmp$4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                mutual_type.a.=<0>(~$left$btail#0:mutual_type.a, ~$right$btail#0:mutual_type.a, ?$$#0:wybe.bool) #3
+                mutual_type.a.=<0>(~$left$btail##0:mutual_type.a, ~$right$btail##0:mutual_type.a, ?$$##0:wybe.bool) #3
 
 
 
@@ -429,110 +429,110 @@ entry:
 
 b > public {inline} (0 calls)
 0: mutual_type.b.b<0>
-b(bhead#0:wybe.int, btail#0:mutual_type.a, ?$#0:mutual_type.b):
+b(bhead##0:wybe.int, btail##0:mutual_type.a, ?$##0:mutual_type.b):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:mutual_type.b)
-    foreign lpvm mutate(~$rec#0:mutual_type.b, ?$rec#1:mutual_type.b, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~bhead#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:mutual_type.b, ?$#0:mutual_type.b, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~btail#0:mutual_type.a)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:mutual_type.b)
+    foreign lpvm mutate(~$rec##0:mutual_type.b, ?$rec##1:mutual_type.b, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~bhead##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:mutual_type.b, ?$##0:mutual_type.b, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~btail##0:mutual_type.a)
 b > public {inline} (12 calls)
 1: mutual_type.b.b<1>
-b(?bhead#0:wybe.int, ?btail#0:mutual_type.a, $#0:mutual_type.b, ?$$#0:wybe.bool):
+b(?bhead##0:wybe.int, ?btail##0:mutual_type.a, $##0:mutual_type.b, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?bhead#0:wybe.int)
-        foreign llvm move(undef:mutual_type.a, ?btail#0:mutual_type.a)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?bhead##0:wybe.int)
+        foreign llvm move(undef:mutual_type.a, ?btail##0:mutual_type.a)
 
     1:
-        foreign lpvm access($#0:mutual_type.b, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?bhead#0:wybe.int)
-        foreign lpvm access(~$#0:mutual_type.b, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?btail#0:mutual_type.a)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access($##0:mutual_type.b, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?bhead##0:wybe.int)
+        foreign lpvm access(~$##0:mutual_type.b, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?btail##0:mutual_type.a)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 bhead > public {inline} (0 calls)
 0: mutual_type.b.bhead<0>
-bhead($rec#0:mutual_type.b, ?$#0:wybe.int, ?$$#0:wybe.bool):
+bhead($rec##0:mutual_type.b, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec#0:mutual_type.b, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:mutual_type.b, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 bhead > public {inline} (0 calls)
 1: mutual_type.b.bhead<1>
-bhead($rec#0:mutual_type.b, ?$rec#1:mutual_type.b, $field#0:wybe.int, ?$$#0:wybe.bool):
+bhead($rec##0:mutual_type.b, ?$rec##1:mutual_type.b, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:mutual_type.b, ?$rec#1:mutual_type.b)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:mutual_type.b, ?$rec##1:mutual_type.b)
 
     1:
-        foreign lpvm mutate(~$rec#0:mutual_type.b, ?$rec#1:mutual_type.b, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~$rec##0:mutual_type.b, ?$rec##1:mutual_type.b, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 btail > public {inline} (0 calls)
 0: mutual_type.b.btail<0>
-btail($rec#0:mutual_type.b, ?$#0:mutual_type.a, ?$$#0:wybe.bool):
+btail($rec##0:mutual_type.b, ?$##0:mutual_type.a, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:mutual_type.a, ?$#0:mutual_type.a)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:mutual_type.a, ?$##0:mutual_type.a)
 
     1:
-        foreign lpvm access(~$rec#0:mutual_type.b, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:mutual_type.a)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:mutual_type.b, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:mutual_type.a)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 btail > public {inline} (0 calls)
 1: mutual_type.b.btail<1>
-btail($rec#0:mutual_type.b, ?$rec#1:mutual_type.b, $field#0:mutual_type.a, ?$$#0:wybe.bool):
+btail($rec##0:mutual_type.b, ?$rec##1:mutual_type.b, $field##0:mutual_type.a, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:mutual_type.b, ?$rec#1:mutual_type.b)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:mutual_type.b, ?$rec##1:mutual_type.b)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec#0:mutual_type.b, ?$rec#1:mutual_type.b, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:mutual_type.a)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm {noalias} mutate(~$rec##0:mutual_type.b, ?$rec##1:mutual_type.b, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:mutual_type.a)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 no_b > public {inline} (0 calls)
 0: mutual_type.b.no_b<0>
-no_b(?$#0:mutual_type.b):
+no_b(?$##0:mutual_type.b):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:mutual_type.b, ?$#0:mutual_type.b)
+    foreign llvm move(0:mutual_type.b, ?$##0:mutual_type.b)
 
 
 ~= > public {inline} (0 calls)
 0: mutual_type.b.~=<0>
-~=($left#0:mutual_type.b, $right#0:mutual_type.b, ?$$#0:wybe.bool):
+~=($left##0:mutual_type.b, $right##0:mutual_type.b, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    mutual_type.b.=<0>(~$left#0:mutual_type.b, ~$right#0:mutual_type.b, ?tmp$0#0:wybe.bool) #0
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    mutual_type.b.=<0>(~$left##0:mutual_type.b, ~$right##0:mutual_type.b, ?tmp$0##0:wybe.bool) #0
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
   LLVM code       :
 
@@ -548,68 +548,68 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"mutual_type.b.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"mutual_type.b.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$left#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %"2$tmp$9#0" = icmp ne i64 %"$right#0", 0 
-  br i1 %"2$tmp$9#0", label %if.then1, label %if.else1 
+  %"2$tmp$9##0" = icmp ne i64 %"$right##0", 0 
+  br i1 %"2$tmp$9##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = icmp eq i64 %"$left#0", %"$right#0" 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
+  ret i1 %"3$$$##0" 
 if.then1:
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"4$tmp$4#0" = icmp eq i64 %3, %10 
-  br i1 %"4$tmp$4#0", label %if.then2, label %if.else2 
+  %"4$tmp$4##0" = icmp eq i64 %3, %10 
+  br i1 %"4$tmp$4##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$$$#0" = tail call fastcc  i1  @"mutual_type.a.=<0>"(i64  %7, i64  %14)  
-  ret i1 %"6$$$#0" 
+  %"6$$$##0" = tail call fastcc  i1  @"mutual_type.a.=<0>"(i64  %7, i64  %14)  
+  ret i1 %"6$$$##0" 
 if.else2:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"mutual_type.b.b<0>"(i64  %"bhead#0", i64  %"btail#0")    {
+define external fastcc  i64 @"mutual_type.b.b<0>"(i64  %"bhead##0", i64  %"btail##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"bhead#0", i64* %19 
+  store  i64 %"bhead##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"btail#0", i64* %22 
+  store  i64 %"btail##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64, i1} @"mutual_type.b.b<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64, i1} @"mutual_type.b.b<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -625,12 +625,12 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mutual_type.b.bhead<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"mutual_type.b.bhead<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %36 = inttoptr i64 %"$rec#0" to i64* 
+  %36 = inttoptr i64 %"$rec##0" to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
   %39 = insertvalue {i64, i1} undef, i64 %38, 0 
@@ -643,37 +643,37 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mutual_type.b.bhead<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"mutual_type.b.bhead<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %43 = trunc i64 16 to i32  
   %44 = tail call ccc  i8*  @wybe_malloc(i32  %43)  
   %45 = ptrtoint i8* %44 to i64 
   %46 = inttoptr i64 %45 to i8* 
-  %47 = inttoptr i64 %"$rec#0" to i8* 
+  %47 = inttoptr i64 %"$rec##0" to i8* 
   %48 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %46, i8*  %47, i32  %48, i32  8, i1  0)  
   %49 = inttoptr i64 %45 to i64* 
   %50 = getelementptr  i64, i64* %49, i64 0 
-  store  i64 %"$field#0", i64* %50 
+  store  i64 %"$field##0", i64* %50 
   %51 = insertvalue {i64, i1} undef, i64 %45, 0 
   %52 = insertvalue {i64, i1} %51, i1 1, 1 
   ret {i64, i1} %52 
 if.else:
-  %53 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %53 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %54 = insertvalue {i64, i1} %53, i1 0, 1 
   ret {i64, i1} %54 
 }
 
 
-define external fastcc  {i64, i1} @"mutual_type.b.btail<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"mutual_type.b.btail<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %55 = add   i64 %"$rec#0", 8 
+  %55 = add   i64 %"$rec##0", 8 
   %56 = inttoptr i64 %55 to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
@@ -687,27 +687,27 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mutual_type.b.btail<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"mutual_type.b.btail<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %63 = trunc i64 16 to i32  
   %64 = tail call ccc  i8*  @wybe_malloc(i32  %63)  
   %65 = ptrtoint i8* %64 to i64 
   %66 = inttoptr i64 %65 to i8* 
-  %67 = inttoptr i64 %"$rec#0" to i8* 
+  %67 = inttoptr i64 %"$rec##0" to i8* 
   %68 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %66, i8*  %67, i32  %68, i32  8, i1  0)  
   %69 = add   i64 %65, 8 
   %70 = inttoptr i64 %69 to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
-  store  i64 %"$field#0", i64* %71 
+  store  i64 %"$field##0", i64* %71 
   %72 = insertvalue {i64, i1} undef, i64 %65, 0 
   %73 = insertvalue {i64, i1} %72, i1 1, 1 
   ret {i64, i1} %73 
 if.else:
-  %74 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %74 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %75 = insertvalue {i64, i1} %74, i1 0, 1 
   ret {i64, i1} %75 
 }
@@ -719,9 +719,9 @@ entry:
 }
 
 
-define external fastcc  i1 @"mutual_type.b.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"mutual_type.b.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = tail call fastcc  i1  @"mutual_type.b.=<0>"(i64  %"$left#0", i64  %"$right#0")  
-  %"1$$$#0" = xor i1 %"1$tmp$0#0", 1 
-  ret i1 %"1$$$#0" 
+  %"1$tmp$0##0" = tail call fastcc  i1  @"mutual_type.b.=<0>"(i64  %"$left##0", i64  %"$right##0")  
+  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
+  ret i1 %"1$$$##0" 
 }

--- a/test-cases/final-dump/mytree.exp
+++ b/test-cases/final-dump/mytree.exp
@@ -37,8 +37,8 @@ printTree1 > public (3 calls)
 printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string, io##0:wybe.phantom, ?io##4:wybe.phantom):
  AliasPairs: [(prefix##0,prefix##3)]
  InterestingCallProperties: []
-    foreign llvm icmp_ne(t##0:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.bool)
-    case ~tmp$2##0:wybe.bool of
+    foreign llvm icmp_ne(t##0:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.bool)
+    case ~tmp#2##0:wybe.bool of
     0:
         foreign llvm move(~prefix##0:wybe.string, ?prefix##3:wybe.string)
         foreign llvm move(~io##0:wybe.phantom, ?io##4:wybe.phantom)
@@ -85,7 +85,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 define external fastcc  void @"mytree.printTree<0>"(i64  %"t##0")    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @mytree.1, i32 0, i32 0) to i64 
-  %"1$prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t##0", i64  %2)  
+  %"1#prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t##0", i64  %2)  
   %4 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @mytree.3, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %4)  
   ret void 
@@ -94,8 +94,8 @@ entry:
 
 define external fastcc  i64 @"mytree.printTree1<0>"(i64  %"t##0", i64  %"prefix##0")    {
 entry:
-  %"1$tmp$2##0" = icmp ne i64 %"t##0", 0 
-  br i1 %"1$tmp$2##0", label %if.then, label %if.else 
+  %"1#tmp#2##0" = icmp ne i64 %"t##0", 0 
+  br i1 %"1#tmp#2##0", label %if.then, label %if.else 
 if.then:
   %5 = inttoptr i64 %"t##0" to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
@@ -108,12 +108,12 @@ if.then:
   %13 = inttoptr i64 %12 to i64* 
   %14 = getelementptr  i64, i64* %13, i64 0 
   %15 = load  i64, i64* %14 
-  %"2$prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %7, i64  %"prefix##0")  
-  tail call ccc  void  @print_string(i64  %"2$prefix##1")  
+  %"2#prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %7, i64  %"prefix##0")  
+  tail call ccc  void  @print_string(i64  %"2#prefix##1")  
   tail call ccc  void  @print_int(i64  %11)  
   %17 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @mytree.16, i32 0, i32 0) to i64 
-  %"2$prefix##3" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %15, i64  %17)  
-  ret i64 %"2$prefix##3" 
+  %"2#prefix##3" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %15, i64  %17)  
+  ret i64 %"2#prefix##3" 
 if.else:
   ret i64 %"prefix##0" 
 }
@@ -140,40 +140,40 @@ if.else:
 
 = > public (7 calls)
 0: mytree.tree.=<0>
-=($left##0:mytree.tree, $right##0:mytree.tree, ?$$##0:wybe.bool):
+=(#left##0:mytree.tree, #right##0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left##0:mytree.tree, ~$right##0:mytree.tree, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:mytree.tree, ~#right##0:mytree.tree, ?####0:wybe.bool)
 
     1:
-        foreign lpvm access($left##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$left##0:mytree.tree)
-        foreign lpvm access($left##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$key##0:wybe.int)
-        foreign lpvm access(~$left##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$right##0:mytree.tree)
-        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.bool)
-        case ~tmp$10##0:wybe.bool of
+        foreign lpvm access(#left##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#left##0:mytree.tree)
+        foreign lpvm access(#left##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#key##0:wybe.int)
+        foreign lpvm access(~#left##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#right##0:mytree.tree)
+        foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
+        case ~tmp#10##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign lpvm access($right##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$left##0:mytree.tree)
-            foreign lpvm access($right##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$key##0:wybe.int)
-            foreign lpvm access(~$right##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$right##0:mytree.tree)
-            mytree.tree.=<0>(~$left$left##0:mytree.tree, ~$right$left##0:mytree.tree, ?tmp$4##0:wybe.bool) #2
-            case ~tmp$4##0:wybe.bool of
+            foreign lpvm access(#right##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#left##0:mytree.tree)
+            foreign lpvm access(#right##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#key##0:wybe.int)
+            foreign lpvm access(~#right##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#right##0:mytree.tree)
+            mytree.tree.=<0>(~#left#left##0:mytree.tree, ~#right#left##0:mytree.tree, ?tmp#4##0:wybe.bool) #2
+            case ~tmp#4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
             1:
-                foreign llvm icmp_eq(~$left$key##0:wybe.int, ~$right$key##0:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
-                case ~tmp$5##0:wybe.bool of
+                foreign llvm icmp_eq(~#left#key##0:wybe.int, ~#right#key##0:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
+                case ~tmp#5##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                 1:
-                    mytree.tree.=<0>(~$left$right##0:mytree.tree, ~$right$right##0:mytree.tree, ?$$##0:wybe.bool) #4
+                    mytree.tree.=<0>(~#left#right##0:mytree.tree, ~#right#right##0:mytree.tree, ?####0:wybe.bool) #4
 
 
 
@@ -182,145 +182,145 @@ if.else:
 
 empty > public {inline} (0 calls)
 0: mytree.tree.empty<0>
-empty(?$##0:mytree.tree):
+empty(?###0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:mytree.tree, ?$##0:mytree.tree)
+    foreign llvm move(0:mytree.tree, ?###0:mytree.tree)
 
 
 key > public {inline} (0 calls)
 0: mytree.tree.key<0>
-key($rec##0:mytree.tree, ?$##0:wybe.int, ?$$##0:wybe.bool):
+key(#rec##0:mytree.tree, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 key > public {inline} (0 calls)
 1: mytree.tree.key<1>
-key($rec##0:mytree.tree, ?$rec##1:mytree.tree, $field##0:wybe.int, ?$$##0:wybe.bool):
+key(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:mytree.tree, ?$rec##1:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~$rec##0:mytree.tree, ?$rec##1:mytree.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 left > public {inline} (0 calls)
 0: mytree.tree.left<0>
-left($rec##0:mytree.tree, ?$##0:mytree.tree, ?$$##0:wybe.bool):
+left(#rec##0:mytree.tree, ?###0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:mytree.tree, ?$##0:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:mytree.tree, ?###0:mytree.tree)
 
     1:
-        foreign lpvm access(~$rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 left > public {inline} (0 calls)
 1: mytree.tree.left<1>
-left($rec##0:mytree.tree, ?$rec##1:mytree.tree, $field##0:mytree.tree, ?$$##0:wybe.bool):
+left(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:mytree.tree, ?$rec##1:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~$rec##0:mytree.tree, ?$rec##1:mytree.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 node > public {inline} (0 calls)
 0: mytree.tree.node<0>
-node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?$##0:mytree.tree):
+node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?###0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?$rec##0:mytree.tree)
-    foreign lpvm mutate(~$rec##0:mytree.tree, ?$rec##1:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:mytree.tree)
-    foreign lpvm mutate(~$rec##1:mytree.tree, ?$rec##2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int)
-    foreign lpvm mutate(~$rec##2:mytree.tree, ?$##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree)
+    foreign lpvm alloc(24:wybe.int, ?#rec##0:mytree.tree)
+    foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:mytree.tree)
+    foreign lpvm mutate(~#rec##1:mytree.tree, ?#rec##2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int)
+    foreign lpvm mutate(~#rec##2:mytree.tree, ?###0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree)
 node > public {inline} (16 calls)
 1: mytree.tree.node<1>
-node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, $##0:mytree.tree, ?$$##0:wybe.bool):
+node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, ###0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:mytree.tree, ?left##0:mytree.tree)
         foreign llvm move(undef:wybe.int, ?key##0:wybe.int)
         foreign llvm move(undef:mytree.tree, ?right##0:mytree.tree)
 
     1:
-        foreign lpvm access($##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:mytree.tree)
-        foreign lpvm access($##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
-        foreign lpvm access(~$##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(###0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:mytree.tree)
+        foreign lpvm access(###0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
+        foreign lpvm access(~###0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 right > public {inline} (0 calls)
 0: mytree.tree.right<0>
-right($rec##0:mytree.tree, ?$##0:mytree.tree, ?$$##0:wybe.bool):
+right(#rec##0:mytree.tree, ?###0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:mytree.tree, ?$##0:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:mytree.tree, ?###0:mytree.tree)
 
     1:
-        foreign lpvm access(~$rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 right > public {inline} (0 calls)
 1: mytree.tree.right<1>
-right($rec##0:mytree.tree, ?$rec##1:mytree.tree, $field##0:mytree.tree, ?$$##0:wybe.bool):
+right(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:mytree.tree, ?$rec##1:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~$rec##0:mytree.tree, ?$rec##1:mytree.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: mytree.tree.~=<0>
-~=($left##0:mytree.tree, $right##0:mytree.tree, ?$$##0:wybe.bool):
+~=(#left##0:mytree.tree, #right##0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    mytree.tree.=<0>(~$left##0:mytree.tree, ~$right##0:mytree.tree, ?tmp$0##0:wybe.bool) #0
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    mytree.tree.=<0>(~#left##0:mytree.tree, ~#right##0:mytree.tree, ?tmp#0##0:wybe.bool) #0
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
   LLVM code       :
 
@@ -336,51 +336,51 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"mytree.tree.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"mytree.tree.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#left##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = add   i64 %"$left##0", 16 
+  %8 = add   i64 %"#left##0", 16 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
-  %"2$tmp$10##0" = icmp ne i64 %"$right##0", 0 
-  br i1 %"2$tmp$10##0", label %if.then1, label %if.else1 
+  %"2#tmp#10##0" = icmp ne i64 %"#right##0", 0 
+  br i1 %"2#tmp#10##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3#####0" 
 if.then1:
-  %12 = inttoptr i64 %"$right##0" to i64* 
+  %12 = inttoptr i64 %"#right##0" to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %15 = add   i64 %"$right##0", 8 
+  %15 = add   i64 %"#right##0", 8 
   %16 = inttoptr i64 %15 to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
-  %19 = add   i64 %"$right##0", 16 
+  %19 = add   i64 %"#right##0", 16 
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %"4$tmp$4##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %3, i64  %14)  
-  br i1 %"4$tmp$4##0", label %if.then2, label %if.else2 
+  %"4#tmp#4##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %3, i64  %14)  
+  br i1 %"4#tmp#4##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$tmp$5##0" = icmp eq i64 %7, %18 
-  br i1 %"6$tmp$5##0", label %if.then3, label %if.else3 
+  %"6#tmp#5##0" = icmp eq i64 %7, %18 
+  br i1 %"6#tmp#5##0", label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %"8$$$##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %11, i64  %22)  
-  ret i1 %"8$$$##0" 
+  %"8#####0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %11, i64  %22)  
+  ret i1 %"8#####0" 
 if.else3:
   ret i1 0 
 }
@@ -392,12 +392,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.key<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.key<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %23 = add   i64 %"$rec##0", 8 
+  %23 = add   i64 %"#rec##0", 8 
   %24 = inttoptr i64 %23 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
   %26 = load  i64, i64* %25 
@@ -411,38 +411,38 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.key<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.key<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %31 = trunc i64 24 to i32  
   %32 = tail call ccc  i8*  @wybe_malloc(i32  %31)  
   %33 = ptrtoint i8* %32 to i64 
   %34 = inttoptr i64 %33 to i8* 
-  %35 = inttoptr i64 %"$rec##0" to i8* 
+  %35 = inttoptr i64 %"#rec##0" to i8* 
   %36 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %34, i8*  %35, i32  %36, i32  8, i1  0)  
   %37 = add   i64 %33, 8 
   %38 = inttoptr i64 %37 to i64* 
   %39 = getelementptr  i64, i64* %38, i64 0 
-  store  i64 %"$field##0", i64* %39 
+  store  i64 %"#field##0", i64* %39 
   %40 = insertvalue {i64, i1} undef, i64 %33, 0 
   %41 = insertvalue {i64, i1} %40, i1 1, 1 
   ret {i64, i1} %41 
 if.else:
-  %42 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %42 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %43 = insertvalue {i64, i1} %42, i1 0, 1 
   ret {i64, i1} %43 
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.left<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.left<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %44 = inttoptr i64 %"$rec##0" to i64* 
+  %44 = inttoptr i64 %"#rec##0" to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
   %47 = insertvalue {i64, i1} undef, i64 %46, 0 
@@ -455,26 +455,26 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.left<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.left<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %51 = trunc i64 24 to i32  
   %52 = tail call ccc  i8*  @wybe_malloc(i32  %51)  
   %53 = ptrtoint i8* %52 to i64 
   %54 = inttoptr i64 %53 to i8* 
-  %55 = inttoptr i64 %"$rec##0" to i8* 
+  %55 = inttoptr i64 %"#rec##0" to i8* 
   %56 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %54, i8*  %55, i32  %56, i32  8, i1  0)  
   %57 = inttoptr i64 %53 to i64* 
   %58 = getelementptr  i64, i64* %57, i64 0 
-  store  i64 %"$field##0", i64* %58 
+  store  i64 %"#field##0", i64* %58 
   %59 = insertvalue {i64, i1} undef, i64 %53, 0 
   %60 = insertvalue {i64, i1} %59, i1 1, 1 
   ret {i64, i1} %60 
 if.else:
-  %61 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %61 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %62 = insertvalue {i64, i1} %61, i1 0, 1 
   ret {i64, i1} %62 
 }
@@ -500,19 +500,19 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64, i1} @"mytree.tree.node<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64, i64, i1} @"mytree.tree.node<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %74 = inttoptr i64 %"$##0" to i64* 
+  %74 = inttoptr i64 %"###0" to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
   %76 = load  i64, i64* %75 
-  %77 = add   i64 %"$##0", 8 
+  %77 = add   i64 %"###0", 8 
   %78 = inttoptr i64 %77 to i64* 
   %79 = getelementptr  i64, i64* %78, i64 0 
   %80 = load  i64, i64* %79 
-  %81 = add   i64 %"$##0", 16 
+  %81 = add   i64 %"###0", 16 
   %82 = inttoptr i64 %81 to i64* 
   %83 = getelementptr  i64, i64* %82, i64 0 
   %84 = load  i64, i64* %83 
@@ -530,12 +530,12 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.right<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.right<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %93 = add   i64 %"$rec##0", 16 
+  %93 = add   i64 %"#rec##0", 16 
   %94 = inttoptr i64 %93 to i64* 
   %95 = getelementptr  i64, i64* %94, i64 0 
   %96 = load  i64, i64* %95 
@@ -549,35 +549,35 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.right<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"mytree.tree.right<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %101 = trunc i64 24 to i32  
   %102 = tail call ccc  i8*  @wybe_malloc(i32  %101)  
   %103 = ptrtoint i8* %102 to i64 
   %104 = inttoptr i64 %103 to i8* 
-  %105 = inttoptr i64 %"$rec##0" to i8* 
+  %105 = inttoptr i64 %"#rec##0" to i8* 
   %106 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %104, i8*  %105, i32  %106, i32  8, i1  0)  
   %107 = add   i64 %103, 16 
   %108 = inttoptr i64 %107 to i64* 
   %109 = getelementptr  i64, i64* %108, i64 0 
-  store  i64 %"$field##0", i64* %109 
+  store  i64 %"#field##0", i64* %109 
   %110 = insertvalue {i64, i1} undef, i64 %103, 0 
   %111 = insertvalue {i64, i1} %110, i1 1, 1 
   ret {i64, i1} %111 
 if.else:
-  %112 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %112 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %113 = insertvalue {i64, i1} %112, i1 0, 1 
   ret {i64, i1} %113 
 }
 
 
-define external fastcc  i1 @"mytree.tree.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"mytree.tree.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %"$left##0", i64  %"$right##0")  
-  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
-  ret i1 %"1$$$##0" 
+  %"1#tmp#0##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %"#left##0", i64  %"#right##0")  
+  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1#####0" 
 }

--- a/test-cases/final-dump/mytree.exp
+++ b/test-cases/final-dump/mytree.exp
@@ -182,25 +182,25 @@ if.else:
 
 empty > public {inline} (0 calls)
 0: mytree.tree.empty<0>
-empty(?###0:mytree.tree):
+empty(?#result##0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:mytree.tree, ?###0:mytree.tree)
+    foreign llvm move(0:mytree.tree, ?#result##0:mytree.tree)
 
 
 key > public {inline} (0 calls)
 0: mytree.tree.key<0>
-key(#rec##0:mytree.tree, ?###0:wybe.int, ?####0:wybe.bool):
+key(#rec##0:mytree.tree, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign lpvm access(~#rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 key > public {inline} (0 calls)
@@ -222,17 +222,17 @@ key(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:wybe.int, ?####0:wybe.b
 
 left > public {inline} (0 calls)
 0: mytree.tree.left<0>
-left(#rec##0:mytree.tree, ?###0:mytree.tree, ?####0:wybe.bool):
+left(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:mytree.tree, ?###0:mytree.tree)
+        foreign llvm move(undef:mytree.tree, ?#result##0:mytree.tree)
 
     1:
-        foreign lpvm access(~#rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:mytree.tree)
+        foreign lpvm access(~#rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 left > public {inline} (0 calls)
@@ -254,19 +254,19 @@ left(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?####0:wy
 
 node > public {inline} (0 calls)
 0: mytree.tree.node<0>
-node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?###0:mytree.tree):
+node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?#result##0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(24:wybe.int, ?#rec##0:mytree.tree)
     foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:mytree.tree)
     foreign lpvm mutate(~#rec##1:mytree.tree, ?#rec##2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int)
-    foreign lpvm mutate(~#rec##2:mytree.tree, ?###0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree)
+    foreign lpvm mutate(~#rec##2:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree)
 node > public {inline} (16 calls)
 1: mytree.tree.node<1>
-node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, ###0:mytree.tree, ?####0:wybe.bool):
+node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, #result##0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
@@ -275,26 +275,26 @@ node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, ###0:mytree.
         foreign llvm move(undef:mytree.tree, ?right##0:mytree.tree)
 
     1:
-        foreign lpvm access(###0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:mytree.tree)
-        foreign lpvm access(###0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
-        foreign lpvm access(~###0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:mytree.tree)
+        foreign lpvm access(#result##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:mytree.tree)
+        foreign lpvm access(#result##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
+        foreign lpvm access(~#result##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:mytree.tree)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 right > public {inline} (0 calls)
 0: mytree.tree.right<0>
-right(#rec##0:mytree.tree, ?###0:mytree.tree, ?####0:wybe.bool):
+right(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:mytree.tree, ?###0:mytree.tree)
+        foreign llvm move(undef:mytree.tree, ?#result##0:mytree.tree)
 
     1:
-        foreign lpvm access(~#rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:mytree.tree)
+        foreign lpvm access(~#rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 right > public {inline} (0 calls)
@@ -500,19 +500,19 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64, i1} @"mytree.tree.node<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64, i64, i1} @"mytree.tree.node<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  %"1#tmp#0##0" = icmp ne i64 %"#result##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %74 = inttoptr i64 %"###0" to i64* 
+  %74 = inttoptr i64 %"#result##0" to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
   %76 = load  i64, i64* %75 
-  %77 = add   i64 %"###0", 8 
+  %77 = add   i64 %"#result##0", 8 
   %78 = inttoptr i64 %77 to i64* 
   %79 = getelementptr  i64, i64* %78, i64 0 
   %80 = load  i64, i64* %79 
-  %81 = add   i64 %"###0", 16 
+  %81 = add   i64 %"#result##0", 16 
   %82 = inttoptr i64 %81 to i64* 
   %83 = getelementptr  i64, i64* %82, i64 0 
   %84 = load  i64, i64* %83 

--- a/test-cases/final-dump/mytree.exp
+++ b/test-cases/final-dump/mytree.exp
@@ -25,32 +25,32 @@ AFTER EVERYTHING:
 
 printTree > public {inline} (0 calls)
 0: mytree.printTree<0>
-printTree(t#0:mytree.tree, io#0:wybe.phantom, ?io#2:wybe.phantom):
+printTree(t##0:mytree.tree, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    mytree.printTree1<0>(~t#0:mytree.tree, "{":wybe.string, ?%prefix#1:wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @mytree:nn:nn
-    foreign c print_string("}":wybe.string, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
+    mytree.printTree1<0>(~t##0:mytree.tree, "{":wybe.string, ?%prefix##1:wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @mytree:nn:nn
+    foreign c print_string("}":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
 
 printTree1 > public (3 calls)
 0: mytree.printTree1<0>
-printTree1(t#0:mytree.tree, prefix#0:wybe.string, ?prefix#3:wybe.string, io#0:wybe.phantom, ?io#4:wybe.phantom):
- AliasPairs: [(prefix#0,prefix#3)]
+printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string, io##0:wybe.phantom, ?io##4:wybe.phantom):
+ AliasPairs: [(prefix##0,prefix##3)]
  InterestingCallProperties: []
-    foreign llvm icmp_ne(t#0:wybe.int, 0:wybe.int, ?tmp$2#0:wybe.bool)
-    case ~tmp$2#0:wybe.bool of
+    foreign llvm icmp_ne(t##0:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.bool)
+    case ~tmp$2##0:wybe.bool of
     0:
-        foreign llvm move(~prefix#0:wybe.string, ?prefix#3:wybe.string)
-        foreign llvm move(~io#0:wybe.phantom, ?io#4:wybe.phantom)
+        foreign llvm move(~prefix##0:wybe.string, ?prefix##3:wybe.string)
+        foreign llvm move(~io##0:wybe.phantom, ?io##4:wybe.phantom)
 
     1:
-        foreign lpvm access(t#0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?l#0:mytree.tree)
-        foreign lpvm access(t#0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k#0:wybe.int)
-        foreign lpvm access(~t#0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?r#0:mytree.tree)
-        mytree.printTree1<0>(~l#0:mytree.tree, ~%prefix#0:wybe.string, ?%prefix#1:wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #1 @mytree:nn:nn
-        foreign c print_string(~prefix#1:wybe.string, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-        foreign c print_int(~k#0:wybe.int, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-        mytree.printTree1<0>(~r#0:mytree.tree, ", ":wybe.string, ?%prefix#3:wybe.string, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #4 @mytree:nn:nn
+        foreign lpvm access(t##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?l##0:mytree.tree)
+        foreign lpvm access(t##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k##0:wybe.int)
+        foreign lpvm access(~t##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?r##0:mytree.tree)
+        mytree.printTree1<0>(~l##0:mytree.tree, ~%prefix##0:wybe.string, ?%prefix##1:wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @mytree:nn:nn
+        foreign c print_string(~prefix##1:wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+        foreign c print_int(~k##0:wybe.int, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+        mytree.printTree1<0>(~r##0:mytree.tree, ", ":wybe.string, ?%prefix##3:wybe.string, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @mytree:nn:nn
 
 
   LLVM code       :
@@ -82,40 +82,40 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"mytree.printTree<0>"(i64  %"t#0")    {
+define external fastcc  void @"mytree.printTree<0>"(i64  %"t##0")    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @mytree.1, i32 0, i32 0) to i64 
-  %"1$prefix#1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t#0", i64  %2)  
+  %"1$prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t##0", i64  %2)  
   %4 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @mytree.3, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %4)  
   ret void 
 }
 
 
-define external fastcc  i64 @"mytree.printTree1<0>"(i64  %"t#0", i64  %"prefix#0")    {
+define external fastcc  i64 @"mytree.printTree1<0>"(i64  %"t##0", i64  %"prefix##0")    {
 entry:
-  %"1$tmp$2#0" = icmp ne i64 %"t#0", 0 
-  br i1 %"1$tmp$2#0", label %if.then, label %if.else 
+  %"1$tmp$2##0" = icmp ne i64 %"t##0", 0 
+  br i1 %"1$tmp$2##0", label %if.then, label %if.else 
 if.then:
-  %5 = inttoptr i64 %"t#0" to i64* 
+  %5 = inttoptr i64 %"t##0" to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = add   i64 %"t#0", 8 
+  %8 = add   i64 %"t##0", 8 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
-  %12 = add   i64 %"t#0", 16 
+  %12 = add   i64 %"t##0", 16 
   %13 = inttoptr i64 %12 to i64* 
   %14 = getelementptr  i64, i64* %13, i64 0 
   %15 = load  i64, i64* %14 
-  %"2$prefix#1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %7, i64  %"prefix#0")  
-  tail call ccc  void  @print_string(i64  %"2$prefix#1")  
+  %"2$prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %7, i64  %"prefix##0")  
+  tail call ccc  void  @print_string(i64  %"2$prefix##1")  
   tail call ccc  void  @print_int(i64  %11)  
   %17 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @mytree.16, i32 0, i32 0) to i64 
-  %"2$prefix#3" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %15, i64  %17)  
-  ret i64 %"2$prefix#3" 
+  %"2$prefix##3" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %15, i64  %17)  
+  ret i64 %"2$prefix##3" 
 if.else:
-  ret i64 %"prefix#0" 
+  ret i64 %"prefix##0" 
 }
 --------------------------------------------------
  Module mytree.tree
@@ -140,40 +140,40 @@ if.else:
 
 = > public (7 calls)
 0: mytree.tree.=<0>
-=($left#0:mytree.tree, $right#0:mytree.tree, ?$$#0:wybe.bool):
+=($left##0:mytree.tree, $right##0:mytree.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left#0:mytree.tree, ~$right#0:mytree.tree, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~$left##0:mytree.tree, ~$right##0:mytree.tree, ?$$##0:wybe.bool)
 
     1:
-        foreign lpvm access($left#0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$left#0:mytree.tree)
-        foreign lpvm access($left#0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$key#0:wybe.int)
-        foreign lpvm access(~$left#0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$right#0:mytree.tree)
-        foreign llvm icmp_ne($right#0:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.bool)
-        case ~tmp$10#0:wybe.bool of
+        foreign lpvm access($left##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$left##0:mytree.tree)
+        foreign lpvm access($left##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$key##0:wybe.int)
+        foreign lpvm access(~$left##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$right##0:mytree.tree)
+        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.bool)
+        case ~tmp$10##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign lpvm access($right#0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$left#0:mytree.tree)
-            foreign lpvm access($right#0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$key#0:wybe.int)
-            foreign lpvm access(~$right#0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$right#0:mytree.tree)
-            mytree.tree.=<0>(~$left$left#0:mytree.tree, ~$right$left#0:mytree.tree, ?tmp$4#0:wybe.bool) #2
-            case ~tmp$4#0:wybe.bool of
+            foreign lpvm access($right##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$left##0:mytree.tree)
+            foreign lpvm access($right##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$key##0:wybe.int)
+            foreign lpvm access(~$right##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$right##0:mytree.tree)
+            mytree.tree.=<0>(~$left$left##0:mytree.tree, ~$right$left##0:mytree.tree, ?tmp$4##0:wybe.bool) #2
+            case ~tmp$4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                foreign llvm icmp_eq(~$left$key#0:wybe.int, ~$right$key#0:wybe.int, ?tmp$5#0:wybe.bool) @int:nn:nn
-                case ~tmp$5#0:wybe.bool of
+                foreign llvm icmp_eq(~$left$key##0:wybe.int, ~$right$key##0:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
+                case ~tmp$5##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                 1:
-                    mytree.tree.=<0>(~$left$right#0:mytree.tree, ~$right$right#0:mytree.tree, ?$$#0:wybe.bool) #4
+                    mytree.tree.=<0>(~$left$right##0:mytree.tree, ~$right$right##0:mytree.tree, ?$$##0:wybe.bool) #4
 
 
 
@@ -182,145 +182,145 @@ if.else:
 
 empty > public {inline} (0 calls)
 0: mytree.tree.empty<0>
-empty(?$#0:mytree.tree):
+empty(?$##0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:mytree.tree, ?$#0:mytree.tree)
+    foreign llvm move(0:mytree.tree, ?$##0:mytree.tree)
 
 
 key > public {inline} (0 calls)
 0: mytree.tree.key<0>
-key($rec#0:mytree.tree, ?$#0:wybe.int, ?$$#0:wybe.bool):
+key($rec##0:mytree.tree, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec#0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 key > public {inline} (0 calls)
 1: mytree.tree.key<1>
-key($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:wybe.int, ?$$#0:wybe.bool):
+key($rec##0:mytree.tree, ?$rec##1:mytree.tree, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:mytree.tree, ?$rec#1:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:mytree.tree, ?$rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~$rec#0:mytree.tree, ?$rec#1:mytree.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~$rec##0:mytree.tree, ?$rec##1:mytree.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 left > public {inline} (0 calls)
 0: mytree.tree.left<0>
-left($rec#0:mytree.tree, ?$#0:mytree.tree, ?$$#0:wybe.bool):
+left($rec##0:mytree.tree, ?$##0:mytree.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:mytree.tree, ?$#0:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:mytree.tree, ?$##0:mytree.tree)
 
     1:
-        foreign lpvm access(~$rec#0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 left > public {inline} (0 calls)
 1: mytree.tree.left<1>
-left($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:mytree.tree, ?$$#0:wybe.bool):
+left($rec##0:mytree.tree, ?$rec##1:mytree.tree, $field##0:mytree.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:mytree.tree, ?$rec#1:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:mytree.tree, ?$rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~$rec#0:mytree.tree, ?$rec#1:mytree.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field#0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~$rec##0:mytree.tree, ?$rec##1:mytree.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 node > public {inline} (0 calls)
 0: mytree.tree.node<0>
-node(left#0:mytree.tree, key#0:wybe.int, right#0:mytree.tree, ?$#0:mytree.tree):
+node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?$##0:mytree.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?$rec#0:mytree.tree)
-    foreign lpvm mutate(~$rec#0:mytree.tree, ?$rec#1:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left#0:mytree.tree)
-    foreign lpvm mutate(~$rec#1:mytree.tree, ?$rec#2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key#0:wybe.int)
-    foreign lpvm mutate(~$rec#2:mytree.tree, ?$#0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right#0:mytree.tree)
+    foreign lpvm alloc(24:wybe.int, ?$rec##0:mytree.tree)
+    foreign lpvm mutate(~$rec##0:mytree.tree, ?$rec##1:mytree.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:mytree.tree)
+    foreign lpvm mutate(~$rec##1:mytree.tree, ?$rec##2:mytree.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int)
+    foreign lpvm mutate(~$rec##2:mytree.tree, ?$##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree)
 node > public {inline} (16 calls)
 1: mytree.tree.node<1>
-node(?left#0:mytree.tree, ?key#0:wybe.int, ?right#0:mytree.tree, $#0:mytree.tree, ?$$#0:wybe.bool):
+node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, $##0:mytree.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:mytree.tree, ?left#0:mytree.tree)
-        foreign llvm move(undef:wybe.int, ?key#0:wybe.int)
-        foreign llvm move(undef:mytree.tree, ?right#0:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:mytree.tree, ?left##0:mytree.tree)
+        foreign llvm move(undef:wybe.int, ?key##0:wybe.int)
+        foreign llvm move(undef:mytree.tree, ?right##0:mytree.tree)
 
     1:
-        foreign lpvm access($#0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left#0:mytree.tree)
-        foreign lpvm access($#0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key#0:wybe.int)
-        foreign lpvm access(~$#0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right#0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access($##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:mytree.tree)
+        foreign lpvm access($##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
+        foreign lpvm access(~$##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 right > public {inline} (0 calls)
 0: mytree.tree.right<0>
-right($rec#0:mytree.tree, ?$#0:mytree.tree, ?$$#0:wybe.bool):
+right($rec##0:mytree.tree, ?$##0:mytree.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:mytree.tree, ?$#0:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:mytree.tree, ?$##0:mytree.tree)
 
     1:
-        foreign lpvm access(~$rec#0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 right > public {inline} (0 calls)
 1: mytree.tree.right<1>
-right($rec#0:mytree.tree, ?$rec#1:mytree.tree, $field#0:mytree.tree, ?$$#0:wybe.bool):
+right($rec##0:mytree.tree, ?$rec##1:mytree.tree, $field##0:mytree.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:mytree.tree, ?$rec#1:mytree.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:mytree.tree, ?$rec##1:mytree.tree)
 
     1:
-        foreign lpvm mutate(~$rec#0:mytree.tree, ?$rec#1:mytree.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field#0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~$rec##0:mytree.tree, ?$rec##1:mytree.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:mytree.tree)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: mytree.tree.~=<0>
-~=($left#0:mytree.tree, $right#0:mytree.tree, ?$$#0:wybe.bool):
+~=($left##0:mytree.tree, $right##0:mytree.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    mytree.tree.=<0>(~$left#0:mytree.tree, ~$right#0:mytree.tree, ?tmp$0#0:wybe.bool) #0
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    mytree.tree.=<0>(~$left##0:mytree.tree, ~$right##0:mytree.tree, ?tmp$0##0:wybe.bool) #0
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
   LLVM code       :
 
@@ -336,51 +336,51 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"mytree.tree.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"mytree.tree.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$left#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = add   i64 %"$left#0", 16 
+  %8 = add   i64 %"$left##0", 16 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
-  %"2$tmp$10#0" = icmp ne i64 %"$right#0", 0 
-  br i1 %"2$tmp$10#0", label %if.then1, label %if.else1 
+  %"2$tmp$10##0" = icmp ne i64 %"$right##0", 0 
+  br i1 %"2$tmp$10##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = icmp eq i64 %"$left#0", %"$right#0" 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
+  ret i1 %"3$$$##0" 
 if.then1:
-  %12 = inttoptr i64 %"$right#0" to i64* 
+  %12 = inttoptr i64 %"$right##0" to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %15 = add   i64 %"$right#0", 8 
+  %15 = add   i64 %"$right##0", 8 
   %16 = inttoptr i64 %15 to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
-  %19 = add   i64 %"$right#0", 16 
+  %19 = add   i64 %"$right##0", 16 
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %"4$tmp$4#0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %3, i64  %14)  
-  br i1 %"4$tmp$4#0", label %if.then2, label %if.else2 
+  %"4$tmp$4##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %3, i64  %14)  
+  br i1 %"4$tmp$4##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$tmp$5#0" = icmp eq i64 %7, %18 
-  br i1 %"6$tmp$5#0", label %if.then3, label %if.else3 
+  %"6$tmp$5##0" = icmp eq i64 %7, %18 
+  br i1 %"6$tmp$5##0", label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %"8$$$#0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %11, i64  %22)  
-  ret i1 %"8$$$#0" 
+  %"8$$$##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %11, i64  %22)  
+  ret i1 %"8$$$##0" 
 if.else3:
   ret i1 0 
 }
@@ -392,12 +392,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.key<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"mytree.tree.key<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %23 = add   i64 %"$rec#0", 8 
+  %23 = add   i64 %"$rec##0", 8 
   %24 = inttoptr i64 %23 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
   %26 = load  i64, i64* %25 
@@ -411,38 +411,38 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.key<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"mytree.tree.key<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %31 = trunc i64 24 to i32  
   %32 = tail call ccc  i8*  @wybe_malloc(i32  %31)  
   %33 = ptrtoint i8* %32 to i64 
   %34 = inttoptr i64 %33 to i8* 
-  %35 = inttoptr i64 %"$rec#0" to i8* 
+  %35 = inttoptr i64 %"$rec##0" to i8* 
   %36 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %34, i8*  %35, i32  %36, i32  8, i1  0)  
   %37 = add   i64 %33, 8 
   %38 = inttoptr i64 %37 to i64* 
   %39 = getelementptr  i64, i64* %38, i64 0 
-  store  i64 %"$field#0", i64* %39 
+  store  i64 %"$field##0", i64* %39 
   %40 = insertvalue {i64, i1} undef, i64 %33, 0 
   %41 = insertvalue {i64, i1} %40, i1 1, 1 
   ret {i64, i1} %41 
 if.else:
-  %42 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %42 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %43 = insertvalue {i64, i1} %42, i1 0, 1 
   ret {i64, i1} %43 
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.left<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"mytree.tree.left<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %44 = inttoptr i64 %"$rec#0" to i64* 
+  %44 = inttoptr i64 %"$rec##0" to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
   %47 = insertvalue {i64, i1} undef, i64 %46, 0 
@@ -455,64 +455,64 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.left<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"mytree.tree.left<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %51 = trunc i64 24 to i32  
   %52 = tail call ccc  i8*  @wybe_malloc(i32  %51)  
   %53 = ptrtoint i8* %52 to i64 
   %54 = inttoptr i64 %53 to i8* 
-  %55 = inttoptr i64 %"$rec#0" to i8* 
+  %55 = inttoptr i64 %"$rec##0" to i8* 
   %56 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %54, i8*  %55, i32  %56, i32  8, i1  0)  
   %57 = inttoptr i64 %53 to i64* 
   %58 = getelementptr  i64, i64* %57, i64 0 
-  store  i64 %"$field#0", i64* %58 
+  store  i64 %"$field##0", i64* %58 
   %59 = insertvalue {i64, i1} undef, i64 %53, 0 
   %60 = insertvalue {i64, i1} %59, i1 1, 1 
   ret {i64, i1} %60 
 if.else:
-  %61 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %61 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %62 = insertvalue {i64, i1} %61, i1 0, 1 
   ret {i64, i1} %62 
 }
 
 
-define external fastcc  i64 @"mytree.tree.node<0>"(i64  %"left#0", i64  %"key#0", i64  %"right#0")    {
+define external fastcc  i64 @"mytree.tree.node<0>"(i64  %"left##0", i64  %"key##0", i64  %"right##0")    {
 entry:
   %63 = trunc i64 24 to i32  
   %64 = tail call ccc  i8*  @wybe_malloc(i32  %63)  
   %65 = ptrtoint i8* %64 to i64 
   %66 = inttoptr i64 %65 to i64* 
   %67 = getelementptr  i64, i64* %66, i64 0 
-  store  i64 %"left#0", i64* %67 
+  store  i64 %"left##0", i64* %67 
   %68 = add   i64 %65, 8 
   %69 = inttoptr i64 %68 to i64* 
   %70 = getelementptr  i64, i64* %69, i64 0 
-  store  i64 %"key#0", i64* %70 
+  store  i64 %"key##0", i64* %70 
   %71 = add   i64 %65, 16 
   %72 = inttoptr i64 %71 to i64* 
   %73 = getelementptr  i64, i64* %72, i64 0 
-  store  i64 %"right#0", i64* %73 
+  store  i64 %"right##0", i64* %73 
   ret i64 %65 
 }
 
 
-define external fastcc  {i64, i64, i64, i1} @"mytree.tree.node<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64, i64, i1} @"mytree.tree.node<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %74 = inttoptr i64 %"$#0" to i64* 
+  %74 = inttoptr i64 %"$##0" to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
   %76 = load  i64, i64* %75 
-  %77 = add   i64 %"$#0", 8 
+  %77 = add   i64 %"$##0", 8 
   %78 = inttoptr i64 %77 to i64* 
   %79 = getelementptr  i64, i64* %78, i64 0 
   %80 = load  i64, i64* %79 
-  %81 = add   i64 %"$#0", 16 
+  %81 = add   i64 %"$##0", 16 
   %82 = inttoptr i64 %81 to i64* 
   %83 = getelementptr  i64, i64* %82, i64 0 
   %84 = load  i64, i64* %83 
@@ -530,12 +530,12 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.right<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"mytree.tree.right<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %93 = add   i64 %"$rec#0", 16 
+  %93 = add   i64 %"$rec##0", 16 
   %94 = inttoptr i64 %93 to i64* 
   %95 = getelementptr  i64, i64* %94, i64 0 
   %96 = load  i64, i64* %95 
@@ -549,35 +549,35 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"mytree.tree.right<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"mytree.tree.right<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %101 = trunc i64 24 to i32  
   %102 = tail call ccc  i8*  @wybe_malloc(i32  %101)  
   %103 = ptrtoint i8* %102 to i64 
   %104 = inttoptr i64 %103 to i8* 
-  %105 = inttoptr i64 %"$rec#0" to i8* 
+  %105 = inttoptr i64 %"$rec##0" to i8* 
   %106 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %104, i8*  %105, i32  %106, i32  8, i1  0)  
   %107 = add   i64 %103, 16 
   %108 = inttoptr i64 %107 to i64* 
   %109 = getelementptr  i64, i64* %108, i64 0 
-  store  i64 %"$field#0", i64* %109 
+  store  i64 %"$field##0", i64* %109 
   %110 = insertvalue {i64, i1} undef, i64 %103, 0 
   %111 = insertvalue {i64, i1} %110, i1 1, 1 
   ret {i64, i1} %111 
 if.else:
-  %112 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %112 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %113 = insertvalue {i64, i1} %112, i1 0, 1 
   ret {i64, i1} %113 
 }
 
 
-define external fastcc  i1 @"mytree.tree.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"mytree.tree.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %"$left#0", i64  %"$right#0")  
-  %"1$$$#0" = xor i1 %"1$tmp$0#0", 1 
-  ret i1 %"1$$$#0" 
+  %"1$tmp$0##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %"$left##0", i64  %"$right##0")  
+  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
+  ret i1 %"1$$$##0" 
 }

--- a/test-cases/final-dump/mytree.exp
+++ b/test-cases/final-dump/mytree.exp
@@ -140,13 +140,13 @@ if.else:
 
 = > public (7 calls)
 0: mytree.tree.=<0>
-=(#left##0:mytree.tree, #right##0:mytree.tree, ?####0:wybe.bool):
+=(#left##0:mytree.tree, #right##0:mytree.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~#left##0:mytree.tree, ~#right##0:mytree.tree, ?####0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:mytree.tree, ~#right##0:mytree.tree, ?#success##0:wybe.bool)
 
     1:
         foreign lpvm access(#left##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#left##0:mytree.tree)
@@ -155,7 +155,7 @@ if.else:
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
         case ~tmp#10##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign lpvm access(#right##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#left##0:mytree.tree)
@@ -164,16 +164,16 @@ if.else:
             mytree.tree.=<0>(~#left#left##0:mytree.tree, ~#right#left##0:mytree.tree, ?tmp#4##0:wybe.bool) #2
             case ~tmp#4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
                 foreign llvm icmp_eq(~#left#key##0:wybe.int, ~#right#key##0:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
                 case ~tmp#5##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                 1:
-                    mytree.tree.=<0>(~#left#right##0:mytree.tree, ~#right#right##0:mytree.tree, ?####0:wybe.bool) #4
+                    mytree.tree.=<0>(~#left#right##0:mytree.tree, ~#right#right##0:mytree.tree, ?#success##0:wybe.bool) #4
 
 
 
@@ -190,65 +190,65 @@ empty(?#result##0:mytree.tree):
 
 key > public {inline} (0 calls)
 0: mytree.tree.key<0>
-key(#rec##0:mytree.tree, ?#result##0:wybe.int, ?####0:wybe.bool):
+key(#rec##0:mytree.tree, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign lpvm access(~#rec##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 key > public {inline} (0 calls)
 1: mytree.tree.key<1>
-key(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:wybe.int, ?####0:wybe.bool):
+key(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
         foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 left > public {inline} (0 calls)
 0: mytree.tree.left<0>
-left(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?####0:wybe.bool):
+left(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:mytree.tree, ?#result##0:mytree.tree)
 
     1:
         foreign lpvm access(~#rec##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 left > public {inline} (0 calls)
 1: mytree.tree.left<1>
-left(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?####0:wybe.bool):
+left(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
         foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -263,13 +263,13 @@ node(left##0:mytree.tree, key##0:wybe.int, right##0:mytree.tree, ?#result##0:myt
     foreign lpvm mutate(~#rec##2:mytree.tree, ?#result##0:mytree.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:mytree.tree)
 node > public {inline} (16 calls)
 1: mytree.tree.node<1>
-node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, #result##0:mytree.tree, ?####0:wybe.bool):
+node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, #result##0:mytree.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:mytree.tree, ?left##0:mytree.tree)
         foreign llvm move(undef:wybe.int, ?key##0:wybe.int)
         foreign llvm move(undef:mytree.tree, ?right##0:mytree.tree)
@@ -278,49 +278,49 @@ node(?left##0:mytree.tree, ?key##0:wybe.int, ?right##0:mytree.tree, #result##0:m
         foreign lpvm access(#result##0:mytree.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:mytree.tree)
         foreign lpvm access(#result##0:mytree.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
         foreign lpvm access(~#result##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 right > public {inline} (0 calls)
 0: mytree.tree.right<0>
-right(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?####0:wybe.bool):
+right(#rec##0:mytree.tree, ?#result##0:mytree.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:mytree.tree, ?#result##0:mytree.tree)
 
     1:
         foreign lpvm access(~#rec##0:mytree.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 right > public {inline} (0 calls)
 1: mytree.tree.right<1>
-right(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?####0:wybe.bool):
+right(#rec##0:mytree.tree, ?#rec##1:mytree.tree, #field##0:mytree.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:mytree.tree, ?#rec##1:mytree.tree)
 
     1:
         foreign lpvm mutate(~#rec##0:mytree.tree, ?#rec##1:mytree.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:mytree.tree)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: mytree.tree.~=<0>
-~=(#left##0:mytree.tree, #right##0:mytree.tree, ?####0:wybe.bool):
+~=(#left##0:mytree.tree, #right##0:mytree.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     mytree.tree.=<0>(~#left##0:mytree.tree, ~#right##0:mytree.tree, ?tmp#0##0:wybe.bool) #0
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 
@@ -355,8 +355,8 @@ if.then:
   %"2#tmp#10##0" = icmp ne i64 %"#right##0", 0 
   br i1 %"2#tmp#10##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %"3#####0" 
+  %"3##success##0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3##success##0" 
 if.then1:
   %12 = inttoptr i64 %"#right##0" to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
@@ -379,8 +379,8 @@ if.then2:
 if.else2:
   ret i1 0 
 if.then3:
-  %"8#####0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %11, i64  %22)  
-  ret i1 %"8#####0" 
+  %"8##success##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %11, i64  %22)  
+  ret i1 %"8##success##0" 
 if.else3:
   ret i1 0 
 }
@@ -578,6 +578,6 @@ if.else:
 define external fastcc  i1 @"mytree.tree.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %"1#tmp#0##0" = tail call fastcc  i1  @"mytree.tree.=<0>"(i64  %"#left##0", i64  %"#right##0")  
-  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
-  ret i1 %"1#####0" 
+  %"1##success##0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1##success##0" 
 }

--- a/test-cases/final-dump/nested_if.exp
+++ b/test-cases/final-dump/nested_if.exp
@@ -11,34 +11,34 @@ AFTER EVERYTHING:
 
 nested_if > public (0 calls)
 0: nested_if.nested_if<0>
-nested_if(i#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+nested_if(i##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(i#0:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.bool) @int:nn:nn
-    case ~tmp$3#0:wybe.bool of
+    foreign llvm icmp_eq(i##0:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
+    case ~tmp$3##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(i#0:wybe.int, 1001:wybe.int, ?tmp$2#0:wybe.bool) @int:nn:nn
-        case ~tmp$2#0:wybe.bool of
+        foreign llvm icmp_eq(i##0:wybe.int, 1001:wybe.int, ?tmp$2##0:wybe.bool) @int:nn:nn
+        case ~tmp$2##0:wybe.bool of
         0:
-            foreign llvm icmp_eq(~i#0:wybe.int, 2:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-            case ~tmp$1#0:wybe.bool of
+            foreign llvm icmp_eq(~i##0:wybe.int, 2:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+            case ~tmp$1##0:wybe.bool of
             0:
-                foreign c print_string("other":wybe.string, ~#io#0:wybe.phantom, ?tmp$12#0:wybe.phantom) @io:nn:nn
-                foreign c putchar('\n':wybe.char, ~tmp$12#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+                foreign c print_string("other":wybe.string, ~#io##0:wybe.phantom, ?tmp$12##0:wybe.phantom) @io:nn:nn
+                foreign c putchar('\n':wybe.char, ~tmp$12##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
             1:
-                foreign c print_string("two":wybe.string, ~#io#0:wybe.phantom, ?tmp$12#0:wybe.phantom) @io:nn:nn
-                foreign c putchar('\n':wybe.char, ~tmp$12#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+                foreign c print_string("two":wybe.string, ~#io##0:wybe.phantom, ?tmp$12##0:wybe.phantom) @io:nn:nn
+                foreign c putchar('\n':wybe.char, ~tmp$12##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
         1:
-            foreign c print_string("one thousand and one":wybe.string, ~#io#0:wybe.phantom, ?tmp$10#0:wybe.phantom) @io:nn:nn
-            foreign c putchar('\n':wybe.char, ~tmp$10#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+            foreign c print_string("one thousand and one":wybe.string, ~#io##0:wybe.phantom, ?tmp$10##0:wybe.phantom) @io:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp$10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
     1:
-        foreign c print_string("zero":wybe.string, ~#io#0:wybe.phantom, ?tmp$8#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$8#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+        foreign c print_string("zero":wybe.string, ~#io##0:wybe.phantom, ?tmp$8##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$8##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
   LLVM code       :
@@ -73,26 +73,26 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"nested_if.nested_if<0>"(i64  %"i#0")    {
+define external fastcc  void @"nested_if.nested_if<0>"(i64  %"i##0")    {
 entry:
-  %"1$tmp$3#0" = icmp eq i64 %"i#0", 0 
-  br i1 %"1$tmp$3#0", label %if.then, label %if.else 
+  %"1$tmp$3##0" = icmp eq i64 %"i##0", 0 
+  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
 if.then:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @nested_if.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else:
-  %"3$tmp$2#0" = icmp eq i64 %"i#0", 1001 
-  br i1 %"3$tmp$2#0", label %if.then1, label %if.else1 
+  %"3$tmp$2##0" = icmp eq i64 %"i##0", 1001 
+  br i1 %"3$tmp$2##0", label %if.then1, label %if.else1 
 if.then1:
   %4 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @nested_if.3, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %4)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else1:
-  %"5$tmp$1#0" = icmp eq i64 %"i#0", 2 
-  br i1 %"5$tmp$1#0", label %if.then2, label %if.else2 
+  %"5$tmp$1##0" = icmp eq i64 %"i##0", 2 
+  br i1 %"5$tmp$1##0", label %if.then2, label %if.else2 
 if.then2:
   %6 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @nested_if.5, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %6)  

--- a/test-cases/final-dump/nested_if.exp
+++ b/test-cases/final-dump/nested_if.exp
@@ -14,31 +14,31 @@ nested_if > public (0 calls)
 nested_if(i##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(i##0:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
-    case ~tmp$3##0:wybe.bool of
+    foreign llvm icmp_eq(i##0:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
+    case ~tmp#3##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(i##0:wybe.int, 1001:wybe.int, ?tmp$2##0:wybe.bool) @int:nn:nn
-        case ~tmp$2##0:wybe.bool of
+        foreign llvm icmp_eq(i##0:wybe.int, 1001:wybe.int, ?tmp#2##0:wybe.bool) @int:nn:nn
+        case ~tmp#2##0:wybe.bool of
         0:
-            foreign llvm icmp_eq(~i##0:wybe.int, 2:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-            case ~tmp$1##0:wybe.bool of
+            foreign llvm icmp_eq(~i##0:wybe.int, 2:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+            case ~tmp#1##0:wybe.bool of
             0:
-                foreign c print_string("other":wybe.string, ~#io##0:wybe.phantom, ?tmp$12##0:wybe.phantom) @io:nn:nn
-                foreign c putchar('\n':wybe.char, ~tmp$12##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+                foreign c print_string("other":wybe.string, ~#io##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @io:nn:nn
+                foreign c putchar('\n':wybe.char, ~tmp#12##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
             1:
-                foreign c print_string("two":wybe.string, ~#io##0:wybe.phantom, ?tmp$12##0:wybe.phantom) @io:nn:nn
-                foreign c putchar('\n':wybe.char, ~tmp$12##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+                foreign c print_string("two":wybe.string, ~#io##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @io:nn:nn
+                foreign c putchar('\n':wybe.char, ~tmp#12##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
         1:
-            foreign c print_string("one thousand and one":wybe.string, ~#io##0:wybe.phantom, ?tmp$10##0:wybe.phantom) @io:nn:nn
-            foreign c putchar('\n':wybe.char, ~tmp$10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+            foreign c print_string("one thousand and one":wybe.string, ~#io##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @io:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
     1:
-        foreign c print_string("zero":wybe.string, ~#io##0:wybe.phantom, ?tmp$8##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$8##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        foreign c print_string("zero":wybe.string, ~#io##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#8##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
   LLVM code       :
@@ -75,24 +75,24 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"nested_if.nested_if<0>"(i64  %"i##0")    {
 entry:
-  %"1$tmp$3##0" = icmp eq i64 %"i##0", 0 
-  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
+  %"1#tmp#3##0" = icmp eq i64 %"i##0", 0 
+  br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @nested_if.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else:
-  %"3$tmp$2##0" = icmp eq i64 %"i##0", 1001 
-  br i1 %"3$tmp$2##0", label %if.then1, label %if.else1 
+  %"3#tmp#2##0" = icmp eq i64 %"i##0", 1001 
+  br i1 %"3#tmp#2##0", label %if.then1, label %if.else1 
 if.then1:
   %4 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @nested_if.3, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %4)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else1:
-  %"5$tmp$1##0" = icmp eq i64 %"i##0", 2 
-  br i1 %"5$tmp$1##0", label %if.then2, label %if.else2 
+  %"5#tmp#1##0" = icmp eq i64 %"i##0", 2 
+  br i1 %"5#tmp#1##0", label %if.then2, label %if.else2 
 if.then2:
   %6 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @nested_if.5, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %6)  

--- a/test-cases/final-dump/nested_loop.exp
+++ b/test-cases/final-dump/nested_loop.exp
@@ -11,36 +11,36 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: nested_loop.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("Outer":wybe.string, ~io#0:wybe.phantom, ?tmp$1#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$1#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c print_string("Inner":wybe.string, ~tmp$2#0:wybe.phantom, ?tmp$3#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$3#0:wybe.phantom, ?tmp$4#0:wybe.phantom) @io:nn:nn
-    nested_loop.gen$2<0>(~tmp$4#0:wybe.phantom, ?io#1:wybe.phantom) #1 @nested_loop:nn:nn
+    foreign c print_string("Outer":wybe.string, ~io##0:wybe.phantom, ?tmp$1##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$1##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c print_string("Inner":wybe.string, ~tmp$2##0:wybe.phantom, ?tmp$3##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$3##0:wybe.phantom, ?tmp$4##0:wybe.phantom) @io:nn:nn
+    nested_loop.gen$2<0>(~tmp$4##0:wybe.phantom, ?io##1:wybe.phantom) #1 @nested_loop:nn:nn
 
 
 gen$1 > {inline} (1 calls)
 0: nested_loop.gen$1<0>
-gen$1(io#0:wybe.phantom, ?io#2:wybe.phantom):
+gen$1(io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("Outer":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_string("Inner":wybe.string, ~io#1:wybe.phantom, ?tmp$4#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$4#0:wybe.phantom, ?tmp$5#0:wybe.phantom) @io:nn:nn
-    nested_loop.gen$2<0>(~tmp$5#0:wybe.phantom, ?io#2:wybe.phantom) #2 @nested_loop:nn:nn
+    foreign c print_string("Outer":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("Inner":wybe.string, ~io##1:wybe.phantom, ?tmp$4##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$4##0:wybe.phantom, ?tmp$5##0:wybe.phantom) @io:nn:nn
+    nested_loop.gen$2<0>(~tmp$5##0:wybe.phantom, ?io##2:wybe.phantom) #2 @nested_loop:nn:nn
 
 
 gen$2 > {inline} (2 calls)
 0: nested_loop.gen$2<0>
-gen$2(io#0:wybe.phantom, ?io#2:wybe.phantom):
+gen$2(io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("Inner":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    nested_loop.gen$2<0>(~io#1:wybe.phantom, ?io#2:wybe.phantom) #1 @nested_loop:nn:nn
+    foreign c print_string("Inner":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    nested_loop.gen$2<0>(~io##1:wybe.phantom, ?io##2:wybe.phantom) #1 @nested_loop:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/nested_loop.exp
+++ b/test-cases/final-dump/nested_loop.exp
@@ -14,33 +14,33 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("Outer":wybe.string, ~io##0:wybe.phantom, ?tmp$1##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$1##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c print_string("Inner":wybe.string, ~tmp$2##0:wybe.phantom, ?tmp$3##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$3##0:wybe.phantom, ?tmp$4##0:wybe.phantom) @io:nn:nn
-    nested_loop.gen$2<0>(~tmp$4##0:wybe.phantom, ?io##1:wybe.phantom) #1 @nested_loop:nn:nn
+    foreign c print_string("Outer":wybe.string, ~io##0:wybe.phantom, ?tmp#1##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#1##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c print_string("Inner":wybe.string, ~tmp#2##0:wybe.phantom, ?tmp#3##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#3##0:wybe.phantom, ?tmp#4##0:wybe.phantom) @io:nn:nn
+    nested_loop.gen#2<0>(~tmp#4##0:wybe.phantom, ?io##1:wybe.phantom) #1 @nested_loop:nn:nn
 
 
-gen$1 > {inline} (1 calls)
-0: nested_loop.gen$1<0>
-gen$1(io##0:wybe.phantom, ?io##2:wybe.phantom):
+gen#1 > {inline} (1 calls)
+0: nested_loop.gen#1<0>
+gen#1(io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("Outer":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign c print_string("Inner":wybe.string, ~io##1:wybe.phantom, ?tmp$4##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$4##0:wybe.phantom, ?tmp$5##0:wybe.phantom) @io:nn:nn
-    nested_loop.gen$2<0>(~tmp$5##0:wybe.phantom, ?io##2:wybe.phantom) #2 @nested_loop:nn:nn
+    foreign c print_string("Outer":wybe.string, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("Inner":wybe.string, ~io##1:wybe.phantom, ?tmp#4##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#4##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
+    nested_loop.gen#2<0>(~tmp#5##0:wybe.phantom, ?io##2:wybe.phantom) #2 @nested_loop:nn:nn
 
 
-gen$2 > {inline} (2 calls)
-0: nested_loop.gen$2<0>
-gen$2(io##0:wybe.phantom, ?io##2:wybe.phantom):
+gen#2 > {inline} (2 calls)
+0: nested_loop.gen#2<0>
+gen#2(io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("Inner":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    nested_loop.gen$2<0>(~io##1:wybe.phantom, ?io##2:wybe.phantom) #1 @nested_loop:nn:nn
+    foreign c print_string("Inner":wybe.string, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    nested_loop.gen#2<0>(~io##1:wybe.phantom, ?io##2:wybe.phantom) #1 @nested_loop:nn:nn
 
   LLVM code       :
 
@@ -85,12 +85,12 @@ entry:
   %4 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @nested_loop.3, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %4)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"nested_loop.gen$2<0>"()  
+  tail call fastcc  void  @"nested_loop.gen#2<0>"()  
   ret void 
 }
 
 
-define external fastcc  void @"nested_loop.gen$1<0>"()    {
+define external fastcc  void @"nested_loop.gen#1<0>"()    {
 entry:
   %6 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @nested_loop.5, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %6)  
@@ -98,16 +98,16 @@ entry:
   %8 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @nested_loop.7, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %8)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"nested_loop.gen$2<0>"()  
+  tail call fastcc  void  @"nested_loop.gen#2<0>"()  
   ret void 
 }
 
 
-define external fastcc  void @"nested_loop.gen$2<0>"()    {
+define external fastcc  void @"nested_loop.gen#2<0>"()    {
 entry:
   %10 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @nested_loop.9, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %10)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"nested_loop.gen$2<0>"()  
+  tail call fastcc  void  @"nested_loop.gen#2<0>"()  
   ret void 
 }

--- a/test-cases/final-dump/numbers.exp
+++ b/test-cases/final-dump/numbers.exp
@@ -22,7 +22,7 @@ AFTER EVERYTHING:
 
 factorial > public (1 calls)
 0: numbers.factorial<0>
-factorial(n##0:wybe.int, ?###0:wybe.int):
+factorial(n##0:wybe.int, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_sle(n##0:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
@@ -30,20 +30,20 @@ factorial(n##0:wybe.int, ?###0:wybe.int):
     0:
         foreign llvm sub(n##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
         numbers.factorial<0>(~tmp#3##0:wybe.int, ?tmp#2##0:wybe.int) #2 @numbers:nn:nn
-        foreign llvm mul(~n##0:wybe.int, ~tmp#2##0:wybe.int, ?###0:wybe.int) @int:nn:nn
+        foreign llvm mul(~n##0:wybe.int, ~tmp#2##0:wybe.int, ?#result##0:wybe.int) @int:nn:nn
 
     1:
-        foreign llvm move(1:wybe.int, ?###0:wybe.int) @numbers:nn:nn
+        foreign llvm move(1:wybe.int, ?#result##0:wybe.int) @numbers:nn:nn
 
 
 
 toCelsius > public {inline} (0 calls)
 0: numbers.toCelsius<0>
-toCelsius(f##0:wybe.float, ?###0:wybe.float):
+toCelsius(f##0:wybe.float, ?#result##0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm fsub(~f##0:wybe.float, 32.0:wybe.float, ?tmp#1##0:wybe.float) @float:nn:nn
-    foreign llvm fdiv(~tmp#1##0:wybe.float, 1.8:wybe.float, ?###0:wybe.float) @float:nn:nn
+    foreign llvm fdiv(~tmp#1##0:wybe.float, 1.8:wybe.float, ?#result##0:wybe.float) @float:nn:nn
 
   LLVM code       :
 
@@ -86,14 +86,14 @@ if.then:
 if.else:
   %"3#tmp#3##0" = sub   i64 %"n##0", 1 
   %"3#tmp#2##0" = tail call fastcc  i64  @"numbers.factorial<0>"(i64  %"3#tmp#3##0")  
-  %"3####0" = mul   i64 %"n##0", %"3#tmp#2##0" 
-  ret i64 %"3####0" 
+  %"3##result##0" = mul   i64 %"n##0", %"3#tmp#2##0" 
+  ret i64 %"3##result##0" 
 }
 
 
 define external fastcc  double @"numbers.toCelsius<0>"(double  %"f##0")    {
 entry:
   %"1#tmp#1##0" = fsub double %"f##0", 3.200000e1 
-  %"1####0" = fdiv double %"1#tmp#1##0", 1.800000e0 
-  ret double %"1####0" 
+  %"1##result##0" = fdiv double %"1#tmp#1##0", 1.800000e0 
+  ret double %"1##result##0" 
 }

--- a/test-cases/final-dump/numbers.exp
+++ b/test-cases/final-dump/numbers.exp
@@ -13,37 +13,37 @@ AFTER EVERYTHING:
 
 *main* > public {inline} (0 calls)
 0: numbers.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("Numbers has been initialised.":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_string("Numbers has been initialised.":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 factorial > public (1 calls)
 0: numbers.factorial<0>
-factorial(n#0:wybe.int, ?$#0:wybe.int):
+factorial(n##0:wybe.int, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_sle(n#0:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.bool) @int:nn:nn
-    case ~tmp$4#0:wybe.bool of
+    foreign llvm icmp_sle(n##0:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
+    case ~tmp$4##0:wybe.bool of
     0:
-        foreign llvm sub(n#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.int) @int:nn:nn
-        numbers.factorial<0>(~tmp$3#0:wybe.int, ?tmp$2#0:wybe.int) #2 @numbers:nn:nn
-        foreign llvm mul(~n#0:wybe.int, ~tmp$2#0:wybe.int, ?$#0:wybe.int) @int:nn:nn
+        foreign llvm sub(n##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
+        numbers.factorial<0>(~tmp$3##0:wybe.int, ?tmp$2##0:wybe.int) #2 @numbers:nn:nn
+        foreign llvm mul(~n##0:wybe.int, ~tmp$2##0:wybe.int, ?$##0:wybe.int) @int:nn:nn
 
     1:
-        foreign llvm move(1:wybe.int, ?$#0:wybe.int) @numbers:nn:nn
+        foreign llvm move(1:wybe.int, ?$##0:wybe.int) @numbers:nn:nn
 
 
 
 toCelsius > public {inline} (0 calls)
 0: numbers.toCelsius<0>
-toCelsius(f#0:wybe.float, ?$#0:wybe.float):
+toCelsius(f##0:wybe.float, ?$##0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm fsub(~f#0:wybe.float, 32.0:wybe.float, ?tmp$1#0:wybe.float) @float:nn:nn
-    foreign llvm fdiv(~tmp$1#0:wybe.float, 1.8:wybe.float, ?$#0:wybe.float) @float:nn:nn
+    foreign llvm fsub(~f##0:wybe.float, 32.0:wybe.float, ?tmp$1##0:wybe.float) @float:nn:nn
+    foreign llvm fdiv(~tmp$1##0:wybe.float, 1.8:wybe.float, ?$##0:wybe.float) @float:nn:nn
 
   LLVM code       :
 
@@ -77,23 +77,23 @@ entry:
 }
 
 
-define external fastcc  i64 @"numbers.factorial<0>"(i64  %"n#0")    {
+define external fastcc  i64 @"numbers.factorial<0>"(i64  %"n##0")    {
 entry:
-  %"1$tmp$4#0" = icmp sle i64 %"n#0", 0 
-  br i1 %"1$tmp$4#0", label %if.then, label %if.else 
+  %"1$tmp$4##0" = icmp sle i64 %"n##0", 0 
+  br i1 %"1$tmp$4##0", label %if.then, label %if.else 
 if.then:
   ret i64 1 
 if.else:
-  %"3$tmp$3#0" = sub   i64 %"n#0", 1 
-  %"3$tmp$2#0" = tail call fastcc  i64  @"numbers.factorial<0>"(i64  %"3$tmp$3#0")  
-  %"3$$#0" = mul   i64 %"n#0", %"3$tmp$2#0" 
-  ret i64 %"3$$#0" 
+  %"3$tmp$3##0" = sub   i64 %"n##0", 1 
+  %"3$tmp$2##0" = tail call fastcc  i64  @"numbers.factorial<0>"(i64  %"3$tmp$3##0")  
+  %"3$$##0" = mul   i64 %"n##0", %"3$tmp$2##0" 
+  ret i64 %"3$$##0" 
 }
 
 
-define external fastcc  double @"numbers.toCelsius<0>"(double  %"f#0")    {
+define external fastcc  double @"numbers.toCelsius<0>"(double  %"f##0")    {
 entry:
-  %"1$tmp$1#0" = fsub double %"f#0", 3.200000e1 
-  %"1$$#0" = fdiv double %"1$tmp$1#0", 1.800000e0 
-  ret double %"1$$#0" 
+  %"1$tmp$1##0" = fsub double %"f##0", 3.200000e1 
+  %"1$$##0" = fdiv double %"1$tmp$1##0", 1.800000e0 
+  ret double %"1$$##0" 
 }

--- a/test-cases/final-dump/numbers.exp
+++ b/test-cases/final-dump/numbers.exp
@@ -16,34 +16,34 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("Numbers has been initialised.":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("Numbers has been initialised.":wybe.string, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 factorial > public (1 calls)
 0: numbers.factorial<0>
-factorial(n##0:wybe.int, ?$##0:wybe.int):
+factorial(n##0:wybe.int, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_sle(n##0:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
-    case ~tmp$4##0:wybe.bool of
+    foreign llvm icmp_sle(n##0:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
+    case ~tmp#4##0:wybe.bool of
     0:
-        foreign llvm sub(n##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
-        numbers.factorial<0>(~tmp$3##0:wybe.int, ?tmp$2##0:wybe.int) #2 @numbers:nn:nn
-        foreign llvm mul(~n##0:wybe.int, ~tmp$2##0:wybe.int, ?$##0:wybe.int) @int:nn:nn
+        foreign llvm sub(n##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
+        numbers.factorial<0>(~tmp#3##0:wybe.int, ?tmp#2##0:wybe.int) #2 @numbers:nn:nn
+        foreign llvm mul(~n##0:wybe.int, ~tmp#2##0:wybe.int, ?###0:wybe.int) @int:nn:nn
 
     1:
-        foreign llvm move(1:wybe.int, ?$##0:wybe.int) @numbers:nn:nn
+        foreign llvm move(1:wybe.int, ?###0:wybe.int) @numbers:nn:nn
 
 
 
 toCelsius > public {inline} (0 calls)
 0: numbers.toCelsius<0>
-toCelsius(f##0:wybe.float, ?$##0:wybe.float):
+toCelsius(f##0:wybe.float, ?###0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm fsub(~f##0:wybe.float, 32.0:wybe.float, ?tmp$1##0:wybe.float) @float:nn:nn
-    foreign llvm fdiv(~tmp$1##0:wybe.float, 1.8:wybe.float, ?$##0:wybe.float) @float:nn:nn
+    foreign llvm fsub(~f##0:wybe.float, 32.0:wybe.float, ?tmp#1##0:wybe.float) @float:nn:nn
+    foreign llvm fdiv(~tmp#1##0:wybe.float, 1.8:wybe.float, ?###0:wybe.float) @float:nn:nn
 
   LLVM code       :
 
@@ -79,21 +79,21 @@ entry:
 
 define external fastcc  i64 @"numbers.factorial<0>"(i64  %"n##0")    {
 entry:
-  %"1$tmp$4##0" = icmp sle i64 %"n##0", 0 
-  br i1 %"1$tmp$4##0", label %if.then, label %if.else 
+  %"1#tmp#4##0" = icmp sle i64 %"n##0", 0 
+  br i1 %"1#tmp#4##0", label %if.then, label %if.else 
 if.then:
   ret i64 1 
 if.else:
-  %"3$tmp$3##0" = sub   i64 %"n##0", 1 
-  %"3$tmp$2##0" = tail call fastcc  i64  @"numbers.factorial<0>"(i64  %"3$tmp$3##0")  
-  %"3$$##0" = mul   i64 %"n##0", %"3$tmp$2##0" 
-  ret i64 %"3$$##0" 
+  %"3#tmp#3##0" = sub   i64 %"n##0", 1 
+  %"3#tmp#2##0" = tail call fastcc  i64  @"numbers.factorial<0>"(i64  %"3#tmp#3##0")  
+  %"3####0" = mul   i64 %"n##0", %"3#tmp#2##0" 
+  ret i64 %"3####0" 
 }
 
 
 define external fastcc  double @"numbers.toCelsius<0>"(double  %"f##0")    {
 entry:
-  %"1$tmp$1##0" = fsub double %"f##0", 3.200000e1 
-  %"1$$##0" = fdiv double %"1$tmp$1##0", 1.800000e0 
-  ret double %"1$$##0" 
+  %"1#tmp#1##0" = fsub double %"f##0", 3.200000e1 
+  %"1####0" = fdiv double %"1#tmp#1##0", 1.800000e0 
+  ret double %"1####0" 
 }

--- a/test-cases/final-dump/person1.exp
+++ b/test-cases/final-dump/person1.exp
@@ -72,7 +72,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: person1.person.=<0>
-=(#left##0:person1.person, #right##0:person1.person, ?####0:wybe.bool):
+=(#left##0:person1.person, #right##0:person1.person, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#firstname##0:wybe.string)
@@ -83,11 +83,11 @@ entry:
     foreign llvm icmp_eq(~tmp#7##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign c strcmp(~#left#lastname##0:wybe.string, ~#right#lastname##0:wybe.string, ?tmp#10##0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp#10##0:wybe.int, 0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~tmp#10##0:wybe.int, 0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -138,7 +138,7 @@ person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person1.p
 
 ~= > public {inline} (0 calls)
 0: person1.person.~=<0>
-~=(#left##0:person1.person, #right##0:person1.person, ?####0:wybe.bool):
+~=(#left##0:person1.person, #right##0:person1.person, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.string)
@@ -150,12 +150,12 @@ person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person1.p
     case ~tmp#8##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign c strcmp(~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ?tmp#9##0:wybe.int) @string:nn:nn
         foreign llvm icmp_eq(~tmp#9##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -196,8 +196,8 @@ entry:
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#10##0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
-  %"2#####0" = icmp eq i64 %"2#tmp#10##0", 0 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %"2#tmp#10##0", 0 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -308,9 +308,9 @@ entry:
 if.then:
   %"2#tmp#9##0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
   %"2#tmp#0##0" = icmp eq i64 %"2#tmp#9##0", 0 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }

--- a/test-cases/final-dump/person1.exp
+++ b/test-cases/final-dump/person1.exp
@@ -72,90 +72,90 @@ entry:
 
 = > public {inline} (1 calls)
 0: person1.person.=<0>
-=($left##0:person1.person, $right##0:person1.person, ?$$##0:wybe.bool):
+=(#left##0:person1.person, #right##0:person1.person, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$firstname##0:wybe.string)
-    foreign lpvm access(~$left##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$lastname##0:wybe.string)
-    foreign lpvm access($right##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$firstname##0:wybe.string)
-    foreign lpvm access(~$right##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$lastname##0:wybe.string)
-    foreign c strcmp(~$left$firstname##0:wybe.string, ~$right$firstname##0:wybe.string, ?tmp$7##0:wybe.int) @string:nn:nn
-    foreign llvm icmp_eq(~tmp$7##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#firstname##0:wybe.string)
+    foreign lpvm access(~#left##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#lastname##0:wybe.string)
+    foreign lpvm access(#right##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#firstname##0:wybe.string)
+    foreign lpvm access(~#right##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#lastname##0:wybe.string)
+    foreign c strcmp(~#left#firstname##0:wybe.string, ~#right#firstname##0:wybe.string, ?tmp#7##0:wybe.int) @string:nn:nn
+    foreign llvm icmp_eq(~tmp#7##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign c strcmp(~$left$lastname##0:wybe.string, ~$right$lastname##0:wybe.string, ?tmp$10##0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp$10##0:wybe.int, 0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign c strcmp(~#left#lastname##0:wybe.string, ~#right#lastname##0:wybe.string, ?tmp#10##0:wybe.int) @string:nn:nn
+        foreign llvm icmp_eq(~tmp#10##0:wybe.int, 0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 firstname > public {inline} (0 calls)
 0: person1.person.firstname<0>
-firstname($rec##0:person1.person, ?$##0:wybe.string):
+firstname(#rec##0:person1.person, ?###0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.string)
+    foreign lpvm access(~#rec##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.string)
 firstname > public {inline} (0 calls)
 1: person1.person.firstname<1>
-firstname($rec##0:person1.person, ?$rec##1:person1.person, $field##0:wybe.string):
+firstname(#rec##0:person1.person, ?#rec##1:person1.person, #field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec##0:person1.person, ?$rec##1:person1.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.string)
+    foreign lpvm mutate(~#rec##0:person1.person, ?#rec##1:person1.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string)
 
 
 lastname > public {inline} (0 calls)
 0: person1.person.lastname<0>
-lastname($rec##0:person1.person, ?$##0:wybe.string):
+lastname(#rec##0:person1.person, ?###0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.string)
+    foreign lpvm access(~#rec##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.string)
 lastname > public {inline} (0 calls)
 1: person1.person.lastname<1>
-lastname($rec##0:person1.person, ?$rec##1:person1.person, $field##0:wybe.string):
+lastname(#rec##0:person1.person, ?#rec##1:person1.person, #field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec##0:person1.person, ?$rec##1:person1.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.string)
+    foreign lpvm mutate(~#rec##0:person1.person, ?#rec##1:person1.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string)
 
 
 person > public {inline} (0 calls)
 0: person1.person.person<0>
-person(firstname##0:wybe.string, lastname##0:wybe.string, ?$##0:person1.person):
+person(firstname##0:wybe.string, lastname##0:wybe.string, ?###0:person1.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:person1.person)
-    foreign lpvm mutate(~$rec##0:person1.person, ?$rec##1:person1.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string)
-    foreign lpvm mutate(~$rec##1:person1.person, ?$##0:person1.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:person1.person)
+    foreign lpvm mutate(~#rec##0:person1.person, ?#rec##1:person1.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string)
+    foreign lpvm mutate(~#rec##1:person1.person, ?###0:person1.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string)
 person > public {inline} (6 calls)
 1: person1.person.person<1>
-person(?firstname##0:wybe.string, ?lastname##0:wybe.string, $##0:person1.person):
+person(?firstname##0:wybe.string, ?lastname##0:wybe.string, ###0:person1.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string)
-    foreign lpvm access(~$##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string)
+    foreign lpvm access(###0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string)
+    foreign lpvm access(~###0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string)
 
 
 ~= > public {inline} (0 calls)
 0: person1.person.~=<0>
-~=($left##0:person1.person, $right##0:person1.person, ?$$##0:wybe.bool):
+~=(#left##0:person1.person, #right##0:person1.person, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.string)
-    foreign lpvm access(~$left##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.string)
-    foreign lpvm access($right##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.string)
-    foreign lpvm access(~$right##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.string)
-    foreign c strcmp(~tmp$3##0:wybe.string, ~tmp$5##0:wybe.string, ?tmp$7##0:wybe.int) @string:nn:nn
-    foreign llvm icmp_eq(~tmp$7##0:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.bool) @int:nn:nn
-    case ~tmp$8##0:wybe.bool of
+    foreign lpvm access(#left##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.string)
+    foreign lpvm access(~#left##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.string)
+    foreign lpvm access(#right##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.string)
+    foreign lpvm access(~#right##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.string)
+    foreign c strcmp(~tmp#3##0:wybe.string, ~tmp#5##0:wybe.string, ?tmp#7##0:wybe.int) @string:nn:nn
+    foreign llvm icmp_eq(~tmp#7##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool) @int:nn:nn
+    case ~tmp#8##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign c strcmp(~tmp$4##0:wybe.string, ~tmp$6##0:wybe.string, ?tmp$9##0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp$9##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign c strcmp(~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ?tmp#9##0:wybe.int) @string:nn:nn
+        foreign llvm icmp_eq(~tmp#9##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -175,62 +175,62 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"person1.person.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"person1.person.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$7##0" = tail call ccc  i64  @strcmp(i64  %3, i64  %10)  
-  %"1$tmp$1##0" = icmp eq i64 %"1$tmp$7##0", 0 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = tail call ccc  i64  @strcmp(i64  %3, i64  %10)  
+  %"1#tmp#1##0" = icmp eq i64 %"1#tmp#7##0", 0 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$10##0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
-  %"2$$$##0" = icmp eq i64 %"2$tmp$10##0", 0 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#10##0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
+  %"2#####0" = icmp eq i64 %"2#tmp#10##0", 0 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"person1.person.firstname<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"person1.person.firstname<0>"(i64  %"#rec##0")    {
 entry:
-  %15 = inttoptr i64 %"$rec##0" to i64* 
+  %15 = inttoptr i64 %"#rec##0" to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
   %17 = load  i64, i64* %16 
   ret i64 %17 
 }
 
 
-define external fastcc  i64 @"person1.person.firstname<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"person1.person.firstname<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %18 = trunc i64 16 to i32  
   %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
   %20 = ptrtoint i8* %19 to i64 
   %21 = inttoptr i64 %20 to i8* 
-  %22 = inttoptr i64 %"$rec##0" to i8* 
+  %22 = inttoptr i64 %"#rec##0" to i8* 
   %23 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %21, i8*  %22, i32  %23, i32  8, i1  0)  
   %24 = inttoptr i64 %20 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
-  store  i64 %"$field##0", i64* %25 
+  store  i64 %"#field##0", i64* %25 
   ret i64 %20 
 }
 
 
-define external fastcc  i64 @"person1.person.lastname<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"person1.person.lastname<0>"(i64  %"#rec##0")    {
 entry:
-  %26 = add   i64 %"$rec##0", 8 
+  %26 = add   i64 %"#rec##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -238,19 +238,19 @@ entry:
 }
 
 
-define external fastcc  i64 @"person1.person.lastname<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"person1.person.lastname<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %30 = trunc i64 16 to i32  
   %31 = tail call ccc  i8*  @wybe_malloc(i32  %30)  
   %32 = ptrtoint i8* %31 to i64 
   %33 = inttoptr i64 %32 to i8* 
-  %34 = inttoptr i64 %"$rec##0" to i8* 
+  %34 = inttoptr i64 %"#rec##0" to i8* 
   %35 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %33, i8*  %34, i32  %35, i32  8, i1  0)  
   %36 = add   i64 %32, 8 
   %37 = inttoptr i64 %36 to i64* 
   %38 = getelementptr  i64, i64* %37, i64 0 
-  store  i64 %"$field##0", i64* %38 
+  store  i64 %"#field##0", i64* %38 
   ret i64 %32 
 }
 
@@ -271,12 +271,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"person1.person.person<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"person1.person.person<1>"(i64  %"###0")    {
 entry:
-  %47 = inttoptr i64 %"$##0" to i64* 
+  %47 = inttoptr i64 %"###0" to i64* 
   %48 = getelementptr  i64, i64* %47, i64 0 
   %49 = load  i64, i64* %48 
-  %50 = add   i64 %"$##0", 8 
+  %50 = add   i64 %"###0", 8 
   %51 = inttoptr i64 %50 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
   %53 = load  i64, i64* %52 
@@ -286,31 +286,31 @@ entry:
 }
 
 
-define external fastcc  i1 @"person1.person.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"person1.person.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = tail call ccc  i64  @strcmp(i64  %58, i64  %65)  
-  %"1$tmp$8##0" = icmp eq i64 %"1$tmp$7##0", 0 
-  br i1 %"1$tmp$8##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = tail call ccc  i64  @strcmp(i64  %58, i64  %65)  
+  %"1#tmp#8##0" = icmp eq i64 %"1#tmp#7##0", 0 
+  br i1 %"1#tmp#8##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$9##0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
-  %"2$tmp$0##0" = icmp eq i64 %"2$tmp$9##0", 0 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#9##0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
+  %"2#tmp#0##0" = icmp eq i64 %"2#tmp#9##0", 0 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }

--- a/test-cases/final-dump/person1.exp
+++ b/test-cases/final-dump/person1.exp
@@ -93,10 +93,10 @@ entry:
 
 firstname > public {inline} (0 calls)
 0: person1.person.firstname<0>
-firstname(#rec##0:person1.person, ?###0:wybe.string):
+firstname(#rec##0:person1.person, ?#result##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.string)
+    foreign lpvm access(~#rec##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string)
 firstname > public {inline} (0 calls)
 1: person1.person.firstname<1>
 firstname(#rec##0:person1.person, ?#rec##1:person1.person, #field##0:wybe.string):
@@ -107,10 +107,10 @@ firstname(#rec##0:person1.person, ?#rec##1:person1.person, #field##0:wybe.string
 
 lastname > public {inline} (0 calls)
 0: person1.person.lastname<0>
-lastname(#rec##0:person1.person, ?###0:wybe.string):
+lastname(#rec##0:person1.person, ?#result##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.string)
+    foreign lpvm access(~#rec##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string)
 lastname > public {inline} (0 calls)
 1: person1.person.lastname<1>
 lastname(#rec##0:person1.person, ?#rec##1:person1.person, #field##0:wybe.string):
@@ -121,19 +121,19 @@ lastname(#rec##0:person1.person, ?#rec##1:person1.person, #field##0:wybe.string)
 
 person > public {inline} (0 calls)
 0: person1.person.person<0>
-person(firstname##0:wybe.string, lastname##0:wybe.string, ?###0:person1.person):
+person(firstname##0:wybe.string, lastname##0:wybe.string, ?#result##0:person1.person):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:person1.person)
     foreign lpvm mutate(~#rec##0:person1.person, ?#rec##1:person1.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string)
-    foreign lpvm mutate(~#rec##1:person1.person, ?###0:person1.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string)
+    foreign lpvm mutate(~#rec##1:person1.person, ?#result##0:person1.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string)
 person > public {inline} (6 calls)
 1: person1.person.person<1>
-person(?firstname##0:wybe.string, ?lastname##0:wybe.string, ###0:person1.person):
+person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person1.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string)
-    foreign lpvm access(~###0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string)
+    foreign lpvm access(#result##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string)
+    foreign lpvm access(~#result##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string)
 
 
 ~= > public {inline} (0 calls)
@@ -271,12 +271,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"person1.person.person<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"person1.person.person<1>"(i64  %"#result##0")    {
 entry:
-  %47 = inttoptr i64 %"###0" to i64* 
+  %47 = inttoptr i64 %"#result##0" to i64* 
   %48 = getelementptr  i64, i64* %47, i64 0 
   %49 = load  i64, i64* %48 
-  %50 = add   i64 %"###0", 8 
+  %50 = add   i64 %"#result##0", 8 
   %51 = inttoptr i64 %50 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
   %53 = load  i64, i64* %52 

--- a/test-cases/final-dump/person1.exp
+++ b/test-cases/final-dump/person1.exp
@@ -21,10 +21,10 @@ AFTER EVERYTHING:
 
 *main* > public {inline} (0 calls)
 0: person1.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("Wang":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_string("Wang":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -72,90 +72,90 @@ entry:
 
 = > public {inline} (1 calls)
 0: person1.person.=<0>
-=($left#0:person1.person, $right#0:person1.person, ?$$#0:wybe.bool):
+=($left##0:person1.person, $right##0:person1.person, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$firstname#0:wybe.string)
-    foreign lpvm access(~$left#0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$lastname#0:wybe.string)
-    foreign lpvm access($right#0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$firstname#0:wybe.string)
-    foreign lpvm access(~$right#0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$lastname#0:wybe.string)
-    foreign c strcmp(~$left$firstname#0:wybe.string, ~$right$firstname#0:wybe.string, ?tmp$7#0:wybe.int) @string:nn:nn
-    foreign llvm icmp_eq(~tmp$7#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$firstname##0:wybe.string)
+    foreign lpvm access(~$left##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$lastname##0:wybe.string)
+    foreign lpvm access($right##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$firstname##0:wybe.string)
+    foreign lpvm access(~$right##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$lastname##0:wybe.string)
+    foreign c strcmp(~$left$firstname##0:wybe.string, ~$right$firstname##0:wybe.string, ?tmp$7##0:wybe.int) @string:nn:nn
+    foreign llvm icmp_eq(~tmp$7##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign c strcmp(~$left$lastname#0:wybe.string, ~$right$lastname#0:wybe.string, ?tmp$10#0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp$10#0:wybe.int, 0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign c strcmp(~$left$lastname##0:wybe.string, ~$right$lastname##0:wybe.string, ?tmp$10##0:wybe.int) @string:nn:nn
+        foreign llvm icmp_eq(~tmp$10##0:wybe.int, 0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 firstname > public {inline} (0 calls)
 0: person1.person.firstname<0>
-firstname($rec#0:person1.person, ?$#0:wybe.string):
+firstname($rec##0:person1.person, ?$##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.string)
+    foreign lpvm access(~$rec##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.string)
 firstname > public {inline} (0 calls)
 1: person1.person.firstname<1>
-firstname($rec#0:person1.person, ?$rec#1:person1.person, $field#0:wybe.string):
+firstname($rec##0:person1.person, ?$rec##1:person1.person, $field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec#0:person1.person, ?$rec#1:person1.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.string)
+    foreign lpvm mutate(~$rec##0:person1.person, ?$rec##1:person1.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.string)
 
 
 lastname > public {inline} (0 calls)
 0: person1.person.lastname<0>
-lastname($rec#0:person1.person, ?$#0:wybe.string):
+lastname($rec##0:person1.person, ?$##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.string)
+    foreign lpvm access(~$rec##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.string)
 lastname > public {inline} (0 calls)
 1: person1.person.lastname<1>
-lastname($rec#0:person1.person, ?$rec#1:person1.person, $field#0:wybe.string):
+lastname($rec##0:person1.person, ?$rec##1:person1.person, $field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec#0:person1.person, ?$rec#1:person1.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.string)
+    foreign lpvm mutate(~$rec##0:person1.person, ?$rec##1:person1.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.string)
 
 
 person > public {inline} (0 calls)
 0: person1.person.person<0>
-person(firstname#0:wybe.string, lastname#0:wybe.string, ?$#0:person1.person):
+person(firstname##0:wybe.string, lastname##0:wybe.string, ?$##0:person1.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:person1.person)
-    foreign lpvm mutate(~$rec#0:person1.person, ?$rec#1:person1.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname#0:wybe.string)
-    foreign lpvm mutate(~$rec#1:person1.person, ?$#0:person1.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname#0:wybe.string)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:person1.person)
+    foreign lpvm mutate(~$rec##0:person1.person, ?$rec##1:person1.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string)
+    foreign lpvm mutate(~$rec##1:person1.person, ?$##0:person1.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string)
 person > public {inline} (6 calls)
 1: person1.person.person<1>
-person(?firstname#0:wybe.string, ?lastname#0:wybe.string, $#0:person1.person):
+person(?firstname##0:wybe.string, ?lastname##0:wybe.string, $##0:person1.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname#0:wybe.string)
-    foreign lpvm access(~$#0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname#0:wybe.string)
+    foreign lpvm access($##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string)
+    foreign lpvm access(~$##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string)
 
 
 ~= > public {inline} (0 calls)
 0: person1.person.~=<0>
-~=($left#0:person1.person, $right#0:person1.person, ?$$#0:wybe.bool):
+~=($left##0:person1.person, $right##0:person1.person, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.string)
-    foreign lpvm access(~$left#0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.string)
-    foreign lpvm access($right#0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.string)
-    foreign lpvm access(~$right#0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.string)
-    foreign c strcmp(~tmp$3#0:wybe.string, ~tmp$5#0:wybe.string, ?tmp$7#0:wybe.int) @string:nn:nn
-    foreign llvm icmp_eq(~tmp$7#0:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.bool) @int:nn:nn
-    case ~tmp$8#0:wybe.bool of
+    foreign lpvm access($left##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.string)
+    foreign lpvm access(~$left##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.string)
+    foreign lpvm access($right##0:person1.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.string)
+    foreign lpvm access(~$right##0:person1.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.string)
+    foreign c strcmp(~tmp$3##0:wybe.string, ~tmp$5##0:wybe.string, ?tmp$7##0:wybe.int) @string:nn:nn
+    foreign llvm icmp_eq(~tmp$7##0:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.bool) @int:nn:nn
+    case ~tmp$8##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign c strcmp(~tmp$4#0:wybe.string, ~tmp$6#0:wybe.string, ?tmp$9#0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp$9#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign c strcmp(~tmp$4##0:wybe.string, ~tmp$6##0:wybe.string, ?tmp$9##0:wybe.int) @string:nn:nn
+        foreign llvm icmp_eq(~tmp$9##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -175,62 +175,62 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"person1.person.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"person1.person.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$7#0" = tail call ccc  i64  @strcmp(i64  %3, i64  %10)  
-  %"1$tmp$1#0" = icmp eq i64 %"1$tmp$7#0", 0 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = tail call ccc  i64  @strcmp(i64  %3, i64  %10)  
+  %"1$tmp$1##0" = icmp eq i64 %"1$tmp$7##0", 0 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$10#0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
-  %"2$$$#0" = icmp eq i64 %"2$tmp$10#0", 0 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$10##0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
+  %"2$$$##0" = icmp eq i64 %"2$tmp$10##0", 0 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"person1.person.firstname<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"person1.person.firstname<0>"(i64  %"$rec##0")    {
 entry:
-  %15 = inttoptr i64 %"$rec#0" to i64* 
+  %15 = inttoptr i64 %"$rec##0" to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
   %17 = load  i64, i64* %16 
   ret i64 %17 
 }
 
 
-define external fastcc  i64 @"person1.person.firstname<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"person1.person.firstname<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %18 = trunc i64 16 to i32  
   %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
   %20 = ptrtoint i8* %19 to i64 
   %21 = inttoptr i64 %20 to i8* 
-  %22 = inttoptr i64 %"$rec#0" to i8* 
+  %22 = inttoptr i64 %"$rec##0" to i8* 
   %23 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %21, i8*  %22, i32  %23, i32  8, i1  0)  
   %24 = inttoptr i64 %20 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
-  store  i64 %"$field#0", i64* %25 
+  store  i64 %"$field##0", i64* %25 
   ret i64 %20 
 }
 
 
-define external fastcc  i64 @"person1.person.lastname<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"person1.person.lastname<0>"(i64  %"$rec##0")    {
 entry:
-  %26 = add   i64 %"$rec#0", 8 
+  %26 = add   i64 %"$rec##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -238,45 +238,45 @@ entry:
 }
 
 
-define external fastcc  i64 @"person1.person.lastname<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"person1.person.lastname<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %30 = trunc i64 16 to i32  
   %31 = tail call ccc  i8*  @wybe_malloc(i32  %30)  
   %32 = ptrtoint i8* %31 to i64 
   %33 = inttoptr i64 %32 to i8* 
-  %34 = inttoptr i64 %"$rec#0" to i8* 
+  %34 = inttoptr i64 %"$rec##0" to i8* 
   %35 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %33, i8*  %34, i32  %35, i32  8, i1  0)  
   %36 = add   i64 %32, 8 
   %37 = inttoptr i64 %36 to i64* 
   %38 = getelementptr  i64, i64* %37, i64 0 
-  store  i64 %"$field#0", i64* %38 
+  store  i64 %"$field##0", i64* %38 
   ret i64 %32 
 }
 
 
-define external fastcc  i64 @"person1.person.person<0>"(i64  %"firstname#0", i64  %"lastname#0")    {
+define external fastcc  i64 @"person1.person.person<0>"(i64  %"firstname##0", i64  %"lastname##0")    {
 entry:
   %39 = trunc i64 16 to i32  
   %40 = tail call ccc  i8*  @wybe_malloc(i32  %39)  
   %41 = ptrtoint i8* %40 to i64 
   %42 = inttoptr i64 %41 to i64* 
   %43 = getelementptr  i64, i64* %42, i64 0 
-  store  i64 %"firstname#0", i64* %43 
+  store  i64 %"firstname##0", i64* %43 
   %44 = add   i64 %41, 8 
   %45 = inttoptr i64 %44 to i64* 
   %46 = getelementptr  i64, i64* %45, i64 0 
-  store  i64 %"lastname#0", i64* %46 
+  store  i64 %"lastname##0", i64* %46 
   ret i64 %41 
 }
 
 
-define external fastcc  {i64, i64} @"person1.person.person<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"person1.person.person<1>"(i64  %"$##0")    {
 entry:
-  %47 = inttoptr i64 %"$#0" to i64* 
+  %47 = inttoptr i64 %"$##0" to i64* 
   %48 = getelementptr  i64, i64* %47, i64 0 
   %49 = load  i64, i64* %48 
-  %50 = add   i64 %"$#0", 8 
+  %50 = add   i64 %"$##0", 8 
   %51 = inttoptr i64 %50 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
   %53 = load  i64, i64* %52 
@@ -286,31 +286,31 @@ entry:
 }
 
 
-define external fastcc  i1 @"person1.person.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"person1.person.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = tail call ccc  i64  @strcmp(i64  %58, i64  %65)  
-  %"1$tmp$8#0" = icmp eq i64 %"1$tmp$7#0", 0 
-  br i1 %"1$tmp$8#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = tail call ccc  i64  @strcmp(i64  %58, i64  %65)  
+  %"1$tmp$8##0" = icmp eq i64 %"1$tmp$7##0", 0 
+  br i1 %"1$tmp$8##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$9#0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
-  %"2$tmp$0#0" = icmp eq i64 %"2$tmp$9#0", 0 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$9##0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
+  %"2$tmp$0##0" = icmp eq i64 %"2$tmp$9##0", 0 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }

--- a/test-cases/final-dump/person2.exp
+++ b/test-cases/final-dump/person2.exp
@@ -78,7 +78,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: person2.person.=<0>
-=(#left##0:person2.person, #right##0:person2.person, ?####0:wybe.bool):
+=(#left##0:person2.person, #right##0:person2.person, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#firstname##0:wybe.string)
@@ -89,11 +89,11 @@ entry:
     foreign llvm icmp_eq(~tmp#7##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign c strcmp(~#left#lastname##0:wybe.string, ~#right#lastname##0:wybe.string, ?tmp#10##0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp#10##0:wybe.int, 0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~tmp#10##0:wybe.int, 0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -144,7 +144,7 @@ person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person2.p
 
 ~= > public {inline} (0 calls)
 0: person2.person.~=<0>
-~=(#left##0:person2.person, #right##0:person2.person, ?####0:wybe.bool):
+~=(#left##0:person2.person, #right##0:person2.person, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.string)
@@ -156,12 +156,12 @@ person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person2.p
     case ~tmp#8##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign c strcmp(~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ?tmp#9##0:wybe.int) @string:nn:nn
         foreign llvm icmp_eq(~tmp#9##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -202,8 +202,8 @@ entry:
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#10##0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
-  %"2#####0" = icmp eq i64 %"2#tmp#10##0", 0 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %"2#tmp#10##0", 0 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -314,9 +314,9 @@ entry:
 if.then:
   %"2#tmp#9##0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
   %"2#tmp#0##0" = icmp eq i64 %"2#tmp#9##0", 0 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }

--- a/test-cases/final-dump/person2.exp
+++ b/test-cases/final-dump/person2.exp
@@ -78,90 +78,90 @@ entry:
 
 = > public {inline} (1 calls)
 0: person2.person.=<0>
-=($left##0:person2.person, $right##0:person2.person, ?$$##0:wybe.bool):
+=(#left##0:person2.person, #right##0:person2.person, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$firstname##0:wybe.string)
-    foreign lpvm access(~$left##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$lastname##0:wybe.string)
-    foreign lpvm access($right##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$firstname##0:wybe.string)
-    foreign lpvm access(~$right##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$lastname##0:wybe.string)
-    foreign c strcmp(~$left$firstname##0:wybe.string, ~$right$firstname##0:wybe.string, ?tmp$7##0:wybe.int) @string:nn:nn
-    foreign llvm icmp_eq(~tmp$7##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#firstname##0:wybe.string)
+    foreign lpvm access(~#left##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#lastname##0:wybe.string)
+    foreign lpvm access(#right##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#firstname##0:wybe.string)
+    foreign lpvm access(~#right##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#lastname##0:wybe.string)
+    foreign c strcmp(~#left#firstname##0:wybe.string, ~#right#firstname##0:wybe.string, ?tmp#7##0:wybe.int) @string:nn:nn
+    foreign llvm icmp_eq(~tmp#7##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign c strcmp(~$left$lastname##0:wybe.string, ~$right$lastname##0:wybe.string, ?tmp$10##0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp$10##0:wybe.int, 0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign c strcmp(~#left#lastname##0:wybe.string, ~#right#lastname##0:wybe.string, ?tmp#10##0:wybe.int) @string:nn:nn
+        foreign llvm icmp_eq(~tmp#10##0:wybe.int, 0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 firstname > public {inline} (0 calls)
 0: person2.person.firstname<0>
-firstname($rec##0:person2.person, ?$##0:wybe.string):
+firstname(#rec##0:person2.person, ?###0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.string)
+    foreign lpvm access(~#rec##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.string)
 firstname > public {inline} (0 calls)
 1: person2.person.firstname<1>
-firstname($rec##0:person2.person, ?$rec##1:person2.person, $field##0:wybe.string):
+firstname(#rec##0:person2.person, ?#rec##1:person2.person, #field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec##0:person2.person, ?$rec##1:person2.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.string)
+    foreign lpvm mutate(~#rec##0:person2.person, ?#rec##1:person2.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string)
 
 
 lastname > public {inline} (0 calls)
 0: person2.person.lastname<0>
-lastname($rec##0:person2.person, ?$##0:wybe.string):
+lastname(#rec##0:person2.person, ?###0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.string)
+    foreign lpvm access(~#rec##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.string)
 lastname > public {inline} (0 calls)
 1: person2.person.lastname<1>
-lastname($rec##0:person2.person, ?$rec##1:person2.person, $field##0:wybe.string):
+lastname(#rec##0:person2.person, ?#rec##1:person2.person, #field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec##0:person2.person, ?$rec##1:person2.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.string)
+    foreign lpvm mutate(~#rec##0:person2.person, ?#rec##1:person2.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string)
 
 
 person > public {inline} (0 calls)
 0: person2.person.person<0>
-person(firstname##0:wybe.string, lastname##0:wybe.string, ?$##0:person2.person):
+person(firstname##0:wybe.string, lastname##0:wybe.string, ?###0:person2.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:person2.person)
-    foreign lpvm mutate(~$rec##0:person2.person, ?$rec##1:person2.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string)
-    foreign lpvm mutate(~$rec##1:person2.person, ?$##0:person2.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:person2.person)
+    foreign lpvm mutate(~#rec##0:person2.person, ?#rec##1:person2.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string)
+    foreign lpvm mutate(~#rec##1:person2.person, ?###0:person2.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string)
 person > public {inline} (6 calls)
 1: person2.person.person<1>
-person(?firstname##0:wybe.string, ?lastname##0:wybe.string, $##0:person2.person):
+person(?firstname##0:wybe.string, ?lastname##0:wybe.string, ###0:person2.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string)
-    foreign lpvm access(~$##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string)
+    foreign lpvm access(###0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string)
+    foreign lpvm access(~###0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string)
 
 
 ~= > public {inline} (0 calls)
 0: person2.person.~=<0>
-~=($left##0:person2.person, $right##0:person2.person, ?$$##0:wybe.bool):
+~=(#left##0:person2.person, #right##0:person2.person, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.string)
-    foreign lpvm access(~$left##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.string)
-    foreign lpvm access($right##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.string)
-    foreign lpvm access(~$right##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.string)
-    foreign c strcmp(~tmp$3##0:wybe.string, ~tmp$5##0:wybe.string, ?tmp$7##0:wybe.int) @string:nn:nn
-    foreign llvm icmp_eq(~tmp$7##0:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.bool) @int:nn:nn
-    case ~tmp$8##0:wybe.bool of
+    foreign lpvm access(#left##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.string)
+    foreign lpvm access(~#left##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.string)
+    foreign lpvm access(#right##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.string)
+    foreign lpvm access(~#right##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.string)
+    foreign c strcmp(~tmp#3##0:wybe.string, ~tmp#5##0:wybe.string, ?tmp#7##0:wybe.int) @string:nn:nn
+    foreign llvm icmp_eq(~tmp#7##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool) @int:nn:nn
+    case ~tmp#8##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign c strcmp(~tmp$4##0:wybe.string, ~tmp$6##0:wybe.string, ?tmp$9##0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp$9##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign c strcmp(~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ?tmp#9##0:wybe.int) @string:nn:nn
+        foreign llvm icmp_eq(~tmp#9##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -181,62 +181,62 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"person2.person.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"person2.person.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$7##0" = tail call ccc  i64  @strcmp(i64  %3, i64  %10)  
-  %"1$tmp$1##0" = icmp eq i64 %"1$tmp$7##0", 0 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = tail call ccc  i64  @strcmp(i64  %3, i64  %10)  
+  %"1#tmp#1##0" = icmp eq i64 %"1#tmp#7##0", 0 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$10##0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
-  %"2$$$##0" = icmp eq i64 %"2$tmp$10##0", 0 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#10##0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
+  %"2#####0" = icmp eq i64 %"2#tmp#10##0", 0 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"person2.person.firstname<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"person2.person.firstname<0>"(i64  %"#rec##0")    {
 entry:
-  %15 = inttoptr i64 %"$rec##0" to i64* 
+  %15 = inttoptr i64 %"#rec##0" to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
   %17 = load  i64, i64* %16 
   ret i64 %17 
 }
 
 
-define external fastcc  i64 @"person2.person.firstname<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"person2.person.firstname<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %18 = trunc i64 16 to i32  
   %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
   %20 = ptrtoint i8* %19 to i64 
   %21 = inttoptr i64 %20 to i8* 
-  %22 = inttoptr i64 %"$rec##0" to i8* 
+  %22 = inttoptr i64 %"#rec##0" to i8* 
   %23 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %21, i8*  %22, i32  %23, i32  8, i1  0)  
   %24 = inttoptr i64 %20 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
-  store  i64 %"$field##0", i64* %25 
+  store  i64 %"#field##0", i64* %25 
   ret i64 %20 
 }
 
 
-define external fastcc  i64 @"person2.person.lastname<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"person2.person.lastname<0>"(i64  %"#rec##0")    {
 entry:
-  %26 = add   i64 %"$rec##0", 8 
+  %26 = add   i64 %"#rec##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -244,19 +244,19 @@ entry:
 }
 
 
-define external fastcc  i64 @"person2.person.lastname<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"person2.person.lastname<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %30 = trunc i64 16 to i32  
   %31 = tail call ccc  i8*  @wybe_malloc(i32  %30)  
   %32 = ptrtoint i8* %31 to i64 
   %33 = inttoptr i64 %32 to i8* 
-  %34 = inttoptr i64 %"$rec##0" to i8* 
+  %34 = inttoptr i64 %"#rec##0" to i8* 
   %35 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %33, i8*  %34, i32  %35, i32  8, i1  0)  
   %36 = add   i64 %32, 8 
   %37 = inttoptr i64 %36 to i64* 
   %38 = getelementptr  i64, i64* %37, i64 0 
-  store  i64 %"$field##0", i64* %38 
+  store  i64 %"#field##0", i64* %38 
   ret i64 %32 
 }
 
@@ -277,12 +277,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"person2.person.person<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"person2.person.person<1>"(i64  %"###0")    {
 entry:
-  %47 = inttoptr i64 %"$##0" to i64* 
+  %47 = inttoptr i64 %"###0" to i64* 
   %48 = getelementptr  i64, i64* %47, i64 0 
   %49 = load  i64, i64* %48 
-  %50 = add   i64 %"$##0", 8 
+  %50 = add   i64 %"###0", 8 
   %51 = inttoptr i64 %50 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
   %53 = load  i64, i64* %52 
@@ -292,31 +292,31 @@ entry:
 }
 
 
-define external fastcc  i1 @"person2.person.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"person2.person.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = tail call ccc  i64  @strcmp(i64  %58, i64  %65)  
-  %"1$tmp$8##0" = icmp eq i64 %"1$tmp$7##0", 0 
-  br i1 %"1$tmp$8##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = tail call ccc  i64  @strcmp(i64  %58, i64  %65)  
+  %"1#tmp#8##0" = icmp eq i64 %"1#tmp#7##0", 0 
+  br i1 %"1#tmp#8##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$9##0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
-  %"2$tmp$0##0" = icmp eq i64 %"2$tmp$9##0", 0 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#9##0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
+  %"2#tmp#0##0" = icmp eq i64 %"2#tmp#9##0", 0 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }

--- a/test-cases/final-dump/person2.exp
+++ b/test-cases/final-dump/person2.exp
@@ -21,11 +21,11 @@ AFTER EVERYTHING:
 
 *main* > public {inline} (0 calls)
 0: person2.<0>
-(io#0:wybe.phantom, ?io#2:wybe.phantom):
+(io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("Smith":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_string("Smith":wybe.string, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
+    foreign c print_string("Smith":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("Smith":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -78,90 +78,90 @@ entry:
 
 = > public {inline} (1 calls)
 0: person2.person.=<0>
-=($left#0:person2.person, $right#0:person2.person, ?$$#0:wybe.bool):
+=($left##0:person2.person, $right##0:person2.person, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$firstname#0:wybe.string)
-    foreign lpvm access(~$left#0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$lastname#0:wybe.string)
-    foreign lpvm access($right#0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$firstname#0:wybe.string)
-    foreign lpvm access(~$right#0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$lastname#0:wybe.string)
-    foreign c strcmp(~$left$firstname#0:wybe.string, ~$right$firstname#0:wybe.string, ?tmp$7#0:wybe.int) @string:nn:nn
-    foreign llvm icmp_eq(~tmp$7#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$firstname##0:wybe.string)
+    foreign lpvm access(~$left##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$lastname##0:wybe.string)
+    foreign lpvm access($right##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$firstname##0:wybe.string)
+    foreign lpvm access(~$right##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$lastname##0:wybe.string)
+    foreign c strcmp(~$left$firstname##0:wybe.string, ~$right$firstname##0:wybe.string, ?tmp$7##0:wybe.int) @string:nn:nn
+    foreign llvm icmp_eq(~tmp$7##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign c strcmp(~$left$lastname#0:wybe.string, ~$right$lastname#0:wybe.string, ?tmp$10#0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp$10#0:wybe.int, 0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign c strcmp(~$left$lastname##0:wybe.string, ~$right$lastname##0:wybe.string, ?tmp$10##0:wybe.int) @string:nn:nn
+        foreign llvm icmp_eq(~tmp$10##0:wybe.int, 0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 firstname > public {inline} (0 calls)
 0: person2.person.firstname<0>
-firstname($rec#0:person2.person, ?$#0:wybe.string):
+firstname($rec##0:person2.person, ?$##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.string)
+    foreign lpvm access(~$rec##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.string)
 firstname > public {inline} (0 calls)
 1: person2.person.firstname<1>
-firstname($rec#0:person2.person, ?$rec#1:person2.person, $field#0:wybe.string):
+firstname($rec##0:person2.person, ?$rec##1:person2.person, $field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec#0:person2.person, ?$rec#1:person2.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.string)
+    foreign lpvm mutate(~$rec##0:person2.person, ?$rec##1:person2.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.string)
 
 
 lastname > public {inline} (0 calls)
 0: person2.person.lastname<0>
-lastname($rec#0:person2.person, ?$#0:wybe.string):
+lastname($rec##0:person2.person, ?$##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.string)
+    foreign lpvm access(~$rec##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.string)
 lastname > public {inline} (0 calls)
 1: person2.person.lastname<1>
-lastname($rec#0:person2.person, ?$rec#1:person2.person, $field#0:wybe.string):
+lastname($rec##0:person2.person, ?$rec##1:person2.person, $field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec#0:person2.person, ?$rec#1:person2.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.string)
+    foreign lpvm mutate(~$rec##0:person2.person, ?$rec##1:person2.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.string)
 
 
 person > public {inline} (0 calls)
 0: person2.person.person<0>
-person(firstname#0:wybe.string, lastname#0:wybe.string, ?$#0:person2.person):
+person(firstname##0:wybe.string, lastname##0:wybe.string, ?$##0:person2.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:person2.person)
-    foreign lpvm mutate(~$rec#0:person2.person, ?$rec#1:person2.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname#0:wybe.string)
-    foreign lpvm mutate(~$rec#1:person2.person, ?$#0:person2.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname#0:wybe.string)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:person2.person)
+    foreign lpvm mutate(~$rec##0:person2.person, ?$rec##1:person2.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string)
+    foreign lpvm mutate(~$rec##1:person2.person, ?$##0:person2.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string)
 person > public {inline} (6 calls)
 1: person2.person.person<1>
-person(?firstname#0:wybe.string, ?lastname#0:wybe.string, $#0:person2.person):
+person(?firstname##0:wybe.string, ?lastname##0:wybe.string, $##0:person2.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname#0:wybe.string)
-    foreign lpvm access(~$#0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname#0:wybe.string)
+    foreign lpvm access($##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string)
+    foreign lpvm access(~$##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string)
 
 
 ~= > public {inline} (0 calls)
 0: person2.person.~=<0>
-~=($left#0:person2.person, $right#0:person2.person, ?$$#0:wybe.bool):
+~=($left##0:person2.person, $right##0:person2.person, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.string)
-    foreign lpvm access(~$left#0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.string)
-    foreign lpvm access($right#0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.string)
-    foreign lpvm access(~$right#0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.string)
-    foreign c strcmp(~tmp$3#0:wybe.string, ~tmp$5#0:wybe.string, ?tmp$7#0:wybe.int) @string:nn:nn
-    foreign llvm icmp_eq(~tmp$7#0:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.bool) @int:nn:nn
-    case ~tmp$8#0:wybe.bool of
+    foreign lpvm access($left##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.string)
+    foreign lpvm access(~$left##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.string)
+    foreign lpvm access($right##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.string)
+    foreign lpvm access(~$right##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.string)
+    foreign c strcmp(~tmp$3##0:wybe.string, ~tmp$5##0:wybe.string, ?tmp$7##0:wybe.int) @string:nn:nn
+    foreign llvm icmp_eq(~tmp$7##0:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.bool) @int:nn:nn
+    case ~tmp$8##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign c strcmp(~tmp$4#0:wybe.string, ~tmp$6#0:wybe.string, ?tmp$9#0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp$9#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign c strcmp(~tmp$4##0:wybe.string, ~tmp$6##0:wybe.string, ?tmp$9##0:wybe.int) @string:nn:nn
+        foreign llvm icmp_eq(~tmp$9##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -181,62 +181,62 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"person2.person.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"person2.person.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$7#0" = tail call ccc  i64  @strcmp(i64  %3, i64  %10)  
-  %"1$tmp$1#0" = icmp eq i64 %"1$tmp$7#0", 0 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = tail call ccc  i64  @strcmp(i64  %3, i64  %10)  
+  %"1$tmp$1##0" = icmp eq i64 %"1$tmp$7##0", 0 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$10#0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
-  %"2$$$#0" = icmp eq i64 %"2$tmp$10#0", 0 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$10##0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
+  %"2$$$##0" = icmp eq i64 %"2$tmp$10##0", 0 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"person2.person.firstname<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"person2.person.firstname<0>"(i64  %"$rec##0")    {
 entry:
-  %15 = inttoptr i64 %"$rec#0" to i64* 
+  %15 = inttoptr i64 %"$rec##0" to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
   %17 = load  i64, i64* %16 
   ret i64 %17 
 }
 
 
-define external fastcc  i64 @"person2.person.firstname<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"person2.person.firstname<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %18 = trunc i64 16 to i32  
   %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
   %20 = ptrtoint i8* %19 to i64 
   %21 = inttoptr i64 %20 to i8* 
-  %22 = inttoptr i64 %"$rec#0" to i8* 
+  %22 = inttoptr i64 %"$rec##0" to i8* 
   %23 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %21, i8*  %22, i32  %23, i32  8, i1  0)  
   %24 = inttoptr i64 %20 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
-  store  i64 %"$field#0", i64* %25 
+  store  i64 %"$field##0", i64* %25 
   ret i64 %20 
 }
 
 
-define external fastcc  i64 @"person2.person.lastname<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"person2.person.lastname<0>"(i64  %"$rec##0")    {
 entry:
-  %26 = add   i64 %"$rec#0", 8 
+  %26 = add   i64 %"$rec##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -244,45 +244,45 @@ entry:
 }
 
 
-define external fastcc  i64 @"person2.person.lastname<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"person2.person.lastname<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %30 = trunc i64 16 to i32  
   %31 = tail call ccc  i8*  @wybe_malloc(i32  %30)  
   %32 = ptrtoint i8* %31 to i64 
   %33 = inttoptr i64 %32 to i8* 
-  %34 = inttoptr i64 %"$rec#0" to i8* 
+  %34 = inttoptr i64 %"$rec##0" to i8* 
   %35 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %33, i8*  %34, i32  %35, i32  8, i1  0)  
   %36 = add   i64 %32, 8 
   %37 = inttoptr i64 %36 to i64* 
   %38 = getelementptr  i64, i64* %37, i64 0 
-  store  i64 %"$field#0", i64* %38 
+  store  i64 %"$field##0", i64* %38 
   ret i64 %32 
 }
 
 
-define external fastcc  i64 @"person2.person.person<0>"(i64  %"firstname#0", i64  %"lastname#0")    {
+define external fastcc  i64 @"person2.person.person<0>"(i64  %"firstname##0", i64  %"lastname##0")    {
 entry:
   %39 = trunc i64 16 to i32  
   %40 = tail call ccc  i8*  @wybe_malloc(i32  %39)  
   %41 = ptrtoint i8* %40 to i64 
   %42 = inttoptr i64 %41 to i64* 
   %43 = getelementptr  i64, i64* %42, i64 0 
-  store  i64 %"firstname#0", i64* %43 
+  store  i64 %"firstname##0", i64* %43 
   %44 = add   i64 %41, 8 
   %45 = inttoptr i64 %44 to i64* 
   %46 = getelementptr  i64, i64* %45, i64 0 
-  store  i64 %"lastname#0", i64* %46 
+  store  i64 %"lastname##0", i64* %46 
   ret i64 %41 
 }
 
 
-define external fastcc  {i64, i64} @"person2.person.person<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"person2.person.person<1>"(i64  %"$##0")    {
 entry:
-  %47 = inttoptr i64 %"$#0" to i64* 
+  %47 = inttoptr i64 %"$##0" to i64* 
   %48 = getelementptr  i64, i64* %47, i64 0 
   %49 = load  i64, i64* %48 
-  %50 = add   i64 %"$#0", 8 
+  %50 = add   i64 %"$##0", 8 
   %51 = inttoptr i64 %50 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
   %53 = load  i64, i64* %52 
@@ -292,31 +292,31 @@ entry:
 }
 
 
-define external fastcc  i1 @"person2.person.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"person2.person.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = tail call ccc  i64  @strcmp(i64  %58, i64  %65)  
-  %"1$tmp$8#0" = icmp eq i64 %"1$tmp$7#0", 0 
-  br i1 %"1$tmp$8#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = tail call ccc  i64  @strcmp(i64  %58, i64  %65)  
+  %"1$tmp$8##0" = icmp eq i64 %"1$tmp$7##0", 0 
+  br i1 %"1$tmp$8##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$9#0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
-  %"2$tmp$0#0" = icmp eq i64 %"2$tmp$9#0", 0 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$9##0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
+  %"2$tmp$0##0" = icmp eq i64 %"2$tmp$9##0", 0 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }

--- a/test-cases/final-dump/person2.exp
+++ b/test-cases/final-dump/person2.exp
@@ -99,10 +99,10 @@ entry:
 
 firstname > public {inline} (0 calls)
 0: person2.person.firstname<0>
-firstname(#rec##0:person2.person, ?###0:wybe.string):
+firstname(#rec##0:person2.person, ?#result##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.string)
+    foreign lpvm access(~#rec##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string)
 firstname > public {inline} (0 calls)
 1: person2.person.firstname<1>
 firstname(#rec##0:person2.person, ?#rec##1:person2.person, #field##0:wybe.string):
@@ -113,10 +113,10 @@ firstname(#rec##0:person2.person, ?#rec##1:person2.person, #field##0:wybe.string
 
 lastname > public {inline} (0 calls)
 0: person2.person.lastname<0>
-lastname(#rec##0:person2.person, ?###0:wybe.string):
+lastname(#rec##0:person2.person, ?#result##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.string)
+    foreign lpvm access(~#rec##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string)
 lastname > public {inline} (0 calls)
 1: person2.person.lastname<1>
 lastname(#rec##0:person2.person, ?#rec##1:person2.person, #field##0:wybe.string):
@@ -127,19 +127,19 @@ lastname(#rec##0:person2.person, ?#rec##1:person2.person, #field##0:wybe.string)
 
 person > public {inline} (0 calls)
 0: person2.person.person<0>
-person(firstname##0:wybe.string, lastname##0:wybe.string, ?###0:person2.person):
+person(firstname##0:wybe.string, lastname##0:wybe.string, ?#result##0:person2.person):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:person2.person)
     foreign lpvm mutate(~#rec##0:person2.person, ?#rec##1:person2.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string)
-    foreign lpvm mutate(~#rec##1:person2.person, ?###0:person2.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string)
+    foreign lpvm mutate(~#rec##1:person2.person, ?#result##0:person2.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string)
 person > public {inline} (6 calls)
 1: person2.person.person<1>
-person(?firstname##0:wybe.string, ?lastname##0:wybe.string, ###0:person2.person):
+person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person2.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string)
-    foreign lpvm access(~###0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string)
+    foreign lpvm access(#result##0:person2.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string)
+    foreign lpvm access(~#result##0:person2.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string)
 
 
 ~= > public {inline} (0 calls)
@@ -277,12 +277,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"person2.person.person<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"person2.person.person<1>"(i64  %"#result##0")    {
 entry:
-  %47 = inttoptr i64 %"###0" to i64* 
+  %47 = inttoptr i64 %"#result##0" to i64* 
   %48 = getelementptr  i64, i64* %47, i64 0 
   %49 = load  i64, i64* %48 
-  %50 = add   i64 %"###0", 8 
+  %50 = add   i64 %"#result##0", 8 
   %51 = inttoptr i64 %50 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
   %53 = load  i64, i64* %52 

--- a/test-cases/final-dump/person3.exp
+++ b/test-cases/final-dump/person3.exp
@@ -99,10 +99,10 @@ entry:
 
 firstname > public {inline} (0 calls)
 0: person3.person.firstname<0>
-firstname(#rec##0:person3.person, ?###0:wybe.string):
+firstname(#rec##0:person3.person, ?#result##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.string)
+    foreign lpvm access(~#rec##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string)
 firstname > public {inline} (0 calls)
 1: person3.person.firstname<1>
 firstname(#rec##0:person3.person, ?#rec##1:person3.person, #field##0:wybe.string):
@@ -113,10 +113,10 @@ firstname(#rec##0:person3.person, ?#rec##1:person3.person, #field##0:wybe.string
 
 lastname > public {inline} (0 calls)
 0: person3.person.lastname<0>
-lastname(#rec##0:person3.person, ?###0:wybe.string):
+lastname(#rec##0:person3.person, ?#result##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.string)
+    foreign lpvm access(~#rec##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string)
 lastname > public {inline} (0 calls)
 1: person3.person.lastname<1>
 lastname(#rec##0:person3.person, ?#rec##1:person3.person, #field##0:wybe.string):
@@ -127,19 +127,19 @@ lastname(#rec##0:person3.person, ?#rec##1:person3.person, #field##0:wybe.string)
 
 person > public {inline} (0 calls)
 0: person3.person.person<0>
-person(firstname##0:wybe.string, lastname##0:wybe.string, ?###0:person3.person):
+person(firstname##0:wybe.string, lastname##0:wybe.string, ?#result##0:person3.person):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:person3.person)
     foreign lpvm mutate(~#rec##0:person3.person, ?#rec##1:person3.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string)
-    foreign lpvm mutate(~#rec##1:person3.person, ?###0:person3.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string)
+    foreign lpvm mutate(~#rec##1:person3.person, ?#result##0:person3.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string)
 person > public {inline} (6 calls)
 1: person3.person.person<1>
-person(?firstname##0:wybe.string, ?lastname##0:wybe.string, ###0:person3.person):
+person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person3.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string)
-    foreign lpvm access(~###0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string)
+    foreign lpvm access(#result##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string)
+    foreign lpvm access(~#result##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string)
 
 
 ~= > public {inline} (0 calls)
@@ -277,12 +277,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"person3.person.person<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"person3.person.person<1>"(i64  %"#result##0")    {
 entry:
-  %47 = inttoptr i64 %"###0" to i64* 
+  %47 = inttoptr i64 %"#result##0" to i64* 
   %48 = getelementptr  i64, i64* %47, i64 0 
   %49 = load  i64, i64* %48 
-  %50 = add   i64 %"###0", 8 
+  %50 = add   i64 %"#result##0", 8 
   %51 = inttoptr i64 %50 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
   %53 = load  i64, i64* %52 

--- a/test-cases/final-dump/person3.exp
+++ b/test-cases/final-dump/person3.exp
@@ -78,90 +78,90 @@ entry:
 
 = > public {inline} (1 calls)
 0: person3.person.=<0>
-=($left##0:person3.person, $right##0:person3.person, ?$$##0:wybe.bool):
+=(#left##0:person3.person, #right##0:person3.person, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$firstname##0:wybe.string)
-    foreign lpvm access(~$left##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$lastname##0:wybe.string)
-    foreign lpvm access($right##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$firstname##0:wybe.string)
-    foreign lpvm access(~$right##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$lastname##0:wybe.string)
-    foreign c strcmp(~$left$firstname##0:wybe.string, ~$right$firstname##0:wybe.string, ?tmp$7##0:wybe.int) @string:nn:nn
-    foreign llvm icmp_eq(~tmp$7##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#firstname##0:wybe.string)
+    foreign lpvm access(~#left##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#lastname##0:wybe.string)
+    foreign lpvm access(#right##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#firstname##0:wybe.string)
+    foreign lpvm access(~#right##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#lastname##0:wybe.string)
+    foreign c strcmp(~#left#firstname##0:wybe.string, ~#right#firstname##0:wybe.string, ?tmp#7##0:wybe.int) @string:nn:nn
+    foreign llvm icmp_eq(~tmp#7##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign c strcmp(~$left$lastname##0:wybe.string, ~$right$lastname##0:wybe.string, ?tmp$10##0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp$10##0:wybe.int, 0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign c strcmp(~#left#lastname##0:wybe.string, ~#right#lastname##0:wybe.string, ?tmp#10##0:wybe.int) @string:nn:nn
+        foreign llvm icmp_eq(~tmp#10##0:wybe.int, 0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 firstname > public {inline} (0 calls)
 0: person3.person.firstname<0>
-firstname($rec##0:person3.person, ?$##0:wybe.string):
+firstname(#rec##0:person3.person, ?###0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.string)
+    foreign lpvm access(~#rec##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.string)
 firstname > public {inline} (0 calls)
 1: person3.person.firstname<1>
-firstname($rec##0:person3.person, ?$rec##1:person3.person, $field##0:wybe.string):
+firstname(#rec##0:person3.person, ?#rec##1:person3.person, #field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec##0:person3.person, ?$rec##1:person3.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.string)
+    foreign lpvm mutate(~#rec##0:person3.person, ?#rec##1:person3.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string)
 
 
 lastname > public {inline} (0 calls)
 0: person3.person.lastname<0>
-lastname($rec##0:person3.person, ?$##0:wybe.string):
+lastname(#rec##0:person3.person, ?###0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.string)
+    foreign lpvm access(~#rec##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.string)
 lastname > public {inline} (0 calls)
 1: person3.person.lastname<1>
-lastname($rec##0:person3.person, ?$rec##1:person3.person, $field##0:wybe.string):
+lastname(#rec##0:person3.person, ?#rec##1:person3.person, #field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec##0:person3.person, ?$rec##1:person3.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.string)
+    foreign lpvm mutate(~#rec##0:person3.person, ?#rec##1:person3.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string)
 
 
 person > public {inline} (0 calls)
 0: person3.person.person<0>
-person(firstname##0:wybe.string, lastname##0:wybe.string, ?$##0:person3.person):
+person(firstname##0:wybe.string, lastname##0:wybe.string, ?###0:person3.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:person3.person)
-    foreign lpvm mutate(~$rec##0:person3.person, ?$rec##1:person3.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string)
-    foreign lpvm mutate(~$rec##1:person3.person, ?$##0:person3.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:person3.person)
+    foreign lpvm mutate(~#rec##0:person3.person, ?#rec##1:person3.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string)
+    foreign lpvm mutate(~#rec##1:person3.person, ?###0:person3.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string)
 person > public {inline} (6 calls)
 1: person3.person.person<1>
-person(?firstname##0:wybe.string, ?lastname##0:wybe.string, $##0:person3.person):
+person(?firstname##0:wybe.string, ?lastname##0:wybe.string, ###0:person3.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string)
-    foreign lpvm access(~$##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string)
+    foreign lpvm access(###0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string)
+    foreign lpvm access(~###0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string)
 
 
 ~= > public {inline} (0 calls)
 0: person3.person.~=<0>
-~=($left##0:person3.person, $right##0:person3.person, ?$$##0:wybe.bool):
+~=(#left##0:person3.person, #right##0:person3.person, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.string)
-    foreign lpvm access(~$left##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.string)
-    foreign lpvm access($right##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.string)
-    foreign lpvm access(~$right##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.string)
-    foreign c strcmp(~tmp$3##0:wybe.string, ~tmp$5##0:wybe.string, ?tmp$7##0:wybe.int) @string:nn:nn
-    foreign llvm icmp_eq(~tmp$7##0:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.bool) @int:nn:nn
-    case ~tmp$8##0:wybe.bool of
+    foreign lpvm access(#left##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.string)
+    foreign lpvm access(~#left##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.string)
+    foreign lpvm access(#right##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.string)
+    foreign lpvm access(~#right##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.string)
+    foreign c strcmp(~tmp#3##0:wybe.string, ~tmp#5##0:wybe.string, ?tmp#7##0:wybe.int) @string:nn:nn
+    foreign llvm icmp_eq(~tmp#7##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool) @int:nn:nn
+    case ~tmp#8##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign c strcmp(~tmp$4##0:wybe.string, ~tmp$6##0:wybe.string, ?tmp$9##0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp$9##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign c strcmp(~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ?tmp#9##0:wybe.int) @string:nn:nn
+        foreign llvm icmp_eq(~tmp#9##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -181,62 +181,62 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"person3.person.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"person3.person.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$7##0" = tail call ccc  i64  @strcmp(i64  %3, i64  %10)  
-  %"1$tmp$1##0" = icmp eq i64 %"1$tmp$7##0", 0 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = tail call ccc  i64  @strcmp(i64  %3, i64  %10)  
+  %"1#tmp#1##0" = icmp eq i64 %"1#tmp#7##0", 0 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$10##0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
-  %"2$$$##0" = icmp eq i64 %"2$tmp$10##0", 0 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#10##0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
+  %"2#####0" = icmp eq i64 %"2#tmp#10##0", 0 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"person3.person.firstname<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"person3.person.firstname<0>"(i64  %"#rec##0")    {
 entry:
-  %15 = inttoptr i64 %"$rec##0" to i64* 
+  %15 = inttoptr i64 %"#rec##0" to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
   %17 = load  i64, i64* %16 
   ret i64 %17 
 }
 
 
-define external fastcc  i64 @"person3.person.firstname<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"person3.person.firstname<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %18 = trunc i64 16 to i32  
   %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
   %20 = ptrtoint i8* %19 to i64 
   %21 = inttoptr i64 %20 to i8* 
-  %22 = inttoptr i64 %"$rec##0" to i8* 
+  %22 = inttoptr i64 %"#rec##0" to i8* 
   %23 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %21, i8*  %22, i32  %23, i32  8, i1  0)  
   %24 = inttoptr i64 %20 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
-  store  i64 %"$field##0", i64* %25 
+  store  i64 %"#field##0", i64* %25 
   ret i64 %20 
 }
 
 
-define external fastcc  i64 @"person3.person.lastname<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"person3.person.lastname<0>"(i64  %"#rec##0")    {
 entry:
-  %26 = add   i64 %"$rec##0", 8 
+  %26 = add   i64 %"#rec##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -244,19 +244,19 @@ entry:
 }
 
 
-define external fastcc  i64 @"person3.person.lastname<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"person3.person.lastname<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %30 = trunc i64 16 to i32  
   %31 = tail call ccc  i8*  @wybe_malloc(i32  %30)  
   %32 = ptrtoint i8* %31 to i64 
   %33 = inttoptr i64 %32 to i8* 
-  %34 = inttoptr i64 %"$rec##0" to i8* 
+  %34 = inttoptr i64 %"#rec##0" to i8* 
   %35 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %33, i8*  %34, i32  %35, i32  8, i1  0)  
   %36 = add   i64 %32, 8 
   %37 = inttoptr i64 %36 to i64* 
   %38 = getelementptr  i64, i64* %37, i64 0 
-  store  i64 %"$field##0", i64* %38 
+  store  i64 %"#field##0", i64* %38 
   ret i64 %32 
 }
 
@@ -277,12 +277,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"person3.person.person<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"person3.person.person<1>"(i64  %"###0")    {
 entry:
-  %47 = inttoptr i64 %"$##0" to i64* 
+  %47 = inttoptr i64 %"###0" to i64* 
   %48 = getelementptr  i64, i64* %47, i64 0 
   %49 = load  i64, i64* %48 
-  %50 = add   i64 %"$##0", 8 
+  %50 = add   i64 %"###0", 8 
   %51 = inttoptr i64 %50 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
   %53 = load  i64, i64* %52 
@@ -292,31 +292,31 @@ entry:
 }
 
 
-define external fastcc  i1 @"person3.person.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"person3.person.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = tail call ccc  i64  @strcmp(i64  %58, i64  %65)  
-  %"1$tmp$8##0" = icmp eq i64 %"1$tmp$7##0", 0 
-  br i1 %"1$tmp$8##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = tail call ccc  i64  @strcmp(i64  %58, i64  %65)  
+  %"1#tmp#8##0" = icmp eq i64 %"1#tmp#7##0", 0 
+  br i1 %"1#tmp#8##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$9##0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
-  %"2$tmp$0##0" = icmp eq i64 %"2$tmp$9##0", 0 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#9##0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
+  %"2#tmp#0##0" = icmp eq i64 %"2#tmp#9##0", 0 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }

--- a/test-cases/final-dump/person3.exp
+++ b/test-cases/final-dump/person3.exp
@@ -78,7 +78,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: person3.person.=<0>
-=(#left##0:person3.person, #right##0:person3.person, ?####0:wybe.bool):
+=(#left##0:person3.person, #right##0:person3.person, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#firstname##0:wybe.string)
@@ -89,11 +89,11 @@ entry:
     foreign llvm icmp_eq(~tmp#7##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign c strcmp(~#left#lastname##0:wybe.string, ~#right#lastname##0:wybe.string, ?tmp#10##0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp#10##0:wybe.int, 0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~tmp#10##0:wybe.int, 0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -144,7 +144,7 @@ person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person3.p
 
 ~= > public {inline} (0 calls)
 0: person3.person.~=<0>
-~=(#left##0:person3.person, #right##0:person3.person, ?####0:wybe.bool):
+~=(#left##0:person3.person, #right##0:person3.person, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.string)
@@ -156,12 +156,12 @@ person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person3.p
     case ~tmp#8##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign c strcmp(~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ?tmp#9##0:wybe.int) @string:nn:nn
         foreign llvm icmp_eq(~tmp#9##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -202,8 +202,8 @@ entry:
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#10##0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
-  %"2#####0" = icmp eq i64 %"2#tmp#10##0", 0 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %"2#tmp#10##0", 0 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -314,9 +314,9 @@ entry:
 if.then:
   %"2#tmp#9##0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
   %"2#tmp#0##0" = icmp eq i64 %"2#tmp#9##0", 0 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }

--- a/test-cases/final-dump/person3.exp
+++ b/test-cases/final-dump/person3.exp
@@ -21,11 +21,11 @@ AFTER EVERYTHING:
 
 *main* > public {inline} (0 calls)
 0: person3.<0>
-(io#0:wybe.phantom, ?io#2:wybe.phantom):
+(io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("Smith":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_string("Wang":wybe.string, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
+    foreign c print_string("Smith":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("Wang":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -78,90 +78,90 @@ entry:
 
 = > public {inline} (1 calls)
 0: person3.person.=<0>
-=($left#0:person3.person, $right#0:person3.person, ?$$#0:wybe.bool):
+=($left##0:person3.person, $right##0:person3.person, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$firstname#0:wybe.string)
-    foreign lpvm access(~$left#0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$lastname#0:wybe.string)
-    foreign lpvm access($right#0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$firstname#0:wybe.string)
-    foreign lpvm access(~$right#0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$lastname#0:wybe.string)
-    foreign c strcmp(~$left$firstname#0:wybe.string, ~$right$firstname#0:wybe.string, ?tmp$7#0:wybe.int) @string:nn:nn
-    foreign llvm icmp_eq(~tmp$7#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$firstname##0:wybe.string)
+    foreign lpvm access(~$left##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$lastname##0:wybe.string)
+    foreign lpvm access($right##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$firstname##0:wybe.string)
+    foreign lpvm access(~$right##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$lastname##0:wybe.string)
+    foreign c strcmp(~$left$firstname##0:wybe.string, ~$right$firstname##0:wybe.string, ?tmp$7##0:wybe.int) @string:nn:nn
+    foreign llvm icmp_eq(~tmp$7##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign c strcmp(~$left$lastname#0:wybe.string, ~$right$lastname#0:wybe.string, ?tmp$10#0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp$10#0:wybe.int, 0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign c strcmp(~$left$lastname##0:wybe.string, ~$right$lastname##0:wybe.string, ?tmp$10##0:wybe.int) @string:nn:nn
+        foreign llvm icmp_eq(~tmp$10##0:wybe.int, 0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 firstname > public {inline} (0 calls)
 0: person3.person.firstname<0>
-firstname($rec#0:person3.person, ?$#0:wybe.string):
+firstname($rec##0:person3.person, ?$##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.string)
+    foreign lpvm access(~$rec##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.string)
 firstname > public {inline} (0 calls)
 1: person3.person.firstname<1>
-firstname($rec#0:person3.person, ?$rec#1:person3.person, $field#0:wybe.string):
+firstname($rec##0:person3.person, ?$rec##1:person3.person, $field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec#0:person3.person, ?$rec#1:person3.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.string)
+    foreign lpvm mutate(~$rec##0:person3.person, ?$rec##1:person3.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.string)
 
 
 lastname > public {inline} (0 calls)
 0: person3.person.lastname<0>
-lastname($rec#0:person3.person, ?$#0:wybe.string):
+lastname($rec##0:person3.person, ?$##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.string)
+    foreign lpvm access(~$rec##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.string)
 lastname > public {inline} (0 calls)
 1: person3.person.lastname<1>
-lastname($rec#0:person3.person, ?$rec#1:person3.person, $field#0:wybe.string):
+lastname($rec##0:person3.person, ?$rec##1:person3.person, $field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec#0:person3.person, ?$rec#1:person3.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.string)
+    foreign lpvm mutate(~$rec##0:person3.person, ?$rec##1:person3.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.string)
 
 
 person > public {inline} (0 calls)
 0: person3.person.person<0>
-person(firstname#0:wybe.string, lastname#0:wybe.string, ?$#0:person3.person):
+person(firstname##0:wybe.string, lastname##0:wybe.string, ?$##0:person3.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:person3.person)
-    foreign lpvm mutate(~$rec#0:person3.person, ?$rec#1:person3.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname#0:wybe.string)
-    foreign lpvm mutate(~$rec#1:person3.person, ?$#0:person3.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname#0:wybe.string)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:person3.person)
+    foreign lpvm mutate(~$rec##0:person3.person, ?$rec##1:person3.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string)
+    foreign lpvm mutate(~$rec##1:person3.person, ?$##0:person3.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string)
 person > public {inline} (6 calls)
 1: person3.person.person<1>
-person(?firstname#0:wybe.string, ?lastname#0:wybe.string, $#0:person3.person):
+person(?firstname##0:wybe.string, ?lastname##0:wybe.string, $##0:person3.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname#0:wybe.string)
-    foreign lpvm access(~$#0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname#0:wybe.string)
+    foreign lpvm access($##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string)
+    foreign lpvm access(~$##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string)
 
 
 ~= > public {inline} (0 calls)
 0: person3.person.~=<0>
-~=($left#0:person3.person, $right#0:person3.person, ?$$#0:wybe.bool):
+~=($left##0:person3.person, $right##0:person3.person, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.string)
-    foreign lpvm access(~$left#0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.string)
-    foreign lpvm access($right#0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.string)
-    foreign lpvm access(~$right#0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.string)
-    foreign c strcmp(~tmp$3#0:wybe.string, ~tmp$5#0:wybe.string, ?tmp$7#0:wybe.int) @string:nn:nn
-    foreign llvm icmp_eq(~tmp$7#0:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.bool) @int:nn:nn
-    case ~tmp$8#0:wybe.bool of
+    foreign lpvm access($left##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.string)
+    foreign lpvm access(~$left##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.string)
+    foreign lpvm access($right##0:person3.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.string)
+    foreign lpvm access(~$right##0:person3.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.string)
+    foreign c strcmp(~tmp$3##0:wybe.string, ~tmp$5##0:wybe.string, ?tmp$7##0:wybe.int) @string:nn:nn
+    foreign llvm icmp_eq(~tmp$7##0:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.bool) @int:nn:nn
+    case ~tmp$8##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign c strcmp(~tmp$4#0:wybe.string, ~tmp$6#0:wybe.string, ?tmp$9#0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp$9#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign c strcmp(~tmp$4##0:wybe.string, ~tmp$6##0:wybe.string, ?tmp$9##0:wybe.int) @string:nn:nn
+        foreign llvm icmp_eq(~tmp$9##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -181,62 +181,62 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"person3.person.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"person3.person.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$7#0" = tail call ccc  i64  @strcmp(i64  %3, i64  %10)  
-  %"1$tmp$1#0" = icmp eq i64 %"1$tmp$7#0", 0 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = tail call ccc  i64  @strcmp(i64  %3, i64  %10)  
+  %"1$tmp$1##0" = icmp eq i64 %"1$tmp$7##0", 0 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$10#0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
-  %"2$$$#0" = icmp eq i64 %"2$tmp$10#0", 0 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$10##0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
+  %"2$$$##0" = icmp eq i64 %"2$tmp$10##0", 0 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"person3.person.firstname<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"person3.person.firstname<0>"(i64  %"$rec##0")    {
 entry:
-  %15 = inttoptr i64 %"$rec#0" to i64* 
+  %15 = inttoptr i64 %"$rec##0" to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
   %17 = load  i64, i64* %16 
   ret i64 %17 
 }
 
 
-define external fastcc  i64 @"person3.person.firstname<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"person3.person.firstname<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %18 = trunc i64 16 to i32  
   %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
   %20 = ptrtoint i8* %19 to i64 
   %21 = inttoptr i64 %20 to i8* 
-  %22 = inttoptr i64 %"$rec#0" to i8* 
+  %22 = inttoptr i64 %"$rec##0" to i8* 
   %23 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %21, i8*  %22, i32  %23, i32  8, i1  0)  
   %24 = inttoptr i64 %20 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
-  store  i64 %"$field#0", i64* %25 
+  store  i64 %"$field##0", i64* %25 
   ret i64 %20 
 }
 
 
-define external fastcc  i64 @"person3.person.lastname<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"person3.person.lastname<0>"(i64  %"$rec##0")    {
 entry:
-  %26 = add   i64 %"$rec#0", 8 
+  %26 = add   i64 %"$rec##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -244,45 +244,45 @@ entry:
 }
 
 
-define external fastcc  i64 @"person3.person.lastname<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"person3.person.lastname<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %30 = trunc i64 16 to i32  
   %31 = tail call ccc  i8*  @wybe_malloc(i32  %30)  
   %32 = ptrtoint i8* %31 to i64 
   %33 = inttoptr i64 %32 to i8* 
-  %34 = inttoptr i64 %"$rec#0" to i8* 
+  %34 = inttoptr i64 %"$rec##0" to i8* 
   %35 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %33, i8*  %34, i32  %35, i32  8, i1  0)  
   %36 = add   i64 %32, 8 
   %37 = inttoptr i64 %36 to i64* 
   %38 = getelementptr  i64, i64* %37, i64 0 
-  store  i64 %"$field#0", i64* %38 
+  store  i64 %"$field##0", i64* %38 
   ret i64 %32 
 }
 
 
-define external fastcc  i64 @"person3.person.person<0>"(i64  %"firstname#0", i64  %"lastname#0")    {
+define external fastcc  i64 @"person3.person.person<0>"(i64  %"firstname##0", i64  %"lastname##0")    {
 entry:
   %39 = trunc i64 16 to i32  
   %40 = tail call ccc  i8*  @wybe_malloc(i32  %39)  
   %41 = ptrtoint i8* %40 to i64 
   %42 = inttoptr i64 %41 to i64* 
   %43 = getelementptr  i64, i64* %42, i64 0 
-  store  i64 %"firstname#0", i64* %43 
+  store  i64 %"firstname##0", i64* %43 
   %44 = add   i64 %41, 8 
   %45 = inttoptr i64 %44 to i64* 
   %46 = getelementptr  i64, i64* %45, i64 0 
-  store  i64 %"lastname#0", i64* %46 
+  store  i64 %"lastname##0", i64* %46 
   ret i64 %41 
 }
 
 
-define external fastcc  {i64, i64} @"person3.person.person<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"person3.person.person<1>"(i64  %"$##0")    {
 entry:
-  %47 = inttoptr i64 %"$#0" to i64* 
+  %47 = inttoptr i64 %"$##0" to i64* 
   %48 = getelementptr  i64, i64* %47, i64 0 
   %49 = load  i64, i64* %48 
-  %50 = add   i64 %"$#0", 8 
+  %50 = add   i64 %"$##0", 8 
   %51 = inttoptr i64 %50 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
   %53 = load  i64, i64* %52 
@@ -292,31 +292,31 @@ entry:
 }
 
 
-define external fastcc  i1 @"person3.person.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"person3.person.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = tail call ccc  i64  @strcmp(i64  %58, i64  %65)  
-  %"1$tmp$8#0" = icmp eq i64 %"1$tmp$7#0", 0 
-  br i1 %"1$tmp$8#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = tail call ccc  i64  @strcmp(i64  %58, i64  %65)  
+  %"1$tmp$8##0" = icmp eq i64 %"1$tmp$7##0", 0 
+  br i1 %"1$tmp$8##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$9#0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
-  %"2$tmp$0#0" = icmp eq i64 %"2$tmp$9#0", 0 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$9##0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
+  %"2$tmp$0##0" = icmp eq i64 %"2$tmp$9##0", 0 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }

--- a/test-cases/final-dump/person4.exp
+++ b/test-cases/final-dump/person4.exp
@@ -99,10 +99,10 @@ entry:
 
 firstname > public {inline} (0 calls)
 0: person4.person.firstname<0>
-firstname(#rec##0:person4.person, ?###0:wybe.string):
+firstname(#rec##0:person4.person, ?#result##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.string)
+    foreign lpvm access(~#rec##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string)
 firstname > public {inline} (0 calls)
 1: person4.person.firstname<1>
 firstname(#rec##0:person4.person, ?#rec##1:person4.person, #field##0:wybe.string):
@@ -113,10 +113,10 @@ firstname(#rec##0:person4.person, ?#rec##1:person4.person, #field##0:wybe.string
 
 lastname > public {inline} (0 calls)
 0: person4.person.lastname<0>
-lastname(#rec##0:person4.person, ?###0:wybe.string):
+lastname(#rec##0:person4.person, ?#result##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.string)
+    foreign lpvm access(~#rec##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string)
 lastname > public {inline} (0 calls)
 1: person4.person.lastname<1>
 lastname(#rec##0:person4.person, ?#rec##1:person4.person, #field##0:wybe.string):
@@ -127,19 +127,19 @@ lastname(#rec##0:person4.person, ?#rec##1:person4.person, #field##0:wybe.string)
 
 person > public {inline} (0 calls)
 0: person4.person.person<0>
-person(firstname##0:wybe.string, lastname##0:wybe.string, ?###0:person4.person):
+person(firstname##0:wybe.string, lastname##0:wybe.string, ?#result##0:person4.person):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:person4.person)
     foreign lpvm mutate(~#rec##0:person4.person, ?#rec##1:person4.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string)
-    foreign lpvm mutate(~#rec##1:person4.person, ?###0:person4.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string)
+    foreign lpvm mutate(~#rec##1:person4.person, ?#result##0:person4.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string)
 person > public {inline} (6 calls)
 1: person4.person.person<1>
-person(?firstname##0:wybe.string, ?lastname##0:wybe.string, ###0:person4.person):
+person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person4.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string)
-    foreign lpvm access(~###0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string)
+    foreign lpvm access(#result##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string)
+    foreign lpvm access(~#result##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string)
 
 
 ~= > public {inline} (0 calls)
@@ -277,12 +277,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"person4.person.person<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"person4.person.person<1>"(i64  %"#result##0")    {
 entry:
-  %47 = inttoptr i64 %"###0" to i64* 
+  %47 = inttoptr i64 %"#result##0" to i64* 
   %48 = getelementptr  i64, i64* %47, i64 0 
   %49 = load  i64, i64* %48 
-  %50 = add   i64 %"###0", 8 
+  %50 = add   i64 %"#result##0", 8 
   %51 = inttoptr i64 %50 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
   %53 = load  i64, i64* %52 

--- a/test-cases/final-dump/person4.exp
+++ b/test-cases/final-dump/person4.exp
@@ -21,11 +21,11 @@ AFTER EVERYTHING:
 
 *main* > public {inline} (0 calls)
 0: person4.<0>
-(io#0:wybe.phantom, ?io#2:wybe.phantom):
+(io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("Wang":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_string("Smith":wybe.string, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
+    foreign c print_string("Wang":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("Smith":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -78,90 +78,90 @@ entry:
 
 = > public {inline} (1 calls)
 0: person4.person.=<0>
-=($left#0:person4.person, $right#0:person4.person, ?$$#0:wybe.bool):
+=($left##0:person4.person, $right##0:person4.person, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$firstname#0:wybe.string)
-    foreign lpvm access(~$left#0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$lastname#0:wybe.string)
-    foreign lpvm access($right#0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$firstname#0:wybe.string)
-    foreign lpvm access(~$right#0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$lastname#0:wybe.string)
-    foreign c strcmp(~$left$firstname#0:wybe.string, ~$right$firstname#0:wybe.string, ?tmp$7#0:wybe.int) @string:nn:nn
-    foreign llvm icmp_eq(~tmp$7#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$firstname##0:wybe.string)
+    foreign lpvm access(~$left##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$lastname##0:wybe.string)
+    foreign lpvm access($right##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$firstname##0:wybe.string)
+    foreign lpvm access(~$right##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$lastname##0:wybe.string)
+    foreign c strcmp(~$left$firstname##0:wybe.string, ~$right$firstname##0:wybe.string, ?tmp$7##0:wybe.int) @string:nn:nn
+    foreign llvm icmp_eq(~tmp$7##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign c strcmp(~$left$lastname#0:wybe.string, ~$right$lastname#0:wybe.string, ?tmp$10#0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp$10#0:wybe.int, 0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign c strcmp(~$left$lastname##0:wybe.string, ~$right$lastname##0:wybe.string, ?tmp$10##0:wybe.int) @string:nn:nn
+        foreign llvm icmp_eq(~tmp$10##0:wybe.int, 0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 firstname > public {inline} (0 calls)
 0: person4.person.firstname<0>
-firstname($rec#0:person4.person, ?$#0:wybe.string):
+firstname($rec##0:person4.person, ?$##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.string)
+    foreign lpvm access(~$rec##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.string)
 firstname > public {inline} (0 calls)
 1: person4.person.firstname<1>
-firstname($rec#0:person4.person, ?$rec#1:person4.person, $field#0:wybe.string):
+firstname($rec##0:person4.person, ?$rec##1:person4.person, $field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec#0:person4.person, ?$rec#1:person4.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.string)
+    foreign lpvm mutate(~$rec##0:person4.person, ?$rec##1:person4.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.string)
 
 
 lastname > public {inline} (0 calls)
 0: person4.person.lastname<0>
-lastname($rec#0:person4.person, ?$#0:wybe.string):
+lastname($rec##0:person4.person, ?$##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.string)
+    foreign lpvm access(~$rec##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.string)
 lastname > public {inline} (0 calls)
 1: person4.person.lastname<1>
-lastname($rec#0:person4.person, ?$rec#1:person4.person, $field#0:wybe.string):
+lastname($rec##0:person4.person, ?$rec##1:person4.person, $field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec#0:person4.person, ?$rec#1:person4.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.string)
+    foreign lpvm mutate(~$rec##0:person4.person, ?$rec##1:person4.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.string)
 
 
 person > public {inline} (0 calls)
 0: person4.person.person<0>
-person(firstname#0:wybe.string, lastname#0:wybe.string, ?$#0:person4.person):
+person(firstname##0:wybe.string, lastname##0:wybe.string, ?$##0:person4.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:person4.person)
-    foreign lpvm mutate(~$rec#0:person4.person, ?$rec#1:person4.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname#0:wybe.string)
-    foreign lpvm mutate(~$rec#1:person4.person, ?$#0:person4.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname#0:wybe.string)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:person4.person)
+    foreign lpvm mutate(~$rec##0:person4.person, ?$rec##1:person4.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string)
+    foreign lpvm mutate(~$rec##1:person4.person, ?$##0:person4.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string)
 person > public {inline} (6 calls)
 1: person4.person.person<1>
-person(?firstname#0:wybe.string, ?lastname#0:wybe.string, $#0:person4.person):
+person(?firstname##0:wybe.string, ?lastname##0:wybe.string, $##0:person4.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname#0:wybe.string)
-    foreign lpvm access(~$#0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname#0:wybe.string)
+    foreign lpvm access($##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string)
+    foreign lpvm access(~$##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string)
 
 
 ~= > public {inline} (0 calls)
 0: person4.person.~=<0>
-~=($left#0:person4.person, $right#0:person4.person, ?$$#0:wybe.bool):
+~=($left##0:person4.person, $right##0:person4.person, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.string)
-    foreign lpvm access(~$left#0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.string)
-    foreign lpvm access($right#0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.string)
-    foreign lpvm access(~$right#0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.string)
-    foreign c strcmp(~tmp$3#0:wybe.string, ~tmp$5#0:wybe.string, ?tmp$7#0:wybe.int) @string:nn:nn
-    foreign llvm icmp_eq(~tmp$7#0:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.bool) @int:nn:nn
-    case ~tmp$8#0:wybe.bool of
+    foreign lpvm access($left##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.string)
+    foreign lpvm access(~$left##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.string)
+    foreign lpvm access($right##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.string)
+    foreign lpvm access(~$right##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.string)
+    foreign c strcmp(~tmp$3##0:wybe.string, ~tmp$5##0:wybe.string, ?tmp$7##0:wybe.int) @string:nn:nn
+    foreign llvm icmp_eq(~tmp$7##0:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.bool) @int:nn:nn
+    case ~tmp$8##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign c strcmp(~tmp$4#0:wybe.string, ~tmp$6#0:wybe.string, ?tmp$9#0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp$9#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign c strcmp(~tmp$4##0:wybe.string, ~tmp$6##0:wybe.string, ?tmp$9##0:wybe.int) @string:nn:nn
+        foreign llvm icmp_eq(~tmp$9##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -181,62 +181,62 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"person4.person.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"person4.person.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$7#0" = tail call ccc  i64  @strcmp(i64  %3, i64  %10)  
-  %"1$tmp$1#0" = icmp eq i64 %"1$tmp$7#0", 0 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = tail call ccc  i64  @strcmp(i64  %3, i64  %10)  
+  %"1$tmp$1##0" = icmp eq i64 %"1$tmp$7##0", 0 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$10#0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
-  %"2$$$#0" = icmp eq i64 %"2$tmp$10#0", 0 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$10##0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
+  %"2$$$##0" = icmp eq i64 %"2$tmp$10##0", 0 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"person4.person.firstname<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"person4.person.firstname<0>"(i64  %"$rec##0")    {
 entry:
-  %15 = inttoptr i64 %"$rec#0" to i64* 
+  %15 = inttoptr i64 %"$rec##0" to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
   %17 = load  i64, i64* %16 
   ret i64 %17 
 }
 
 
-define external fastcc  i64 @"person4.person.firstname<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"person4.person.firstname<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %18 = trunc i64 16 to i32  
   %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
   %20 = ptrtoint i8* %19 to i64 
   %21 = inttoptr i64 %20 to i8* 
-  %22 = inttoptr i64 %"$rec#0" to i8* 
+  %22 = inttoptr i64 %"$rec##0" to i8* 
   %23 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %21, i8*  %22, i32  %23, i32  8, i1  0)  
   %24 = inttoptr i64 %20 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
-  store  i64 %"$field#0", i64* %25 
+  store  i64 %"$field##0", i64* %25 
   ret i64 %20 
 }
 
 
-define external fastcc  i64 @"person4.person.lastname<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"person4.person.lastname<0>"(i64  %"$rec##0")    {
 entry:
-  %26 = add   i64 %"$rec#0", 8 
+  %26 = add   i64 %"$rec##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -244,45 +244,45 @@ entry:
 }
 
 
-define external fastcc  i64 @"person4.person.lastname<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"person4.person.lastname<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %30 = trunc i64 16 to i32  
   %31 = tail call ccc  i8*  @wybe_malloc(i32  %30)  
   %32 = ptrtoint i8* %31 to i64 
   %33 = inttoptr i64 %32 to i8* 
-  %34 = inttoptr i64 %"$rec#0" to i8* 
+  %34 = inttoptr i64 %"$rec##0" to i8* 
   %35 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %33, i8*  %34, i32  %35, i32  8, i1  0)  
   %36 = add   i64 %32, 8 
   %37 = inttoptr i64 %36 to i64* 
   %38 = getelementptr  i64, i64* %37, i64 0 
-  store  i64 %"$field#0", i64* %38 
+  store  i64 %"$field##0", i64* %38 
   ret i64 %32 
 }
 
 
-define external fastcc  i64 @"person4.person.person<0>"(i64  %"firstname#0", i64  %"lastname#0")    {
+define external fastcc  i64 @"person4.person.person<0>"(i64  %"firstname##0", i64  %"lastname##0")    {
 entry:
   %39 = trunc i64 16 to i32  
   %40 = tail call ccc  i8*  @wybe_malloc(i32  %39)  
   %41 = ptrtoint i8* %40 to i64 
   %42 = inttoptr i64 %41 to i64* 
   %43 = getelementptr  i64, i64* %42, i64 0 
-  store  i64 %"firstname#0", i64* %43 
+  store  i64 %"firstname##0", i64* %43 
   %44 = add   i64 %41, 8 
   %45 = inttoptr i64 %44 to i64* 
   %46 = getelementptr  i64, i64* %45, i64 0 
-  store  i64 %"lastname#0", i64* %46 
+  store  i64 %"lastname##0", i64* %46 
   ret i64 %41 
 }
 
 
-define external fastcc  {i64, i64} @"person4.person.person<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"person4.person.person<1>"(i64  %"$##0")    {
 entry:
-  %47 = inttoptr i64 %"$#0" to i64* 
+  %47 = inttoptr i64 %"$##0" to i64* 
   %48 = getelementptr  i64, i64* %47, i64 0 
   %49 = load  i64, i64* %48 
-  %50 = add   i64 %"$#0", 8 
+  %50 = add   i64 %"$##0", 8 
   %51 = inttoptr i64 %50 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
   %53 = load  i64, i64* %52 
@@ -292,31 +292,31 @@ entry:
 }
 
 
-define external fastcc  i1 @"person4.person.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"person4.person.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = tail call ccc  i64  @strcmp(i64  %58, i64  %65)  
-  %"1$tmp$8#0" = icmp eq i64 %"1$tmp$7#0", 0 
-  br i1 %"1$tmp$8#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = tail call ccc  i64  @strcmp(i64  %58, i64  %65)  
+  %"1$tmp$8##0" = icmp eq i64 %"1$tmp$7##0", 0 
+  br i1 %"1$tmp$8##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$9#0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
-  %"2$tmp$0#0" = icmp eq i64 %"2$tmp$9#0", 0 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$9##0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
+  %"2$tmp$0##0" = icmp eq i64 %"2$tmp$9##0", 0 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }

--- a/test-cases/final-dump/person4.exp
+++ b/test-cases/final-dump/person4.exp
@@ -78,90 +78,90 @@ entry:
 
 = > public {inline} (1 calls)
 0: person4.person.=<0>
-=($left##0:person4.person, $right##0:person4.person, ?$$##0:wybe.bool):
+=(#left##0:person4.person, #right##0:person4.person, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$firstname##0:wybe.string)
-    foreign lpvm access(~$left##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$lastname##0:wybe.string)
-    foreign lpvm access($right##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$firstname##0:wybe.string)
-    foreign lpvm access(~$right##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$lastname##0:wybe.string)
-    foreign c strcmp(~$left$firstname##0:wybe.string, ~$right$firstname##0:wybe.string, ?tmp$7##0:wybe.int) @string:nn:nn
-    foreign llvm icmp_eq(~tmp$7##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#firstname##0:wybe.string)
+    foreign lpvm access(~#left##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#lastname##0:wybe.string)
+    foreign lpvm access(#right##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#firstname##0:wybe.string)
+    foreign lpvm access(~#right##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#lastname##0:wybe.string)
+    foreign c strcmp(~#left#firstname##0:wybe.string, ~#right#firstname##0:wybe.string, ?tmp#7##0:wybe.int) @string:nn:nn
+    foreign llvm icmp_eq(~tmp#7##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign c strcmp(~$left$lastname##0:wybe.string, ~$right$lastname##0:wybe.string, ?tmp$10##0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp$10##0:wybe.int, 0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign c strcmp(~#left#lastname##0:wybe.string, ~#right#lastname##0:wybe.string, ?tmp#10##0:wybe.int) @string:nn:nn
+        foreign llvm icmp_eq(~tmp#10##0:wybe.int, 0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 firstname > public {inline} (0 calls)
 0: person4.person.firstname<0>
-firstname($rec##0:person4.person, ?$##0:wybe.string):
+firstname(#rec##0:person4.person, ?###0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.string)
+    foreign lpvm access(~#rec##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.string)
 firstname > public {inline} (0 calls)
 1: person4.person.firstname<1>
-firstname($rec##0:person4.person, ?$rec##1:person4.person, $field##0:wybe.string):
+firstname(#rec##0:person4.person, ?#rec##1:person4.person, #field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec##0:person4.person, ?$rec##1:person4.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.string)
+    foreign lpvm mutate(~#rec##0:person4.person, ?#rec##1:person4.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string)
 
 
 lastname > public {inline} (0 calls)
 0: person4.person.lastname<0>
-lastname($rec##0:person4.person, ?$##0:wybe.string):
+lastname(#rec##0:person4.person, ?###0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.string)
+    foreign lpvm access(~#rec##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.string)
 lastname > public {inline} (0 calls)
 1: person4.person.lastname<1>
-lastname($rec##0:person4.person, ?$rec##1:person4.person, $field##0:wybe.string):
+lastname(#rec##0:person4.person, ?#rec##1:person4.person, #field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec##0:person4.person, ?$rec##1:person4.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.string)
+    foreign lpvm mutate(~#rec##0:person4.person, ?#rec##1:person4.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string)
 
 
 person > public {inline} (0 calls)
 0: person4.person.person<0>
-person(firstname##0:wybe.string, lastname##0:wybe.string, ?$##0:person4.person):
+person(firstname##0:wybe.string, lastname##0:wybe.string, ?###0:person4.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:person4.person)
-    foreign lpvm mutate(~$rec##0:person4.person, ?$rec##1:person4.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string)
-    foreign lpvm mutate(~$rec##1:person4.person, ?$##0:person4.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:person4.person)
+    foreign lpvm mutate(~#rec##0:person4.person, ?#rec##1:person4.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string)
+    foreign lpvm mutate(~#rec##1:person4.person, ?###0:person4.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string)
 person > public {inline} (6 calls)
 1: person4.person.person<1>
-person(?firstname##0:wybe.string, ?lastname##0:wybe.string, $##0:person4.person):
+person(?firstname##0:wybe.string, ?lastname##0:wybe.string, ###0:person4.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string)
-    foreign lpvm access(~$##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string)
+    foreign lpvm access(###0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string)
+    foreign lpvm access(~###0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string)
 
 
 ~= > public {inline} (0 calls)
 0: person4.person.~=<0>
-~=($left##0:person4.person, $right##0:person4.person, ?$$##0:wybe.bool):
+~=(#left##0:person4.person, #right##0:person4.person, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.string)
-    foreign lpvm access(~$left##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.string)
-    foreign lpvm access($right##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.string)
-    foreign lpvm access(~$right##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.string)
-    foreign c strcmp(~tmp$3##0:wybe.string, ~tmp$5##0:wybe.string, ?tmp$7##0:wybe.int) @string:nn:nn
-    foreign llvm icmp_eq(~tmp$7##0:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.bool) @int:nn:nn
-    case ~tmp$8##0:wybe.bool of
+    foreign lpvm access(#left##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.string)
+    foreign lpvm access(~#left##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.string)
+    foreign lpvm access(#right##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.string)
+    foreign lpvm access(~#right##0:person4.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.string)
+    foreign c strcmp(~tmp#3##0:wybe.string, ~tmp#5##0:wybe.string, ?tmp#7##0:wybe.int) @string:nn:nn
+    foreign llvm icmp_eq(~tmp#7##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool) @int:nn:nn
+    case ~tmp#8##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign c strcmp(~tmp$4##0:wybe.string, ~tmp$6##0:wybe.string, ?tmp$9##0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp$9##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign c strcmp(~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ?tmp#9##0:wybe.int) @string:nn:nn
+        foreign llvm icmp_eq(~tmp#9##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -181,62 +181,62 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"person4.person.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"person4.person.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$7##0" = tail call ccc  i64  @strcmp(i64  %3, i64  %10)  
-  %"1$tmp$1##0" = icmp eq i64 %"1$tmp$7##0", 0 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = tail call ccc  i64  @strcmp(i64  %3, i64  %10)  
+  %"1#tmp#1##0" = icmp eq i64 %"1#tmp#7##0", 0 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$10##0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
-  %"2$$$##0" = icmp eq i64 %"2$tmp$10##0", 0 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#10##0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
+  %"2#####0" = icmp eq i64 %"2#tmp#10##0", 0 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"person4.person.firstname<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"person4.person.firstname<0>"(i64  %"#rec##0")    {
 entry:
-  %15 = inttoptr i64 %"$rec##0" to i64* 
+  %15 = inttoptr i64 %"#rec##0" to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
   %17 = load  i64, i64* %16 
   ret i64 %17 
 }
 
 
-define external fastcc  i64 @"person4.person.firstname<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"person4.person.firstname<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %18 = trunc i64 16 to i32  
   %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
   %20 = ptrtoint i8* %19 to i64 
   %21 = inttoptr i64 %20 to i8* 
-  %22 = inttoptr i64 %"$rec##0" to i8* 
+  %22 = inttoptr i64 %"#rec##0" to i8* 
   %23 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %21, i8*  %22, i32  %23, i32  8, i1  0)  
   %24 = inttoptr i64 %20 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
-  store  i64 %"$field##0", i64* %25 
+  store  i64 %"#field##0", i64* %25 
   ret i64 %20 
 }
 
 
-define external fastcc  i64 @"person4.person.lastname<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"person4.person.lastname<0>"(i64  %"#rec##0")    {
 entry:
-  %26 = add   i64 %"$rec##0", 8 
+  %26 = add   i64 %"#rec##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -244,19 +244,19 @@ entry:
 }
 
 
-define external fastcc  i64 @"person4.person.lastname<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"person4.person.lastname<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %30 = trunc i64 16 to i32  
   %31 = tail call ccc  i8*  @wybe_malloc(i32  %30)  
   %32 = ptrtoint i8* %31 to i64 
   %33 = inttoptr i64 %32 to i8* 
-  %34 = inttoptr i64 %"$rec##0" to i8* 
+  %34 = inttoptr i64 %"#rec##0" to i8* 
   %35 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %33, i8*  %34, i32  %35, i32  8, i1  0)  
   %36 = add   i64 %32, 8 
   %37 = inttoptr i64 %36 to i64* 
   %38 = getelementptr  i64, i64* %37, i64 0 
-  store  i64 %"$field##0", i64* %38 
+  store  i64 %"#field##0", i64* %38 
   ret i64 %32 
 }
 
@@ -277,12 +277,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"person4.person.person<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"person4.person.person<1>"(i64  %"###0")    {
 entry:
-  %47 = inttoptr i64 %"$##0" to i64* 
+  %47 = inttoptr i64 %"###0" to i64* 
   %48 = getelementptr  i64, i64* %47, i64 0 
   %49 = load  i64, i64* %48 
-  %50 = add   i64 %"$##0", 8 
+  %50 = add   i64 %"###0", 8 
   %51 = inttoptr i64 %50 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
   %53 = load  i64, i64* %52 
@@ -292,31 +292,31 @@ entry:
 }
 
 
-define external fastcc  i1 @"person4.person.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"person4.person.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = tail call ccc  i64  @strcmp(i64  %58, i64  %65)  
-  %"1$tmp$8##0" = icmp eq i64 %"1$tmp$7##0", 0 
-  br i1 %"1$tmp$8##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = tail call ccc  i64  @strcmp(i64  %58, i64  %65)  
+  %"1#tmp#8##0" = icmp eq i64 %"1#tmp#7##0", 0 
+  br i1 %"1#tmp#8##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$9##0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
-  %"2$tmp$0##0" = icmp eq i64 %"2$tmp$9##0", 0 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#9##0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
+  %"2#tmp#0##0" = icmp eq i64 %"2#tmp#9##0", 0 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }

--- a/test-cases/final-dump/person4.exp
+++ b/test-cases/final-dump/person4.exp
@@ -78,7 +78,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: person4.person.=<0>
-=(#left##0:person4.person, #right##0:person4.person, ?####0:wybe.bool):
+=(#left##0:person4.person, #right##0:person4.person, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#firstname##0:wybe.string)
@@ -89,11 +89,11 @@ entry:
     foreign llvm icmp_eq(~tmp#7##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign c strcmp(~#left#lastname##0:wybe.string, ~#right#lastname##0:wybe.string, ?tmp#10##0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp#10##0:wybe.int, 0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~tmp#10##0:wybe.int, 0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -144,7 +144,7 @@ person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person4.p
 
 ~= > public {inline} (0 calls)
 0: person4.person.~=<0>
-~=(#left##0:person4.person, #right##0:person4.person, ?####0:wybe.bool):
+~=(#left##0:person4.person, #right##0:person4.person, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:person4.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.string)
@@ -156,12 +156,12 @@ person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person4.p
     case ~tmp#8##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign c strcmp(~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ?tmp#9##0:wybe.int) @string:nn:nn
         foreign llvm icmp_eq(~tmp#9##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -202,8 +202,8 @@ entry:
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#10##0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
-  %"2#####0" = icmp eq i64 %"2#tmp#10##0", 0 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %"2#tmp#10##0", 0 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -314,9 +314,9 @@ entry:
 if.then:
   %"2#tmp#9##0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
   %"2#tmp#0##0" = icmp eq i64 %"2#tmp#9##0", 0 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }

--- a/test-cases/final-dump/person5.exp
+++ b/test-cases/final-dump/person5.exp
@@ -123,7 +123,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: person5.person.=<0>
-=(#left##0:person5.person, #right##0:person5.person, ?####0:wybe.bool):
+=(#left##0:person5.person, #right##0:person5.person, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#firstname##0:wybe.string)
@@ -134,11 +134,11 @@ entry:
     foreign llvm icmp_eq(~tmp#7##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign c strcmp(~#left#lastname##0:wybe.string, ~#right#lastname##0:wybe.string, ?tmp#10##0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp#10##0:wybe.int, 0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~tmp#10##0:wybe.int, 0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -189,7 +189,7 @@ person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person5.p
 
 ~= > public {inline} (0 calls)
 0: person5.person.~=<0>
-~=(#left##0:person5.person, #right##0:person5.person, ?####0:wybe.bool):
+~=(#left##0:person5.person, #right##0:person5.person, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.string)
@@ -201,12 +201,12 @@ person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person5.p
     case ~tmp#8##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign c strcmp(~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ?tmp#9##0:wybe.int) @string:nn:nn
         foreign llvm icmp_eq(~tmp#9##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -247,8 +247,8 @@ entry:
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#10##0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
-  %"2#####0" = icmp eq i64 %"2#tmp#10##0", 0 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %"2#tmp#10##0", 0 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -359,9 +359,9 @@ entry:
 if.then:
   %"2#tmp#9##0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
   %"2#tmp#0##0" = icmp eq i64 %"2#tmp#9##0", 0 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }

--- a/test-cases/final-dump/person5.exp
+++ b/test-cases/final-dump/person5.exp
@@ -144,10 +144,10 @@ entry:
 
 firstname > public {inline} (0 calls)
 0: person5.person.firstname<0>
-firstname(#rec##0:person5.person, ?###0:wybe.string):
+firstname(#rec##0:person5.person, ?#result##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.string)
+    foreign lpvm access(~#rec##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string)
 firstname > public {inline} (0 calls)
 1: person5.person.firstname<1>
 firstname(#rec##0:person5.person, ?#rec##1:person5.person, #field##0:wybe.string):
@@ -158,10 +158,10 @@ firstname(#rec##0:person5.person, ?#rec##1:person5.person, #field##0:wybe.string
 
 lastname > public {inline} (0 calls)
 0: person5.person.lastname<0>
-lastname(#rec##0:person5.person, ?###0:wybe.string):
+lastname(#rec##0:person5.person, ?#result##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.string)
+    foreign lpvm access(~#rec##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string)
 lastname > public {inline} (0 calls)
 1: person5.person.lastname<1>
 lastname(#rec##0:person5.person, ?#rec##1:person5.person, #field##0:wybe.string):
@@ -172,19 +172,19 @@ lastname(#rec##0:person5.person, ?#rec##1:person5.person, #field##0:wybe.string)
 
 person > public {inline} (0 calls)
 0: person5.person.person<0>
-person(firstname##0:wybe.string, lastname##0:wybe.string, ?###0:person5.person):
+person(firstname##0:wybe.string, lastname##0:wybe.string, ?#result##0:person5.person):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:person5.person)
     foreign lpvm mutate(~#rec##0:person5.person, ?#rec##1:person5.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string)
-    foreign lpvm mutate(~#rec##1:person5.person, ?###0:person5.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string)
+    foreign lpvm mutate(~#rec##1:person5.person, ?#result##0:person5.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string)
 person > public {inline} (6 calls)
 1: person5.person.person<1>
-person(?firstname##0:wybe.string, ?lastname##0:wybe.string, ###0:person5.person):
+person(?firstname##0:wybe.string, ?lastname##0:wybe.string, #result##0:person5.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string)
-    foreign lpvm access(~###0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string)
+    foreign lpvm access(#result##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string)
+    foreign lpvm access(~#result##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string)
 
 
 ~= > public {inline} (0 calls)
@@ -322,12 +322,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"person5.person.person<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"person5.person.person<1>"(i64  %"#result##0")    {
 entry:
-  %47 = inttoptr i64 %"###0" to i64* 
+  %47 = inttoptr i64 %"#result##0" to i64* 
   %48 = getelementptr  i64, i64* %47, i64 0 
   %49 = load  i64, i64* %48 
-  %50 = add   i64 %"###0", 8 
+  %50 = add   i64 %"#result##0", 8 
   %51 = inttoptr i64 %50 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
   %53 = load  i64, i64* %52 

--- a/test-cases/final-dump/person5.exp
+++ b/test-cases/final-dump/person5.exp
@@ -21,20 +21,20 @@ AFTER EVERYTHING:
 
 *main* > public {inline} (0 calls)
 0: person5.<0>
-(io#0:wybe.phantom, ?io#3:wybe.phantom):
+(io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("Amy":wybe.string, ~#io#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string("Bob":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
+    foreign c print_string("Amy":wybe.string, ~#io##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string("Bob":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
 
 
 update_both > {inline} (1 calls)
 0: person5.update_both<0>
-update_both(p1#0:person5.person, ?p1#1:person5.person, p2#0:person5.person, ?p2#1:person5.person, io#0:wybe.phantom, [?io#0:wybe.phantom]):
+update_both(p1##0:person5.person, ?p1##1:person5.person, p2##0:person5.person, ?p2##1:person5.person, io##0:wybe.phantom, [?io##0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~%p1#0:person5.person, ?%p1#1:person5.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, "Amy":wybe.string)
-    foreign lpvm mutate(~%p2#0:person5.person, ?%p2#1:person5.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, "Bob":wybe.string)
+    foreign lpvm mutate(~%p1##0:person5.person, ?%p1##1:person5.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, "Amy":wybe.string)
+    foreign lpvm mutate(~%p2##0:person5.person, ?%p2##1:person5.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, "Bob":wybe.string)
 
   LLVM code       :
 
@@ -75,13 +75,13 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"person5.update_both<0>"(i64  %"p1#0", i64  %"p2#0")    {
+define external fastcc  {i64, i64} @"person5.update_both<0>"(i64  %"p1##0", i64  %"p2##0")    {
 entry:
   %5 = trunc i64 16 to i32  
   %6 = tail call ccc  i8*  @wybe_malloc(i32  %5)  
   %7 = ptrtoint i8* %6 to i64 
   %8 = inttoptr i64 %7 to i8* 
-  %9 = inttoptr i64 %"p1#0" to i8* 
+  %9 = inttoptr i64 %"p1##0" to i8* 
   %10 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %8, i8*  %9, i32  %10, i32  8, i1  0)  
   %11 = inttoptr i64 %7 to i64* 
@@ -92,7 +92,7 @@ entry:
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i8* 
-  %19 = inttoptr i64 %"p2#0" to i8* 
+  %19 = inttoptr i64 %"p2##0" to i8* 
   %20 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %18, i8*  %19, i32  %20, i32  8, i1  0)  
   %21 = inttoptr i64 %17 to i64* 
@@ -123,90 +123,90 @@ entry:
 
 = > public {inline} (1 calls)
 0: person5.person.=<0>
-=($left#0:person5.person, $right#0:person5.person, ?$$#0:wybe.bool):
+=($left##0:person5.person, $right##0:person5.person, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$firstname#0:wybe.string)
-    foreign lpvm access(~$left#0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$lastname#0:wybe.string)
-    foreign lpvm access($right#0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$firstname#0:wybe.string)
-    foreign lpvm access(~$right#0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$lastname#0:wybe.string)
-    foreign c strcmp(~$left$firstname#0:wybe.string, ~$right$firstname#0:wybe.string, ?tmp$7#0:wybe.int) @string:nn:nn
-    foreign llvm icmp_eq(~tmp$7#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$firstname##0:wybe.string)
+    foreign lpvm access(~$left##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$lastname##0:wybe.string)
+    foreign lpvm access($right##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$firstname##0:wybe.string)
+    foreign lpvm access(~$right##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$lastname##0:wybe.string)
+    foreign c strcmp(~$left$firstname##0:wybe.string, ~$right$firstname##0:wybe.string, ?tmp$7##0:wybe.int) @string:nn:nn
+    foreign llvm icmp_eq(~tmp$7##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign c strcmp(~$left$lastname#0:wybe.string, ~$right$lastname#0:wybe.string, ?tmp$10#0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp$10#0:wybe.int, 0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign c strcmp(~$left$lastname##0:wybe.string, ~$right$lastname##0:wybe.string, ?tmp$10##0:wybe.int) @string:nn:nn
+        foreign llvm icmp_eq(~tmp$10##0:wybe.int, 0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 firstname > public {inline} (0 calls)
 0: person5.person.firstname<0>
-firstname($rec#0:person5.person, ?$#0:wybe.string):
+firstname($rec##0:person5.person, ?$##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.string)
+    foreign lpvm access(~$rec##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.string)
 firstname > public {inline} (0 calls)
 1: person5.person.firstname<1>
-firstname($rec#0:person5.person, ?$rec#1:person5.person, $field#0:wybe.string):
+firstname($rec##0:person5.person, ?$rec##1:person5.person, $field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec#0:person5.person, ?$rec#1:person5.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.string)
+    foreign lpvm mutate(~$rec##0:person5.person, ?$rec##1:person5.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.string)
 
 
 lastname > public {inline} (0 calls)
 0: person5.person.lastname<0>
-lastname($rec#0:person5.person, ?$#0:wybe.string):
+lastname($rec##0:person5.person, ?$##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.string)
+    foreign lpvm access(~$rec##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.string)
 lastname > public {inline} (0 calls)
 1: person5.person.lastname<1>
-lastname($rec#0:person5.person, ?$rec#1:person5.person, $field#0:wybe.string):
+lastname($rec##0:person5.person, ?$rec##1:person5.person, $field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec#0:person5.person, ?$rec#1:person5.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.string)
+    foreign lpvm mutate(~$rec##0:person5.person, ?$rec##1:person5.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.string)
 
 
 person > public {inline} (0 calls)
 0: person5.person.person<0>
-person(firstname#0:wybe.string, lastname#0:wybe.string, ?$#0:person5.person):
+person(firstname##0:wybe.string, lastname##0:wybe.string, ?$##0:person5.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:person5.person)
-    foreign lpvm mutate(~$rec#0:person5.person, ?$rec#1:person5.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname#0:wybe.string)
-    foreign lpvm mutate(~$rec#1:person5.person, ?$#0:person5.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname#0:wybe.string)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:person5.person)
+    foreign lpvm mutate(~$rec##0:person5.person, ?$rec##1:person5.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string)
+    foreign lpvm mutate(~$rec##1:person5.person, ?$##0:person5.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string)
 person > public {inline} (6 calls)
 1: person5.person.person<1>
-person(?firstname#0:wybe.string, ?lastname#0:wybe.string, $#0:person5.person):
+person(?firstname##0:wybe.string, ?lastname##0:wybe.string, $##0:person5.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname#0:wybe.string)
-    foreign lpvm access(~$#0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname#0:wybe.string)
+    foreign lpvm access($##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string)
+    foreign lpvm access(~$##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string)
 
 
 ~= > public {inline} (0 calls)
 0: person5.person.~=<0>
-~=($left#0:person5.person, $right#0:person5.person, ?$$#0:wybe.bool):
+~=($left##0:person5.person, $right##0:person5.person, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.string)
-    foreign lpvm access(~$left#0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.string)
-    foreign lpvm access($right#0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.string)
-    foreign lpvm access(~$right#0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.string)
-    foreign c strcmp(~tmp$3#0:wybe.string, ~tmp$5#0:wybe.string, ?tmp$7#0:wybe.int) @string:nn:nn
-    foreign llvm icmp_eq(~tmp$7#0:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.bool) @int:nn:nn
-    case ~tmp$8#0:wybe.bool of
+    foreign lpvm access($left##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.string)
+    foreign lpvm access(~$left##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.string)
+    foreign lpvm access($right##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.string)
+    foreign lpvm access(~$right##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.string)
+    foreign c strcmp(~tmp$3##0:wybe.string, ~tmp$5##0:wybe.string, ?tmp$7##0:wybe.int) @string:nn:nn
+    foreign llvm icmp_eq(~tmp$7##0:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.bool) @int:nn:nn
+    case ~tmp$8##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign c strcmp(~tmp$4#0:wybe.string, ~tmp$6#0:wybe.string, ?tmp$9#0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp$9#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign c strcmp(~tmp$4##0:wybe.string, ~tmp$6##0:wybe.string, ?tmp$9##0:wybe.int) @string:nn:nn
+        foreign llvm icmp_eq(~tmp$9##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -226,62 +226,62 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"person5.person.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"person5.person.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$7#0" = tail call ccc  i64  @strcmp(i64  %3, i64  %10)  
-  %"1$tmp$1#0" = icmp eq i64 %"1$tmp$7#0", 0 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = tail call ccc  i64  @strcmp(i64  %3, i64  %10)  
+  %"1$tmp$1##0" = icmp eq i64 %"1$tmp$7##0", 0 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$10#0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
-  %"2$$$#0" = icmp eq i64 %"2$tmp$10#0", 0 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$10##0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
+  %"2$$$##0" = icmp eq i64 %"2$tmp$10##0", 0 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"person5.person.firstname<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"person5.person.firstname<0>"(i64  %"$rec##0")    {
 entry:
-  %15 = inttoptr i64 %"$rec#0" to i64* 
+  %15 = inttoptr i64 %"$rec##0" to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
   %17 = load  i64, i64* %16 
   ret i64 %17 
 }
 
 
-define external fastcc  i64 @"person5.person.firstname<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"person5.person.firstname<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %18 = trunc i64 16 to i32  
   %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
   %20 = ptrtoint i8* %19 to i64 
   %21 = inttoptr i64 %20 to i8* 
-  %22 = inttoptr i64 %"$rec#0" to i8* 
+  %22 = inttoptr i64 %"$rec##0" to i8* 
   %23 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %21, i8*  %22, i32  %23, i32  8, i1  0)  
   %24 = inttoptr i64 %20 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
-  store  i64 %"$field#0", i64* %25 
+  store  i64 %"$field##0", i64* %25 
   ret i64 %20 
 }
 
 
-define external fastcc  i64 @"person5.person.lastname<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"person5.person.lastname<0>"(i64  %"$rec##0")    {
 entry:
-  %26 = add   i64 %"$rec#0", 8 
+  %26 = add   i64 %"$rec##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -289,45 +289,45 @@ entry:
 }
 
 
-define external fastcc  i64 @"person5.person.lastname<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"person5.person.lastname<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %30 = trunc i64 16 to i32  
   %31 = tail call ccc  i8*  @wybe_malloc(i32  %30)  
   %32 = ptrtoint i8* %31 to i64 
   %33 = inttoptr i64 %32 to i8* 
-  %34 = inttoptr i64 %"$rec#0" to i8* 
+  %34 = inttoptr i64 %"$rec##0" to i8* 
   %35 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %33, i8*  %34, i32  %35, i32  8, i1  0)  
   %36 = add   i64 %32, 8 
   %37 = inttoptr i64 %36 to i64* 
   %38 = getelementptr  i64, i64* %37, i64 0 
-  store  i64 %"$field#0", i64* %38 
+  store  i64 %"$field##0", i64* %38 
   ret i64 %32 
 }
 
 
-define external fastcc  i64 @"person5.person.person<0>"(i64  %"firstname#0", i64  %"lastname#0")    {
+define external fastcc  i64 @"person5.person.person<0>"(i64  %"firstname##0", i64  %"lastname##0")    {
 entry:
   %39 = trunc i64 16 to i32  
   %40 = tail call ccc  i8*  @wybe_malloc(i32  %39)  
   %41 = ptrtoint i8* %40 to i64 
   %42 = inttoptr i64 %41 to i64* 
   %43 = getelementptr  i64, i64* %42, i64 0 
-  store  i64 %"firstname#0", i64* %43 
+  store  i64 %"firstname##0", i64* %43 
   %44 = add   i64 %41, 8 
   %45 = inttoptr i64 %44 to i64* 
   %46 = getelementptr  i64, i64* %45, i64 0 
-  store  i64 %"lastname#0", i64* %46 
+  store  i64 %"lastname##0", i64* %46 
   ret i64 %41 
 }
 
 
-define external fastcc  {i64, i64} @"person5.person.person<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"person5.person.person<1>"(i64  %"$##0")    {
 entry:
-  %47 = inttoptr i64 %"$#0" to i64* 
+  %47 = inttoptr i64 %"$##0" to i64* 
   %48 = getelementptr  i64, i64* %47, i64 0 
   %49 = load  i64, i64* %48 
-  %50 = add   i64 %"$#0", 8 
+  %50 = add   i64 %"$##0", 8 
   %51 = inttoptr i64 %50 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
   %53 = load  i64, i64* %52 
@@ -337,31 +337,31 @@ entry:
 }
 
 
-define external fastcc  i1 @"person5.person.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"person5.person.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = tail call ccc  i64  @strcmp(i64  %58, i64  %65)  
-  %"1$tmp$8#0" = icmp eq i64 %"1$tmp$7#0", 0 
-  br i1 %"1$tmp$8#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = tail call ccc  i64  @strcmp(i64  %58, i64  %65)  
+  %"1$tmp$8##0" = icmp eq i64 %"1$tmp$7##0", 0 
+  br i1 %"1$tmp$8##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$9#0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
-  %"2$tmp$0#0" = icmp eq i64 %"2$tmp$9#0", 0 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$9##0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
+  %"2$tmp$0##0" = icmp eq i64 %"2$tmp$9##0", 0 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }

--- a/test-cases/final-dump/person5.exp
+++ b/test-cases/final-dump/person5.exp
@@ -123,90 +123,90 @@ entry:
 
 = > public {inline} (1 calls)
 0: person5.person.=<0>
-=($left##0:person5.person, $right##0:person5.person, ?$$##0:wybe.bool):
+=(#left##0:person5.person, #right##0:person5.person, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$firstname##0:wybe.string)
-    foreign lpvm access(~$left##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$lastname##0:wybe.string)
-    foreign lpvm access($right##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$firstname##0:wybe.string)
-    foreign lpvm access(~$right##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$lastname##0:wybe.string)
-    foreign c strcmp(~$left$firstname##0:wybe.string, ~$right$firstname##0:wybe.string, ?tmp$7##0:wybe.int) @string:nn:nn
-    foreign llvm icmp_eq(~tmp$7##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#firstname##0:wybe.string)
+    foreign lpvm access(~#left##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#lastname##0:wybe.string)
+    foreign lpvm access(#right##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#firstname##0:wybe.string)
+    foreign lpvm access(~#right##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#lastname##0:wybe.string)
+    foreign c strcmp(~#left#firstname##0:wybe.string, ~#right#firstname##0:wybe.string, ?tmp#7##0:wybe.int) @string:nn:nn
+    foreign llvm icmp_eq(~tmp#7##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign c strcmp(~$left$lastname##0:wybe.string, ~$right$lastname##0:wybe.string, ?tmp$10##0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp$10##0:wybe.int, 0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign c strcmp(~#left#lastname##0:wybe.string, ~#right#lastname##0:wybe.string, ?tmp#10##0:wybe.int) @string:nn:nn
+        foreign llvm icmp_eq(~tmp#10##0:wybe.int, 0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 firstname > public {inline} (0 calls)
 0: person5.person.firstname<0>
-firstname($rec##0:person5.person, ?$##0:wybe.string):
+firstname(#rec##0:person5.person, ?###0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.string)
+    foreign lpvm access(~#rec##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.string)
 firstname > public {inline} (0 calls)
 1: person5.person.firstname<1>
-firstname($rec##0:person5.person, ?$rec##1:person5.person, $field##0:wybe.string):
+firstname(#rec##0:person5.person, ?#rec##1:person5.person, #field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec##0:person5.person, ?$rec##1:person5.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.string)
+    foreign lpvm mutate(~#rec##0:person5.person, ?#rec##1:person5.person, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string)
 
 
 lastname > public {inline} (0 calls)
 0: person5.person.lastname<0>
-lastname($rec##0:person5.person, ?$##0:wybe.string):
+lastname(#rec##0:person5.person, ?###0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.string)
+    foreign lpvm access(~#rec##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.string)
 lastname > public {inline} (0 calls)
 1: person5.person.lastname<1>
-lastname($rec##0:person5.person, ?$rec##1:person5.person, $field##0:wybe.string):
+lastname(#rec##0:person5.person, ?#rec##1:person5.person, #field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec##0:person5.person, ?$rec##1:person5.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.string)
+    foreign lpvm mutate(~#rec##0:person5.person, ?#rec##1:person5.person, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string)
 
 
 person > public {inline} (0 calls)
 0: person5.person.person<0>
-person(firstname##0:wybe.string, lastname##0:wybe.string, ?$##0:person5.person):
+person(firstname##0:wybe.string, lastname##0:wybe.string, ?###0:person5.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:person5.person)
-    foreign lpvm mutate(~$rec##0:person5.person, ?$rec##1:person5.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string)
-    foreign lpvm mutate(~$rec##1:person5.person, ?$##0:person5.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:person5.person)
+    foreign lpvm mutate(~#rec##0:person5.person, ?#rec##1:person5.person, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~firstname##0:wybe.string)
+    foreign lpvm mutate(~#rec##1:person5.person, ?###0:person5.person, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~lastname##0:wybe.string)
 person > public {inline} (6 calls)
 1: person5.person.person<1>
-person(?firstname##0:wybe.string, ?lastname##0:wybe.string, $##0:person5.person):
+person(?firstname##0:wybe.string, ?lastname##0:wybe.string, ###0:person5.person):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string)
-    foreign lpvm access(~$##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string)
+    foreign lpvm access(###0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?firstname##0:wybe.string)
+    foreign lpvm access(~###0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?lastname##0:wybe.string)
 
 
 ~= > public {inline} (0 calls)
 0: person5.person.~=<0>
-~=($left##0:person5.person, $right##0:person5.person, ?$$##0:wybe.bool):
+~=(#left##0:person5.person, #right##0:person5.person, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.string)
-    foreign lpvm access(~$left##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.string)
-    foreign lpvm access($right##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.string)
-    foreign lpvm access(~$right##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.string)
-    foreign c strcmp(~tmp$3##0:wybe.string, ~tmp$5##0:wybe.string, ?tmp$7##0:wybe.int) @string:nn:nn
-    foreign llvm icmp_eq(~tmp$7##0:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.bool) @int:nn:nn
-    case ~tmp$8##0:wybe.bool of
+    foreign lpvm access(#left##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.string)
+    foreign lpvm access(~#left##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.string)
+    foreign lpvm access(#right##0:person5.person, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.string)
+    foreign lpvm access(~#right##0:person5.person, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.string)
+    foreign c strcmp(~tmp#3##0:wybe.string, ~tmp#5##0:wybe.string, ?tmp#7##0:wybe.int) @string:nn:nn
+    foreign llvm icmp_eq(~tmp#7##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool) @int:nn:nn
+    case ~tmp#8##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign c strcmp(~tmp$4##0:wybe.string, ~tmp$6##0:wybe.string, ?tmp$9##0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp$9##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign c strcmp(~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ?tmp#9##0:wybe.int) @string:nn:nn
+        foreign llvm icmp_eq(~tmp#9##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -226,62 +226,62 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"person5.person.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"person5.person.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$7##0" = tail call ccc  i64  @strcmp(i64  %3, i64  %10)  
-  %"1$tmp$1##0" = icmp eq i64 %"1$tmp$7##0", 0 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = tail call ccc  i64  @strcmp(i64  %3, i64  %10)  
+  %"1#tmp#1##0" = icmp eq i64 %"1#tmp#7##0", 0 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$10##0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
-  %"2$$$##0" = icmp eq i64 %"2$tmp$10##0", 0 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#10##0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
+  %"2#####0" = icmp eq i64 %"2#tmp#10##0", 0 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"person5.person.firstname<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"person5.person.firstname<0>"(i64  %"#rec##0")    {
 entry:
-  %15 = inttoptr i64 %"$rec##0" to i64* 
+  %15 = inttoptr i64 %"#rec##0" to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
   %17 = load  i64, i64* %16 
   ret i64 %17 
 }
 
 
-define external fastcc  i64 @"person5.person.firstname<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"person5.person.firstname<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %18 = trunc i64 16 to i32  
   %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
   %20 = ptrtoint i8* %19 to i64 
   %21 = inttoptr i64 %20 to i8* 
-  %22 = inttoptr i64 %"$rec##0" to i8* 
+  %22 = inttoptr i64 %"#rec##0" to i8* 
   %23 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %21, i8*  %22, i32  %23, i32  8, i1  0)  
   %24 = inttoptr i64 %20 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
-  store  i64 %"$field##0", i64* %25 
+  store  i64 %"#field##0", i64* %25 
   ret i64 %20 
 }
 
 
-define external fastcc  i64 @"person5.person.lastname<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"person5.person.lastname<0>"(i64  %"#rec##0")    {
 entry:
-  %26 = add   i64 %"$rec##0", 8 
+  %26 = add   i64 %"#rec##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -289,19 +289,19 @@ entry:
 }
 
 
-define external fastcc  i64 @"person5.person.lastname<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"person5.person.lastname<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %30 = trunc i64 16 to i32  
   %31 = tail call ccc  i8*  @wybe_malloc(i32  %30)  
   %32 = ptrtoint i8* %31 to i64 
   %33 = inttoptr i64 %32 to i8* 
-  %34 = inttoptr i64 %"$rec##0" to i8* 
+  %34 = inttoptr i64 %"#rec##0" to i8* 
   %35 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %33, i8*  %34, i32  %35, i32  8, i1  0)  
   %36 = add   i64 %32, 8 
   %37 = inttoptr i64 %36 to i64* 
   %38 = getelementptr  i64, i64* %37, i64 0 
-  store  i64 %"$field##0", i64* %38 
+  store  i64 %"#field##0", i64* %38 
   ret i64 %32 
 }
 
@@ -322,12 +322,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"person5.person.person<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"person5.person.person<1>"(i64  %"###0")    {
 entry:
-  %47 = inttoptr i64 %"$##0" to i64* 
+  %47 = inttoptr i64 %"###0" to i64* 
   %48 = getelementptr  i64, i64* %47, i64 0 
   %49 = load  i64, i64* %48 
-  %50 = add   i64 %"$##0", 8 
+  %50 = add   i64 %"###0", 8 
   %51 = inttoptr i64 %50 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
   %53 = load  i64, i64* %52 
@@ -337,31 +337,31 @@ entry:
 }
 
 
-define external fastcc  i1 @"person5.person.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"person5.person.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = tail call ccc  i64  @strcmp(i64  %58, i64  %65)  
-  %"1$tmp$8##0" = icmp eq i64 %"1$tmp$7##0", 0 
-  br i1 %"1$tmp$8##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = tail call ccc  i64  @strcmp(i64  %58, i64  %65)  
+  %"1#tmp#8##0" = icmp eq i64 %"1#tmp#7##0", 0 
+  br i1 %"1#tmp#8##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$9##0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
-  %"2$tmp$0##0" = icmp eq i64 %"2$tmp$9##0", 0 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#9##0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
+  %"2#tmp#0##0" = icmp eq i64 %"2#tmp#9##0", 0 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }

--- a/test-cases/final-dump/position.exp
+++ b/test-cases/final-dump/position.exp
@@ -25,13 +25,13 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -105,86 +105,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
-    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
-    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec##0:position.position, ?$##0:wybe.int):
+x(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec##0:position.position, ?$##0:wybe.int):
+y(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -201,27 +201,27 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$##0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$##0" 
+  %"2#####0" = icmp eq i64 %7, %14 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
@@ -243,12 +243,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
 entry:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -258,34 +258,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec##0" to i64* 
+  %32 = inttoptr i64 %"#rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec##0" to i8* 
+  %39 = inttoptr i64 %"#rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field##0", i64* %42 
+  store  i64 %"#field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = add   i64 %"$rec##0", 8 
+  %43 = add   i64 %"#rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -293,46 +293,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec##0" to i8* 
+  %51 = inttoptr i64 %"#rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field##0", i64* %55 
+  store  i64 %"#field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %58, %65 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = icmp eq i64 %62, %69 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#0##0" = icmp eq i64 %62, %69 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }

--- a/test-cases/final-dump/position.exp
+++ b/test-cases/final-dump/position.exp
@@ -105,7 +105,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
@@ -115,10 +115,10 @@ entry:
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -169,7 +169,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -180,11 +180,11 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -220,8 +220,8 @@ entry:
   %"1#tmp#1##0" = icmp eq i64 %3, %10 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2#####0" = icmp eq i64 %7, %14 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %7, %14 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -330,9 +330,9 @@ entry:
   br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#0##0" = icmp eq i64 %62, %69 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }

--- a/test-cases/final-dump/position.exp
+++ b/test-cases/final-dump/position.exp
@@ -124,27 +124,27 @@ entry:
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x(#rec##0:position.position, ?###0:wybe.int):
+x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -155,10 +155,10 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y(#rec##0:position.position, ?###0:wybe.int):
+y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -243,12 +243,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 

--- a/test-cases/final-dump/position.exp
+++ b/test-cases/final-dump/position.exp
@@ -21,17 +21,17 @@ AFTER EVERYTHING:
 
 printPosition > public (0 calls)
 0: position.printPosition<0>
-printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string(",":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io#4:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -65,17 +65,17 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"position.printPosition<0>"(i64  %"pos#0")    {
+define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
-  %3 = inttoptr i64 %"pos#0" to i64* 
+  %3 = inttoptr i64 %"pos##0" to i64* 
   %4 = getelementptr  i64, i64* %3, i64 0 
   %5 = load  i64, i64* %4 
   tail call ccc  void  @print_int(i64  %5)  
   %7 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.6, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %7)  
-  %8 = add   i64 %"pos#0", 8 
+  %8 = add   i64 %"pos##0", 8 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
@@ -105,86 +105,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y#0:wybe.int)
-    foreign llvm icmp_eq(~$left$x#0:wybe.int, ~$right$x#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
+    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y#0:wybe.int, ~$right$y#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
-    foreign lpvm mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:position.position, ?$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
+    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
-    foreign lpvm access(~$#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y#0:wybe.int)
+    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec#0:position.position, ?$#0:wybe.int):
+x($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec#0:position.position, ?$#0:wybe.int):
+y($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -201,54 +201,54 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$#0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = icmp eq i64 %7, %14 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"x#0", i64* %19 
+  store  i64 %"x##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"y#0", i64* %22 
+  store  i64 %"y##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
 entry:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -258,34 +258,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec#0" to i64* 
+  %32 = inttoptr i64 %"$rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec#0" to i8* 
+  %39 = inttoptr i64 %"$rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field#0", i64* %42 
+  store  i64 %"$field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = add   i64 %"$rec#0", 8 
+  %43 = add   i64 %"$rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -293,46 +293,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec#0" to i8* 
+  %51 = inttoptr i64 %"$rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field#0", i64* %55 
+  store  i64 %"$field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %58, %65 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = icmp eq i64 %62, %69 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$0##0" = icmp eq i64 %62, %69 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }

--- a/test-cases/final-dump/position1.exp
+++ b/test-cases/final-dump/position1.exp
@@ -21,17 +21,17 @@ AFTER EVERYTHING:
 
 printPosition > public (0 calls)
 0: position.printPosition<0>
-printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string(",":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io#4:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -65,17 +65,17 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"position.printPosition<0>"(i64  %"pos#0")    {
+define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
-  %3 = inttoptr i64 %"pos#0" to i64* 
+  %3 = inttoptr i64 %"pos##0" to i64* 
   %4 = getelementptr  i64, i64* %3, i64 0 
   %5 = load  i64, i64* %4 
   tail call ccc  void  @print_int(i64  %5)  
   %7 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.6, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %7)  
-  %8 = add   i64 %"pos#0", 8 
+  %8 = add   i64 %"pos##0", 8 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
@@ -105,86 +105,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y#0:wybe.int)
-    foreign llvm icmp_eq(~$left$x#0:wybe.int, ~$right$x#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
+    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y#0:wybe.int, ~$right$y#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
-    foreign lpvm mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:position.position, ?$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
+    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
-    foreign lpvm access(~$#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y#0:wybe.int)
+    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec#0:position.position, ?$#0:wybe.int):
+x($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec#0:position.position, ?$#0:wybe.int):
+y($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -201,54 +201,54 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$#0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = icmp eq i64 %7, %14 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"x#0", i64* %19 
+  store  i64 %"x##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"y#0", i64* %22 
+  store  i64 %"y##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
 entry:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -258,34 +258,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec#0" to i64* 
+  %32 = inttoptr i64 %"$rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec#0" to i8* 
+  %39 = inttoptr i64 %"$rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field#0", i64* %42 
+  store  i64 %"$field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = add   i64 %"$rec#0", 8 
+  %43 = add   i64 %"$rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -293,48 +293,48 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec#0" to i8* 
+  %51 = inttoptr i64 %"$rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field#0", i64* %55 
+  store  i64 %"$field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %58, %65 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = icmp eq i64 %62, %69 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$0##0" = icmp eq i64 %62, %69 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }
 --------------------------------------------------
  Module position1
@@ -349,15 +349,15 @@ if.else:
 
 *main* > public (0 calls)
 0: position1.<0>
-(io#0:wybe.phantom, ?io#2:wybe.phantom):
+(io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$4#0:position.position)
-    foreign lpvm mutate(~tmp$4#0:position.position, ?tmp$5#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 111:wybe.int)
-    foreign lpvm mutate(~tmp$5#0:position.position, ?tmp$0#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 222:wybe.int)
-    foreign lpvm {noalias} mutate(~tmp$0#0:position.position, ?%posA#1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 112:wybe.int)
-    foreign c print_string("expect posA(111,112):":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~posA#1:position.position, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #4 @position1:8:2
+    foreign lpvm alloc(16:wybe.int, ?tmp$4##0:position.position)
+    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 111:wybe.int)
+    foreign lpvm mutate(~tmp$5##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 222:wybe.int)
+    foreign lpvm {noalias} mutate(~tmp$0##0:position.position, ?%posA##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 112:wybe.int)
+    foreign c print_string("expect posA(111,112):":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~posA##1:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @position1:8:2
 
   LLVM code       :
 

--- a/test-cases/final-dump/position1.exp
+++ b/test-cases/final-dump/position1.exp
@@ -105,7 +105,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
@@ -115,10 +115,10 @@ entry:
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -169,7 +169,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -180,11 +180,11 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -220,8 +220,8 @@ entry:
   %"1#tmp#1##0" = icmp eq i64 %3, %10 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2#####0" = icmp eq i64 %7, %14 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %7, %14 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -330,11 +330,11 @@ entry:
   br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#0##0" = icmp eq i64 %62, %69 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }
 --------------------------------------------------
  Module position1

--- a/test-cases/final-dump/position1.exp
+++ b/test-cases/final-dump/position1.exp
@@ -25,13 +25,13 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -105,86 +105,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
-    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
-    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec##0:position.position, ?$##0:wybe.int):
+x(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec##0:position.position, ?$##0:wybe.int):
+y(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -201,27 +201,27 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$##0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$##0" 
+  %"2#####0" = icmp eq i64 %7, %14 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
@@ -243,12 +243,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
 entry:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -258,34 +258,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec##0" to i64* 
+  %32 = inttoptr i64 %"#rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec##0" to i8* 
+  %39 = inttoptr i64 %"#rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field##0", i64* %42 
+  store  i64 %"#field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = add   i64 %"$rec##0", 8 
+  %43 = add   i64 %"#rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -293,48 +293,48 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec##0" to i8* 
+  %51 = inttoptr i64 %"#rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field##0", i64* %55 
+  store  i64 %"#field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %58, %65 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = icmp eq i64 %62, %69 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#0##0" = icmp eq i64 %62, %69 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }
 --------------------------------------------------
  Module position1
@@ -352,10 +352,10 @@ if.else:
 (io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$4##0:position.position)
-    foreign lpvm mutate(~tmp$4##0:position.position, ?tmp$5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 111:wybe.int)
-    foreign lpvm mutate(~tmp$5##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 222:wybe.int)
-    foreign lpvm {noalias} mutate(~tmp$0##0:position.position, ?%posA##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 112:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:position.position)
+    foreign lpvm mutate(~tmp#4##0:position.position, ?tmp#5##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 111:wybe.int)
+    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 222:wybe.int)
+    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%posA##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 112:wybe.int)
     foreign c print_string("expect posA(111,112):":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     position.printPosition<0>(~posA##1:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @position1:8:2
 

--- a/test-cases/final-dump/position1.exp
+++ b/test-cases/final-dump/position1.exp
@@ -124,27 +124,27 @@ entry:
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x(#rec##0:position.position, ?###0:wybe.int):
+x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -155,10 +155,10 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y(#rec##0:position.position, ?###0:wybe.int):
+y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -243,12 +243,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 

--- a/test-cases/final-dump/position2.exp
+++ b/test-cases/final-dump/position2.exp
@@ -105,7 +105,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
@@ -115,10 +115,10 @@ entry:
     foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -169,7 +169,7 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -180,11 +180,11 @@ y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -220,8 +220,8 @@ entry:
   %"1#tmp#1##0" = icmp eq i64 %3, %10 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2#####0" = icmp eq i64 %7, %14 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %7, %14 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -330,11 +330,11 @@ entry:
   br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#0##0" = icmp eq i64 %62, %69 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }
 --------------------------------------------------
  Module position2

--- a/test-cases/final-dump/position2.exp
+++ b/test-cases/final-dump/position2.exp
@@ -25,13 +25,13 @@ printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom)
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
-    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.int)
+    foreign c print_int(~tmp#1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -105,86 +105,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
-    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.int)
+    foreign llvm icmp_eq(~#left#x##0:wybe.int, ~#right#x##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~#left#y##0:wybe.int, ~#right#y##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
-    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
+    foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec##0:position.position, ?$##0:wybe.int):
+x(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec##0:position.position, ?$##0:wybe.int):
+y(#rec##0:position.position, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
+y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:position.position, ?#rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
+~=(#left##0:position.position, #right##0:position.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(#right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -201,27 +201,27 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$##0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$##0" 
+  %"2#####0" = icmp eq i64 %7, %14 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
@@ -243,12 +243,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
 entry:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -258,34 +258,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"#rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec##0" to i64* 
+  %32 = inttoptr i64 %"#rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec##0" to i8* 
+  %39 = inttoptr i64 %"#rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field##0", i64* %42 
+  store  i64 %"#field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = add   i64 %"$rec##0", 8 
+  %43 = add   i64 %"#rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -293,48 +293,48 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec##0" to i8* 
+  %51 = inttoptr i64 %"#rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field##0", i64* %55 
+  store  i64 %"#field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %58, %65 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = icmp eq i64 %62, %69 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#0##0" = icmp eq i64 %62, %69 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }
 --------------------------------------------------
  Module position2
@@ -352,19 +352,19 @@ if.else:
 (io##0:wybe.phantom, ?io##6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$5##0:position.position)
-    foreign lpvm mutate(~tmp$5##0:position.position, ?tmp$6##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 111:wybe.int)
-    foreign lpvm mutate(~tmp$6##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 222:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$10##0:position.position)
-    foreign lpvm mutate(~tmp$10##0:position.position, ?tmp$11##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 333:wybe.int)
-    foreign lpvm mutate(~tmp$11##0:position.position, ?tmp$1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 222:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:position.position)
+    foreign lpvm mutate(~tmp#5##0:position.position, ?tmp#6##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 111:wybe.int)
+    foreign lpvm mutate(~tmp#6##0:position.position, ?tmp#0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 222:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#10##0:position.position)
+    foreign lpvm mutate(~tmp#10##0:position.position, ?tmp#11##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 333:wybe.int)
+    foreign lpvm mutate(~tmp#11##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 222:wybe.int)
     foreign c print_string("expect posA(111,222):":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(tmp$0##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @position2:7:2
-    foreign lpvm {noalias} mutate(~tmp$0##0:position.position, ?%posA##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 20000:wybe.int)
+    position.printPosition<0>(tmp#0##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @position2:7:2
+    foreign lpvm {noalias} mutate(~tmp#0##0:position.position, ?%posA##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 20000:wybe.int)
     foreign c print_string("expect posA(111,20000):":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
     position.printPosition<0>(~posA##1:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #7 @position2:11:2
     foreign c print_string("expect posB(333,222):":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~tmp$1##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #9 @position2:13:2
+    position.printPosition<0>(~tmp#1##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #9 @position2:13:2
 
   LLVM code       :
 

--- a/test-cases/final-dump/position2.exp
+++ b/test-cases/final-dump/position2.exp
@@ -124,27 +124,27 @@ entry:
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x##0:wybe.int, y##0:wybe.int, ?###0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?#result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position.position)
     foreign lpvm mutate(~#rec##0:position.position, ?#rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:position.position, ?###0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:position.position, ?#result##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x##0:wybe.int, ?y##0:wybe.int, ###0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, #result##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
-    foreign lpvm access(~###0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
+    foreign lpvm access(#result##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~#result##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x(#rec##0:position.position, ?###0:wybe.int):
+x(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
 x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -155,10 +155,10 @@ x(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y(#rec##0:position.position, ?###0:wybe.int):
+y(#rec##0:position.position, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
 y(#rec##0:position.position, ?#rec##1:position.position, #field##0:wybe.int):
@@ -243,12 +243,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"#result##0")    {
 entry:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 

--- a/test-cases/final-dump/position2.exp
+++ b/test-cases/final-dump/position2.exp
@@ -21,17 +21,17 @@ AFTER EVERYTHING:
 
 printPosition > public (0 calls)
 0: position.printPosition<0>
-printPosition(pos#0:position.position, io#0:wybe.phantom, ?io#5:wybe.phantom):
+printPosition(pos##0:position.position, io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(" (":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(pos#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_string(",":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~pos#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.int)
-    foreign c print_int(~tmp$1#0:wybe.int, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_string(")":wybe.string, ~#io#4:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(pos##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(",":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~pos##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.int)
+    foreign c print_int(~tmp$1##0:wybe.int, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string(")":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -65,17 +65,17 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"position.printPosition<0>"(i64  %"pos#0")    {
+define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
-  %3 = inttoptr i64 %"pos#0" to i64* 
+  %3 = inttoptr i64 %"pos##0" to i64* 
   %4 = getelementptr  i64, i64* %3, i64 0 
   %5 = load  i64, i64* %4 
   tail call ccc  void  @print_int(i64  %5)  
   %7 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @position.6, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %7)  
-  %8 = add   i64 %"pos#0", 8 
+  %8 = add   i64 %"pos##0", 8 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
@@ -105,86 +105,86 @@ entry:
 
 = > public {inline} (1 calls)
 0: position.position.=<0>
-=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y#0:wybe.int)
-    foreign llvm icmp_eq(~$left$x#0:wybe.int, ~$right$x#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.int)
+    foreign llvm icmp_eq(~$left$x##0:wybe.int, ~$right$x##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$y#0:wybe.int, ~$right$y#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~$left$y##0:wybe.int, ~$right$y##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position.position.position<0>
-position(x#0:wybe.int, y#0:wybe.int, ?$#0:position.position):
+position(x##0:wybe.int, y##0:wybe.int, ?$##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:position.position)
-    foreign lpvm mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:position.position, ?$#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:position.position)
+    foreign lpvm mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:position.position, ?$##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.int)
 position > public {inline} (6 calls)
 1: position.position.position<1>
-position(?x#0:wybe.int, ?y#0:wybe.int, $#0:position.position):
+position(?x##0:wybe.int, ?y##0:wybe.int, $##0:position.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.int)
-    foreign lpvm access(~$#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y#0:wybe.int)
+    foreign lpvm access($##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.int)
+    foreign lpvm access(~$##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.int)
 
 
 x > public {inline} (0 calls)
 0: position.position.x<0>
-x($rec#0:position.position, ?$#0:wybe.int):
+x($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 x > public {inline} (0 calls)
 1: position.position.x<1>
-x($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+x($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 y > public {inline} (0 calls)
 0: position.position.y<0>
-y($rec#0:position.position, ?$#0:wybe.int):
+y($rec##0:position.position, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 y > public {inline} (0 calls)
 1: position.position.y<1>
-y($rec#0:position.position, ?$rec#1:position.position, $field#0:wybe.int):
+y($rec##0:position.position, ?$rec##1:position.position, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position.position, ?$rec#1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:position.position, ?$rec##1:position.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: position.position.~=<0>
-~=($left#0:position.position, $right#0:position.position, ?$$#0:wybe.bool):
+~=($left##0:position.position, $right##0:position.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access($right#0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access($right##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:position.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -201,54 +201,54 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position.position.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$#0" = icmp eq i64 %7, %14 
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = icmp eq i64 %7, %14 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"position.position.position<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"position.position.position<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"x#0", i64* %19 
+  store  i64 %"x##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"y#0", i64* %22 
+  store  i64 %"y##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"position.position.position<1>"(i64  %"$##0")    {
 entry:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -258,34 +258,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.x<0>"(i64  %"$rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec#0" to i64* 
+  %32 = inttoptr i64 %"$rec##0" to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.x<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec#0" to i8* 
+  %39 = inttoptr i64 %"$rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 %"$field#0", i64* %42 
+  store  i64 %"$field##0", i64* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"position.position.y<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = add   i64 %"$rec#0", 8 
+  %43 = add   i64 %"$rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -293,48 +293,48 @@ entry:
 }
 
 
-define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"position.position.y<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec#0" to i8* 
+  %51 = inttoptr i64 %"$rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field#0", i64* %55 
+  store  i64 %"$field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %58, %65 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = icmp eq i64 %62, %69 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$0##0" = icmp eq i64 %62, %69 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }
 --------------------------------------------------
  Module position2
@@ -349,22 +349,22 @@ if.else:
 
 *main* > public (0 calls)
 0: position2.<0>
-(io#0:wybe.phantom, ?io#6:wybe.phantom):
+(io##0:wybe.phantom, ?io##6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$5#0:position.position)
-    foreign lpvm mutate(~tmp$5#0:position.position, ?tmp$6#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 111:wybe.int)
-    foreign lpvm mutate(~tmp$6#0:position.position, ?tmp$0#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 222:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp$10#0:position.position)
-    foreign lpvm mutate(~tmp$10#0:position.position, ?tmp$11#0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 333:wybe.int)
-    foreign lpvm mutate(~tmp$11#0:position.position, ?tmp$1#0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 222:wybe.int)
-    foreign c print_string("expect posA(111,222):":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(tmp$0#0:position.position, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #4 @position2:7:2
-    foreign lpvm {noalias} mutate(~tmp$0#0:position.position, ?%posA#1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 20000:wybe.int)
-    foreign c print_string("expect posA(111,20000):":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~posA#1:position.position, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #7 @position2:11:2
-    foreign c print_string("expect posB(333,222):":wybe.string, ~#io#4:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-    position.printPosition<0>(~tmp$1#0:position.position, ~#io#5:wybe.phantom, ?#io#6:wybe.phantom) #9 @position2:13:2
+    foreign lpvm alloc(16:wybe.int, ?tmp$5##0:position.position)
+    foreign lpvm mutate(~tmp$5##0:position.position, ?tmp$6##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 111:wybe.int)
+    foreign lpvm mutate(~tmp$6##0:position.position, ?tmp$0##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 222:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp$10##0:position.position)
+    foreign lpvm mutate(~tmp$10##0:position.position, ?tmp$11##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 333:wybe.int)
+    foreign lpvm mutate(~tmp$11##0:position.position, ?tmp$1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 222:wybe.int)
+    foreign c print_string("expect posA(111,222):":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(tmp$0##0:position.position, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #4 @position2:7:2
+    foreign lpvm {noalias} mutate(~tmp$0##0:position.position, ?%posA##1:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 20000:wybe.int)
+    foreign c print_string("expect posA(111,20000):":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~posA##1:position.position, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #7 @position2:11:2
+    foreign c print_string("expect posB(333,222):":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    position.printPosition<0>(~tmp$1##0:position.position, ~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #9 @position2:13:2
 
   LLVM code       :
 

--- a/test-cases/final-dump/position_float.exp
+++ b/test-cases/final-dump/position_float.exp
@@ -51,86 +51,86 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 = > public {inline} (1 calls)
 0: position_float.position.=<0>
-=($left##0:position_float.position, $right##0:position_float.position, ?$$##0:wybe.bool):
+=(#left##0:position_float.position, #right##0:position_float.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.float)
-    foreign lpvm access(~$left##0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.float)
-    foreign lpvm access($right##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.float)
-    foreign lpvm access(~$right##0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.float)
-    foreign llvm fcmp_eq(~$left$x##0:wybe.float, ~$right$x##0:wybe.float, ?tmp$1##0:wybe.bool) @float:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.float)
+    foreign lpvm access(~#left##0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#y##0:wybe.float)
+    foreign lpvm access(#right##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#x##0:wybe.float)
+    foreign lpvm access(~#right##0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#y##0:wybe.float)
+    foreign llvm fcmp_eq(~#left#x##0:wybe.float, ~#right#x##0:wybe.float, ?tmp#1##0:wybe.bool) @float:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm fcmp_eq(~$left$y##0:wybe.float, ~$right$y##0:wybe.float, ?$$##0:wybe.bool) @float:nn:nn
+        foreign llvm fcmp_eq(~#left#y##0:wybe.float, ~#right#y##0:wybe.float, ?####0:wybe.bool) @float:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position_float.position.position<0>
-position(x##0:wybe.float, y##0:wybe.float, ?$##0:position_float.position):
+position(x##0:wybe.float, y##0:wybe.float, ?###0:position_float.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:position_float.position)
-    foreign lpvm mutate(~$rec##0:position_float.position, ?$rec##1:position_float.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.float)
-    foreign lpvm mutate(~$rec##1:position_float.position, ?$##0:position_float.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.float)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:position_float.position)
+    foreign lpvm mutate(~#rec##0:position_float.position, ?#rec##1:position_float.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.float)
+    foreign lpvm mutate(~#rec##1:position_float.position, ?###0:position_float.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.float)
 position > public {inline} (6 calls)
 1: position_float.position.position<1>
-position(?x##0:wybe.float, ?y##0:wybe.float, $##0:position_float.position):
+position(?x##0:wybe.float, ?y##0:wybe.float, ###0:position_float.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.float)
-    foreign lpvm access(~$##0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.float)
+    foreign lpvm access(###0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.float)
+    foreign lpvm access(~###0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.float)
 
 
 x > public {inline} (0 calls)
 0: position_float.position.x<0>
-x($rec##0:position_float.position, ?$##0:wybe.float):
+x(#rec##0:position_float.position, ?###0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.float)
+    foreign lpvm access(~#rec##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.float)
 x > public {inline} (0 calls)
 1: position_float.position.x<1>
-x($rec##0:position_float.position, ?$rec##1:position_float.position, $field##0:wybe.float):
+x(#rec##0:position_float.position, ?#rec##1:position_float.position, #field##0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position_float.position, ?$rec##1:position_float.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.float)
+    foreign lpvm {noalias} mutate(~#rec##0:position_float.position, ?#rec##1:position_float.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.float)
 
 
 y > public {inline} (0 calls)
 0: position_float.position.y<0>
-y($rec##0:position_float.position, ?$##0:wybe.float):
+y(#rec##0:position_float.position, ?###0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.float)
+    foreign lpvm access(~#rec##0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.float)
 y > public {inline} (0 calls)
 1: position_float.position.y<1>
-y($rec##0:position_float.position, ?$rec##1:position_float.position, $field##0:wybe.float):
+y(#rec##0:position_float.position, ?#rec##1:position_float.position, #field##0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:position_float.position, ?$rec##1:position_float.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.float)
+    foreign lpvm {noalias} mutate(~#rec##0:position_float.position, ?#rec##1:position_float.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.float)
 
 
 ~= > public {inline} (0 calls)
 0: position_float.position.~=<0>
-~=($left##0:position_float.position, $right##0:position_float.position, ?$$##0:wybe.bool):
+~=(#left##0:position_float.position, #right##0:position_float.position, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.float)
-    foreign lpvm access(~$left##0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.float)
-    foreign lpvm access($right##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.float)
-    foreign lpvm access(~$right##0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.float)
-    foreign llvm fcmp_eq(~tmp$3##0:wybe.float, ~tmp$5##0:wybe.float, ?tmp$7##0:wybe.bool) @float:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.float)
+    foreign lpvm access(~#left##0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.float)
+    foreign lpvm access(#right##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.float)
+    foreign lpvm access(~#right##0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.float)
+    foreign llvm fcmp_eq(~tmp#3##0:wybe.float, ~tmp#5##0:wybe.float, ?tmp#7##0:wybe.bool) @float:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm fcmp_eq(~tmp$4##0:wybe.float, ~tmp$6##0:wybe.float, ?tmp$0##0:wybe.bool) @float:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm fcmp_eq(~tmp#4##0:wybe.float, ~tmp#6##0:wybe.float, ?tmp#0##0:wybe.bool) @float:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -147,27 +147,27 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position_float.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position_float.position.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to double* 
+  %1 = inttoptr i64 %"#left##0" to double* 
   %2 = getelementptr  double, double* %1, i64 0 
   %3 = load  double, double* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to double* 
   %6 = getelementptr  double, double* %5, i64 0 
   %7 = load  double, double* %6 
-  %8 = inttoptr i64 %"$right##0" to double* 
+  %8 = inttoptr i64 %"#right##0" to double* 
   %9 = getelementptr  double, double* %8, i64 0 
   %10 = load  double, double* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to double* 
   %13 = getelementptr  double, double* %12, i64 0 
   %14 = load  double, double* %13 
-  %"1$tmp$1##0" = fcmp oeq double %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = fcmp oeq double %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$##0" = fcmp oeq double %7, %14 
-  ret i1 %"2$$$##0" 
+  %"2#####0" = fcmp oeq double %7, %14 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
@@ -189,12 +189,12 @@ entry:
 }
 
 
-define external fastcc  {double, double} @"position_float.position.position<1>"(i64  %"$##0")    {
+define external fastcc  {double, double} @"position_float.position.position<1>"(i64  %"###0")    {
 entry:
-  %23 = inttoptr i64 %"$##0" to double* 
+  %23 = inttoptr i64 %"###0" to double* 
   %24 = getelementptr  double, double* %23, i64 0 
   %25 = load  double, double* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to double* 
   %28 = getelementptr  double, double* %27, i64 0 
   %29 = load  double, double* %28 
@@ -204,34 +204,34 @@ entry:
 }
 
 
-define external fastcc  double @"position_float.position.x<0>"(i64  %"$rec##0")    {
+define external fastcc  double @"position_float.position.x<0>"(i64  %"#rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec##0" to double* 
+  %32 = inttoptr i64 %"#rec##0" to double* 
   %33 = getelementptr  double, double* %32, i64 0 
   %34 = load  double, double* %33 
   ret double %34 
 }
 
 
-define external fastcc  i64 @"position_float.position.x<1>"(i64  %"$rec##0", double  %"$field##0")    {
+define external fastcc  i64 @"position_float.position.x<1>"(i64  %"#rec##0", double  %"#field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec##0" to i8* 
+  %39 = inttoptr i64 %"#rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to double* 
   %42 = getelementptr  double, double* %41, i64 0 
-  store  double %"$field##0", double* %42 
+  store  double %"#field##0", double* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  double @"position_float.position.y<0>"(i64  %"$rec##0")    {
+define external fastcc  double @"position_float.position.y<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = add   i64 %"$rec##0", 8 
+  %43 = add   i64 %"#rec##0", 8 
   %44 = inttoptr i64 %43 to double* 
   %45 = getelementptr  double, double* %44, i64 0 
   %46 = load  double, double* %45 
@@ -239,46 +239,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position_float.position.y<1>"(i64  %"$rec##0", double  %"$field##0")    {
+define external fastcc  i64 @"position_float.position.y<1>"(i64  %"#rec##0", double  %"#field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec##0" to i8* 
+  %51 = inttoptr i64 %"#rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to double* 
   %55 = getelementptr  double, double* %54, i64 0 
-  store  double %"$field##0", double* %55 
+  store  double %"#field##0", double* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position_float.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"position_float.position.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to double* 
+  %56 = inttoptr i64 %"#left##0" to double* 
   %57 = getelementptr  double, double* %56, i64 0 
   %58 = load  double, double* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to double* 
   %61 = getelementptr  double, double* %60, i64 0 
   %62 = load  double, double* %61 
-  %63 = inttoptr i64 %"$right##0" to double* 
+  %63 = inttoptr i64 %"#right##0" to double* 
   %64 = getelementptr  double, double* %63, i64 0 
   %65 = load  double, double* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to double* 
   %68 = getelementptr  double, double* %67, i64 0 
   %69 = load  double, double* %68 
-  %"1$tmp$7##0" = fcmp oeq double %58, %65 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = fcmp oeq double %58, %65 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = fcmp oeq double %62, %69 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#0##0" = fcmp oeq double %62, %69 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }

--- a/test-cases/final-dump/position_float.exp
+++ b/test-cases/final-dump/position_float.exp
@@ -51,86 +51,86 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 = > public {inline} (1 calls)
 0: position_float.position.=<0>
-=($left#0:position_float.position, $right#0:position_float.position, ?$$#0:wybe.bool):
+=($left##0:position_float.position, $right##0:position_float.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x#0:wybe.float)
-    foreign lpvm access(~$left#0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y#0:wybe.float)
-    foreign lpvm access($right#0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x#0:wybe.float)
-    foreign lpvm access(~$right#0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y#0:wybe.float)
-    foreign llvm fcmp_eq(~$left$x#0:wybe.float, ~$right$x#0:wybe.float, ?tmp$1#0:wybe.bool) @float:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$x##0:wybe.float)
+    foreign lpvm access(~$left##0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$y##0:wybe.float)
+    foreign lpvm access($right##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$x##0:wybe.float)
+    foreign lpvm access(~$right##0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$y##0:wybe.float)
+    foreign llvm fcmp_eq(~$left$x##0:wybe.float, ~$right$x##0:wybe.float, ?tmp$1##0:wybe.bool) @float:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm fcmp_eq(~$left$y#0:wybe.float, ~$right$y#0:wybe.float, ?$$#0:wybe.bool) @float:nn:nn
+        foreign llvm fcmp_eq(~$left$y##0:wybe.float, ~$right$y##0:wybe.float, ?$$##0:wybe.bool) @float:nn:nn
 
 
 
 position > public {inline} (0 calls)
 0: position_float.position.position<0>
-position(x#0:wybe.float, y#0:wybe.float, ?$#0:position_float.position):
+position(x##0:wybe.float, y##0:wybe.float, ?$##0:position_float.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:position_float.position)
-    foreign lpvm mutate(~$rec#0:position_float.position, ?$rec#1:position_float.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:wybe.float)
-    foreign lpvm mutate(~$rec#1:position_float.position, ?$#0:position_float.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y#0:wybe.float)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:position_float.position)
+    foreign lpvm mutate(~$rec##0:position_float.position, ?$rec##1:position_float.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.float)
+    foreign lpvm mutate(~$rec##1:position_float.position, ?$##0:position_float.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.float)
 position > public {inline} (6 calls)
 1: position_float.position.position<1>
-position(?x#0:wybe.float, ?y#0:wybe.float, $#0:position_float.position):
+position(?x##0:wybe.float, ?y##0:wybe.float, $##0:position_float.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x#0:wybe.float)
-    foreign lpvm access(~$#0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y#0:wybe.float)
+    foreign lpvm access($##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.float)
+    foreign lpvm access(~$##0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.float)
 
 
 x > public {inline} (0 calls)
 0: position_float.position.x<0>
-x($rec#0:position_float.position, ?$#0:wybe.float):
+x($rec##0:position_float.position, ?$##0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.float)
+    foreign lpvm access(~$rec##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.float)
 x > public {inline} (0 calls)
 1: position_float.position.x<1>
-x($rec#0:position_float.position, ?$rec#1:position_float.position, $field#0:wybe.float):
+x($rec##0:position_float.position, ?$rec##1:position_float.position, $field##0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position_float.position, ?$rec#1:position_float.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.float)
+    foreign lpvm {noalias} mutate(~$rec##0:position_float.position, ?$rec##1:position_float.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.float)
 
 
 y > public {inline} (0 calls)
 0: position_float.position.y<0>
-y($rec#0:position_float.position, ?$#0:wybe.float):
+y($rec##0:position_float.position, ?$##0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.float)
+    foreign lpvm access(~$rec##0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.float)
 y > public {inline} (0 calls)
 1: position_float.position.y<1>
-y($rec#0:position_float.position, ?$rec#1:position_float.position, $field#0:wybe.float):
+y($rec##0:position_float.position, ?$rec##1:position_float.position, $field##0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:position_float.position, ?$rec#1:position_float.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.float)
+    foreign lpvm {noalias} mutate(~$rec##0:position_float.position, ?$rec##1:position_float.position, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.float)
 
 
 ~= > public {inline} (0 calls)
 0: position_float.position.~=<0>
-~=($left#0:position_float.position, $right#0:position_float.position, ?$$#0:wybe.bool):
+~=($left##0:position_float.position, $right##0:position_float.position, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.float)
-    foreign lpvm access(~$left#0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.float)
-    foreign lpvm access($right#0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.float)
-    foreign lpvm access(~$right#0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.float)
-    foreign llvm fcmp_eq(~tmp$3#0:wybe.float, ~tmp$5#0:wybe.float, ?tmp$7#0:wybe.bool) @float:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.float)
+    foreign lpvm access(~$left##0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.float)
+    foreign lpvm access($right##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.float)
+    foreign lpvm access(~$right##0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.float)
+    foreign llvm fcmp_eq(~tmp$3##0:wybe.float, ~tmp$5##0:wybe.float, ?tmp$7##0:wybe.bool) @float:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm fcmp_eq(~tmp$4#0:wybe.float, ~tmp$6#0:wybe.float, ?tmp$0#0:wybe.bool) @float:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm fcmp_eq(~tmp$4##0:wybe.float, ~tmp$6##0:wybe.float, ?tmp$0##0:wybe.bool) @float:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -147,54 +147,54 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"position_float.position.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position_float.position.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to double* 
+  %1 = inttoptr i64 %"$left##0" to double* 
   %2 = getelementptr  double, double* %1, i64 0 
   %3 = load  double, double* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to double* 
   %6 = getelementptr  double, double* %5, i64 0 
   %7 = load  double, double* %6 
-  %8 = inttoptr i64 %"$right#0" to double* 
+  %8 = inttoptr i64 %"$right##0" to double* 
   %9 = getelementptr  double, double* %8, i64 0 
   %10 = load  double, double* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to double* 
   %13 = getelementptr  double, double* %12, i64 0 
   %14 = load  double, double* %13 
-  %"1$tmp$1#0" = fcmp oeq double %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = fcmp oeq double %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$$$#0" = fcmp oeq double %7, %14 
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = fcmp oeq double %7, %14 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"position_float.position.position<0>"(double  %"x#0", double  %"y#0")    {
+define external fastcc  i64 @"position_float.position.position<0>"(double  %"x##0", double  %"y##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to double* 
   %19 = getelementptr  double, double* %18, i64 0 
-  store  double %"x#0", double* %19 
+  store  double %"x##0", double* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to double* 
   %22 = getelementptr  double, double* %21, i64 0 
-  store  double %"y#0", double* %22 
+  store  double %"y##0", double* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {double, double} @"position_float.position.position<1>"(i64  %"$#0")    {
+define external fastcc  {double, double} @"position_float.position.position<1>"(i64  %"$##0")    {
 entry:
-  %23 = inttoptr i64 %"$#0" to double* 
+  %23 = inttoptr i64 %"$##0" to double* 
   %24 = getelementptr  double, double* %23, i64 0 
   %25 = load  double, double* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to double* 
   %28 = getelementptr  double, double* %27, i64 0 
   %29 = load  double, double* %28 
@@ -204,34 +204,34 @@ entry:
 }
 
 
-define external fastcc  double @"position_float.position.x<0>"(i64  %"$rec#0")    {
+define external fastcc  double @"position_float.position.x<0>"(i64  %"$rec##0")    {
 entry:
-  %32 = inttoptr i64 %"$rec#0" to double* 
+  %32 = inttoptr i64 %"$rec##0" to double* 
   %33 = getelementptr  double, double* %32, i64 0 
   %34 = load  double, double* %33 
   ret double %34 
 }
 
 
-define external fastcc  i64 @"position_float.position.x<1>"(i64  %"$rec#0", double  %"$field#0")    {
+define external fastcc  i64 @"position_float.position.x<1>"(i64  %"$rec##0", double  %"$field##0")    {
 entry:
   %35 = trunc i64 16 to i32  
   %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
   %37 = ptrtoint i8* %36 to i64 
   %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"$rec#0" to i8* 
+  %39 = inttoptr i64 %"$rec##0" to i8* 
   %40 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
   %41 = inttoptr i64 %37 to double* 
   %42 = getelementptr  double, double* %41, i64 0 
-  store  double %"$field#0", double* %42 
+  store  double %"$field##0", double* %42 
   ret i64 %37 
 }
 
 
-define external fastcc  double @"position_float.position.y<0>"(i64  %"$rec#0")    {
+define external fastcc  double @"position_float.position.y<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = add   i64 %"$rec#0", 8 
+  %43 = add   i64 %"$rec##0", 8 
   %44 = inttoptr i64 %43 to double* 
   %45 = getelementptr  double, double* %44, i64 0 
   %46 = load  double, double* %45 
@@ -239,46 +239,46 @@ entry:
 }
 
 
-define external fastcc  i64 @"position_float.position.y<1>"(i64  %"$rec#0", double  %"$field#0")    {
+define external fastcc  i64 @"position_float.position.y<1>"(i64  %"$rec##0", double  %"$field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec#0" to i8* 
+  %51 = inttoptr i64 %"$rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to double* 
   %55 = getelementptr  double, double* %54, i64 0 
-  store  double %"$field#0", double* %55 
+  store  double %"$field##0", double* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"position_float.position.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"position_float.position.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to double* 
+  %56 = inttoptr i64 %"$left##0" to double* 
   %57 = getelementptr  double, double* %56, i64 0 
   %58 = load  double, double* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to double* 
   %61 = getelementptr  double, double* %60, i64 0 
   %62 = load  double, double* %61 
-  %63 = inttoptr i64 %"$right#0" to double* 
+  %63 = inttoptr i64 %"$right##0" to double* 
   %64 = getelementptr  double, double* %63, i64 0 
   %65 = load  double, double* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to double* 
   %68 = getelementptr  double, double* %67, i64 0 
   %69 = load  double, double* %68 
-  %"1$tmp$7#0" = fcmp oeq double %58, %65 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = fcmp oeq double %58, %65 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = fcmp oeq double %62, %69 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$0##0" = fcmp oeq double %62, %69 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }

--- a/test-cases/final-dump/position_float.exp
+++ b/test-cases/final-dump/position_float.exp
@@ -70,27 +70,27 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 position > public {inline} (0 calls)
 0: position_float.position.position<0>
-position(x##0:wybe.float, y##0:wybe.float, ?###0:position_float.position):
+position(x##0:wybe.float, y##0:wybe.float, ?#result##0:position_float.position):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:position_float.position)
     foreign lpvm mutate(~#rec##0:position_float.position, ?#rec##1:position_float.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:wybe.float)
-    foreign lpvm mutate(~#rec##1:position_float.position, ?###0:position_float.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.float)
+    foreign lpvm mutate(~#rec##1:position_float.position, ?#result##0:position_float.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~y##0:wybe.float)
 position > public {inline} (6 calls)
 1: position_float.position.position<1>
-position(?x##0:wybe.float, ?y##0:wybe.float, ###0:position_float.position):
+position(?x##0:wybe.float, ?y##0:wybe.float, #result##0:position_float.position):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.float)
-    foreign lpvm access(~###0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.float)
+    foreign lpvm access(#result##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?x##0:wybe.float)
+    foreign lpvm access(~#result##0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:wybe.float)
 
 
 x > public {inline} (0 calls)
 0: position_float.position.x<0>
-x(#rec##0:position_float.position, ?###0:wybe.float):
+x(#rec##0:position_float.position, ?#result##0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.float)
+    foreign lpvm access(~#rec##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.float)
 x > public {inline} (0 calls)
 1: position_float.position.x<1>
 x(#rec##0:position_float.position, ?#rec##1:position_float.position, #field##0:wybe.float):
@@ -101,10 +101,10 @@ x(#rec##0:position_float.position, ?#rec##1:position_float.position, #field##0:w
 
 y > public {inline} (0 calls)
 0: position_float.position.y<0>
-y(#rec##0:position_float.position, ?###0:wybe.float):
+y(#rec##0:position_float.position, ?#result##0:wybe.float):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.float)
+    foreign lpvm access(~#rec##0:position_float.position, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.float)
 y > public {inline} (0 calls)
 1: position_float.position.y<1>
 y(#rec##0:position_float.position, ?#rec##1:position_float.position, #field##0:wybe.float):
@@ -189,12 +189,12 @@ entry:
 }
 
 
-define external fastcc  {double, double} @"position_float.position.position<1>"(i64  %"###0")    {
+define external fastcc  {double, double} @"position_float.position.position<1>"(i64  %"#result##0")    {
 entry:
-  %23 = inttoptr i64 %"###0" to double* 
+  %23 = inttoptr i64 %"#result##0" to double* 
   %24 = getelementptr  double, double* %23, i64 0 
   %25 = load  double, double* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to double* 
   %28 = getelementptr  double, double* %27, i64 0 
   %29 = load  double, double* %28 

--- a/test-cases/final-dump/position_float.exp
+++ b/test-cases/final-dump/position_float.exp
@@ -51,7 +51,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 = > public {inline} (1 calls)
 0: position_float.position.=<0>
-=(#left##0:position_float.position, #right##0:position_float.position, ?####0:wybe.bool):
+=(#left##0:position_float.position, #right##0:position_float.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#x##0:wybe.float)
@@ -61,10 +61,10 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
     foreign llvm fcmp_eq(~#left#x##0:wybe.float, ~#right#x##0:wybe.float, ?tmp#1##0:wybe.bool) @float:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign llvm fcmp_eq(~#left#y##0:wybe.float, ~#right#y##0:wybe.float, ?####0:wybe.bool) @float:nn:nn
+        foreign llvm fcmp_eq(~#left#y##0:wybe.float, ~#right#y##0:wybe.float, ?#success##0:wybe.bool) @float:nn:nn
 
 
 
@@ -115,7 +115,7 @@ y(#rec##0:position_float.position, ?#rec##1:position_float.position, #field##0:w
 
 ~= > public {inline} (0 calls)
 0: position_float.position.~=<0>
-~=(#left##0:position_float.position, #right##0:position_float.position, ?####0:wybe.bool):
+~=(#left##0:position_float.position, #right##0:position_float.position, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:position_float.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.float)
@@ -126,11 +126,11 @@ y(#rec##0:position_float.position, ?#rec##1:position_float.position, #field##0:w
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm fcmp_eq(~tmp#4##0:wybe.float, ~tmp#6##0:wybe.float, ?tmp#0##0:wybe.bool) @float:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -166,8 +166,8 @@ entry:
   %"1#tmp#1##0" = fcmp oeq double %3, %10 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2#####0" = fcmp oeq double %7, %14 
-  ret i1 %"2#####0" 
+  %"2##success##0" = fcmp oeq double %7, %14 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -276,9 +276,9 @@ entry:
   br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#0##0" = fcmp oeq double %62, %69 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }

--- a/test-cases/final-dump/proc_allin.exp
+++ b/test-cases/final-dump/proc_allin.exp
@@ -11,7 +11,7 @@ AFTER EVERYTHING:
 
 nada > public {inline} (0 calls)
 0: proc_allin.nada<0>
-nada([x#0:wybe.int], [y#0:wybe.int]):
+nada([x##0:wybe.int], [y##0:wybe.int]):
  AliasPairs: []
  InterestingCallProperties: []
 

--- a/test-cases/final-dump/proc_beer.exp
+++ b/test-cases/final-dump/proc_beer.exp
@@ -12,49 +12,49 @@ AFTER EVERYTHING:
 
 *main* > public {inline} (0 calls)
 0: proc_beer.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    proc_beer.gen$1<0>(99:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #1 @proc_beer:nn:nn
+    proc_beer.gen$1<0>(99:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @proc_beer:nn:nn
 
 
 beer99 > public {inline} (1 calls)
 0: proc_beer.beer99<0>
-beer99(io#0:wybe.phantom, ?io#1:wybe.phantom):
+beer99(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    proc_beer.gen$1<0>(99:wybe.int, ~io#0:wybe.phantom, ?io#1:wybe.phantom) #0 @proc_beer:nn:nn
+    proc_beer.gen$1<0>(99:wybe.int, ~io##0:wybe.phantom, ?io##1:wybe.phantom) #0 @proc_beer:nn:nn
 
 
 gen$1 > (2 calls)
 0: proc_beer.gen$1<0>
-gen$1(count#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+gen$1(count##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_sge(count#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_sge(count##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign c print_int(count#0:wybe.int, ~io#0:wybe.phantom, ?tmp$5#0:wybe.phantom) @io:nn:nn
-        foreign c print_string(" bottles of beer on the wall":wybe.string, ~tmp$5#0:wybe.phantom, ?tmp$6#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$6#0:wybe.phantom, ?tmp$7#0:wybe.phantom) @io:nn:nn
-        foreign llvm sub(~count#0:wybe.int, 1:wybe.int, ?tmp$8#0:wybe.int) @int:nn:nn
-        proc_beer.gen$1<0>(~tmp$8#0:wybe.int, ~tmp$7#0:wybe.phantom, ?io#1:wybe.phantom) #2 @proc_beer:nn:nn
+        foreign c print_int(count##0:wybe.int, ~io##0:wybe.phantom, ?tmp$5##0:wybe.phantom) @io:nn:nn
+        foreign c print_string(" bottles of beer on the wall":wybe.string, ~tmp$5##0:wybe.phantom, ?tmp$6##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$6##0:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
+        foreign llvm sub(~count##0:wybe.int, 1:wybe.int, ?tmp$8##0:wybe.int) @int:nn:nn
+        proc_beer.gen$1<0>(~tmp$8##0:wybe.int, ~tmp$7##0:wybe.phantom, ?io##1:wybe.phantom) #2 @proc_beer:nn:nn
 
 
 
 gen$2 > {inline} (1 calls)
 0: proc_beer.gen$2<0>
-gen$2(count#0:wybe.int, io#0:wybe.phantom, ?io#3:wybe.phantom):
+gen$2(count##0:wybe.int, io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(count#0:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_string(" bottles of beer on the wall":wybe.string, ~#io#1:wybe.phantom, ?tmp$4#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$4#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign llvm sub(~%count#0:wybe.int, 1:wybe.int, ?%count#1:wybe.int) @int:nn:nn
-    proc_beer.gen$1<0>(~count#1:wybe.int, ~io#2:wybe.phantom, ?io#3:wybe.phantom) #3 @proc_beer:nn:nn
+    foreign c print_int(count##0:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string(" bottles of beer on the wall":wybe.string, ~#io##1:wybe.phantom, ?tmp$4##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$4##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign llvm sub(~%count##0:wybe.int, 1:wybe.int, ?%count##1:wybe.int) @int:nn:nn
+    proc_beer.gen$1<0>(~count##1:wybe.int, ~io##2:wybe.phantom, ?io##3:wybe.phantom) #3 @proc_beer:nn:nn
 
   LLVM code       :
 
@@ -99,30 +99,30 @@ entry:
 }
 
 
-define external fastcc  void @"proc_beer.gen$1<0>"(i64  %"count#0")    {
+define external fastcc  void @"proc_beer.gen$1<0>"(i64  %"count##0")    {
 entry:
-  %"1$tmp$0#0" = icmp sge i64 %"count#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp sge i64 %"count##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  tail call ccc  void  @print_int(i64  %"count#0")  
+  tail call ccc  void  @print_int(i64  %"count##0")  
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @proc_beer.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
   tail call ccc  void  @putchar(i8  10)  
-  %"2$tmp$8#0" = sub   i64 %"count#0", 1 
-  tail call fastcc  void  @"proc_beer.gen$1<0>"(i64  %"2$tmp$8#0")  
+  %"2$tmp$8##0" = sub   i64 %"count##0", 1 
+  tail call fastcc  void  @"proc_beer.gen$1<0>"(i64  %"2$tmp$8##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"proc_beer.gen$2<0>"(i64  %"count#0")    {
+define external fastcc  void @"proc_beer.gen$2<0>"(i64  %"count##0")    {
 entry:
-  tail call ccc  void  @print_int(i64  %"count#0")  
+  tail call ccc  void  @print_int(i64  %"count##0")  
   %4 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @proc_beer.3, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %4)  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$count#1" = sub   i64 %"count#0", 1 
-  tail call fastcc  void  @"proc_beer.gen$1<0>"(i64  %"1$count#1")  
+  %"1$count##1" = sub   i64 %"count##0", 1 
+  tail call fastcc  void  @"proc_beer.gen$1<0>"(i64  %"1$count##1")  
   ret void 
 }

--- a/test-cases/final-dump/proc_beer.exp
+++ b/test-cases/final-dump/proc_beer.exp
@@ -15,7 +15,7 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    proc_beer.gen$1<0>(99:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @proc_beer:nn:nn
+    proc_beer.gen#1<0>(99:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #1 @proc_beer:nn:nn
 
 
 beer99 > public {inline} (1 calls)
@@ -23,38 +23,38 @@ beer99 > public {inline} (1 calls)
 beer99(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    proc_beer.gen$1<0>(99:wybe.int, ~io##0:wybe.phantom, ?io##1:wybe.phantom) #0 @proc_beer:nn:nn
+    proc_beer.gen#1<0>(99:wybe.int, ~io##0:wybe.phantom, ?io##1:wybe.phantom) #0 @proc_beer:nn:nn
 
 
-gen$1 > (2 calls)
-0: proc_beer.gen$1<0>
-gen$1(count##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
+gen#1 > (2 calls)
+0: proc_beer.gen#1<0>
+gen#1(count##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_sge(count##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_sge(count##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+    case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign c print_int(count##0:wybe.int, ~io##0:wybe.phantom, ?tmp$5##0:wybe.phantom) @io:nn:nn
-        foreign c print_string(" bottles of beer on the wall":wybe.string, ~tmp$5##0:wybe.phantom, ?tmp$6##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$6##0:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
-        foreign llvm sub(~count##0:wybe.int, 1:wybe.int, ?tmp$8##0:wybe.int) @int:nn:nn
-        proc_beer.gen$1<0>(~tmp$8##0:wybe.int, ~tmp$7##0:wybe.phantom, ?io##1:wybe.phantom) #2 @proc_beer:nn:nn
+        foreign c print_int(count##0:wybe.int, ~io##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
+        foreign c print_string(" bottles of beer on the wall":wybe.string, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
+        foreign llvm sub(~count##0:wybe.int, 1:wybe.int, ?tmp#8##0:wybe.int) @int:nn:nn
+        proc_beer.gen#1<0>(~tmp#8##0:wybe.int, ~tmp#7##0:wybe.phantom, ?io##1:wybe.phantom) #2 @proc_beer:nn:nn
 
 
 
-gen$2 > {inline} (1 calls)
-0: proc_beer.gen$2<0>
-gen$2(count##0:wybe.int, io##0:wybe.phantom, ?io##3:wybe.phantom):
+gen#2 > {inline} (1 calls)
+0: proc_beer.gen#2<0>
+gen#2(count##0:wybe.int, io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_int(count##0:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign c print_string(" bottles of beer on the wall":wybe.string, ~#io##1:wybe.phantom, ?tmp$4##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$4##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(" bottles of beer on the wall":wybe.string, ~#io##1:wybe.phantom, ?tmp#4##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#4##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign llvm sub(~%count##0:wybe.int, 1:wybe.int, ?%count##1:wybe.int) @int:nn:nn
-    proc_beer.gen$1<0>(~count##1:wybe.int, ~io##2:wybe.phantom, ?io##3:wybe.phantom) #3 @proc_beer:nn:nn
+    proc_beer.gen#1<0>(~count##1:wybe.int, ~io##2:wybe.phantom, ?io##3:wybe.phantom) #3 @proc_beer:nn:nn
 
   LLVM code       :
 
@@ -87,42 +87,42 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"proc_beer.<0>"()    {
 entry:
-  tail call fastcc  void  @"proc_beer.gen$1<0>"(i64  99)  
+  tail call fastcc  void  @"proc_beer.gen#1<0>"(i64  99)  
   ret void 
 }
 
 
 define external fastcc  void @"proc_beer.beer99<0>"()    {
 entry:
-  tail call fastcc  void  @"proc_beer.gen$1<0>"(i64  99)  
+  tail call fastcc  void  @"proc_beer.gen#1<0>"(i64  99)  
   ret void 
 }
 
 
-define external fastcc  void @"proc_beer.gen$1<0>"(i64  %"count##0")    {
+define external fastcc  void @"proc_beer.gen#1<0>"(i64  %"count##0")    {
 entry:
-  %"1$tmp$0##0" = icmp sge i64 %"count##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp sge i64 %"count##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   tail call ccc  void  @print_int(i64  %"count##0")  
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @proc_beer.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
   tail call ccc  void  @putchar(i8  10)  
-  %"2$tmp$8##0" = sub   i64 %"count##0", 1 
-  tail call fastcc  void  @"proc_beer.gen$1<0>"(i64  %"2$tmp$8##0")  
+  %"2#tmp#8##0" = sub   i64 %"count##0", 1 
+  tail call fastcc  void  @"proc_beer.gen#1<0>"(i64  %"2#tmp#8##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"proc_beer.gen$2<0>"(i64  %"count##0")    {
+define external fastcc  void @"proc_beer.gen#2<0>"(i64  %"count##0")    {
 entry:
   tail call ccc  void  @print_int(i64  %"count##0")  
   %4 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @proc_beer.3, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %4)  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$count##1" = sub   i64 %"count##0", 1 
-  tail call fastcc  void  @"proc_beer.gen$1<0>"(i64  %"1$count##1")  
+  %"1#count##1" = sub   i64 %"count##0", 1 
+  tail call fastcc  void  @"proc_beer.gen#1<0>"(i64  %"1#count##1")  
   ret void 
 }

--- a/test-cases/final-dump/proc_factorial.exp
+++ b/test-cases/final-dump/proc_factorial.exp
@@ -12,47 +12,47 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: proc_factorial.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    proc_factorial.gen$1<0>(5:wybe.int, 1:wybe.int, ?tmp$0#0:wybe.int) #2 @proc_factorial:nn:nn
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$4#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$4#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    proc_factorial.gen$1<0>(5:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.int) #2 @proc_factorial:nn:nn
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$4##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$4##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 factorial > public {inline} (1 calls)
 0: proc_factorial.factorial<0>
-factorial(n#0:wybe.int, ?result#1:wybe.int):
+factorial(n##0:wybe.int, ?result##1:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    proc_factorial.gen$1<0>(~n#0:wybe.int, 1:wybe.int, ?result#1:wybe.int) #0 @proc_factorial:nn:nn
+    proc_factorial.gen$1<0>(~n##0:wybe.int, 1:wybe.int, ?result##1:wybe.int) #0 @proc_factorial:nn:nn
 
 
 gen$1 > (2 calls)
 0: proc_factorial.gen$1<0>
-gen$1(n#0:wybe.int, result#0:wybe.int, ?result#1:wybe.int):
+gen$1(n##0:wybe.int, result##0:wybe.int, ?result##1:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_sgt(n#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.bool) @int:nn:nn
-    case ~tmp$2#0:wybe.bool of
+    foreign llvm icmp_sgt(n##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.bool) @int:nn:nn
+    case ~tmp$2##0:wybe.bool of
     0:
-        foreign llvm move(~result#0:wybe.int, ?result#1:wybe.int)
+        foreign llvm move(~result##0:wybe.int, ?result##1:wybe.int)
 
     1:
-        foreign llvm mul(n#0:wybe.int, ~result#0:wybe.int, ?tmp$7#0:wybe.int) @int:nn:nn
-        foreign llvm sub(~n#0:wybe.int, 1:wybe.int, ?tmp$8#0:wybe.int) @int:nn:nn
-        proc_factorial.gen$1<0>(~tmp$8#0:wybe.int, ~tmp$7#0:wybe.int, ?result#1:wybe.int) #2 @proc_factorial:nn:nn
+        foreign llvm mul(n##0:wybe.int, ~result##0:wybe.int, ?tmp$7##0:wybe.int) @int:nn:nn
+        foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$8##0:wybe.int) @int:nn:nn
+        proc_factorial.gen$1<0>(~tmp$8##0:wybe.int, ~tmp$7##0:wybe.int, ?result##1:wybe.int) #2 @proc_factorial:nn:nn
 
 
 
 gen$2 > {inline} (1 calls)
 0: proc_factorial.gen$2<0>
-gen$2(n#0:wybe.int, result#0:wybe.int, ?result#2:wybe.int):
+gen$2(n##0:wybe.int, result##0:wybe.int, ?result##2:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm mul(n#0:wybe.int, ~result#0:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn
-    foreign llvm sub(~n#0:wybe.int, 1:wybe.int, ?tmp$1#0:wybe.int) @int:nn:nn
-    proc_factorial.gen$1<0>(~tmp$1#0:wybe.int, ~tmp$0#0:wybe.int, ?result#2:wybe.int) #2 @proc_factorial:nn:nn
+    foreign llvm mul(n##0:wybe.int, ~result##0:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
+    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.int) @int:nn:nn
+    proc_factorial.gen$1<0>(~tmp$1##0:wybe.int, ~tmp$0##0:wybe.int, ?result##2:wybe.int) #2 @proc_factorial:nn:nn
 
   LLVM code       :
 
@@ -76,38 +76,38 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"proc_factorial.<0>"()    {
 entry:
-  %"1$tmp$0#0" = tail call fastcc  i64  @"proc_factorial.gen$1<0>"(i64  5, i64  1)  
-  tail call ccc  void  @print_int(i64  %"1$tmp$0#0")  
+  %"1$tmp$0##0" = tail call fastcc  i64  @"proc_factorial.gen$1<0>"(i64  5, i64  1)  
+  tail call ccc  void  @print_int(i64  %"1$tmp$0##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  i64 @"proc_factorial.factorial<0>"(i64  %"n#0")    {
+define external fastcc  i64 @"proc_factorial.factorial<0>"(i64  %"n##0")    {
 entry:
-  %"1$result#1" = tail call fastcc  i64  @"proc_factorial.gen$1<0>"(i64  %"n#0", i64  1)  
-  ret i64 %"1$result#1" 
+  %"1$result##1" = tail call fastcc  i64  @"proc_factorial.gen$1<0>"(i64  %"n##0", i64  1)  
+  ret i64 %"1$result##1" 
 }
 
 
-define external fastcc  i64 @"proc_factorial.gen$1<0>"(i64  %"n#0", i64  %"result#0")    {
+define external fastcc  i64 @"proc_factorial.gen$1<0>"(i64  %"n##0", i64  %"result##0")    {
 entry:
-  %"1$tmp$2#0" = icmp sgt i64 %"n#0", 1 
-  br i1 %"1$tmp$2#0", label %if.then, label %if.else 
+  %"1$tmp$2##0" = icmp sgt i64 %"n##0", 1 
+  br i1 %"1$tmp$2##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$7#0" = mul   i64 %"n#0", %"result#0" 
-  %"2$tmp$8#0" = sub   i64 %"n#0", 1 
-  %"2$result#1" = tail call fastcc  i64  @"proc_factorial.gen$1<0>"(i64  %"2$tmp$8#0", i64  %"2$tmp$7#0")  
-  ret i64 %"2$result#1" 
+  %"2$tmp$7##0" = mul   i64 %"n##0", %"result##0" 
+  %"2$tmp$8##0" = sub   i64 %"n##0", 1 
+  %"2$result##1" = tail call fastcc  i64  @"proc_factorial.gen$1<0>"(i64  %"2$tmp$8##0", i64  %"2$tmp$7##0")  
+  ret i64 %"2$result##1" 
 if.else:
-  ret i64 %"result#0" 
+  ret i64 %"result##0" 
 }
 
 
-define external fastcc  i64 @"proc_factorial.gen$2<0>"(i64  %"n#0", i64  %"result#0")    {
+define external fastcc  i64 @"proc_factorial.gen$2<0>"(i64  %"n##0", i64  %"result##0")    {
 entry:
-  %"1$tmp$0#0" = mul   i64 %"n#0", %"result#0" 
-  %"1$tmp$1#0" = sub   i64 %"n#0", 1 
-  %"1$result#2" = tail call fastcc  i64  @"proc_factorial.gen$1<0>"(i64  %"1$tmp$1#0", i64  %"1$tmp$0#0")  
-  ret i64 %"1$result#2" 
+  %"1$tmp$0##0" = mul   i64 %"n##0", %"result##0" 
+  %"1$tmp$1##0" = sub   i64 %"n##0", 1 
+  %"1$result##2" = tail call fastcc  i64  @"proc_factorial.gen$1<0>"(i64  %"1$tmp$1##0", i64  %"1$tmp$0##0")  
+  ret i64 %"1$result##2" 
 }

--- a/test-cases/final-dump/proc_factorial.exp
+++ b/test-cases/final-dump/proc_factorial.exp
@@ -15,9 +15,9 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    proc_factorial.gen$1<0>(5:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.int) #2 @proc_factorial:nn:nn
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$4##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$4##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    proc_factorial.gen#1<0>(5:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.int) #2 @proc_factorial:nn:nn
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#4##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#4##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 factorial > public {inline} (1 calls)
@@ -25,34 +25,34 @@ factorial > public {inline} (1 calls)
 factorial(n##0:wybe.int, ?result##1:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    proc_factorial.gen$1<0>(~n##0:wybe.int, 1:wybe.int, ?result##1:wybe.int) #0 @proc_factorial:nn:nn
+    proc_factorial.gen#1<0>(~n##0:wybe.int, 1:wybe.int, ?result##1:wybe.int) #0 @proc_factorial:nn:nn
 
 
-gen$1 > (2 calls)
-0: proc_factorial.gen$1<0>
-gen$1(n##0:wybe.int, result##0:wybe.int, ?result##1:wybe.int):
+gen#1 > (2 calls)
+0: proc_factorial.gen#1<0>
+gen#1(n##0:wybe.int, result##0:wybe.int, ?result##1:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_sgt(n##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.bool) @int:nn:nn
-    case ~tmp$2##0:wybe.bool of
+    foreign llvm icmp_sgt(n##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.bool) @int:nn:nn
+    case ~tmp#2##0:wybe.bool of
     0:
         foreign llvm move(~result##0:wybe.int, ?result##1:wybe.int)
 
     1:
-        foreign llvm mul(n##0:wybe.int, ~result##0:wybe.int, ?tmp$7##0:wybe.int) @int:nn:nn
-        foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$8##0:wybe.int) @int:nn:nn
-        proc_factorial.gen$1<0>(~tmp$8##0:wybe.int, ~tmp$7##0:wybe.int, ?result##1:wybe.int) #2 @proc_factorial:nn:nn
+        foreign llvm mul(n##0:wybe.int, ~result##0:wybe.int, ?tmp#7##0:wybe.int) @int:nn:nn
+        foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp#8##0:wybe.int) @int:nn:nn
+        proc_factorial.gen#1<0>(~tmp#8##0:wybe.int, ~tmp#7##0:wybe.int, ?result##1:wybe.int) #2 @proc_factorial:nn:nn
 
 
 
-gen$2 > {inline} (1 calls)
-0: proc_factorial.gen$2<0>
-gen$2(n##0:wybe.int, result##0:wybe.int, ?result##2:wybe.int):
+gen#2 > {inline} (1 calls)
+0: proc_factorial.gen#2<0>
+gen#2(n##0:wybe.int, result##0:wybe.int, ?result##2:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm mul(n##0:wybe.int, ~result##0:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
-    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.int) @int:nn:nn
-    proc_factorial.gen$1<0>(~tmp$1##0:wybe.int, ~tmp$0##0:wybe.int, ?result##2:wybe.int) #2 @proc_factorial:nn:nn
+    foreign llvm mul(n##0:wybe.int, ~result##0:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
+    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int) @int:nn:nn
+    proc_factorial.gen#1<0>(~tmp#1##0:wybe.int, ~tmp#0##0:wybe.int, ?result##2:wybe.int) #2 @proc_factorial:nn:nn
 
   LLVM code       :
 
@@ -76,8 +76,8 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"proc_factorial.<0>"()    {
 entry:
-  %"1$tmp$0##0" = tail call fastcc  i64  @"proc_factorial.gen$1<0>"(i64  5, i64  1)  
-  tail call ccc  void  @print_int(i64  %"1$tmp$0##0")  
+  %"1#tmp#0##0" = tail call fastcc  i64  @"proc_factorial.gen#1<0>"(i64  5, i64  1)  
+  tail call ccc  void  @print_int(i64  %"1#tmp#0##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -85,29 +85,29 @@ entry:
 
 define external fastcc  i64 @"proc_factorial.factorial<0>"(i64  %"n##0")    {
 entry:
-  %"1$result##1" = tail call fastcc  i64  @"proc_factorial.gen$1<0>"(i64  %"n##0", i64  1)  
-  ret i64 %"1$result##1" 
+  %"1#result##1" = tail call fastcc  i64  @"proc_factorial.gen#1<0>"(i64  %"n##0", i64  1)  
+  ret i64 %"1#result##1" 
 }
 
 
-define external fastcc  i64 @"proc_factorial.gen$1<0>"(i64  %"n##0", i64  %"result##0")    {
+define external fastcc  i64 @"proc_factorial.gen#1<0>"(i64  %"n##0", i64  %"result##0")    {
 entry:
-  %"1$tmp$2##0" = icmp sgt i64 %"n##0", 1 
-  br i1 %"1$tmp$2##0", label %if.then, label %if.else 
+  %"1#tmp#2##0" = icmp sgt i64 %"n##0", 1 
+  br i1 %"1#tmp#2##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$7##0" = mul   i64 %"n##0", %"result##0" 
-  %"2$tmp$8##0" = sub   i64 %"n##0", 1 
-  %"2$result##1" = tail call fastcc  i64  @"proc_factorial.gen$1<0>"(i64  %"2$tmp$8##0", i64  %"2$tmp$7##0")  
-  ret i64 %"2$result##1" 
+  %"2#tmp#7##0" = mul   i64 %"n##0", %"result##0" 
+  %"2#tmp#8##0" = sub   i64 %"n##0", 1 
+  %"2#result##1" = tail call fastcc  i64  @"proc_factorial.gen#1<0>"(i64  %"2#tmp#8##0", i64  %"2#tmp#7##0")  
+  ret i64 %"2#result##1" 
 if.else:
   ret i64 %"result##0" 
 }
 
 
-define external fastcc  i64 @"proc_factorial.gen$2<0>"(i64  %"n##0", i64  %"result##0")    {
+define external fastcc  i64 @"proc_factorial.gen#2<0>"(i64  %"n##0", i64  %"result##0")    {
 entry:
-  %"1$tmp$0##0" = mul   i64 %"n##0", %"result##0" 
-  %"1$tmp$1##0" = sub   i64 %"n##0", 1 
-  %"1$result##2" = tail call fastcc  i64  @"proc_factorial.gen$1<0>"(i64  %"1$tmp$1##0", i64  %"1$tmp$0##0")  
-  ret i64 %"1$result##2" 
+  %"1#tmp#0##0" = mul   i64 %"n##0", %"result##0" 
+  %"1#tmp#1##0" = sub   i64 %"n##0", 1 
+  %"1#result##2" = tail call fastcc  i64  @"proc_factorial.gen#1<0>"(i64  %"1#tmp#1##0", i64  %"1#tmp#0##0")  
+  ret i64 %"1#result##2" 
 }

--- a/test-cases/final-dump/proc_gcd.exp
+++ b/test-cases/final-dump/proc_gcd.exp
@@ -16,7 +16,7 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    proc_gcd.gen$1<0>(18:wybe.int, 24:wybe.int, ~#io##0:wybe.phantom, _:wybe.int, 18:wybe.int, 24:wybe.int, ?r##0:wybe.int, ?#io##1:wybe.phantom) #2 @proc_gcd:nn:nn
+    proc_gcd.gen#1<0>(18:wybe.int, 24:wybe.int, ~#io##0:wybe.phantom, _:wybe.int, 18:wybe.int, 24:wybe.int, ?r##0:wybe.int, ?#io##1:wybe.phantom) #2 @proc_gcd:nn:nn
     foreign c print_int(~r##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
 
@@ -25,33 +25,33 @@ gcd > public {inline} (1 calls)
 gcd(a##0:wybe.int, b##0:wybe.int, ?r##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    proc_gcd.gen$1<0>(~a##0:wybe.int, ~b##0:wybe.int, ~io##0:wybe.phantom, _:wybe.int, ~a##0:wybe.int, ~b##0:wybe.int, ?r##0:wybe.int, ?io##1:wybe.phantom) #0 @proc_gcd:nn:nn
+    proc_gcd.gen#1<0>(~a##0:wybe.int, ~b##0:wybe.int, ~io##0:wybe.phantom, _:wybe.int, ~a##0:wybe.int, ~b##0:wybe.int, ?r##0:wybe.int, ?io##1:wybe.phantom) #0 @proc_gcd:nn:nn
 
 
-gen$1 > (2 calls)
-0: proc_gcd.gen$1<0>
-gen$1(a##0:wybe.int, b##0:wybe.int, io##0:wybe.phantom, [t##0:wybe.int], x##0:wybe.int, y##0:wybe.int, ?r##0:wybe.int, ?io##1:wybe.phantom):
+gen#1 > (2 calls)
+0: proc_gcd.gen#1<0>
+gen#1(a##0:wybe.int, b##0:wybe.int, io##0:wybe.phantom, [t##0:wybe.int], x##0:wybe.int, y##0:wybe.int, ?r##0:wybe.int, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(y##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(y##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+    case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(~x##0:wybe.int, ?r##0:wybe.int) @proc_gcd:nn:nn
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        proc_gcd.mod<0>(~x##0:wybe.int, y##0:wybe.int, ?tmp$9##0:wybe.int, ~io##0:wybe.phantom, ?tmp$10##0:wybe.phantom) #2 @proc_gcd:nn:nn
-        proc_gcd.gen$1<0>(~a##0:wybe.int, ~b##0:wybe.int, ~tmp$10##0:wybe.phantom, _:wybe.int, ~y##0:wybe.int, ~tmp$9##0:wybe.int, ?r##0:wybe.int, ?io##1:wybe.phantom) #3 @proc_gcd:nn:nn
+        proc_gcd.mod<0>(~x##0:wybe.int, y##0:wybe.int, ?tmp#9##0:wybe.int, ~io##0:wybe.phantom, ?tmp#10##0:wybe.phantom) #2 @proc_gcd:nn:nn
+        proc_gcd.gen#1<0>(~a##0:wybe.int, ~b##0:wybe.int, ~tmp#10##0:wybe.phantom, _:wybe.int, ~y##0:wybe.int, ~tmp#9##0:wybe.int, ?r##0:wybe.int, ?io##1:wybe.phantom) #3 @proc_gcd:nn:nn
 
 
 
-gen$2 > {inline} (1 calls)
-0: proc_gcd.gen$2<0>
-gen$2(a##0:wybe.int, b##0:wybe.int, io##0:wybe.phantom, [t##0:wybe.int], x##0:wybe.int, y##0:wybe.int, ?r##0:wybe.int, ?io##2:wybe.phantom):
+gen#2 > {inline} (1 calls)
+0: proc_gcd.gen#2<0>
+gen#2(a##0:wybe.int, b##0:wybe.int, io##0:wybe.phantom, [t##0:wybe.int], x##0:wybe.int, y##0:wybe.int, ?r##0:wybe.int, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     proc_gcd.mod<0>(~x##0:wybe.int, y##0:wybe.int, ?y##1:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @proc_gcd:nn:nn
-    proc_gcd.gen$1<0>(~a##0:wybe.int, ~b##0:wybe.int, ~io##1:wybe.phantom, _:wybe.int, ~y##0:wybe.int, ~y##1:wybe.int, ?r##0:wybe.int, ?io##2:wybe.phantom) #1 @proc_gcd:nn:nn
+    proc_gcd.gen#1<0>(~a##0:wybe.int, ~b##0:wybe.int, ~io##1:wybe.phantom, _:wybe.int, ~y##0:wybe.int, ~y##1:wybe.int, ?r##0:wybe.int, ?io##2:wybe.phantom) #1 @proc_gcd:nn:nn
 
 
 mod > public (1 calls)
@@ -63,8 +63,8 @@ mod(x##0:wybe.int, y##0:wybe.int, ?r##0:wybe.int, io##0:wybe.phantom, ?io##5:wyb
     foreign c print_int(x##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c putchar(' ':wybe.char, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
     foreign c putchar('y':wybe.char, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign c print_int(y##0:wybe.int, ~#io##4:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$11##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign c print_int(y##0:wybe.int, ~#io##4:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
     foreign llvm urem(~x##0:wybe.int, ~y##0:wybe.int, ?r##0:wybe.int) @proc_gcd:nn:nn
 
   LLVM code       :
@@ -89,37 +89,37 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"proc_gcd.<0>"()    {
 entry:
-  %"1$r##0" = tail call fastcc  i64  @"proc_gcd.gen$1<0>"(i64  18, i64  24, i64  18, i64  24)  
-  tail call ccc  void  @print_int(i64  %"1$r##0")  
+  %"1#r##0" = tail call fastcc  i64  @"proc_gcd.gen#1<0>"(i64  18, i64  24, i64  18, i64  24)  
+  tail call ccc  void  @print_int(i64  %"1#r##0")  
   ret void 
 }
 
 
 define external fastcc  i64 @"proc_gcd.gcd<0>"(i64  %"a##0", i64  %"b##0")    {
 entry:
-  %"1$r##0" = tail call fastcc  i64  @"proc_gcd.gen$1<0>"(i64  %"a##0", i64  %"b##0", i64  %"a##0", i64  %"b##0")  
-  ret i64 %"1$r##0" 
+  %"1#r##0" = tail call fastcc  i64  @"proc_gcd.gen#1<0>"(i64  %"a##0", i64  %"b##0", i64  %"a##0", i64  %"b##0")  
+  ret i64 %"1#r##0" 
 }
 
 
-define external fastcc  i64 @"proc_gcd.gen$1<0>"(i64  %"a##0", i64  %"b##0", i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"proc_gcd.gen#1<0>"(i64  %"a##0", i64  %"b##0", i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"y##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"y##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$9##0" = tail call fastcc  i64  @"proc_gcd.mod<0>"(i64  %"x##0", i64  %"y##0")  
-  %"2$r##0" = tail call fastcc  i64  @"proc_gcd.gen$1<0>"(i64  %"a##0", i64  %"b##0", i64  %"y##0", i64  %"2$tmp$9##0")  
-  ret i64 %"2$r##0" 
+  %"2#tmp#9##0" = tail call fastcc  i64  @"proc_gcd.mod<0>"(i64  %"x##0", i64  %"y##0")  
+  %"2#r##0" = tail call fastcc  i64  @"proc_gcd.gen#1<0>"(i64  %"a##0", i64  %"b##0", i64  %"y##0", i64  %"2#tmp#9##0")  
+  ret i64 %"2#r##0" 
 if.else:
   ret i64 %"x##0" 
 }
 
 
-define external fastcc  i64 @"proc_gcd.gen$2<0>"(i64  %"a##0", i64  %"b##0", i64  %"x##0", i64  %"y##0")    {
+define external fastcc  i64 @"proc_gcd.gen#2<0>"(i64  %"a##0", i64  %"b##0", i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$y##1" = tail call fastcc  i64  @"proc_gcd.mod<0>"(i64  %"x##0", i64  %"y##0")  
-  %"1$r##0" = tail call fastcc  i64  @"proc_gcd.gen$1<0>"(i64  %"a##0", i64  %"b##0", i64  %"y##0", i64  %"1$y##1")  
-  ret i64 %"1$r##0" 
+  %"1#y##1" = tail call fastcc  i64  @"proc_gcd.mod<0>"(i64  %"x##0", i64  %"y##0")  
+  %"1#r##0" = tail call fastcc  i64  @"proc_gcd.gen#1<0>"(i64  %"a##0", i64  %"b##0", i64  %"y##0", i64  %"1#y##1")  
+  ret i64 %"1#r##0" 
 }
 
 
@@ -131,6 +131,6 @@ entry:
   tail call ccc  void  @putchar(i8  121)  
   tail call ccc  void  @print_int(i64  %"y##0")  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$r##0" = urem i64 %"x##0", %"y##0" 
-  ret i64 %"1$r##0" 
+  %"1#r##0" = urem i64 %"x##0", %"y##0" 
+  ret i64 %"1#r##0" 
 }

--- a/test-cases/final-dump/proc_gcd.exp
+++ b/test-cases/final-dump/proc_gcd.exp
@@ -13,59 +13,59 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: proc_gcd.<0>
-(io#0:wybe.phantom, ?io#2:wybe.phantom):
+(io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    proc_gcd.gen$1<0>(18:wybe.int, 24:wybe.int, ~#io#0:wybe.phantom, _:wybe.int, 18:wybe.int, 24:wybe.int, ?r#0:wybe.int, ?#io#1:wybe.phantom) #2 @proc_gcd:nn:nn
-    foreign c print_int(~r#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
+    proc_gcd.gen$1<0>(18:wybe.int, 24:wybe.int, ~#io##0:wybe.phantom, _:wybe.int, 18:wybe.int, 24:wybe.int, ?r##0:wybe.int, ?#io##1:wybe.phantom) #2 @proc_gcd:nn:nn
+    foreign c print_int(~r##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
 
 gcd > public {inline} (1 calls)
 0: proc_gcd.gcd<0>
-gcd(a#0:wybe.int, b#0:wybe.int, ?r#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+gcd(a##0:wybe.int, b##0:wybe.int, ?r##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    proc_gcd.gen$1<0>(~a#0:wybe.int, ~b#0:wybe.int, ~io#0:wybe.phantom, _:wybe.int, ~a#0:wybe.int, ~b#0:wybe.int, ?r#0:wybe.int, ?io#1:wybe.phantom) #0 @proc_gcd:nn:nn
+    proc_gcd.gen$1<0>(~a##0:wybe.int, ~b##0:wybe.int, ~io##0:wybe.phantom, _:wybe.int, ~a##0:wybe.int, ~b##0:wybe.int, ?r##0:wybe.int, ?io##1:wybe.phantom) #0 @proc_gcd:nn:nn
 
 
 gen$1 > (2 calls)
 0: proc_gcd.gen$1<0>
-gen$1(a#0:wybe.int, b#0:wybe.int, io#0:wybe.phantom, [t#0:wybe.int], x#0:wybe.int, y#0:wybe.int, ?r#0:wybe.int, ?io#1:wybe.phantom):
+gen$1(a##0:wybe.int, b##0:wybe.int, io##0:wybe.phantom, [t##0:wybe.int], x##0:wybe.int, y##0:wybe.int, ?r##0:wybe.int, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(y#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne(y##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(~x#0:wybe.int, ?r#0:wybe.int) @proc_gcd:nn:nn
-        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+        foreign llvm move(~x##0:wybe.int, ?r##0:wybe.int) @proc_gcd:nn:nn
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        proc_gcd.mod<0>(~x#0:wybe.int, y#0:wybe.int, ?tmp$9#0:wybe.int, ~io#0:wybe.phantom, ?tmp$10#0:wybe.phantom) #2 @proc_gcd:nn:nn
-        proc_gcd.gen$1<0>(~a#0:wybe.int, ~b#0:wybe.int, ~tmp$10#0:wybe.phantom, _:wybe.int, ~y#0:wybe.int, ~tmp$9#0:wybe.int, ?r#0:wybe.int, ?io#1:wybe.phantom) #3 @proc_gcd:nn:nn
+        proc_gcd.mod<0>(~x##0:wybe.int, y##0:wybe.int, ?tmp$9##0:wybe.int, ~io##0:wybe.phantom, ?tmp$10##0:wybe.phantom) #2 @proc_gcd:nn:nn
+        proc_gcd.gen$1<0>(~a##0:wybe.int, ~b##0:wybe.int, ~tmp$10##0:wybe.phantom, _:wybe.int, ~y##0:wybe.int, ~tmp$9##0:wybe.int, ?r##0:wybe.int, ?io##1:wybe.phantom) #3 @proc_gcd:nn:nn
 
 
 
 gen$2 > {inline} (1 calls)
 0: proc_gcd.gen$2<0>
-gen$2(a#0:wybe.int, b#0:wybe.int, io#0:wybe.phantom, [t#0:wybe.int], x#0:wybe.int, y#0:wybe.int, ?r#0:wybe.int, ?io#2:wybe.phantom):
+gen$2(a##0:wybe.int, b##0:wybe.int, io##0:wybe.phantom, [t##0:wybe.int], x##0:wybe.int, y##0:wybe.int, ?r##0:wybe.int, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    proc_gcd.mod<0>(~x#0:wybe.int, y#0:wybe.int, ?y#1:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @proc_gcd:nn:nn
-    proc_gcd.gen$1<0>(~a#0:wybe.int, ~b#0:wybe.int, ~io#1:wybe.phantom, _:wybe.int, ~y#0:wybe.int, ~y#1:wybe.int, ?r#0:wybe.int, ?io#2:wybe.phantom) #1 @proc_gcd:nn:nn
+    proc_gcd.mod<0>(~x##0:wybe.int, y##0:wybe.int, ?y##1:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @proc_gcd:nn:nn
+    proc_gcd.gen$1<0>(~a##0:wybe.int, ~b##0:wybe.int, ~io##1:wybe.phantom, _:wybe.int, ~y##0:wybe.int, ~y##1:wybe.int, ?r##0:wybe.int, ?io##2:wybe.phantom) #1 @proc_gcd:nn:nn
 
 
 mod > public (1 calls)
 0: proc_gcd.mod<0>
-mod(x#0:wybe.int, y#0:wybe.int, ?r#0:wybe.int, io#0:wybe.phantom, ?io#5:wybe.phantom):
+mod(x##0:wybe.int, y##0:wybe.int, ?r##0:wybe.int, io##0:wybe.phantom, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c putchar('x':wybe.char, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_int(x#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c putchar(' ':wybe.char, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign c putchar('y':wybe.char, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_int(y#0:wybe.int, ~#io#4:wybe.phantom, ?tmp$11#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$11#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-    foreign llvm urem(~x#0:wybe.int, ~y#0:wybe.int, ?r#0:wybe.int) @proc_gcd:nn:nn
+    foreign c putchar('x':wybe.char, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(x##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c putchar(' ':wybe.char, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign c putchar('y':wybe.char, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_int(y##0:wybe.int, ~#io##4:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$11##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign llvm urem(~x##0:wybe.int, ~y##0:wybe.int, ?r##0:wybe.int) @proc_gcd:nn:nn
 
   LLVM code       :
 
@@ -89,48 +89,48 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"proc_gcd.<0>"()    {
 entry:
-  %"1$r#0" = tail call fastcc  i64  @"proc_gcd.gen$1<0>"(i64  18, i64  24, i64  18, i64  24)  
-  tail call ccc  void  @print_int(i64  %"1$r#0")  
+  %"1$r##0" = tail call fastcc  i64  @"proc_gcd.gen$1<0>"(i64  18, i64  24, i64  18, i64  24)  
+  tail call ccc  void  @print_int(i64  %"1$r##0")  
   ret void 
 }
 
 
-define external fastcc  i64 @"proc_gcd.gcd<0>"(i64  %"a#0", i64  %"b#0")    {
+define external fastcc  i64 @"proc_gcd.gcd<0>"(i64  %"a##0", i64  %"b##0")    {
 entry:
-  %"1$r#0" = tail call fastcc  i64  @"proc_gcd.gen$1<0>"(i64  %"a#0", i64  %"b#0", i64  %"a#0", i64  %"b#0")  
-  ret i64 %"1$r#0" 
+  %"1$r##0" = tail call fastcc  i64  @"proc_gcd.gen$1<0>"(i64  %"a##0", i64  %"b##0", i64  %"a##0", i64  %"b##0")  
+  ret i64 %"1$r##0" 
 }
 
 
-define external fastcc  i64 @"proc_gcd.gen$1<0>"(i64  %"a#0", i64  %"b#0", i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"proc_gcd.gen$1<0>"(i64  %"a##0", i64  %"b##0", i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"y#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"y##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$9#0" = tail call fastcc  i64  @"proc_gcd.mod<0>"(i64  %"x#0", i64  %"y#0")  
-  %"2$r#0" = tail call fastcc  i64  @"proc_gcd.gen$1<0>"(i64  %"a#0", i64  %"b#0", i64  %"y#0", i64  %"2$tmp$9#0")  
-  ret i64 %"2$r#0" 
+  %"2$tmp$9##0" = tail call fastcc  i64  @"proc_gcd.mod<0>"(i64  %"x##0", i64  %"y##0")  
+  %"2$r##0" = tail call fastcc  i64  @"proc_gcd.gen$1<0>"(i64  %"a##0", i64  %"b##0", i64  %"y##0", i64  %"2$tmp$9##0")  
+  ret i64 %"2$r##0" 
 if.else:
-  ret i64 %"x#0" 
+  ret i64 %"x##0" 
 }
 
 
-define external fastcc  i64 @"proc_gcd.gen$2<0>"(i64  %"a#0", i64  %"b#0", i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"proc_gcd.gen$2<0>"(i64  %"a##0", i64  %"b##0", i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$y#1" = tail call fastcc  i64  @"proc_gcd.mod<0>"(i64  %"x#0", i64  %"y#0")  
-  %"1$r#0" = tail call fastcc  i64  @"proc_gcd.gen$1<0>"(i64  %"a#0", i64  %"b#0", i64  %"y#0", i64  %"1$y#1")  
-  ret i64 %"1$r#0" 
+  %"1$y##1" = tail call fastcc  i64  @"proc_gcd.mod<0>"(i64  %"x##0", i64  %"y##0")  
+  %"1$r##0" = tail call fastcc  i64  @"proc_gcd.gen$1<0>"(i64  %"a##0", i64  %"b##0", i64  %"y##0", i64  %"1$y##1")  
+  ret i64 %"1$r##0" 
 }
 
 
-define external fastcc  i64 @"proc_gcd.mod<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"proc_gcd.mod<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
   tail call ccc  void  @putchar(i8  120)  
-  tail call ccc  void  @print_int(i64  %"x#0")  
+  tail call ccc  void  @print_int(i64  %"x##0")  
   tail call ccc  void  @putchar(i8  32)  
   tail call ccc  void  @putchar(i8  121)  
-  tail call ccc  void  @print_int(i64  %"y#0")  
+  tail call ccc  void  @print_int(i64  %"y##0")  
   tail call ccc  void  @putchar(i8  10)  
-  %"1$r#0" = urem i64 %"x#0", %"y#0" 
-  ret i64 %"1$r#0" 
+  %"1$r##0" = urem i64 %"x##0", %"y##0" 
+  ret i64 %"1$r##0" 
 }

--- a/test-cases/final-dump/proc_hello.exp
+++ b/test-cases/final-dump/proc_hello.exp
@@ -11,11 +11,11 @@ AFTER EVERYTHING:
 
 print2 > public {inline} (0 calls)
 0: proc_hello.print2<0>
-print2([x#0:wybe.int], [y#0:wybe.int], io#0:wybe.phantom, ?io#1:wybe.phantom):
+print2([x##0:wybe.int], [y##0:wybe.int], io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("hello, world":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_string("hello, world":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/proc_hello.exp
+++ b/test-cases/final-dump/proc_hello.exp
@@ -14,8 +14,8 @@ print2 > public {inline} (0 calls)
 print2([x##0:wybe.int], [y##0:wybe.int], io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("hello, world":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("hello, world":wybe.string, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/proc_print2.exp
+++ b/test-cases/final-dump/proc_print2.exp
@@ -11,11 +11,11 @@ AFTER EVERYTHING:
 
 print2 > public {inline} (0 calls)
 0: proc_print2.print2<0>
-print2(x#0:wybe.int, y#0:wybe.int, io#0:wybe.phantom, ?io#2:wybe.phantom):
+print2(x##0:wybe.int, y##0:wybe.int, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(~x#0:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_int(~y#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
+    foreign c print_int(~x##0:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~y##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -34,9 +34,9 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"proc_print2.print2<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  void @"proc_print2.print2<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  tail call ccc  void  @print_int(i64  %"x#0")  
-  tail call ccc  void  @print_int(i64  %"y#0")  
+  tail call ccc  void  @print_int(i64  %"x##0")  
+  tail call ccc  void  @print_int(i64  %"y##0")  
   ret void 
 }

--- a/test-cases/final-dump/proc_yorn.exp
+++ b/test-cases/final-dump/proc_yorn.exp
@@ -12,71 +12,71 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: proc_yorn.<0>
-(io#0:wybe.phantom, ?io#2:wybe.phantom):
+(io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    proc_yorn.gen$1<0>(~#io#0:wybe.phantom, "Well, yes or no?":wybe.string, ?r#0:wybe.bool, ?#io#1:wybe.phantom) #2 @proc_yorn:nn:nn
-    wybe.io.print<5>(~r#0:wybe.bool, ~#io#1:wybe.phantom, ?tmp$4#0:wybe.phantom) #3 @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$4#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
+    proc_yorn.gen$1<0>(~#io##0:wybe.phantom, "Well, yes or no?":wybe.string, ?r##0:wybe.bool, ?#io##1:wybe.phantom) #2 @proc_yorn:nn:nn
+    wybe.io.print<5>(~r##0:wybe.bool, ~#io##1:wybe.phantom, ?tmp$4##0:wybe.phantom) #3 @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$4##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
 
 gen$1 > (2 calls)
 0: proc_yorn.gen$1<0>
-gen$1(io#0:wybe.phantom, prompt#0:wybe.string, ?result#1:wybe.bool, ?io#5:wybe.phantom):
+gen$1(io##0:wybe.phantom, prompt##0:wybe.string, ?result##1:wybe.bool, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(prompt#0:wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_string(" (y/n) ":wybe.string, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c read_char(?response#0:wybe.char, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign llvm icmp_ne(response#0:wybe.char, 'y':wybe.char, ?tmp$8#0:wybe.bool) @char:nn:nn
-    foreign llvm icmp_ne(response#0:wybe.char, 'Y':wybe.char, ?tmp$9#0:wybe.bool) @char:nn:nn
-    foreign llvm and(~tmp$8#0:wybe.bool, ~tmp$9#0:wybe.bool, ?tmp$10#0:wybe.bool) @bool:nn:nn
-    foreign llvm xor(~tmp$10#0:wybe.bool, 1:wybe.bool, ?tmp$0#0:wybe.bool) @bool:nn:nn
-    proc_yorn.is_yes_or_no<0>(~response#0:wybe.char, ?tmp$1#0:wybe.bool) #4 @proc_yorn:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign c print_string(prompt##0:wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (y/n) ":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c read_char(?response##0:wybe.char, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign llvm icmp_ne(response##0:wybe.char, 'y':wybe.char, ?tmp$8##0:wybe.bool) @char:nn:nn
+    foreign llvm icmp_ne(response##0:wybe.char, 'Y':wybe.char, ?tmp$9##0:wybe.bool) @char:nn:nn
+    foreign llvm and(~tmp$8##0:wybe.bool, ~tmp$9##0:wybe.bool, ?tmp$10##0:wybe.bool) @bool:nn:nn
+    foreign llvm xor(~tmp$10##0:wybe.bool, 1:wybe.bool, ?tmp$0##0:wybe.bool) @bool:nn:nn
+    proc_yorn.is_yes_or_no<0>(~response##0:wybe.char, ?tmp$1##0:wybe.bool) #4 @proc_yorn:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign c print_string("Please answer 'yes' or 'no'.":wybe.string, ~#io#3:wybe.phantom, ?tmp$13#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$13#0:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-        proc_yorn.gen$1<0>(~io#4:wybe.phantom, ~prompt#0:wybe.string, ?result#1:wybe.bool, ?io#5:wybe.phantom) #6 @proc_yorn:nn:nn
+        foreign c print_string("Please answer 'yes' or 'no'.":wybe.string, ~#io##3:wybe.phantom, ?tmp$13##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$13##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+        proc_yorn.gen$1<0>(~io##4:wybe.phantom, ~prompt##0:wybe.string, ?result##1:wybe.bool, ?io##5:wybe.phantom) #6 @proc_yorn:nn:nn
 
     1:
-        foreign llvm move(~tmp$0#0:wybe.bool, ?result#1:wybe.bool)
-        foreign llvm move(~io#3:wybe.phantom, ?io#5:wybe.phantom)
+        foreign llvm move(~tmp$0##0:wybe.bool, ?result##1:wybe.bool)
+        foreign llvm move(~io##3:wybe.phantom, ?io##5:wybe.phantom)
 
 
 
 is_yes > {inline} (4 calls)
 0: proc_yorn.is_yes<0>
-is_yes(ch#0:wybe.char, ?$#0:wybe.bool):
+is_yes(ch##0:wybe.char, ?$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(ch#0:wybe.char, 'y':wybe.char, ?tmp$2#0:wybe.bool) @char:nn:nn
-    foreign llvm icmp_ne(~ch#0:wybe.char, 'Y':wybe.char, ?tmp$3#0:wybe.bool) @char:nn:nn
-    foreign llvm and(~tmp$2#0:wybe.bool, ~tmp$3#0:wybe.bool, ?tmp$1#0:wybe.bool) @bool:nn:nn
-    foreign llvm xor(~tmp$1#0:wybe.bool, 1:wybe.bool, ?$#0:wybe.bool) @bool:nn:nn
+    foreign llvm icmp_ne(ch##0:wybe.char, 'y':wybe.char, ?tmp$2##0:wybe.bool) @char:nn:nn
+    foreign llvm icmp_ne(~ch##0:wybe.char, 'Y':wybe.char, ?tmp$3##0:wybe.bool) @char:nn:nn
+    foreign llvm and(~tmp$2##0:wybe.bool, ~tmp$3##0:wybe.bool, ?tmp$1##0:wybe.bool) @bool:nn:nn
+    foreign llvm xor(~tmp$1##0:wybe.bool, 1:wybe.bool, ?$##0:wybe.bool) @bool:nn:nn
 
 
 is_yes_or_no > (3 calls)
 0: proc_yorn.is_yes_or_no<0>
-is_yes_or_no(ch#0:wybe.char, ?$#0:wybe.bool):
+is_yes_or_no(ch##0:wybe.char, ?$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(ch#0:wybe.char, 'y':wybe.char, ?tmp$6#0:wybe.bool) @char:nn:nn
-    foreign llvm icmp_ne(ch#0:wybe.char, 'Y':wybe.char, ?tmp$7#0:wybe.bool) @char:nn:nn
-    foreign llvm and(~tmp$6#0:wybe.bool, ~tmp$7#0:wybe.bool, ?tmp$8#0:wybe.bool) @bool:nn:nn
-    foreign llvm xor(~tmp$8#0:wybe.bool, 1:wybe.bool, ?tmp$1#0:wybe.bool) @bool:nn:nn
-    foreign llvm icmp_eq(ch#0:wybe.char, 'n':wybe.char, ?tmp$3#0:wybe.bool) @char:nn:nn
-    foreign llvm icmp_eq(~ch#0:wybe.char, 'N':wybe.char, ?tmp$4#0:wybe.bool) @char:nn:nn
-    foreign llvm or(~tmp$3#0:wybe.bool, ~tmp$4#0:wybe.bool, ?tmp$2#0:wybe.bool) @bool:nn:nn
-    foreign llvm or(~tmp$1#0:wybe.bool, ~tmp$2#0:wybe.bool, ?$#0:wybe.bool) @bool:nn:nn
+    foreign llvm icmp_ne(ch##0:wybe.char, 'y':wybe.char, ?tmp$6##0:wybe.bool) @char:nn:nn
+    foreign llvm icmp_ne(ch##0:wybe.char, 'Y':wybe.char, ?tmp$7##0:wybe.bool) @char:nn:nn
+    foreign llvm and(~tmp$6##0:wybe.bool, ~tmp$7##0:wybe.bool, ?tmp$8##0:wybe.bool) @bool:nn:nn
+    foreign llvm xor(~tmp$8##0:wybe.bool, 1:wybe.bool, ?tmp$1##0:wybe.bool) @bool:nn:nn
+    foreign llvm icmp_eq(ch##0:wybe.char, 'n':wybe.char, ?tmp$3##0:wybe.bool) @char:nn:nn
+    foreign llvm icmp_eq(~ch##0:wybe.char, 'N':wybe.char, ?tmp$4##0:wybe.bool) @char:nn:nn
+    foreign llvm or(~tmp$3##0:wybe.bool, ~tmp$4##0:wybe.bool, ?tmp$2##0:wybe.bool) @bool:nn:nn
+    foreign llvm or(~tmp$1##0:wybe.bool, ~tmp$2##0:wybe.bool, ?$##0:wybe.bool) @bool:nn:nn
 
 
 yorn > public {inline} (1 calls)
 0: proc_yorn.yorn<0>
-yorn(prompt#0:wybe.string, ?result#0:wybe.bool, io#0:wybe.phantom, ?io#1:wybe.phantom):
+yorn(prompt##0:wybe.string, ?result##0:wybe.bool, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    proc_yorn.gen$1<0>(~io#0:wybe.phantom, ~prompt#0:wybe.string, ?result#0:wybe.bool, ?io#1:wybe.phantom) #0 @proc_yorn:nn:nn
+    proc_yorn.gen$1<0>(~io##0:wybe.phantom, ~prompt##0:wybe.string, ?result##0:wybe.bool, ?io##1:wybe.phantom) #0 @proc_yorn:nn:nn
 
   LLVM code       :
 
@@ -116,62 +116,62 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 define external fastcc  void @"proc_yorn.<0>"()    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @proc_yorn.1, i32 0, i32 0) to i64 
-  %"1$r#0" = tail call fastcc  i1  @"proc_yorn.gen$1<0>"(i64  %2)  
-  tail call fastcc  void  @"wybe.io.print<5>"(i1  %"1$r#0")  
+  %"1$r##0" = tail call fastcc  i1  @"proc_yorn.gen$1<0>"(i64  %2)  
+  tail call fastcc  void  @"wybe.io.print<5>"(i1  %"1$r##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  i1 @"proc_yorn.gen$1<0>"(i64  %"prompt#0")    {
+define external fastcc  i1 @"proc_yorn.gen$1<0>"(i64  %"prompt##0")    {
 entry:
-  tail call ccc  void  @print_string(i64  %"prompt#0")  
+  tail call ccc  void  @print_string(i64  %"prompt##0")  
   %4 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @proc_yorn.3, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %4)  
-  %"1$response#0" = tail call ccc  i8  @read_char()  
-  %"1$tmp$8#0" = icmp ne i8 %"1$response#0", 121 
-  %"1$tmp$9#0" = icmp ne i8 %"1$response#0", 89 
-  %"1$tmp$10#0" = and i1 %"1$tmp$8#0", %"1$tmp$9#0" 
-  %"1$tmp$0#0" = xor i1 %"1$tmp$10#0", 1 
-  %"1$tmp$1#0" = tail call fastcc  i1  @"proc_yorn.is_yes_or_no<0>"(i8  %"1$response#0")  
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$response##0" = tail call ccc  i8  @read_char()  
+  %"1$tmp$8##0" = icmp ne i8 %"1$response##0", 121 
+  %"1$tmp$9##0" = icmp ne i8 %"1$response##0", 89 
+  %"1$tmp$10##0" = and i1 %"1$tmp$8##0", %"1$tmp$9##0" 
+  %"1$tmp$0##0" = xor i1 %"1$tmp$10##0", 1 
+  %"1$tmp$1##0" = tail call fastcc  i1  @"proc_yorn.is_yes_or_no<0>"(i8  %"1$response##0")  
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  ret i1 %"1$tmp$0#0" 
+  ret i1 %"1$tmp$0##0" 
 if.else:
   %6 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @proc_yorn.5, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %6)  
   tail call ccc  void  @putchar(i8  10)  
-  %"3$result#1" = tail call fastcc  i1  @"proc_yorn.gen$1<0>"(i64  %"prompt#0")  
-  ret i1 %"3$result#1" 
+  %"3$result##1" = tail call fastcc  i1  @"proc_yorn.gen$1<0>"(i64  %"prompt##0")  
+  ret i1 %"3$result##1" 
 }
 
 
-define external fastcc  i1 @"proc_yorn.is_yes<0>"(i8  %"ch#0")    {
+define external fastcc  i1 @"proc_yorn.is_yes<0>"(i8  %"ch##0")    {
 entry:
-  %"1$tmp$2#0" = icmp ne i8 %"ch#0", 121 
-  %"1$tmp$3#0" = icmp ne i8 %"ch#0", 89 
-  %"1$tmp$1#0" = and i1 %"1$tmp$2#0", %"1$tmp$3#0" 
-  %"1$$#0" = xor i1 %"1$tmp$1#0", 1 
-  ret i1 %"1$$#0" 
+  %"1$tmp$2##0" = icmp ne i8 %"ch##0", 121 
+  %"1$tmp$3##0" = icmp ne i8 %"ch##0", 89 
+  %"1$tmp$1##0" = and i1 %"1$tmp$2##0", %"1$tmp$3##0" 
+  %"1$$##0" = xor i1 %"1$tmp$1##0", 1 
+  ret i1 %"1$$##0" 
 }
 
 
-define external fastcc  i1 @"proc_yorn.is_yes_or_no<0>"(i8  %"ch#0")    {
+define external fastcc  i1 @"proc_yorn.is_yes_or_no<0>"(i8  %"ch##0")    {
 entry:
-  %"1$tmp$6#0" = icmp ne i8 %"ch#0", 121 
-  %"1$tmp$7#0" = icmp ne i8 %"ch#0", 89 
-  %"1$tmp$8#0" = and i1 %"1$tmp$6#0", %"1$tmp$7#0" 
-  %"1$tmp$1#0" = xor i1 %"1$tmp$8#0", 1 
-  %"1$tmp$3#0" = icmp eq i8 %"ch#0", 110 
-  %"1$tmp$4#0" = icmp eq i8 %"ch#0", 78 
-  %"1$tmp$2#0" = or i1 %"1$tmp$3#0", %"1$tmp$4#0" 
-  %"1$$#0" = or i1 %"1$tmp$1#0", %"1$tmp$2#0" 
-  ret i1 %"1$$#0" 
+  %"1$tmp$6##0" = icmp ne i8 %"ch##0", 121 
+  %"1$tmp$7##0" = icmp ne i8 %"ch##0", 89 
+  %"1$tmp$8##0" = and i1 %"1$tmp$6##0", %"1$tmp$7##0" 
+  %"1$tmp$1##0" = xor i1 %"1$tmp$8##0", 1 
+  %"1$tmp$3##0" = icmp eq i8 %"ch##0", 110 
+  %"1$tmp$4##0" = icmp eq i8 %"ch##0", 78 
+  %"1$tmp$2##0" = or i1 %"1$tmp$3##0", %"1$tmp$4##0" 
+  %"1$$##0" = or i1 %"1$tmp$1##0", %"1$tmp$2##0" 
+  ret i1 %"1$$##0" 
 }
 
 
-define external fastcc  i1 @"proc_yorn.yorn<0>"(i64  %"prompt#0")    {
+define external fastcc  i1 @"proc_yorn.yorn<0>"(i64  %"prompt##0")    {
 entry:
-  %"1$result#0" = tail call fastcc  i1  @"proc_yorn.gen$1<0>"(i64  %"prompt#0")  
-  ret i1 %"1$result#0" 
+  %"1$result##0" = tail call fastcc  i1  @"proc_yorn.gen$1<0>"(i64  %"prompt##0")  
+  ret i1 %"1$result##0" 
 }

--- a/test-cases/final-dump/proc_yorn.exp
+++ b/test-cases/final-dump/proc_yorn.exp
@@ -47,18 +47,18 @@ gen#1(io##0:wybe.phantom, prompt##0:wybe.string, ?result##1:wybe.bool, ?io##5:wy
 
 is_yes > {inline} (4 calls)
 0: proc_yorn.is_yes<0>
-is_yes(ch##0:wybe.char, ?###0:wybe.bool):
+is_yes(ch##0:wybe.char, ?#result##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(ch##0:wybe.char, 'y':wybe.char, ?tmp#2##0:wybe.bool) @char:nn:nn
     foreign llvm icmp_ne(~ch##0:wybe.char, 'Y':wybe.char, ?tmp#3##0:wybe.bool) @char:nn:nn
     foreign llvm and(~tmp#2##0:wybe.bool, ~tmp#3##0:wybe.bool, ?tmp#1##0:wybe.bool) @bool:nn:nn
-    foreign llvm xor(~tmp#1##0:wybe.bool, 1:wybe.bool, ?###0:wybe.bool) @bool:nn:nn
+    foreign llvm xor(~tmp#1##0:wybe.bool, 1:wybe.bool, ?#result##0:wybe.bool) @bool:nn:nn
 
 
 is_yes_or_no > (3 calls)
 0: proc_yorn.is_yes_or_no<0>
-is_yes_or_no(ch##0:wybe.char, ?###0:wybe.bool):
+is_yes_or_no(ch##0:wybe.char, ?#result##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(ch##0:wybe.char, 'y':wybe.char, ?tmp#6##0:wybe.bool) @char:nn:nn
@@ -68,7 +68,7 @@ is_yes_or_no(ch##0:wybe.char, ?###0:wybe.bool):
     foreign llvm icmp_eq(ch##0:wybe.char, 'n':wybe.char, ?tmp#3##0:wybe.bool) @char:nn:nn
     foreign llvm icmp_eq(~ch##0:wybe.char, 'N':wybe.char, ?tmp#4##0:wybe.bool) @char:nn:nn
     foreign llvm or(~tmp#3##0:wybe.bool, ~tmp#4##0:wybe.bool, ?tmp#2##0:wybe.bool) @bool:nn:nn
-    foreign llvm or(~tmp#1##0:wybe.bool, ~tmp#2##0:wybe.bool, ?###0:wybe.bool) @bool:nn:nn
+    foreign llvm or(~tmp#1##0:wybe.bool, ~tmp#2##0:wybe.bool, ?#result##0:wybe.bool) @bool:nn:nn
 
 
 yorn > public {inline} (1 calls)
@@ -151,8 +151,8 @@ entry:
   %"1#tmp#2##0" = icmp ne i8 %"ch##0", 121 
   %"1#tmp#3##0" = icmp ne i8 %"ch##0", 89 
   %"1#tmp#1##0" = and i1 %"1#tmp#2##0", %"1#tmp#3##0" 
-  %"1####0" = xor i1 %"1#tmp#1##0", 1 
-  ret i1 %"1####0" 
+  %"1##result##0" = xor i1 %"1#tmp#1##0", 1 
+  ret i1 %"1##result##0" 
 }
 
 
@@ -165,8 +165,8 @@ entry:
   %"1#tmp#3##0" = icmp eq i8 %"ch##0", 110 
   %"1#tmp#4##0" = icmp eq i8 %"ch##0", 78 
   %"1#tmp#2##0" = or i1 %"1#tmp#3##0", %"1#tmp#4##0" 
-  %"1####0" = or i1 %"1#tmp#1##0", %"1#tmp#2##0" 
-  ret i1 %"1####0" 
+  %"1##result##0" = or i1 %"1#tmp#1##0", %"1#tmp#2##0" 
+  ret i1 %"1##result##0" 
 }
 
 

--- a/test-cases/final-dump/proc_yorn.exp
+++ b/test-cases/final-dump/proc_yorn.exp
@@ -15,60 +15,60 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    proc_yorn.gen$1<0>(~#io##0:wybe.phantom, "Well, yes or no?":wybe.string, ?r##0:wybe.bool, ?#io##1:wybe.phantom) #2 @proc_yorn:nn:nn
-    wybe.io.print<5>(~r##0:wybe.bool, ~#io##1:wybe.phantom, ?tmp$4##0:wybe.phantom) #3 @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$4##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    proc_yorn.gen#1<0>(~#io##0:wybe.phantom, "Well, yes or no?":wybe.string, ?r##0:wybe.bool, ?#io##1:wybe.phantom) #2 @proc_yorn:nn:nn
+    wybe.io.print<5>(~r##0:wybe.bool, ~#io##1:wybe.phantom, ?tmp#4##0:wybe.phantom) #3 @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#4##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
 
-gen$1 > (2 calls)
-0: proc_yorn.gen$1<0>
-gen$1(io##0:wybe.phantom, prompt##0:wybe.string, ?result##1:wybe.bool, ?io##5:wybe.phantom):
+gen#1 > (2 calls)
+0: proc_yorn.gen#1<0>
+gen#1(io##0:wybe.phantom, prompt##0:wybe.string, ?result##1:wybe.bool, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(prompt##0:wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     foreign c print_string(" (y/n) ":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c read_char(?response##0:wybe.char, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign llvm icmp_ne(response##0:wybe.char, 'y':wybe.char, ?tmp$8##0:wybe.bool) @char:nn:nn
-    foreign llvm icmp_ne(response##0:wybe.char, 'Y':wybe.char, ?tmp$9##0:wybe.bool) @char:nn:nn
-    foreign llvm and(~tmp$8##0:wybe.bool, ~tmp$9##0:wybe.bool, ?tmp$10##0:wybe.bool) @bool:nn:nn
-    foreign llvm xor(~tmp$10##0:wybe.bool, 1:wybe.bool, ?tmp$0##0:wybe.bool) @bool:nn:nn
-    proc_yorn.is_yes_or_no<0>(~response##0:wybe.char, ?tmp$1##0:wybe.bool) #4 @proc_yorn:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign llvm icmp_ne(response##0:wybe.char, 'y':wybe.char, ?tmp#8##0:wybe.bool) @char:nn:nn
+    foreign llvm icmp_ne(response##0:wybe.char, 'Y':wybe.char, ?tmp#9##0:wybe.bool) @char:nn:nn
+    foreign llvm and(~tmp#8##0:wybe.bool, ~tmp#9##0:wybe.bool, ?tmp#10##0:wybe.bool) @bool:nn:nn
+    foreign llvm xor(~tmp#10##0:wybe.bool, 1:wybe.bool, ?tmp#0##0:wybe.bool) @bool:nn:nn
+    proc_yorn.is_yes_or_no<0>(~response##0:wybe.char, ?tmp#1##0:wybe.bool) #4 @proc_yorn:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign c print_string("Please answer 'yes' or 'no'.":wybe.string, ~#io##3:wybe.phantom, ?tmp$13##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$13##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-        proc_yorn.gen$1<0>(~io##4:wybe.phantom, ~prompt##0:wybe.string, ?result##1:wybe.bool, ?io##5:wybe.phantom) #6 @proc_yorn:nn:nn
+        foreign c print_string("Please answer 'yes' or 'no'.":wybe.string, ~#io##3:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+        proc_yorn.gen#1<0>(~io##4:wybe.phantom, ~prompt##0:wybe.string, ?result##1:wybe.bool, ?io##5:wybe.phantom) #6 @proc_yorn:nn:nn
 
     1:
-        foreign llvm move(~tmp$0##0:wybe.bool, ?result##1:wybe.bool)
+        foreign llvm move(~tmp#0##0:wybe.bool, ?result##1:wybe.bool)
         foreign llvm move(~io##3:wybe.phantom, ?io##5:wybe.phantom)
 
 
 
 is_yes > {inline} (4 calls)
 0: proc_yorn.is_yes<0>
-is_yes(ch##0:wybe.char, ?$##0:wybe.bool):
+is_yes(ch##0:wybe.char, ?###0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(ch##0:wybe.char, 'y':wybe.char, ?tmp$2##0:wybe.bool) @char:nn:nn
-    foreign llvm icmp_ne(~ch##0:wybe.char, 'Y':wybe.char, ?tmp$3##0:wybe.bool) @char:nn:nn
-    foreign llvm and(~tmp$2##0:wybe.bool, ~tmp$3##0:wybe.bool, ?tmp$1##0:wybe.bool) @bool:nn:nn
-    foreign llvm xor(~tmp$1##0:wybe.bool, 1:wybe.bool, ?$##0:wybe.bool) @bool:nn:nn
+    foreign llvm icmp_ne(ch##0:wybe.char, 'y':wybe.char, ?tmp#2##0:wybe.bool) @char:nn:nn
+    foreign llvm icmp_ne(~ch##0:wybe.char, 'Y':wybe.char, ?tmp#3##0:wybe.bool) @char:nn:nn
+    foreign llvm and(~tmp#2##0:wybe.bool, ~tmp#3##0:wybe.bool, ?tmp#1##0:wybe.bool) @bool:nn:nn
+    foreign llvm xor(~tmp#1##0:wybe.bool, 1:wybe.bool, ?###0:wybe.bool) @bool:nn:nn
 
 
 is_yes_or_no > (3 calls)
 0: proc_yorn.is_yes_or_no<0>
-is_yes_or_no(ch##0:wybe.char, ?$##0:wybe.bool):
+is_yes_or_no(ch##0:wybe.char, ?###0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(ch##0:wybe.char, 'y':wybe.char, ?tmp$6##0:wybe.bool) @char:nn:nn
-    foreign llvm icmp_ne(ch##0:wybe.char, 'Y':wybe.char, ?tmp$7##0:wybe.bool) @char:nn:nn
-    foreign llvm and(~tmp$6##0:wybe.bool, ~tmp$7##0:wybe.bool, ?tmp$8##0:wybe.bool) @bool:nn:nn
-    foreign llvm xor(~tmp$8##0:wybe.bool, 1:wybe.bool, ?tmp$1##0:wybe.bool) @bool:nn:nn
-    foreign llvm icmp_eq(ch##0:wybe.char, 'n':wybe.char, ?tmp$3##0:wybe.bool) @char:nn:nn
-    foreign llvm icmp_eq(~ch##0:wybe.char, 'N':wybe.char, ?tmp$4##0:wybe.bool) @char:nn:nn
-    foreign llvm or(~tmp$3##0:wybe.bool, ~tmp$4##0:wybe.bool, ?tmp$2##0:wybe.bool) @bool:nn:nn
-    foreign llvm or(~tmp$1##0:wybe.bool, ~tmp$2##0:wybe.bool, ?$##0:wybe.bool) @bool:nn:nn
+    foreign llvm icmp_ne(ch##0:wybe.char, 'y':wybe.char, ?tmp#6##0:wybe.bool) @char:nn:nn
+    foreign llvm icmp_ne(ch##0:wybe.char, 'Y':wybe.char, ?tmp#7##0:wybe.bool) @char:nn:nn
+    foreign llvm and(~tmp#6##0:wybe.bool, ~tmp#7##0:wybe.bool, ?tmp#8##0:wybe.bool) @bool:nn:nn
+    foreign llvm xor(~tmp#8##0:wybe.bool, 1:wybe.bool, ?tmp#1##0:wybe.bool) @bool:nn:nn
+    foreign llvm icmp_eq(ch##0:wybe.char, 'n':wybe.char, ?tmp#3##0:wybe.bool) @char:nn:nn
+    foreign llvm icmp_eq(~ch##0:wybe.char, 'N':wybe.char, ?tmp#4##0:wybe.bool) @char:nn:nn
+    foreign llvm or(~tmp#3##0:wybe.bool, ~tmp#4##0:wybe.bool, ?tmp#2##0:wybe.bool) @bool:nn:nn
+    foreign llvm or(~tmp#1##0:wybe.bool, ~tmp#2##0:wybe.bool, ?###0:wybe.bool) @bool:nn:nn
 
 
 yorn > public {inline} (1 calls)
@@ -76,7 +76,7 @@ yorn > public {inline} (1 calls)
 yorn(prompt##0:wybe.string, ?result##0:wybe.bool, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    proc_yorn.gen$1<0>(~io##0:wybe.phantom, ~prompt##0:wybe.string, ?result##0:wybe.bool, ?io##1:wybe.phantom) #0 @proc_yorn:nn:nn
+    proc_yorn.gen#1<0>(~io##0:wybe.phantom, ~prompt##0:wybe.string, ?result##0:wybe.bool, ?io##1:wybe.phantom) #0 @proc_yorn:nn:nn
 
   LLVM code       :
 
@@ -116,62 +116,62 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 define external fastcc  void @"proc_yorn.<0>"()    {
 entry:
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @proc_yorn.1, i32 0, i32 0) to i64 
-  %"1$r##0" = tail call fastcc  i1  @"proc_yorn.gen$1<0>"(i64  %2)  
-  tail call fastcc  void  @"wybe.io.print<5>"(i1  %"1$r##0")  
+  %"1#r##0" = tail call fastcc  i1  @"proc_yorn.gen#1<0>"(i64  %2)  
+  tail call fastcc  void  @"wybe.io.print<5>"(i1  %"1#r##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  i1 @"proc_yorn.gen$1<0>"(i64  %"prompt##0")    {
+define external fastcc  i1 @"proc_yorn.gen#1<0>"(i64  %"prompt##0")    {
 entry:
   tail call ccc  void  @print_string(i64  %"prompt##0")  
   %4 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @proc_yorn.3, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %4)  
-  %"1$response##0" = tail call ccc  i8  @read_char()  
-  %"1$tmp$8##0" = icmp ne i8 %"1$response##0", 121 
-  %"1$tmp$9##0" = icmp ne i8 %"1$response##0", 89 
-  %"1$tmp$10##0" = and i1 %"1$tmp$8##0", %"1$tmp$9##0" 
-  %"1$tmp$0##0" = xor i1 %"1$tmp$10##0", 1 
-  %"1$tmp$1##0" = tail call fastcc  i1  @"proc_yorn.is_yes_or_no<0>"(i8  %"1$response##0")  
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#response##0" = tail call ccc  i8  @read_char()  
+  %"1#tmp#8##0" = icmp ne i8 %"1#response##0", 121 
+  %"1#tmp#9##0" = icmp ne i8 %"1#response##0", 89 
+  %"1#tmp#10##0" = and i1 %"1#tmp#8##0", %"1#tmp#9##0" 
+  %"1#tmp#0##0" = xor i1 %"1#tmp#10##0", 1 
+  %"1#tmp#1##0" = tail call fastcc  i1  @"proc_yorn.is_yes_or_no<0>"(i8  %"1#response##0")  
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  ret i1 %"1$tmp$0##0" 
+  ret i1 %"1#tmp#0##0" 
 if.else:
   %6 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @proc_yorn.5, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %6)  
   tail call ccc  void  @putchar(i8  10)  
-  %"3$result##1" = tail call fastcc  i1  @"proc_yorn.gen$1<0>"(i64  %"prompt##0")  
-  ret i1 %"3$result##1" 
+  %"3#result##1" = tail call fastcc  i1  @"proc_yorn.gen#1<0>"(i64  %"prompt##0")  
+  ret i1 %"3#result##1" 
 }
 
 
 define external fastcc  i1 @"proc_yorn.is_yes<0>"(i8  %"ch##0")    {
 entry:
-  %"1$tmp$2##0" = icmp ne i8 %"ch##0", 121 
-  %"1$tmp$3##0" = icmp ne i8 %"ch##0", 89 
-  %"1$tmp$1##0" = and i1 %"1$tmp$2##0", %"1$tmp$3##0" 
-  %"1$$##0" = xor i1 %"1$tmp$1##0", 1 
-  ret i1 %"1$$##0" 
+  %"1#tmp#2##0" = icmp ne i8 %"ch##0", 121 
+  %"1#tmp#3##0" = icmp ne i8 %"ch##0", 89 
+  %"1#tmp#1##0" = and i1 %"1#tmp#2##0", %"1#tmp#3##0" 
+  %"1####0" = xor i1 %"1#tmp#1##0", 1 
+  ret i1 %"1####0" 
 }
 
 
 define external fastcc  i1 @"proc_yorn.is_yes_or_no<0>"(i8  %"ch##0")    {
 entry:
-  %"1$tmp$6##0" = icmp ne i8 %"ch##0", 121 
-  %"1$tmp$7##0" = icmp ne i8 %"ch##0", 89 
-  %"1$tmp$8##0" = and i1 %"1$tmp$6##0", %"1$tmp$7##0" 
-  %"1$tmp$1##0" = xor i1 %"1$tmp$8##0", 1 
-  %"1$tmp$3##0" = icmp eq i8 %"ch##0", 110 
-  %"1$tmp$4##0" = icmp eq i8 %"ch##0", 78 
-  %"1$tmp$2##0" = or i1 %"1$tmp$3##0", %"1$tmp$4##0" 
-  %"1$$##0" = or i1 %"1$tmp$1##0", %"1$tmp$2##0" 
-  ret i1 %"1$$##0" 
+  %"1#tmp#6##0" = icmp ne i8 %"ch##0", 121 
+  %"1#tmp#7##0" = icmp ne i8 %"ch##0", 89 
+  %"1#tmp#8##0" = and i1 %"1#tmp#6##0", %"1#tmp#7##0" 
+  %"1#tmp#1##0" = xor i1 %"1#tmp#8##0", 1 
+  %"1#tmp#3##0" = icmp eq i8 %"ch##0", 110 
+  %"1#tmp#4##0" = icmp eq i8 %"ch##0", 78 
+  %"1#tmp#2##0" = or i1 %"1#tmp#3##0", %"1#tmp#4##0" 
+  %"1####0" = or i1 %"1#tmp#1##0", %"1#tmp#2##0" 
+  ret i1 %"1####0" 
 }
 
 
 define external fastcc  i1 @"proc_yorn.yorn<0>"(i64  %"prompt##0")    {
 entry:
-  %"1$result##0" = tail call fastcc  i1  @"proc_yorn.gen$1<0>"(i64  %"prompt##0")  
-  ret i1 %"1$result##0" 
+  %"1#result##0" = tail call fastcc  i1  @"proc_yorn.gen#1<0>"(i64  %"prompt##0")  
+  ret i1 %"1#result##0" 
 }

--- a/test-cases/final-dump/proc_yorn2.exp
+++ b/test-cases/final-dump/proc_yorn2.exp
@@ -9,25 +9,25 @@ AFTER EVERYTHING:
   resources       : 
   procs           : 
 
-gen$1 > (2 calls)
-0: proc_yorn2.gen$1<0>
-gen$1(io##0:wybe.phantom, prompt##0:wybe.string, ?result##1:wybe.bool, ?io##5:wybe.phantom):
+gen#1 > (2 calls)
+0: proc_yorn2.gen#1<0>
+gen#1(io##0:wybe.phantom, prompt##0:wybe.string, ?result##1:wybe.bool, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(prompt##0:wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     foreign c print_string(" (y/n) ":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign c read_char(?response##0:wybe.char, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign llvm icmp_eq(response##0:wybe.char, 'Y':wybe.char, ?tmp$0##0:wybe.bool) @char:nn:nn
-    foreign llvm icmp_eq(~response##0:wybe.char, 'N':wybe.char, ?tmp$1##0:wybe.bool) @char:nn:nn
-    foreign llvm or(tmp$0##0:wybe.bool, ~tmp$1##0:wybe.bool, ?tmp$2##0:wybe.bool) @bool:nn:nn
-    case ~tmp$2##0:wybe.bool of
+    foreign llvm icmp_eq(response##0:wybe.char, 'Y':wybe.char, ?tmp#0##0:wybe.bool) @char:nn:nn
+    foreign llvm icmp_eq(~response##0:wybe.char, 'N':wybe.char, ?tmp#1##0:wybe.bool) @char:nn:nn
+    foreign llvm or(tmp#0##0:wybe.bool, ~tmp#1##0:wybe.bool, ?tmp#2##0:wybe.bool) @bool:nn:nn
+    case ~tmp#2##0:wybe.bool of
     0:
-        foreign c print_string("Please answer 'yes' or 'no'.":wybe.string, ~#io##3:wybe.phantom, ?tmp$16##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$16##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-        proc_yorn2.gen$1<0>(~io##4:wybe.phantom, ~prompt##0:wybe.string, ?result##1:wybe.bool, ?io##5:wybe.phantom) #7 @proc_yorn2:2:5
+        foreign c print_string("Please answer 'yes' or 'no'.":wybe.string, ~#io##3:wybe.phantom, ?tmp#16##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+        proc_yorn2.gen#1<0>(~io##4:wybe.phantom, ~prompt##0:wybe.string, ?result##1:wybe.bool, ?io##5:wybe.phantom) #7 @proc_yorn2:2:5
 
     1:
-        foreign llvm move(~tmp$0##0:wybe.bool, ?result##1:wybe.bool)
+        foreign llvm move(~tmp#0##0:wybe.bool, ?result##1:wybe.bool)
         foreign llvm move(~io##3:wybe.phantom, ?io##5:wybe.phantom)
 
 
@@ -37,7 +37,7 @@ yorn > public {inline} (0 calls)
 yorn(prompt##0:wybe.string, ?result##0:wybe.bool, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    proc_yorn2.gen$1<0>(~io##0:wybe.phantom, ~prompt##0:wybe.string, ?result##0:wybe.bool, ?io##1:wybe.phantom) #0 @proc_yorn2:2:5
+    proc_yorn2.gen#1<0>(~io##0:wybe.phantom, ~prompt##0:wybe.string, ?result##0:wybe.bool, ?io##1:wybe.phantom) #0 @proc_yorn2:2:5
 
   LLVM code       :
 
@@ -68,29 +68,29 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"proc_yorn2.gen$1<0>"(i64  %"prompt##0")    {
+define external fastcc  i1 @"proc_yorn2.gen#1<0>"(i64  %"prompt##0")    {
 entry:
   tail call ccc  void  @print_string(i64  %"prompt##0")  
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @proc_yorn2.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
-  %"1$response##0" = tail call ccc  i8  @read_char()  
-  %"1$tmp$0##0" = icmp eq i8 %"1$response##0", 89 
-  %"1$tmp$1##0" = icmp eq i8 %"1$response##0", 78 
-  %"1$tmp$2##0" = or i1 %"1$tmp$0##0", %"1$tmp$1##0" 
-  br i1 %"1$tmp$2##0", label %if.then, label %if.else 
+  %"1#response##0" = tail call ccc  i8  @read_char()  
+  %"1#tmp#0##0" = icmp eq i8 %"1#response##0", 89 
+  %"1#tmp#1##0" = icmp eq i8 %"1#response##0", 78 
+  %"1#tmp#2##0" = or i1 %"1#tmp#0##0", %"1#tmp#1##0" 
+  br i1 %"1#tmp#2##0", label %if.then, label %if.else 
 if.then:
-  ret i1 %"1$tmp$0##0" 
+  ret i1 %"1#tmp#0##0" 
 if.else:
   %4 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @proc_yorn2.3, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %4)  
   tail call ccc  void  @putchar(i8  10)  
-  %"3$result##1" = tail call fastcc  i1  @"proc_yorn2.gen$1<0>"(i64  %"prompt##0")  
-  ret i1 %"3$result##1" 
+  %"3#result##1" = tail call fastcc  i1  @"proc_yorn2.gen#1<0>"(i64  %"prompt##0")  
+  ret i1 %"3#result##1" 
 }
 
 
 define external fastcc  i1 @"proc_yorn2.yorn<0>"(i64  %"prompt##0")    {
 entry:
-  %"1$result##0" = tail call fastcc  i1  @"proc_yorn2.gen$1<0>"(i64  %"prompt##0")  
-  ret i1 %"1$result##0" 
+  %"1#result##0" = tail call fastcc  i1  @"proc_yorn2.gen#1<0>"(i64  %"prompt##0")  
+  ret i1 %"1#result##0" 
 }

--- a/test-cases/final-dump/proc_yorn2.exp
+++ b/test-cases/final-dump/proc_yorn2.exp
@@ -11,33 +11,33 @@ AFTER EVERYTHING:
 
 gen$1 > (2 calls)
 0: proc_yorn2.gen$1<0>
-gen$1(io#0:wybe.phantom, prompt#0:wybe.string, ?result#1:wybe.bool, ?io#5:wybe.phantom):
+gen$1(io##0:wybe.phantom, prompt##0:wybe.string, ?result##1:wybe.bool, ?io##5:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(prompt#0:wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_string(" (y/n) ":wybe.string, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c read_char(?response#0:wybe.char, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign llvm icmp_eq(response#0:wybe.char, 'Y':wybe.char, ?tmp$0#0:wybe.bool) @char:nn:nn
-    foreign llvm icmp_eq(~response#0:wybe.char, 'N':wybe.char, ?tmp$1#0:wybe.bool) @char:nn:nn
-    foreign llvm or(tmp$0#0:wybe.bool, ~tmp$1#0:wybe.bool, ?tmp$2#0:wybe.bool) @bool:nn:nn
-    case ~tmp$2#0:wybe.bool of
+    foreign c print_string(prompt##0:wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (y/n) ":wybe.string, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c read_char(?response##0:wybe.char, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign llvm icmp_eq(response##0:wybe.char, 'Y':wybe.char, ?tmp$0##0:wybe.bool) @char:nn:nn
+    foreign llvm icmp_eq(~response##0:wybe.char, 'N':wybe.char, ?tmp$1##0:wybe.bool) @char:nn:nn
+    foreign llvm or(tmp$0##0:wybe.bool, ~tmp$1##0:wybe.bool, ?tmp$2##0:wybe.bool) @bool:nn:nn
+    case ~tmp$2##0:wybe.bool of
     0:
-        foreign c print_string("Please answer 'yes' or 'no'.":wybe.string, ~#io#3:wybe.phantom, ?tmp$16#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$16#0:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-        proc_yorn2.gen$1<0>(~io#4:wybe.phantom, ~prompt#0:wybe.string, ?result#1:wybe.bool, ?io#5:wybe.phantom) #7 @proc_yorn2:2:5
+        foreign c print_string("Please answer 'yes' or 'no'.":wybe.string, ~#io##3:wybe.phantom, ?tmp$16##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$16##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+        proc_yorn2.gen$1<0>(~io##4:wybe.phantom, ~prompt##0:wybe.string, ?result##1:wybe.bool, ?io##5:wybe.phantom) #7 @proc_yorn2:2:5
 
     1:
-        foreign llvm move(~tmp$0#0:wybe.bool, ?result#1:wybe.bool)
-        foreign llvm move(~io#3:wybe.phantom, ?io#5:wybe.phantom)
+        foreign llvm move(~tmp$0##0:wybe.bool, ?result##1:wybe.bool)
+        foreign llvm move(~io##3:wybe.phantom, ?io##5:wybe.phantom)
 
 
 
 yorn > public {inline} (0 calls)
 0: proc_yorn2.yorn<0>
-yorn(prompt#0:wybe.string, ?result#0:wybe.bool, io#0:wybe.phantom, ?io#1:wybe.phantom):
+yorn(prompt##0:wybe.string, ?result##0:wybe.bool, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    proc_yorn2.gen$1<0>(~io#0:wybe.phantom, ~prompt#0:wybe.string, ?result#0:wybe.bool, ?io#1:wybe.phantom) #0 @proc_yorn2:2:5
+    proc_yorn2.gen$1<0>(~io##0:wybe.phantom, ~prompt##0:wybe.string, ?result##0:wybe.bool, ?io##1:wybe.phantom) #0 @proc_yorn2:2:5
 
   LLVM code       :
 
@@ -68,29 +68,29 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"proc_yorn2.gen$1<0>"(i64  %"prompt#0")    {
+define external fastcc  i1 @"proc_yorn2.gen$1<0>"(i64  %"prompt##0")    {
 entry:
-  tail call ccc  void  @print_string(i64  %"prompt#0")  
+  tail call ccc  void  @print_string(i64  %"prompt##0")  
   %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @proc_yorn2.1, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %2)  
-  %"1$response#0" = tail call ccc  i8  @read_char()  
-  %"1$tmp$0#0" = icmp eq i8 %"1$response#0", 89 
-  %"1$tmp$1#0" = icmp eq i8 %"1$response#0", 78 
-  %"1$tmp$2#0" = or i1 %"1$tmp$0#0", %"1$tmp$1#0" 
-  br i1 %"1$tmp$2#0", label %if.then, label %if.else 
+  %"1$response##0" = tail call ccc  i8  @read_char()  
+  %"1$tmp$0##0" = icmp eq i8 %"1$response##0", 89 
+  %"1$tmp$1##0" = icmp eq i8 %"1$response##0", 78 
+  %"1$tmp$2##0" = or i1 %"1$tmp$0##0", %"1$tmp$1##0" 
+  br i1 %"1$tmp$2##0", label %if.then, label %if.else 
 if.then:
-  ret i1 %"1$tmp$0#0" 
+  ret i1 %"1$tmp$0##0" 
 if.else:
   %4 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @proc_yorn2.3, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %4)  
   tail call ccc  void  @putchar(i8  10)  
-  %"3$result#1" = tail call fastcc  i1  @"proc_yorn2.gen$1<0>"(i64  %"prompt#0")  
-  ret i1 %"3$result#1" 
+  %"3$result##1" = tail call fastcc  i1  @"proc_yorn2.gen$1<0>"(i64  %"prompt##0")  
+  ret i1 %"3$result##1" 
 }
 
 
-define external fastcc  i1 @"proc_yorn2.yorn<0>"(i64  %"prompt#0")    {
+define external fastcc  i1 @"proc_yorn2.yorn<0>"(i64  %"prompt##0")    {
 entry:
-  %"1$result#0" = tail call fastcc  i1  @"proc_yorn2.gen$1<0>"(i64  %"prompt#0")  
-  ret i1 %"1$result#0" 
+  %"1$result##0" = tail call fastcc  i1  @"proc_yorn2.gen$1<0>"(i64  %"prompt##0")  
+  ret i1 %"1$result##0" 
 }

--- a/test-cases/final-dump/representation.exp
+++ b/test-cases/final-dump/representation.exp
@@ -11,10 +11,10 @@ AFTER EVERYTHING:
 
 + > public {inline} (0 calls)
 0: representation.+<0>
-+(x##0:representation, y##0:representation, ?###0:representation):
++(x##0:representation, y##0:representation, ?#result##0:representation):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~x##0:representation, ~y##0:representation, ?###0:representation) @representation:nn:nn
+    foreign llvm add(~x##0:representation, ~y##0:representation, ?#result##0:representation) @representation:nn:nn
 
   LLVM code       :
 
@@ -32,6 +32,6 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  i16 @"representation.+<0>"(i16  %"x##0", i16  %"y##0")    {
 entry:
-  %"1####0" = add   i16 %"x##0", %"y##0" 
-  ret i16 %"1####0" 
+  %"1##result##0" = add   i16 %"x##0", %"y##0" 
+  ret i16 %"1##result##0" 
 }

--- a/test-cases/final-dump/representation.exp
+++ b/test-cases/final-dump/representation.exp
@@ -11,10 +11,10 @@ AFTER EVERYTHING:
 
 + > public {inline} (0 calls)
 0: representation.+<0>
-+(x#0:representation, y#0:representation, ?$#0:representation):
++(x##0:representation, y##0:representation, ?$##0:representation):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~x#0:representation, ~y#0:representation, ?$#0:representation) @representation:nn:nn
+    foreign llvm add(~x##0:representation, ~y##0:representation, ?$##0:representation) @representation:nn:nn
 
   LLVM code       :
 
@@ -30,8 +30,8 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i16 @"representation.+<0>"(i16  %"x#0", i16  %"y#0")    {
+define external fastcc  i16 @"representation.+<0>"(i16  %"x##0", i16  %"y##0")    {
 entry:
-  %"1$$#0" = add   i16 %"x#0", %"y#0" 
-  ret i16 %"1$$#0" 
+  %"1$$##0" = add   i16 %"x##0", %"y##0" 
+  ret i16 %"1$$##0" 
 }

--- a/test-cases/final-dump/representation.exp
+++ b/test-cases/final-dump/representation.exp
@@ -11,10 +11,10 @@ AFTER EVERYTHING:
 
 + > public {inline} (0 calls)
 0: representation.+<0>
-+(x##0:representation, y##0:representation, ?$##0:representation):
++(x##0:representation, y##0:representation, ?###0:representation):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~x##0:representation, ~y##0:representation, ?$##0:representation) @representation:nn:nn
+    foreign llvm add(~x##0:representation, ~y##0:representation, ?###0:representation) @representation:nn:nn
 
   LLVM code       :
 
@@ -32,6 +32,6 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  i16 @"representation.+<0>"(i16  %"x##0", i16  %"y##0")    {
 entry:
-  %"1$$##0" = add   i16 %"x##0", %"y##0" 
-  ret i16 %"1$$##0" 
+  %"1####0" = add   i16 %"x##0", %"y##0" 
+  ret i16 %"1####0" 
 }

--- a/test-cases/final-dump/simple_loop.exp
+++ b/test-cases/final-dump/simple_loop.exp
@@ -11,26 +11,26 @@ AFTER EVERYTHING:
 
 *main* > public {inline} (0 calls)
 0: simple_loop.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    simple_loop.gen$1<0>(~io#0:wybe.phantom, ?io#1:wybe.phantom) #0 @simple_loop:nn:nn
+    simple_loop.gen$1<0>(~io##0:wybe.phantom, ?io##1:wybe.phantom) #0 @simple_loop:nn:nn
 
 
 gen$1 > (2 calls)
 0: simple_loop.gen$1<0>
-gen$1(io#0:wybe.phantom, ?io#3:wybe.phantom):
+gen$1(io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c read_char(?c#0:wybe.char, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign llvm icmp_ne(c#0:wybe.char, 'a':wybe.char, ?tmp$0#0:wybe.bool) @char:nn:nn
-    case ~tmp$0#0:wybe.bool of
+    foreign c read_char(?c##0:wybe.char, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign llvm icmp_ne(c##0:wybe.char, 'a':wybe.char, ?tmp$0##0:wybe.bool) @char:nn:nn
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(~io#1:wybe.phantom, ?io#3:wybe.phantom)
+        foreign llvm move(~io##1:wybe.phantom, ?io##3:wybe.phantom)
 
     1:
-        foreign c putchar(~c#0:wybe.char, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-        simple_loop.gen$1<0>(~io#2:wybe.phantom, ?io#3:wybe.phantom) #3 @simple_loop:nn:nn
+        foreign c putchar(~c##0:wybe.char, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+        simple_loop.gen$1<0>(~io##2:wybe.phantom, ?io##3:wybe.phantom) #3 @simple_loop:nn:nn
 
 
   LLVM code       :
@@ -62,11 +62,11 @@ entry:
 
 define external fastcc  void @"simple_loop.gen$1<0>"()    {
 entry:
-  %"1$c#0" = tail call ccc  i8  @read_char()  
-  %"1$tmp$0#0" = icmp ne i8 %"1$c#0", 97 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$c##0" = tail call ccc  i8  @read_char()  
+  %"1$tmp$0##0" = icmp ne i8 %"1$c##0", 97 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  tail call ccc  void  @putchar(i8  %"1$c#0")  
+  tail call ccc  void  @putchar(i8  %"1$c##0")  
   tail call fastcc  void  @"simple_loop.gen$1<0>"()  
   ret void 
 if.else:

--- a/test-cases/final-dump/simple_loop.exp
+++ b/test-cases/final-dump/simple_loop.exp
@@ -14,23 +14,23 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    simple_loop.gen$1<0>(~io##0:wybe.phantom, ?io##1:wybe.phantom) #0 @simple_loop:nn:nn
+    simple_loop.gen#1<0>(~io##0:wybe.phantom, ?io##1:wybe.phantom) #0 @simple_loop:nn:nn
 
 
-gen$1 > (2 calls)
-0: simple_loop.gen$1<0>
-gen$1(io##0:wybe.phantom, ?io##3:wybe.phantom):
+gen#1 > (2 calls)
+0: simple_loop.gen#1<0>
+gen#1(io##0:wybe.phantom, ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c read_char(?c##0:wybe.char, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign llvm icmp_ne(c##0:wybe.char, 'a':wybe.char, ?tmp$0##0:wybe.bool) @char:nn:nn
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(c##0:wybe.char, 'a':wybe.char, ?tmp#0##0:wybe.bool) @char:nn:nn
+    case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(~io##1:wybe.phantom, ?io##3:wybe.phantom)
 
     1:
         foreign c putchar(~c##0:wybe.char, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-        simple_loop.gen$1<0>(~io##2:wybe.phantom, ?io##3:wybe.phantom) #3 @simple_loop:nn:nn
+        simple_loop.gen#1<0>(~io##2:wybe.phantom, ?io##3:wybe.phantom) #3 @simple_loop:nn:nn
 
 
   LLVM code       :
@@ -55,19 +55,19 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"simple_loop.<0>"()    {
 entry:
-  tail call fastcc  void  @"simple_loop.gen$1<0>"()  
+  tail call fastcc  void  @"simple_loop.gen#1<0>"()  
   ret void 
 }
 
 
-define external fastcc  void @"simple_loop.gen$1<0>"()    {
+define external fastcc  void @"simple_loop.gen#1<0>"()    {
 entry:
-  %"1$c##0" = tail call ccc  i8  @read_char()  
-  %"1$tmp$0##0" = icmp ne i8 %"1$c##0", 97 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#c##0" = tail call ccc  i8  @read_char()  
+  %"1#tmp#0##0" = icmp ne i8 %"1#c##0", 97 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  tail call ccc  void  @putchar(i8  %"1$c##0")  
-  tail call fastcc  void  @"simple_loop.gen$1<0>"()  
+  tail call ccc  void  @putchar(i8  %"1#c##0")  
+  tail call fastcc  void  @"simple_loop.gen#1<0>"()  
   ret void 
 if.else:
   ret void 

--- a/test-cases/final-dump/sister_module.exp
+++ b/test-cases/final-dump/sister_module.exp
@@ -14,18 +14,18 @@ AFTER EVERYTHING:
 
 baz > {inline} (0 calls)
 0: sister_module.baz<0>
-baz(i#0:wybe.int, ?j#0:wybe.int):
+baz(i##0:wybe.int, ?j##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    sister_module.m1.foo<0>(~i#0:wybe.int, ?j#0:wybe.int) #0 @sister_module:nn:nn
+    sister_module.m1.foo<0>(~i##0:wybe.int, ?j##0:wybe.int) #0 @sister_module:nn:nn
 
 
 buzz > {inline} (0 calls)
 0: sister_module.buzz<0>
-buzz(i#0:wybe.int, ?j#0:wybe.int):
+buzz(i##0:wybe.int, ?j##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    sister_module.m2.bar<0>(~i#0:wybe.int, ?j#0:wybe.int) #0 @sister_module:nn:nn
+    sister_module.m2.bar<0>(~i##0:wybe.int, ?j##0:wybe.int) #0 @sister_module:nn:nn
 
   LLVM code       :
 
@@ -41,17 +41,17 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i64 @"sister_module.baz<0>"(i64  %"i#0")    {
+define external fastcc  i64 @"sister_module.baz<0>"(i64  %"i##0")    {
 entry:
-  %"1$j#0" = tail call fastcc  i64  @"sister_module.m1.foo<0>"(i64  %"i#0")  
-  ret i64 %"1$j#0" 
+  %"1$j##0" = tail call fastcc  i64  @"sister_module.m1.foo<0>"(i64  %"i##0")  
+  ret i64 %"1$j##0" 
 }
 
 
-define external fastcc  i64 @"sister_module.buzz<0>"(i64  %"i#0")    {
+define external fastcc  i64 @"sister_module.buzz<0>"(i64  %"i##0")    {
 entry:
-  %"1$j#0" = tail call fastcc  i64  @"sister_module.m2.bar<0>"(i64  %"i#0")  
-  ret i64 %"1$j#0" 
+  %"1$j##0" = tail call fastcc  i64  @"sister_module.m2.bar<0>"(i64  %"i##0")  
+  ret i64 %"1$j##0" 
 }
 --------------------------------------------------
  Module sister_module.m1
@@ -66,10 +66,10 @@ entry:
 
 foo > public {inline} (0 calls)
 0: sister_module.m1.foo<0>
-foo(i#0:wybe.int, ?j#0:wybe.int):
+foo(i##0:wybe.int, ?j##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~i#0:wybe.int, 1:wybe.int, ?j#0:wybe.int) @int:nn:nn
+    foreign llvm add(~i##0:wybe.int, 1:wybe.int, ?j##0:wybe.int) @int:nn:nn
 
   LLVM code       :
 
@@ -85,10 +85,10 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i64 @"sister_module.m1.foo<0>"(i64  %"i#0")    {
+define external fastcc  i64 @"sister_module.m1.foo<0>"(i64  %"i##0")    {
 entry:
-  %"1$j#0" = add   i64 %"i#0", 1 
-  ret i64 %"1$j#0" 
+  %"1$j##0" = add   i64 %"i##0", 1 
+  ret i64 %"1$j##0" 
 }
 --------------------------------------------------
  Module sister_module.m2
@@ -103,11 +103,11 @@ entry:
 
 bar > public {inline} (0 calls)
 0: sister_module.m2.bar<0>
-bar(i#0:wybe.int, ?j#0:wybe.int):
+bar(i##0:wybe.int, ?j##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~i#0:wybe.int, 1:wybe.int, ?k#0:wybe.int) @int:nn:nn
-    sister_module.m1.foo<0>(~k#0:wybe.int, ?j#0:wybe.int) #2 @sister_module:nn:nn
+    foreign llvm add(~i##0:wybe.int, 1:wybe.int, ?k##0:wybe.int) @int:nn:nn
+    sister_module.m1.foo<0>(~k##0:wybe.int, ?j##0:wybe.int) #2 @sister_module:nn:nn
 
   LLVM code       :
 
@@ -123,9 +123,9 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i64 @"sister_module.m2.bar<0>"(i64  %"i#0")    {
+define external fastcc  i64 @"sister_module.m2.bar<0>"(i64  %"i##0")    {
 entry:
-  %"1$k#0" = add   i64 %"i#0", 1 
-  %"1$j#0" = tail call fastcc  i64  @"sister_module.m1.foo<0>"(i64  %"1$k#0")  
-  ret i64 %"1$j#0" 
+  %"1$k##0" = add   i64 %"i##0", 1 
+  %"1$j##0" = tail call fastcc  i64  @"sister_module.m1.foo<0>"(i64  %"1$k##0")  
+  ret i64 %"1$j##0" 
 }

--- a/test-cases/final-dump/sister_module.exp
+++ b/test-cases/final-dump/sister_module.exp
@@ -43,15 +43,15 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  i64 @"sister_module.baz<0>"(i64  %"i##0")    {
 entry:
-  %"1$j##0" = tail call fastcc  i64  @"sister_module.m1.foo<0>"(i64  %"i##0")  
-  ret i64 %"1$j##0" 
+  %"1#j##0" = tail call fastcc  i64  @"sister_module.m1.foo<0>"(i64  %"i##0")  
+  ret i64 %"1#j##0" 
 }
 
 
 define external fastcc  i64 @"sister_module.buzz<0>"(i64  %"i##0")    {
 entry:
-  %"1$j##0" = tail call fastcc  i64  @"sister_module.m2.bar<0>"(i64  %"i##0")  
-  ret i64 %"1$j##0" 
+  %"1#j##0" = tail call fastcc  i64  @"sister_module.m2.bar<0>"(i64  %"i##0")  
+  ret i64 %"1#j##0" 
 }
 --------------------------------------------------
  Module sister_module.m1
@@ -87,8 +87,8 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  i64 @"sister_module.m1.foo<0>"(i64  %"i##0")    {
 entry:
-  %"1$j##0" = add   i64 %"i##0", 1 
-  ret i64 %"1$j##0" 
+  %"1#j##0" = add   i64 %"i##0", 1 
+  ret i64 %"1#j##0" 
 }
 --------------------------------------------------
  Module sister_module.m2
@@ -125,7 +125,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  i64 @"sister_module.m2.bar<0>"(i64  %"i##0")    {
 entry:
-  %"1$k##0" = add   i64 %"i##0", 1 
-  %"1$j##0" = tail call fastcc  i64  @"sister_module.m1.foo<0>"(i64  %"1$k##0")  
-  ret i64 %"1$j##0" 
+  %"1#k##0" = add   i64 %"i##0", 1 
+  %"1#j##0" = tail call fastcc  i64  @"sister_module.m1.foo<0>"(i64  %"1#k##0")  
+  ret i64 %"1#j##0" 
 }

--- a/test-cases/final-dump/specials.exp
+++ b/test-cases/final-dump/specials.exp
@@ -19,8 +19,8 @@ show_column > public {inline} (0 calls)
 show_column(call_source_column_number##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(~call_source_column_number##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~call_source_column_number##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 show_file > public {inline} (0 calls)
@@ -28,8 +28,8 @@ show_file > public {inline} (0 calls)
 show_file(call_source_file_name##0:wybe.string, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(~call_source_file_name##0:wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string(~call_source_file_name##0:wybe.string, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 show_full_file > public {inline} (0 calls)
@@ -37,8 +37,8 @@ show_full_file > public {inline} (0 calls)
 show_full_file(call_source_file_full_name##0:wybe.string, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(~call_source_file_full_name##0:wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string(~call_source_file_full_name##0:wybe.string, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 show_full_location > public {inline} (0 calls)
@@ -46,8 +46,8 @@ show_full_location > public {inline} (0 calls)
 show_full_location(call_source_full_location##0:wybe.string, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(~call_source_full_location##0:wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string(~call_source_full_location##0:wybe.string, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 show_line > public {inline} (0 calls)
@@ -55,8 +55,8 @@ show_line > public {inline} (0 calls)
 show_line(call_source_line_number##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(~call_source_line_number##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~call_source_line_number##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 show_location > public {inline} (0 calls)
@@ -64,8 +64,8 @@ show_location > public {inline} (0 calls)
 show_location(call_source_location##0:wybe.string, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(~call_source_location##0:wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string(~call_source_location##0:wybe.string, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/specials.exp
+++ b/test-cases/final-dump/specials.exp
@@ -16,56 +16,56 @@ AFTER EVERYTHING:
 
 show_column > public {inline} (0 calls)
 0: specials.show_column<0>
-show_column(call_source_column_number#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+show_column(call_source_column_number##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(~call_source_column_number#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~call_source_column_number##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 show_file > public {inline} (0 calls)
 0: specials.show_file<0>
-show_file(call_source_file_name#0:wybe.string, io#0:wybe.phantom, ?io#1:wybe.phantom):
+show_file(call_source_file_name##0:wybe.string, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(~call_source_file_name#0:wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_string(~call_source_file_name##0:wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 show_full_file > public {inline} (0 calls)
 0: specials.show_full_file<0>
-show_full_file(call_source_file_full_name#0:wybe.string, io#0:wybe.phantom, ?io#1:wybe.phantom):
+show_full_file(call_source_file_full_name##0:wybe.string, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(~call_source_file_full_name#0:wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_string(~call_source_file_full_name##0:wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 show_full_location > public {inline} (0 calls)
 0: specials.show_full_location<0>
-show_full_location(call_source_full_location#0:wybe.string, io#0:wybe.phantom, ?io#1:wybe.phantom):
+show_full_location(call_source_full_location##0:wybe.string, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(~call_source_full_location#0:wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_string(~call_source_full_location##0:wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 show_line > public {inline} (0 calls)
 0: specials.show_line<0>
-show_line(call_source_line_number#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+show_line(call_source_line_number##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(~call_source_line_number#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~call_source_line_number##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 show_location > public {inline} (0 calls)
 0: specials.show_location<0>
-show_location(call_source_location#0:wybe.string, io#0:wybe.phantom, ?io#1:wybe.phantom):
+show_location(call_source_location##0:wybe.string, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(~call_source_location#0:wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_string(~call_source_location##0:wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -90,49 +90,49 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"specials.show_column<0>"(i64  %"call_source_column_number#0")    {
+define external fastcc  void @"specials.show_column<0>"(i64  %"call_source_column_number##0")    {
 entry:
-  tail call ccc  void  @print_int(i64  %"call_source_column_number#0")  
+  tail call ccc  void  @print_int(i64  %"call_source_column_number##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  void @"specials.show_file<0>"(i64  %"call_source_file_name#0")    {
+define external fastcc  void @"specials.show_file<0>"(i64  %"call_source_file_name##0")    {
 entry:
-  tail call ccc  void  @print_string(i64  %"call_source_file_name#0")  
+  tail call ccc  void  @print_string(i64  %"call_source_file_name##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  void @"specials.show_full_file<0>"(i64  %"call_source_file_full_name#0")    {
+define external fastcc  void @"specials.show_full_file<0>"(i64  %"call_source_file_full_name##0")    {
 entry:
-  tail call ccc  void  @print_string(i64  %"call_source_file_full_name#0")  
+  tail call ccc  void  @print_string(i64  %"call_source_file_full_name##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  void @"specials.show_full_location<0>"(i64  %"call_source_full_location#0")    {
+define external fastcc  void @"specials.show_full_location<0>"(i64  %"call_source_full_location##0")    {
 entry:
-  tail call ccc  void  @print_string(i64  %"call_source_full_location#0")  
+  tail call ccc  void  @print_string(i64  %"call_source_full_location##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  void @"specials.show_line<0>"(i64  %"call_source_line_number#0")    {
+define external fastcc  void @"specials.show_line<0>"(i64  %"call_source_line_number##0")    {
 entry:
-  tail call ccc  void  @print_int(i64  %"call_source_line_number#0")  
+  tail call ccc  void  @print_int(i64  %"call_source_line_number##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  void @"specials.show_location<0>"(i64  %"call_source_location#0")    {
+define external fastcc  void @"specials.show_location<0>"(i64  %"call_source_location##0")    {
 entry:
-  tail call ccc  void  @print_string(i64  %"call_source_location#0")  
+  tail call ccc  void  @print_string(i64  %"call_source_location##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/specials_one_module.exp
+++ b/test-cases/final-dump/specials_one_module.exp
@@ -19,15 +19,15 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("specials_one_module":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign c print_int(27:wybe.int, ~#io##1:wybe.phantom, ?tmp$5##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$5##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    foreign c print_int(2:wybe.int, ~#io##2:wybe.phantom, ?tmp$8##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$8##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign c print_string("specials_one_module:29:2":wybe.string, ~#io##3:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
-    foreign c print_string(" (should be line 28)":wybe.string, ~tmp$11##0:wybe.phantom, ?tmp$12##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$12##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string("specials_one_module":wybe.string, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(27:wybe.int, ~#io##1:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_int(2:wybe.int, ~#io##2:wybe.phantom, ?tmp#8##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#8##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign c print_string("specials_one_module:29:2":wybe.string, ~#io##3:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (should be line 28)":wybe.string, ~tmp#11##0:wybe.phantom, ?tmp#12##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#12##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
 
 
 indirect_call_location > public {inline} (1 calls)
@@ -36,8 +36,8 @@ indirect_call_location(call_source_location##0:wybe.string, io##0:wybe.phantom, 
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string(~call_source_location##0:wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign c print_string(" (should be line 28)":wybe.string, ~#io##1:wybe.phantom, ?tmp$4##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$4##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (should be line 28)":wybe.string, ~#io##1:wybe.phantom, ?tmp#4##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#4##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
 
 show_column > public {inline} (1 calls)
@@ -45,8 +45,8 @@ show_column > public {inline} (1 calls)
 show_column(call_source_column_number##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(~call_source_column_number##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~call_source_column_number##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 show_file > public {inline} (1 calls)
@@ -54,8 +54,8 @@ show_file > public {inline} (1 calls)
 show_file(call_source_file_name##0:wybe.string, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(~call_source_file_name##0:wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string(~call_source_file_name##0:wybe.string, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 show_line > public {inline} (1 calls)
@@ -63,8 +63,8 @@ show_line > public {inline} (1 calls)
 show_line(call_source_line_number##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(~call_source_line_number##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~call_source_line_number##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 show_location > public {inline} (1 calls)
@@ -72,9 +72,9 @@ show_location > public {inline} (1 calls)
 show_location(call_source_location##0:wybe.string, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(~#call_source_location##0:wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c print_string(" (should be line 28)":wybe.string, ~tmp$2##0:wybe.phantom, ?tmp$3##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$3##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string(~#call_source_location##0:wybe.string, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (should be line 28)":wybe.string, ~tmp#2##0:wybe.phantom, ?tmp#3##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#3##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/specials_one_module.exp
+++ b/test-cases/final-dump/specials_one_module.exp
@@ -16,65 +16,65 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: specials_one_module.<0>
-(io#0:wybe.phantom, ?io#4:wybe.phantom):
+(io##0:wybe.phantom, ?io##4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("specials_one_module":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_int(27:wybe.int, ~#io#1:wybe.phantom, ?tmp$5#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$5#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_int(2:wybe.int, ~#io#2:wybe.phantom, ?tmp$8#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$8#0:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign c print_string("specials_one_module:29:2":wybe.string, ~#io#3:wybe.phantom, ?tmp$11#0:wybe.phantom) @io:nn:nn
-    foreign c print_string(" (should be line 28)":wybe.string, ~tmp$11#0:wybe.phantom, ?tmp$12#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$12#0:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
+    foreign c print_string("specials_one_module":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(27:wybe.int, ~#io##1:wybe.phantom, ?tmp$5##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$5##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_int(2:wybe.int, ~#io##2:wybe.phantom, ?tmp$8##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$8##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign c print_string("specials_one_module:29:2":wybe.string, ~#io##3:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (should be line 28)":wybe.string, ~tmp$11##0:wybe.phantom, ?tmp$12##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$12##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
 
 
 indirect_call_location > public {inline} (1 calls)
 0: specials_one_module.indirect_call_location<0>
-indirect_call_location(call_source_location#0:wybe.string, io#0:wybe.phantom, ?io#2:wybe.phantom):
+indirect_call_location(call_source_location##0:wybe.string, io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(~call_source_location#0:wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_string(" (should be line 28)":wybe.string, ~#io#1:wybe.phantom, ?tmp$4#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$4#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
+    foreign c print_string(~call_source_location##0:wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (should be line 28)":wybe.string, ~#io##1:wybe.phantom, ?tmp$4##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$4##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
 
 show_column > public {inline} (1 calls)
 0: specials_one_module.show_column<0>
-show_column(call_source_column_number#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+show_column(call_source_column_number##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(~call_source_column_number#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~call_source_column_number##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 show_file > public {inline} (1 calls)
 0: specials_one_module.show_file<0>
-show_file(call_source_file_name#0:wybe.string, io#0:wybe.phantom, ?io#1:wybe.phantom):
+show_file(call_source_file_name##0:wybe.string, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(~call_source_file_name#0:wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_string(~call_source_file_name##0:wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 show_line > public {inline} (1 calls)
 0: specials_one_module.show_line<0>
-show_line(call_source_line_number#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+show_line(call_source_line_number##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(~call_source_line_number#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~call_source_line_number##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 show_location > public {inline} (1 calls)
 0: specials_one_module.show_location<0>
-show_location(call_source_location#0:wybe.string, io#0:wybe.phantom, ?io#1:wybe.phantom):
+show_location(call_source_location##0:wybe.string, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(~#call_source_location#0:wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c print_string(" (should be line 28)":wybe.string, ~tmp$2#0:wybe.phantom, ?tmp$3#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$3#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_string(~#call_source_location##0:wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c print_string(" (should be line 28)":wybe.string, ~tmp$2##0:wybe.phantom, ?tmp$3##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$3##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -132,9 +132,9 @@ entry:
 }
 
 
-define external fastcc  void @"specials_one_module.indirect_call_location<0>"(i64  %"call_source_location#0")    {
+define external fastcc  void @"specials_one_module.indirect_call_location<0>"(i64  %"call_source_location##0")    {
 entry:
-  tail call ccc  void  @print_string(i64  %"call_source_location#0")  
+  tail call ccc  void  @print_string(i64  %"call_source_location##0")  
   %8 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @specials_one_module.7, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %8)  
   tail call ccc  void  @putchar(i8  10)  
@@ -142,33 +142,33 @@ entry:
 }
 
 
-define external fastcc  void @"specials_one_module.show_column<0>"(i64  %"call_source_column_number#0")    {
+define external fastcc  void @"specials_one_module.show_column<0>"(i64  %"call_source_column_number##0")    {
 entry:
-  tail call ccc  void  @print_int(i64  %"call_source_column_number#0")  
+  tail call ccc  void  @print_int(i64  %"call_source_column_number##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  void @"specials_one_module.show_file<0>"(i64  %"call_source_file_name#0")    {
+define external fastcc  void @"specials_one_module.show_file<0>"(i64  %"call_source_file_name##0")    {
 entry:
-  tail call ccc  void  @print_string(i64  %"call_source_file_name#0")  
+  tail call ccc  void  @print_string(i64  %"call_source_file_name##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  void @"specials_one_module.show_line<0>"(i64  %"call_source_line_number#0")    {
+define external fastcc  void @"specials_one_module.show_line<0>"(i64  %"call_source_line_number##0")    {
 entry:
-  tail call ccc  void  @print_int(i64  %"call_source_line_number#0")  
+  tail call ccc  void  @print_int(i64  %"call_source_line_number##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  void @"specials_one_module.show_location<0>"(i64  %"call_source_location#0")    {
+define external fastcc  void @"specials_one_module.show_location<0>"(i64  %"call_source_location##0")    {
 entry:
-  tail call ccc  void  @print_string(i64  %"call_source_location#0")  
+  tail call ccc  void  @print_string(i64  %"call_source_location##0")  
   %10 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @specials_one_module.9, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %10)  
   tail call ccc  void  @putchar(i8  10)  

--- a/test-cases/final-dump/specials_use.exp
+++ b/test-cases/final-dump/specials_use.exp
@@ -19,8 +19,8 @@ show_column > public {inline} (0 calls)
 show_column(call_source_column_number##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(~call_source_column_number##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~call_source_column_number##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 show_file > public {inline} (0 calls)
@@ -28,8 +28,8 @@ show_file > public {inline} (0 calls)
 show_file(call_source_file_name##0:wybe.string, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(~call_source_file_name##0:wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string(~call_source_file_name##0:wybe.string, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 show_full_file > public {inline} (0 calls)
@@ -37,8 +37,8 @@ show_full_file > public {inline} (0 calls)
 show_full_file(call_source_file_full_name##0:wybe.string, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(~call_source_file_full_name##0:wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string(~call_source_file_full_name##0:wybe.string, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 show_full_location > public {inline} (0 calls)
@@ -46,8 +46,8 @@ show_full_location > public {inline} (0 calls)
 show_full_location(call_source_full_location##0:wybe.string, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(~call_source_full_location##0:wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string(~call_source_full_location##0:wybe.string, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 show_line > public {inline} (0 calls)
@@ -55,8 +55,8 @@ show_line > public {inline} (0 calls)
 show_line(call_source_line_number##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(~call_source_line_number##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~call_source_line_number##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 show_location > public {inline} (0 calls)
@@ -64,8 +64,8 @@ show_location > public {inline} (0 calls)
 show_location(call_source_location##0:wybe.string, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(~call_source_location##0:wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string(~call_source_location##0:wybe.string, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -152,18 +152,18 @@ entry:
 (io##0:wybe.phantom, ?io##6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("specials_use":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign c print_string("!ROOT!/final-dump/specials_use.wybe":wybe.string, ~#io##1:wybe.phantom, ?tmp$5##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$5##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    foreign c print_int(5:wybe.int, ~#io##2:wybe.phantom, ?tmp$8##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$8##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign c print_int(2:wybe.int, ~#io##3:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$11##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    foreign c print_string("specials_use:7:2":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
-    foreign c print_string("!ROOT!/final-dump/specials_use.wybe:8:2":wybe.string, ~#io##5:wybe.phantom, ?tmp$17##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$17##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+    foreign c print_string("specials_use":wybe.string, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("!ROOT!/final-dump/specials_use.wybe":wybe.string, ~#io##1:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_int(5:wybe.int, ~#io##2:wybe.phantom, ?tmp#8##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#8##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign c print_int(2:wybe.int, ~#io##3:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string("specials_use:7:2":wybe.string, ~#io##4:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign c print_string("!ROOT!/final-dump/specials_use.wybe:8:2":wybe.string, ~#io##5:wybe.phantom, ?tmp#17##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#17##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/specials_use.exp
+++ b/test-cases/final-dump/specials_use.exp
@@ -16,56 +16,56 @@ AFTER EVERYTHING:
 
 show_column > public {inline} (0 calls)
 0: specials.show_column<0>
-show_column(call_source_column_number#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+show_column(call_source_column_number##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(~call_source_column_number#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~call_source_column_number##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 show_file > public {inline} (0 calls)
 0: specials.show_file<0>
-show_file(call_source_file_name#0:wybe.string, io#0:wybe.phantom, ?io#1:wybe.phantom):
+show_file(call_source_file_name##0:wybe.string, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(~call_source_file_name#0:wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_string(~call_source_file_name##0:wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 show_full_file > public {inline} (0 calls)
 0: specials.show_full_file<0>
-show_full_file(call_source_file_full_name#0:wybe.string, io#0:wybe.phantom, ?io#1:wybe.phantom):
+show_full_file(call_source_file_full_name##0:wybe.string, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(~call_source_file_full_name#0:wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_string(~call_source_file_full_name##0:wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 show_full_location > public {inline} (0 calls)
 0: specials.show_full_location<0>
-show_full_location(call_source_full_location#0:wybe.string, io#0:wybe.phantom, ?io#1:wybe.phantom):
+show_full_location(call_source_full_location##0:wybe.string, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(~call_source_full_location#0:wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_string(~call_source_full_location##0:wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 show_line > public {inline} (0 calls)
 0: specials.show_line<0>
-show_line(call_source_line_number#0:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+show_line(call_source_line_number##0:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(~call_source_line_number#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~call_source_line_number##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 show_location > public {inline} (0 calls)
 0: specials.show_location<0>
-show_location(call_source_location#0:wybe.string, io#0:wybe.phantom, ?io#1:wybe.phantom):
+show_location(call_source_location##0:wybe.string, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string(~call_source_location#0:wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_string(~call_source_location##0:wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -90,49 +90,49 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  void @"specials.show_column<0>"(i64  %"call_source_column_number#0")    {
+define external fastcc  void @"specials.show_column<0>"(i64  %"call_source_column_number##0")    {
 entry:
-  tail call ccc  void  @print_int(i64  %"call_source_column_number#0")  
+  tail call ccc  void  @print_int(i64  %"call_source_column_number##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  void @"specials.show_file<0>"(i64  %"call_source_file_name#0")    {
+define external fastcc  void @"specials.show_file<0>"(i64  %"call_source_file_name##0")    {
 entry:
-  tail call ccc  void  @print_string(i64  %"call_source_file_name#0")  
+  tail call ccc  void  @print_string(i64  %"call_source_file_name##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  void @"specials.show_full_file<0>"(i64  %"call_source_file_full_name#0")    {
+define external fastcc  void @"specials.show_full_file<0>"(i64  %"call_source_file_full_name##0")    {
 entry:
-  tail call ccc  void  @print_string(i64  %"call_source_file_full_name#0")  
+  tail call ccc  void  @print_string(i64  %"call_source_file_full_name##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  void @"specials.show_full_location<0>"(i64  %"call_source_full_location#0")    {
+define external fastcc  void @"specials.show_full_location<0>"(i64  %"call_source_full_location##0")    {
 entry:
-  tail call ccc  void  @print_string(i64  %"call_source_full_location#0")  
+  tail call ccc  void  @print_string(i64  %"call_source_full_location##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  void @"specials.show_line<0>"(i64  %"call_source_line_number#0")    {
+define external fastcc  void @"specials.show_line<0>"(i64  %"call_source_line_number##0")    {
 entry:
-  tail call ccc  void  @print_int(i64  %"call_source_line_number#0")  
+  tail call ccc  void  @print_int(i64  %"call_source_line_number##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  void @"specials.show_location<0>"(i64  %"call_source_location#0")    {
+define external fastcc  void @"specials.show_location<0>"(i64  %"call_source_location##0")    {
 entry:
-  tail call ccc  void  @print_string(i64  %"call_source_location#0")  
+  tail call ccc  void  @print_string(i64  %"call_source_location##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -149,21 +149,21 @@ entry:
 
 *main* > public (0 calls)
 0: specials_use.<0>
-(io#0:wybe.phantom, ?io#6:wybe.phantom):
+(io##0:wybe.phantom, ?io##6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("specials_use":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_string("!ROOT!/final-dump/specials_use.wybe":wybe.string, ~#io#1:wybe.phantom, ?tmp$5#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$5#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign c print_int(5:wybe.int, ~#io#2:wybe.phantom, ?tmp$8#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$8#0:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign c print_int(2:wybe.int, ~#io#3:wybe.phantom, ?tmp$11#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$11#0:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_string("specials_use:7:2":wybe.string, ~#io#4:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-    foreign c print_string("!ROOT!/final-dump/specials_use.wybe:8:2":wybe.string, ~#io#5:wybe.phantom, ?tmp$17#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$17#0:wybe.phantom, ?#io#6:wybe.phantom) @io:nn:nn
+    foreign c print_string("specials_use":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("!ROOT!/final-dump/specials_use.wybe":wybe.string, ~#io##1:wybe.phantom, ?tmp$5##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$5##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_int(5:wybe.int, ~#io##2:wybe.phantom, ?tmp$8##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$8##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign c print_int(2:wybe.int, ~#io##3:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$11##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string("specials_use:7:2":wybe.string, ~#io##4:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign c print_string("!ROOT!/final-dump/specials_use.wybe:8:2":wybe.string, ~#io##5:wybe.phantom, ?tmp$17##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$17##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/stmt_for.exp
+++ b/test-cases/final-dump/stmt_for.exp
@@ -511,7 +511,7 @@ gen#9(io##0:wybe.phantom, tmp#0##0:wybe.list(?T), tmp#1##0:wybe.list(?T), tmp#2#
 
 irange > public (2 calls)
 0: stmt_for.irange<0>
-irange(start##0:wybe.int, stride##0:wybe.int, end##0:wybe.int, ?###0:stmt_for.int_sequence):
+irange(start##0:wybe.int, stride##0:wybe.int, end##0:wybe.int, ?#result##0:stmt_for.int_sequence):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_slt(stride##0:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
@@ -521,14 +521,14 @@ irange(start##0:wybe.int, stride##0:wybe.int, end##0:wybe.int, ?###0:stmt_for.in
         foreign lpvm alloc(24:wybe.int, ?tmp#12##0:stmt_for.int_sequence)
         foreign lpvm mutate(~tmp#12##0:stmt_for.int_sequence, ?tmp#13##0:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~start##0:wybe.int)
         foreign lpvm mutate(~tmp#13##0:stmt_for.int_sequence, ?tmp#14##0:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~stride##0:wybe.int)
-        foreign lpvm mutate(~tmp#14##0:stmt_for.int_sequence, ?###0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int)
+        foreign lpvm mutate(~tmp#14##0:stmt_for.int_sequence, ?#result##0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int)
 
     1:
         foreign llvm sub(~end##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
         foreign lpvm alloc(24:wybe.int, ?tmp#12##0:stmt_for.int_sequence)
         foreign lpvm mutate(~tmp#12##0:stmt_for.int_sequence, ?tmp#13##0:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~start##0:wybe.int)
         foreign lpvm mutate(~tmp#13##0:stmt_for.int_sequence, ?tmp#14##0:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~stride##0:wybe.int)
-        foreign lpvm mutate(~tmp#14##0:stmt_for.int_sequence, ?###0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
+        foreign lpvm mutate(~tmp#14##0:stmt_for.int_sequence, ?#result##0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
 
 
 
@@ -768,13 +768,13 @@ using_xrange_reverse(io##0:wybe.phantom, ?io##1:wybe.phantom):
 
 xrange > public (3 calls)
 0: stmt_for.xrange<0>
-xrange(start##0:wybe.int, stride##0:wybe.int, end##0:wybe.int, ?###0:stmt_for.int_sequence):
+xrange(start##0:wybe.int, stride##0:wybe.int, end##0:wybe.int, ?#result##0:stmt_for.int_sequence):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(24:wybe.int, ?tmp#4##0:stmt_for.int_sequence)
     foreign lpvm mutate(~tmp#4##0:stmt_for.int_sequence, ?tmp#5##0:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~start##0:wybe.int)
     foreign lpvm mutate(~tmp#5##0:stmt_for.int_sequence, ?tmp#6##0:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~stride##0:wybe.int)
-    foreign lpvm mutate(~tmp#6##0:stmt_for.int_sequence, ?###0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~end##0:wybe.int)
+    foreign lpvm mutate(~tmp#6##0:stmt_for.int_sequence, ?#result##0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~end##0:wybe.int)
 
   LLVM code       :
 
@@ -1960,10 +1960,10 @@ entry:
 
 end > public {inline} (0 calls)
 0: stmt_for.int_sequence.end<0>
-end(#rec##0:stmt_for.int_sequence, ?###0:wybe.int):
+end(#rec##0:stmt_for.int_sequence, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 end > public {inline} (0 calls)
 1: stmt_for.int_sequence.end<1>
 end(#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, #field##0:wybe.int):
@@ -1988,29 +1988,29 @@ gen#1([current##0:stmt_for.int_sequence], en##0:wybe.int, s##0:wybe.int, st##0:w
 
 int_sequence > public {inline} (1 calls)
 0: stmt_for.int_sequence.int_sequence<0>
-int_sequence(start##0:wybe.int, stride##0:wybe.int, end##0:wybe.int, ?###0:stmt_for.int_sequence):
+int_sequence(start##0:wybe.int, stride##0:wybe.int, end##0:wybe.int, ?#result##0:stmt_for.int_sequence):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(24:wybe.int, ?#rec##0:stmt_for.int_sequence)
     foreign lpvm mutate(~#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~start##0:wybe.int)
     foreign lpvm mutate(~#rec##1:stmt_for.int_sequence, ?#rec##2:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~stride##0:wybe.int)
-    foreign lpvm mutate(~#rec##2:stmt_for.int_sequence, ?###0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~end##0:wybe.int)
+    foreign lpvm mutate(~#rec##2:stmt_for.int_sequence, ?#result##0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~end##0:wybe.int)
 int_sequence > public {inline} (16 calls)
 1: stmt_for.int_sequence.int_sequence<1>
-int_sequence(?start##0:wybe.int, ?stride##0:wybe.int, ?end##0:wybe.int, ###0:stmt_for.int_sequence):
+int_sequence(?start##0:wybe.int, ?stride##0:wybe.int, ?end##0:wybe.int, #result##0:stmt_for.int_sequence):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?start##0:wybe.int)
-    foreign lpvm access(###0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?stride##0:wybe.int)
-    foreign lpvm access(~###0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?end##0:wybe.int)
+    foreign lpvm access(#result##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?start##0:wybe.int)
+    foreign lpvm access(#result##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?stride##0:wybe.int)
+    foreign lpvm access(~#result##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?end##0:wybe.int)
 
 
 start > public {inline} (0 calls)
 0: stmt_for.int_sequence.start<0>
-start(#rec##0:stmt_for.int_sequence, ?###0:wybe.int):
+start(#rec##0:stmt_for.int_sequence, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 start > public {inline} (0 calls)
 1: stmt_for.int_sequence.start<1>
 start(#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, #field##0:wybe.int):
@@ -2021,10 +2021,10 @@ start(#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, #field##0:w
 
 stride > public {inline} (0 calls)
 0: stmt_for.int_sequence.stride<0>
-stride(#rec##0:stmt_for.int_sequence, ?###0:wybe.int):
+stride(#rec##0:stmt_for.int_sequence, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 stride > public {inline} (0 calls)
 1: stmt_for.int_sequence.stride<1>
 stride(#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, #field##0:wybe.int):
@@ -2239,16 +2239,16 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64} @"stmt_for.int_sequence.int_sequence<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64, i64} @"stmt_for.int_sequence.int_sequence<1>"(i64  %"#result##0")    {
 entry:
-  %92 = inttoptr i64 %"###0" to i64* 
+  %92 = inttoptr i64 %"#result##0" to i64* 
   %93 = getelementptr  i64, i64* %92, i64 0 
   %94 = load  i64, i64* %93 
-  %95 = add   i64 %"###0", 8 
+  %95 = add   i64 %"#result##0", 8 
   %96 = inttoptr i64 %95 to i64* 
   %97 = getelementptr  i64, i64* %96, i64 0 
   %98 = load  i64, i64* %97 
-  %99 = add   i64 %"###0", 16 
+  %99 = add   i64 %"#result##0", 16 
   %100 = inttoptr i64 %99 to i64* 
   %101 = getelementptr  i64, i64* %100, i64 0 
   %102 = load  i64, i64* %101 

--- a/test-cases/final-dump/stmt_for.exp
+++ b/test-cases/final-dump/stmt_for.exp
@@ -408,35 +408,35 @@ gen#3(i##0:wybe.int, io##0:wybe.phantom, j##0:wybe.int, tmp#0##0:wybe.list(wybe.
 
 gen#4 > (2 calls)
 0: stmt_for.gen#4<0>
-gen#4(io##0:wybe.phantom, tmp#0##0:stmt_for.int_sequence, tmp#3##0:stmt_for.int_sequence, ?io##1:wybe.phantom, ?####0:wybe.bool):
+gen#4(io##0:wybe.phantom, tmp#0##0:stmt_for.int_sequence, tmp#3##0:stmt_for.int_sequence, ?io##1:wybe.phantom, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp#1##0:stmt_for.int_sequence, ~tmp#0##0:stmt_for.int_sequence, ?tmp#2##0:wybe.bool) #0
     case ~tmp#2##0:wybe.bool of
     0:
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        stmt_for.gen#5<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp#1##0:stmt_for.int_sequence, _:stmt_for.int_sequence, _:wybe.bool, ~tmp#3##0:stmt_for.int_sequence, ?io##1:wybe.phantom, ?####0:wybe.bool) #1
+        stmt_for.gen#5<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp#1##0:stmt_for.int_sequence, _:stmt_for.int_sequence, _:wybe.bool, ~tmp#3##0:stmt_for.int_sequence, ?io##1:wybe.phantom, ?#success##0:wybe.bool) #1
 
 
 
 gen#5 > (1 calls)
 0: stmt_for.gen#5<0>
-gen#5(i##0:wybe.int, io##0:wybe.phantom, tmp#0##0:stmt_for.int_sequence, [tmp#1##0:stmt_for.int_sequence], [tmp#2##0:wybe.bool], tmp#3##0:stmt_for.int_sequence, ?io##2:wybe.phantom, ?####0:wybe.bool):
+gen#5(i##0:wybe.int, io##0:wybe.phantom, tmp#0##0:stmt_for.int_sequence, [tmp#1##0:stmt_for.int_sequence], [tmp#2##0:wybe.bool], tmp#3##0:stmt_for.int_sequence, ?io##2:wybe.phantom, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_slt(i##0:wybe.int, 5:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
     case ~tmp#4##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
         foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @io:nn:nn
         foreign c putchar('\n':wybe.char, ~tmp#9##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_for.gen#4<0>(~io##1:wybe.phantom, ~tmp#0##0:stmt_for.int_sequence, ~tmp#3##0:stmt_for.int_sequence, ?io##2:wybe.phantom, ?####0:wybe.bool) #2 @stmt_for:nn:nn
+        stmt_for.gen#4<0>(~io##1:wybe.phantom, ~tmp#0##0:stmt_for.int_sequence, ~tmp#3##0:stmt_for.int_sequence, ?io##2:wybe.phantom, ?#success##0:wybe.bool) #2 @stmt_for:nn:nn
 
 
 
@@ -560,11 +560,11 @@ multiple_generator(io##0:wybe.phantom, ?io##1:wybe.phantom):
 
 semi_det_for_loop > public (0 calls)
 0: stmt_for.semi_det_for_loop<0>
-semi_det_for_loop(io##0:wybe.phantom, ?io##1:wybe.phantom, ?####0:wybe.bool):
+semi_det_for_loop(io##0:wybe.phantom, ?io##1:wybe.phantom, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     stmt_for.xrange<0>(0:wybe.int, 1:wybe.int, 10:wybe.int, ?tmp#3##0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
-    stmt_for.gen#4<0>(~io##0:wybe.phantom, ~tmp#3##0:stmt_for.int_sequence, ~tmp#3##0:stmt_for.int_sequence, ?io##1:wybe.phantom, ?####0:wybe.bool) #1 @stmt_for:nn:nn
+    stmt_for.gen#4<0>(~io##0:wybe.phantom, ~tmp#3##0:stmt_for.int_sequence, ~tmp#3##0:stmt_for.int_sequence, ?io##1:wybe.phantom, ?#success##0:wybe.bool) #1 @stmt_for:nn:nn
 
 
 shortest_generator_termination > public (1 calls)
@@ -1226,8 +1226,8 @@ entry:
   %102 = extractvalue {i64, i64, i1} %99, 2 
   br i1 %102, label %if.then, label %if.else 
 if.then:
-  %"2#####0" = tail call fastcc  i1  @"stmt_for.gen#5<0>"(i64  %100, i64  %101, i64  %"tmp#3##0")  
-  ret i1 %"2#####0" 
+  %"2##success##0" = tail call fastcc  i1  @"stmt_for.gen#5<0>"(i64  %100, i64  %101, i64  %"tmp#3##0")  
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 1 
 }
@@ -1240,8 +1240,8 @@ entry:
 if.then:
   tail call ccc  void  @print_int(i64  %"i##0")  
   tail call ccc  void  @putchar(i8  10)  
-  %"2#####0" = tail call fastcc  i1  @"stmt_for.gen#4<0>"(i64  %"tmp#0##0", i64  %"tmp#3##0")  
-  ret i1 %"2#####0" 
+  %"2##success##0" = tail call fastcc  i1  @"stmt_for.gen#4<0>"(i64  %"tmp#0##0", i64  %"tmp#3##0")  
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -1432,8 +1432,8 @@ entry:
 define external fastcc  i1 @"stmt_for.semi_det_for_loop<0>"()    {
 entry:
   %"1#tmp#3##0" = tail call fastcc  i64  @"stmt_for.xrange<0>"(i64  0, i64  1, i64  10)  
-  %"1#####0" = tail call fastcc  i1  @"stmt_for.gen#4<0>"(i64  %"1#tmp#3##0", i64  %"1#tmp#3##0")  
-  ret i1 %"1#####0" 
+  %"1##success##0" = tail call fastcc  i1  @"stmt_for.gen#4<0>"(i64  %"1#tmp#3##0", i64  %"1#tmp#3##0")  
+  ret i1 %"1##success##0" 
 }
 
 
@@ -1896,7 +1896,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: stmt_for.int_sequence.=<0>
-=(#left##0:stmt_for.int_sequence, #right##0:stmt_for.int_sequence, ?####0:wybe.bool):
+=(#left##0:stmt_for.int_sequence, #right##0:stmt_for.int_sequence, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#start##0:wybe.int)
@@ -1908,23 +1908,23 @@ entry:
     foreign llvm icmp_eq(~#left#start##0:wybe.int, ~#right#start##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~#left#stride##0:wybe.int, ~#right#stride##0:wybe.int, ?tmp#2##0:wybe.bool) @int:nn:nn
         case ~tmp#2##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~#left#end##0:wybe.int, ~#right#end##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+            foreign llvm icmp_eq(~#left#end##0:wybe.int, ~#right#end##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
 
 [|] > public (0 calls)
 0: stmt_for.int_sequence.[|]<0>
-[|](?value##0:wybe.int, ?rest##0:stmt_for.int_sequence, current##0:stmt_for.int_sequence, ?####0:wybe.bool):
+[|](?value##0:wybe.int, ?rest##0:stmt_for.int_sequence, current##0:stmt_for.int_sequence, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(current##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?s##0:wybe.int)
@@ -1936,24 +1936,24 @@ entry:
         foreign llvm icmp_sgt(en##0:wybe.int, s##0:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
         case ~tmp#3##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?value##0:wybe.int)
             foreign llvm move(undef:stmt_for.int_sequence, ?rest##0:stmt_for.int_sequence)
 
         1:
-            stmt_for.int_sequence.gen#1<0>(_:stmt_for.int_sequence, ~en##0:wybe.int, ~s##0:wybe.int, ~st##0:wybe.int, ?value##0:wybe.int, ?rest##0:stmt_for.int_sequence, ?####0:wybe.bool) #5
+            stmt_for.int_sequence.gen#1<0>(_:stmt_for.int_sequence, ~en##0:wybe.int, ~s##0:wybe.int, ~st##0:wybe.int, ?value##0:wybe.int, ?rest##0:stmt_for.int_sequence, ?#success##0:wybe.bool) #5
 
 
     1:
         foreign llvm icmp_slt(en##0:wybe.int, s##0:wybe.int, ?tmp#2##0:wybe.bool) @int:nn:nn
         case ~tmp#2##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?value##0:wybe.int)
             foreign llvm move(undef:stmt_for.int_sequence, ?rest##0:stmt_for.int_sequence)
 
         1:
-            stmt_for.int_sequence.gen#1<0>(_:stmt_for.int_sequence, ~en##0:wybe.int, ~s##0:wybe.int, ~st##0:wybe.int, ?value##0:wybe.int, ?rest##0:stmt_for.int_sequence, ?####0:wybe.bool) #3
+            stmt_for.int_sequence.gen#1<0>(_:stmt_for.int_sequence, ~en##0:wybe.int, ~s##0:wybe.int, ~st##0:wybe.int, ?value##0:wybe.int, ?rest##0:stmt_for.int_sequence, ?#success##0:wybe.bool) #3
 
 
 
@@ -1974,7 +1974,7 @@ end(#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, #field##0:wyb
 
 gen#1 > (2 calls)
 0: stmt_for.int_sequence.gen#1<0>
-gen#1([current##0:stmt_for.int_sequence], en##0:wybe.int, s##0:wybe.int, st##0:wybe.int, ?value##0:wybe.int, ?rest##0:stmt_for.int_sequence, ?####0:wybe.bool):
+gen#1([current##0:stmt_for.int_sequence], en##0:wybe.int, s##0:wybe.int, st##0:wybe.int, ?value##0:wybe.int, ?rest##0:stmt_for.int_sequence, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(s##0:wybe.int, ?value##0:wybe.int) @stmt_for:nn:nn
@@ -1983,7 +1983,7 @@ gen#1([current##0:stmt_for.int_sequence], en##0:wybe.int, s##0:wybe.int, st##0:w
     foreign lpvm mutate(~tmp#7##0:stmt_for.int_sequence, ?tmp#8##0:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int)
     foreign lpvm mutate(~tmp#8##0:stmt_for.int_sequence, ?tmp#9##0:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~st##0:wybe.int)
     foreign lpvm mutate(~tmp#9##0:stmt_for.int_sequence, ?rest##0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~en##0:wybe.int)
-    foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 int_sequence > public {inline} (1 calls)
@@ -2035,7 +2035,7 @@ stride(#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, #field##0:
 
 ~= > public {inline} (0 calls)
 0: stmt_for.int_sequence.~=<0>
-~=(#left##0:stmt_for.int_sequence, #right##0:stmt_for.int_sequence, ?####0:wybe.bool):
+~=(#left##0:stmt_for.int_sequence, #right##0:stmt_for.int_sequence, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -2048,18 +2048,18 @@ stride(#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, #field##0:
     case ~tmp#9##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#7##0:wybe.int, ?tmp#10##0:wybe.bool) @int:nn:nn
         case ~tmp#10##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign llvm icmp_eq(~tmp#5##0:wybe.int, ~tmp#8##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -2109,8 +2109,8 @@ if.then:
 if.else:
   ret i1 0 
 if.then1:
-  %"4#####0" = icmp eq i64 %11, %22 
-  ret i1 %"4#####0" 
+  %"4##success##0" = icmp eq i64 %11, %22 
+  ret i1 %"4##success##0" 
 if.else1:
   ret i1 0 
 }
@@ -2341,13 +2341,13 @@ if.then:
   %"2#tmp#10##0" = icmp eq i64 %136, %147 
   br i1 %"2#tmp#10##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 if.then1:
   %"4#tmp#0##0" = icmp eq i64 %140, %151 
-  %"4#####0" = xor i1 %"4#tmp#0##0", 1 
-  ret i1 %"4#####0" 
+  %"4##success##0" = xor i1 %"4#tmp#0##0", 1 
+  ret i1 %"4##success##0" 
 if.else1:
-  %"5#####0" = xor i1 0, 1 
-  ret i1 %"5#####0" 
+  %"5##success##0" = xor i1 0, 1 
+  ret i1 %"5##success##0" 
 }

--- a/test-cases/final-dump/stmt_for.exp
+++ b/test-cases/final-dump/stmt_for.exp
@@ -43,492 +43,492 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##26:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("single_generator:":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("single_generator:":wybe.string, ~#io##0:wybe.phantom, ?tmp#2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     stmt_for.single_generator<0>(~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #1 @stmt_for:nn:nn
-    foreign c print_string("\nmultiple_generator":wybe.string, ~#io##2:wybe.phantom, ?tmp$5##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$5##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign c print_string("\nmultiple_generator":wybe.string, ~#io##2:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
     stmt_for.multiple_generator<0>(~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #3 @stmt_for:nn:nn
-    foreign c print_string("\nshortest_generator_termination":wybe.string, ~#io##4:wybe.phantom, ?tmp$8##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$8##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign c print_string("\nshortest_generator_termination":wybe.string, ~#io##4:wybe.phantom, ?tmp#8##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#8##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
     stmt_for.shortest_generator_termination<0>(~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #5 @stmt_for:nn:nn
-    foreign c print_string("\nusing_break":wybe.string, ~#io##6:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$11##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
+    foreign c print_string("\nusing_break":wybe.string, ~#io##6:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
     stmt_for.using_break<0>(~#io##7:wybe.phantom, ?#io##8:wybe.phantom) #7 @stmt_for:nn:nn
-    foreign c print_string("\nusing_next":wybe.string, ~#io##8:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
+    foreign c print_string("\nusing_next":wybe.string, ~#io##8:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
     stmt_for.using_next<0>(~#io##9:wybe.phantom, ?#io##10:wybe.phantom) #9 @stmt_for:nn:nn
-    foreign c print_string("\nusing_while":wybe.string, ~#io##10:wybe.phantom, ?tmp$17##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$17##0:wybe.phantom, ?#io##11:wybe.phantom) @io:nn:nn
+    foreign c print_string("\nusing_while":wybe.string, ~#io##10:wybe.phantom, ?tmp#17##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#17##0:wybe.phantom, ?#io##11:wybe.phantom) @io:nn:nn
     stmt_for.using_while<0>(~#io##11:wybe.phantom, ?#io##12:wybe.phantom) #11 @stmt_for:nn:nn
-    foreign c print_string("\nusing_until":wybe.string, ~#io##12:wybe.phantom, ?tmp$20##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$20##0:wybe.phantom, ?#io##13:wybe.phantom) @io:nn:nn
+    foreign c print_string("\nusing_until":wybe.string, ~#io##12:wybe.phantom, ?tmp#20##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#20##0:wybe.phantom, ?#io##13:wybe.phantom) @io:nn:nn
     stmt_for.using_until<0>(~#io##13:wybe.phantom, ?#io##14:wybe.phantom) #13 @stmt_for:nn:nn
-    foreign c print_string("\nusing_when":wybe.string, ~#io##14:wybe.phantom, ?tmp$23##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$23##0:wybe.phantom, ?#io##15:wybe.phantom) @io:nn:nn
+    foreign c print_string("\nusing_when":wybe.string, ~#io##14:wybe.phantom, ?tmp#23##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#23##0:wybe.phantom, ?#io##15:wybe.phantom) @io:nn:nn
     stmt_for.using_when<0>(~#io##15:wybe.phantom, ?#io##16:wybe.phantom) #15 @stmt_for:nn:nn
-    foreign c print_string("\nusing_unless":wybe.string, ~#io##16:wybe.phantom, ?tmp$26##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$26##0:wybe.phantom, ?#io##17:wybe.phantom) @io:nn:nn
+    foreign c print_string("\nusing_unless":wybe.string, ~#io##16:wybe.phantom, ?tmp#26##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#26##0:wybe.phantom, ?#io##17:wybe.phantom) @io:nn:nn
     stmt_for.using_unless<0>(~#io##17:wybe.phantom, ?#io##18:wybe.phantom) #17 @stmt_for:nn:nn
-    foreign c print_string("\nusing_xrange":wybe.string, ~#io##18:wybe.phantom, ?tmp$29##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$29##0:wybe.phantom, ?#io##19:wybe.phantom) @io:nn:nn
+    foreign c print_string("\nusing_xrange":wybe.string, ~#io##18:wybe.phantom, ?tmp#29##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#29##0:wybe.phantom, ?#io##19:wybe.phantom) @io:nn:nn
     stmt_for.using_xrange<0>(~#io##19:wybe.phantom, ?#io##20:wybe.phantom) #19 @stmt_for:nn:nn
-    foreign c print_string("\nusing_xrange_reverse":wybe.string, ~#io##20:wybe.phantom, ?tmp$32##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$32##0:wybe.phantom, ?#io##21:wybe.phantom) @io:nn:nn
+    foreign c print_string("\nusing_xrange_reverse":wybe.string, ~#io##20:wybe.phantom, ?tmp#32##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#32##0:wybe.phantom, ?#io##21:wybe.phantom) @io:nn:nn
     stmt_for.using_xrange_reverse<0>(~#io##21:wybe.phantom, ?#io##22:wybe.phantom) #21 @stmt_for:nn:nn
-    foreign c print_string("\nusing_irange":wybe.string, ~#io##22:wybe.phantom, ?tmp$35##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$35##0:wybe.phantom, ?#io##23:wybe.phantom) @io:nn:nn
+    foreign c print_string("\nusing_irange":wybe.string, ~#io##22:wybe.phantom, ?tmp#35##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#35##0:wybe.phantom, ?#io##23:wybe.phantom) @io:nn:nn
     stmt_for.using_irange<0>(~#io##23:wybe.phantom, ?#io##24:wybe.phantom) #23 @stmt_for:nn:nn
-    foreign c print_string("\nusing_irange_reverse":wybe.string, ~#io##24:wybe.phantom, ?tmp$38##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$38##0:wybe.phantom, ?#io##25:wybe.phantom) @io:nn:nn
+    foreign c print_string("\nusing_irange_reverse":wybe.string, ~#io##24:wybe.phantom, ?tmp#38##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#38##0:wybe.phantom, ?#io##25:wybe.phantom) @io:nn:nn
     stmt_for.using_irange_reverse<0>(~#io##25:wybe.phantom, ?#io##26:wybe.phantom) #25 @stmt_for:nn:nn
 
 
-gen$1 > (2 calls)
-0: stmt_for.gen$1<0>
-gen$1(io##0:wybe.phantom, tmp$0##0:wybe.list(?T), tmp$1##0:wybe.list(?T), tmp$2##0:wybe.list(?T), tmp$3##0:wybe.list(?T), tmp$4##0:wybe.list(?T), tmp$5##0:wybe.list(?T), tmp$6##0:wybe.list(?T), tmp$7##0:wybe.list(?T), tmp$8##0:wybe.list(wybe.int), tmp$9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
+gen#1 > (2 calls)
+0: stmt_for.gen#1<0>
+gen#1(io##0:wybe.phantom, tmp#0##0:wybe.list(?T), tmp#1##0:wybe.list(?T), tmp#2##0:wybe.list(?T), tmp#3##0:wybe.list(?T), tmp#4##0:wybe.list(?T), tmp#5##0:wybe.list(?T), tmp#6##0:wybe.list(?T), tmp#7##0:wybe.list(?T), tmp#8##0:wybe.list(wybe.int), tmp#9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp$8##0:wybe.int, 0:wybe.int, ?tmp$14##0:wybe.bool)
-    case ~tmp$14##0:wybe.bool of
+    foreign llvm icmp_ne(tmp#8##0:wybe.int, 0:wybe.int, ?tmp#14##0:wybe.bool)
+    case ~tmp#14##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp$8##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
-        foreign lpvm access(~tmp$8##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.list(?T))
-        stmt_for.gen$2<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp$0##0:wybe.list(wybe.int), ~tmp$1##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~tmp$2##0:wybe.list(wybe.int), ~tmp$3##0:wybe.list(wybe.int), ~tmp$4##0:wybe.list(wybe.int), ~tmp$5##0:wybe.list(wybe.int), ~tmp$6##0:wybe.list(wybe.int), ~tmp$7##0:wybe.list(wybe.int), ~tmp$10##0:wybe.list(wybe.int), ~tmp$9##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
+        foreign lpvm access(tmp#8##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
+        foreign lpvm access(~tmp#8##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.list(?T))
+        stmt_for.gen#2<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int), ~tmp#6##0:wybe.list(wybe.int), ~tmp#7##0:wybe.list(wybe.int), ~tmp#10##0:wybe.list(wybe.int), ~tmp#9##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
 
 
 
-gen$10 > (2 calls)
-0: stmt_for.gen$10<0>
-gen$10(io##0:wybe.phantom, tmp$0##0:wybe.list(?T), tmp$1##0:wybe.list(?T), tmp$2##0:wybe.list(?T), tmp$3##0:wybe.list(?T), tmp$4##0:wybe.list(?T), tmp$5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
+gen#10 > (2 calls)
+0: stmt_for.gen#10<0>
+gen#10(io##0:wybe.phantom, tmp#0##0:wybe.list(?T), tmp#1##0:wybe.list(?T), tmp#2##0:wybe.list(?T), tmp#3##0:wybe.list(?T), tmp#4##0:wybe.list(?T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp$5##0:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.bool)
-    case ~tmp$10##0:wybe.bool of
+    foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
+    case ~tmp#10##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp$5##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
-        foreign lpvm access(~tmp$5##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.list(?T))
-        stmt_for.gen$11<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp$0##0:wybe.list(wybe.int), ~tmp$1##0:wybe.list(wybe.int), ~tmp$2##0:wybe.list(wybe.int), ~tmp$3##0:wybe.list(wybe.int), ~tmp$4##0:wybe.list(wybe.int), ~tmp$6##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
+        foreign lpvm access(tmp#5##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
+        foreign lpvm access(~tmp#5##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.list(?T))
+        stmt_for.gen#11<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#6##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
 
 
 
-gen$11 > (1 calls)
-0: stmt_for.gen$11<0>
-gen$11(i##0:wybe.int, io##0:wybe.phantom, tmp$0##0:wybe.list(wybe.int), tmp$1##0:wybe.list(wybe.int), tmp$2##0:wybe.list(wybe.int), tmp$3##0:wybe.list(wybe.int), tmp$4##0:wybe.list(wybe.int), tmp$5##0:wybe.list(wybe.int), [tmp$6##0:wybe.list(wybe.int)], [tmp$7##0:wybe.bool], x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
+gen#11 > (1 calls)
+0: stmt_for.gen#11<0>
+gen#11(i##0:wybe.int, io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), [tmp#6##0:wybe.list(wybe.int)], [tmp#7##0:wybe.bool], x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(i##0:wybe.int, 3:wybe.int, ?tmp$8##0:wybe.bool) @int:nn:nn
-    case ~tmp$8##0:wybe.bool of
+    foreign llvm icmp_eq(i##0:wybe.int, 3:wybe.int, ?tmp#8##0:wybe.bool) @int:nn:nn
+    case ~tmp#8##0:wybe.bool of
     0:
-        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$13##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$13##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_for.gen$10<0>(~io##1:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), ~tmp$4##0:wybe.list(?T), ~tmp$5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_for.gen#10<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), ~tmp#4##0:wybe.list(?T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
 
     1:
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
 
 
-gen$12 > (2 calls)
-0: stmt_for.gen$12<0>
-gen$12(io##0:wybe.phantom, tmp$0##0:stmt_for.int_sequence, tmp$3##0:stmt_for.int_sequence, ?io##2:wybe.phantom):
+gen#12 > (2 calls)
+0: stmt_for.gen#12<0>
+gen#12(io##0:wybe.phantom, tmp#0##0:stmt_for.int_sequence, tmp#3##0:stmt_for.int_sequence, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp$1##0:stmt_for.int_sequence, ~tmp$0##0:stmt_for.int_sequence, ?tmp$2##0:wybe.bool) #0
-    case ~tmp$2##0:wybe.bool of
+    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp#1##0:stmt_for.int_sequence, ~tmp#0##0:stmt_for.int_sequence, ?tmp#2##0:wybe.bool) #0
+    case ~tmp#2##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$6##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_for.gen$12<0>(~io##1:wybe.phantom, ~tmp$1##0:stmt_for.int_sequence, ~tmp$3##0:stmt_for.int_sequence, ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_for.gen#12<0>(~io##1:wybe.phantom, ~tmp#1##0:stmt_for.int_sequence, ~tmp#3##0:stmt_for.int_sequence, ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
 
 
 
-gen$13 > (2 calls)
-0: stmt_for.gen$13<0>
-gen$13(io##0:wybe.phantom, tmp$0##0:stmt_for.int_sequence, tmp$3##0:stmt_for.int_sequence, ?io##2:wybe.phantom):
+gen#13 > (2 calls)
+0: stmt_for.gen#13<0>
+gen#13(io##0:wybe.phantom, tmp#0##0:stmt_for.int_sequence, tmp#3##0:stmt_for.int_sequence, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp$1##0:stmt_for.int_sequence, ~tmp$0##0:stmt_for.int_sequence, ?tmp$2##0:wybe.bool) #0
-    case ~tmp$2##0:wybe.bool of
+    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp#1##0:stmt_for.int_sequence, ~tmp#0##0:stmt_for.int_sequence, ?tmp#2##0:wybe.bool) #0
+    case ~tmp#2##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$6##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_for.gen$13<0>(~io##1:wybe.phantom, ~tmp$1##0:stmt_for.int_sequence, ~tmp$3##0:stmt_for.int_sequence, ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_for.gen#13<0>(~io##1:wybe.phantom, ~tmp#1##0:stmt_for.int_sequence, ~tmp#3##0:stmt_for.int_sequence, ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
 
 
 
-gen$14 > (3 calls)
-0: stmt_for.gen$14<0>
-gen$14(io##0:wybe.phantom, tmp$0##0:wybe.list(?T), tmp$1##0:wybe.list(?T), tmp$2##0:wybe.list(?T), tmp$3##0:wybe.list(?T), tmp$4##0:wybe.list(?T), tmp$5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
+gen#14 > (3 calls)
+0: stmt_for.gen#14<0>
+gen#14(io##0:wybe.phantom, tmp#0##0:wybe.list(?T), tmp#1##0:wybe.list(?T), tmp#2##0:wybe.list(?T), tmp#3##0:wybe.list(?T), tmp#4##0:wybe.list(?T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp$5##0:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.bool)
-    case ~tmp$10##0:wybe.bool of
+    foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
+    case ~tmp#10##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp$5##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
-        foreign lpvm access(~tmp$5##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.list(?T))
-        stmt_for.gen$15<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp$0##0:wybe.list(wybe.int), ~tmp$1##0:wybe.list(wybe.int), ~tmp$2##0:wybe.list(wybe.int), ~tmp$3##0:wybe.list(wybe.int), ~tmp$4##0:wybe.list(wybe.int), ~tmp$6##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
+        foreign lpvm access(tmp#5##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
+        foreign lpvm access(~tmp#5##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.list(?T))
+        stmt_for.gen#15<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#6##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
 
 
 
-gen$15 > (1 calls)
-0: stmt_for.gen$15<0>
-gen$15(i##0:wybe.int, io##0:wybe.phantom, tmp$0##0:wybe.list(wybe.int), tmp$1##0:wybe.list(wybe.int), tmp$2##0:wybe.list(wybe.int), tmp$3##0:wybe.list(wybe.int), tmp$4##0:wybe.list(wybe.int), tmp$5##0:wybe.list(wybe.int), [tmp$6##0:wybe.list(wybe.int)], [tmp$7##0:wybe.bool], x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
+gen#15 > (1 calls)
+0: stmt_for.gen#15<0>
+gen#15(i##0:wybe.int, io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), [tmp#6##0:wybe.list(wybe.int)], [tmp#7##0:wybe.bool], x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(i##0:wybe.int, 3:wybe.int, ?tmp$8##0:wybe.bool) @int:nn:nn
-    case ~tmp$8##0:wybe.bool of
+    foreign llvm icmp_eq(i##0:wybe.int, 3:wybe.int, ?tmp#8##0:wybe.bool) @int:nn:nn
+    case ~tmp#8##0:wybe.bool of
     0:
-        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$13##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$13##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_for.gen$14<0>(~io##1:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), ~tmp$4##0:wybe.list(?T), ~tmp$5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #3 @stmt_for:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_for.gen#14<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), ~tmp#4##0:wybe.list(?T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #3 @stmt_for:nn:nn
 
     1:
-        stmt_for.gen$14<0>(~io##0:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), ~tmp$4##0:wybe.list(?T), ~tmp$5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #1 @stmt_for:nn:nn
+        stmt_for.gen#14<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), ~tmp#4##0:wybe.list(?T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #1 @stmt_for:nn:nn
 
 
 
-gen$16 > (3 calls)
-0: stmt_for.gen$16<0>
-gen$16(io##0:wybe.phantom, tmp$0##0:wybe.list(?T), tmp$1##0:wybe.list(?T), tmp$2##0:wybe.list(?T), tmp$3##0:wybe.list(?T), tmp$4##0:wybe.list(?T), tmp$5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
+gen#16 > (3 calls)
+0: stmt_for.gen#16<0>
+gen#16(io##0:wybe.phantom, tmp#0##0:wybe.list(?T), tmp#1##0:wybe.list(?T), tmp#2##0:wybe.list(?T), tmp#3##0:wybe.list(?T), tmp#4##0:wybe.list(?T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp$5##0:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.bool)
-    case ~tmp$10##0:wybe.bool of
+    foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
+    case ~tmp#10##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp$5##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
-        foreign lpvm access(~tmp$5##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.list(?T))
-        stmt_for.gen$17<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp$0##0:wybe.list(wybe.int), ~tmp$1##0:wybe.list(wybe.int), ~tmp$2##0:wybe.list(wybe.int), ~tmp$3##0:wybe.list(wybe.int), ~tmp$4##0:wybe.list(wybe.int), ~tmp$6##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
+        foreign lpvm access(tmp#5##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
+        foreign lpvm access(~tmp#5##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.list(?T))
+        stmt_for.gen#17<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#6##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
 
 
 
-gen$17 > (1 calls)
-0: stmt_for.gen$17<0>
-gen$17(i##0:wybe.int, io##0:wybe.phantom, tmp$0##0:wybe.list(wybe.int), tmp$1##0:wybe.list(wybe.int), tmp$2##0:wybe.list(wybe.int), tmp$3##0:wybe.list(wybe.int), tmp$4##0:wybe.list(wybe.int), tmp$5##0:wybe.list(wybe.int), [tmp$6##0:wybe.list(wybe.int)], [tmp$7##0:wybe.bool], x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
+gen#17 > (1 calls)
+0: stmt_for.gen#17<0>
+gen#17(i##0:wybe.int, io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), [tmp#6##0:wybe.list(wybe.int)], [tmp#7##0:wybe.bool], x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_slt(i##0:wybe.int, 3:wybe.int, ?tmp$8##0:wybe.bool) @int:nn:nn
-    case ~tmp$8##0:wybe.bool of
+    foreign llvm icmp_slt(i##0:wybe.int, 3:wybe.int, ?tmp#8##0:wybe.bool) @int:nn:nn
+    case ~tmp#8##0:wybe.bool of
     0:
-        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$13##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$13##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_for.gen$16<0>(~io##1:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), ~tmp$4##0:wybe.list(?T), ~tmp$5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #3 @stmt_for:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_for.gen#16<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), ~tmp#4##0:wybe.list(?T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #3 @stmt_for:nn:nn
 
     1:
-        stmt_for.gen$16<0>(~io##0:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), ~tmp$4##0:wybe.list(?T), ~tmp$5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #1 @stmt_for:nn:nn
+        stmt_for.gen#16<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), ~tmp#4##0:wybe.list(?T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #1 @stmt_for:nn:nn
 
 
 
-gen$18 > (2 calls)
-0: stmt_for.gen$18<0>
-gen$18(io##0:wybe.phantom, tmp$0##0:wybe.list(?T), tmp$1##0:wybe.list(?T), tmp$2##0:wybe.list(?T), tmp$3##0:wybe.list(?T), tmp$4##0:wybe.list(?T), tmp$5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
+gen#18 > (2 calls)
+0: stmt_for.gen#18<0>
+gen#18(io##0:wybe.phantom, tmp#0##0:wybe.list(?T), tmp#1##0:wybe.list(?T), tmp#2##0:wybe.list(?T), tmp#3##0:wybe.list(?T), tmp#4##0:wybe.list(?T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp$5##0:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.bool)
-    case ~tmp$10##0:wybe.bool of
+    foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
+    case ~tmp#10##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp$5##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
-        foreign lpvm access(~tmp$5##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.list(?T))
-        stmt_for.gen$19<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp$0##0:wybe.list(wybe.int), ~tmp$1##0:wybe.list(wybe.int), ~tmp$2##0:wybe.list(wybe.int), ~tmp$3##0:wybe.list(wybe.int), ~tmp$4##0:wybe.list(wybe.int), ~tmp$6##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
+        foreign lpvm access(tmp#5##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
+        foreign lpvm access(~tmp#5##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.list(?T))
+        stmt_for.gen#19<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#6##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
 
 
 
-gen$19 > (1 calls)
-0: stmt_for.gen$19<0>
-gen$19(i##0:wybe.int, io##0:wybe.phantom, tmp$0##0:wybe.list(wybe.int), tmp$1##0:wybe.list(wybe.int), tmp$2##0:wybe.list(wybe.int), tmp$3##0:wybe.list(wybe.int), tmp$4##0:wybe.list(wybe.int), tmp$5##0:wybe.list(wybe.int), [tmp$6##0:wybe.list(wybe.int)], [tmp$7##0:wybe.bool], x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
+gen#19 > (1 calls)
+0: stmt_for.gen#19<0>
+gen#19(i##0:wybe.int, io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), [tmp#6##0:wybe.list(wybe.int)], [tmp#7##0:wybe.bool], x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(i##0:wybe.int, 3:wybe.int, ?tmp$8##0:wybe.bool) @int:nn:nn
-    case ~tmp$8##0:wybe.bool of
+    foreign llvm icmp_eq(i##0:wybe.int, 3:wybe.int, ?tmp#8##0:wybe.bool) @int:nn:nn
+    case ~tmp#8##0:wybe.bool of
     0:
-        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$13##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$13##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_for.gen$18<0>(~io##1:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), ~tmp$4##0:wybe.list(?T), ~tmp$5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_for.gen#18<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), ~tmp#4##0:wybe.list(?T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
 
     1:
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
 
 
-gen$2 > (1 calls)
-0: stmt_for.gen$2<0>
-gen$2(i##0:wybe.int, io##0:wybe.phantom, tmp$0##0:wybe.list(wybe.int), tmp$1##0:wybe.list(wybe.int), [tmp$10##0:wybe.list(wybe.int)], [tmp$12##0:wybe.bool], tmp$2##0:wybe.list(wybe.int), tmp$3##0:wybe.list(wybe.int), tmp$4##0:wybe.list(wybe.int), tmp$5##0:wybe.list(wybe.int), tmp$6##0:wybe.list(wybe.int), tmp$7##0:wybe.list(wybe.int), tmp$8##0:wybe.list(wybe.int), tmp$9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
+gen#2 > (1 calls)
+0: stmt_for.gen#2<0>
+gen#2(i##0:wybe.int, io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), [tmp#10##0:wybe.list(wybe.int)], [tmp#12##0:wybe.bool], tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), tmp#6##0:wybe.list(wybe.int), tmp#7##0:wybe.list(wybe.int), tmp#8##0:wybe.list(wybe.int), tmp#9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp$9##0:wybe.int, 0:wybe.int, ?tmp$14##0:wybe.bool)
-    case ~tmp$14##0:wybe.bool of
+    foreign llvm icmp_ne(tmp#9##0:wybe.int, 0:wybe.int, ?tmp#14##0:wybe.bool)
+    case ~tmp#14##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp$9##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?j##0:?T)
-        foreign lpvm access(~tmp$9##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$11##0:wybe.list(?T))
-        foreign c print_int(~i##0:wybe.int, ~io##0:wybe.phantom, ?tmp$33##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$33##0:wybe.phantom, ?tmp$34##0:wybe.phantom) @io:nn:nn
-        foreign c print_int(~j##0:wybe.int, ~tmp$34##0:wybe.phantom, ?tmp$35##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$35##0:wybe.phantom, ?tmp$36##0:wybe.phantom) @io:nn:nn
-        stmt_for.gen$1<0>(~tmp$36##0:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), ~tmp$4##0:wybe.list(?T), ~tmp$5##0:wybe.list(?T), ~tmp$6##0:wybe.list(?T), ~tmp$7##0:wybe.list(?T), ~tmp$8##0:wybe.list(wybe.int), ~tmp$11##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #2 @stmt_for:nn:nn
+        foreign lpvm access(tmp#9##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?j##0:?T)
+        foreign lpvm access(~tmp#9##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#11##0:wybe.list(?T))
+        foreign c print_int(~i##0:wybe.int, ~io##0:wybe.phantom, ?tmp#33##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#33##0:wybe.phantom, ?tmp#34##0:wybe.phantom) @io:nn:nn
+        foreign c print_int(~j##0:wybe.int, ~tmp#34##0:wybe.phantom, ?tmp#35##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#35##0:wybe.phantom, ?tmp#36##0:wybe.phantom) @io:nn:nn
+        stmt_for.gen#1<0>(~tmp#36##0:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), ~tmp#4##0:wybe.list(?T), ~tmp#5##0:wybe.list(?T), ~tmp#6##0:wybe.list(?T), ~tmp#7##0:wybe.list(?T), ~tmp#8##0:wybe.list(wybe.int), ~tmp#11##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #2 @stmt_for:nn:nn
 
 
 
-gen$20 > (3 calls)
-0: stmt_for.gen$20<0>
-gen$20(io##0:wybe.phantom, tmp$0##0:wybe.list(?T), tmp$1##0:wybe.list(?T), tmp$2##0:wybe.list(?T), tmp$3##0:wybe.list(?T), tmp$4##0:wybe.list(?T), tmp$5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
+gen#20 > (3 calls)
+0: stmt_for.gen#20<0>
+gen#20(io##0:wybe.phantom, tmp#0##0:wybe.list(?T), tmp#1##0:wybe.list(?T), tmp#2##0:wybe.list(?T), tmp#3##0:wybe.list(?T), tmp#4##0:wybe.list(?T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp$5##0:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.bool)
-    case ~tmp$10##0:wybe.bool of
+    foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
+    case ~tmp#10##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp$5##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
-        foreign lpvm access(~tmp$5##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.list(?T))
-        stmt_for.gen$21<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp$0##0:wybe.list(wybe.int), ~tmp$1##0:wybe.list(wybe.int), ~tmp$2##0:wybe.list(wybe.int), ~tmp$3##0:wybe.list(wybe.int), ~tmp$4##0:wybe.list(wybe.int), ~tmp$6##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
+        foreign lpvm access(tmp#5##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
+        foreign lpvm access(~tmp#5##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.list(?T))
+        stmt_for.gen#21<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#6##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
 
 
 
-gen$21 > (1 calls)
-0: stmt_for.gen$21<0>
-gen$21(i##0:wybe.int, io##0:wybe.phantom, tmp$0##0:wybe.list(wybe.int), tmp$1##0:wybe.list(wybe.int), tmp$2##0:wybe.list(wybe.int), tmp$3##0:wybe.list(wybe.int), tmp$4##0:wybe.list(wybe.int), tmp$5##0:wybe.list(wybe.int), [tmp$6##0:wybe.list(wybe.int)], [tmp$7##0:wybe.bool], x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
+gen#21 > (1 calls)
+0: stmt_for.gen#21<0>
+gen#21(i##0:wybe.int, io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), [tmp#6##0:wybe.list(wybe.int)], [tmp#7##0:wybe.bool], x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_slt(i##0:wybe.int, 3:wybe.int, ?tmp$8##0:wybe.bool) @int:nn:nn
-    case ~tmp$8##0:wybe.bool of
+    foreign llvm icmp_slt(i##0:wybe.int, 3:wybe.int, ?tmp#8##0:wybe.bool) @int:nn:nn
+    case ~tmp#8##0:wybe.bool of
     0:
-        stmt_for.gen$20<0>(~io##0:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), ~tmp$4##0:wybe.list(?T), ~tmp$5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #3 @stmt_for:nn:nn
+        stmt_for.gen#20<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), ~tmp#4##0:wybe.list(?T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #3 @stmt_for:nn:nn
 
     1:
-        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$13##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$13##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_for.gen$20<0>(~io##1:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), ~tmp$4##0:wybe.list(?T), ~tmp$5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_for.gen#20<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), ~tmp#4##0:wybe.list(?T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
 
 
 
-gen$22 > (2 calls)
-0: stmt_for.gen$22<0>
-gen$22(io##0:wybe.phantom, tmp$0##0:wybe.list(?T), tmp$1##0:wybe.list(?T), tmp$2##0:wybe.list(?T), tmp$3##0:wybe.list(?T), tmp$4##0:wybe.list(?T), tmp$5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
+gen#22 > (2 calls)
+0: stmt_for.gen#22<0>
+gen#22(io##0:wybe.phantom, tmp#0##0:wybe.list(?T), tmp#1##0:wybe.list(?T), tmp#2##0:wybe.list(?T), tmp#3##0:wybe.list(?T), tmp#4##0:wybe.list(?T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp$5##0:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.bool)
-    case ~tmp$10##0:wybe.bool of
+    foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
+    case ~tmp#10##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp$5##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
-        foreign lpvm access(~tmp$5##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.list(?T))
-        stmt_for.gen$23<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp$0##0:wybe.list(wybe.int), ~tmp$1##0:wybe.list(wybe.int), ~tmp$2##0:wybe.list(wybe.int), ~tmp$3##0:wybe.list(wybe.int), ~tmp$4##0:wybe.list(wybe.int), ~tmp$6##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
+        foreign lpvm access(tmp#5##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
+        foreign lpvm access(~tmp#5##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.list(?T))
+        stmt_for.gen#23<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#6##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
 
 
 
-gen$23 > (1 calls)
-0: stmt_for.gen$23<0>
-gen$23(i##0:wybe.int, io##0:wybe.phantom, tmp$0##0:wybe.list(wybe.int), tmp$1##0:wybe.list(wybe.int), tmp$2##0:wybe.list(wybe.int), tmp$3##0:wybe.list(wybe.int), tmp$4##0:wybe.list(wybe.int), tmp$5##0:wybe.list(wybe.int), [tmp$6##0:wybe.list(wybe.int)], [tmp$7##0:wybe.bool], x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
+gen#23 > (1 calls)
+0: stmt_for.gen#23<0>
+gen#23(i##0:wybe.int, io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), [tmp#6##0:wybe.list(wybe.int)], [tmp#7##0:wybe.bool], x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_slt(i##0:wybe.int, 3:wybe.int, ?tmp$8##0:wybe.bool) @int:nn:nn
-    case ~tmp$8##0:wybe.bool of
+    foreign llvm icmp_slt(i##0:wybe.int, 3:wybe.int, ?tmp#8##0:wybe.bool) @int:nn:nn
+    case ~tmp#8##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$13##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$13##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_for.gen$22<0>(~io##1:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), ~tmp$4##0:wybe.list(?T), ~tmp$5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_for.gen#22<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), ~tmp#4##0:wybe.list(?T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
 
 
 
-gen$24 > (2 calls)
-0: stmt_for.gen$24<0>
-gen$24(io##0:wybe.phantom, tmp$0##0:stmt_for.int_sequence, tmp$3##0:stmt_for.int_sequence, ?io##2:wybe.phantom):
+gen#24 > (2 calls)
+0: stmt_for.gen#24<0>
+gen#24(io##0:wybe.phantom, tmp#0##0:stmt_for.int_sequence, tmp#3##0:stmt_for.int_sequence, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp$1##0:stmt_for.int_sequence, ~tmp$0##0:stmt_for.int_sequence, ?tmp$2##0:wybe.bool) #0
-    case ~tmp$2##0:wybe.bool of
+    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp#1##0:stmt_for.int_sequence, ~tmp#0##0:stmt_for.int_sequence, ?tmp#2##0:wybe.bool) #0
+    case ~tmp#2##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$6##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_for.gen$24<0>(~io##1:wybe.phantom, ~tmp$1##0:stmt_for.int_sequence, ~tmp$3##0:stmt_for.int_sequence, ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_for.gen#24<0>(~io##1:wybe.phantom, ~tmp#1##0:stmt_for.int_sequence, ~tmp#3##0:stmt_for.int_sequence, ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
 
 
 
-gen$25 > (2 calls)
-0: stmt_for.gen$25<0>
-gen$25(io##0:wybe.phantom, tmp$0##0:stmt_for.int_sequence, tmp$3##0:stmt_for.int_sequence, ?io##2:wybe.phantom):
+gen#25 > (2 calls)
+0: stmt_for.gen#25<0>
+gen#25(io##0:wybe.phantom, tmp#0##0:stmt_for.int_sequence, tmp#3##0:stmt_for.int_sequence, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp$1##0:stmt_for.int_sequence, ~tmp$0##0:stmt_for.int_sequence, ?tmp$2##0:wybe.bool) #0
-    case ~tmp$2##0:wybe.bool of
+    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp#1##0:stmt_for.int_sequence, ~tmp#0##0:stmt_for.int_sequence, ?tmp#2##0:wybe.bool) #0
+    case ~tmp#2##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$6##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_for.gen$25<0>(~io##1:wybe.phantom, ~tmp$1##0:stmt_for.int_sequence, ~tmp$3##0:stmt_for.int_sequence, ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_for.gen#25<0>(~io##1:wybe.phantom, ~tmp#1##0:stmt_for.int_sequence, ~tmp#3##0:stmt_for.int_sequence, ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
 
 
 
-gen$3 > {inline} (1 calls)
-0: stmt_for.gen$3<0>
-gen$3(i##0:wybe.int, io##0:wybe.phantom, j##0:wybe.int, tmp$0##0:wybe.list(wybe.int), tmp$1##0:wybe.list(wybe.int), [tmp$10##0:wybe.list(wybe.int)], [tmp$11##0:wybe.list(wybe.int)], [tmp$12##0:wybe.bool], tmp$2##0:wybe.list(wybe.int), tmp$3##0:wybe.list(wybe.int), tmp$4##0:wybe.list(wybe.int), tmp$5##0:wybe.list(wybe.int), tmp$6##0:wybe.list(wybe.int), tmp$7##0:wybe.list(wybe.int), tmp$8##0:wybe.list(wybe.int), tmp$9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int), ?io##3:wybe.phantom):
+gen#3 > {inline} (1 calls)
+0: stmt_for.gen#3<0>
+gen#3(i##0:wybe.int, io##0:wybe.phantom, j##0:wybe.int, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), [tmp#10##0:wybe.list(wybe.int)], [tmp#11##0:wybe.list(wybe.int)], [tmp#12##0:wybe.bool], tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), tmp#6##0:wybe.list(wybe.int), tmp#7##0:wybe.list(wybe.int), tmp#8##0:wybe.list(wybe.int), tmp#9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int), ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$15##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$15##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign c print_int(~j##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$18##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$18##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    stmt_for.gen$1<0>(~io##2:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), ~tmp$4##0:wybe.list(?T), ~tmp$5##0:wybe.list(?T), ~tmp$6##0:wybe.list(?T), ~tmp$7##0:wybe.list(?T), ~tmp$8##0:wybe.list(wybe.int), ~tmp$9##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##3:wybe.phantom) #2 @stmt_for:nn:nn
+    foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#15##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~j##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#18##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#18##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    stmt_for.gen#1<0>(~io##2:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), ~tmp#4##0:wybe.list(?T), ~tmp#5##0:wybe.list(?T), ~tmp#6##0:wybe.list(?T), ~tmp#7##0:wybe.list(?T), ~tmp#8##0:wybe.list(wybe.int), ~tmp#9##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##3:wybe.phantom) #2 @stmt_for:nn:nn
 
 
-gen$4 > (2 calls)
-0: stmt_for.gen$4<0>
-gen$4(io##0:wybe.phantom, tmp$0##0:stmt_for.int_sequence, tmp$3##0:stmt_for.int_sequence, ?io##1:wybe.phantom, ?$$##0:wybe.bool):
+gen#4 > (2 calls)
+0: stmt_for.gen#4<0>
+gen#4(io##0:wybe.phantom, tmp#0##0:stmt_for.int_sequence, tmp#3##0:stmt_for.int_sequence, ?io##1:wybe.phantom, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp$1##0:stmt_for.int_sequence, ~tmp$0##0:stmt_for.int_sequence, ?tmp$2##0:wybe.bool) #0
-    case ~tmp$2##0:wybe.bool of
+    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp#1##0:stmt_for.int_sequence, ~tmp#0##0:stmt_for.int_sequence, ?tmp#2##0:wybe.bool) #0
+    case ~tmp#2##0:wybe.bool of
     0:
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        stmt_for.gen$5<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp$1##0:stmt_for.int_sequence, _:stmt_for.int_sequence, _:wybe.bool, ~tmp$3##0:stmt_for.int_sequence, ?io##1:wybe.phantom, ?$$##0:wybe.bool) #1
+        stmt_for.gen#5<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp#1##0:stmt_for.int_sequence, _:stmt_for.int_sequence, _:wybe.bool, ~tmp#3##0:stmt_for.int_sequence, ?io##1:wybe.phantom, ?####0:wybe.bool) #1
 
 
 
-gen$5 > (1 calls)
-0: stmt_for.gen$5<0>
-gen$5(i##0:wybe.int, io##0:wybe.phantom, tmp$0##0:stmt_for.int_sequence, [tmp$1##0:stmt_for.int_sequence], [tmp$2##0:wybe.bool], tmp$3##0:stmt_for.int_sequence, ?io##2:wybe.phantom, ?$$##0:wybe.bool):
+gen#5 > (1 calls)
+0: stmt_for.gen#5<0>
+gen#5(i##0:wybe.int, io##0:wybe.phantom, tmp#0##0:stmt_for.int_sequence, [tmp#1##0:stmt_for.int_sequence], [tmp#2##0:wybe.bool], tmp#3##0:stmt_for.int_sequence, ?io##2:wybe.phantom, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_slt(i##0:wybe.int, 5:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
-    case ~tmp$4##0:wybe.bool of
+    foreign llvm icmp_slt(i##0:wybe.int, 5:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
+    case ~tmp#4##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$9##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$9##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_for.gen$4<0>(~io##1:wybe.phantom, ~tmp$0##0:stmt_for.int_sequence, ~tmp$3##0:stmt_for.int_sequence, ?io##2:wybe.phantom, ?$$##0:wybe.bool) #2 @stmt_for:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#9##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_for.gen#4<0>(~io##1:wybe.phantom, ~tmp#0##0:stmt_for.int_sequence, ~tmp#3##0:stmt_for.int_sequence, ?io##2:wybe.phantom, ?####0:wybe.bool) #2 @stmt_for:nn:nn
 
 
 
-gen$6 > (2 calls)
-0: stmt_for.gen$6<0>
-gen$6(io##0:wybe.phantom, tmp$0##0:wybe.list(?T), tmp$1##0:wybe.list(?T), tmp$2##0:wybe.list(?T), tmp$3##0:wybe.list(?T), tmp$4##0:wybe.list(?T), tmp$5##0:wybe.list(?T), tmp$6##0:wybe.list(?T), tmp$7##0:wybe.list(?T), tmp$8##0:wybe.list(wybe.int), tmp$9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
+gen#6 > (2 calls)
+0: stmt_for.gen#6<0>
+gen#6(io##0:wybe.phantom, tmp#0##0:wybe.list(?T), tmp#1##0:wybe.list(?T), tmp#2##0:wybe.list(?T), tmp#3##0:wybe.list(?T), tmp#4##0:wybe.list(?T), tmp#5##0:wybe.list(?T), tmp#6##0:wybe.list(?T), tmp#7##0:wybe.list(?T), tmp#8##0:wybe.list(wybe.int), tmp#9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp$8##0:wybe.int, 0:wybe.int, ?tmp$14##0:wybe.bool)
-    case ~tmp$14##0:wybe.bool of
-    0:
-        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
-
-    1:
-        foreign lpvm access(tmp$8##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
-        foreign lpvm access(~tmp$8##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.list(?T))
-        stmt_for.gen$7<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp$0##0:wybe.list(wybe.int), ~tmp$1##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~tmp$2##0:wybe.list(wybe.int), ~tmp$3##0:wybe.list(wybe.int), ~tmp$4##0:wybe.list(wybe.int), ~tmp$5##0:wybe.list(wybe.int), ~tmp$6##0:wybe.list(wybe.int), ~tmp$7##0:wybe.list(wybe.int), ~tmp$10##0:wybe.list(wybe.int), ~tmp$9##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
-
-
-
-gen$7 > (1 calls)
-0: stmt_for.gen$7<0>
-gen$7(i##0:wybe.int, io##0:wybe.phantom, tmp$0##0:wybe.list(wybe.int), tmp$1##0:wybe.list(wybe.int), [tmp$10##0:wybe.list(wybe.int)], [tmp$12##0:wybe.bool], tmp$2##0:wybe.list(wybe.int), tmp$3##0:wybe.list(wybe.int), tmp$4##0:wybe.list(wybe.int), tmp$5##0:wybe.list(wybe.int), tmp$6##0:wybe.list(wybe.int), tmp$7##0:wybe.list(wybe.int), tmp$8##0:wybe.list(wybe.int), tmp$9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
- AliasPairs: []
- InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp$9##0:wybe.int, 0:wybe.int, ?tmp$14##0:wybe.bool)
-    case ~tmp$14##0:wybe.bool of
+    foreign llvm icmp_ne(tmp#8##0:wybe.int, 0:wybe.int, ?tmp#14##0:wybe.bool)
+    case ~tmp#14##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp$9##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?j##0:?T)
-        foreign lpvm access(~tmp$9##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$11##0:wybe.list(?T))
-        foreign c print_int(~i##0:wybe.int, ~io##0:wybe.phantom, ?tmp$33##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$33##0:wybe.phantom, ?tmp$34##0:wybe.phantom) @io:nn:nn
-        foreign c print_int(~j##0:wybe.int, ~tmp$34##0:wybe.phantom, ?tmp$35##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$35##0:wybe.phantom, ?tmp$36##0:wybe.phantom) @io:nn:nn
-        stmt_for.gen$6<0>(~tmp$36##0:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), ~tmp$4##0:wybe.list(?T), ~tmp$5##0:wybe.list(?T), ~tmp$6##0:wybe.list(?T), ~tmp$7##0:wybe.list(?T), ~tmp$8##0:wybe.list(wybe.int), ~tmp$11##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #2 @stmt_for:nn:nn
+        foreign lpvm access(tmp#8##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
+        foreign lpvm access(~tmp#8##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.list(?T))
+        stmt_for.gen#7<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int), ~tmp#6##0:wybe.list(wybe.int), ~tmp#7##0:wybe.list(wybe.int), ~tmp#10##0:wybe.list(wybe.int), ~tmp#9##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
 
 
 
-gen$8 > {inline} (1 calls)
-0: stmt_for.gen$8<0>
-gen$8(i##0:wybe.int, io##0:wybe.phantom, j##0:wybe.int, tmp$0##0:wybe.list(wybe.int), tmp$1##0:wybe.list(wybe.int), [tmp$10##0:wybe.list(wybe.int)], [tmp$11##0:wybe.list(wybe.int)], [tmp$12##0:wybe.bool], tmp$2##0:wybe.list(wybe.int), tmp$3##0:wybe.list(wybe.int), tmp$4##0:wybe.list(wybe.int), tmp$5##0:wybe.list(wybe.int), tmp$6##0:wybe.list(wybe.int), tmp$7##0:wybe.list(wybe.int), tmp$8##0:wybe.list(wybe.int), tmp$9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int), ?io##3:wybe.phantom):
+gen#7 > (1 calls)
+0: stmt_for.gen#7<0>
+gen#7(i##0:wybe.int, io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), [tmp#10##0:wybe.list(wybe.int)], [tmp#12##0:wybe.bool], tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), tmp#6##0:wybe.list(wybe.int), tmp#7##0:wybe.list(wybe.int), tmp#8##0:wybe.list(wybe.int), tmp#9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$15##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$15##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign c print_int(~j##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$18##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$18##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    stmt_for.gen$6<0>(~io##2:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), ~tmp$4##0:wybe.list(?T), ~tmp$5##0:wybe.list(?T), ~tmp$6##0:wybe.list(?T), ~tmp$7##0:wybe.list(?T), ~tmp$8##0:wybe.list(wybe.int), ~tmp$9##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##3:wybe.phantom) #2 @stmt_for:nn:nn
+    foreign llvm icmp_ne(tmp#9##0:wybe.int, 0:wybe.int, ?tmp#14##0:wybe.bool)
+    case ~tmp#14##0:wybe.bool of
+    0:
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
+
+    1:
+        foreign lpvm access(tmp#9##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?j##0:?T)
+        foreign lpvm access(~tmp#9##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#11##0:wybe.list(?T))
+        foreign c print_int(~i##0:wybe.int, ~io##0:wybe.phantom, ?tmp#33##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#33##0:wybe.phantom, ?tmp#34##0:wybe.phantom) @io:nn:nn
+        foreign c print_int(~j##0:wybe.int, ~tmp#34##0:wybe.phantom, ?tmp#35##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#35##0:wybe.phantom, ?tmp#36##0:wybe.phantom) @io:nn:nn
+        stmt_for.gen#6<0>(~tmp#36##0:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), ~tmp#4##0:wybe.list(?T), ~tmp#5##0:wybe.list(?T), ~tmp#6##0:wybe.list(?T), ~tmp#7##0:wybe.list(?T), ~tmp#8##0:wybe.list(wybe.int), ~tmp#11##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #2 @stmt_for:nn:nn
 
 
-gen$9 > (2 calls)
-0: stmt_for.gen$9<0>
-gen$9(io##0:wybe.phantom, tmp$0##0:wybe.list(?T), tmp$1##0:wybe.list(?T), tmp$2##0:wybe.list(?T), tmp$3##0:wybe.list(?T), tmp$4##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
+
+gen#8 > {inline} (1 calls)
+0: stmt_for.gen#8<0>
+gen#8(i##0:wybe.int, io##0:wybe.phantom, j##0:wybe.int, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), [tmp#10##0:wybe.list(wybe.int)], [tmp#11##0:wybe.list(wybe.int)], [tmp#12##0:wybe.bool], tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), tmp#6##0:wybe.list(wybe.int), tmp#7##0:wybe.list(wybe.int), tmp#8##0:wybe.list(wybe.int), tmp#9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int), ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp$4##0:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.bool)
-    case ~tmp$8##0:wybe.bool of
+    foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#15##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~j##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#18##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#18##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    stmt_for.gen#6<0>(~io##2:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), ~tmp#4##0:wybe.list(?T), ~tmp#5##0:wybe.list(?T), ~tmp#6##0:wybe.list(?T), ~tmp#7##0:wybe.list(?T), ~tmp#8##0:wybe.list(wybe.int), ~tmp#9##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##3:wybe.phantom) #2 @stmt_for:nn:nn
+
+
+gen#9 > (2 calls)
+0: stmt_for.gen#9<0>
+gen#9(io##0:wybe.phantom, tmp#0##0:wybe.list(?T), tmp#1##0:wybe.list(?T), tmp#2##0:wybe.list(?T), tmp#3##0:wybe.list(?T), tmp#4##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
+ AliasPairs: []
+ InterestingCallProperties: []
+    foreign llvm icmp_ne(tmp#4##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool)
+    case ~tmp#8##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp$4##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
-        foreign lpvm access(~tmp$4##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.list(?T))
-        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$11##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_for.gen$9<0>(~io##1:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), ~tmp$5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
+        foreign lpvm access(tmp#4##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
+        foreign lpvm access(~tmp#4##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.list(?T))
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_for.gen#9<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
 
 
 
 irange > public (2 calls)
 0: stmt_for.irange<0>
-irange(start##0:wybe.int, stride##0:wybe.int, end##0:wybe.int, ?$##0:stmt_for.int_sequence):
+irange(start##0:wybe.int, stride##0:wybe.int, end##0:wybe.int, ?###0:stmt_for.int_sequence):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_slt(stride##0:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
-    case ~tmp$4##0:wybe.bool of
+    foreign llvm icmp_slt(stride##0:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
+    case ~tmp#4##0:wybe.bool of
     0:
-        foreign llvm add(~end##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
-        foreign lpvm alloc(24:wybe.int, ?tmp$12##0:stmt_for.int_sequence)
-        foreign lpvm mutate(~tmp$12##0:stmt_for.int_sequence, ?tmp$13##0:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~start##0:wybe.int)
-        foreign lpvm mutate(~tmp$13##0:stmt_for.int_sequence, ?tmp$14##0:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~stride##0:wybe.int)
-        foreign lpvm mutate(~tmp$14##0:stmt_for.int_sequence, ?$##0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp$3##0:wybe.int)
+        foreign llvm add(~end##0:wybe.int, 1:wybe.int, ?tmp#3##0:wybe.int) @int:nn:nn
+        foreign lpvm alloc(24:wybe.int, ?tmp#12##0:stmt_for.int_sequence)
+        foreign lpvm mutate(~tmp#12##0:stmt_for.int_sequence, ?tmp#13##0:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~start##0:wybe.int)
+        foreign lpvm mutate(~tmp#13##0:stmt_for.int_sequence, ?tmp#14##0:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~stride##0:wybe.int)
+        foreign lpvm mutate(~tmp#14##0:stmt_for.int_sequence, ?###0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp#3##0:wybe.int)
 
     1:
-        foreign llvm sub(~end##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
-        foreign lpvm alloc(24:wybe.int, ?tmp$12##0:stmt_for.int_sequence)
-        foreign lpvm mutate(~tmp$12##0:stmt_for.int_sequence, ?tmp$13##0:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~start##0:wybe.int)
-        foreign lpvm mutate(~tmp$13##0:stmt_for.int_sequence, ?tmp$14##0:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~stride##0:wybe.int)
-        foreign lpvm mutate(~tmp$14##0:stmt_for.int_sequence, ?$##0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp$2##0:wybe.int)
+        foreign llvm sub(~end##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
+        foreign lpvm alloc(24:wybe.int, ?tmp#12##0:stmt_for.int_sequence)
+        foreign lpvm mutate(~tmp#12##0:stmt_for.int_sequence, ?tmp#13##0:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~start##0:wybe.int)
+        foreign lpvm mutate(~tmp#13##0:stmt_for.int_sequence, ?tmp#14##0:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~stride##0:wybe.int)
+        foreign lpvm mutate(~tmp#14##0:stmt_for.int_sequence, ?###0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp#2##0:wybe.int)
 
 
 
@@ -537,34 +537,34 @@ multiple_generator > public (1 calls)
 multiple_generator(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$15##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$15##0:wybe.list(?T), ?tmp$16##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
-    foreign lpvm mutate(~tmp$16##0:wybe.list(?T), ?tmp$2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$19##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$19##0:wybe.list(?T), ?tmp$20##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
-    foreign lpvm mutate(~tmp$20##0:wybe.list(?T), ?tmp$1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$2##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$23##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$23##0:wybe.list(?T), ?tmp$24##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
-    foreign lpvm mutate(~tmp$24##0:wybe.list(?T), ?tmp$0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$1##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$27##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$27##0:wybe.list(?T), ?tmp$28##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 6:?T)
-    foreign lpvm mutate(~tmp$28##0:wybe.list(?T), ?tmp$6##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$31##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$31##0:wybe.list(?T), ?tmp$32##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 5:?T)
-    foreign lpvm mutate(~tmp$32##0:wybe.list(?T), ?tmp$5##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$6##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$35##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$35##0:wybe.list(?T), ?tmp$36##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
-    foreign lpvm mutate(~tmp$36##0:wybe.list(?T), ?tmp$4##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$5##0:wybe.list(?T))
-    stmt_for.gen$1<0>(~io##0:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), 0:wybe.list(?T), ~tmp$4##0:wybe.list(?T), ~tmp$5##0:wybe.list(?T), ~tmp$6##0:wybe.list(?T), 0:wybe.list(?T), ~tmp$0##0:wybe.list(wybe.int), ~tmp$4##0:wybe.list(wybe.int), ~tmp$0##0:wybe.list(wybe.int), ~tmp$4##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #8 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#15##0:wybe.list(?T), ?tmp#16##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
+    foreign lpvm mutate(~tmp#16##0:wybe.list(?T), ?tmp#2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#19##0:wybe.list(?T), ?tmp#20##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
+    foreign lpvm mutate(~tmp#20##0:wybe.list(?T), ?tmp#1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#23##0:wybe.list(?T), ?tmp#24##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
+    foreign lpvm mutate(~tmp#24##0:wybe.list(?T), ?tmp#0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#27##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#27##0:wybe.list(?T), ?tmp#28##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 6:?T)
+    foreign lpvm mutate(~tmp#28##0:wybe.list(?T), ?tmp#6##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#31##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#31##0:wybe.list(?T), ?tmp#32##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 5:?T)
+    foreign lpvm mutate(~tmp#32##0:wybe.list(?T), ?tmp#5##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#6##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#35##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#35##0:wybe.list(?T), ?tmp#36##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
+    foreign lpvm mutate(~tmp#36##0:wybe.list(?T), ?tmp#4##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#5##0:wybe.list(?T))
+    stmt_for.gen#1<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), 0:wybe.list(?T), ~tmp#4##0:wybe.list(?T), ~tmp#5##0:wybe.list(?T), ~tmp#6##0:wybe.list(?T), 0:wybe.list(?T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #8 @stmt_for:nn:nn
 
 
 semi_det_for_loop > public (0 calls)
 0: stmt_for.semi_det_for_loop<0>
-semi_det_for_loop(io##0:wybe.phantom, ?io##1:wybe.phantom, ?$$##0:wybe.bool):
+semi_det_for_loop(io##0:wybe.phantom, ?io##1:wybe.phantom, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_for.xrange<0>(0:wybe.int, 1:wybe.int, 10:wybe.int, ?tmp$3##0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
-    stmt_for.gen$4<0>(~io##0:wybe.phantom, ~tmp$3##0:stmt_for.int_sequence, ~tmp$3##0:stmt_for.int_sequence, ?io##1:wybe.phantom, ?$$##0:wybe.bool) #1 @stmt_for:nn:nn
+    stmt_for.xrange<0>(0:wybe.int, 1:wybe.int, 10:wybe.int, ?tmp#3##0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
+    stmt_for.gen#4<0>(~io##0:wybe.phantom, ~tmp#3##0:stmt_for.int_sequence, ~tmp#3##0:stmt_for.int_sequence, ?io##1:wybe.phantom, ?####0:wybe.bool) #1 @stmt_for:nn:nn
 
 
 shortest_generator_termination > public (1 calls)
@@ -572,25 +572,25 @@ shortest_generator_termination > public (1 calls)
 shortest_generator_termination(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$15##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$15##0:wybe.list(?T), ?tmp$16##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
-    foreign lpvm mutate(~tmp$16##0:wybe.list(?T), ?tmp$3##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$19##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$19##0:wybe.list(?T), ?tmp$20##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
-    foreign lpvm mutate(~tmp$20##0:wybe.list(?T), ?tmp$2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$3##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$23##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$23##0:wybe.list(?T), ?tmp$24##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
-    foreign lpvm mutate(~tmp$24##0:wybe.list(?T), ?tmp$1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$2##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$27##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$27##0:wybe.list(?T), ?tmp$28##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
-    foreign lpvm mutate(~tmp$28##0:wybe.list(?T), ?tmp$0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$1##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$31##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$31##0:wybe.list(?T), ?tmp$32##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 5:?T)
-    foreign lpvm mutate(~tmp$32##0:wybe.list(?T), ?tmp$6##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$35##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$35##0:wybe.list(?T), ?tmp$36##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
-    foreign lpvm mutate(~tmp$36##0:wybe.list(?T), ?tmp$5##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$6##0:wybe.list(?T))
-    stmt_for.gen$6<0>(~io##0:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), 0:wybe.list(?T), ~tmp$5##0:wybe.list(?T), ~tmp$6##0:wybe.list(?T), 0:wybe.list(?T), ~tmp$0##0:wybe.list(wybe.int), ~tmp$5##0:wybe.list(wybe.int), ~tmp$0##0:wybe.list(wybe.int), ~tmp$5##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #8 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#15##0:wybe.list(?T), ?tmp#16##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
+    foreign lpvm mutate(~tmp#16##0:wybe.list(?T), ?tmp#3##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#19##0:wybe.list(?T), ?tmp#20##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
+    foreign lpvm mutate(~tmp#20##0:wybe.list(?T), ?tmp#2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#23##0:wybe.list(?T), ?tmp#24##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
+    foreign lpvm mutate(~tmp#24##0:wybe.list(?T), ?tmp#1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#27##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#27##0:wybe.list(?T), ?tmp#28##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
+    foreign lpvm mutate(~tmp#28##0:wybe.list(?T), ?tmp#0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#31##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#31##0:wybe.list(?T), ?tmp#32##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 5:?T)
+    foreign lpvm mutate(~tmp#32##0:wybe.list(?T), ?tmp#6##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#35##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#35##0:wybe.list(?T), ?tmp#36##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
+    foreign lpvm mutate(~tmp#36##0:wybe.list(?T), ?tmp#5##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#6##0:wybe.list(?T))
+    stmt_for.gen#6<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), 0:wybe.list(?T), ~tmp#5##0:wybe.list(?T), ~tmp#6##0:wybe.list(?T), 0:wybe.list(?T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #8 @stmt_for:nn:nn
 
 
 single_generator > public (1 calls)
@@ -598,16 +598,16 @@ single_generator > public (1 calls)
 single_generator(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$9##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$9##0:wybe.list(?T), ?tmp$10##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
-    foreign lpvm mutate(~tmp$10##0:wybe.list(?T), ?tmp$2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$13##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$13##0:wybe.list(?T), ?tmp$14##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
-    foreign lpvm mutate(~tmp$14##0:wybe.list(?T), ?tmp$1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$2##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$17##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$17##0:wybe.list(?T), ?tmp$18##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
-    foreign lpvm mutate(~tmp$18##0:wybe.list(?T), ?tmp$0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$1##0:wybe.list(?T))
-    stmt_for.gen$9<0>(~io##0:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), 0:wybe.list(?T), ~tmp$0##0:wybe.list(wybe.int), ~tmp$0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #4 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#9##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#9##0:wybe.list(?T), ?tmp#10##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
+    foreign lpvm mutate(~tmp#10##0:wybe.list(?T), ?tmp#2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#13##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#13##0:wybe.list(?T), ?tmp#14##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
+    foreign lpvm mutate(~tmp#14##0:wybe.list(?T), ?tmp#1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#17##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#17##0:wybe.list(?T), ?tmp#18##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
+    foreign lpvm mutate(~tmp#18##0:wybe.list(?T), ?tmp#0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(?T))
+    stmt_for.gen#9<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), 0:wybe.list(?T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #4 @stmt_for:nn:nn
 
 
 using_break > public (1 calls)
@@ -615,19 +615,19 @@ using_break > public (1 calls)
 using_break(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$11##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$11##0:wybe.list(?T), ?tmp$12##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
-    foreign lpvm mutate(~tmp$12##0:wybe.list(?T), ?tmp$3##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$15##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$15##0:wybe.list(?T), ?tmp$16##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
-    foreign lpvm mutate(~tmp$16##0:wybe.list(?T), ?tmp$2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$3##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$19##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$19##0:wybe.list(?T), ?tmp$20##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
-    foreign lpvm mutate(~tmp$20##0:wybe.list(?T), ?tmp$1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$2##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$23##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$23##0:wybe.list(?T), ?tmp$24##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
-    foreign lpvm mutate(~tmp$24##0:wybe.list(?T), ?tmp$0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$1##0:wybe.list(?T))
-    stmt_for.gen$10<0>(~io##0:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), 0:wybe.list(?T), ~tmp$0##0:wybe.list(wybe.int), ~tmp$0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#11##0:wybe.list(?T), ?tmp#12##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
+    foreign lpvm mutate(~tmp#12##0:wybe.list(?T), ?tmp#3##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#15##0:wybe.list(?T), ?tmp#16##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
+    foreign lpvm mutate(~tmp#16##0:wybe.list(?T), ?tmp#2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#19##0:wybe.list(?T), ?tmp#20##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
+    foreign lpvm mutate(~tmp#20##0:wybe.list(?T), ?tmp#1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#23##0:wybe.list(?T), ?tmp#24##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
+    foreign lpvm mutate(~tmp#24##0:wybe.list(?T), ?tmp#0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(?T))
+    stmt_for.gen#10<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), 0:wybe.list(?T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
 using_irange > public (1 calls)
@@ -635,8 +635,8 @@ using_irange > public (1 calls)
 using_irange(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_for.irange<0>(1:wybe.int, 1:wybe.int, 10:wybe.int, ?tmp$3##0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
-    stmt_for.gen$12<0>(~io##0:wybe.phantom, ~tmp$3##0:stmt_for.int_sequence, ~tmp$3##0:stmt_for.int_sequence, ?io##1:wybe.phantom) #1 @stmt_for:nn:nn
+    stmt_for.irange<0>(1:wybe.int, 1:wybe.int, 10:wybe.int, ?tmp#3##0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
+    stmt_for.gen#12<0>(~io##0:wybe.phantom, ~tmp#3##0:stmt_for.int_sequence, ~tmp#3##0:stmt_for.int_sequence, ?io##1:wybe.phantom) #1 @stmt_for:nn:nn
 
 
 using_irange_reverse > public (1 calls)
@@ -644,8 +644,8 @@ using_irange_reverse > public (1 calls)
 using_irange_reverse(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_for.irange<0>(10:wybe.int, -1:wybe.int, 1:wybe.int, ?tmp$3##0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
-    stmt_for.gen$13<0>(~io##0:wybe.phantom, ~tmp$3##0:stmt_for.int_sequence, ~tmp$3##0:stmt_for.int_sequence, ?io##1:wybe.phantom) #1 @stmt_for:nn:nn
+    stmt_for.irange<0>(10:wybe.int, -1:wybe.int, 1:wybe.int, ?tmp#3##0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
+    stmt_for.gen#13<0>(~io##0:wybe.phantom, ~tmp#3##0:stmt_for.int_sequence, ~tmp#3##0:stmt_for.int_sequence, ?io##1:wybe.phantom) #1 @stmt_for:nn:nn
 
 
 using_next > public (1 calls)
@@ -653,19 +653,19 @@ using_next > public (1 calls)
 using_next(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$11##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$11##0:wybe.list(?T), ?tmp$12##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
-    foreign lpvm mutate(~tmp$12##0:wybe.list(?T), ?tmp$3##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$15##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$15##0:wybe.list(?T), ?tmp$16##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
-    foreign lpvm mutate(~tmp$16##0:wybe.list(?T), ?tmp$2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$3##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$19##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$19##0:wybe.list(?T), ?tmp$20##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
-    foreign lpvm mutate(~tmp$20##0:wybe.list(?T), ?tmp$1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$2##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$23##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$23##0:wybe.list(?T), ?tmp$24##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
-    foreign lpvm mutate(~tmp$24##0:wybe.list(?T), ?tmp$0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$1##0:wybe.list(?T))
-    stmt_for.gen$14<0>(~io##0:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), 0:wybe.list(?T), ~tmp$0##0:wybe.list(wybe.int), ~tmp$0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#11##0:wybe.list(?T), ?tmp#12##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
+    foreign lpvm mutate(~tmp#12##0:wybe.list(?T), ?tmp#3##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#15##0:wybe.list(?T), ?tmp#16##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
+    foreign lpvm mutate(~tmp#16##0:wybe.list(?T), ?tmp#2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#19##0:wybe.list(?T), ?tmp#20##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
+    foreign lpvm mutate(~tmp#20##0:wybe.list(?T), ?tmp#1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#23##0:wybe.list(?T), ?tmp#24##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
+    foreign lpvm mutate(~tmp#24##0:wybe.list(?T), ?tmp#0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(?T))
+    stmt_for.gen#14<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), 0:wybe.list(?T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
 using_unless > public (1 calls)
@@ -673,19 +673,19 @@ using_unless > public (1 calls)
 using_unless(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$11##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$11##0:wybe.list(?T), ?tmp$12##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
-    foreign lpvm mutate(~tmp$12##0:wybe.list(?T), ?tmp$3##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$15##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$15##0:wybe.list(?T), ?tmp$16##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
-    foreign lpvm mutate(~tmp$16##0:wybe.list(?T), ?tmp$2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$3##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$19##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$19##0:wybe.list(?T), ?tmp$20##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
-    foreign lpvm mutate(~tmp$20##0:wybe.list(?T), ?tmp$1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$2##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$23##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$23##0:wybe.list(?T), ?tmp$24##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
-    foreign lpvm mutate(~tmp$24##0:wybe.list(?T), ?tmp$0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$1##0:wybe.list(?T))
-    stmt_for.gen$16<0>(~io##0:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), 0:wybe.list(?T), ~tmp$0##0:wybe.list(wybe.int), ~tmp$0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#11##0:wybe.list(?T), ?tmp#12##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
+    foreign lpvm mutate(~tmp#12##0:wybe.list(?T), ?tmp#3##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#15##0:wybe.list(?T), ?tmp#16##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
+    foreign lpvm mutate(~tmp#16##0:wybe.list(?T), ?tmp#2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#19##0:wybe.list(?T), ?tmp#20##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
+    foreign lpvm mutate(~tmp#20##0:wybe.list(?T), ?tmp#1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#23##0:wybe.list(?T), ?tmp#24##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
+    foreign lpvm mutate(~tmp#24##0:wybe.list(?T), ?tmp#0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(?T))
+    stmt_for.gen#16<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), 0:wybe.list(?T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
 using_until > public (1 calls)
@@ -693,19 +693,19 @@ using_until > public (1 calls)
 using_until(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$11##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$11##0:wybe.list(?T), ?tmp$12##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
-    foreign lpvm mutate(~tmp$12##0:wybe.list(?T), ?tmp$3##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$15##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$15##0:wybe.list(?T), ?tmp$16##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
-    foreign lpvm mutate(~tmp$16##0:wybe.list(?T), ?tmp$2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$3##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$19##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$19##0:wybe.list(?T), ?tmp$20##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
-    foreign lpvm mutate(~tmp$20##0:wybe.list(?T), ?tmp$1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$2##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$23##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$23##0:wybe.list(?T), ?tmp$24##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
-    foreign lpvm mutate(~tmp$24##0:wybe.list(?T), ?tmp$0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$1##0:wybe.list(?T))
-    stmt_for.gen$18<0>(~io##0:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), 0:wybe.list(?T), ~tmp$0##0:wybe.list(wybe.int), ~tmp$0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#11##0:wybe.list(?T), ?tmp#12##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
+    foreign lpvm mutate(~tmp#12##0:wybe.list(?T), ?tmp#3##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#15##0:wybe.list(?T), ?tmp#16##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
+    foreign lpvm mutate(~tmp#16##0:wybe.list(?T), ?tmp#2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#19##0:wybe.list(?T), ?tmp#20##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
+    foreign lpvm mutate(~tmp#20##0:wybe.list(?T), ?tmp#1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#23##0:wybe.list(?T), ?tmp#24##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
+    foreign lpvm mutate(~tmp#24##0:wybe.list(?T), ?tmp#0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(?T))
+    stmt_for.gen#18<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), 0:wybe.list(?T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
 using_when > public (1 calls)
@@ -713,19 +713,19 @@ using_when > public (1 calls)
 using_when(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$11##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$11##0:wybe.list(?T), ?tmp$12##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
-    foreign lpvm mutate(~tmp$12##0:wybe.list(?T), ?tmp$3##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$15##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$15##0:wybe.list(?T), ?tmp$16##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
-    foreign lpvm mutate(~tmp$16##0:wybe.list(?T), ?tmp$2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$3##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$19##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$19##0:wybe.list(?T), ?tmp$20##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
-    foreign lpvm mutate(~tmp$20##0:wybe.list(?T), ?tmp$1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$2##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$23##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$23##0:wybe.list(?T), ?tmp$24##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
-    foreign lpvm mutate(~tmp$24##0:wybe.list(?T), ?tmp$0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$1##0:wybe.list(?T))
-    stmt_for.gen$20<0>(~io##0:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), 0:wybe.list(?T), ~tmp$0##0:wybe.list(wybe.int), ~tmp$0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#11##0:wybe.list(?T), ?tmp#12##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
+    foreign lpvm mutate(~tmp#12##0:wybe.list(?T), ?tmp#3##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#15##0:wybe.list(?T), ?tmp#16##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
+    foreign lpvm mutate(~tmp#16##0:wybe.list(?T), ?tmp#2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#19##0:wybe.list(?T), ?tmp#20##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
+    foreign lpvm mutate(~tmp#20##0:wybe.list(?T), ?tmp#1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#23##0:wybe.list(?T), ?tmp#24##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
+    foreign lpvm mutate(~tmp#24##0:wybe.list(?T), ?tmp#0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(?T))
+    stmt_for.gen#20<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), 0:wybe.list(?T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
 using_while > public (1 calls)
@@ -733,19 +733,19 @@ using_while > public (1 calls)
 using_while(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$11##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$11##0:wybe.list(?T), ?tmp$12##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
-    foreign lpvm mutate(~tmp$12##0:wybe.list(?T), ?tmp$3##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$15##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$15##0:wybe.list(?T), ?tmp$16##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
-    foreign lpvm mutate(~tmp$16##0:wybe.list(?T), ?tmp$2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$3##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$19##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$19##0:wybe.list(?T), ?tmp$20##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
-    foreign lpvm mutate(~tmp$20##0:wybe.list(?T), ?tmp$1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$2##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$23##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$23##0:wybe.list(?T), ?tmp$24##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
-    foreign lpvm mutate(~tmp$24##0:wybe.list(?T), ?tmp$0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$1##0:wybe.list(?T))
-    stmt_for.gen$22<0>(~io##0:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), 0:wybe.list(?T), ~tmp$0##0:wybe.list(wybe.int), ~tmp$0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#11##0:wybe.list(?T), ?tmp#12##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
+    foreign lpvm mutate(~tmp#12##0:wybe.list(?T), ?tmp#3##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#15##0:wybe.list(?T), ?tmp#16##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
+    foreign lpvm mutate(~tmp#16##0:wybe.list(?T), ?tmp#2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#19##0:wybe.list(?T), ?tmp#20##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
+    foreign lpvm mutate(~tmp#20##0:wybe.list(?T), ?tmp#1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#23##0:wybe.list(?T), ?tmp#24##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
+    foreign lpvm mutate(~tmp#24##0:wybe.list(?T), ?tmp#0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(?T))
+    stmt_for.gen#22<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), 0:wybe.list(?T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
 using_xrange > public (1 calls)
@@ -753,8 +753,8 @@ using_xrange > public (1 calls)
 using_xrange(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_for.xrange<0>(1:wybe.int, 1:wybe.int, 10:wybe.int, ?tmp$3##0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
-    stmt_for.gen$24<0>(~io##0:wybe.phantom, ~tmp$3##0:stmt_for.int_sequence, ~tmp$3##0:stmt_for.int_sequence, ?io##1:wybe.phantom) #1 @stmt_for:nn:nn
+    stmt_for.xrange<0>(1:wybe.int, 1:wybe.int, 10:wybe.int, ?tmp#3##0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
+    stmt_for.gen#24<0>(~io##0:wybe.phantom, ~tmp#3##0:stmt_for.int_sequence, ~tmp#3##0:stmt_for.int_sequence, ?io##1:wybe.phantom) #1 @stmt_for:nn:nn
 
 
 using_xrange_reverse > public (1 calls)
@@ -762,19 +762,19 @@ using_xrange_reverse > public (1 calls)
 using_xrange_reverse(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_for.xrange<0>(10:wybe.int, -1:wybe.int, 1:wybe.int, ?tmp$3##0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
-    stmt_for.gen$25<0>(~io##0:wybe.phantom, ~tmp$3##0:stmt_for.int_sequence, ~tmp$3##0:stmt_for.int_sequence, ?io##1:wybe.phantom) #1 @stmt_for:nn:nn
+    stmt_for.xrange<0>(10:wybe.int, -1:wybe.int, 1:wybe.int, ?tmp#3##0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
+    stmt_for.gen#25<0>(~io##0:wybe.phantom, ~tmp#3##0:stmt_for.int_sequence, ~tmp#3##0:stmt_for.int_sequence, ?io##1:wybe.phantom) #1 @stmt_for:nn:nn
 
 
 xrange > public (3 calls)
 0: stmt_for.xrange<0>
-xrange(start##0:wybe.int, stride##0:wybe.int, end##0:wybe.int, ?$##0:stmt_for.int_sequence):
+xrange(start##0:wybe.int, stride##0:wybe.int, end##0:wybe.int, ?###0:stmt_for.int_sequence):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp$4##0:stmt_for.int_sequence)
-    foreign lpvm mutate(~tmp$4##0:stmt_for.int_sequence, ?tmp$5##0:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~start##0:wybe.int)
-    foreign lpvm mutate(~tmp$5##0:stmt_for.int_sequence, ?tmp$6##0:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~stride##0:wybe.int)
-    foreign lpvm mutate(~tmp$6##0:stmt_for.int_sequence, ?$##0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~end##0:wybe.int)
+    foreign lpvm alloc(24:wybe.int, ?tmp#4##0:stmt_for.int_sequence)
+    foreign lpvm mutate(~tmp#4##0:stmt_for.int_sequence, ?tmp#5##0:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~start##0:wybe.int)
+    foreign lpvm mutate(~tmp#5##0:stmt_for.int_sequence, ?tmp#6##0:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~stride##0:wybe.int)
+    foreign lpvm mutate(~tmp#6##0:stmt_for.int_sequence, ?###0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~end##0:wybe.int)
 
   LLVM code       :
 
@@ -896,61 +896,61 @@ entry:
 }
 
 
-define external fastcc  void @"stmt_for.gen$1<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"tmp$6##0", i64  %"tmp$7##0", i64  %"tmp$8##0", i64  %"tmp$9##0", i64  %"x##0", i64  %"y##0")    {
+define external fastcc  void @"stmt_for.gen#1<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %"tmp#8##0", i64  %"tmp#9##0", i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$tmp$14##0" = icmp ne i64 %"tmp$8##0", 0 
-  br i1 %"1$tmp$14##0", label %if.then, label %if.else 
+  %"1#tmp#14##0" = icmp ne i64 %"tmp#8##0", 0 
+  br i1 %"1#tmp#14##0", label %if.then, label %if.else 
 if.then:
-  %27 = inttoptr i64 %"tmp$8##0" to i64* 
+  %27 = inttoptr i64 %"tmp#8##0" to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
-  %30 = add   i64 %"tmp$8##0", 8 
+  %30 = add   i64 %"tmp#8##0", 8 
   %31 = inttoptr i64 %30 to i64* 
   %32 = getelementptr  i64, i64* %31, i64 0 
   %33 = load  i64, i64* %32 
-  tail call fastcc  void  @"stmt_for.gen$2<0>"(i64  %29, i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"tmp$6##0", i64  %"tmp$7##0", i64  %33, i64  %"tmp$9##0", i64  %"x##0", i64  %"y##0")  
+  tail call fastcc  void  @"stmt_for.gen#2<0>"(i64  %29, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %33, i64  %"tmp#9##0", i64  %"x##0", i64  %"y##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$10<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")    {
+define external fastcc  void @"stmt_for.gen#10<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
 entry:
-  %"1$tmp$10##0" = icmp ne i64 %"tmp$5##0", 0 
-  br i1 %"1$tmp$10##0", label %if.then, label %if.else 
+  %"1#tmp#10##0" = icmp ne i64 %"tmp#5##0", 0 
+  br i1 %"1#tmp#10##0", label %if.then, label %if.else 
 if.then:
-  %34 = inttoptr i64 %"tmp$5##0" to i64* 
+  %34 = inttoptr i64 %"tmp#5##0" to i64* 
   %35 = getelementptr  i64, i64* %34, i64 0 
   %36 = load  i64, i64* %35 
-  %37 = add   i64 %"tmp$5##0", 8 
+  %37 = add   i64 %"tmp#5##0", 8 
   %38 = inttoptr i64 %37 to i64* 
   %39 = getelementptr  i64, i64* %38, i64 0 
   %40 = load  i64, i64* %39 
-  tail call fastcc  void  @"stmt_for.gen$11<0>"(i64  %36, i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %40, i64  %"x##0")  
+  tail call fastcc  void  @"stmt_for.gen#11<0>"(i64  %36, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %40, i64  %"x##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$11<0>"(i64  %"i##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")    {
+define external fastcc  void @"stmt_for.gen#11<0>"(i64  %"i##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
 entry:
-  %"1$tmp$8##0" = icmp eq i64 %"i##0", 3 
-  br i1 %"1$tmp$8##0", label %if.then, label %if.else 
+  %"1#tmp#8##0" = icmp eq i64 %"i##0", 3 
+  br i1 %"1#tmp#8##0", label %if.then, label %if.else 
 if.then:
   ret void 
 if.else:
   tail call ccc  void  @print_int(i64  %"i##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen$10<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")  
+  tail call fastcc  void  @"stmt_for.gen#10<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")  
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$12<0>"(i64  %"tmp$0##0", i64  %"tmp$3##0")    {
+define external fastcc  void @"stmt_for.gen#12<0>"(i64  %"tmp#0##0", i64  %"tmp#3##0")    {
 entry:
-  %41 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp$0##0")  
+  %41 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
   %42 = extractvalue {i64, i64, i1} %41, 0 
   %43 = extractvalue {i64, i64, i1} %41, 1 
   %44 = extractvalue {i64, i64, i1} %41, 2 
@@ -958,16 +958,16 @@ entry:
 if.then:
   tail call ccc  void  @print_int(i64  %42)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen$12<0>"(i64  %43, i64  %"tmp$3##0")  
+  tail call fastcc  void  @"stmt_for.gen#12<0>"(i64  %43, i64  %"tmp#3##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$13<0>"(i64  %"tmp$0##0", i64  %"tmp$3##0")    {
+define external fastcc  void @"stmt_for.gen#13<0>"(i64  %"tmp#0##0", i64  %"tmp#3##0")    {
 entry:
-  %45 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp$0##0")  
+  %45 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
   %46 = extractvalue {i64, i64, i1} %45, 0 
   %47 = extractvalue {i64, i64, i1} %45, 1 
   %48 = extractvalue {i64, i64, i1} %45, 2 
@@ -975,123 +975,123 @@ entry:
 if.then:
   tail call ccc  void  @print_int(i64  %46)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen$13<0>"(i64  %47, i64  %"tmp$3##0")  
+  tail call fastcc  void  @"stmt_for.gen#13<0>"(i64  %47, i64  %"tmp#3##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$14<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")    {
+define external fastcc  void @"stmt_for.gen#14<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
 entry:
-  %"1$tmp$10##0" = icmp ne i64 %"tmp$5##0", 0 
-  br i1 %"1$tmp$10##0", label %if.then, label %if.else 
+  %"1#tmp#10##0" = icmp ne i64 %"tmp#5##0", 0 
+  br i1 %"1#tmp#10##0", label %if.then, label %if.else 
 if.then:
-  %49 = inttoptr i64 %"tmp$5##0" to i64* 
+  %49 = inttoptr i64 %"tmp#5##0" to i64* 
   %50 = getelementptr  i64, i64* %49, i64 0 
   %51 = load  i64, i64* %50 
-  %52 = add   i64 %"tmp$5##0", 8 
+  %52 = add   i64 %"tmp#5##0", 8 
   %53 = inttoptr i64 %52 to i64* 
   %54 = getelementptr  i64, i64* %53, i64 0 
   %55 = load  i64, i64* %54 
-  tail call fastcc  void  @"stmt_for.gen$15<0>"(i64  %51, i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %55, i64  %"x##0")  
+  tail call fastcc  void  @"stmt_for.gen#15<0>"(i64  %51, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %55, i64  %"x##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$15<0>"(i64  %"i##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")    {
+define external fastcc  void @"stmt_for.gen#15<0>"(i64  %"i##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
 entry:
-  %"1$tmp$8##0" = icmp eq i64 %"i##0", 3 
-  br i1 %"1$tmp$8##0", label %if.then, label %if.else 
+  %"1#tmp#8##0" = icmp eq i64 %"i##0", 3 
+  br i1 %"1#tmp#8##0", label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"stmt_for.gen$14<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")  
+  tail call fastcc  void  @"stmt_for.gen#14<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")  
   ret void 
 if.else:
   tail call ccc  void  @print_int(i64  %"i##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen$14<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")  
+  tail call fastcc  void  @"stmt_for.gen#14<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")  
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$16<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")    {
+define external fastcc  void @"stmt_for.gen#16<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
 entry:
-  %"1$tmp$10##0" = icmp ne i64 %"tmp$5##0", 0 
-  br i1 %"1$tmp$10##0", label %if.then, label %if.else 
+  %"1#tmp#10##0" = icmp ne i64 %"tmp#5##0", 0 
+  br i1 %"1#tmp#10##0", label %if.then, label %if.else 
 if.then:
-  %56 = inttoptr i64 %"tmp$5##0" to i64* 
+  %56 = inttoptr i64 %"tmp#5##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"tmp$5##0", 8 
+  %59 = add   i64 %"tmp#5##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  tail call fastcc  void  @"stmt_for.gen$17<0>"(i64  %58, i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %62, i64  %"x##0")  
+  tail call fastcc  void  @"stmt_for.gen#17<0>"(i64  %58, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %62, i64  %"x##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$17<0>"(i64  %"i##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")    {
+define external fastcc  void @"stmt_for.gen#17<0>"(i64  %"i##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
 entry:
-  %"1$tmp$8##0" = icmp slt i64 %"i##0", 3 
-  br i1 %"1$tmp$8##0", label %if.then, label %if.else 
+  %"1#tmp#8##0" = icmp slt i64 %"i##0", 3 
+  br i1 %"1#tmp#8##0", label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"stmt_for.gen$16<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")  
+  tail call fastcc  void  @"stmt_for.gen#16<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")  
   ret void 
 if.else:
   tail call ccc  void  @print_int(i64  %"i##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen$16<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")  
+  tail call fastcc  void  @"stmt_for.gen#16<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")  
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$18<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")    {
+define external fastcc  void @"stmt_for.gen#18<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
 entry:
-  %"1$tmp$10##0" = icmp ne i64 %"tmp$5##0", 0 
-  br i1 %"1$tmp$10##0", label %if.then, label %if.else 
+  %"1#tmp#10##0" = icmp ne i64 %"tmp#5##0", 0 
+  br i1 %"1#tmp#10##0", label %if.then, label %if.else 
 if.then:
-  %63 = inttoptr i64 %"tmp$5##0" to i64* 
+  %63 = inttoptr i64 %"tmp#5##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"tmp$5##0", 8 
+  %66 = add   i64 %"tmp#5##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  tail call fastcc  void  @"stmt_for.gen$19<0>"(i64  %65, i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %69, i64  %"x##0")  
+  tail call fastcc  void  @"stmt_for.gen#19<0>"(i64  %65, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %69, i64  %"x##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$19<0>"(i64  %"i##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")    {
+define external fastcc  void @"stmt_for.gen#19<0>"(i64  %"i##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
 entry:
-  %"1$tmp$8##0" = icmp eq i64 %"i##0", 3 
-  br i1 %"1$tmp$8##0", label %if.then, label %if.else 
+  %"1#tmp#8##0" = icmp eq i64 %"i##0", 3 
+  br i1 %"1#tmp#8##0", label %if.then, label %if.else 
 if.then:
   ret void 
 if.else:
   tail call ccc  void  @print_int(i64  %"i##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen$18<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")  
+  tail call fastcc  void  @"stmt_for.gen#18<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")  
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$2<0>"(i64  %"i##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"tmp$6##0", i64  %"tmp$7##0", i64  %"tmp$8##0", i64  %"tmp$9##0", i64  %"x##0", i64  %"y##0")    {
+define external fastcc  void @"stmt_for.gen#2<0>"(i64  %"i##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %"tmp#8##0", i64  %"tmp#9##0", i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$tmp$14##0" = icmp ne i64 %"tmp$9##0", 0 
-  br i1 %"1$tmp$14##0", label %if.then, label %if.else 
+  %"1#tmp#14##0" = icmp ne i64 %"tmp#9##0", 0 
+  br i1 %"1#tmp#14##0", label %if.then, label %if.else 
 if.then:
-  %70 = inttoptr i64 %"tmp$9##0" to i64* 
+  %70 = inttoptr i64 %"tmp#9##0" to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
   %72 = load  i64, i64* %71 
-  %73 = add   i64 %"tmp$9##0", 8 
+  %73 = add   i64 %"tmp#9##0", 8 
   %74 = inttoptr i64 %73 to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
   %76 = load  i64, i64* %75 
@@ -1099,83 +1099,83 @@ if.then:
   tail call ccc  void  @putchar(i8  10)  
   tail call ccc  void  @print_int(i64  %72)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen$1<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"tmp$6##0", i64  %"tmp$7##0", i64  %"tmp$8##0", i64  %76, i64  %"x##0", i64  %"y##0")  
+  tail call fastcc  void  @"stmt_for.gen#1<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %"tmp#8##0", i64  %76, i64  %"x##0", i64  %"y##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$20<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")    {
+define external fastcc  void @"stmt_for.gen#20<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
 entry:
-  %"1$tmp$10##0" = icmp ne i64 %"tmp$5##0", 0 
-  br i1 %"1$tmp$10##0", label %if.then, label %if.else 
+  %"1#tmp#10##0" = icmp ne i64 %"tmp#5##0", 0 
+  br i1 %"1#tmp#10##0", label %if.then, label %if.else 
 if.then:
-  %77 = inttoptr i64 %"tmp$5##0" to i64* 
+  %77 = inttoptr i64 %"tmp#5##0" to i64* 
   %78 = getelementptr  i64, i64* %77, i64 0 
   %79 = load  i64, i64* %78 
-  %80 = add   i64 %"tmp$5##0", 8 
+  %80 = add   i64 %"tmp#5##0", 8 
   %81 = inttoptr i64 %80 to i64* 
   %82 = getelementptr  i64, i64* %81, i64 0 
   %83 = load  i64, i64* %82 
-  tail call fastcc  void  @"stmt_for.gen$21<0>"(i64  %79, i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %83, i64  %"x##0")  
+  tail call fastcc  void  @"stmt_for.gen#21<0>"(i64  %79, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %83, i64  %"x##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$21<0>"(i64  %"i##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")    {
+define external fastcc  void @"stmt_for.gen#21<0>"(i64  %"i##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
 entry:
-  %"1$tmp$8##0" = icmp slt i64 %"i##0", 3 
-  br i1 %"1$tmp$8##0", label %if.then, label %if.else 
+  %"1#tmp#8##0" = icmp slt i64 %"i##0", 3 
+  br i1 %"1#tmp#8##0", label %if.then, label %if.else 
 if.then:
   tail call ccc  void  @print_int(i64  %"i##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen$20<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")  
+  tail call fastcc  void  @"stmt_for.gen#20<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")  
   ret void 
 if.else:
-  tail call fastcc  void  @"stmt_for.gen$20<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")  
+  tail call fastcc  void  @"stmt_for.gen#20<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")  
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$22<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")    {
+define external fastcc  void @"stmt_for.gen#22<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
 entry:
-  %"1$tmp$10##0" = icmp ne i64 %"tmp$5##0", 0 
-  br i1 %"1$tmp$10##0", label %if.then, label %if.else 
+  %"1#tmp#10##0" = icmp ne i64 %"tmp#5##0", 0 
+  br i1 %"1#tmp#10##0", label %if.then, label %if.else 
 if.then:
-  %84 = inttoptr i64 %"tmp$5##0" to i64* 
+  %84 = inttoptr i64 %"tmp#5##0" to i64* 
   %85 = getelementptr  i64, i64* %84, i64 0 
   %86 = load  i64, i64* %85 
-  %87 = add   i64 %"tmp$5##0", 8 
+  %87 = add   i64 %"tmp#5##0", 8 
   %88 = inttoptr i64 %87 to i64* 
   %89 = getelementptr  i64, i64* %88, i64 0 
   %90 = load  i64, i64* %89 
-  tail call fastcc  void  @"stmt_for.gen$23<0>"(i64  %86, i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %90, i64  %"x##0")  
+  tail call fastcc  void  @"stmt_for.gen#23<0>"(i64  %86, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %90, i64  %"x##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$23<0>"(i64  %"i##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")    {
+define external fastcc  void @"stmt_for.gen#23<0>"(i64  %"i##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
 entry:
-  %"1$tmp$8##0" = icmp slt i64 %"i##0", 3 
-  br i1 %"1$tmp$8##0", label %if.then, label %if.else 
+  %"1#tmp#8##0" = icmp slt i64 %"i##0", 3 
+  br i1 %"1#tmp#8##0", label %if.then, label %if.else 
 if.then:
   tail call ccc  void  @print_int(i64  %"i##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen$22<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")  
+  tail call fastcc  void  @"stmt_for.gen#22<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$24<0>"(i64  %"tmp$0##0", i64  %"tmp$3##0")    {
+define external fastcc  void @"stmt_for.gen#24<0>"(i64  %"tmp#0##0", i64  %"tmp#3##0")    {
 entry:
-  %91 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp$0##0")  
+  %91 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
   %92 = extractvalue {i64, i64, i1} %91, 0 
   %93 = extractvalue {i64, i64, i1} %91, 1 
   %94 = extractvalue {i64, i64, i1} %91, 2 
@@ -1183,16 +1183,16 @@ entry:
 if.then:
   tail call ccc  void  @print_int(i64  %92)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen$24<0>"(i64  %93, i64  %"tmp$3##0")  
+  tail call fastcc  void  @"stmt_for.gen#24<0>"(i64  %93, i64  %"tmp#3##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$25<0>"(i64  %"tmp$0##0", i64  %"tmp$3##0")    {
+define external fastcc  void @"stmt_for.gen#25<0>"(i64  %"tmp#0##0", i64  %"tmp#3##0")    {
 entry:
-  %95 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp$0##0")  
+  %95 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
   %96 = extractvalue {i64, i64, i1} %95, 0 
   %97 = extractvalue {i64, i64, i1} %95, 1 
   %98 = extractvalue {i64, i64, i1} %95, 2 
@@ -1200,81 +1200,81 @@ entry:
 if.then:
   tail call ccc  void  @print_int(i64  %96)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen$25<0>"(i64  %97, i64  %"tmp$3##0")  
+  tail call fastcc  void  @"stmt_for.gen#25<0>"(i64  %97, i64  %"tmp#3##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$3<0>"(i64  %"i##0", i64  %"j##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"tmp$6##0", i64  %"tmp$7##0", i64  %"tmp$8##0", i64  %"tmp$9##0", i64  %"x##0", i64  %"y##0")    {
+define external fastcc  void @"stmt_for.gen#3<0>"(i64  %"i##0", i64  %"j##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %"tmp#8##0", i64  %"tmp#9##0", i64  %"x##0", i64  %"y##0")    {
 entry:
   tail call ccc  void  @print_int(i64  %"i##0")  
   tail call ccc  void  @putchar(i8  10)  
   tail call ccc  void  @print_int(i64  %"j##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen$1<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"tmp$6##0", i64  %"tmp$7##0", i64  %"tmp$8##0", i64  %"tmp$9##0", i64  %"x##0", i64  %"y##0")  
+  tail call fastcc  void  @"stmt_for.gen#1<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %"tmp#8##0", i64  %"tmp#9##0", i64  %"x##0", i64  %"y##0")  
   ret void 
 }
 
 
-define external fastcc  i1 @"stmt_for.gen$4<0>"(i64  %"tmp$0##0", i64  %"tmp$3##0")    {
+define external fastcc  i1 @"stmt_for.gen#4<0>"(i64  %"tmp#0##0", i64  %"tmp#3##0")    {
 entry:
-  %99 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp$0##0")  
+  %99 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
   %100 = extractvalue {i64, i64, i1} %99, 0 
   %101 = extractvalue {i64, i64, i1} %99, 1 
   %102 = extractvalue {i64, i64, i1} %99, 2 
   br i1 %102, label %if.then, label %if.else 
 if.then:
-  %"2$$$##0" = tail call fastcc  i1  @"stmt_for.gen$5<0>"(i64  %100, i64  %101, i64  %"tmp$3##0")  
-  ret i1 %"2$$$##0" 
+  %"2#####0" = tail call fastcc  i1  @"stmt_for.gen#5<0>"(i64  %100, i64  %101, i64  %"tmp#3##0")  
+  ret i1 %"2#####0" 
 if.else:
   ret i1 1 
 }
 
 
-define external fastcc  i1 @"stmt_for.gen$5<0>"(i64  %"i##0", i64  %"tmp$0##0", i64  %"tmp$3##0")    {
+define external fastcc  i1 @"stmt_for.gen#5<0>"(i64  %"i##0", i64  %"tmp#0##0", i64  %"tmp#3##0")    {
 entry:
-  %"1$tmp$4##0" = icmp slt i64 %"i##0", 5 
-  br i1 %"1$tmp$4##0", label %if.then, label %if.else 
+  %"1#tmp#4##0" = icmp slt i64 %"i##0", 5 
+  br i1 %"1#tmp#4##0", label %if.then, label %if.else 
 if.then:
   tail call ccc  void  @print_int(i64  %"i##0")  
   tail call ccc  void  @putchar(i8  10)  
-  %"2$$$##0" = tail call fastcc  i1  @"stmt_for.gen$4<0>"(i64  %"tmp$0##0", i64  %"tmp$3##0")  
-  ret i1 %"2$$$##0" 
+  %"2#####0" = tail call fastcc  i1  @"stmt_for.gen#4<0>"(i64  %"tmp#0##0", i64  %"tmp#3##0")  
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  void @"stmt_for.gen$6<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"tmp$6##0", i64  %"tmp$7##0", i64  %"tmp$8##0", i64  %"tmp$9##0", i64  %"x##0", i64  %"y##0")    {
+define external fastcc  void @"stmt_for.gen#6<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %"tmp#8##0", i64  %"tmp#9##0", i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$tmp$14##0" = icmp ne i64 %"tmp$8##0", 0 
-  br i1 %"1$tmp$14##0", label %if.then, label %if.else 
+  %"1#tmp#14##0" = icmp ne i64 %"tmp#8##0", 0 
+  br i1 %"1#tmp#14##0", label %if.then, label %if.else 
 if.then:
-  %103 = inttoptr i64 %"tmp$8##0" to i64* 
+  %103 = inttoptr i64 %"tmp#8##0" to i64* 
   %104 = getelementptr  i64, i64* %103, i64 0 
   %105 = load  i64, i64* %104 
-  %106 = add   i64 %"tmp$8##0", 8 
+  %106 = add   i64 %"tmp#8##0", 8 
   %107 = inttoptr i64 %106 to i64* 
   %108 = getelementptr  i64, i64* %107, i64 0 
   %109 = load  i64, i64* %108 
-  tail call fastcc  void  @"stmt_for.gen$7<0>"(i64  %105, i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"tmp$6##0", i64  %"tmp$7##0", i64  %109, i64  %"tmp$9##0", i64  %"x##0", i64  %"y##0")  
+  tail call fastcc  void  @"stmt_for.gen#7<0>"(i64  %105, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %109, i64  %"tmp#9##0", i64  %"x##0", i64  %"y##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$7<0>"(i64  %"i##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"tmp$6##0", i64  %"tmp$7##0", i64  %"tmp$8##0", i64  %"tmp$9##0", i64  %"x##0", i64  %"y##0")    {
+define external fastcc  void @"stmt_for.gen#7<0>"(i64  %"i##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %"tmp#8##0", i64  %"tmp#9##0", i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$tmp$14##0" = icmp ne i64 %"tmp$9##0", 0 
-  br i1 %"1$tmp$14##0", label %if.then, label %if.else 
+  %"1#tmp#14##0" = icmp ne i64 %"tmp#9##0", 0 
+  br i1 %"1#tmp#14##0", label %if.then, label %if.else 
 if.then:
-  %110 = inttoptr i64 %"tmp$9##0" to i64* 
+  %110 = inttoptr i64 %"tmp#9##0" to i64* 
   %111 = getelementptr  i64, i64* %110, i64 0 
   %112 = load  i64, i64* %111 
-  %113 = add   i64 %"tmp$9##0", 8 
+  %113 = add   i64 %"tmp#9##0", 8 
   %114 = inttoptr i64 %113 to i64* 
   %115 = getelementptr  i64, i64* %114, i64 0 
   %116 = load  i64, i64* %115 
@@ -1282,39 +1282,39 @@ if.then:
   tail call ccc  void  @putchar(i8  10)  
   tail call ccc  void  @print_int(i64  %112)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen$6<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"tmp$6##0", i64  %"tmp$7##0", i64  %"tmp$8##0", i64  %116, i64  %"x##0", i64  %"y##0")  
+  tail call fastcc  void  @"stmt_for.gen#6<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %"tmp#8##0", i64  %116, i64  %"x##0", i64  %"y##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$8<0>"(i64  %"i##0", i64  %"j##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"tmp$6##0", i64  %"tmp$7##0", i64  %"tmp$8##0", i64  %"tmp$9##0", i64  %"x##0", i64  %"y##0")    {
+define external fastcc  void @"stmt_for.gen#8<0>"(i64  %"i##0", i64  %"j##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %"tmp#8##0", i64  %"tmp#9##0", i64  %"x##0", i64  %"y##0")    {
 entry:
   tail call ccc  void  @print_int(i64  %"i##0")  
   tail call ccc  void  @putchar(i8  10)  
   tail call ccc  void  @print_int(i64  %"j##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen$6<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"tmp$6##0", i64  %"tmp$7##0", i64  %"tmp$8##0", i64  %"tmp$9##0", i64  %"x##0", i64  %"y##0")  
+  tail call fastcc  void  @"stmt_for.gen#6<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %"tmp#8##0", i64  %"tmp#9##0", i64  %"x##0", i64  %"y##0")  
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$9<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"x##0")    {
+define external fastcc  void @"stmt_for.gen#9<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"x##0")    {
 entry:
-  %"1$tmp$8##0" = icmp ne i64 %"tmp$4##0", 0 
-  br i1 %"1$tmp$8##0", label %if.then, label %if.else 
+  %"1#tmp#8##0" = icmp ne i64 %"tmp#4##0", 0 
+  br i1 %"1#tmp#8##0", label %if.then, label %if.else 
 if.then:
-  %117 = inttoptr i64 %"tmp$4##0" to i64* 
+  %117 = inttoptr i64 %"tmp#4##0" to i64* 
   %118 = getelementptr  i64, i64* %117, i64 0 
   %119 = load  i64, i64* %118 
-  %120 = add   i64 %"tmp$4##0", 8 
+  %120 = add   i64 %"tmp#4##0", 8 
   %121 = inttoptr i64 %120 to i64* 
   %122 = getelementptr  i64, i64* %121, i64 0 
   %123 = load  i64, i64* %122 
   tail call ccc  void  @print_int(i64  %119)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen$9<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %123, i64  %"x##0")  
+  tail call fastcc  void  @"stmt_for.gen#9<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %123, i64  %"x##0")  
   ret void 
 if.else:
   ret void 
@@ -1323,10 +1323,10 @@ if.else:
 
 define external fastcc  i64 @"stmt_for.irange<0>"(i64  %"start##0", i64  %"stride##0", i64  %"end##0")    {
 entry:
-  %"1$tmp$4##0" = icmp slt i64 %"stride##0", 0 
-  br i1 %"1$tmp$4##0", label %if.then, label %if.else 
+  %"1#tmp#4##0" = icmp slt i64 %"stride##0", 0 
+  br i1 %"1#tmp#4##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = sub   i64 %"end##0", 1 
+  %"2#tmp#2##0" = sub   i64 %"end##0", 1 
   %124 = trunc i64 24 to i32  
   %125 = tail call ccc  i8*  @wybe_malloc(i32  %124)  
   %126 = ptrtoint i8* %125 to i64 
@@ -1340,10 +1340,10 @@ if.then:
   %132 = add   i64 %126, 16 
   %133 = inttoptr i64 %132 to i64* 
   %134 = getelementptr  i64, i64* %133, i64 0 
-  store  i64 %"2$tmp$2##0", i64* %134 
+  store  i64 %"2#tmp#2##0", i64* %134 
   ret i64 %126 
 if.else:
-  %"3$tmp$3##0" = add   i64 %"end##0", 1 
+  %"3#tmp#3##0" = add   i64 %"end##0", 1 
   %135 = trunc i64 24 to i32  
   %136 = tail call ccc  i8*  @wybe_malloc(i32  %135)  
   %137 = ptrtoint i8* %136 to i64 
@@ -1357,7 +1357,7 @@ if.else:
   %143 = add   i64 %137, 16 
   %144 = inttoptr i64 %143 to i64* 
   %145 = getelementptr  i64, i64* %144, i64 0 
-  store  i64 %"3$tmp$3##0", i64* %145 
+  store  i64 %"3#tmp#3##0", i64* %145 
   ret i64 %137 
 }
 
@@ -1424,16 +1424,16 @@ entry:
   %192 = inttoptr i64 %191 to i64* 
   %193 = getelementptr  i64, i64* %192, i64 0 
   store  i64 %180, i64* %193 
-  tail call fastcc  void  @"stmt_for.gen$1<0>"(i64  %164, i64  %156, i64  %148, i64  0, i64  %188, i64  %180, i64  %172, i64  0, i64  %164, i64  %188, i64  %164, i64  %188)  
+  tail call fastcc  void  @"stmt_for.gen#1<0>"(i64  %164, i64  %156, i64  %148, i64  0, i64  %188, i64  %180, i64  %172, i64  0, i64  %164, i64  %188, i64  %164, i64  %188)  
   ret void 
 }
 
 
 define external fastcc  i1 @"stmt_for.semi_det_for_loop<0>"()    {
 entry:
-  %"1$tmp$3##0" = tail call fastcc  i64  @"stmt_for.xrange<0>"(i64  0, i64  1, i64  10)  
-  %"1$$$##0" = tail call fastcc  i1  @"stmt_for.gen$4<0>"(i64  %"1$tmp$3##0", i64  %"1$tmp$3##0")  
-  ret i1 %"1$$$##0" 
+  %"1#tmp#3##0" = tail call fastcc  i64  @"stmt_for.xrange<0>"(i64  0, i64  1, i64  10)  
+  %"1#####0" = tail call fastcc  i1  @"stmt_for.gen#4<0>"(i64  %"1#tmp#3##0", i64  %"1#tmp#3##0")  
+  ret i1 %"1#####0" 
 }
 
 
@@ -1499,7 +1499,7 @@ entry:
   %240 = inttoptr i64 %239 to i64* 
   %241 = getelementptr  i64, i64* %240, i64 0 
   store  i64 %228, i64* %241 
-  tail call fastcc  void  @"stmt_for.gen$6<0>"(i64  %220, i64  %212, i64  %204, i64  %196, i64  0, i64  %236, i64  %228, i64  0, i64  %220, i64  %236, i64  %220, i64  %236)  
+  tail call fastcc  void  @"stmt_for.gen#6<0>"(i64  %220, i64  %212, i64  %204, i64  %196, i64  0, i64  %236, i64  %228, i64  0, i64  %220, i64  %236, i64  %220, i64  %236)  
   ret void 
 }
 
@@ -1536,7 +1536,7 @@ entry:
   %264 = inttoptr i64 %263 to i64* 
   %265 = getelementptr  i64, i64* %264, i64 0 
   store  i64 %252, i64* %265 
-  tail call fastcc  void  @"stmt_for.gen$9<0>"(i64  %260, i64  %252, i64  %244, i64  0, i64  %260, i64  %260)  
+  tail call fastcc  void  @"stmt_for.gen#9<0>"(i64  %260, i64  %252, i64  %244, i64  0, i64  %260, i64  %260)  
   ret void 
 }
 
@@ -1583,23 +1583,23 @@ entry:
   %296 = inttoptr i64 %295 to i64* 
   %297 = getelementptr  i64, i64* %296, i64 0 
   store  i64 %284, i64* %297 
-  tail call fastcc  void  @"stmt_for.gen$10<0>"(i64  %292, i64  %284, i64  %276, i64  %268, i64  0, i64  %292, i64  %292)  
+  tail call fastcc  void  @"stmt_for.gen#10<0>"(i64  %292, i64  %284, i64  %276, i64  %268, i64  0, i64  %292, i64  %292)  
   ret void 
 }
 
 
 define external fastcc  void @"stmt_for.using_irange<0>"()    {
 entry:
-  %"1$tmp$3##0" = tail call fastcc  i64  @"stmt_for.irange<0>"(i64  1, i64  1, i64  10)  
-  tail call fastcc  void  @"stmt_for.gen$12<0>"(i64  %"1$tmp$3##0", i64  %"1$tmp$3##0")  
+  %"1#tmp#3##0" = tail call fastcc  i64  @"stmt_for.irange<0>"(i64  1, i64  1, i64  10)  
+  tail call fastcc  void  @"stmt_for.gen#12<0>"(i64  %"1#tmp#3##0", i64  %"1#tmp#3##0")  
   ret void 
 }
 
 
 define external fastcc  void @"stmt_for.using_irange_reverse<0>"()    {
 entry:
-  %"1$tmp$3##0" = tail call fastcc  i64  @"stmt_for.irange<0>"(i64  10, i64  -1, i64  1)  
-  tail call fastcc  void  @"stmt_for.gen$13<0>"(i64  %"1$tmp$3##0", i64  %"1$tmp$3##0")  
+  %"1#tmp#3##0" = tail call fastcc  i64  @"stmt_for.irange<0>"(i64  10, i64  -1, i64  1)  
+  tail call fastcc  void  @"stmt_for.gen#13<0>"(i64  %"1#tmp#3##0", i64  %"1#tmp#3##0")  
   ret void 
 }
 
@@ -1646,7 +1646,7 @@ entry:
   %328 = inttoptr i64 %327 to i64* 
   %329 = getelementptr  i64, i64* %328, i64 0 
   store  i64 %316, i64* %329 
-  tail call fastcc  void  @"stmt_for.gen$14<0>"(i64  %324, i64  %316, i64  %308, i64  %300, i64  0, i64  %324, i64  %324)  
+  tail call fastcc  void  @"stmt_for.gen#14<0>"(i64  %324, i64  %316, i64  %308, i64  %300, i64  0, i64  %324, i64  %324)  
   ret void 
 }
 
@@ -1693,7 +1693,7 @@ entry:
   %360 = inttoptr i64 %359 to i64* 
   %361 = getelementptr  i64, i64* %360, i64 0 
   store  i64 %348, i64* %361 
-  tail call fastcc  void  @"stmt_for.gen$16<0>"(i64  %356, i64  %348, i64  %340, i64  %332, i64  0, i64  %356, i64  %356)  
+  tail call fastcc  void  @"stmt_for.gen#16<0>"(i64  %356, i64  %348, i64  %340, i64  %332, i64  0, i64  %356, i64  %356)  
   ret void 
 }
 
@@ -1740,7 +1740,7 @@ entry:
   %392 = inttoptr i64 %391 to i64* 
   %393 = getelementptr  i64, i64* %392, i64 0 
   store  i64 %380, i64* %393 
-  tail call fastcc  void  @"stmt_for.gen$18<0>"(i64  %388, i64  %380, i64  %372, i64  %364, i64  0, i64  %388, i64  %388)  
+  tail call fastcc  void  @"stmt_for.gen#18<0>"(i64  %388, i64  %380, i64  %372, i64  %364, i64  0, i64  %388, i64  %388)  
   ret void 
 }
 
@@ -1787,7 +1787,7 @@ entry:
   %424 = inttoptr i64 %423 to i64* 
   %425 = getelementptr  i64, i64* %424, i64 0 
   store  i64 %412, i64* %425 
-  tail call fastcc  void  @"stmt_for.gen$20<0>"(i64  %420, i64  %412, i64  %404, i64  %396, i64  0, i64  %420, i64  %420)  
+  tail call fastcc  void  @"stmt_for.gen#20<0>"(i64  %420, i64  %412, i64  %404, i64  %396, i64  0, i64  %420, i64  %420)  
   ret void 
 }
 
@@ -1834,23 +1834,23 @@ entry:
   %456 = inttoptr i64 %455 to i64* 
   %457 = getelementptr  i64, i64* %456, i64 0 
   store  i64 %444, i64* %457 
-  tail call fastcc  void  @"stmt_for.gen$22<0>"(i64  %452, i64  %444, i64  %436, i64  %428, i64  0, i64  %452, i64  %452)  
+  tail call fastcc  void  @"stmt_for.gen#22<0>"(i64  %452, i64  %444, i64  %436, i64  %428, i64  0, i64  %452, i64  %452)  
   ret void 
 }
 
 
 define external fastcc  void @"stmt_for.using_xrange<0>"()    {
 entry:
-  %"1$tmp$3##0" = tail call fastcc  i64  @"stmt_for.xrange<0>"(i64  1, i64  1, i64  10)  
-  tail call fastcc  void  @"stmt_for.gen$24<0>"(i64  %"1$tmp$3##0", i64  %"1$tmp$3##0")  
+  %"1#tmp#3##0" = tail call fastcc  i64  @"stmt_for.xrange<0>"(i64  1, i64  1, i64  10)  
+  tail call fastcc  void  @"stmt_for.gen#24<0>"(i64  %"1#tmp#3##0", i64  %"1#tmp#3##0")  
   ret void 
 }
 
 
 define external fastcc  void @"stmt_for.using_xrange_reverse<0>"()    {
 entry:
-  %"1$tmp$3##0" = tail call fastcc  i64  @"stmt_for.xrange<0>"(i64  10, i64  -1, i64  1)  
-  tail call fastcc  void  @"stmt_for.gen$25<0>"(i64  %"1$tmp$3##0", i64  %"1$tmp$3##0")  
+  %"1#tmp#3##0" = tail call fastcc  i64  @"stmt_for.xrange<0>"(i64  10, i64  -1, i64  1)  
+  tail call fastcc  void  @"stmt_for.gen#25<0>"(i64  %"1#tmp#3##0", i64  %"1#tmp#3##0")  
   ret void 
 }
 
@@ -1896,170 +1896,170 @@ entry:
 
 = > public {inline} (1 calls)
 0: stmt_for.int_sequence.=<0>
-=($left##0:stmt_for.int_sequence, $right##0:stmt_for.int_sequence, ?$$##0:wybe.bool):
+=(#left##0:stmt_for.int_sequence, #right##0:stmt_for.int_sequence, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$start##0:wybe.int)
-    foreign lpvm access($left##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$stride##0:wybe.int)
-    foreign lpvm access(~$left##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$end##0:wybe.int)
-    foreign lpvm access($right##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$start##0:wybe.int)
-    foreign lpvm access($right##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$stride##0:wybe.int)
-    foreign lpvm access(~$right##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$end##0:wybe.int)
-    foreign llvm icmp_eq(~$left$start##0:wybe.int, ~$right$start##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#start##0:wybe.int)
+    foreign lpvm access(#left##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#stride##0:wybe.int)
+    foreign lpvm access(~#left##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#end##0:wybe.int)
+    foreign lpvm access(#right##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#start##0:wybe.int)
+    foreign lpvm access(#right##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#stride##0:wybe.int)
+    foreign lpvm access(~#right##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#end##0:wybe.int)
+    foreign llvm icmp_eq(~#left#start##0:wybe.int, ~#right#start##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$stride##0:wybe.int, ~$right$stride##0:wybe.int, ?tmp$2##0:wybe.bool) @int:nn:nn
-        case ~tmp$2##0:wybe.bool of
+        foreign llvm icmp_eq(~#left#stride##0:wybe.int, ~#right#stride##0:wybe.int, ?tmp#2##0:wybe.bool) @int:nn:nn
+        case ~tmp#2##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~$left$end##0:wybe.int, ~$right$end##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+            foreign llvm icmp_eq(~#left#end##0:wybe.int, ~#right#end##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 
 [|] > public (0 calls)
 0: stmt_for.int_sequence.[|]<0>
-[|](?value##0:wybe.int, ?rest##0:stmt_for.int_sequence, current##0:stmt_for.int_sequence, ?$$##0:wybe.bool):
+[|](?value##0:wybe.int, ?rest##0:stmt_for.int_sequence, current##0:stmt_for.int_sequence, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(current##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?s##0:wybe.int)
     foreign lpvm access(current##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?st##0:wybe.int)
     foreign lpvm access(~current##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?en##0:wybe.int)
-    foreign llvm icmp_slt(st##0:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
-    case ~tmp$4##0:wybe.bool of
+    foreign llvm icmp_slt(st##0:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
+    case ~tmp#4##0:wybe.bool of
     0:
-        foreign llvm icmp_sgt(en##0:wybe.int, s##0:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
-        case ~tmp$3##0:wybe.bool of
+        foreign llvm icmp_sgt(en##0:wybe.int, s##0:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
+        case ~tmp#3##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?value##0:wybe.int)
             foreign llvm move(undef:stmt_for.int_sequence, ?rest##0:stmt_for.int_sequence)
 
         1:
-            stmt_for.int_sequence.gen$1<0>(_:stmt_for.int_sequence, ~en##0:wybe.int, ~s##0:wybe.int, ~st##0:wybe.int, ?value##0:wybe.int, ?rest##0:stmt_for.int_sequence, ?$$##0:wybe.bool) #5
+            stmt_for.int_sequence.gen#1<0>(_:stmt_for.int_sequence, ~en##0:wybe.int, ~s##0:wybe.int, ~st##0:wybe.int, ?value##0:wybe.int, ?rest##0:stmt_for.int_sequence, ?####0:wybe.bool) #5
 
 
     1:
-        foreign llvm icmp_slt(en##0:wybe.int, s##0:wybe.int, ?tmp$2##0:wybe.bool) @int:nn:nn
-        case ~tmp$2##0:wybe.bool of
+        foreign llvm icmp_slt(en##0:wybe.int, s##0:wybe.int, ?tmp#2##0:wybe.bool) @int:nn:nn
+        case ~tmp#2##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
             foreign llvm move(undef:wybe.int, ?value##0:wybe.int)
             foreign llvm move(undef:stmt_for.int_sequence, ?rest##0:stmt_for.int_sequence)
 
         1:
-            stmt_for.int_sequence.gen$1<0>(_:stmt_for.int_sequence, ~en##0:wybe.int, ~s##0:wybe.int, ~st##0:wybe.int, ?value##0:wybe.int, ?rest##0:stmt_for.int_sequence, ?$$##0:wybe.bool) #3
+            stmt_for.int_sequence.gen#1<0>(_:stmt_for.int_sequence, ~en##0:wybe.int, ~s##0:wybe.int, ~st##0:wybe.int, ?value##0:wybe.int, ?rest##0:stmt_for.int_sequence, ?####0:wybe.bool) #3
 
 
 
 
 end > public {inline} (0 calls)
 0: stmt_for.int_sequence.end<0>
-end($rec##0:stmt_for.int_sequence, ?$##0:wybe.int):
+end(#rec##0:stmt_for.int_sequence, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:wybe.int)
 end > public {inline} (0 calls)
 1: stmt_for.int_sequence.end<1>
-end($rec##0:stmt_for.int_sequence, ?$rec##1:stmt_for.int_sequence, $field##0:wybe.int):
+end(#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:stmt_for.int_sequence, ?$rec##1:stmt_for.int_sequence, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
-gen$1 > (2 calls)
-0: stmt_for.int_sequence.gen$1<0>
-gen$1([current##0:stmt_for.int_sequence], en##0:wybe.int, s##0:wybe.int, st##0:wybe.int, ?value##0:wybe.int, ?rest##0:stmt_for.int_sequence, ?$$##0:wybe.bool):
+gen#1 > (2 calls)
+0: stmt_for.int_sequence.gen#1<0>
+gen#1([current##0:stmt_for.int_sequence], en##0:wybe.int, s##0:wybe.int, st##0:wybe.int, ?value##0:wybe.int, ?rest##0:stmt_for.int_sequence, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm move(s##0:wybe.int, ?value##0:wybe.int) @stmt_for:nn:nn
-    foreign llvm add(~s##0:wybe.int, st##0:wybe.int, ?tmp$1##0:wybe.int) @int:nn:nn
-    foreign lpvm alloc(24:wybe.int, ?tmp$7##0:stmt_for.int_sequence)
-    foreign lpvm mutate(~tmp$7##0:stmt_for.int_sequence, ?tmp$8##0:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp$1##0:wybe.int)
-    foreign lpvm mutate(~tmp$8##0:stmt_for.int_sequence, ?tmp$9##0:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~st##0:wybe.int)
-    foreign lpvm mutate(~tmp$9##0:stmt_for.int_sequence, ?rest##0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~en##0:wybe.int)
-    foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+    foreign llvm add(~s##0:wybe.int, st##0:wybe.int, ?tmp#1##0:wybe.int) @int:nn:nn
+    foreign lpvm alloc(24:wybe.int, ?tmp#7##0:stmt_for.int_sequence)
+    foreign lpvm mutate(~tmp#7##0:stmt_for.int_sequence, ?tmp#8##0:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp#1##0:wybe.int)
+    foreign lpvm mutate(~tmp#8##0:stmt_for.int_sequence, ?tmp#9##0:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~st##0:wybe.int)
+    foreign lpvm mutate(~tmp#9##0:stmt_for.int_sequence, ?rest##0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~en##0:wybe.int)
+    foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 int_sequence > public {inline} (1 calls)
 0: stmt_for.int_sequence.int_sequence<0>
-int_sequence(start##0:wybe.int, stride##0:wybe.int, end##0:wybe.int, ?$##0:stmt_for.int_sequence):
+int_sequence(start##0:wybe.int, stride##0:wybe.int, end##0:wybe.int, ?###0:stmt_for.int_sequence):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?$rec##0:stmt_for.int_sequence)
-    foreign lpvm mutate(~$rec##0:stmt_for.int_sequence, ?$rec##1:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~start##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:stmt_for.int_sequence, ?$rec##2:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~stride##0:wybe.int)
-    foreign lpvm mutate(~$rec##2:stmt_for.int_sequence, ?$##0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~end##0:wybe.int)
+    foreign lpvm alloc(24:wybe.int, ?#rec##0:stmt_for.int_sequence)
+    foreign lpvm mutate(~#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~start##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:stmt_for.int_sequence, ?#rec##2:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~stride##0:wybe.int)
+    foreign lpvm mutate(~#rec##2:stmt_for.int_sequence, ?###0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~end##0:wybe.int)
 int_sequence > public {inline} (16 calls)
 1: stmt_for.int_sequence.int_sequence<1>
-int_sequence(?start##0:wybe.int, ?stride##0:wybe.int, ?end##0:wybe.int, $##0:stmt_for.int_sequence):
+int_sequence(?start##0:wybe.int, ?stride##0:wybe.int, ?end##0:wybe.int, ###0:stmt_for.int_sequence):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?start##0:wybe.int)
-    foreign lpvm access($##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?stride##0:wybe.int)
-    foreign lpvm access(~$##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?end##0:wybe.int)
+    foreign lpvm access(###0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?start##0:wybe.int)
+    foreign lpvm access(###0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?stride##0:wybe.int)
+    foreign lpvm access(~###0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?end##0:wybe.int)
 
 
 start > public {inline} (0 calls)
 0: stmt_for.int_sequence.start<0>
-start($rec##0:stmt_for.int_sequence, ?$##0:wybe.int):
+start(#rec##0:stmt_for.int_sequence, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:wybe.int)
 start > public {inline} (0 calls)
 1: stmt_for.int_sequence.start<1>
-start($rec##0:stmt_for.int_sequence, ?$rec##1:stmt_for.int_sequence, $field##0:wybe.int):
+start(#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:stmt_for.int_sequence, ?$rec##1:stmt_for.int_sequence, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 stride > public {inline} (0 calls)
 0: stmt_for.int_sequence.stride<0>
-stride($rec##0:stmt_for.int_sequence, ?$##0:wybe.int):
+stride(#rec##0:stmt_for.int_sequence, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:wybe.int)
 stride > public {inline} (0 calls)
 1: stmt_for.int_sequence.stride<1>
-stride($rec##0:stmt_for.int_sequence, ?$rec##1:stmt_for.int_sequence, $field##0:wybe.int):
+stride(#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:stmt_for.int_sequence, ?$rec##1:stmt_for.int_sequence, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:stmt_for.int_sequence, ?#rec##1:stmt_for.int_sequence, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: stmt_for.int_sequence.~=<0>
-~=($left##0:stmt_for.int_sequence, $right##0:stmt_for.int_sequence, ?$$##0:wybe.bool):
+~=(#left##0:stmt_for.int_sequence, #right##0:stmt_for.int_sequence, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access($left##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access(~$left##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access($right##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign lpvm access($right##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.int)
-    foreign lpvm access(~$right##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$9##0:wybe.bool) @int:nn:nn
-    case ~tmp$9##0:wybe.bool of
+    foreign lpvm access(#left##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(#left##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(~#left##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(#right##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#right##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int)
+    foreign lpvm access(~#right##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#9##0:wybe.bool) @int:nn:nn
+    case ~tmp#9##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$7##0:wybe.int, ?tmp$10##0:wybe.bool) @int:nn:nn
-        case ~tmp$10##0:wybe.bool of
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#7##0:wybe.int, ?tmp#10##0:wybe.bool) @int:nn:nn
+        case ~tmp#10##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~tmp$5##0:wybe.int, ~tmp$8##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm icmp_eq(~tmp#5##0:wybe.int, ~tmp#8##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
 
@@ -2077,40 +2077,40 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"stmt_for.int_sequence.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"stmt_for.int_sequence.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = add   i64 %"$left##0", 16 
+  %8 = add   i64 %"#left##0", 16 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
-  %12 = inttoptr i64 %"$right##0" to i64* 
+  %12 = inttoptr i64 %"#right##0" to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %15 = add   i64 %"$right##0", 8 
+  %15 = add   i64 %"#right##0", 8 
   %16 = inttoptr i64 %15 to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
-  %19 = add   i64 %"$right##0", 16 
+  %19 = add   i64 %"#right##0", 16 
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %"1$tmp$1##0" = icmp eq i64 %3, %14 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %14 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = icmp eq i64 %7, %18 
-  br i1 %"2$tmp$2##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = icmp eq i64 %7, %18 
+  br i1 %"2#tmp#2##0", label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %"4$$$##0" = icmp eq i64 %11, %22 
-  ret i1 %"4$$$##0" 
+  %"4#####0" = icmp eq i64 %11, %22 
+  ret i1 %"4#####0" 
 if.else1:
   ret i1 0 
 }
@@ -2129,16 +2129,16 @@ entry:
   %31 = inttoptr i64 %30 to i64* 
   %32 = getelementptr  i64, i64* %31, i64 0 
   %33 = load  i64, i64* %32 
-  %"1$tmp$4##0" = icmp slt i64 %29, 0 
-  br i1 %"1$tmp$4##0", label %if.then, label %if.else 
+  %"1#tmp#4##0" = icmp slt i64 %29, 0 
+  br i1 %"1#tmp#4##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = icmp slt i64 %33, %25 
-  br i1 %"2$tmp$2##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = icmp slt i64 %33, %25 
+  br i1 %"2#tmp#2##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$tmp$3##0" = icmp sgt i64 %33, %25 
-  br i1 %"3$tmp$3##0", label %if.then2, label %if.else2 
+  %"3#tmp#3##0" = icmp sgt i64 %33, %25 
+  br i1 %"3#tmp#3##0", label %if.then2, label %if.else2 
 if.then1:
-  %34 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.gen$1<0>"(i64  %33, i64  %25, i64  %29)  
+  %34 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.gen#1<0>"(i64  %33, i64  %25, i64  %29)  
   %35 = extractvalue {i64, i64, i1} %34, 0 
   %36 = extractvalue {i64, i64, i1} %34, 1 
   %37 = extractvalue {i64, i64, i1} %34, 2 
@@ -2152,7 +2152,7 @@ if.else1:
   %43 = insertvalue {i64, i64, i1} %42, i1 0, 2 
   ret {i64, i64, i1} %43 
 if.then2:
-  %44 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.gen$1<0>"(i64  %33, i64  %25, i64  %29)  
+  %44 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.gen#1<0>"(i64  %33, i64  %25, i64  %29)  
   %45 = extractvalue {i64, i64, i1} %44, 0 
   %46 = extractvalue {i64, i64, i1} %44, 1 
   %47 = extractvalue {i64, i64, i1} %44, 2 
@@ -2168,9 +2168,9 @@ if.else2:
 }
 
 
-define external fastcc  i64 @"stmt_for.int_sequence.end<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"stmt_for.int_sequence.end<0>"(i64  %"#rec##0")    {
 entry:
-  %54 = add   i64 %"$rec##0", 16 
+  %54 = add   i64 %"#rec##0", 16 
   %55 = inttoptr i64 %54 to i64* 
   %56 = getelementptr  i64, i64* %55, i64 0 
   %57 = load  i64, i64* %56 
@@ -2178,32 +2178,32 @@ entry:
 }
 
 
-define external fastcc  i64 @"stmt_for.int_sequence.end<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"stmt_for.int_sequence.end<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %58 = trunc i64 24 to i32  
   %59 = tail call ccc  i8*  @wybe_malloc(i32  %58)  
   %60 = ptrtoint i8* %59 to i64 
   %61 = inttoptr i64 %60 to i8* 
-  %62 = inttoptr i64 %"$rec##0" to i8* 
+  %62 = inttoptr i64 %"#rec##0" to i8* 
   %63 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %61, i8*  %62, i32  %63, i32  8, i1  0)  
   %64 = add   i64 %60, 16 
   %65 = inttoptr i64 %64 to i64* 
   %66 = getelementptr  i64, i64* %65, i64 0 
-  store  i64 %"$field##0", i64* %66 
+  store  i64 %"#field##0", i64* %66 
   ret i64 %60 
 }
 
 
-define external fastcc  {i64, i64, i1} @"stmt_for.int_sequence.gen$1<0>"(i64  %"en##0", i64  %"s##0", i64  %"st##0")    {
+define external fastcc  {i64, i64, i1} @"stmt_for.int_sequence.gen#1<0>"(i64  %"en##0", i64  %"s##0", i64  %"st##0")    {
 entry:
-  %"1$tmp$1##0" = add   i64 %"s##0", %"st##0" 
+  %"1#tmp#1##0" = add   i64 %"s##0", %"st##0" 
   %67 = trunc i64 24 to i32  
   %68 = tail call ccc  i8*  @wybe_malloc(i32  %67)  
   %69 = ptrtoint i8* %68 to i64 
   %70 = inttoptr i64 %69 to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
-  store  i64 %"1$tmp$1##0", i64* %71 
+  store  i64 %"1#tmp#1##0", i64* %71 
   %72 = add   i64 %69, 8 
   %73 = inttoptr i64 %72 to i64* 
   %74 = getelementptr  i64, i64* %73, i64 0 
@@ -2239,16 +2239,16 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64} @"stmt_for.int_sequence.int_sequence<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64, i64} @"stmt_for.int_sequence.int_sequence<1>"(i64  %"###0")    {
 entry:
-  %92 = inttoptr i64 %"$##0" to i64* 
+  %92 = inttoptr i64 %"###0" to i64* 
   %93 = getelementptr  i64, i64* %92, i64 0 
   %94 = load  i64, i64* %93 
-  %95 = add   i64 %"$##0", 8 
+  %95 = add   i64 %"###0", 8 
   %96 = inttoptr i64 %95 to i64* 
   %97 = getelementptr  i64, i64* %96, i64 0 
   %98 = load  i64, i64* %97 
-  %99 = add   i64 %"$##0", 16 
+  %99 = add   i64 %"###0", 16 
   %100 = inttoptr i64 %99 to i64* 
   %101 = getelementptr  i64, i64* %100, i64 0 
   %102 = load  i64, i64* %101 
@@ -2259,34 +2259,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"stmt_for.int_sequence.start<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"stmt_for.int_sequence.start<0>"(i64  %"#rec##0")    {
 entry:
-  %106 = inttoptr i64 %"$rec##0" to i64* 
+  %106 = inttoptr i64 %"#rec##0" to i64* 
   %107 = getelementptr  i64, i64* %106, i64 0 
   %108 = load  i64, i64* %107 
   ret i64 %108 
 }
 
 
-define external fastcc  i64 @"stmt_for.int_sequence.start<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"stmt_for.int_sequence.start<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %109 = trunc i64 24 to i32  
   %110 = tail call ccc  i8*  @wybe_malloc(i32  %109)  
   %111 = ptrtoint i8* %110 to i64 
   %112 = inttoptr i64 %111 to i8* 
-  %113 = inttoptr i64 %"$rec##0" to i8* 
+  %113 = inttoptr i64 %"#rec##0" to i8* 
   %114 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %112, i8*  %113, i32  %114, i32  8, i1  0)  
   %115 = inttoptr i64 %111 to i64* 
   %116 = getelementptr  i64, i64* %115, i64 0 
-  store  i64 %"$field##0", i64* %116 
+  store  i64 %"#field##0", i64* %116 
   ret i64 %111 
 }
 
 
-define external fastcc  i64 @"stmt_for.int_sequence.stride<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"stmt_for.int_sequence.stride<0>"(i64  %"#rec##0")    {
 entry:
-  %117 = add   i64 %"$rec##0", 8 
+  %117 = add   i64 %"#rec##0", 8 
   %118 = inttoptr i64 %117 to i64* 
   %119 = getelementptr  i64, i64* %118, i64 0 
   %120 = load  i64, i64* %119 
@@ -2294,60 +2294,60 @@ entry:
 }
 
 
-define external fastcc  i64 @"stmt_for.int_sequence.stride<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"stmt_for.int_sequence.stride<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %121 = trunc i64 24 to i32  
   %122 = tail call ccc  i8*  @wybe_malloc(i32  %121)  
   %123 = ptrtoint i8* %122 to i64 
   %124 = inttoptr i64 %123 to i8* 
-  %125 = inttoptr i64 %"$rec##0" to i8* 
+  %125 = inttoptr i64 %"#rec##0" to i8* 
   %126 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %124, i8*  %125, i32  %126, i32  8, i1  0)  
   %127 = add   i64 %123, 8 
   %128 = inttoptr i64 %127 to i64* 
   %129 = getelementptr  i64, i64* %128, i64 0 
-  store  i64 %"$field##0", i64* %129 
+  store  i64 %"#field##0", i64* %129 
   ret i64 %123 
 }
 
 
-define external fastcc  i1 @"stmt_for.int_sequence.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"stmt_for.int_sequence.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %130 = inttoptr i64 %"$left##0" to i64* 
+  %130 = inttoptr i64 %"#left##0" to i64* 
   %131 = getelementptr  i64, i64* %130, i64 0 
   %132 = load  i64, i64* %131 
-  %133 = add   i64 %"$left##0", 8 
+  %133 = add   i64 %"#left##0", 8 
   %134 = inttoptr i64 %133 to i64* 
   %135 = getelementptr  i64, i64* %134, i64 0 
   %136 = load  i64, i64* %135 
-  %137 = add   i64 %"$left##0", 16 
+  %137 = add   i64 %"#left##0", 16 
   %138 = inttoptr i64 %137 to i64* 
   %139 = getelementptr  i64, i64* %138, i64 0 
   %140 = load  i64, i64* %139 
-  %141 = inttoptr i64 %"$right##0" to i64* 
+  %141 = inttoptr i64 %"#right##0" to i64* 
   %142 = getelementptr  i64, i64* %141, i64 0 
   %143 = load  i64, i64* %142 
-  %144 = add   i64 %"$right##0", 8 
+  %144 = add   i64 %"#right##0", 8 
   %145 = inttoptr i64 %144 to i64* 
   %146 = getelementptr  i64, i64* %145, i64 0 
   %147 = load  i64, i64* %146 
-  %148 = add   i64 %"$right##0", 16 
+  %148 = add   i64 %"#right##0", 16 
   %149 = inttoptr i64 %148 to i64* 
   %150 = getelementptr  i64, i64* %149, i64 0 
   %151 = load  i64, i64* %150 
-  %"1$tmp$9##0" = icmp eq i64 %132, %143 
-  br i1 %"1$tmp$9##0", label %if.then, label %if.else 
+  %"1#tmp#9##0" = icmp eq i64 %132, %143 
+  br i1 %"1#tmp#9##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$10##0" = icmp eq i64 %136, %147 
-  br i1 %"2$tmp$10##0", label %if.then1, label %if.else1 
+  %"2#tmp#10##0" = icmp eq i64 %136, %147 
+  br i1 %"2#tmp#10##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 if.then1:
-  %"4$tmp$0##0" = icmp eq i64 %140, %151 
-  %"4$$$##0" = xor i1 %"4$tmp$0##0", 1 
-  ret i1 %"4$$$##0" 
+  %"4#tmp#0##0" = icmp eq i64 %140, %151 
+  %"4#####0" = xor i1 %"4#tmp#0##0", 1 
+  ret i1 %"4#####0" 
 if.else1:
-  %"5$$$##0" = xor i1 0, 1 
-  ret i1 %"5$$$##0" 
+  %"5#####0" = xor i1 0, 1 
+  ret i1 %"5#####0" 
 }

--- a/test-cases/final-dump/stmt_for.exp
+++ b/test-cases/final-dump/stmt_for.exp
@@ -40,741 +40,741 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: stmt_for.<0>
-(io#0:wybe.phantom, ?io#26:wybe.phantom):
+(io##0:wybe.phantom, ?io##26:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("single_generator:":wybe.string, ~#io#0:wybe.phantom, ?tmp$2#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$2#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    stmt_for.single_generator<0>(~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #1 @stmt_for:nn:nn
-    foreign c print_string("\nmultiple_generator":wybe.string, ~#io#2:wybe.phantom, ?tmp$5#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$5#0:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    stmt_for.multiple_generator<0>(~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #3 @stmt_for:nn:nn
-    foreign c print_string("\nshortest_generator_termination":wybe.string, ~#io#4:wybe.phantom, ?tmp$8#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$8#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-    stmt_for.shortest_generator_termination<0>(~#io#5:wybe.phantom, ?#io#6:wybe.phantom) #5 @stmt_for:nn:nn
-    foreign c print_string("\nusing_break":wybe.string, ~#io#6:wybe.phantom, ?tmp$11#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$11#0:wybe.phantom, ?#io#7:wybe.phantom) @io:nn:nn
-    stmt_for.using_break<0>(~#io#7:wybe.phantom, ?#io#8:wybe.phantom) #7 @stmt_for:nn:nn
-    foreign c print_string("\nusing_next":wybe.string, ~#io#8:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#9:wybe.phantom) @io:nn:nn
-    stmt_for.using_next<0>(~#io#9:wybe.phantom, ?#io#10:wybe.phantom) #9 @stmt_for:nn:nn
-    foreign c print_string("\nusing_while":wybe.string, ~#io#10:wybe.phantom, ?tmp$17#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$17#0:wybe.phantom, ?#io#11:wybe.phantom) @io:nn:nn
-    stmt_for.using_while<0>(~#io#11:wybe.phantom, ?#io#12:wybe.phantom) #11 @stmt_for:nn:nn
-    foreign c print_string("\nusing_until":wybe.string, ~#io#12:wybe.phantom, ?tmp$20#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$20#0:wybe.phantom, ?#io#13:wybe.phantom) @io:nn:nn
-    stmt_for.using_until<0>(~#io#13:wybe.phantom, ?#io#14:wybe.phantom) #13 @stmt_for:nn:nn
-    foreign c print_string("\nusing_when":wybe.string, ~#io#14:wybe.phantom, ?tmp$23#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$23#0:wybe.phantom, ?#io#15:wybe.phantom) @io:nn:nn
-    stmt_for.using_when<0>(~#io#15:wybe.phantom, ?#io#16:wybe.phantom) #15 @stmt_for:nn:nn
-    foreign c print_string("\nusing_unless":wybe.string, ~#io#16:wybe.phantom, ?tmp$26#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$26#0:wybe.phantom, ?#io#17:wybe.phantom) @io:nn:nn
-    stmt_for.using_unless<0>(~#io#17:wybe.phantom, ?#io#18:wybe.phantom) #17 @stmt_for:nn:nn
-    foreign c print_string("\nusing_xrange":wybe.string, ~#io#18:wybe.phantom, ?tmp$29#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$29#0:wybe.phantom, ?#io#19:wybe.phantom) @io:nn:nn
-    stmt_for.using_xrange<0>(~#io#19:wybe.phantom, ?#io#20:wybe.phantom) #19 @stmt_for:nn:nn
-    foreign c print_string("\nusing_xrange_reverse":wybe.string, ~#io#20:wybe.phantom, ?tmp$32#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$32#0:wybe.phantom, ?#io#21:wybe.phantom) @io:nn:nn
-    stmt_for.using_xrange_reverse<0>(~#io#21:wybe.phantom, ?#io#22:wybe.phantom) #21 @stmt_for:nn:nn
-    foreign c print_string("\nusing_irange":wybe.string, ~#io#22:wybe.phantom, ?tmp$35#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$35#0:wybe.phantom, ?#io#23:wybe.phantom) @io:nn:nn
-    stmt_for.using_irange<0>(~#io#23:wybe.phantom, ?#io#24:wybe.phantom) #23 @stmt_for:nn:nn
-    foreign c print_string("\nusing_irange_reverse":wybe.string, ~#io#24:wybe.phantom, ?tmp$38#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$38#0:wybe.phantom, ?#io#25:wybe.phantom) @io:nn:nn
-    stmt_for.using_irange_reverse<0>(~#io#25:wybe.phantom, ?#io#26:wybe.phantom) #25 @stmt_for:nn:nn
+    foreign c print_string("single_generator:":wybe.string, ~#io##0:wybe.phantom, ?tmp$2##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$2##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    stmt_for.single_generator<0>(~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #1 @stmt_for:nn:nn
+    foreign c print_string("\nmultiple_generator":wybe.string, ~#io##2:wybe.phantom, ?tmp$5##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$5##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    stmt_for.multiple_generator<0>(~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #3 @stmt_for:nn:nn
+    foreign c print_string("\nshortest_generator_termination":wybe.string, ~#io##4:wybe.phantom, ?tmp$8##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$8##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    stmt_for.shortest_generator_termination<0>(~#io##5:wybe.phantom, ?#io##6:wybe.phantom) #5 @stmt_for:nn:nn
+    foreign c print_string("\nusing_break":wybe.string, ~#io##6:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$11##0:wybe.phantom, ?#io##7:wybe.phantom) @io:nn:nn
+    stmt_for.using_break<0>(~#io##7:wybe.phantom, ?#io##8:wybe.phantom) #7 @stmt_for:nn:nn
+    foreign c print_string("\nusing_next":wybe.string, ~#io##8:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##9:wybe.phantom) @io:nn:nn
+    stmt_for.using_next<0>(~#io##9:wybe.phantom, ?#io##10:wybe.phantom) #9 @stmt_for:nn:nn
+    foreign c print_string("\nusing_while":wybe.string, ~#io##10:wybe.phantom, ?tmp$17##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$17##0:wybe.phantom, ?#io##11:wybe.phantom) @io:nn:nn
+    stmt_for.using_while<0>(~#io##11:wybe.phantom, ?#io##12:wybe.phantom) #11 @stmt_for:nn:nn
+    foreign c print_string("\nusing_until":wybe.string, ~#io##12:wybe.phantom, ?tmp$20##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$20##0:wybe.phantom, ?#io##13:wybe.phantom) @io:nn:nn
+    stmt_for.using_until<0>(~#io##13:wybe.phantom, ?#io##14:wybe.phantom) #13 @stmt_for:nn:nn
+    foreign c print_string("\nusing_when":wybe.string, ~#io##14:wybe.phantom, ?tmp$23##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$23##0:wybe.phantom, ?#io##15:wybe.phantom) @io:nn:nn
+    stmt_for.using_when<0>(~#io##15:wybe.phantom, ?#io##16:wybe.phantom) #15 @stmt_for:nn:nn
+    foreign c print_string("\nusing_unless":wybe.string, ~#io##16:wybe.phantom, ?tmp$26##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$26##0:wybe.phantom, ?#io##17:wybe.phantom) @io:nn:nn
+    stmt_for.using_unless<0>(~#io##17:wybe.phantom, ?#io##18:wybe.phantom) #17 @stmt_for:nn:nn
+    foreign c print_string("\nusing_xrange":wybe.string, ~#io##18:wybe.phantom, ?tmp$29##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$29##0:wybe.phantom, ?#io##19:wybe.phantom) @io:nn:nn
+    stmt_for.using_xrange<0>(~#io##19:wybe.phantom, ?#io##20:wybe.phantom) #19 @stmt_for:nn:nn
+    foreign c print_string("\nusing_xrange_reverse":wybe.string, ~#io##20:wybe.phantom, ?tmp$32##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$32##0:wybe.phantom, ?#io##21:wybe.phantom) @io:nn:nn
+    stmt_for.using_xrange_reverse<0>(~#io##21:wybe.phantom, ?#io##22:wybe.phantom) #21 @stmt_for:nn:nn
+    foreign c print_string("\nusing_irange":wybe.string, ~#io##22:wybe.phantom, ?tmp$35##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$35##0:wybe.phantom, ?#io##23:wybe.phantom) @io:nn:nn
+    stmt_for.using_irange<0>(~#io##23:wybe.phantom, ?#io##24:wybe.phantom) #23 @stmt_for:nn:nn
+    foreign c print_string("\nusing_irange_reverse":wybe.string, ~#io##24:wybe.phantom, ?tmp$38##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$38##0:wybe.phantom, ?#io##25:wybe.phantom) @io:nn:nn
+    stmt_for.using_irange_reverse<0>(~#io##25:wybe.phantom, ?#io##26:wybe.phantom) #25 @stmt_for:nn:nn
 
 
 gen$1 > (2 calls)
 0: stmt_for.gen$1<0>
-gen$1(io#0:wybe.phantom, tmp$0#0:wybe.list(?T), tmp$1#0:wybe.list(?T), tmp$2#0:wybe.list(?T), tmp$3#0:wybe.list(?T), tmp$4#0:wybe.list(?T), tmp$5#0:wybe.list(?T), tmp$6#0:wybe.list(?T), tmp$7#0:wybe.list(?T), tmp$8#0:wybe.list(wybe.int), tmp$9#0:wybe.list(wybe.int), x#0:wybe.list(wybe.int), y#0:wybe.list(wybe.int), ?io#1:wybe.phantom):
+gen$1(io##0:wybe.phantom, tmp$0##0:wybe.list(?T), tmp$1##0:wybe.list(?T), tmp$2##0:wybe.list(?T), tmp$3##0:wybe.list(?T), tmp$4##0:wybe.list(?T), tmp$5##0:wybe.list(?T), tmp$6##0:wybe.list(?T), tmp$7##0:wybe.list(?T), tmp$8##0:wybe.list(wybe.int), tmp$9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp$8#0:wybe.int, 0:wybe.int, ?tmp$14#0:wybe.bool)
-    case ~tmp$14#0:wybe.bool of
+    foreign llvm icmp_ne(tmp$8##0:wybe.int, 0:wybe.int, ?tmp$14##0:wybe.bool)
+    case ~tmp$14##0:wybe.bool of
     0:
-        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp$8#0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i#0:?T)
-        foreign lpvm access(~tmp$8#0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.list(?T))
-        stmt_for.gen$2<0>(~i#0:wybe.int, ~io#0:wybe.phantom, ~tmp$0#0:wybe.list(wybe.int), ~tmp$1#0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~tmp$2#0:wybe.list(wybe.int), ~tmp$3#0:wybe.list(wybe.int), ~tmp$4#0:wybe.list(wybe.int), ~tmp$5#0:wybe.list(wybe.int), ~tmp$6#0:wybe.list(wybe.int), ~tmp$7#0:wybe.list(wybe.int), ~tmp$10#0:wybe.list(wybe.int), ~tmp$9#0:wybe.list(wybe.int), ~x#0:wybe.list(wybe.int), ~y#0:wybe.list(wybe.int), ?io#1:wybe.phantom) #1
+        foreign lpvm access(tmp$8##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
+        foreign lpvm access(~tmp$8##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.list(?T))
+        stmt_for.gen$2<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp$0##0:wybe.list(wybe.int), ~tmp$1##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~tmp$2##0:wybe.list(wybe.int), ~tmp$3##0:wybe.list(wybe.int), ~tmp$4##0:wybe.list(wybe.int), ~tmp$5##0:wybe.list(wybe.int), ~tmp$6##0:wybe.list(wybe.int), ~tmp$7##0:wybe.list(wybe.int), ~tmp$10##0:wybe.list(wybe.int), ~tmp$9##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
 
 
 
 gen$10 > (2 calls)
 0: stmt_for.gen$10<0>
-gen$10(io#0:wybe.phantom, tmp$0#0:wybe.list(?T), tmp$1#0:wybe.list(?T), tmp$2#0:wybe.list(?T), tmp$3#0:wybe.list(?T), tmp$4#0:wybe.list(?T), tmp$5#0:wybe.list(wybe.int), x#0:wybe.list(wybe.int), ?io#1:wybe.phantom):
+gen$10(io##0:wybe.phantom, tmp$0##0:wybe.list(?T), tmp$1##0:wybe.list(?T), tmp$2##0:wybe.list(?T), tmp$3##0:wybe.list(?T), tmp$4##0:wybe.list(?T), tmp$5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp$5#0:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.bool)
-    case ~tmp$10#0:wybe.bool of
+    foreign llvm icmp_ne(tmp$5##0:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.bool)
+    case ~tmp$10##0:wybe.bool of
     0:
-        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp$5#0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i#0:?T)
-        foreign lpvm access(~tmp$5#0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.list(?T))
-        stmt_for.gen$11<0>(~i#0:wybe.int, ~io#0:wybe.phantom, ~tmp$0#0:wybe.list(wybe.int), ~tmp$1#0:wybe.list(wybe.int), ~tmp$2#0:wybe.list(wybe.int), ~tmp$3#0:wybe.list(wybe.int), ~tmp$4#0:wybe.list(wybe.int), ~tmp$6#0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x#0:wybe.list(wybe.int), ?io#1:wybe.phantom) #1
+        foreign lpvm access(tmp$5##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
+        foreign lpvm access(~tmp$5##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.list(?T))
+        stmt_for.gen$11<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp$0##0:wybe.list(wybe.int), ~tmp$1##0:wybe.list(wybe.int), ~tmp$2##0:wybe.list(wybe.int), ~tmp$3##0:wybe.list(wybe.int), ~tmp$4##0:wybe.list(wybe.int), ~tmp$6##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
 
 
 
 gen$11 > (1 calls)
 0: stmt_for.gen$11<0>
-gen$11(i#0:wybe.int, io#0:wybe.phantom, tmp$0#0:wybe.list(wybe.int), tmp$1#0:wybe.list(wybe.int), tmp$2#0:wybe.list(wybe.int), tmp$3#0:wybe.list(wybe.int), tmp$4#0:wybe.list(wybe.int), tmp$5#0:wybe.list(wybe.int), [tmp$6#0:wybe.list(wybe.int)], [tmp$7#0:wybe.bool], x#0:wybe.list(wybe.int), ?io#2:wybe.phantom):
+gen$11(i##0:wybe.int, io##0:wybe.phantom, tmp$0##0:wybe.list(wybe.int), tmp$1##0:wybe.list(wybe.int), tmp$2##0:wybe.list(wybe.int), tmp$3##0:wybe.list(wybe.int), tmp$4##0:wybe.list(wybe.int), tmp$5##0:wybe.list(wybe.int), [tmp$6##0:wybe.list(wybe.int)], [tmp$7##0:wybe.bool], x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(i#0:wybe.int, 3:wybe.int, ?tmp$8#0:wybe.bool) @int:nn:nn
-    case ~tmp$8#0:wybe.bool of
+    foreign llvm icmp_eq(i##0:wybe.int, 3:wybe.int, ?tmp$8##0:wybe.bool) @int:nn:nn
+    case ~tmp$8##0:wybe.bool of
     0:
-        foreign c print_int(~i#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$13#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$13#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        stmt_for.gen$10<0>(~io#1:wybe.phantom, ~tmp$0#0:wybe.list(?T), ~tmp$1#0:wybe.list(?T), ~tmp$2#0:wybe.list(?T), ~tmp$3#0:wybe.list(?T), ~tmp$4#0:wybe.list(?T), ~tmp$5#0:wybe.list(wybe.int), ~x#0:wybe.list(wybe.int), ?io#2:wybe.phantom) #2 @stmt_for:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$13##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$13##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_for.gen$10<0>(~io##1:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), ~tmp$4##0:wybe.list(?T), ~tmp$5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
 
     1:
-        foreign llvm move(~io#0:wybe.phantom, ?io#2:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
 
 
 gen$12 > (2 calls)
 0: stmt_for.gen$12<0>
-gen$12(io#0:wybe.phantom, tmp$0#0:stmt_for.int_sequence, tmp$3#0:stmt_for.int_sequence, ?io#2:wybe.phantom):
+gen$12(io##0:wybe.phantom, tmp$0##0:stmt_for.int_sequence, tmp$3##0:stmt_for.int_sequence, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_for.int_sequence.[|]<0>(?i#0:wybe.int, ?tmp$1#0:stmt_for.int_sequence, ~tmp$0#0:stmt_for.int_sequence, ?tmp$2#0:wybe.bool) #0
-    case ~tmp$2#0:wybe.bool of
+    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp$1##0:stmt_for.int_sequence, ~tmp$0##0:stmt_for.int_sequence, ?tmp$2##0:wybe.bool) #0
+    case ~tmp$2##0:wybe.bool of
     0:
-        foreign llvm move(~io#0:wybe.phantom, ?io#2:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign c print_int(~i#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$6#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$6#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        stmt_for.gen$12<0>(~io#1:wybe.phantom, ~tmp$1#0:stmt_for.int_sequence, ~tmp$3#0:stmt_for.int_sequence, ?io#2:wybe.phantom) #2 @stmt_for:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$6##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_for.gen$12<0>(~io##1:wybe.phantom, ~tmp$1##0:stmt_for.int_sequence, ~tmp$3##0:stmt_for.int_sequence, ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
 
 
 
 gen$13 > (2 calls)
 0: stmt_for.gen$13<0>
-gen$13(io#0:wybe.phantom, tmp$0#0:stmt_for.int_sequence, tmp$3#0:stmt_for.int_sequence, ?io#2:wybe.phantom):
+gen$13(io##0:wybe.phantom, tmp$0##0:stmt_for.int_sequence, tmp$3##0:stmt_for.int_sequence, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_for.int_sequence.[|]<0>(?i#0:wybe.int, ?tmp$1#0:stmt_for.int_sequence, ~tmp$0#0:stmt_for.int_sequence, ?tmp$2#0:wybe.bool) #0
-    case ~tmp$2#0:wybe.bool of
+    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp$1##0:stmt_for.int_sequence, ~tmp$0##0:stmt_for.int_sequence, ?tmp$2##0:wybe.bool) #0
+    case ~tmp$2##0:wybe.bool of
     0:
-        foreign llvm move(~io#0:wybe.phantom, ?io#2:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign c print_int(~i#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$6#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$6#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        stmt_for.gen$13<0>(~io#1:wybe.phantom, ~tmp$1#0:stmt_for.int_sequence, ~tmp$3#0:stmt_for.int_sequence, ?io#2:wybe.phantom) #2 @stmt_for:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$6##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_for.gen$13<0>(~io##1:wybe.phantom, ~tmp$1##0:stmt_for.int_sequence, ~tmp$3##0:stmt_for.int_sequence, ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
 
 
 
 gen$14 > (3 calls)
 0: stmt_for.gen$14<0>
-gen$14(io#0:wybe.phantom, tmp$0#0:wybe.list(?T), tmp$1#0:wybe.list(?T), tmp$2#0:wybe.list(?T), tmp$3#0:wybe.list(?T), tmp$4#0:wybe.list(?T), tmp$5#0:wybe.list(wybe.int), x#0:wybe.list(wybe.int), ?io#1:wybe.phantom):
+gen$14(io##0:wybe.phantom, tmp$0##0:wybe.list(?T), tmp$1##0:wybe.list(?T), tmp$2##0:wybe.list(?T), tmp$3##0:wybe.list(?T), tmp$4##0:wybe.list(?T), tmp$5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp$5#0:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.bool)
-    case ~tmp$10#0:wybe.bool of
+    foreign llvm icmp_ne(tmp$5##0:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.bool)
+    case ~tmp$10##0:wybe.bool of
     0:
-        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp$5#0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i#0:?T)
-        foreign lpvm access(~tmp$5#0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.list(?T))
-        stmt_for.gen$15<0>(~i#0:wybe.int, ~io#0:wybe.phantom, ~tmp$0#0:wybe.list(wybe.int), ~tmp$1#0:wybe.list(wybe.int), ~tmp$2#0:wybe.list(wybe.int), ~tmp$3#0:wybe.list(wybe.int), ~tmp$4#0:wybe.list(wybe.int), ~tmp$6#0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x#0:wybe.list(wybe.int), ?io#1:wybe.phantom) #1
+        foreign lpvm access(tmp$5##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
+        foreign lpvm access(~tmp$5##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.list(?T))
+        stmt_for.gen$15<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp$0##0:wybe.list(wybe.int), ~tmp$1##0:wybe.list(wybe.int), ~tmp$2##0:wybe.list(wybe.int), ~tmp$3##0:wybe.list(wybe.int), ~tmp$4##0:wybe.list(wybe.int), ~tmp$6##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
 
 
 
 gen$15 > (1 calls)
 0: stmt_for.gen$15<0>
-gen$15(i#0:wybe.int, io#0:wybe.phantom, tmp$0#0:wybe.list(wybe.int), tmp$1#0:wybe.list(wybe.int), tmp$2#0:wybe.list(wybe.int), tmp$3#0:wybe.list(wybe.int), tmp$4#0:wybe.list(wybe.int), tmp$5#0:wybe.list(wybe.int), [tmp$6#0:wybe.list(wybe.int)], [tmp$7#0:wybe.bool], x#0:wybe.list(wybe.int), ?io#2:wybe.phantom):
+gen$15(i##0:wybe.int, io##0:wybe.phantom, tmp$0##0:wybe.list(wybe.int), tmp$1##0:wybe.list(wybe.int), tmp$2##0:wybe.list(wybe.int), tmp$3##0:wybe.list(wybe.int), tmp$4##0:wybe.list(wybe.int), tmp$5##0:wybe.list(wybe.int), [tmp$6##0:wybe.list(wybe.int)], [tmp$7##0:wybe.bool], x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(i#0:wybe.int, 3:wybe.int, ?tmp$8#0:wybe.bool) @int:nn:nn
-    case ~tmp$8#0:wybe.bool of
+    foreign llvm icmp_eq(i##0:wybe.int, 3:wybe.int, ?tmp$8##0:wybe.bool) @int:nn:nn
+    case ~tmp$8##0:wybe.bool of
     0:
-        foreign c print_int(~i#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$13#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$13#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        stmt_for.gen$14<0>(~io#1:wybe.phantom, ~tmp$0#0:wybe.list(?T), ~tmp$1#0:wybe.list(?T), ~tmp$2#0:wybe.list(?T), ~tmp$3#0:wybe.list(?T), ~tmp$4#0:wybe.list(?T), ~tmp$5#0:wybe.list(wybe.int), ~x#0:wybe.list(wybe.int), ?io#2:wybe.phantom) #3 @stmt_for:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$13##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$13##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_for.gen$14<0>(~io##1:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), ~tmp$4##0:wybe.list(?T), ~tmp$5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #3 @stmt_for:nn:nn
 
     1:
-        stmt_for.gen$14<0>(~io#0:wybe.phantom, ~tmp$0#0:wybe.list(?T), ~tmp$1#0:wybe.list(?T), ~tmp$2#0:wybe.list(?T), ~tmp$3#0:wybe.list(?T), ~tmp$4#0:wybe.list(?T), ~tmp$5#0:wybe.list(wybe.int), ~x#0:wybe.list(wybe.int), ?io#2:wybe.phantom) #1 @stmt_for:nn:nn
+        stmt_for.gen$14<0>(~io##0:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), ~tmp$4##0:wybe.list(?T), ~tmp$5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #1 @stmt_for:nn:nn
 
 
 
 gen$16 > (3 calls)
 0: stmt_for.gen$16<0>
-gen$16(io#0:wybe.phantom, tmp$0#0:wybe.list(?T), tmp$1#0:wybe.list(?T), tmp$2#0:wybe.list(?T), tmp$3#0:wybe.list(?T), tmp$4#0:wybe.list(?T), tmp$5#0:wybe.list(wybe.int), x#0:wybe.list(wybe.int), ?io#1:wybe.phantom):
+gen$16(io##0:wybe.phantom, tmp$0##0:wybe.list(?T), tmp$1##0:wybe.list(?T), tmp$2##0:wybe.list(?T), tmp$3##0:wybe.list(?T), tmp$4##0:wybe.list(?T), tmp$5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp$5#0:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.bool)
-    case ~tmp$10#0:wybe.bool of
+    foreign llvm icmp_ne(tmp$5##0:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.bool)
+    case ~tmp$10##0:wybe.bool of
     0:
-        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp$5#0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i#0:?T)
-        foreign lpvm access(~tmp$5#0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.list(?T))
-        stmt_for.gen$17<0>(~i#0:wybe.int, ~io#0:wybe.phantom, ~tmp$0#0:wybe.list(wybe.int), ~tmp$1#0:wybe.list(wybe.int), ~tmp$2#0:wybe.list(wybe.int), ~tmp$3#0:wybe.list(wybe.int), ~tmp$4#0:wybe.list(wybe.int), ~tmp$6#0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x#0:wybe.list(wybe.int), ?io#1:wybe.phantom) #1
+        foreign lpvm access(tmp$5##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
+        foreign lpvm access(~tmp$5##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.list(?T))
+        stmt_for.gen$17<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp$0##0:wybe.list(wybe.int), ~tmp$1##0:wybe.list(wybe.int), ~tmp$2##0:wybe.list(wybe.int), ~tmp$3##0:wybe.list(wybe.int), ~tmp$4##0:wybe.list(wybe.int), ~tmp$6##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
 
 
 
 gen$17 > (1 calls)
 0: stmt_for.gen$17<0>
-gen$17(i#0:wybe.int, io#0:wybe.phantom, tmp$0#0:wybe.list(wybe.int), tmp$1#0:wybe.list(wybe.int), tmp$2#0:wybe.list(wybe.int), tmp$3#0:wybe.list(wybe.int), tmp$4#0:wybe.list(wybe.int), tmp$5#0:wybe.list(wybe.int), [tmp$6#0:wybe.list(wybe.int)], [tmp$7#0:wybe.bool], x#0:wybe.list(wybe.int), ?io#2:wybe.phantom):
+gen$17(i##0:wybe.int, io##0:wybe.phantom, tmp$0##0:wybe.list(wybe.int), tmp$1##0:wybe.list(wybe.int), tmp$2##0:wybe.list(wybe.int), tmp$3##0:wybe.list(wybe.int), tmp$4##0:wybe.list(wybe.int), tmp$5##0:wybe.list(wybe.int), [tmp$6##0:wybe.list(wybe.int)], [tmp$7##0:wybe.bool], x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_slt(i#0:wybe.int, 3:wybe.int, ?tmp$8#0:wybe.bool) @int:nn:nn
-    case ~tmp$8#0:wybe.bool of
+    foreign llvm icmp_slt(i##0:wybe.int, 3:wybe.int, ?tmp$8##0:wybe.bool) @int:nn:nn
+    case ~tmp$8##0:wybe.bool of
     0:
-        foreign c print_int(~i#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$13#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$13#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        stmt_for.gen$16<0>(~io#1:wybe.phantom, ~tmp$0#0:wybe.list(?T), ~tmp$1#0:wybe.list(?T), ~tmp$2#0:wybe.list(?T), ~tmp$3#0:wybe.list(?T), ~tmp$4#0:wybe.list(?T), ~tmp$5#0:wybe.list(wybe.int), ~x#0:wybe.list(wybe.int), ?io#2:wybe.phantom) #3 @stmt_for:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$13##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$13##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_for.gen$16<0>(~io##1:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), ~tmp$4##0:wybe.list(?T), ~tmp$5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #3 @stmt_for:nn:nn
 
     1:
-        stmt_for.gen$16<0>(~io#0:wybe.phantom, ~tmp$0#0:wybe.list(?T), ~tmp$1#0:wybe.list(?T), ~tmp$2#0:wybe.list(?T), ~tmp$3#0:wybe.list(?T), ~tmp$4#0:wybe.list(?T), ~tmp$5#0:wybe.list(wybe.int), ~x#0:wybe.list(wybe.int), ?io#2:wybe.phantom) #1 @stmt_for:nn:nn
+        stmt_for.gen$16<0>(~io##0:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), ~tmp$4##0:wybe.list(?T), ~tmp$5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #1 @stmt_for:nn:nn
 
 
 
 gen$18 > (2 calls)
 0: stmt_for.gen$18<0>
-gen$18(io#0:wybe.phantom, tmp$0#0:wybe.list(?T), tmp$1#0:wybe.list(?T), tmp$2#0:wybe.list(?T), tmp$3#0:wybe.list(?T), tmp$4#0:wybe.list(?T), tmp$5#0:wybe.list(wybe.int), x#0:wybe.list(wybe.int), ?io#1:wybe.phantom):
+gen$18(io##0:wybe.phantom, tmp$0##0:wybe.list(?T), tmp$1##0:wybe.list(?T), tmp$2##0:wybe.list(?T), tmp$3##0:wybe.list(?T), tmp$4##0:wybe.list(?T), tmp$5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp$5#0:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.bool)
-    case ~tmp$10#0:wybe.bool of
+    foreign llvm icmp_ne(tmp$5##0:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.bool)
+    case ~tmp$10##0:wybe.bool of
     0:
-        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp$5#0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i#0:?T)
-        foreign lpvm access(~tmp$5#0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.list(?T))
-        stmt_for.gen$19<0>(~i#0:wybe.int, ~io#0:wybe.phantom, ~tmp$0#0:wybe.list(wybe.int), ~tmp$1#0:wybe.list(wybe.int), ~tmp$2#0:wybe.list(wybe.int), ~tmp$3#0:wybe.list(wybe.int), ~tmp$4#0:wybe.list(wybe.int), ~tmp$6#0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x#0:wybe.list(wybe.int), ?io#1:wybe.phantom) #1
+        foreign lpvm access(tmp$5##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
+        foreign lpvm access(~tmp$5##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.list(?T))
+        stmt_for.gen$19<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp$0##0:wybe.list(wybe.int), ~tmp$1##0:wybe.list(wybe.int), ~tmp$2##0:wybe.list(wybe.int), ~tmp$3##0:wybe.list(wybe.int), ~tmp$4##0:wybe.list(wybe.int), ~tmp$6##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
 
 
 
 gen$19 > (1 calls)
 0: stmt_for.gen$19<0>
-gen$19(i#0:wybe.int, io#0:wybe.phantom, tmp$0#0:wybe.list(wybe.int), tmp$1#0:wybe.list(wybe.int), tmp$2#0:wybe.list(wybe.int), tmp$3#0:wybe.list(wybe.int), tmp$4#0:wybe.list(wybe.int), tmp$5#0:wybe.list(wybe.int), [tmp$6#0:wybe.list(wybe.int)], [tmp$7#0:wybe.bool], x#0:wybe.list(wybe.int), ?io#2:wybe.phantom):
+gen$19(i##0:wybe.int, io##0:wybe.phantom, tmp$0##0:wybe.list(wybe.int), tmp$1##0:wybe.list(wybe.int), tmp$2##0:wybe.list(wybe.int), tmp$3##0:wybe.list(wybe.int), tmp$4##0:wybe.list(wybe.int), tmp$5##0:wybe.list(wybe.int), [tmp$6##0:wybe.list(wybe.int)], [tmp$7##0:wybe.bool], x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(i#0:wybe.int, 3:wybe.int, ?tmp$8#0:wybe.bool) @int:nn:nn
-    case ~tmp$8#0:wybe.bool of
+    foreign llvm icmp_eq(i##0:wybe.int, 3:wybe.int, ?tmp$8##0:wybe.bool) @int:nn:nn
+    case ~tmp$8##0:wybe.bool of
     0:
-        foreign c print_int(~i#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$13#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$13#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        stmt_for.gen$18<0>(~io#1:wybe.phantom, ~tmp$0#0:wybe.list(?T), ~tmp$1#0:wybe.list(?T), ~tmp$2#0:wybe.list(?T), ~tmp$3#0:wybe.list(?T), ~tmp$4#0:wybe.list(?T), ~tmp$5#0:wybe.list(wybe.int), ~x#0:wybe.list(wybe.int), ?io#2:wybe.phantom) #2 @stmt_for:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$13##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$13##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_for.gen$18<0>(~io##1:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), ~tmp$4##0:wybe.list(?T), ~tmp$5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
 
     1:
-        foreign llvm move(~io#0:wybe.phantom, ?io#2:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
 
 
 gen$2 > (1 calls)
 0: stmt_for.gen$2<0>
-gen$2(i#0:wybe.int, io#0:wybe.phantom, tmp$0#0:wybe.list(wybe.int), tmp$1#0:wybe.list(wybe.int), [tmp$10#0:wybe.list(wybe.int)], [tmp$12#0:wybe.bool], tmp$2#0:wybe.list(wybe.int), tmp$3#0:wybe.list(wybe.int), tmp$4#0:wybe.list(wybe.int), tmp$5#0:wybe.list(wybe.int), tmp$6#0:wybe.list(wybe.int), tmp$7#0:wybe.list(wybe.int), tmp$8#0:wybe.list(wybe.int), tmp$9#0:wybe.list(wybe.int), x#0:wybe.list(wybe.int), y#0:wybe.list(wybe.int), ?io#1:wybe.phantom):
+gen$2(i##0:wybe.int, io##0:wybe.phantom, tmp$0##0:wybe.list(wybe.int), tmp$1##0:wybe.list(wybe.int), [tmp$10##0:wybe.list(wybe.int)], [tmp$12##0:wybe.bool], tmp$2##0:wybe.list(wybe.int), tmp$3##0:wybe.list(wybe.int), tmp$4##0:wybe.list(wybe.int), tmp$5##0:wybe.list(wybe.int), tmp$6##0:wybe.list(wybe.int), tmp$7##0:wybe.list(wybe.int), tmp$8##0:wybe.list(wybe.int), tmp$9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp$9#0:wybe.int, 0:wybe.int, ?tmp$14#0:wybe.bool)
-    case ~tmp$14#0:wybe.bool of
+    foreign llvm icmp_ne(tmp$9##0:wybe.int, 0:wybe.int, ?tmp$14##0:wybe.bool)
+    case ~tmp$14##0:wybe.bool of
     0:
-        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp$9#0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?j#0:?T)
-        foreign lpvm access(~tmp$9#0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$11#0:wybe.list(?T))
-        foreign c print_int(~i#0:wybe.int, ~io#0:wybe.phantom, ?tmp$33#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$33#0:wybe.phantom, ?tmp$34#0:wybe.phantom) @io:nn:nn
-        foreign c print_int(~j#0:wybe.int, ~tmp$34#0:wybe.phantom, ?tmp$35#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$35#0:wybe.phantom, ?tmp$36#0:wybe.phantom) @io:nn:nn
-        stmt_for.gen$1<0>(~tmp$36#0:wybe.phantom, ~tmp$0#0:wybe.list(?T), ~tmp$1#0:wybe.list(?T), ~tmp$2#0:wybe.list(?T), ~tmp$3#0:wybe.list(?T), ~tmp$4#0:wybe.list(?T), ~tmp$5#0:wybe.list(?T), ~tmp$6#0:wybe.list(?T), ~tmp$7#0:wybe.list(?T), ~tmp$8#0:wybe.list(wybe.int), ~tmp$11#0:wybe.list(wybe.int), ~x#0:wybe.list(wybe.int), ~y#0:wybe.list(wybe.int), ?io#1:wybe.phantom) #2 @stmt_for:nn:nn
+        foreign lpvm access(tmp$9##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?j##0:?T)
+        foreign lpvm access(~tmp$9##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$11##0:wybe.list(?T))
+        foreign c print_int(~i##0:wybe.int, ~io##0:wybe.phantom, ?tmp$33##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$33##0:wybe.phantom, ?tmp$34##0:wybe.phantom) @io:nn:nn
+        foreign c print_int(~j##0:wybe.int, ~tmp$34##0:wybe.phantom, ?tmp$35##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$35##0:wybe.phantom, ?tmp$36##0:wybe.phantom) @io:nn:nn
+        stmt_for.gen$1<0>(~tmp$36##0:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), ~tmp$4##0:wybe.list(?T), ~tmp$5##0:wybe.list(?T), ~tmp$6##0:wybe.list(?T), ~tmp$7##0:wybe.list(?T), ~tmp$8##0:wybe.list(wybe.int), ~tmp$11##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #2 @stmt_for:nn:nn
 
 
 
 gen$20 > (3 calls)
 0: stmt_for.gen$20<0>
-gen$20(io#0:wybe.phantom, tmp$0#0:wybe.list(?T), tmp$1#0:wybe.list(?T), tmp$2#0:wybe.list(?T), tmp$3#0:wybe.list(?T), tmp$4#0:wybe.list(?T), tmp$5#0:wybe.list(wybe.int), x#0:wybe.list(wybe.int), ?io#1:wybe.phantom):
+gen$20(io##0:wybe.phantom, tmp$0##0:wybe.list(?T), tmp$1##0:wybe.list(?T), tmp$2##0:wybe.list(?T), tmp$3##0:wybe.list(?T), tmp$4##0:wybe.list(?T), tmp$5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp$5#0:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.bool)
-    case ~tmp$10#0:wybe.bool of
+    foreign llvm icmp_ne(tmp$5##0:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.bool)
+    case ~tmp$10##0:wybe.bool of
     0:
-        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp$5#0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i#0:?T)
-        foreign lpvm access(~tmp$5#0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.list(?T))
-        stmt_for.gen$21<0>(~i#0:wybe.int, ~io#0:wybe.phantom, ~tmp$0#0:wybe.list(wybe.int), ~tmp$1#0:wybe.list(wybe.int), ~tmp$2#0:wybe.list(wybe.int), ~tmp$3#0:wybe.list(wybe.int), ~tmp$4#0:wybe.list(wybe.int), ~tmp$6#0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x#0:wybe.list(wybe.int), ?io#1:wybe.phantom) #1
+        foreign lpvm access(tmp$5##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
+        foreign lpvm access(~tmp$5##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.list(?T))
+        stmt_for.gen$21<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp$0##0:wybe.list(wybe.int), ~tmp$1##0:wybe.list(wybe.int), ~tmp$2##0:wybe.list(wybe.int), ~tmp$3##0:wybe.list(wybe.int), ~tmp$4##0:wybe.list(wybe.int), ~tmp$6##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
 
 
 
 gen$21 > (1 calls)
 0: stmt_for.gen$21<0>
-gen$21(i#0:wybe.int, io#0:wybe.phantom, tmp$0#0:wybe.list(wybe.int), tmp$1#0:wybe.list(wybe.int), tmp$2#0:wybe.list(wybe.int), tmp$3#0:wybe.list(wybe.int), tmp$4#0:wybe.list(wybe.int), tmp$5#0:wybe.list(wybe.int), [tmp$6#0:wybe.list(wybe.int)], [tmp$7#0:wybe.bool], x#0:wybe.list(wybe.int), ?io#2:wybe.phantom):
+gen$21(i##0:wybe.int, io##0:wybe.phantom, tmp$0##0:wybe.list(wybe.int), tmp$1##0:wybe.list(wybe.int), tmp$2##0:wybe.list(wybe.int), tmp$3##0:wybe.list(wybe.int), tmp$4##0:wybe.list(wybe.int), tmp$5##0:wybe.list(wybe.int), [tmp$6##0:wybe.list(wybe.int)], [tmp$7##0:wybe.bool], x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_slt(i#0:wybe.int, 3:wybe.int, ?tmp$8#0:wybe.bool) @int:nn:nn
-    case ~tmp$8#0:wybe.bool of
+    foreign llvm icmp_slt(i##0:wybe.int, 3:wybe.int, ?tmp$8##0:wybe.bool) @int:nn:nn
+    case ~tmp$8##0:wybe.bool of
     0:
-        stmt_for.gen$20<0>(~io#0:wybe.phantom, ~tmp$0#0:wybe.list(?T), ~tmp$1#0:wybe.list(?T), ~tmp$2#0:wybe.list(?T), ~tmp$3#0:wybe.list(?T), ~tmp$4#0:wybe.list(?T), ~tmp$5#0:wybe.list(wybe.int), ~x#0:wybe.list(wybe.int), ?io#2:wybe.phantom) #3 @stmt_for:nn:nn
+        stmt_for.gen$20<0>(~io##0:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), ~tmp$4##0:wybe.list(?T), ~tmp$5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #3 @stmt_for:nn:nn
 
     1:
-        foreign c print_int(~i#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$13#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$13#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        stmt_for.gen$20<0>(~io#1:wybe.phantom, ~tmp$0#0:wybe.list(?T), ~tmp$1#0:wybe.list(?T), ~tmp$2#0:wybe.list(?T), ~tmp$3#0:wybe.list(?T), ~tmp$4#0:wybe.list(?T), ~tmp$5#0:wybe.list(wybe.int), ~x#0:wybe.list(wybe.int), ?io#2:wybe.phantom) #2 @stmt_for:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$13##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$13##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_for.gen$20<0>(~io##1:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), ~tmp$4##0:wybe.list(?T), ~tmp$5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
 
 
 
 gen$22 > (2 calls)
 0: stmt_for.gen$22<0>
-gen$22(io#0:wybe.phantom, tmp$0#0:wybe.list(?T), tmp$1#0:wybe.list(?T), tmp$2#0:wybe.list(?T), tmp$3#0:wybe.list(?T), tmp$4#0:wybe.list(?T), tmp$5#0:wybe.list(wybe.int), x#0:wybe.list(wybe.int), ?io#1:wybe.phantom):
+gen$22(io##0:wybe.phantom, tmp$0##0:wybe.list(?T), tmp$1##0:wybe.list(?T), tmp$2##0:wybe.list(?T), tmp$3##0:wybe.list(?T), tmp$4##0:wybe.list(?T), tmp$5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp$5#0:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.bool)
-    case ~tmp$10#0:wybe.bool of
+    foreign llvm icmp_ne(tmp$5##0:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.bool)
+    case ~tmp$10##0:wybe.bool of
     0:
-        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp$5#0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i#0:?T)
-        foreign lpvm access(~tmp$5#0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.list(?T))
-        stmt_for.gen$23<0>(~i#0:wybe.int, ~io#0:wybe.phantom, ~tmp$0#0:wybe.list(wybe.int), ~tmp$1#0:wybe.list(wybe.int), ~tmp$2#0:wybe.list(wybe.int), ~tmp$3#0:wybe.list(wybe.int), ~tmp$4#0:wybe.list(wybe.int), ~tmp$6#0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x#0:wybe.list(wybe.int), ?io#1:wybe.phantom) #1
+        foreign lpvm access(tmp$5##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
+        foreign lpvm access(~tmp$5##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.list(?T))
+        stmt_for.gen$23<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp$0##0:wybe.list(wybe.int), ~tmp$1##0:wybe.list(wybe.int), ~tmp$2##0:wybe.list(wybe.int), ~tmp$3##0:wybe.list(wybe.int), ~tmp$4##0:wybe.list(wybe.int), ~tmp$6##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
 
 
 
 gen$23 > (1 calls)
 0: stmt_for.gen$23<0>
-gen$23(i#0:wybe.int, io#0:wybe.phantom, tmp$0#0:wybe.list(wybe.int), tmp$1#0:wybe.list(wybe.int), tmp$2#0:wybe.list(wybe.int), tmp$3#0:wybe.list(wybe.int), tmp$4#0:wybe.list(wybe.int), tmp$5#0:wybe.list(wybe.int), [tmp$6#0:wybe.list(wybe.int)], [tmp$7#0:wybe.bool], x#0:wybe.list(wybe.int), ?io#2:wybe.phantom):
+gen$23(i##0:wybe.int, io##0:wybe.phantom, tmp$0##0:wybe.list(wybe.int), tmp$1##0:wybe.list(wybe.int), tmp$2##0:wybe.list(wybe.int), tmp$3##0:wybe.list(wybe.int), tmp$4##0:wybe.list(wybe.int), tmp$5##0:wybe.list(wybe.int), [tmp$6##0:wybe.list(wybe.int)], [tmp$7##0:wybe.bool], x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_slt(i#0:wybe.int, 3:wybe.int, ?tmp$8#0:wybe.bool) @int:nn:nn
-    case ~tmp$8#0:wybe.bool of
+    foreign llvm icmp_slt(i##0:wybe.int, 3:wybe.int, ?tmp$8##0:wybe.bool) @int:nn:nn
+    case ~tmp$8##0:wybe.bool of
     0:
-        foreign llvm move(~io#0:wybe.phantom, ?io#2:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign c print_int(~i#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$13#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$13#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        stmt_for.gen$22<0>(~io#1:wybe.phantom, ~tmp$0#0:wybe.list(?T), ~tmp$1#0:wybe.list(?T), ~tmp$2#0:wybe.list(?T), ~tmp$3#0:wybe.list(?T), ~tmp$4#0:wybe.list(?T), ~tmp$5#0:wybe.list(wybe.int), ~x#0:wybe.list(wybe.int), ?io#2:wybe.phantom) #2 @stmt_for:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$13##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$13##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_for.gen$22<0>(~io##1:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), ~tmp$4##0:wybe.list(?T), ~tmp$5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
 
 
 
 gen$24 > (2 calls)
 0: stmt_for.gen$24<0>
-gen$24(io#0:wybe.phantom, tmp$0#0:stmt_for.int_sequence, tmp$3#0:stmt_for.int_sequence, ?io#2:wybe.phantom):
+gen$24(io##0:wybe.phantom, tmp$0##0:stmt_for.int_sequence, tmp$3##0:stmt_for.int_sequence, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_for.int_sequence.[|]<0>(?i#0:wybe.int, ?tmp$1#0:stmt_for.int_sequence, ~tmp$0#0:stmt_for.int_sequence, ?tmp$2#0:wybe.bool) #0
-    case ~tmp$2#0:wybe.bool of
+    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp$1##0:stmt_for.int_sequence, ~tmp$0##0:stmt_for.int_sequence, ?tmp$2##0:wybe.bool) #0
+    case ~tmp$2##0:wybe.bool of
     0:
-        foreign llvm move(~io#0:wybe.phantom, ?io#2:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign c print_int(~i#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$6#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$6#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        stmt_for.gen$24<0>(~io#1:wybe.phantom, ~tmp$1#0:stmt_for.int_sequence, ~tmp$3#0:stmt_for.int_sequence, ?io#2:wybe.phantom) #2 @stmt_for:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$6##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_for.gen$24<0>(~io##1:wybe.phantom, ~tmp$1##0:stmt_for.int_sequence, ~tmp$3##0:stmt_for.int_sequence, ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
 
 
 
 gen$25 > (2 calls)
 0: stmt_for.gen$25<0>
-gen$25(io#0:wybe.phantom, tmp$0#0:stmt_for.int_sequence, tmp$3#0:stmt_for.int_sequence, ?io#2:wybe.phantom):
+gen$25(io##0:wybe.phantom, tmp$0##0:stmt_for.int_sequence, tmp$3##0:stmt_for.int_sequence, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_for.int_sequence.[|]<0>(?i#0:wybe.int, ?tmp$1#0:stmt_for.int_sequence, ~tmp$0#0:stmt_for.int_sequence, ?tmp$2#0:wybe.bool) #0
-    case ~tmp$2#0:wybe.bool of
+    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp$1##0:stmt_for.int_sequence, ~tmp$0##0:stmt_for.int_sequence, ?tmp$2##0:wybe.bool) #0
+    case ~tmp$2##0:wybe.bool of
     0:
-        foreign llvm move(~io#0:wybe.phantom, ?io#2:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign c print_int(~i#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$6#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$6#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        stmt_for.gen$25<0>(~io#1:wybe.phantom, ~tmp$1#0:stmt_for.int_sequence, ~tmp$3#0:stmt_for.int_sequence, ?io#2:wybe.phantom) #2 @stmt_for:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$6##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_for.gen$25<0>(~io##1:wybe.phantom, ~tmp$1##0:stmt_for.int_sequence, ~tmp$3##0:stmt_for.int_sequence, ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
 
 
 
 gen$3 > {inline} (1 calls)
 0: stmt_for.gen$3<0>
-gen$3(i#0:wybe.int, io#0:wybe.phantom, j#0:wybe.int, tmp$0#0:wybe.list(wybe.int), tmp$1#0:wybe.list(wybe.int), [tmp$10#0:wybe.list(wybe.int)], [tmp$11#0:wybe.list(wybe.int)], [tmp$12#0:wybe.bool], tmp$2#0:wybe.list(wybe.int), tmp$3#0:wybe.list(wybe.int), tmp$4#0:wybe.list(wybe.int), tmp$5#0:wybe.list(wybe.int), tmp$6#0:wybe.list(wybe.int), tmp$7#0:wybe.list(wybe.int), tmp$8#0:wybe.list(wybe.int), tmp$9#0:wybe.list(wybe.int), x#0:wybe.list(wybe.int), y#0:wybe.list(wybe.int), ?io#3:wybe.phantom):
+gen$3(i##0:wybe.int, io##0:wybe.phantom, j##0:wybe.int, tmp$0##0:wybe.list(wybe.int), tmp$1##0:wybe.list(wybe.int), [tmp$10##0:wybe.list(wybe.int)], [tmp$11##0:wybe.list(wybe.int)], [tmp$12##0:wybe.bool], tmp$2##0:wybe.list(wybe.int), tmp$3##0:wybe.list(wybe.int), tmp$4##0:wybe.list(wybe.int), tmp$5##0:wybe.list(wybe.int), tmp$6##0:wybe.list(wybe.int), tmp$7##0:wybe.list(wybe.int), tmp$8##0:wybe.list(wybe.int), tmp$9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int), ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(~i#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$15#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$15#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_int(~j#0:wybe.int, ~#io#1:wybe.phantom, ?tmp$18#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$18#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    stmt_for.gen$1<0>(~io#2:wybe.phantom, ~tmp$0#0:wybe.list(?T), ~tmp$1#0:wybe.list(?T), ~tmp$2#0:wybe.list(?T), ~tmp$3#0:wybe.list(?T), ~tmp$4#0:wybe.list(?T), ~tmp$5#0:wybe.list(?T), ~tmp$6#0:wybe.list(?T), ~tmp$7#0:wybe.list(?T), ~tmp$8#0:wybe.list(wybe.int), ~tmp$9#0:wybe.list(wybe.int), ~x#0:wybe.list(wybe.int), ~y#0:wybe.list(wybe.int), ?io#3:wybe.phantom) #2 @stmt_for:nn:nn
+    foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$15##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$15##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~j##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$18##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$18##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    stmt_for.gen$1<0>(~io##2:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), ~tmp$4##0:wybe.list(?T), ~tmp$5##0:wybe.list(?T), ~tmp$6##0:wybe.list(?T), ~tmp$7##0:wybe.list(?T), ~tmp$8##0:wybe.list(wybe.int), ~tmp$9##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##3:wybe.phantom) #2 @stmt_for:nn:nn
 
 
 gen$4 > (2 calls)
 0: stmt_for.gen$4<0>
-gen$4(io#0:wybe.phantom, tmp$0#0:stmt_for.int_sequence, tmp$3#0:stmt_for.int_sequence, ?io#1:wybe.phantom, ?$$#0:wybe.bool):
+gen$4(io##0:wybe.phantom, tmp$0##0:stmt_for.int_sequence, tmp$3##0:stmt_for.int_sequence, ?io##1:wybe.phantom, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_for.int_sequence.[|]<0>(?i#0:wybe.int, ?tmp$1#0:stmt_for.int_sequence, ~tmp$0#0:stmt_for.int_sequence, ?tmp$2#0:wybe.bool) #0
-    case ~tmp$2#0:wybe.bool of
+    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp$1##0:stmt_for.int_sequence, ~tmp$0##0:stmt_for.int_sequence, ?tmp$2##0:wybe.bool) #0
+    case ~tmp$2##0:wybe.bool of
     0:
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        stmt_for.gen$5<0>(~i#0:wybe.int, ~io#0:wybe.phantom, ~tmp$1#0:stmt_for.int_sequence, _:stmt_for.int_sequence, _:wybe.bool, ~tmp$3#0:stmt_for.int_sequence, ?io#1:wybe.phantom, ?$$#0:wybe.bool) #1
+        stmt_for.gen$5<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp$1##0:stmt_for.int_sequence, _:stmt_for.int_sequence, _:wybe.bool, ~tmp$3##0:stmt_for.int_sequence, ?io##1:wybe.phantom, ?$$##0:wybe.bool) #1
 
 
 
 gen$5 > (1 calls)
 0: stmt_for.gen$5<0>
-gen$5(i#0:wybe.int, io#0:wybe.phantom, tmp$0#0:stmt_for.int_sequence, [tmp$1#0:stmt_for.int_sequence], [tmp$2#0:wybe.bool], tmp$3#0:stmt_for.int_sequence, ?io#2:wybe.phantom, ?$$#0:wybe.bool):
+gen$5(i##0:wybe.int, io##0:wybe.phantom, tmp$0##0:stmt_for.int_sequence, [tmp$1##0:stmt_for.int_sequence], [tmp$2##0:wybe.bool], tmp$3##0:stmt_for.int_sequence, ?io##2:wybe.phantom, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_slt(i#0:wybe.int, 5:wybe.int, ?tmp$4#0:wybe.bool) @int:nn:nn
-    case ~tmp$4#0:wybe.bool of
+    foreign llvm icmp_slt(i##0:wybe.int, 5:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
+    case ~tmp$4##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~io#0:wybe.phantom, ?io#2:wybe.phantom)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign c print_int(~i#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$9#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$9#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        stmt_for.gen$4<0>(~io#1:wybe.phantom, ~tmp$0#0:stmt_for.int_sequence, ~tmp$3#0:stmt_for.int_sequence, ?io#2:wybe.phantom, ?$$#0:wybe.bool) #2 @stmt_for:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$9##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$9##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_for.gen$4<0>(~io##1:wybe.phantom, ~tmp$0##0:stmt_for.int_sequence, ~tmp$3##0:stmt_for.int_sequence, ?io##2:wybe.phantom, ?$$##0:wybe.bool) #2 @stmt_for:nn:nn
 
 
 
 gen$6 > (2 calls)
 0: stmt_for.gen$6<0>
-gen$6(io#0:wybe.phantom, tmp$0#0:wybe.list(?T), tmp$1#0:wybe.list(?T), tmp$2#0:wybe.list(?T), tmp$3#0:wybe.list(?T), tmp$4#0:wybe.list(?T), tmp$5#0:wybe.list(?T), tmp$6#0:wybe.list(?T), tmp$7#0:wybe.list(?T), tmp$8#0:wybe.list(wybe.int), tmp$9#0:wybe.list(wybe.int), x#0:wybe.list(wybe.int), y#0:wybe.list(wybe.int), ?io#1:wybe.phantom):
+gen$6(io##0:wybe.phantom, tmp$0##0:wybe.list(?T), tmp$1##0:wybe.list(?T), tmp$2##0:wybe.list(?T), tmp$3##0:wybe.list(?T), tmp$4##0:wybe.list(?T), tmp$5##0:wybe.list(?T), tmp$6##0:wybe.list(?T), tmp$7##0:wybe.list(?T), tmp$8##0:wybe.list(wybe.int), tmp$9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp$8#0:wybe.int, 0:wybe.int, ?tmp$14#0:wybe.bool)
-    case ~tmp$14#0:wybe.bool of
+    foreign llvm icmp_ne(tmp$8##0:wybe.int, 0:wybe.int, ?tmp$14##0:wybe.bool)
+    case ~tmp$14##0:wybe.bool of
     0:
-        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp$8#0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i#0:?T)
-        foreign lpvm access(~tmp$8#0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.list(?T))
-        stmt_for.gen$7<0>(~i#0:wybe.int, ~io#0:wybe.phantom, ~tmp$0#0:wybe.list(wybe.int), ~tmp$1#0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~tmp$2#0:wybe.list(wybe.int), ~tmp$3#0:wybe.list(wybe.int), ~tmp$4#0:wybe.list(wybe.int), ~tmp$5#0:wybe.list(wybe.int), ~tmp$6#0:wybe.list(wybe.int), ~tmp$7#0:wybe.list(wybe.int), ~tmp$10#0:wybe.list(wybe.int), ~tmp$9#0:wybe.list(wybe.int), ~x#0:wybe.list(wybe.int), ~y#0:wybe.list(wybe.int), ?io#1:wybe.phantom) #1
+        foreign lpvm access(tmp$8##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
+        foreign lpvm access(~tmp$8##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.list(?T))
+        stmt_for.gen$7<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp$0##0:wybe.list(wybe.int), ~tmp$1##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~tmp$2##0:wybe.list(wybe.int), ~tmp$3##0:wybe.list(wybe.int), ~tmp$4##0:wybe.list(wybe.int), ~tmp$5##0:wybe.list(wybe.int), ~tmp$6##0:wybe.list(wybe.int), ~tmp$7##0:wybe.list(wybe.int), ~tmp$10##0:wybe.list(wybe.int), ~tmp$9##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
 
 
 
 gen$7 > (1 calls)
 0: stmt_for.gen$7<0>
-gen$7(i#0:wybe.int, io#0:wybe.phantom, tmp$0#0:wybe.list(wybe.int), tmp$1#0:wybe.list(wybe.int), [tmp$10#0:wybe.list(wybe.int)], [tmp$12#0:wybe.bool], tmp$2#0:wybe.list(wybe.int), tmp$3#0:wybe.list(wybe.int), tmp$4#0:wybe.list(wybe.int), tmp$5#0:wybe.list(wybe.int), tmp$6#0:wybe.list(wybe.int), tmp$7#0:wybe.list(wybe.int), tmp$8#0:wybe.list(wybe.int), tmp$9#0:wybe.list(wybe.int), x#0:wybe.list(wybe.int), y#0:wybe.list(wybe.int), ?io#1:wybe.phantom):
+gen$7(i##0:wybe.int, io##0:wybe.phantom, tmp$0##0:wybe.list(wybe.int), tmp$1##0:wybe.list(wybe.int), [tmp$10##0:wybe.list(wybe.int)], [tmp$12##0:wybe.bool], tmp$2##0:wybe.list(wybe.int), tmp$3##0:wybe.list(wybe.int), tmp$4##0:wybe.list(wybe.int), tmp$5##0:wybe.list(wybe.int), tmp$6##0:wybe.list(wybe.int), tmp$7##0:wybe.list(wybe.int), tmp$8##0:wybe.list(wybe.int), tmp$9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp$9#0:wybe.int, 0:wybe.int, ?tmp$14#0:wybe.bool)
-    case ~tmp$14#0:wybe.bool of
+    foreign llvm icmp_ne(tmp$9##0:wybe.int, 0:wybe.int, ?tmp$14##0:wybe.bool)
+    case ~tmp$14##0:wybe.bool of
     0:
-        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp$9#0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?j#0:?T)
-        foreign lpvm access(~tmp$9#0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$11#0:wybe.list(?T))
-        foreign c print_int(~i#0:wybe.int, ~io#0:wybe.phantom, ?tmp$33#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$33#0:wybe.phantom, ?tmp$34#0:wybe.phantom) @io:nn:nn
-        foreign c print_int(~j#0:wybe.int, ~tmp$34#0:wybe.phantom, ?tmp$35#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$35#0:wybe.phantom, ?tmp$36#0:wybe.phantom) @io:nn:nn
-        stmt_for.gen$6<0>(~tmp$36#0:wybe.phantom, ~tmp$0#0:wybe.list(?T), ~tmp$1#0:wybe.list(?T), ~tmp$2#0:wybe.list(?T), ~tmp$3#0:wybe.list(?T), ~tmp$4#0:wybe.list(?T), ~tmp$5#0:wybe.list(?T), ~tmp$6#0:wybe.list(?T), ~tmp$7#0:wybe.list(?T), ~tmp$8#0:wybe.list(wybe.int), ~tmp$11#0:wybe.list(wybe.int), ~x#0:wybe.list(wybe.int), ~y#0:wybe.list(wybe.int), ?io#1:wybe.phantom) #2 @stmt_for:nn:nn
+        foreign lpvm access(tmp$9##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?j##0:?T)
+        foreign lpvm access(~tmp$9##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$11##0:wybe.list(?T))
+        foreign c print_int(~i##0:wybe.int, ~io##0:wybe.phantom, ?tmp$33##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$33##0:wybe.phantom, ?tmp$34##0:wybe.phantom) @io:nn:nn
+        foreign c print_int(~j##0:wybe.int, ~tmp$34##0:wybe.phantom, ?tmp$35##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$35##0:wybe.phantom, ?tmp$36##0:wybe.phantom) @io:nn:nn
+        stmt_for.gen$6<0>(~tmp$36##0:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), ~tmp$4##0:wybe.list(?T), ~tmp$5##0:wybe.list(?T), ~tmp$6##0:wybe.list(?T), ~tmp$7##0:wybe.list(?T), ~tmp$8##0:wybe.list(wybe.int), ~tmp$11##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #2 @stmt_for:nn:nn
 
 
 
 gen$8 > {inline} (1 calls)
 0: stmt_for.gen$8<0>
-gen$8(i#0:wybe.int, io#0:wybe.phantom, j#0:wybe.int, tmp$0#0:wybe.list(wybe.int), tmp$1#0:wybe.list(wybe.int), [tmp$10#0:wybe.list(wybe.int)], [tmp$11#0:wybe.list(wybe.int)], [tmp$12#0:wybe.bool], tmp$2#0:wybe.list(wybe.int), tmp$3#0:wybe.list(wybe.int), tmp$4#0:wybe.list(wybe.int), tmp$5#0:wybe.list(wybe.int), tmp$6#0:wybe.list(wybe.int), tmp$7#0:wybe.list(wybe.int), tmp$8#0:wybe.list(wybe.int), tmp$9#0:wybe.list(wybe.int), x#0:wybe.list(wybe.int), y#0:wybe.list(wybe.int), ?io#3:wybe.phantom):
+gen$8(i##0:wybe.int, io##0:wybe.phantom, j##0:wybe.int, tmp$0##0:wybe.list(wybe.int), tmp$1##0:wybe.list(wybe.int), [tmp$10##0:wybe.list(wybe.int)], [tmp$11##0:wybe.list(wybe.int)], [tmp$12##0:wybe.bool], tmp$2##0:wybe.list(wybe.int), tmp$3##0:wybe.list(wybe.int), tmp$4##0:wybe.list(wybe.int), tmp$5##0:wybe.list(wybe.int), tmp$6##0:wybe.list(wybe.int), tmp$7##0:wybe.list(wybe.int), tmp$8##0:wybe.list(wybe.int), tmp$9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int), ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(~i#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$15#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$15#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_int(~j#0:wybe.int, ~#io#1:wybe.phantom, ?tmp$18#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$18#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    stmt_for.gen$6<0>(~io#2:wybe.phantom, ~tmp$0#0:wybe.list(?T), ~tmp$1#0:wybe.list(?T), ~tmp$2#0:wybe.list(?T), ~tmp$3#0:wybe.list(?T), ~tmp$4#0:wybe.list(?T), ~tmp$5#0:wybe.list(?T), ~tmp$6#0:wybe.list(?T), ~tmp$7#0:wybe.list(?T), ~tmp$8#0:wybe.list(wybe.int), ~tmp$9#0:wybe.list(wybe.int), ~x#0:wybe.list(wybe.int), ~y#0:wybe.list(wybe.int), ?io#3:wybe.phantom) #2 @stmt_for:nn:nn
+    foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$15##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$15##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~j##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$18##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$18##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    stmt_for.gen$6<0>(~io##2:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), ~tmp$4##0:wybe.list(?T), ~tmp$5##0:wybe.list(?T), ~tmp$6##0:wybe.list(?T), ~tmp$7##0:wybe.list(?T), ~tmp$8##0:wybe.list(wybe.int), ~tmp$9##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##3:wybe.phantom) #2 @stmt_for:nn:nn
 
 
 gen$9 > (2 calls)
 0: stmt_for.gen$9<0>
-gen$9(io#0:wybe.phantom, tmp$0#0:wybe.list(?T), tmp$1#0:wybe.list(?T), tmp$2#0:wybe.list(?T), tmp$3#0:wybe.list(?T), tmp$4#0:wybe.list(wybe.int), x#0:wybe.list(wybe.int), ?io#2:wybe.phantom):
+gen$9(io##0:wybe.phantom, tmp$0##0:wybe.list(?T), tmp$1##0:wybe.list(?T), tmp$2##0:wybe.list(?T), tmp$3##0:wybe.list(?T), tmp$4##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp$4#0:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.bool)
-    case ~tmp$8#0:wybe.bool of
+    foreign llvm icmp_ne(tmp$4##0:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.bool)
+    case ~tmp$8##0:wybe.bool of
     0:
-        foreign llvm move(~io#0:wybe.phantom, ?io#2:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp$4#0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i#0:?T)
-        foreign lpvm access(~tmp$4#0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.list(?T))
-        foreign c print_int(~i#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$11#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$11#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        stmt_for.gen$9<0>(~io#1:wybe.phantom, ~tmp$0#0:wybe.list(?T), ~tmp$1#0:wybe.list(?T), ~tmp$2#0:wybe.list(?T), ~tmp$3#0:wybe.list(?T), ~tmp$5#0:wybe.list(wybe.int), ~x#0:wybe.list(wybe.int), ?io#2:wybe.phantom) #2 @stmt_for:nn:nn
+        foreign lpvm access(tmp$4##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
+        foreign lpvm access(~tmp$4##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.list(?T))
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$11##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_for.gen$9<0>(~io##1:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), ~tmp$5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
 
 
 
 irange > public (2 calls)
 0: stmt_for.irange<0>
-irange(start#0:wybe.int, stride#0:wybe.int, end#0:wybe.int, ?$#0:stmt_for.int_sequence):
+irange(start##0:wybe.int, stride##0:wybe.int, end##0:wybe.int, ?$##0:stmt_for.int_sequence):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_slt(stride#0:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.bool) @int:nn:nn
-    case ~tmp$4#0:wybe.bool of
+    foreign llvm icmp_slt(stride##0:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
+    case ~tmp$4##0:wybe.bool of
     0:
-        foreign llvm add(~end#0:wybe.int, 1:wybe.int, ?tmp$3#0:wybe.int) @int:nn:nn
-        foreign lpvm alloc(24:wybe.int, ?tmp$12#0:stmt_for.int_sequence)
-        foreign lpvm mutate(~tmp$12#0:stmt_for.int_sequence, ?tmp$13#0:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~start#0:wybe.int)
-        foreign lpvm mutate(~tmp$13#0:stmt_for.int_sequence, ?tmp$14#0:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~stride#0:wybe.int)
-        foreign lpvm mutate(~tmp$14#0:stmt_for.int_sequence, ?$#0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp$3#0:wybe.int)
+        foreign llvm add(~end##0:wybe.int, 1:wybe.int, ?tmp$3##0:wybe.int) @int:nn:nn
+        foreign lpvm alloc(24:wybe.int, ?tmp$12##0:stmt_for.int_sequence)
+        foreign lpvm mutate(~tmp$12##0:stmt_for.int_sequence, ?tmp$13##0:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~start##0:wybe.int)
+        foreign lpvm mutate(~tmp$13##0:stmt_for.int_sequence, ?tmp$14##0:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~stride##0:wybe.int)
+        foreign lpvm mutate(~tmp$14##0:stmt_for.int_sequence, ?$##0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp$3##0:wybe.int)
 
     1:
-        foreign llvm sub(~end#0:wybe.int, 1:wybe.int, ?tmp$2#0:wybe.int) @int:nn:nn
-        foreign lpvm alloc(24:wybe.int, ?tmp$12#0:stmt_for.int_sequence)
-        foreign lpvm mutate(~tmp$12#0:stmt_for.int_sequence, ?tmp$13#0:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~start#0:wybe.int)
-        foreign lpvm mutate(~tmp$13#0:stmt_for.int_sequence, ?tmp$14#0:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~stride#0:wybe.int)
-        foreign lpvm mutate(~tmp$14#0:stmt_for.int_sequence, ?$#0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp$2#0:wybe.int)
+        foreign llvm sub(~end##0:wybe.int, 1:wybe.int, ?tmp$2##0:wybe.int) @int:nn:nn
+        foreign lpvm alloc(24:wybe.int, ?tmp$12##0:stmt_for.int_sequence)
+        foreign lpvm mutate(~tmp$12##0:stmt_for.int_sequence, ?tmp$13##0:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~start##0:wybe.int)
+        foreign lpvm mutate(~tmp$13##0:stmt_for.int_sequence, ?tmp$14##0:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~stride##0:wybe.int)
+        foreign lpvm mutate(~tmp$14##0:stmt_for.int_sequence, ?$##0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp$2##0:wybe.int)
 
 
 
 multiple_generator > public (1 calls)
 0: stmt_for.multiple_generator<0>
-multiple_generator(io#0:wybe.phantom, ?io#1:wybe.phantom):
+multiple_generator(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$15#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$15#0:wybe.list(?T), ?tmp$16#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
-    foreign lpvm mutate(~tmp$16#0:wybe.list(?T), ?tmp$2#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$19#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$19#0:wybe.list(?T), ?tmp$20#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
-    foreign lpvm mutate(~tmp$20#0:wybe.list(?T), ?tmp$1#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$2#0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$23#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$23#0:wybe.list(?T), ?tmp$24#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
-    foreign lpvm mutate(~tmp$24#0:wybe.list(?T), ?tmp$0#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$1#0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$27#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$27#0:wybe.list(?T), ?tmp$28#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 6:?T)
-    foreign lpvm mutate(~tmp$28#0:wybe.list(?T), ?tmp$6#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$31#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$31#0:wybe.list(?T), ?tmp$32#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 5:?T)
-    foreign lpvm mutate(~tmp$32#0:wybe.list(?T), ?tmp$5#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$6#0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$35#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$35#0:wybe.list(?T), ?tmp$36#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
-    foreign lpvm mutate(~tmp$36#0:wybe.list(?T), ?tmp$4#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$5#0:wybe.list(?T))
-    stmt_for.gen$1<0>(~io#0:wybe.phantom, ~tmp$0#0:wybe.list(?T), ~tmp$1#0:wybe.list(?T), ~tmp$2#0:wybe.list(?T), 0:wybe.list(?T), ~tmp$4#0:wybe.list(?T), ~tmp$5#0:wybe.list(?T), ~tmp$6#0:wybe.list(?T), 0:wybe.list(?T), ~tmp$0#0:wybe.list(wybe.int), ~tmp$4#0:wybe.list(wybe.int), ~tmp$0#0:wybe.list(wybe.int), ~tmp$4#0:wybe.list(wybe.int), ?io#1:wybe.phantom) #8 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$15##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$15##0:wybe.list(?T), ?tmp$16##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
+    foreign lpvm mutate(~tmp$16##0:wybe.list(?T), ?tmp$2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp$19##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$19##0:wybe.list(?T), ?tmp$20##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
+    foreign lpvm mutate(~tmp$20##0:wybe.list(?T), ?tmp$1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$2##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp$23##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$23##0:wybe.list(?T), ?tmp$24##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
+    foreign lpvm mutate(~tmp$24##0:wybe.list(?T), ?tmp$0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$1##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp$27##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$27##0:wybe.list(?T), ?tmp$28##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 6:?T)
+    foreign lpvm mutate(~tmp$28##0:wybe.list(?T), ?tmp$6##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp$31##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$31##0:wybe.list(?T), ?tmp$32##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 5:?T)
+    foreign lpvm mutate(~tmp$32##0:wybe.list(?T), ?tmp$5##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$6##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp$35##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$35##0:wybe.list(?T), ?tmp$36##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
+    foreign lpvm mutate(~tmp$36##0:wybe.list(?T), ?tmp$4##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$5##0:wybe.list(?T))
+    stmt_for.gen$1<0>(~io##0:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), 0:wybe.list(?T), ~tmp$4##0:wybe.list(?T), ~tmp$5##0:wybe.list(?T), ~tmp$6##0:wybe.list(?T), 0:wybe.list(?T), ~tmp$0##0:wybe.list(wybe.int), ~tmp$4##0:wybe.list(wybe.int), ~tmp$0##0:wybe.list(wybe.int), ~tmp$4##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #8 @stmt_for:nn:nn
 
 
 semi_det_for_loop > public (0 calls)
 0: stmt_for.semi_det_for_loop<0>
-semi_det_for_loop(io#0:wybe.phantom, ?io#1:wybe.phantom, ?$$#0:wybe.bool):
+semi_det_for_loop(io##0:wybe.phantom, ?io##1:wybe.phantom, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_for.xrange<0>(0:wybe.int, 1:wybe.int, 10:wybe.int, ?tmp$3#0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
-    stmt_for.gen$4<0>(~io#0:wybe.phantom, ~tmp$3#0:stmt_for.int_sequence, ~tmp$3#0:stmt_for.int_sequence, ?io#1:wybe.phantom, ?$$#0:wybe.bool) #1 @stmt_for:nn:nn
+    stmt_for.xrange<0>(0:wybe.int, 1:wybe.int, 10:wybe.int, ?tmp$3##0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
+    stmt_for.gen$4<0>(~io##0:wybe.phantom, ~tmp$3##0:stmt_for.int_sequence, ~tmp$3##0:stmt_for.int_sequence, ?io##1:wybe.phantom, ?$$##0:wybe.bool) #1 @stmt_for:nn:nn
 
 
 shortest_generator_termination > public (1 calls)
 0: stmt_for.shortest_generator_termination<0>
-shortest_generator_termination(io#0:wybe.phantom, ?io#1:wybe.phantom):
+shortest_generator_termination(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$15#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$15#0:wybe.list(?T), ?tmp$16#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
-    foreign lpvm mutate(~tmp$16#0:wybe.list(?T), ?tmp$3#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$19#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$19#0:wybe.list(?T), ?tmp$20#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
-    foreign lpvm mutate(~tmp$20#0:wybe.list(?T), ?tmp$2#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$3#0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$23#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$23#0:wybe.list(?T), ?tmp$24#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
-    foreign lpvm mutate(~tmp$24#0:wybe.list(?T), ?tmp$1#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$2#0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$27#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$27#0:wybe.list(?T), ?tmp$28#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
-    foreign lpvm mutate(~tmp$28#0:wybe.list(?T), ?tmp$0#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$1#0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$31#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$31#0:wybe.list(?T), ?tmp$32#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 5:?T)
-    foreign lpvm mutate(~tmp$32#0:wybe.list(?T), ?tmp$6#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$35#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$35#0:wybe.list(?T), ?tmp$36#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
-    foreign lpvm mutate(~tmp$36#0:wybe.list(?T), ?tmp$5#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$6#0:wybe.list(?T))
-    stmt_for.gen$6<0>(~io#0:wybe.phantom, ~tmp$0#0:wybe.list(?T), ~tmp$1#0:wybe.list(?T), ~tmp$2#0:wybe.list(?T), ~tmp$3#0:wybe.list(?T), 0:wybe.list(?T), ~tmp$5#0:wybe.list(?T), ~tmp$6#0:wybe.list(?T), 0:wybe.list(?T), ~tmp$0#0:wybe.list(wybe.int), ~tmp$5#0:wybe.list(wybe.int), ~tmp$0#0:wybe.list(wybe.int), ~tmp$5#0:wybe.list(wybe.int), ?io#1:wybe.phantom) #8 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$15##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$15##0:wybe.list(?T), ?tmp$16##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
+    foreign lpvm mutate(~tmp$16##0:wybe.list(?T), ?tmp$3##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp$19##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$19##0:wybe.list(?T), ?tmp$20##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
+    foreign lpvm mutate(~tmp$20##0:wybe.list(?T), ?tmp$2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$3##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp$23##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$23##0:wybe.list(?T), ?tmp$24##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
+    foreign lpvm mutate(~tmp$24##0:wybe.list(?T), ?tmp$1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$2##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp$27##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$27##0:wybe.list(?T), ?tmp$28##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
+    foreign lpvm mutate(~tmp$28##0:wybe.list(?T), ?tmp$0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$1##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp$31##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$31##0:wybe.list(?T), ?tmp$32##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 5:?T)
+    foreign lpvm mutate(~tmp$32##0:wybe.list(?T), ?tmp$6##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp$35##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$35##0:wybe.list(?T), ?tmp$36##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
+    foreign lpvm mutate(~tmp$36##0:wybe.list(?T), ?tmp$5##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$6##0:wybe.list(?T))
+    stmt_for.gen$6<0>(~io##0:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), 0:wybe.list(?T), ~tmp$5##0:wybe.list(?T), ~tmp$6##0:wybe.list(?T), 0:wybe.list(?T), ~tmp$0##0:wybe.list(wybe.int), ~tmp$5##0:wybe.list(wybe.int), ~tmp$0##0:wybe.list(wybe.int), ~tmp$5##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #8 @stmt_for:nn:nn
 
 
 single_generator > public (1 calls)
 0: stmt_for.single_generator<0>
-single_generator(io#0:wybe.phantom, ?io#1:wybe.phantom):
+single_generator(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$9#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$9#0:wybe.list(?T), ?tmp$10#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
-    foreign lpvm mutate(~tmp$10#0:wybe.list(?T), ?tmp$2#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$13#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$13#0:wybe.list(?T), ?tmp$14#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
-    foreign lpvm mutate(~tmp$14#0:wybe.list(?T), ?tmp$1#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$2#0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$17#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$17#0:wybe.list(?T), ?tmp$18#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
-    foreign lpvm mutate(~tmp$18#0:wybe.list(?T), ?tmp$0#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$1#0:wybe.list(?T))
-    stmt_for.gen$9<0>(~io#0:wybe.phantom, ~tmp$0#0:wybe.list(?T), ~tmp$1#0:wybe.list(?T), ~tmp$2#0:wybe.list(?T), 0:wybe.list(?T), ~tmp$0#0:wybe.list(wybe.int), ~tmp$0#0:wybe.list(wybe.int), ?io#1:wybe.phantom) #4 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$9##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$9##0:wybe.list(?T), ?tmp$10##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
+    foreign lpvm mutate(~tmp$10##0:wybe.list(?T), ?tmp$2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp$13##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$13##0:wybe.list(?T), ?tmp$14##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
+    foreign lpvm mutate(~tmp$14##0:wybe.list(?T), ?tmp$1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$2##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp$17##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$17##0:wybe.list(?T), ?tmp$18##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
+    foreign lpvm mutate(~tmp$18##0:wybe.list(?T), ?tmp$0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$1##0:wybe.list(?T))
+    stmt_for.gen$9<0>(~io##0:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), 0:wybe.list(?T), ~tmp$0##0:wybe.list(wybe.int), ~tmp$0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #4 @stmt_for:nn:nn
 
 
 using_break > public (1 calls)
 0: stmt_for.using_break<0>
-using_break(io#0:wybe.phantom, ?io#1:wybe.phantom):
+using_break(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$11#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$11#0:wybe.list(?T), ?tmp$12#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
-    foreign lpvm mutate(~tmp$12#0:wybe.list(?T), ?tmp$3#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$15#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$15#0:wybe.list(?T), ?tmp$16#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
-    foreign lpvm mutate(~tmp$16#0:wybe.list(?T), ?tmp$2#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$3#0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$19#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$19#0:wybe.list(?T), ?tmp$20#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
-    foreign lpvm mutate(~tmp$20#0:wybe.list(?T), ?tmp$1#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$2#0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$23#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$23#0:wybe.list(?T), ?tmp$24#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
-    foreign lpvm mutate(~tmp$24#0:wybe.list(?T), ?tmp$0#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$1#0:wybe.list(?T))
-    stmt_for.gen$10<0>(~io#0:wybe.phantom, ~tmp$0#0:wybe.list(?T), ~tmp$1#0:wybe.list(?T), ~tmp$2#0:wybe.list(?T), ~tmp$3#0:wybe.list(?T), 0:wybe.list(?T), ~tmp$0#0:wybe.list(wybe.int), ~tmp$0#0:wybe.list(wybe.int), ?io#1:wybe.phantom) #5 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$11##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$11##0:wybe.list(?T), ?tmp$12##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
+    foreign lpvm mutate(~tmp$12##0:wybe.list(?T), ?tmp$3##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp$15##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$15##0:wybe.list(?T), ?tmp$16##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
+    foreign lpvm mutate(~tmp$16##0:wybe.list(?T), ?tmp$2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$3##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp$19##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$19##0:wybe.list(?T), ?tmp$20##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
+    foreign lpvm mutate(~tmp$20##0:wybe.list(?T), ?tmp$1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$2##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp$23##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$23##0:wybe.list(?T), ?tmp$24##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
+    foreign lpvm mutate(~tmp$24##0:wybe.list(?T), ?tmp$0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$1##0:wybe.list(?T))
+    stmt_for.gen$10<0>(~io##0:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), 0:wybe.list(?T), ~tmp$0##0:wybe.list(wybe.int), ~tmp$0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
 using_irange > public (1 calls)
 0: stmt_for.using_irange<0>
-using_irange(io#0:wybe.phantom, ?io#1:wybe.phantom):
+using_irange(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_for.irange<0>(1:wybe.int, 1:wybe.int, 10:wybe.int, ?tmp$3#0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
-    stmt_for.gen$12<0>(~io#0:wybe.phantom, ~tmp$3#0:stmt_for.int_sequence, ~tmp$3#0:stmt_for.int_sequence, ?io#1:wybe.phantom) #1 @stmt_for:nn:nn
+    stmt_for.irange<0>(1:wybe.int, 1:wybe.int, 10:wybe.int, ?tmp$3##0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
+    stmt_for.gen$12<0>(~io##0:wybe.phantom, ~tmp$3##0:stmt_for.int_sequence, ~tmp$3##0:stmt_for.int_sequence, ?io##1:wybe.phantom) #1 @stmt_for:nn:nn
 
 
 using_irange_reverse > public (1 calls)
 0: stmt_for.using_irange_reverse<0>
-using_irange_reverse(io#0:wybe.phantom, ?io#1:wybe.phantom):
+using_irange_reverse(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_for.irange<0>(10:wybe.int, -1:wybe.int, 1:wybe.int, ?tmp$3#0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
-    stmt_for.gen$13<0>(~io#0:wybe.phantom, ~tmp$3#0:stmt_for.int_sequence, ~tmp$3#0:stmt_for.int_sequence, ?io#1:wybe.phantom) #1 @stmt_for:nn:nn
+    stmt_for.irange<0>(10:wybe.int, -1:wybe.int, 1:wybe.int, ?tmp$3##0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
+    stmt_for.gen$13<0>(~io##0:wybe.phantom, ~tmp$3##0:stmt_for.int_sequence, ~tmp$3##0:stmt_for.int_sequence, ?io##1:wybe.phantom) #1 @stmt_for:nn:nn
 
 
 using_next > public (1 calls)
 0: stmt_for.using_next<0>
-using_next(io#0:wybe.phantom, ?io#1:wybe.phantom):
+using_next(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$11#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$11#0:wybe.list(?T), ?tmp$12#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
-    foreign lpvm mutate(~tmp$12#0:wybe.list(?T), ?tmp$3#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$15#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$15#0:wybe.list(?T), ?tmp$16#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
-    foreign lpvm mutate(~tmp$16#0:wybe.list(?T), ?tmp$2#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$3#0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$19#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$19#0:wybe.list(?T), ?tmp$20#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
-    foreign lpvm mutate(~tmp$20#0:wybe.list(?T), ?tmp$1#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$2#0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$23#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$23#0:wybe.list(?T), ?tmp$24#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
-    foreign lpvm mutate(~tmp$24#0:wybe.list(?T), ?tmp$0#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$1#0:wybe.list(?T))
-    stmt_for.gen$14<0>(~io#0:wybe.phantom, ~tmp$0#0:wybe.list(?T), ~tmp$1#0:wybe.list(?T), ~tmp$2#0:wybe.list(?T), ~tmp$3#0:wybe.list(?T), 0:wybe.list(?T), ~tmp$0#0:wybe.list(wybe.int), ~tmp$0#0:wybe.list(wybe.int), ?io#1:wybe.phantom) #5 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$11##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$11##0:wybe.list(?T), ?tmp$12##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
+    foreign lpvm mutate(~tmp$12##0:wybe.list(?T), ?tmp$3##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp$15##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$15##0:wybe.list(?T), ?tmp$16##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
+    foreign lpvm mutate(~tmp$16##0:wybe.list(?T), ?tmp$2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$3##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp$19##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$19##0:wybe.list(?T), ?tmp$20##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
+    foreign lpvm mutate(~tmp$20##0:wybe.list(?T), ?tmp$1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$2##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp$23##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$23##0:wybe.list(?T), ?tmp$24##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
+    foreign lpvm mutate(~tmp$24##0:wybe.list(?T), ?tmp$0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$1##0:wybe.list(?T))
+    stmt_for.gen$14<0>(~io##0:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), 0:wybe.list(?T), ~tmp$0##0:wybe.list(wybe.int), ~tmp$0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
 using_unless > public (1 calls)
 0: stmt_for.using_unless<0>
-using_unless(io#0:wybe.phantom, ?io#1:wybe.phantom):
+using_unless(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$11#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$11#0:wybe.list(?T), ?tmp$12#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
-    foreign lpvm mutate(~tmp$12#0:wybe.list(?T), ?tmp$3#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$15#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$15#0:wybe.list(?T), ?tmp$16#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
-    foreign lpvm mutate(~tmp$16#0:wybe.list(?T), ?tmp$2#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$3#0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$19#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$19#0:wybe.list(?T), ?tmp$20#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
-    foreign lpvm mutate(~tmp$20#0:wybe.list(?T), ?tmp$1#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$2#0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$23#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$23#0:wybe.list(?T), ?tmp$24#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
-    foreign lpvm mutate(~tmp$24#0:wybe.list(?T), ?tmp$0#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$1#0:wybe.list(?T))
-    stmt_for.gen$16<0>(~io#0:wybe.phantom, ~tmp$0#0:wybe.list(?T), ~tmp$1#0:wybe.list(?T), ~tmp$2#0:wybe.list(?T), ~tmp$3#0:wybe.list(?T), 0:wybe.list(?T), ~tmp$0#0:wybe.list(wybe.int), ~tmp$0#0:wybe.list(wybe.int), ?io#1:wybe.phantom) #5 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$11##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$11##0:wybe.list(?T), ?tmp$12##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
+    foreign lpvm mutate(~tmp$12##0:wybe.list(?T), ?tmp$3##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp$15##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$15##0:wybe.list(?T), ?tmp$16##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
+    foreign lpvm mutate(~tmp$16##0:wybe.list(?T), ?tmp$2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$3##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp$19##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$19##0:wybe.list(?T), ?tmp$20##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
+    foreign lpvm mutate(~tmp$20##0:wybe.list(?T), ?tmp$1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$2##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp$23##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$23##0:wybe.list(?T), ?tmp$24##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
+    foreign lpvm mutate(~tmp$24##0:wybe.list(?T), ?tmp$0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$1##0:wybe.list(?T))
+    stmt_for.gen$16<0>(~io##0:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), 0:wybe.list(?T), ~tmp$0##0:wybe.list(wybe.int), ~tmp$0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
 using_until > public (1 calls)
 0: stmt_for.using_until<0>
-using_until(io#0:wybe.phantom, ?io#1:wybe.phantom):
+using_until(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$11#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$11#0:wybe.list(?T), ?tmp$12#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
-    foreign lpvm mutate(~tmp$12#0:wybe.list(?T), ?tmp$3#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$15#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$15#0:wybe.list(?T), ?tmp$16#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
-    foreign lpvm mutate(~tmp$16#0:wybe.list(?T), ?tmp$2#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$3#0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$19#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$19#0:wybe.list(?T), ?tmp$20#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
-    foreign lpvm mutate(~tmp$20#0:wybe.list(?T), ?tmp$1#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$2#0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$23#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$23#0:wybe.list(?T), ?tmp$24#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
-    foreign lpvm mutate(~tmp$24#0:wybe.list(?T), ?tmp$0#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$1#0:wybe.list(?T))
-    stmt_for.gen$18<0>(~io#0:wybe.phantom, ~tmp$0#0:wybe.list(?T), ~tmp$1#0:wybe.list(?T), ~tmp$2#0:wybe.list(?T), ~tmp$3#0:wybe.list(?T), 0:wybe.list(?T), ~tmp$0#0:wybe.list(wybe.int), ~tmp$0#0:wybe.list(wybe.int), ?io#1:wybe.phantom) #5 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$11##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$11##0:wybe.list(?T), ?tmp$12##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
+    foreign lpvm mutate(~tmp$12##0:wybe.list(?T), ?tmp$3##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp$15##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$15##0:wybe.list(?T), ?tmp$16##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
+    foreign lpvm mutate(~tmp$16##0:wybe.list(?T), ?tmp$2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$3##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp$19##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$19##0:wybe.list(?T), ?tmp$20##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
+    foreign lpvm mutate(~tmp$20##0:wybe.list(?T), ?tmp$1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$2##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp$23##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$23##0:wybe.list(?T), ?tmp$24##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
+    foreign lpvm mutate(~tmp$24##0:wybe.list(?T), ?tmp$0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$1##0:wybe.list(?T))
+    stmt_for.gen$18<0>(~io##0:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), 0:wybe.list(?T), ~tmp$0##0:wybe.list(wybe.int), ~tmp$0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
 using_when > public (1 calls)
 0: stmt_for.using_when<0>
-using_when(io#0:wybe.phantom, ?io#1:wybe.phantom):
+using_when(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$11#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$11#0:wybe.list(?T), ?tmp$12#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
-    foreign lpvm mutate(~tmp$12#0:wybe.list(?T), ?tmp$3#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$15#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$15#0:wybe.list(?T), ?tmp$16#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
-    foreign lpvm mutate(~tmp$16#0:wybe.list(?T), ?tmp$2#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$3#0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$19#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$19#0:wybe.list(?T), ?tmp$20#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
-    foreign lpvm mutate(~tmp$20#0:wybe.list(?T), ?tmp$1#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$2#0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$23#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$23#0:wybe.list(?T), ?tmp$24#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
-    foreign lpvm mutate(~tmp$24#0:wybe.list(?T), ?tmp$0#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$1#0:wybe.list(?T))
-    stmt_for.gen$20<0>(~io#0:wybe.phantom, ~tmp$0#0:wybe.list(?T), ~tmp$1#0:wybe.list(?T), ~tmp$2#0:wybe.list(?T), ~tmp$3#0:wybe.list(?T), 0:wybe.list(?T), ~tmp$0#0:wybe.list(wybe.int), ~tmp$0#0:wybe.list(wybe.int), ?io#1:wybe.phantom) #5 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$11##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$11##0:wybe.list(?T), ?tmp$12##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
+    foreign lpvm mutate(~tmp$12##0:wybe.list(?T), ?tmp$3##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp$15##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$15##0:wybe.list(?T), ?tmp$16##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
+    foreign lpvm mutate(~tmp$16##0:wybe.list(?T), ?tmp$2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$3##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp$19##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$19##0:wybe.list(?T), ?tmp$20##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
+    foreign lpvm mutate(~tmp$20##0:wybe.list(?T), ?tmp$1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$2##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp$23##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$23##0:wybe.list(?T), ?tmp$24##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
+    foreign lpvm mutate(~tmp$24##0:wybe.list(?T), ?tmp$0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$1##0:wybe.list(?T))
+    stmt_for.gen$20<0>(~io##0:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), 0:wybe.list(?T), ~tmp$0##0:wybe.list(wybe.int), ~tmp$0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
 using_while > public (1 calls)
 0: stmt_for.using_while<0>
-using_while(io#0:wybe.phantom, ?io#1:wybe.phantom):
+using_while(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$11#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$11#0:wybe.list(?T), ?tmp$12#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
-    foreign lpvm mutate(~tmp$12#0:wybe.list(?T), ?tmp$3#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$15#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$15#0:wybe.list(?T), ?tmp$16#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
-    foreign lpvm mutate(~tmp$16#0:wybe.list(?T), ?tmp$2#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$3#0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$19#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$19#0:wybe.list(?T), ?tmp$20#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
-    foreign lpvm mutate(~tmp$20#0:wybe.list(?T), ?tmp$1#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$2#0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp$23#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$23#0:wybe.list(?T), ?tmp$24#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
-    foreign lpvm mutate(~tmp$24#0:wybe.list(?T), ?tmp$0#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$1#0:wybe.list(?T))
-    stmt_for.gen$22<0>(~io#0:wybe.phantom, ~tmp$0#0:wybe.list(?T), ~tmp$1#0:wybe.list(?T), ~tmp$2#0:wybe.list(?T), ~tmp$3#0:wybe.list(?T), 0:wybe.list(?T), ~tmp$0#0:wybe.list(wybe.int), ~tmp$0#0:wybe.list(wybe.int), ?io#1:wybe.phantom) #5 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$11##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$11##0:wybe.list(?T), ?tmp$12##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
+    foreign lpvm mutate(~tmp$12##0:wybe.list(?T), ?tmp$3##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp$15##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$15##0:wybe.list(?T), ?tmp$16##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
+    foreign lpvm mutate(~tmp$16##0:wybe.list(?T), ?tmp$2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$3##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp$19##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$19##0:wybe.list(?T), ?tmp$20##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
+    foreign lpvm mutate(~tmp$20##0:wybe.list(?T), ?tmp$1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$2##0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp$23##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$23##0:wybe.list(?T), ?tmp$24##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
+    foreign lpvm mutate(~tmp$24##0:wybe.list(?T), ?tmp$0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp$1##0:wybe.list(?T))
+    stmt_for.gen$22<0>(~io##0:wybe.phantom, ~tmp$0##0:wybe.list(?T), ~tmp$1##0:wybe.list(?T), ~tmp$2##0:wybe.list(?T), ~tmp$3##0:wybe.list(?T), 0:wybe.list(?T), ~tmp$0##0:wybe.list(wybe.int), ~tmp$0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
 using_xrange > public (1 calls)
 0: stmt_for.using_xrange<0>
-using_xrange(io#0:wybe.phantom, ?io#1:wybe.phantom):
+using_xrange(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_for.xrange<0>(1:wybe.int, 1:wybe.int, 10:wybe.int, ?tmp$3#0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
-    stmt_for.gen$24<0>(~io#0:wybe.phantom, ~tmp$3#0:stmt_for.int_sequence, ~tmp$3#0:stmt_for.int_sequence, ?io#1:wybe.phantom) #1 @stmt_for:nn:nn
+    stmt_for.xrange<0>(1:wybe.int, 1:wybe.int, 10:wybe.int, ?tmp$3##0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
+    stmt_for.gen$24<0>(~io##0:wybe.phantom, ~tmp$3##0:stmt_for.int_sequence, ~tmp$3##0:stmt_for.int_sequence, ?io##1:wybe.phantom) #1 @stmt_for:nn:nn
 
 
 using_xrange_reverse > public (1 calls)
 0: stmt_for.using_xrange_reverse<0>
-using_xrange_reverse(io#0:wybe.phantom, ?io#1:wybe.phantom):
+using_xrange_reverse(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_for.xrange<0>(10:wybe.int, -1:wybe.int, 1:wybe.int, ?tmp$3#0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
-    stmt_for.gen$25<0>(~io#0:wybe.phantom, ~tmp$3#0:stmt_for.int_sequence, ~tmp$3#0:stmt_for.int_sequence, ?io#1:wybe.phantom) #1 @stmt_for:nn:nn
+    stmt_for.xrange<0>(10:wybe.int, -1:wybe.int, 1:wybe.int, ?tmp$3##0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
+    stmt_for.gen$25<0>(~io##0:wybe.phantom, ~tmp$3##0:stmt_for.int_sequence, ~tmp$3##0:stmt_for.int_sequence, ?io##1:wybe.phantom) #1 @stmt_for:nn:nn
 
 
 xrange > public (3 calls)
 0: stmt_for.xrange<0>
-xrange(start#0:wybe.int, stride#0:wybe.int, end#0:wybe.int, ?$#0:stmt_for.int_sequence):
+xrange(start##0:wybe.int, stride##0:wybe.int, end##0:wybe.int, ?$##0:stmt_for.int_sequence):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp$4#0:stmt_for.int_sequence)
-    foreign lpvm mutate(~tmp$4#0:stmt_for.int_sequence, ?tmp$5#0:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~start#0:wybe.int)
-    foreign lpvm mutate(~tmp$5#0:stmt_for.int_sequence, ?tmp$6#0:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~stride#0:wybe.int)
-    foreign lpvm mutate(~tmp$6#0:stmt_for.int_sequence, ?$#0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~end#0:wybe.int)
+    foreign lpvm alloc(24:wybe.int, ?tmp$4##0:stmt_for.int_sequence)
+    foreign lpvm mutate(~tmp$4##0:stmt_for.int_sequence, ?tmp$5##0:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~start##0:wybe.int)
+    foreign lpvm mutate(~tmp$5##0:stmt_for.int_sequence, ?tmp$6##0:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~stride##0:wybe.int)
+    foreign lpvm mutate(~tmp$6##0:stmt_for.int_sequence, ?$##0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~end##0:wybe.int)
 
   LLVM code       :
 
@@ -896,61 +896,61 @@ entry:
 }
 
 
-define external fastcc  void @"stmt_for.gen$1<0>"(i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %"tmp$5#0", i64  %"tmp$6#0", i64  %"tmp$7#0", i64  %"tmp$8#0", i64  %"tmp$9#0", i64  %"x#0", i64  %"y#0")    {
+define external fastcc  void @"stmt_for.gen$1<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"tmp$6##0", i64  %"tmp$7##0", i64  %"tmp$8##0", i64  %"tmp$9##0", i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$tmp$14#0" = icmp ne i64 %"tmp$8#0", 0 
-  br i1 %"1$tmp$14#0", label %if.then, label %if.else 
+  %"1$tmp$14##0" = icmp ne i64 %"tmp$8##0", 0 
+  br i1 %"1$tmp$14##0", label %if.then, label %if.else 
 if.then:
-  %27 = inttoptr i64 %"tmp$8#0" to i64* 
+  %27 = inttoptr i64 %"tmp$8##0" to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
-  %30 = add   i64 %"tmp$8#0", 8 
+  %30 = add   i64 %"tmp$8##0", 8 
   %31 = inttoptr i64 %30 to i64* 
   %32 = getelementptr  i64, i64* %31, i64 0 
   %33 = load  i64, i64* %32 
-  tail call fastcc  void  @"stmt_for.gen$2<0>"(i64  %29, i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %"tmp$5#0", i64  %"tmp$6#0", i64  %"tmp$7#0", i64  %33, i64  %"tmp$9#0", i64  %"x#0", i64  %"y#0")  
+  tail call fastcc  void  @"stmt_for.gen$2<0>"(i64  %29, i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"tmp$6##0", i64  %"tmp$7##0", i64  %33, i64  %"tmp$9##0", i64  %"x##0", i64  %"y##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$10<0>"(i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %"tmp$5#0", i64  %"x#0")    {
+define external fastcc  void @"stmt_for.gen$10<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")    {
 entry:
-  %"1$tmp$10#0" = icmp ne i64 %"tmp$5#0", 0 
-  br i1 %"1$tmp$10#0", label %if.then, label %if.else 
+  %"1$tmp$10##0" = icmp ne i64 %"tmp$5##0", 0 
+  br i1 %"1$tmp$10##0", label %if.then, label %if.else 
 if.then:
-  %34 = inttoptr i64 %"tmp$5#0" to i64* 
+  %34 = inttoptr i64 %"tmp$5##0" to i64* 
   %35 = getelementptr  i64, i64* %34, i64 0 
   %36 = load  i64, i64* %35 
-  %37 = add   i64 %"tmp$5#0", 8 
+  %37 = add   i64 %"tmp$5##0", 8 
   %38 = inttoptr i64 %37 to i64* 
   %39 = getelementptr  i64, i64* %38, i64 0 
   %40 = load  i64, i64* %39 
-  tail call fastcc  void  @"stmt_for.gen$11<0>"(i64  %36, i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %40, i64  %"x#0")  
+  tail call fastcc  void  @"stmt_for.gen$11<0>"(i64  %36, i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %40, i64  %"x##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$11<0>"(i64  %"i#0", i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %"tmp$5#0", i64  %"x#0")    {
+define external fastcc  void @"stmt_for.gen$11<0>"(i64  %"i##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")    {
 entry:
-  %"1$tmp$8#0" = icmp eq i64 %"i#0", 3 
-  br i1 %"1$tmp$8#0", label %if.then, label %if.else 
+  %"1$tmp$8##0" = icmp eq i64 %"i##0", 3 
+  br i1 %"1$tmp$8##0", label %if.then, label %if.else 
 if.then:
   ret void 
 if.else:
-  tail call ccc  void  @print_int(i64  %"i#0")  
+  tail call ccc  void  @print_int(i64  %"i##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen$10<0>"(i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %"tmp$5#0", i64  %"x#0")  
+  tail call fastcc  void  @"stmt_for.gen$10<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")  
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$12<0>"(i64  %"tmp$0#0", i64  %"tmp$3#0")    {
+define external fastcc  void @"stmt_for.gen$12<0>"(i64  %"tmp$0##0", i64  %"tmp$3##0")    {
 entry:
-  %41 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp$0#0")  
+  %41 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp$0##0")  
   %42 = extractvalue {i64, i64, i1} %41, 0 
   %43 = extractvalue {i64, i64, i1} %41, 1 
   %44 = extractvalue {i64, i64, i1} %41, 2 
@@ -958,16 +958,16 @@ entry:
 if.then:
   tail call ccc  void  @print_int(i64  %42)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen$12<0>"(i64  %43, i64  %"tmp$3#0")  
+  tail call fastcc  void  @"stmt_for.gen$12<0>"(i64  %43, i64  %"tmp$3##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$13<0>"(i64  %"tmp$0#0", i64  %"tmp$3#0")    {
+define external fastcc  void @"stmt_for.gen$13<0>"(i64  %"tmp$0##0", i64  %"tmp$3##0")    {
 entry:
-  %45 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp$0#0")  
+  %45 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp$0##0")  
   %46 = extractvalue {i64, i64, i1} %45, 0 
   %47 = extractvalue {i64, i64, i1} %45, 1 
   %48 = extractvalue {i64, i64, i1} %45, 2 
@@ -975,207 +975,207 @@ entry:
 if.then:
   tail call ccc  void  @print_int(i64  %46)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen$13<0>"(i64  %47, i64  %"tmp$3#0")  
+  tail call fastcc  void  @"stmt_for.gen$13<0>"(i64  %47, i64  %"tmp$3##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$14<0>"(i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %"tmp$5#0", i64  %"x#0")    {
+define external fastcc  void @"stmt_for.gen$14<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")    {
 entry:
-  %"1$tmp$10#0" = icmp ne i64 %"tmp$5#0", 0 
-  br i1 %"1$tmp$10#0", label %if.then, label %if.else 
+  %"1$tmp$10##0" = icmp ne i64 %"tmp$5##0", 0 
+  br i1 %"1$tmp$10##0", label %if.then, label %if.else 
 if.then:
-  %49 = inttoptr i64 %"tmp$5#0" to i64* 
+  %49 = inttoptr i64 %"tmp$5##0" to i64* 
   %50 = getelementptr  i64, i64* %49, i64 0 
   %51 = load  i64, i64* %50 
-  %52 = add   i64 %"tmp$5#0", 8 
+  %52 = add   i64 %"tmp$5##0", 8 
   %53 = inttoptr i64 %52 to i64* 
   %54 = getelementptr  i64, i64* %53, i64 0 
   %55 = load  i64, i64* %54 
-  tail call fastcc  void  @"stmt_for.gen$15<0>"(i64  %51, i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %55, i64  %"x#0")  
+  tail call fastcc  void  @"stmt_for.gen$15<0>"(i64  %51, i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %55, i64  %"x##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$15<0>"(i64  %"i#0", i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %"tmp$5#0", i64  %"x#0")    {
+define external fastcc  void @"stmt_for.gen$15<0>"(i64  %"i##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")    {
 entry:
-  %"1$tmp$8#0" = icmp eq i64 %"i#0", 3 
-  br i1 %"1$tmp$8#0", label %if.then, label %if.else 
+  %"1$tmp$8##0" = icmp eq i64 %"i##0", 3 
+  br i1 %"1$tmp$8##0", label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"stmt_for.gen$14<0>"(i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %"tmp$5#0", i64  %"x#0")  
+  tail call fastcc  void  @"stmt_for.gen$14<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")  
   ret void 
 if.else:
-  tail call ccc  void  @print_int(i64  %"i#0")  
+  tail call ccc  void  @print_int(i64  %"i##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen$14<0>"(i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %"tmp$5#0", i64  %"x#0")  
+  tail call fastcc  void  @"stmt_for.gen$14<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")  
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$16<0>"(i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %"tmp$5#0", i64  %"x#0")    {
+define external fastcc  void @"stmt_for.gen$16<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")    {
 entry:
-  %"1$tmp$10#0" = icmp ne i64 %"tmp$5#0", 0 
-  br i1 %"1$tmp$10#0", label %if.then, label %if.else 
+  %"1$tmp$10##0" = icmp ne i64 %"tmp$5##0", 0 
+  br i1 %"1$tmp$10##0", label %if.then, label %if.else 
 if.then:
-  %56 = inttoptr i64 %"tmp$5#0" to i64* 
+  %56 = inttoptr i64 %"tmp$5##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"tmp$5#0", 8 
+  %59 = add   i64 %"tmp$5##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  tail call fastcc  void  @"stmt_for.gen$17<0>"(i64  %58, i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %62, i64  %"x#0")  
+  tail call fastcc  void  @"stmt_for.gen$17<0>"(i64  %58, i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %62, i64  %"x##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$17<0>"(i64  %"i#0", i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %"tmp$5#0", i64  %"x#0")    {
+define external fastcc  void @"stmt_for.gen$17<0>"(i64  %"i##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")    {
 entry:
-  %"1$tmp$8#0" = icmp slt i64 %"i#0", 3 
-  br i1 %"1$tmp$8#0", label %if.then, label %if.else 
+  %"1$tmp$8##0" = icmp slt i64 %"i##0", 3 
+  br i1 %"1$tmp$8##0", label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"stmt_for.gen$16<0>"(i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %"tmp$5#0", i64  %"x#0")  
+  tail call fastcc  void  @"stmt_for.gen$16<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")  
   ret void 
 if.else:
-  tail call ccc  void  @print_int(i64  %"i#0")  
+  tail call ccc  void  @print_int(i64  %"i##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen$16<0>"(i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %"tmp$5#0", i64  %"x#0")  
+  tail call fastcc  void  @"stmt_for.gen$16<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")  
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$18<0>"(i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %"tmp$5#0", i64  %"x#0")    {
+define external fastcc  void @"stmt_for.gen$18<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")    {
 entry:
-  %"1$tmp$10#0" = icmp ne i64 %"tmp$5#0", 0 
-  br i1 %"1$tmp$10#0", label %if.then, label %if.else 
+  %"1$tmp$10##0" = icmp ne i64 %"tmp$5##0", 0 
+  br i1 %"1$tmp$10##0", label %if.then, label %if.else 
 if.then:
-  %63 = inttoptr i64 %"tmp$5#0" to i64* 
+  %63 = inttoptr i64 %"tmp$5##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"tmp$5#0", 8 
+  %66 = add   i64 %"tmp$5##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  tail call fastcc  void  @"stmt_for.gen$19<0>"(i64  %65, i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %69, i64  %"x#0")  
+  tail call fastcc  void  @"stmt_for.gen$19<0>"(i64  %65, i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %69, i64  %"x##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$19<0>"(i64  %"i#0", i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %"tmp$5#0", i64  %"x#0")    {
+define external fastcc  void @"stmt_for.gen$19<0>"(i64  %"i##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")    {
 entry:
-  %"1$tmp$8#0" = icmp eq i64 %"i#0", 3 
-  br i1 %"1$tmp$8#0", label %if.then, label %if.else 
+  %"1$tmp$8##0" = icmp eq i64 %"i##0", 3 
+  br i1 %"1$tmp$8##0", label %if.then, label %if.else 
 if.then:
   ret void 
 if.else:
-  tail call ccc  void  @print_int(i64  %"i#0")  
+  tail call ccc  void  @print_int(i64  %"i##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen$18<0>"(i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %"tmp$5#0", i64  %"x#0")  
+  tail call fastcc  void  @"stmt_for.gen$18<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")  
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$2<0>"(i64  %"i#0", i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %"tmp$5#0", i64  %"tmp$6#0", i64  %"tmp$7#0", i64  %"tmp$8#0", i64  %"tmp$9#0", i64  %"x#0", i64  %"y#0")    {
+define external fastcc  void @"stmt_for.gen$2<0>"(i64  %"i##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"tmp$6##0", i64  %"tmp$7##0", i64  %"tmp$8##0", i64  %"tmp$9##0", i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$tmp$14#0" = icmp ne i64 %"tmp$9#0", 0 
-  br i1 %"1$tmp$14#0", label %if.then, label %if.else 
+  %"1$tmp$14##0" = icmp ne i64 %"tmp$9##0", 0 
+  br i1 %"1$tmp$14##0", label %if.then, label %if.else 
 if.then:
-  %70 = inttoptr i64 %"tmp$9#0" to i64* 
+  %70 = inttoptr i64 %"tmp$9##0" to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
   %72 = load  i64, i64* %71 
-  %73 = add   i64 %"tmp$9#0", 8 
+  %73 = add   i64 %"tmp$9##0", 8 
   %74 = inttoptr i64 %73 to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
   %76 = load  i64, i64* %75 
-  tail call ccc  void  @print_int(i64  %"i#0")  
+  tail call ccc  void  @print_int(i64  %"i##0")  
   tail call ccc  void  @putchar(i8  10)  
   tail call ccc  void  @print_int(i64  %72)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen$1<0>"(i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %"tmp$5#0", i64  %"tmp$6#0", i64  %"tmp$7#0", i64  %"tmp$8#0", i64  %76, i64  %"x#0", i64  %"y#0")  
+  tail call fastcc  void  @"stmt_for.gen$1<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"tmp$6##0", i64  %"tmp$7##0", i64  %"tmp$8##0", i64  %76, i64  %"x##0", i64  %"y##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$20<0>"(i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %"tmp$5#0", i64  %"x#0")    {
+define external fastcc  void @"stmt_for.gen$20<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")    {
 entry:
-  %"1$tmp$10#0" = icmp ne i64 %"tmp$5#0", 0 
-  br i1 %"1$tmp$10#0", label %if.then, label %if.else 
+  %"1$tmp$10##0" = icmp ne i64 %"tmp$5##0", 0 
+  br i1 %"1$tmp$10##0", label %if.then, label %if.else 
 if.then:
-  %77 = inttoptr i64 %"tmp$5#0" to i64* 
+  %77 = inttoptr i64 %"tmp$5##0" to i64* 
   %78 = getelementptr  i64, i64* %77, i64 0 
   %79 = load  i64, i64* %78 
-  %80 = add   i64 %"tmp$5#0", 8 
+  %80 = add   i64 %"tmp$5##0", 8 
   %81 = inttoptr i64 %80 to i64* 
   %82 = getelementptr  i64, i64* %81, i64 0 
   %83 = load  i64, i64* %82 
-  tail call fastcc  void  @"stmt_for.gen$21<0>"(i64  %79, i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %83, i64  %"x#0")  
+  tail call fastcc  void  @"stmt_for.gen$21<0>"(i64  %79, i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %83, i64  %"x##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$21<0>"(i64  %"i#0", i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %"tmp$5#0", i64  %"x#0")    {
+define external fastcc  void @"stmt_for.gen$21<0>"(i64  %"i##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")    {
 entry:
-  %"1$tmp$8#0" = icmp slt i64 %"i#0", 3 
-  br i1 %"1$tmp$8#0", label %if.then, label %if.else 
+  %"1$tmp$8##0" = icmp slt i64 %"i##0", 3 
+  br i1 %"1$tmp$8##0", label %if.then, label %if.else 
 if.then:
-  tail call ccc  void  @print_int(i64  %"i#0")  
+  tail call ccc  void  @print_int(i64  %"i##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen$20<0>"(i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %"tmp$5#0", i64  %"x#0")  
+  tail call fastcc  void  @"stmt_for.gen$20<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")  
   ret void 
 if.else:
-  tail call fastcc  void  @"stmt_for.gen$20<0>"(i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %"tmp$5#0", i64  %"x#0")  
+  tail call fastcc  void  @"stmt_for.gen$20<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")  
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$22<0>"(i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %"tmp$5#0", i64  %"x#0")    {
+define external fastcc  void @"stmt_for.gen$22<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")    {
 entry:
-  %"1$tmp$10#0" = icmp ne i64 %"tmp$5#0", 0 
-  br i1 %"1$tmp$10#0", label %if.then, label %if.else 
+  %"1$tmp$10##0" = icmp ne i64 %"tmp$5##0", 0 
+  br i1 %"1$tmp$10##0", label %if.then, label %if.else 
 if.then:
-  %84 = inttoptr i64 %"tmp$5#0" to i64* 
+  %84 = inttoptr i64 %"tmp$5##0" to i64* 
   %85 = getelementptr  i64, i64* %84, i64 0 
   %86 = load  i64, i64* %85 
-  %87 = add   i64 %"tmp$5#0", 8 
+  %87 = add   i64 %"tmp$5##0", 8 
   %88 = inttoptr i64 %87 to i64* 
   %89 = getelementptr  i64, i64* %88, i64 0 
   %90 = load  i64, i64* %89 
-  tail call fastcc  void  @"stmt_for.gen$23<0>"(i64  %86, i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %90, i64  %"x#0")  
+  tail call fastcc  void  @"stmt_for.gen$23<0>"(i64  %86, i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %90, i64  %"x##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$23<0>"(i64  %"i#0", i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %"tmp$5#0", i64  %"x#0")    {
+define external fastcc  void @"stmt_for.gen$23<0>"(i64  %"i##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")    {
 entry:
-  %"1$tmp$8#0" = icmp slt i64 %"i#0", 3 
-  br i1 %"1$tmp$8#0", label %if.then, label %if.else 
+  %"1$tmp$8##0" = icmp slt i64 %"i##0", 3 
+  br i1 %"1$tmp$8##0", label %if.then, label %if.else 
 if.then:
-  tail call ccc  void  @print_int(i64  %"i#0")  
+  tail call ccc  void  @print_int(i64  %"i##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen$22<0>"(i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %"tmp$5#0", i64  %"x#0")  
+  tail call fastcc  void  @"stmt_for.gen$22<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"x##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$24<0>"(i64  %"tmp$0#0", i64  %"tmp$3#0")    {
+define external fastcc  void @"stmt_for.gen$24<0>"(i64  %"tmp$0##0", i64  %"tmp$3##0")    {
 entry:
-  %91 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp$0#0")  
+  %91 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp$0##0")  
   %92 = extractvalue {i64, i64, i1} %91, 0 
   %93 = extractvalue {i64, i64, i1} %91, 1 
   %94 = extractvalue {i64, i64, i1} %91, 2 
@@ -1183,16 +1183,16 @@ entry:
 if.then:
   tail call ccc  void  @print_int(i64  %92)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen$24<0>"(i64  %93, i64  %"tmp$3#0")  
+  tail call fastcc  void  @"stmt_for.gen$24<0>"(i64  %93, i64  %"tmp$3##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$25<0>"(i64  %"tmp$0#0", i64  %"tmp$3#0")    {
+define external fastcc  void @"stmt_for.gen$25<0>"(i64  %"tmp$0##0", i64  %"tmp$3##0")    {
 entry:
-  %95 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp$0#0")  
+  %95 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp$0##0")  
   %96 = extractvalue {i64, i64, i1} %95, 0 
   %97 = extractvalue {i64, i64, i1} %95, 1 
   %98 = extractvalue {i64, i64, i1} %95, 2 
@@ -1200,164 +1200,164 @@ entry:
 if.then:
   tail call ccc  void  @print_int(i64  %96)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen$25<0>"(i64  %97, i64  %"tmp$3#0")  
+  tail call fastcc  void  @"stmt_for.gen$25<0>"(i64  %97, i64  %"tmp$3##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$3<0>"(i64  %"i#0", i64  %"j#0", i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %"tmp$5#0", i64  %"tmp$6#0", i64  %"tmp$7#0", i64  %"tmp$8#0", i64  %"tmp$9#0", i64  %"x#0", i64  %"y#0")    {
+define external fastcc  void @"stmt_for.gen$3<0>"(i64  %"i##0", i64  %"j##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"tmp$6##0", i64  %"tmp$7##0", i64  %"tmp$8##0", i64  %"tmp$9##0", i64  %"x##0", i64  %"y##0")    {
 entry:
-  tail call ccc  void  @print_int(i64  %"i#0")  
+  tail call ccc  void  @print_int(i64  %"i##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call ccc  void  @print_int(i64  %"j#0")  
+  tail call ccc  void  @print_int(i64  %"j##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen$1<0>"(i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %"tmp$5#0", i64  %"tmp$6#0", i64  %"tmp$7#0", i64  %"tmp$8#0", i64  %"tmp$9#0", i64  %"x#0", i64  %"y#0")  
+  tail call fastcc  void  @"stmt_for.gen$1<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"tmp$6##0", i64  %"tmp$7##0", i64  %"tmp$8##0", i64  %"tmp$9##0", i64  %"x##0", i64  %"y##0")  
   ret void 
 }
 
 
-define external fastcc  i1 @"stmt_for.gen$4<0>"(i64  %"tmp$0#0", i64  %"tmp$3#0")    {
+define external fastcc  i1 @"stmt_for.gen$4<0>"(i64  %"tmp$0##0", i64  %"tmp$3##0")    {
 entry:
-  %99 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp$0#0")  
+  %99 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp$0##0")  
   %100 = extractvalue {i64, i64, i1} %99, 0 
   %101 = extractvalue {i64, i64, i1} %99, 1 
   %102 = extractvalue {i64, i64, i1} %99, 2 
   br i1 %102, label %if.then, label %if.else 
 if.then:
-  %"2$$$#0" = tail call fastcc  i1  @"stmt_for.gen$5<0>"(i64  %100, i64  %101, i64  %"tmp$3#0")  
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = tail call fastcc  i1  @"stmt_for.gen$5<0>"(i64  %100, i64  %101, i64  %"tmp$3##0")  
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 1 
 }
 
 
-define external fastcc  i1 @"stmt_for.gen$5<0>"(i64  %"i#0", i64  %"tmp$0#0", i64  %"tmp$3#0")    {
+define external fastcc  i1 @"stmt_for.gen$5<0>"(i64  %"i##0", i64  %"tmp$0##0", i64  %"tmp$3##0")    {
 entry:
-  %"1$tmp$4#0" = icmp slt i64 %"i#0", 5 
-  br i1 %"1$tmp$4#0", label %if.then, label %if.else 
+  %"1$tmp$4##0" = icmp slt i64 %"i##0", 5 
+  br i1 %"1$tmp$4##0", label %if.then, label %if.else 
 if.then:
-  tail call ccc  void  @print_int(i64  %"i#0")  
+  tail call ccc  void  @print_int(i64  %"i##0")  
   tail call ccc  void  @putchar(i8  10)  
-  %"2$$$#0" = tail call fastcc  i1  @"stmt_for.gen$4<0>"(i64  %"tmp$0#0", i64  %"tmp$3#0")  
-  ret i1 %"2$$$#0" 
+  %"2$$$##0" = tail call fastcc  i1  @"stmt_for.gen$4<0>"(i64  %"tmp$0##0", i64  %"tmp$3##0")  
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  void @"stmt_for.gen$6<0>"(i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %"tmp$5#0", i64  %"tmp$6#0", i64  %"tmp$7#0", i64  %"tmp$8#0", i64  %"tmp$9#0", i64  %"x#0", i64  %"y#0")    {
+define external fastcc  void @"stmt_for.gen$6<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"tmp$6##0", i64  %"tmp$7##0", i64  %"tmp$8##0", i64  %"tmp$9##0", i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$tmp$14#0" = icmp ne i64 %"tmp$8#0", 0 
-  br i1 %"1$tmp$14#0", label %if.then, label %if.else 
+  %"1$tmp$14##0" = icmp ne i64 %"tmp$8##0", 0 
+  br i1 %"1$tmp$14##0", label %if.then, label %if.else 
 if.then:
-  %103 = inttoptr i64 %"tmp$8#0" to i64* 
+  %103 = inttoptr i64 %"tmp$8##0" to i64* 
   %104 = getelementptr  i64, i64* %103, i64 0 
   %105 = load  i64, i64* %104 
-  %106 = add   i64 %"tmp$8#0", 8 
+  %106 = add   i64 %"tmp$8##0", 8 
   %107 = inttoptr i64 %106 to i64* 
   %108 = getelementptr  i64, i64* %107, i64 0 
   %109 = load  i64, i64* %108 
-  tail call fastcc  void  @"stmt_for.gen$7<0>"(i64  %105, i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %"tmp$5#0", i64  %"tmp$6#0", i64  %"tmp$7#0", i64  %109, i64  %"tmp$9#0", i64  %"x#0", i64  %"y#0")  
+  tail call fastcc  void  @"stmt_for.gen$7<0>"(i64  %105, i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"tmp$6##0", i64  %"tmp$7##0", i64  %109, i64  %"tmp$9##0", i64  %"x##0", i64  %"y##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$7<0>"(i64  %"i#0", i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %"tmp$5#0", i64  %"tmp$6#0", i64  %"tmp$7#0", i64  %"tmp$8#0", i64  %"tmp$9#0", i64  %"x#0", i64  %"y#0")    {
+define external fastcc  void @"stmt_for.gen$7<0>"(i64  %"i##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"tmp$6##0", i64  %"tmp$7##0", i64  %"tmp$8##0", i64  %"tmp$9##0", i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$tmp$14#0" = icmp ne i64 %"tmp$9#0", 0 
-  br i1 %"1$tmp$14#0", label %if.then, label %if.else 
+  %"1$tmp$14##0" = icmp ne i64 %"tmp$9##0", 0 
+  br i1 %"1$tmp$14##0", label %if.then, label %if.else 
 if.then:
-  %110 = inttoptr i64 %"tmp$9#0" to i64* 
+  %110 = inttoptr i64 %"tmp$9##0" to i64* 
   %111 = getelementptr  i64, i64* %110, i64 0 
   %112 = load  i64, i64* %111 
-  %113 = add   i64 %"tmp$9#0", 8 
+  %113 = add   i64 %"tmp$9##0", 8 
   %114 = inttoptr i64 %113 to i64* 
   %115 = getelementptr  i64, i64* %114, i64 0 
   %116 = load  i64, i64* %115 
-  tail call ccc  void  @print_int(i64  %"i#0")  
+  tail call ccc  void  @print_int(i64  %"i##0")  
   tail call ccc  void  @putchar(i8  10)  
   tail call ccc  void  @print_int(i64  %112)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen$6<0>"(i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %"tmp$5#0", i64  %"tmp$6#0", i64  %"tmp$7#0", i64  %"tmp$8#0", i64  %116, i64  %"x#0", i64  %"y#0")  
+  tail call fastcc  void  @"stmt_for.gen$6<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"tmp$6##0", i64  %"tmp$7##0", i64  %"tmp$8##0", i64  %116, i64  %"x##0", i64  %"y##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$8<0>"(i64  %"i#0", i64  %"j#0", i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %"tmp$5#0", i64  %"tmp$6#0", i64  %"tmp$7#0", i64  %"tmp$8#0", i64  %"tmp$9#0", i64  %"x#0", i64  %"y#0")    {
+define external fastcc  void @"stmt_for.gen$8<0>"(i64  %"i##0", i64  %"j##0", i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"tmp$6##0", i64  %"tmp$7##0", i64  %"tmp$8##0", i64  %"tmp$9##0", i64  %"x##0", i64  %"y##0")    {
 entry:
-  tail call ccc  void  @print_int(i64  %"i#0")  
+  tail call ccc  void  @print_int(i64  %"i##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call ccc  void  @print_int(i64  %"j#0")  
+  tail call ccc  void  @print_int(i64  %"j##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen$6<0>"(i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %"tmp$5#0", i64  %"tmp$6#0", i64  %"tmp$7#0", i64  %"tmp$8#0", i64  %"tmp$9#0", i64  %"x#0", i64  %"y#0")  
+  tail call fastcc  void  @"stmt_for.gen$6<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"tmp$5##0", i64  %"tmp$6##0", i64  %"tmp$7##0", i64  %"tmp$8##0", i64  %"tmp$9##0", i64  %"x##0", i64  %"y##0")  
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen$9<0>"(i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %"tmp$4#0", i64  %"x#0")    {
+define external fastcc  void @"stmt_for.gen$9<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %"tmp$4##0", i64  %"x##0")    {
 entry:
-  %"1$tmp$8#0" = icmp ne i64 %"tmp$4#0", 0 
-  br i1 %"1$tmp$8#0", label %if.then, label %if.else 
+  %"1$tmp$8##0" = icmp ne i64 %"tmp$4##0", 0 
+  br i1 %"1$tmp$8##0", label %if.then, label %if.else 
 if.then:
-  %117 = inttoptr i64 %"tmp$4#0" to i64* 
+  %117 = inttoptr i64 %"tmp$4##0" to i64* 
   %118 = getelementptr  i64, i64* %117, i64 0 
   %119 = load  i64, i64* %118 
-  %120 = add   i64 %"tmp$4#0", 8 
+  %120 = add   i64 %"tmp$4##0", 8 
   %121 = inttoptr i64 %120 to i64* 
   %122 = getelementptr  i64, i64* %121, i64 0 
   %123 = load  i64, i64* %122 
   tail call ccc  void  @print_int(i64  %119)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen$9<0>"(i64  %"tmp$0#0", i64  %"tmp$1#0", i64  %"tmp$2#0", i64  %"tmp$3#0", i64  %123, i64  %"x#0")  
+  tail call fastcc  void  @"stmt_for.gen$9<0>"(i64  %"tmp$0##0", i64  %"tmp$1##0", i64  %"tmp$2##0", i64  %"tmp$3##0", i64  %123, i64  %"x##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  i64 @"stmt_for.irange<0>"(i64  %"start#0", i64  %"stride#0", i64  %"end#0")    {
+define external fastcc  i64 @"stmt_for.irange<0>"(i64  %"start##0", i64  %"stride##0", i64  %"end##0")    {
 entry:
-  %"1$tmp$4#0" = icmp slt i64 %"stride#0", 0 
-  br i1 %"1$tmp$4#0", label %if.then, label %if.else 
+  %"1$tmp$4##0" = icmp slt i64 %"stride##0", 0 
+  br i1 %"1$tmp$4##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = sub   i64 %"end#0", 1 
+  %"2$tmp$2##0" = sub   i64 %"end##0", 1 
   %124 = trunc i64 24 to i32  
   %125 = tail call ccc  i8*  @wybe_malloc(i32  %124)  
   %126 = ptrtoint i8* %125 to i64 
   %127 = inttoptr i64 %126 to i64* 
   %128 = getelementptr  i64, i64* %127, i64 0 
-  store  i64 %"start#0", i64* %128 
+  store  i64 %"start##0", i64* %128 
   %129 = add   i64 %126, 8 
   %130 = inttoptr i64 %129 to i64* 
   %131 = getelementptr  i64, i64* %130, i64 0 
-  store  i64 %"stride#0", i64* %131 
+  store  i64 %"stride##0", i64* %131 
   %132 = add   i64 %126, 16 
   %133 = inttoptr i64 %132 to i64* 
   %134 = getelementptr  i64, i64* %133, i64 0 
-  store  i64 %"2$tmp$2#0", i64* %134 
+  store  i64 %"2$tmp$2##0", i64* %134 
   ret i64 %126 
 if.else:
-  %"3$tmp$3#0" = add   i64 %"end#0", 1 
+  %"3$tmp$3##0" = add   i64 %"end##0", 1 
   %135 = trunc i64 24 to i32  
   %136 = tail call ccc  i8*  @wybe_malloc(i32  %135)  
   %137 = ptrtoint i8* %136 to i64 
   %138 = inttoptr i64 %137 to i64* 
   %139 = getelementptr  i64, i64* %138, i64 0 
-  store  i64 %"start#0", i64* %139 
+  store  i64 %"start##0", i64* %139 
   %140 = add   i64 %137, 8 
   %141 = inttoptr i64 %140 to i64* 
   %142 = getelementptr  i64, i64* %141, i64 0 
-  store  i64 %"stride#0", i64* %142 
+  store  i64 %"stride##0", i64* %142 
   %143 = add   i64 %137, 16 
   %144 = inttoptr i64 %143 to i64* 
   %145 = getelementptr  i64, i64* %144, i64 0 
-  store  i64 %"3$tmp$3#0", i64* %145 
+  store  i64 %"3$tmp$3##0", i64* %145 
   ret i64 %137 
 }
 
@@ -1431,9 +1431,9 @@ entry:
 
 define external fastcc  i1 @"stmt_for.semi_det_for_loop<0>"()    {
 entry:
-  %"1$tmp$3#0" = tail call fastcc  i64  @"stmt_for.xrange<0>"(i64  0, i64  1, i64  10)  
-  %"1$$$#0" = tail call fastcc  i1  @"stmt_for.gen$4<0>"(i64  %"1$tmp$3#0", i64  %"1$tmp$3#0")  
-  ret i1 %"1$$$#0" 
+  %"1$tmp$3##0" = tail call fastcc  i64  @"stmt_for.xrange<0>"(i64  0, i64  1, i64  10)  
+  %"1$$$##0" = tail call fastcc  i1  @"stmt_for.gen$4<0>"(i64  %"1$tmp$3##0", i64  %"1$tmp$3##0")  
+  ret i1 %"1$$$##0" 
 }
 
 
@@ -1590,16 +1590,16 @@ entry:
 
 define external fastcc  void @"stmt_for.using_irange<0>"()    {
 entry:
-  %"1$tmp$3#0" = tail call fastcc  i64  @"stmt_for.irange<0>"(i64  1, i64  1, i64  10)  
-  tail call fastcc  void  @"stmt_for.gen$12<0>"(i64  %"1$tmp$3#0", i64  %"1$tmp$3#0")  
+  %"1$tmp$3##0" = tail call fastcc  i64  @"stmt_for.irange<0>"(i64  1, i64  1, i64  10)  
+  tail call fastcc  void  @"stmt_for.gen$12<0>"(i64  %"1$tmp$3##0", i64  %"1$tmp$3##0")  
   ret void 
 }
 
 
 define external fastcc  void @"stmt_for.using_irange_reverse<0>"()    {
 entry:
-  %"1$tmp$3#0" = tail call fastcc  i64  @"stmt_for.irange<0>"(i64  10, i64  -1, i64  1)  
-  tail call fastcc  void  @"stmt_for.gen$13<0>"(i64  %"1$tmp$3#0", i64  %"1$tmp$3#0")  
+  %"1$tmp$3##0" = tail call fastcc  i64  @"stmt_for.irange<0>"(i64  10, i64  -1, i64  1)  
+  tail call fastcc  void  @"stmt_for.gen$13<0>"(i64  %"1$tmp$3##0", i64  %"1$tmp$3##0")  
   ret void 
 }
 
@@ -1841,36 +1841,36 @@ entry:
 
 define external fastcc  void @"stmt_for.using_xrange<0>"()    {
 entry:
-  %"1$tmp$3#0" = tail call fastcc  i64  @"stmt_for.xrange<0>"(i64  1, i64  1, i64  10)  
-  tail call fastcc  void  @"stmt_for.gen$24<0>"(i64  %"1$tmp$3#0", i64  %"1$tmp$3#0")  
+  %"1$tmp$3##0" = tail call fastcc  i64  @"stmt_for.xrange<0>"(i64  1, i64  1, i64  10)  
+  tail call fastcc  void  @"stmt_for.gen$24<0>"(i64  %"1$tmp$3##0", i64  %"1$tmp$3##0")  
   ret void 
 }
 
 
 define external fastcc  void @"stmt_for.using_xrange_reverse<0>"()    {
 entry:
-  %"1$tmp$3#0" = tail call fastcc  i64  @"stmt_for.xrange<0>"(i64  10, i64  -1, i64  1)  
-  tail call fastcc  void  @"stmt_for.gen$25<0>"(i64  %"1$tmp$3#0", i64  %"1$tmp$3#0")  
+  %"1$tmp$3##0" = tail call fastcc  i64  @"stmt_for.xrange<0>"(i64  10, i64  -1, i64  1)  
+  tail call fastcc  void  @"stmt_for.gen$25<0>"(i64  %"1$tmp$3##0", i64  %"1$tmp$3##0")  
   ret void 
 }
 
 
-define external fastcc  i64 @"stmt_for.xrange<0>"(i64  %"start#0", i64  %"stride#0", i64  %"end#0")    {
+define external fastcc  i64 @"stmt_for.xrange<0>"(i64  %"start##0", i64  %"stride##0", i64  %"end##0")    {
 entry:
   %458 = trunc i64 24 to i32  
   %459 = tail call ccc  i8*  @wybe_malloc(i32  %458)  
   %460 = ptrtoint i8* %459 to i64 
   %461 = inttoptr i64 %460 to i64* 
   %462 = getelementptr  i64, i64* %461, i64 0 
-  store  i64 %"start#0", i64* %462 
+  store  i64 %"start##0", i64* %462 
   %463 = add   i64 %460, 8 
   %464 = inttoptr i64 %463 to i64* 
   %465 = getelementptr  i64, i64* %464, i64 0 
-  store  i64 %"stride#0", i64* %465 
+  store  i64 %"stride##0", i64* %465 
   %466 = add   i64 %460, 16 
   %467 = inttoptr i64 %466 to i64* 
   %468 = getelementptr  i64, i64* %467, i64 0 
-  store  i64 %"end#0", i64* %468 
+  store  i64 %"end##0", i64* %468 
   ret i64 %460 
 }
 --------------------------------------------------
@@ -1896,170 +1896,170 @@ entry:
 
 = > public {inline} (1 calls)
 0: stmt_for.int_sequence.=<0>
-=($left#0:stmt_for.int_sequence, $right#0:stmt_for.int_sequence, ?$$#0:wybe.bool):
+=($left##0:stmt_for.int_sequence, $right##0:stmt_for.int_sequence, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$start#0:wybe.int)
-    foreign lpvm access($left#0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$stride#0:wybe.int)
-    foreign lpvm access(~$left#0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$end#0:wybe.int)
-    foreign lpvm access($right#0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$start#0:wybe.int)
-    foreign lpvm access($right#0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$stride#0:wybe.int)
-    foreign lpvm access(~$right#0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$end#0:wybe.int)
-    foreign llvm icmp_eq(~$left$start#0:wybe.int, ~$right$start#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$start##0:wybe.int)
+    foreign lpvm access($left##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$stride##0:wybe.int)
+    foreign lpvm access(~$left##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$end##0:wybe.int)
+    foreign lpvm access($right##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$start##0:wybe.int)
+    foreign lpvm access($right##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$stride##0:wybe.int)
+    foreign lpvm access(~$right##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$end##0:wybe.int)
+    foreign llvm icmp_eq(~$left$start##0:wybe.int, ~$right$start##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$stride#0:wybe.int, ~$right$stride#0:wybe.int, ?tmp$2#0:wybe.bool) @int:nn:nn
-        case ~tmp$2#0:wybe.bool of
+        foreign llvm icmp_eq(~$left$stride##0:wybe.int, ~$right$stride##0:wybe.int, ?tmp$2##0:wybe.bool) @int:nn:nn
+        case ~tmp$2##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~$left$end#0:wybe.int, ~$right$end#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+            foreign llvm icmp_eq(~$left$end##0:wybe.int, ~$right$end##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 
 [|] > public (0 calls)
 0: stmt_for.int_sequence.[|]<0>
-[|](?value#0:wybe.int, ?rest#0:stmt_for.int_sequence, current#0:stmt_for.int_sequence, ?$$#0:wybe.bool):
+[|](?value##0:wybe.int, ?rest##0:stmt_for.int_sequence, current##0:stmt_for.int_sequence, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(current#0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?s#0:wybe.int)
-    foreign lpvm access(current#0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?st#0:wybe.int)
-    foreign lpvm access(~current#0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?en#0:wybe.int)
-    foreign llvm icmp_slt(st#0:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.bool) @int:nn:nn
-    case ~tmp$4#0:wybe.bool of
+    foreign lpvm access(current##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?s##0:wybe.int)
+    foreign lpvm access(current##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?st##0:wybe.int)
+    foreign lpvm access(~current##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?en##0:wybe.int)
+    foreign llvm icmp_slt(st##0:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
+    case ~tmp$4##0:wybe.bool of
     0:
-        foreign llvm icmp_sgt(en#0:wybe.int, s#0:wybe.int, ?tmp$3#0:wybe.bool) @int:nn:nn
-        case ~tmp$3#0:wybe.bool of
+        foreign llvm icmp_sgt(en##0:wybe.int, s##0:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
+        case ~tmp$3##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?value#0:wybe.int)
-            foreign llvm move(undef:stmt_for.int_sequence, ?rest#0:stmt_for.int_sequence)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?value##0:wybe.int)
+            foreign llvm move(undef:stmt_for.int_sequence, ?rest##0:stmt_for.int_sequence)
 
         1:
-            stmt_for.int_sequence.gen$1<0>(_:stmt_for.int_sequence, ~en#0:wybe.int, ~s#0:wybe.int, ~st#0:wybe.int, ?value#0:wybe.int, ?rest#0:stmt_for.int_sequence, ?$$#0:wybe.bool) #5
+            stmt_for.int_sequence.gen$1<0>(_:stmt_for.int_sequence, ~en##0:wybe.int, ~s##0:wybe.int, ~st##0:wybe.int, ?value##0:wybe.int, ?rest##0:stmt_for.int_sequence, ?$$##0:wybe.bool) #5
 
 
     1:
-        foreign llvm icmp_slt(en#0:wybe.int, s#0:wybe.int, ?tmp$2#0:wybe.bool) @int:nn:nn
-        case ~tmp$2#0:wybe.bool of
+        foreign llvm icmp_slt(en##0:wybe.int, s##0:wybe.int, ?tmp$2##0:wybe.bool) @int:nn:nn
+        case ~tmp$2##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(undef:wybe.int, ?value#0:wybe.int)
-            foreign llvm move(undef:stmt_for.int_sequence, ?rest#0:stmt_for.int_sequence)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(undef:wybe.int, ?value##0:wybe.int)
+            foreign llvm move(undef:stmt_for.int_sequence, ?rest##0:stmt_for.int_sequence)
 
         1:
-            stmt_for.int_sequence.gen$1<0>(_:stmt_for.int_sequence, ~en#0:wybe.int, ~s#0:wybe.int, ~st#0:wybe.int, ?value#0:wybe.int, ?rest#0:stmt_for.int_sequence, ?$$#0:wybe.bool) #3
+            stmt_for.int_sequence.gen$1<0>(_:stmt_for.int_sequence, ~en##0:wybe.int, ~s##0:wybe.int, ~st##0:wybe.int, ?value##0:wybe.int, ?rest##0:stmt_for.int_sequence, ?$$##0:wybe.bool) #3
 
 
 
 
 end > public {inline} (0 calls)
 0: stmt_for.int_sequence.end<0>
-end($rec#0:stmt_for.int_sequence, ?$#0:wybe.int):
+end($rec##0:stmt_for.int_sequence, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 end > public {inline} (0 calls)
 1: stmt_for.int_sequence.end<1>
-end($rec#0:stmt_for.int_sequence, ?$rec#1:stmt_for.int_sequence, $field#0:wybe.int):
+end($rec##0:stmt_for.int_sequence, ?$rec##1:stmt_for.int_sequence, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:stmt_for.int_sequence, ?$rec#1:stmt_for.int_sequence, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:stmt_for.int_sequence, ?$rec##1:stmt_for.int_sequence, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 gen$1 > (2 calls)
 0: stmt_for.int_sequence.gen$1<0>
-gen$1([current#0:stmt_for.int_sequence], en#0:wybe.int, s#0:wybe.int, st#0:wybe.int, ?value#0:wybe.int, ?rest#0:stmt_for.int_sequence, ?$$#0:wybe.bool):
+gen$1([current##0:stmt_for.int_sequence], en##0:wybe.int, s##0:wybe.int, st##0:wybe.int, ?value##0:wybe.int, ?rest##0:stmt_for.int_sequence, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(s#0:wybe.int, ?value#0:wybe.int) @stmt_for:nn:nn
-    foreign llvm add(~s#0:wybe.int, st#0:wybe.int, ?tmp$1#0:wybe.int) @int:nn:nn
-    foreign lpvm alloc(24:wybe.int, ?tmp$7#0:stmt_for.int_sequence)
-    foreign lpvm mutate(~tmp$7#0:stmt_for.int_sequence, ?tmp$8#0:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp$1#0:wybe.int)
-    foreign lpvm mutate(~tmp$8#0:stmt_for.int_sequence, ?tmp$9#0:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~st#0:wybe.int)
-    foreign lpvm mutate(~tmp$9#0:stmt_for.int_sequence, ?rest#0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~en#0:wybe.int)
-    foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+    foreign llvm move(s##0:wybe.int, ?value##0:wybe.int) @stmt_for:nn:nn
+    foreign llvm add(~s##0:wybe.int, st##0:wybe.int, ?tmp$1##0:wybe.int) @int:nn:nn
+    foreign lpvm alloc(24:wybe.int, ?tmp$7##0:stmt_for.int_sequence)
+    foreign lpvm mutate(~tmp$7##0:stmt_for.int_sequence, ?tmp$8##0:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp$1##0:wybe.int)
+    foreign lpvm mutate(~tmp$8##0:stmt_for.int_sequence, ?tmp$9##0:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~st##0:wybe.int)
+    foreign lpvm mutate(~tmp$9##0:stmt_for.int_sequence, ?rest##0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~en##0:wybe.int)
+    foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 int_sequence > public {inline} (1 calls)
 0: stmt_for.int_sequence.int_sequence<0>
-int_sequence(start#0:wybe.int, stride#0:wybe.int, end#0:wybe.int, ?$#0:stmt_for.int_sequence):
+int_sequence(start##0:wybe.int, stride##0:wybe.int, end##0:wybe.int, ?$##0:stmt_for.int_sequence):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?$rec#0:stmt_for.int_sequence)
-    foreign lpvm mutate(~$rec#0:stmt_for.int_sequence, ?$rec#1:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~start#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:stmt_for.int_sequence, ?$rec#2:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~stride#0:wybe.int)
-    foreign lpvm mutate(~$rec#2:stmt_for.int_sequence, ?$#0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~end#0:wybe.int)
+    foreign lpvm alloc(24:wybe.int, ?$rec##0:stmt_for.int_sequence)
+    foreign lpvm mutate(~$rec##0:stmt_for.int_sequence, ?$rec##1:stmt_for.int_sequence, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~start##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:stmt_for.int_sequence, ?$rec##2:stmt_for.int_sequence, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~stride##0:wybe.int)
+    foreign lpvm mutate(~$rec##2:stmt_for.int_sequence, ?$##0:stmt_for.int_sequence, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~end##0:wybe.int)
 int_sequence > public {inline} (16 calls)
 1: stmt_for.int_sequence.int_sequence<1>
-int_sequence(?start#0:wybe.int, ?stride#0:wybe.int, ?end#0:wybe.int, $#0:stmt_for.int_sequence):
+int_sequence(?start##0:wybe.int, ?stride##0:wybe.int, ?end##0:wybe.int, $##0:stmt_for.int_sequence):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?start#0:wybe.int)
-    foreign lpvm access($#0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?stride#0:wybe.int)
-    foreign lpvm access(~$#0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?end#0:wybe.int)
+    foreign lpvm access($##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?start##0:wybe.int)
+    foreign lpvm access($##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?stride##0:wybe.int)
+    foreign lpvm access(~$##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?end##0:wybe.int)
 
 
 start > public {inline} (0 calls)
 0: stmt_for.int_sequence.start<0>
-start($rec#0:stmt_for.int_sequence, ?$#0:wybe.int):
+start($rec##0:stmt_for.int_sequence, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 start > public {inline} (0 calls)
 1: stmt_for.int_sequence.start<1>
-start($rec#0:stmt_for.int_sequence, ?$rec#1:stmt_for.int_sequence, $field#0:wybe.int):
+start($rec##0:stmt_for.int_sequence, ?$rec##1:stmt_for.int_sequence, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:stmt_for.int_sequence, ?$rec#1:stmt_for.int_sequence, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:stmt_for.int_sequence, ?$rec##1:stmt_for.int_sequence, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 stride > public {inline} (0 calls)
 0: stmt_for.int_sequence.stride<0>
-stride($rec#0:stmt_for.int_sequence, ?$#0:wybe.int):
+stride($rec##0:stmt_for.int_sequence, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 stride > public {inline} (0 calls)
 1: stmt_for.int_sequence.stride<1>
-stride($rec#0:stmt_for.int_sequence, ?$rec#1:stmt_for.int_sequence, $field#0:wybe.int):
+stride($rec##0:stmt_for.int_sequence, ?$rec##1:stmt_for.int_sequence, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:stmt_for.int_sequence, ?$rec#1:stmt_for.int_sequence, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:stmt_for.int_sequence, ?$rec##1:stmt_for.int_sequence, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: stmt_for.int_sequence.~=<0>
-~=($left#0:stmt_for.int_sequence, $right#0:stmt_for.int_sequence, ?$$#0:wybe.bool):
+~=($left##0:stmt_for.int_sequence, $right##0:stmt_for.int_sequence, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access($left#0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access(~$left#0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access($right#0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign lpvm access($right#0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$7#0:wybe.int)
-    foreign lpvm access(~$right#0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$9#0:wybe.bool) @int:nn:nn
-    case ~tmp$9#0:wybe.bool of
+    foreign lpvm access($left##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access($left##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access(~$left##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access($right##0:stmt_for.int_sequence, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign lpvm access($right##0:stmt_for.int_sequence, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.int)
+    foreign lpvm access(~$right##0:stmt_for.int_sequence, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$9##0:wybe.bool) @int:nn:nn
+    case ~tmp$9##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$7#0:wybe.int, ?tmp$10#0:wybe.bool) @int:nn:nn
-        case ~tmp$10#0:wybe.bool of
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$7##0:wybe.int, ?tmp$10##0:wybe.bool) @int:nn:nn
+        case ~tmp$10##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-            foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~tmp$5#0:wybe.int, ~tmp$8#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-            foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm icmp_eq(~tmp$5##0:wybe.int, ~tmp$8##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
@@ -2077,66 +2077,66 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"stmt_for.int_sequence.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"stmt_for.int_sequence.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = add   i64 %"$left#0", 16 
+  %8 = add   i64 %"$left##0", 16 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
-  %12 = inttoptr i64 %"$right#0" to i64* 
+  %12 = inttoptr i64 %"$right##0" to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %15 = add   i64 %"$right#0", 8 
+  %15 = add   i64 %"$right##0", 8 
   %16 = inttoptr i64 %15 to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
-  %19 = add   i64 %"$right#0", 16 
+  %19 = add   i64 %"$right##0", 16 
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %"1$tmp$1#0" = icmp eq i64 %3, %14 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %14 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = icmp eq i64 %7, %18 
-  br i1 %"2$tmp$2#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = icmp eq i64 %7, %18 
+  br i1 %"2$tmp$2##0", label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %"4$$$#0" = icmp eq i64 %11, %22 
-  ret i1 %"4$$$#0" 
+  %"4$$$##0" = icmp eq i64 %11, %22 
+  ret i1 %"4$$$##0" 
 if.else1:
   ret i1 0 
 }
 
 
-define external fastcc  {i64, i64, i1} @"stmt_for.int_sequence.[|]<0>"(i64  %"current#0")    {
+define external fastcc  {i64, i64, i1} @"stmt_for.int_sequence.[|]<0>"(i64  %"current##0")    {
 entry:
-  %23 = inttoptr i64 %"current#0" to i64* 
+  %23 = inttoptr i64 %"current##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"current#0", 8 
+  %26 = add   i64 %"current##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
-  %30 = add   i64 %"current#0", 16 
+  %30 = add   i64 %"current##0", 16 
   %31 = inttoptr i64 %30 to i64* 
   %32 = getelementptr  i64, i64* %31, i64 0 
   %33 = load  i64, i64* %32 
-  %"1$tmp$4#0" = icmp slt i64 %29, 0 
-  br i1 %"1$tmp$4#0", label %if.then, label %if.else 
+  %"1$tmp$4##0" = icmp slt i64 %29, 0 
+  br i1 %"1$tmp$4##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = icmp slt i64 %33, %25 
-  br i1 %"2$tmp$2#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = icmp slt i64 %33, %25 
+  br i1 %"2$tmp$2##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$tmp$3#0" = icmp sgt i64 %33, %25 
-  br i1 %"3$tmp$3#0", label %if.then2, label %if.else2 
+  %"3$tmp$3##0" = icmp sgt i64 %33, %25 
+  br i1 %"3$tmp$3##0", label %if.then2, label %if.else2 
 if.then1:
   %34 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.gen$1<0>"(i64  %33, i64  %25, i64  %29)  
   %35 = extractvalue {i64, i64, i1} %34, 0 
@@ -2168,9 +2168,9 @@ if.else2:
 }
 
 
-define external fastcc  i64 @"stmt_for.int_sequence.end<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"stmt_for.int_sequence.end<0>"(i64  %"$rec##0")    {
 entry:
-  %54 = add   i64 %"$rec#0", 16 
+  %54 = add   i64 %"$rec##0", 16 
   %55 = inttoptr i64 %54 to i64* 
   %56 = getelementptr  i64, i64* %55, i64 0 
   %57 = load  i64, i64* %56 
@@ -2178,77 +2178,77 @@ entry:
 }
 
 
-define external fastcc  i64 @"stmt_for.int_sequence.end<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"stmt_for.int_sequence.end<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %58 = trunc i64 24 to i32  
   %59 = tail call ccc  i8*  @wybe_malloc(i32  %58)  
   %60 = ptrtoint i8* %59 to i64 
   %61 = inttoptr i64 %60 to i8* 
-  %62 = inttoptr i64 %"$rec#0" to i8* 
+  %62 = inttoptr i64 %"$rec##0" to i8* 
   %63 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %61, i8*  %62, i32  %63, i32  8, i1  0)  
   %64 = add   i64 %60, 16 
   %65 = inttoptr i64 %64 to i64* 
   %66 = getelementptr  i64, i64* %65, i64 0 
-  store  i64 %"$field#0", i64* %66 
+  store  i64 %"$field##0", i64* %66 
   ret i64 %60 
 }
 
 
-define external fastcc  {i64, i64, i1} @"stmt_for.int_sequence.gen$1<0>"(i64  %"en#0", i64  %"s#0", i64  %"st#0")    {
+define external fastcc  {i64, i64, i1} @"stmt_for.int_sequence.gen$1<0>"(i64  %"en##0", i64  %"s##0", i64  %"st##0")    {
 entry:
-  %"1$tmp$1#0" = add   i64 %"s#0", %"st#0" 
+  %"1$tmp$1##0" = add   i64 %"s##0", %"st##0" 
   %67 = trunc i64 24 to i32  
   %68 = tail call ccc  i8*  @wybe_malloc(i32  %67)  
   %69 = ptrtoint i8* %68 to i64 
   %70 = inttoptr i64 %69 to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
-  store  i64 %"1$tmp$1#0", i64* %71 
+  store  i64 %"1$tmp$1##0", i64* %71 
   %72 = add   i64 %69, 8 
   %73 = inttoptr i64 %72 to i64* 
   %74 = getelementptr  i64, i64* %73, i64 0 
-  store  i64 %"st#0", i64* %74 
+  store  i64 %"st##0", i64* %74 
   %75 = add   i64 %69, 16 
   %76 = inttoptr i64 %75 to i64* 
   %77 = getelementptr  i64, i64* %76, i64 0 
-  store  i64 %"en#0", i64* %77 
-  %78 = insertvalue {i64, i64, i1} undef, i64 %"s#0", 0 
+  store  i64 %"en##0", i64* %77 
+  %78 = insertvalue {i64, i64, i1} undef, i64 %"s##0", 0 
   %79 = insertvalue {i64, i64, i1} %78, i64 %69, 1 
   %80 = insertvalue {i64, i64, i1} %79, i1 1, 2 
   ret {i64, i64, i1} %80 
 }
 
 
-define external fastcc  i64 @"stmt_for.int_sequence.int_sequence<0>"(i64  %"start#0", i64  %"stride#0", i64  %"end#0")    {
+define external fastcc  i64 @"stmt_for.int_sequence.int_sequence<0>"(i64  %"start##0", i64  %"stride##0", i64  %"end##0")    {
 entry:
   %81 = trunc i64 24 to i32  
   %82 = tail call ccc  i8*  @wybe_malloc(i32  %81)  
   %83 = ptrtoint i8* %82 to i64 
   %84 = inttoptr i64 %83 to i64* 
   %85 = getelementptr  i64, i64* %84, i64 0 
-  store  i64 %"start#0", i64* %85 
+  store  i64 %"start##0", i64* %85 
   %86 = add   i64 %83, 8 
   %87 = inttoptr i64 %86 to i64* 
   %88 = getelementptr  i64, i64* %87, i64 0 
-  store  i64 %"stride#0", i64* %88 
+  store  i64 %"stride##0", i64* %88 
   %89 = add   i64 %83, 16 
   %90 = inttoptr i64 %89 to i64* 
   %91 = getelementptr  i64, i64* %90, i64 0 
-  store  i64 %"end#0", i64* %91 
+  store  i64 %"end##0", i64* %91 
   ret i64 %83 
 }
 
 
-define external fastcc  {i64, i64, i64} @"stmt_for.int_sequence.int_sequence<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64, i64} @"stmt_for.int_sequence.int_sequence<1>"(i64  %"$##0")    {
 entry:
-  %92 = inttoptr i64 %"$#0" to i64* 
+  %92 = inttoptr i64 %"$##0" to i64* 
   %93 = getelementptr  i64, i64* %92, i64 0 
   %94 = load  i64, i64* %93 
-  %95 = add   i64 %"$#0", 8 
+  %95 = add   i64 %"$##0", 8 
   %96 = inttoptr i64 %95 to i64* 
   %97 = getelementptr  i64, i64* %96, i64 0 
   %98 = load  i64, i64* %97 
-  %99 = add   i64 %"$#0", 16 
+  %99 = add   i64 %"$##0", 16 
   %100 = inttoptr i64 %99 to i64* 
   %101 = getelementptr  i64, i64* %100, i64 0 
   %102 = load  i64, i64* %101 
@@ -2259,34 +2259,34 @@ entry:
 }
 
 
-define external fastcc  i64 @"stmt_for.int_sequence.start<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"stmt_for.int_sequence.start<0>"(i64  %"$rec##0")    {
 entry:
-  %106 = inttoptr i64 %"$rec#0" to i64* 
+  %106 = inttoptr i64 %"$rec##0" to i64* 
   %107 = getelementptr  i64, i64* %106, i64 0 
   %108 = load  i64, i64* %107 
   ret i64 %108 
 }
 
 
-define external fastcc  i64 @"stmt_for.int_sequence.start<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"stmt_for.int_sequence.start<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %109 = trunc i64 24 to i32  
   %110 = tail call ccc  i8*  @wybe_malloc(i32  %109)  
   %111 = ptrtoint i8* %110 to i64 
   %112 = inttoptr i64 %111 to i8* 
-  %113 = inttoptr i64 %"$rec#0" to i8* 
+  %113 = inttoptr i64 %"$rec##0" to i8* 
   %114 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %112, i8*  %113, i32  %114, i32  8, i1  0)  
   %115 = inttoptr i64 %111 to i64* 
   %116 = getelementptr  i64, i64* %115, i64 0 
-  store  i64 %"$field#0", i64* %116 
+  store  i64 %"$field##0", i64* %116 
   ret i64 %111 
 }
 
 
-define external fastcc  i64 @"stmt_for.int_sequence.stride<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"stmt_for.int_sequence.stride<0>"(i64  %"$rec##0")    {
 entry:
-  %117 = add   i64 %"$rec#0", 8 
+  %117 = add   i64 %"$rec##0", 8 
   %118 = inttoptr i64 %117 to i64* 
   %119 = getelementptr  i64, i64* %118, i64 0 
   %120 = load  i64, i64* %119 
@@ -2294,60 +2294,60 @@ entry:
 }
 
 
-define external fastcc  i64 @"stmt_for.int_sequence.stride<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"stmt_for.int_sequence.stride<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %121 = trunc i64 24 to i32  
   %122 = tail call ccc  i8*  @wybe_malloc(i32  %121)  
   %123 = ptrtoint i8* %122 to i64 
   %124 = inttoptr i64 %123 to i8* 
-  %125 = inttoptr i64 %"$rec#0" to i8* 
+  %125 = inttoptr i64 %"$rec##0" to i8* 
   %126 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %124, i8*  %125, i32  %126, i32  8, i1  0)  
   %127 = add   i64 %123, 8 
   %128 = inttoptr i64 %127 to i64* 
   %129 = getelementptr  i64, i64* %128, i64 0 
-  store  i64 %"$field#0", i64* %129 
+  store  i64 %"$field##0", i64* %129 
   ret i64 %123 
 }
 
 
-define external fastcc  i1 @"stmt_for.int_sequence.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"stmt_for.int_sequence.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %130 = inttoptr i64 %"$left#0" to i64* 
+  %130 = inttoptr i64 %"$left##0" to i64* 
   %131 = getelementptr  i64, i64* %130, i64 0 
   %132 = load  i64, i64* %131 
-  %133 = add   i64 %"$left#0", 8 
+  %133 = add   i64 %"$left##0", 8 
   %134 = inttoptr i64 %133 to i64* 
   %135 = getelementptr  i64, i64* %134, i64 0 
   %136 = load  i64, i64* %135 
-  %137 = add   i64 %"$left#0", 16 
+  %137 = add   i64 %"$left##0", 16 
   %138 = inttoptr i64 %137 to i64* 
   %139 = getelementptr  i64, i64* %138, i64 0 
   %140 = load  i64, i64* %139 
-  %141 = inttoptr i64 %"$right#0" to i64* 
+  %141 = inttoptr i64 %"$right##0" to i64* 
   %142 = getelementptr  i64, i64* %141, i64 0 
   %143 = load  i64, i64* %142 
-  %144 = add   i64 %"$right#0", 8 
+  %144 = add   i64 %"$right##0", 8 
   %145 = inttoptr i64 %144 to i64* 
   %146 = getelementptr  i64, i64* %145, i64 0 
   %147 = load  i64, i64* %146 
-  %148 = add   i64 %"$right#0", 16 
+  %148 = add   i64 %"$right##0", 16 
   %149 = inttoptr i64 %148 to i64* 
   %150 = getelementptr  i64, i64* %149, i64 0 
   %151 = load  i64, i64* %150 
-  %"1$tmp$9#0" = icmp eq i64 %132, %143 
-  br i1 %"1$tmp$9#0", label %if.then, label %if.else 
+  %"1$tmp$9##0" = icmp eq i64 %132, %143 
+  br i1 %"1$tmp$9##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$10#0" = icmp eq i64 %136, %147 
-  br i1 %"2$tmp$10#0", label %if.then1, label %if.else1 
+  %"2$tmp$10##0" = icmp eq i64 %136, %147 
+  br i1 %"2$tmp$10##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 if.then1:
-  %"4$tmp$0#0" = icmp eq i64 %140, %151 
-  %"4$$$#0" = xor i1 %"4$tmp$0#0", 1 
-  ret i1 %"4$$$#0" 
+  %"4$tmp$0##0" = icmp eq i64 %140, %151 
+  %"4$$$##0" = xor i1 %"4$tmp$0##0", 1 
+  ret i1 %"4$$$##0" 
 if.else1:
-  %"5$$$#0" = xor i1 0, 1 
-  ret i1 %"5$$$#0" 
+  %"5$$$##0" = xor i1 0, 1 
+  ret i1 %"5$$$##0" 
 }

--- a/test-cases/final-dump/stmt_if.exp
+++ b/test-cases/final-dump/stmt_if.exp
@@ -272,25 +272,25 @@ if.else2:
 
 empty > public {inline} (0 calls)
 0: stmt_if.tree.empty<0>
-empty(?###0:stmt_if.tree):
+empty(?#result##0:stmt_if.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:stmt_if.tree, ?###0:stmt_if.tree)
+    foreign llvm move(0:stmt_if.tree, ?#result##0:stmt_if.tree)
 
 
 key > public {inline} (0 calls)
 0: stmt_if.tree.key<0>
-key(#rec##0:stmt_if.tree, ?###0:wybe.int, ?####0:wybe.bool):
+key(#rec##0:stmt_if.tree, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign lpvm access(~#rec##0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 key > public {inline} (0 calls)
@@ -312,17 +312,17 @@ key(#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, #field##0:wybe.int, ?####0:wybe
 
 left > public {inline} (0 calls)
 0: stmt_if.tree.left<0>
-left(#rec##0:stmt_if.tree, ?###0:stmt_if.tree, ?####0:wybe.bool):
+left(#rec##0:stmt_if.tree, ?#result##0:stmt_if.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:stmt_if.tree, ?###0:stmt_if.tree)
+        foreign llvm move(undef:stmt_if.tree, ?#result##0:stmt_if.tree)
 
     1:
-        foreign lpvm access(~#rec##0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:stmt_if.tree)
+        foreign lpvm access(~#rec##0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:stmt_if.tree)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 left > public {inline} (0 calls)
@@ -344,19 +344,19 @@ left(#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, #field##0:stmt_if.tree, ?####0
 
 node > public {inline} (0 calls)
 0: stmt_if.tree.node<0>
-node(left##0:stmt_if.tree, key##0:wybe.int, right##0:stmt_if.tree, ?###0:stmt_if.tree):
+node(left##0:stmt_if.tree, key##0:wybe.int, right##0:stmt_if.tree, ?#result##0:stmt_if.tree):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(24:wybe.int, ?#rec##0:stmt_if.tree)
     foreign lpvm mutate(~#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:stmt_if.tree)
     foreign lpvm mutate(~#rec##1:stmt_if.tree, ?#rec##2:stmt_if.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int)
-    foreign lpvm mutate(~#rec##2:stmt_if.tree, ?###0:stmt_if.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:stmt_if.tree)
+    foreign lpvm mutate(~#rec##2:stmt_if.tree, ?#result##0:stmt_if.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:stmt_if.tree)
 node > public {inline} (16 calls)
 1: stmt_if.tree.node<1>
-node(?left##0:stmt_if.tree, ?key##0:wybe.int, ?right##0:stmt_if.tree, ###0:stmt_if.tree, ?####0:wybe.bool):
+node(?left##0:stmt_if.tree, ?key##0:wybe.int, ?right##0:stmt_if.tree, #result##0:stmt_if.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
@@ -365,26 +365,26 @@ node(?left##0:stmt_if.tree, ?key##0:wybe.int, ?right##0:stmt_if.tree, ###0:stmt_
         foreign llvm move(undef:stmt_if.tree, ?right##0:stmt_if.tree)
 
     1:
-        foreign lpvm access(###0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:stmt_if.tree)
-        foreign lpvm access(###0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
-        foreign lpvm access(~###0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:stmt_if.tree)
+        foreign lpvm access(#result##0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:stmt_if.tree)
+        foreign lpvm access(#result##0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
+        foreign lpvm access(~#result##0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:stmt_if.tree)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 right > public {inline} (0 calls)
 0: stmt_if.tree.right<0>
-right(#rec##0:stmt_if.tree, ?###0:stmt_if.tree, ?####0:wybe.bool):
+right(#rec##0:stmt_if.tree, ?#result##0:stmt_if.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:stmt_if.tree, ?###0:stmt_if.tree)
+        foreign llvm move(undef:stmt_if.tree, ?#result##0:stmt_if.tree)
 
     1:
-        foreign lpvm access(~#rec##0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:stmt_if.tree)
+        foreign lpvm access(~#rec##0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:stmt_if.tree)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 right > public {inline} (0 calls)
@@ -590,19 +590,19 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64, i1} @"stmt_if.tree.node<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64, i64, i1} @"stmt_if.tree.node<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  %"1#tmp#0##0" = icmp ne i64 %"#result##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %74 = inttoptr i64 %"###0" to i64* 
+  %74 = inttoptr i64 %"#result##0" to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
   %76 = load  i64, i64* %75 
-  %77 = add   i64 %"###0", 8 
+  %77 = add   i64 %"#result##0", 8 
   %78 = inttoptr i64 %77 to i64* 
   %79 = getelementptr  i64, i64* %78, i64 0 
   %80 = load  i64, i64* %79 
-  %81 = add   i64 %"###0", 16 
+  %81 = add   i64 %"#result##0", 16 
   %82 = inttoptr i64 %81 to i64* 
   %83 = getelementptr  i64, i64* %82, i64 0 
   %84 = load  i64, i64* %83 

--- a/test-cases/final-dump/stmt_if.exp
+++ b/test-cases/final-dump/stmt_if.exp
@@ -27,38 +27,38 @@ foobar > (0 calls)
 foobar(io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp$8##0:stmt_if.tree)
-    foreign lpvm mutate(~tmp$8##0:stmt_if.tree, ?tmp$9##0:stmt_if.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:stmt_if.tree)
-    foreign lpvm mutate(~tmp$9##0:stmt_if.tree, ?tmp$10##0:stmt_if.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp$10##0:stmt_if.tree, ?tmp$11##0:stmt_if.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:stmt_if.tree)
-    stmt_if.lookup<0>(1:wybe.int, tmp$11##0:stmt_if.tree, ?tmp$4##0:wybe.bool) #3 @stmt_if:nn:nn
-    case ~tmp$4##0:wybe.bool of
+    foreign lpvm alloc(24:wybe.int, ?tmp#8##0:stmt_if.tree)
+    foreign lpvm mutate(~tmp#8##0:stmt_if.tree, ?tmp#9##0:stmt_if.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:stmt_if.tree)
+    foreign lpvm mutate(~tmp#9##0:stmt_if.tree, ?tmp#10##0:stmt_if.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp#10##0:stmt_if.tree, ?tmp#11##0:stmt_if.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:stmt_if.tree)
+    stmt_if.lookup<0>(1:wybe.int, tmp#11##0:stmt_if.tree, ?tmp#4##0:wybe.bool) #3 @stmt_if:nn:nn
+    case ~tmp#4##0:wybe.bool of
     0:
-        foreign c print_string("lookup fails when it should succeed":wybe.string, ~#io##0:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_if.gen$1<0>(~io##1:wybe.phantom, _:stmt_if.tree, _:stmt_if.tree, _:stmt_if.tree, ~tmp$11##0:stmt_if.tree, ?io##2:wybe.phantom) #7
+        foreign c print_string("lookup fails when it should succeed":wybe.string, ~#io##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_if.gen#1<0>(~io##1:wybe.phantom, _:stmt_if.tree, _:stmt_if.tree, _:stmt_if.tree, ~tmp#11##0:stmt_if.tree, ?io##2:wybe.phantom) #7
 
     1:
-        foreign c print_string("lookup succeeds when it should":wybe.string, ~#io##0:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_if.gen$1<0>(~io##1:wybe.phantom, _:stmt_if.tree, _:stmt_if.tree, _:stmt_if.tree, ~tmp$11##0:stmt_if.tree, ?io##2:wybe.phantom) #5
+        foreign c print_string("lookup succeeds when it should":wybe.string, ~#io##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_if.gen#1<0>(~io##1:wybe.phantom, _:stmt_if.tree, _:stmt_if.tree, _:stmt_if.tree, ~tmp#11##0:stmt_if.tree, ?io##2:wybe.phantom) #5
 
 
 
-gen$1 > (2 calls)
-0: stmt_if.gen$1<0>
-gen$1(io##0:wybe.phantom, [tmp$0##0:stmt_if.tree], [tmp$1##0:stmt_if.tree], [tmp$2##0:stmt_if.tree], tr##0:stmt_if.tree, ?io##1:wybe.phantom):
+gen#1 > (2 calls)
+0: stmt_if.gen#1<0>
+gen#1(io##0:wybe.phantom, [tmp#0##0:stmt_if.tree], [tmp#1##0:stmt_if.tree], [tmp#2##0:stmt_if.tree], tr##0:stmt_if.tree, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_if.lookup<0>(3:wybe.int, ~tr##0:stmt_if.tree, ?tmp$3##0:wybe.bool) #0 @stmt_if:nn:nn
-    case ~tmp$3##0:wybe.bool of
+    stmt_if.lookup<0>(3:wybe.int, ~tr##0:stmt_if.tree, ?tmp#3##0:wybe.bool) #0 @stmt_if:nn:nn
+    case ~tmp#3##0:wybe.bool of
     0:
-        foreign c print_string("lookup succeeds when it should fail":wybe.string, ~#io##0:wybe.phantom, ?tmp$6##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        foreign c print_string("lookup succeeds when it should fail":wybe.string, ~#io##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
     1:
-        foreign c print_string("lookup fails when it should":wybe.string, ~#io##0:wybe.phantom, ?tmp$6##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        foreign c print_string("lookup fails when it should":wybe.string, ~#io##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 
@@ -67,8 +67,8 @@ lookup > public (8 calls)
 lookup(key##0:wybe.int, tree##0:stmt_if.tree, ?result##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(tree##0:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.bool)
-    case ~tmp$6##0:wybe.bool of
+    foreign llvm icmp_ne(tree##0:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.bool)
+    case ~tmp#6##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?result##0:wybe.bool) @stmt_if:nn:nn
 
@@ -76,11 +76,11 @@ lookup(key##0:wybe.int, tree##0:stmt_if.tree, ?result##0:wybe.bool):
         foreign lpvm access(tree##0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:stmt_if.tree)
         foreign lpvm access(tree##0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?nodekey##0:wybe.int)
         foreign lpvm access(~tree##0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:stmt_if.tree)
-        foreign llvm icmp_eq(key##0:wybe.int, nodekey##0:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
-        case ~tmp$3##0:wybe.bool of
+        foreign llvm icmp_eq(key##0:wybe.int, nodekey##0:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
+        case ~tmp#3##0:wybe.bool of
         0:
-            foreign llvm icmp_slt(key##0:wybe.int, ~nodekey##0:wybe.int, ?tmp$2##0:wybe.bool) @int:nn:nn
-            case ~tmp$2##0:wybe.bool of
+            foreign llvm icmp_slt(key##0:wybe.int, ~nodekey##0:wybe.int, ?tmp#2##0:wybe.bool) @int:nn:nn
+            case ~tmp#2##0:wybe.bool of
             0:
                 stmt_if.lookup<0>(~key##0:wybe.int, ~right##0:stmt_if.tree, ?result##0:wybe.bool) #5 @stmt_if:nn:nn
 
@@ -141,27 +141,27 @@ entry:
   %10 = inttoptr i64 %9 to i64* 
   %11 = getelementptr  i64, i64* %10, i64 0 
   store  i64 0, i64* %11 
-  %"1$tmp$4##0" = tail call fastcc  i1  @"stmt_if.lookup<0>"(i64  1, i64  %3)  
-  br i1 %"1$tmp$4##0", label %if.then, label %if.else 
+  %"1#tmp#4##0" = tail call fastcc  i1  @"stmt_if.lookup<0>"(i64  1, i64  %3)  
+  br i1 %"1#tmp#4##0", label %if.then, label %if.else 
 if.then:
   %13 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @stmt_if.12, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %13)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_if.gen$1<0>"(i64  %3)  
+  tail call fastcc  void  @"stmt_if.gen#1<0>"(i64  %3)  
   ret void 
 if.else:
   %15 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @stmt_if.14, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %15)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_if.gen$1<0>"(i64  %3)  
+  tail call fastcc  void  @"stmt_if.gen#1<0>"(i64  %3)  
   ret void 
 }
 
 
-define external fastcc  void @"stmt_if.gen$1<0>"(i64  %"tr##0")    {
+define external fastcc  void @"stmt_if.gen#1<0>"(i64  %"tr##0")    {
 entry:
-  %"1$tmp$3##0" = tail call fastcc  i1  @"stmt_if.lookup<0>"(i64  3, i64  %"tr##0")  
-  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
+  %"1#tmp#3##0" = tail call fastcc  i1  @"stmt_if.lookup<0>"(i64  3, i64  %"tr##0")  
+  br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
   %17 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @stmt_if.16, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %17)  
@@ -177,8 +177,8 @@ if.else:
 
 define external fastcc  i1 @"stmt_if.lookup<0>"(i64  %"key##0", i64  %"tree##0")    {
 entry:
-  %"1$tmp$6##0" = icmp ne i64 %"tree##0", 0 
-  br i1 %"1$tmp$6##0", label %if.then, label %if.else 
+  %"1#tmp#6##0" = icmp ne i64 %"tree##0", 0 
+  br i1 %"1#tmp#6##0", label %if.then, label %if.else 
 if.then:
   %20 = inttoptr i64 %"tree##0" to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
@@ -191,21 +191,21 @@ if.then:
   %28 = inttoptr i64 %27 to i64* 
   %29 = getelementptr  i64, i64* %28, i64 0 
   %30 = load  i64, i64* %29 
-  %"2$tmp$3##0" = icmp eq i64 %"key##0", %26 
-  br i1 %"2$tmp$3##0", label %if.then1, label %if.else1 
+  %"2#tmp#3##0" = icmp eq i64 %"key##0", %26 
+  br i1 %"2#tmp#3##0", label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
   ret i1 1 
 if.else1:
-  %"5$tmp$2##0" = icmp slt i64 %"key##0", %26 
-  br i1 %"5$tmp$2##0", label %if.then2, label %if.else2 
+  %"5#tmp#2##0" = icmp slt i64 %"key##0", %26 
+  br i1 %"5#tmp#2##0", label %if.then2, label %if.else2 
 if.then2:
-  %"6$result##0" = tail call fastcc  i1  @"stmt_if.lookup<0>"(i64  %"key##0", i64  %22)  
-  ret i1 %"6$result##0" 
+  %"6#result##0" = tail call fastcc  i1  @"stmt_if.lookup<0>"(i64  %"key##0", i64  %22)  
+  ret i1 %"6#result##0" 
 if.else2:
-  %"7$result##0" = tail call fastcc  i1  @"stmt_if.lookup<0>"(i64  %"key##0", i64  %30)  
-  ret i1 %"7$result##0" 
+  %"7#result##0" = tail call fastcc  i1  @"stmt_if.lookup<0>"(i64  %"key##0", i64  %30)  
+  ret i1 %"7#result##0" 
 }
 --------------------------------------------------
  Module stmt_if.tree
@@ -230,40 +230,40 @@ if.else2:
 
 = > public (7 calls)
 0: stmt_if.tree.=<0>
-=($left##0:stmt_if.tree, $right##0:stmt_if.tree, ?$$##0:wybe.bool):
+=(#left##0:stmt_if.tree, #right##0:stmt_if.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left##0:stmt_if.tree, ~$right##0:stmt_if.tree, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:stmt_if.tree, ~#right##0:stmt_if.tree, ?####0:wybe.bool)
 
     1:
-        foreign lpvm access($left##0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$left##0:stmt_if.tree)
-        foreign lpvm access($left##0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$key##0:wybe.int)
-        foreign lpvm access(~$left##0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$right##0:stmt_if.tree)
-        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.bool)
-        case ~tmp$10##0:wybe.bool of
+        foreign lpvm access(#left##0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#left##0:stmt_if.tree)
+        foreign lpvm access(#left##0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#key##0:wybe.int)
+        foreign lpvm access(~#left##0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#right##0:stmt_if.tree)
+        foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
+        case ~tmp#10##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign lpvm access($right##0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$left##0:stmt_if.tree)
-            foreign lpvm access($right##0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$key##0:wybe.int)
-            foreign lpvm access(~$right##0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$right##0:stmt_if.tree)
-            stmt_if.tree.=<0>(~$left$left##0:stmt_if.tree, ~$right$left##0:stmt_if.tree, ?tmp$4##0:wybe.bool) #2
-            case ~tmp$4##0:wybe.bool of
+            foreign lpvm access(#right##0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#left##0:stmt_if.tree)
+            foreign lpvm access(#right##0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#key##0:wybe.int)
+            foreign lpvm access(~#right##0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#right##0:stmt_if.tree)
+            stmt_if.tree.=<0>(~#left#left##0:stmt_if.tree, ~#right#left##0:stmt_if.tree, ?tmp#4##0:wybe.bool) #2
+            case ~tmp#4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
             1:
-                foreign llvm icmp_eq(~$left$key##0:wybe.int, ~$right$key##0:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
-                case ~tmp$5##0:wybe.bool of
+                foreign llvm icmp_eq(~#left#key##0:wybe.int, ~#right#key##0:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
+                case ~tmp#5##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                 1:
-                    stmt_if.tree.=<0>(~$left$right##0:stmt_if.tree, ~$right$right##0:stmt_if.tree, ?$$##0:wybe.bool) #4
+                    stmt_if.tree.=<0>(~#left#right##0:stmt_if.tree, ~#right#right##0:stmt_if.tree, ?####0:wybe.bool) #4
 
 
 
@@ -272,145 +272,145 @@ if.else2:
 
 empty > public {inline} (0 calls)
 0: stmt_if.tree.empty<0>
-empty(?$##0:stmt_if.tree):
+empty(?###0:stmt_if.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:stmt_if.tree, ?$##0:stmt_if.tree)
+    foreign llvm move(0:stmt_if.tree, ?###0:stmt_if.tree)
 
 
 key > public {inline} (0 calls)
 0: stmt_if.tree.key<0>
-key($rec##0:stmt_if.tree, ?$##0:wybe.int, ?$$##0:wybe.bool):
+key(#rec##0:stmt_if.tree, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec##0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 key > public {inline} (0 calls)
 1: stmt_if.tree.key<1>
-key($rec##0:stmt_if.tree, ?$rec##1:stmt_if.tree, $field##0:wybe.int, ?$$##0:wybe.bool):
+key(#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:stmt_if.tree, ?$rec##1:stmt_if.tree)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree)
 
     1:
-        foreign lpvm mutate(~$rec##0:stmt_if.tree, ?$rec##1:stmt_if.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 left > public {inline} (0 calls)
 0: stmt_if.tree.left<0>
-left($rec##0:stmt_if.tree, ?$##0:stmt_if.tree, ?$$##0:wybe.bool):
+left(#rec##0:stmt_if.tree, ?###0:stmt_if.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:stmt_if.tree, ?$##0:stmt_if.tree)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:stmt_if.tree, ?###0:stmt_if.tree)
 
     1:
-        foreign lpvm access(~$rec##0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:stmt_if.tree)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:stmt_if.tree)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 left > public {inline} (0 calls)
 1: stmt_if.tree.left<1>
-left($rec##0:stmt_if.tree, ?$rec##1:stmt_if.tree, $field##0:stmt_if.tree, ?$$##0:wybe.bool):
+left(#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, #field##0:stmt_if.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:stmt_if.tree, ?$rec##1:stmt_if.tree)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree)
 
     1:
-        foreign lpvm mutate(~$rec##0:stmt_if.tree, ?$rec##1:stmt_if.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:stmt_if.tree)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:stmt_if.tree)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 node > public {inline} (0 calls)
 0: stmt_if.tree.node<0>
-node(left##0:stmt_if.tree, key##0:wybe.int, right##0:stmt_if.tree, ?$##0:stmt_if.tree):
+node(left##0:stmt_if.tree, key##0:wybe.int, right##0:stmt_if.tree, ?###0:stmt_if.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?$rec##0:stmt_if.tree)
-    foreign lpvm mutate(~$rec##0:stmt_if.tree, ?$rec##1:stmt_if.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:stmt_if.tree)
-    foreign lpvm mutate(~$rec##1:stmt_if.tree, ?$rec##2:stmt_if.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int)
-    foreign lpvm mutate(~$rec##2:stmt_if.tree, ?$##0:stmt_if.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:stmt_if.tree)
+    foreign lpvm alloc(24:wybe.int, ?#rec##0:stmt_if.tree)
+    foreign lpvm mutate(~#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:stmt_if.tree)
+    foreign lpvm mutate(~#rec##1:stmt_if.tree, ?#rec##2:stmt_if.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int)
+    foreign lpvm mutate(~#rec##2:stmt_if.tree, ?###0:stmt_if.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:stmt_if.tree)
 node > public {inline} (16 calls)
 1: stmt_if.tree.node<1>
-node(?left##0:stmt_if.tree, ?key##0:wybe.int, ?right##0:stmt_if.tree, $##0:stmt_if.tree, ?$$##0:wybe.bool):
+node(?left##0:stmt_if.tree, ?key##0:wybe.int, ?right##0:stmt_if.tree, ###0:stmt_if.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:stmt_if.tree, ?left##0:stmt_if.tree)
         foreign llvm move(undef:wybe.int, ?key##0:wybe.int)
         foreign llvm move(undef:stmt_if.tree, ?right##0:stmt_if.tree)
 
     1:
-        foreign lpvm access($##0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:stmt_if.tree)
-        foreign lpvm access($##0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
-        foreign lpvm access(~$##0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:stmt_if.tree)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(###0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:stmt_if.tree)
+        foreign lpvm access(###0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
+        foreign lpvm access(~###0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:stmt_if.tree)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 right > public {inline} (0 calls)
 0: stmt_if.tree.right<0>
-right($rec##0:stmt_if.tree, ?$##0:stmt_if.tree, ?$$##0:wybe.bool):
+right(#rec##0:stmt_if.tree, ?###0:stmt_if.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:stmt_if.tree, ?$##0:stmt_if.tree)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:stmt_if.tree, ?###0:stmt_if.tree)
 
     1:
-        foreign lpvm access(~$rec##0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:stmt_if.tree)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:stmt_if.tree)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 right > public {inline} (0 calls)
 1: stmt_if.tree.right<1>
-right($rec##0:stmt_if.tree, ?$rec##1:stmt_if.tree, $field##0:stmt_if.tree, ?$$##0:wybe.bool):
+right(#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, #field##0:stmt_if.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:stmt_if.tree, ?$rec##1:stmt_if.tree)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree)
 
     1:
-        foreign lpvm mutate(~$rec##0:stmt_if.tree, ?$rec##1:stmt_if.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:stmt_if.tree)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:stmt_if.tree)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: stmt_if.tree.~=<0>
-~=($left##0:stmt_if.tree, $right##0:stmt_if.tree, ?$$##0:wybe.bool):
+~=(#left##0:stmt_if.tree, #right##0:stmt_if.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_if.tree.=<0>(~$left##0:stmt_if.tree, ~$right##0:stmt_if.tree, ?tmp$0##0:wybe.bool) #0
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    stmt_if.tree.=<0>(~#left##0:stmt_if.tree, ~#right##0:stmt_if.tree, ?tmp#0##0:wybe.bool) #0
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
   LLVM code       :
 
@@ -426,51 +426,51 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"stmt_if.tree.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"stmt_if.tree.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#left##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = add   i64 %"$left##0", 16 
+  %8 = add   i64 %"#left##0", 16 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
-  %"2$tmp$10##0" = icmp ne i64 %"$right##0", 0 
-  br i1 %"2$tmp$10##0", label %if.then1, label %if.else1 
+  %"2#tmp#10##0" = icmp ne i64 %"#right##0", 0 
+  br i1 %"2#tmp#10##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3#####0" 
 if.then1:
-  %12 = inttoptr i64 %"$right##0" to i64* 
+  %12 = inttoptr i64 %"#right##0" to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %15 = add   i64 %"$right##0", 8 
+  %15 = add   i64 %"#right##0", 8 
   %16 = inttoptr i64 %15 to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
-  %19 = add   i64 %"$right##0", 16 
+  %19 = add   i64 %"#right##0", 16 
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %"4$tmp$4##0" = tail call fastcc  i1  @"stmt_if.tree.=<0>"(i64  %3, i64  %14)  
-  br i1 %"4$tmp$4##0", label %if.then2, label %if.else2 
+  %"4#tmp#4##0" = tail call fastcc  i1  @"stmt_if.tree.=<0>"(i64  %3, i64  %14)  
+  br i1 %"4#tmp#4##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$tmp$5##0" = icmp eq i64 %7, %18 
-  br i1 %"6$tmp$5##0", label %if.then3, label %if.else3 
+  %"6#tmp#5##0" = icmp eq i64 %7, %18 
+  br i1 %"6#tmp#5##0", label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %"8$$$##0" = tail call fastcc  i1  @"stmt_if.tree.=<0>"(i64  %11, i64  %22)  
-  ret i1 %"8$$$##0" 
+  %"8#####0" = tail call fastcc  i1  @"stmt_if.tree.=<0>"(i64  %11, i64  %22)  
+  ret i1 %"8#####0" 
 if.else3:
   ret i1 0 
 }
@@ -482,12 +482,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if.tree.key<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"stmt_if.tree.key<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %23 = add   i64 %"$rec##0", 8 
+  %23 = add   i64 %"#rec##0", 8 
   %24 = inttoptr i64 %23 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
   %26 = load  i64, i64* %25 
@@ -501,38 +501,38 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if.tree.key<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"stmt_if.tree.key<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %31 = trunc i64 24 to i32  
   %32 = tail call ccc  i8*  @wybe_malloc(i32  %31)  
   %33 = ptrtoint i8* %32 to i64 
   %34 = inttoptr i64 %33 to i8* 
-  %35 = inttoptr i64 %"$rec##0" to i8* 
+  %35 = inttoptr i64 %"#rec##0" to i8* 
   %36 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %34, i8*  %35, i32  %36, i32  8, i1  0)  
   %37 = add   i64 %33, 8 
   %38 = inttoptr i64 %37 to i64* 
   %39 = getelementptr  i64, i64* %38, i64 0 
-  store  i64 %"$field##0", i64* %39 
+  store  i64 %"#field##0", i64* %39 
   %40 = insertvalue {i64, i1} undef, i64 %33, 0 
   %41 = insertvalue {i64, i1} %40, i1 1, 1 
   ret {i64, i1} %41 
 if.else:
-  %42 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %42 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %43 = insertvalue {i64, i1} %42, i1 0, 1 
   ret {i64, i1} %43 
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if.tree.left<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"stmt_if.tree.left<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %44 = inttoptr i64 %"$rec##0" to i64* 
+  %44 = inttoptr i64 %"#rec##0" to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
   %47 = insertvalue {i64, i1} undef, i64 %46, 0 
@@ -545,26 +545,26 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if.tree.left<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"stmt_if.tree.left<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %51 = trunc i64 24 to i32  
   %52 = tail call ccc  i8*  @wybe_malloc(i32  %51)  
   %53 = ptrtoint i8* %52 to i64 
   %54 = inttoptr i64 %53 to i8* 
-  %55 = inttoptr i64 %"$rec##0" to i8* 
+  %55 = inttoptr i64 %"#rec##0" to i8* 
   %56 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %54, i8*  %55, i32  %56, i32  8, i1  0)  
   %57 = inttoptr i64 %53 to i64* 
   %58 = getelementptr  i64, i64* %57, i64 0 
-  store  i64 %"$field##0", i64* %58 
+  store  i64 %"#field##0", i64* %58 
   %59 = insertvalue {i64, i1} undef, i64 %53, 0 
   %60 = insertvalue {i64, i1} %59, i1 1, 1 
   ret {i64, i1} %60 
 if.else:
-  %61 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %61 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %62 = insertvalue {i64, i1} %61, i1 0, 1 
   ret {i64, i1} %62 
 }
@@ -590,19 +590,19 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64, i1} @"stmt_if.tree.node<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64, i64, i1} @"stmt_if.tree.node<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %74 = inttoptr i64 %"$##0" to i64* 
+  %74 = inttoptr i64 %"###0" to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
   %76 = load  i64, i64* %75 
-  %77 = add   i64 %"$##0", 8 
+  %77 = add   i64 %"###0", 8 
   %78 = inttoptr i64 %77 to i64* 
   %79 = getelementptr  i64, i64* %78, i64 0 
   %80 = load  i64, i64* %79 
-  %81 = add   i64 %"$##0", 16 
+  %81 = add   i64 %"###0", 16 
   %82 = inttoptr i64 %81 to i64* 
   %83 = getelementptr  i64, i64* %82, i64 0 
   %84 = load  i64, i64* %83 
@@ -620,12 +620,12 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if.tree.right<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"stmt_if.tree.right<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %93 = add   i64 %"$rec##0", 16 
+  %93 = add   i64 %"#rec##0", 16 
   %94 = inttoptr i64 %93 to i64* 
   %95 = getelementptr  i64, i64* %94, i64 0 
   %96 = load  i64, i64* %95 
@@ -639,35 +639,35 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if.tree.right<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"stmt_if.tree.right<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %101 = trunc i64 24 to i32  
   %102 = tail call ccc  i8*  @wybe_malloc(i32  %101)  
   %103 = ptrtoint i8* %102 to i64 
   %104 = inttoptr i64 %103 to i8* 
-  %105 = inttoptr i64 %"$rec##0" to i8* 
+  %105 = inttoptr i64 %"#rec##0" to i8* 
   %106 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %104, i8*  %105, i32  %106, i32  8, i1  0)  
   %107 = add   i64 %103, 16 
   %108 = inttoptr i64 %107 to i64* 
   %109 = getelementptr  i64, i64* %108, i64 0 
-  store  i64 %"$field##0", i64* %109 
+  store  i64 %"#field##0", i64* %109 
   %110 = insertvalue {i64, i1} undef, i64 %103, 0 
   %111 = insertvalue {i64, i1} %110, i1 1, 1 
   ret {i64, i1} %111 
 if.else:
-  %112 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %112 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %113 = insertvalue {i64, i1} %112, i1 0, 1 
   ret {i64, i1} %113 
 }
 
 
-define external fastcc  i1 @"stmt_if.tree.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"stmt_if.tree.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = tail call fastcc  i1  @"stmt_if.tree.=<0>"(i64  %"$left##0", i64  %"$right##0")  
-  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
-  ret i1 %"1$$$##0" 
+  %"1#tmp#0##0" = tail call fastcc  i1  @"stmt_if.tree.=<0>"(i64  %"#left##0", i64  %"#right##0")  
+  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1#####0" 
 }

--- a/test-cases/final-dump/stmt_if.exp
+++ b/test-cases/final-dump/stmt_if.exp
@@ -230,13 +230,13 @@ if.else2:
 
 = > public (7 calls)
 0: stmt_if.tree.=<0>
-=(#left##0:stmt_if.tree, #right##0:stmt_if.tree, ?####0:wybe.bool):
+=(#left##0:stmt_if.tree, #right##0:stmt_if.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~#left##0:stmt_if.tree, ~#right##0:stmt_if.tree, ?####0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:stmt_if.tree, ~#right##0:stmt_if.tree, ?#success##0:wybe.bool)
 
     1:
         foreign lpvm access(#left##0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#left##0:stmt_if.tree)
@@ -245,7 +245,7 @@ if.else2:
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
         case ~tmp#10##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign lpvm access(#right##0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#left##0:stmt_if.tree)
@@ -254,16 +254,16 @@ if.else2:
             stmt_if.tree.=<0>(~#left#left##0:stmt_if.tree, ~#right#left##0:stmt_if.tree, ?tmp#4##0:wybe.bool) #2
             case ~tmp#4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
                 foreign llvm icmp_eq(~#left#key##0:wybe.int, ~#right#key##0:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
                 case ~tmp#5##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                 1:
-                    stmt_if.tree.=<0>(~#left#right##0:stmt_if.tree, ~#right#right##0:stmt_if.tree, ?####0:wybe.bool) #4
+                    stmt_if.tree.=<0>(~#left#right##0:stmt_if.tree, ~#right#right##0:stmt_if.tree, ?#success##0:wybe.bool) #4
 
 
 
@@ -280,65 +280,65 @@ empty(?#result##0:stmt_if.tree):
 
 key > public {inline} (0 calls)
 0: stmt_if.tree.key<0>
-key(#rec##0:stmt_if.tree, ?#result##0:wybe.int, ?####0:wybe.bool):
+key(#rec##0:stmt_if.tree, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign lpvm access(~#rec##0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 key > public {inline} (0 calls)
 1: stmt_if.tree.key<1>
-key(#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, #field##0:wybe.int, ?####0:wybe.bool):
+key(#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree)
 
     1:
         foreign lpvm mutate(~#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 left > public {inline} (0 calls)
 0: stmt_if.tree.left<0>
-left(#rec##0:stmt_if.tree, ?#result##0:stmt_if.tree, ?####0:wybe.bool):
+left(#rec##0:stmt_if.tree, ?#result##0:stmt_if.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:stmt_if.tree, ?#result##0:stmt_if.tree)
 
     1:
         foreign lpvm access(~#rec##0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:stmt_if.tree)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 left > public {inline} (0 calls)
 1: stmt_if.tree.left<1>
-left(#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, #field##0:stmt_if.tree, ?####0:wybe.bool):
+left(#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, #field##0:stmt_if.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree)
 
     1:
         foreign lpvm mutate(~#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:stmt_if.tree)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -353,13 +353,13 @@ node(left##0:stmt_if.tree, key##0:wybe.int, right##0:stmt_if.tree, ?#result##0:s
     foreign lpvm mutate(~#rec##2:stmt_if.tree, ?#result##0:stmt_if.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:stmt_if.tree)
 node > public {inline} (16 calls)
 1: stmt_if.tree.node<1>
-node(?left##0:stmt_if.tree, ?key##0:wybe.int, ?right##0:stmt_if.tree, #result##0:stmt_if.tree, ?####0:wybe.bool):
+node(?left##0:stmt_if.tree, ?key##0:wybe.int, ?right##0:stmt_if.tree, #result##0:stmt_if.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:stmt_if.tree, ?left##0:stmt_if.tree)
         foreign llvm move(undef:wybe.int, ?key##0:wybe.int)
         foreign llvm move(undef:stmt_if.tree, ?right##0:stmt_if.tree)
@@ -368,49 +368,49 @@ node(?left##0:stmt_if.tree, ?key##0:wybe.int, ?right##0:stmt_if.tree, #result##0
         foreign lpvm access(#result##0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:stmt_if.tree)
         foreign lpvm access(#result##0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
         foreign lpvm access(~#result##0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:stmt_if.tree)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 right > public {inline} (0 calls)
 0: stmt_if.tree.right<0>
-right(#rec##0:stmt_if.tree, ?#result##0:stmt_if.tree, ?####0:wybe.bool):
+right(#rec##0:stmt_if.tree, ?#result##0:stmt_if.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:stmt_if.tree, ?#result##0:stmt_if.tree)
 
     1:
         foreign lpvm access(~#rec##0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:stmt_if.tree)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 right > public {inline} (0 calls)
 1: stmt_if.tree.right<1>
-right(#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, #field##0:stmt_if.tree, ?####0:wybe.bool):
+right(#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, #field##0:stmt_if.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree)
 
     1:
         foreign lpvm mutate(~#rec##0:stmt_if.tree, ?#rec##1:stmt_if.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:stmt_if.tree)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: stmt_if.tree.~=<0>
-~=(#left##0:stmt_if.tree, #right##0:stmt_if.tree, ?####0:wybe.bool):
+~=(#left##0:stmt_if.tree, #right##0:stmt_if.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     stmt_if.tree.=<0>(~#left##0:stmt_if.tree, ~#right##0:stmt_if.tree, ?tmp#0##0:wybe.bool) #0
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 
@@ -445,8 +445,8 @@ if.then:
   %"2#tmp#10##0" = icmp ne i64 %"#right##0", 0 
   br i1 %"2#tmp#10##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %"3#####0" 
+  %"3##success##0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3##success##0" 
 if.then1:
   %12 = inttoptr i64 %"#right##0" to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
@@ -469,8 +469,8 @@ if.then2:
 if.else2:
   ret i1 0 
 if.then3:
-  %"8#####0" = tail call fastcc  i1  @"stmt_if.tree.=<0>"(i64  %11, i64  %22)  
-  ret i1 %"8#####0" 
+  %"8##success##0" = tail call fastcc  i1  @"stmt_if.tree.=<0>"(i64  %11, i64  %22)  
+  ret i1 %"8##success##0" 
 if.else3:
   ret i1 0 
 }
@@ -668,6 +668,6 @@ if.else:
 define external fastcc  i1 @"stmt_if.tree.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %"1#tmp#0##0" = tail call fastcc  i1  @"stmt_if.tree.=<0>"(i64  %"#left##0", i64  %"#right##0")  
-  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
-  ret i1 %"1#####0" 
+  %"1##success##0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1##success##0" 
 }

--- a/test-cases/final-dump/stmt_if.exp
+++ b/test-cases/final-dump/stmt_if.exp
@@ -24,72 +24,72 @@ AFTER EVERYTHING:
 
 foobar > (0 calls)
 0: stmt_if.foobar<0>
-foobar(io#0:wybe.phantom, ?io#2:wybe.phantom):
+foobar(io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp$8#0:stmt_if.tree)
-    foreign lpvm mutate(~tmp$8#0:stmt_if.tree, ?tmp$9#0:stmt_if.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:stmt_if.tree)
-    foreign lpvm mutate(~tmp$9#0:stmt_if.tree, ?tmp$10#0:stmt_if.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp$10#0:stmt_if.tree, ?tmp$11#0:stmt_if.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:stmt_if.tree)
-    stmt_if.lookup<0>(1:wybe.int, tmp$11#0:stmt_if.tree, ?tmp$4#0:wybe.bool) #3 @stmt_if:nn:nn
-    case ~tmp$4#0:wybe.bool of
+    foreign lpvm alloc(24:wybe.int, ?tmp$8##0:stmt_if.tree)
+    foreign lpvm mutate(~tmp$8##0:stmt_if.tree, ?tmp$9##0:stmt_if.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:stmt_if.tree)
+    foreign lpvm mutate(~tmp$9##0:stmt_if.tree, ?tmp$10##0:stmt_if.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp$10##0:stmt_if.tree, ?tmp$11##0:stmt_if.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:stmt_if.tree)
+    stmt_if.lookup<0>(1:wybe.int, tmp$11##0:stmt_if.tree, ?tmp$4##0:wybe.bool) #3 @stmt_if:nn:nn
+    case ~tmp$4##0:wybe.bool of
     0:
-        foreign c print_string("lookup fails when it should succeed":wybe.string, ~#io#0:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        stmt_if.gen$1<0>(~io#1:wybe.phantom, _:stmt_if.tree, _:stmt_if.tree, _:stmt_if.tree, ~tmp$11#0:stmt_if.tree, ?io#2:wybe.phantom) #7
+        foreign c print_string("lookup fails when it should succeed":wybe.string, ~#io##0:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_if.gen$1<0>(~io##1:wybe.phantom, _:stmt_if.tree, _:stmt_if.tree, _:stmt_if.tree, ~tmp$11##0:stmt_if.tree, ?io##2:wybe.phantom) #7
 
     1:
-        foreign c print_string("lookup succeeds when it should":wybe.string, ~#io#0:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        stmt_if.gen$1<0>(~io#1:wybe.phantom, _:stmt_if.tree, _:stmt_if.tree, _:stmt_if.tree, ~tmp$11#0:stmt_if.tree, ?io#2:wybe.phantom) #5
+        foreign c print_string("lookup succeeds when it should":wybe.string, ~#io##0:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_if.gen$1<0>(~io##1:wybe.phantom, _:stmt_if.tree, _:stmt_if.tree, _:stmt_if.tree, ~tmp$11##0:stmt_if.tree, ?io##2:wybe.phantom) #5
 
 
 
 gen$1 > (2 calls)
 0: stmt_if.gen$1<0>
-gen$1(io#0:wybe.phantom, [tmp$0#0:stmt_if.tree], [tmp$1#0:stmt_if.tree], [tmp$2#0:stmt_if.tree], tr#0:stmt_if.tree, ?io#1:wybe.phantom):
+gen$1(io##0:wybe.phantom, [tmp$0##0:stmt_if.tree], [tmp$1##0:stmt_if.tree], [tmp$2##0:stmt_if.tree], tr##0:stmt_if.tree, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_if.lookup<0>(3:wybe.int, ~tr#0:stmt_if.tree, ?tmp$3#0:wybe.bool) #0 @stmt_if:nn:nn
-    case ~tmp$3#0:wybe.bool of
+    stmt_if.lookup<0>(3:wybe.int, ~tr##0:stmt_if.tree, ?tmp$3##0:wybe.bool) #0 @stmt_if:nn:nn
+    case ~tmp$3##0:wybe.bool of
     0:
-        foreign c print_string("lookup succeeds when it should fail":wybe.string, ~#io#0:wybe.phantom, ?tmp$6#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$6#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+        foreign c print_string("lookup succeeds when it should fail":wybe.string, ~#io##0:wybe.phantom, ?tmp$6##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
     1:
-        foreign c print_string("lookup fails when it should":wybe.string, ~#io#0:wybe.phantom, ?tmp$6#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$6#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+        foreign c print_string("lookup fails when it should":wybe.string, ~#io##0:wybe.phantom, ?tmp$6##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 
 lookup > public (8 calls)
 0: stmt_if.lookup<0>
-lookup(key#0:wybe.int, tree#0:stmt_if.tree, ?result#0:wybe.bool):
+lookup(key##0:wybe.int, tree##0:stmt_if.tree, ?result##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(tree#0:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.bool)
-    case ~tmp$6#0:wybe.bool of
+    foreign llvm icmp_ne(tree##0:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.bool)
+    case ~tmp$6##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?result#0:wybe.bool) @stmt_if:nn:nn
+        foreign llvm move(0:wybe.bool, ?result##0:wybe.bool) @stmt_if:nn:nn
 
     1:
-        foreign lpvm access(tree#0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left#0:stmt_if.tree)
-        foreign lpvm access(tree#0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?nodekey#0:wybe.int)
-        foreign lpvm access(~tree#0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right#0:stmt_if.tree)
-        foreign llvm icmp_eq(key#0:wybe.int, nodekey#0:wybe.int, ?tmp$3#0:wybe.bool) @int:nn:nn
-        case ~tmp$3#0:wybe.bool of
+        foreign lpvm access(tree##0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:stmt_if.tree)
+        foreign lpvm access(tree##0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?nodekey##0:wybe.int)
+        foreign lpvm access(~tree##0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:stmt_if.tree)
+        foreign llvm icmp_eq(key##0:wybe.int, nodekey##0:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
+        case ~tmp$3##0:wybe.bool of
         0:
-            foreign llvm icmp_slt(key#0:wybe.int, ~nodekey#0:wybe.int, ?tmp$2#0:wybe.bool) @int:nn:nn
-            case ~tmp$2#0:wybe.bool of
+            foreign llvm icmp_slt(key##0:wybe.int, ~nodekey##0:wybe.int, ?tmp$2##0:wybe.bool) @int:nn:nn
+            case ~tmp$2##0:wybe.bool of
             0:
-                stmt_if.lookup<0>(~key#0:wybe.int, ~right#0:stmt_if.tree, ?result#0:wybe.bool) #5 @stmt_if:nn:nn
+                stmt_if.lookup<0>(~key##0:wybe.int, ~right##0:stmt_if.tree, ?result##0:wybe.bool) #5 @stmt_if:nn:nn
 
             1:
-                stmt_if.lookup<0>(~key#0:wybe.int, ~left#0:stmt_if.tree, ?result#0:wybe.bool) #4 @stmt_if:nn:nn
+                stmt_if.lookup<0>(~key##0:wybe.int, ~left##0:stmt_if.tree, ?result##0:wybe.bool) #4 @stmt_if:nn:nn
 
 
         1:
-            foreign llvm move(1:wybe.bool, ?result#0:wybe.bool) @stmt_if:nn:nn
+            foreign llvm move(1:wybe.bool, ?result##0:wybe.bool) @stmt_if:nn:nn
 
 
 
@@ -141,8 +141,8 @@ entry:
   %10 = inttoptr i64 %9 to i64* 
   %11 = getelementptr  i64, i64* %10, i64 0 
   store  i64 0, i64* %11 
-  %"1$tmp$4#0" = tail call fastcc  i1  @"stmt_if.lookup<0>"(i64  1, i64  %3)  
-  br i1 %"1$tmp$4#0", label %if.then, label %if.else 
+  %"1$tmp$4##0" = tail call fastcc  i1  @"stmt_if.lookup<0>"(i64  1, i64  %3)  
+  br i1 %"1$tmp$4##0", label %if.then, label %if.else 
 if.then:
   %13 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @stmt_if.12, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %13)  
@@ -158,10 +158,10 @@ if.else:
 }
 
 
-define external fastcc  void @"stmt_if.gen$1<0>"(i64  %"tr#0")    {
+define external fastcc  void @"stmt_if.gen$1<0>"(i64  %"tr##0")    {
 entry:
-  %"1$tmp$3#0" = tail call fastcc  i1  @"stmt_if.lookup<0>"(i64  3, i64  %"tr#0")  
-  br i1 %"1$tmp$3#0", label %if.then, label %if.else 
+  %"1$tmp$3##0" = tail call fastcc  i1  @"stmt_if.lookup<0>"(i64  3, i64  %"tr##0")  
+  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
 if.then:
   %17 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @stmt_if.16, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %17)  
@@ -175,37 +175,37 @@ if.else:
 }
 
 
-define external fastcc  i1 @"stmt_if.lookup<0>"(i64  %"key#0", i64  %"tree#0")    {
+define external fastcc  i1 @"stmt_if.lookup<0>"(i64  %"key##0", i64  %"tree##0")    {
 entry:
-  %"1$tmp$6#0" = icmp ne i64 %"tree#0", 0 
-  br i1 %"1$tmp$6#0", label %if.then, label %if.else 
+  %"1$tmp$6##0" = icmp ne i64 %"tree##0", 0 
+  br i1 %"1$tmp$6##0", label %if.then, label %if.else 
 if.then:
-  %20 = inttoptr i64 %"tree#0" to i64* 
+  %20 = inttoptr i64 %"tree##0" to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %23 = add   i64 %"tree#0", 8 
+  %23 = add   i64 %"tree##0", 8 
   %24 = inttoptr i64 %23 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
   %26 = load  i64, i64* %25 
-  %27 = add   i64 %"tree#0", 16 
+  %27 = add   i64 %"tree##0", 16 
   %28 = inttoptr i64 %27 to i64* 
   %29 = getelementptr  i64, i64* %28, i64 0 
   %30 = load  i64, i64* %29 
-  %"2$tmp$3#0" = icmp eq i64 %"key#0", %26 
-  br i1 %"2$tmp$3#0", label %if.then1, label %if.else1 
+  %"2$tmp$3##0" = icmp eq i64 %"key##0", %26 
+  br i1 %"2$tmp$3##0", label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
   ret i1 1 
 if.else1:
-  %"5$tmp$2#0" = icmp slt i64 %"key#0", %26 
-  br i1 %"5$tmp$2#0", label %if.then2, label %if.else2 
+  %"5$tmp$2##0" = icmp slt i64 %"key##0", %26 
+  br i1 %"5$tmp$2##0", label %if.then2, label %if.else2 
 if.then2:
-  %"6$result#0" = tail call fastcc  i1  @"stmt_if.lookup<0>"(i64  %"key#0", i64  %22)  
-  ret i1 %"6$result#0" 
+  %"6$result##0" = tail call fastcc  i1  @"stmt_if.lookup<0>"(i64  %"key##0", i64  %22)  
+  ret i1 %"6$result##0" 
 if.else2:
-  %"7$result#0" = tail call fastcc  i1  @"stmt_if.lookup<0>"(i64  %"key#0", i64  %30)  
-  ret i1 %"7$result#0" 
+  %"7$result##0" = tail call fastcc  i1  @"stmt_if.lookup<0>"(i64  %"key##0", i64  %30)  
+  ret i1 %"7$result##0" 
 }
 --------------------------------------------------
  Module stmt_if.tree
@@ -230,40 +230,40 @@ if.else2:
 
 = > public (7 calls)
 0: stmt_if.tree.=<0>
-=($left#0:stmt_if.tree, $right#0:stmt_if.tree, ?$$#0:wybe.bool):
+=($left##0:stmt_if.tree, $right##0:stmt_if.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left#0:stmt_if.tree, ~$right#0:stmt_if.tree, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~$left##0:stmt_if.tree, ~$right##0:stmt_if.tree, ?$$##0:wybe.bool)
 
     1:
-        foreign lpvm access($left#0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$left#0:stmt_if.tree)
-        foreign lpvm access($left#0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$key#0:wybe.int)
-        foreign lpvm access(~$left#0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$right#0:stmt_if.tree)
-        foreign llvm icmp_ne($right#0:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.bool)
-        case ~tmp$10#0:wybe.bool of
+        foreign lpvm access($left##0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$left##0:stmt_if.tree)
+        foreign lpvm access($left##0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$key##0:wybe.int)
+        foreign lpvm access(~$left##0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$right##0:stmt_if.tree)
+        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.bool)
+        case ~tmp$10##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign lpvm access($right#0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$left#0:stmt_if.tree)
-            foreign lpvm access($right#0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$key#0:wybe.int)
-            foreign lpvm access(~$right#0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$right#0:stmt_if.tree)
-            stmt_if.tree.=<0>(~$left$left#0:stmt_if.tree, ~$right$left#0:stmt_if.tree, ?tmp$4#0:wybe.bool) #2
-            case ~tmp$4#0:wybe.bool of
+            foreign lpvm access($right##0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$left##0:stmt_if.tree)
+            foreign lpvm access($right##0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$key##0:wybe.int)
+            foreign lpvm access(~$right##0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$right##0:stmt_if.tree)
+            stmt_if.tree.=<0>(~$left$left##0:stmt_if.tree, ~$right$left##0:stmt_if.tree, ?tmp$4##0:wybe.bool) #2
+            case ~tmp$4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                foreign llvm icmp_eq(~$left$key#0:wybe.int, ~$right$key#0:wybe.int, ?tmp$5#0:wybe.bool) @int:nn:nn
-                case ~tmp$5#0:wybe.bool of
+                foreign llvm icmp_eq(~$left$key##0:wybe.int, ~$right$key##0:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
+                case ~tmp$5##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                 1:
-                    stmt_if.tree.=<0>(~$left$right#0:stmt_if.tree, ~$right$right#0:stmt_if.tree, ?$$#0:wybe.bool) #4
+                    stmt_if.tree.=<0>(~$left$right##0:stmt_if.tree, ~$right$right##0:stmt_if.tree, ?$$##0:wybe.bool) #4
 
 
 
@@ -272,145 +272,145 @@ if.else2:
 
 empty > public {inline} (0 calls)
 0: stmt_if.tree.empty<0>
-empty(?$#0:stmt_if.tree):
+empty(?$##0:stmt_if.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:stmt_if.tree, ?$#0:stmt_if.tree)
+    foreign llvm move(0:stmt_if.tree, ?$##0:stmt_if.tree)
 
 
 key > public {inline} (0 calls)
 0: stmt_if.tree.key<0>
-key($rec#0:stmt_if.tree, ?$#0:wybe.int, ?$$#0:wybe.bool):
+key($rec##0:stmt_if.tree, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec#0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 key > public {inline} (0 calls)
 1: stmt_if.tree.key<1>
-key($rec#0:stmt_if.tree, ?$rec#1:stmt_if.tree, $field#0:wybe.int, ?$$#0:wybe.bool):
+key($rec##0:stmt_if.tree, ?$rec##1:stmt_if.tree, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:stmt_if.tree, ?$rec#1:stmt_if.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:stmt_if.tree, ?$rec##1:stmt_if.tree)
 
     1:
-        foreign lpvm mutate(~$rec#0:stmt_if.tree, ?$rec#1:stmt_if.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~$rec##0:stmt_if.tree, ?$rec##1:stmt_if.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 left > public {inline} (0 calls)
 0: stmt_if.tree.left<0>
-left($rec#0:stmt_if.tree, ?$#0:stmt_if.tree, ?$$#0:wybe.bool):
+left($rec##0:stmt_if.tree, ?$##0:stmt_if.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:stmt_if.tree, ?$#0:stmt_if.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:stmt_if.tree, ?$##0:stmt_if.tree)
 
     1:
-        foreign lpvm access(~$rec#0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:stmt_if.tree)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:stmt_if.tree)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 left > public {inline} (0 calls)
 1: stmt_if.tree.left<1>
-left($rec#0:stmt_if.tree, ?$rec#1:stmt_if.tree, $field#0:stmt_if.tree, ?$$#0:wybe.bool):
+left($rec##0:stmt_if.tree, ?$rec##1:stmt_if.tree, $field##0:stmt_if.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:stmt_if.tree, ?$rec#1:stmt_if.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:stmt_if.tree, ?$rec##1:stmt_if.tree)
 
     1:
-        foreign lpvm mutate(~$rec#0:stmt_if.tree, ?$rec#1:stmt_if.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field#0:stmt_if.tree)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~$rec##0:stmt_if.tree, ?$rec##1:stmt_if.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:stmt_if.tree)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 node > public {inline} (0 calls)
 0: stmt_if.tree.node<0>
-node(left#0:stmt_if.tree, key#0:wybe.int, right#0:stmt_if.tree, ?$#0:stmt_if.tree):
+node(left##0:stmt_if.tree, key##0:wybe.int, right##0:stmt_if.tree, ?$##0:stmt_if.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?$rec#0:stmt_if.tree)
-    foreign lpvm mutate(~$rec#0:stmt_if.tree, ?$rec#1:stmt_if.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left#0:stmt_if.tree)
-    foreign lpvm mutate(~$rec#1:stmt_if.tree, ?$rec#2:stmt_if.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key#0:wybe.int)
-    foreign lpvm mutate(~$rec#2:stmt_if.tree, ?$#0:stmt_if.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right#0:stmt_if.tree)
+    foreign lpvm alloc(24:wybe.int, ?$rec##0:stmt_if.tree)
+    foreign lpvm mutate(~$rec##0:stmt_if.tree, ?$rec##1:stmt_if.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:stmt_if.tree)
+    foreign lpvm mutate(~$rec##1:stmt_if.tree, ?$rec##2:stmt_if.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int)
+    foreign lpvm mutate(~$rec##2:stmt_if.tree, ?$##0:stmt_if.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:stmt_if.tree)
 node > public {inline} (16 calls)
 1: stmt_if.tree.node<1>
-node(?left#0:stmt_if.tree, ?key#0:wybe.int, ?right#0:stmt_if.tree, $#0:stmt_if.tree, ?$$#0:wybe.bool):
+node(?left##0:stmt_if.tree, ?key##0:wybe.int, ?right##0:stmt_if.tree, $##0:stmt_if.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:stmt_if.tree, ?left#0:stmt_if.tree)
-        foreign llvm move(undef:wybe.int, ?key#0:wybe.int)
-        foreign llvm move(undef:stmt_if.tree, ?right#0:stmt_if.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:stmt_if.tree, ?left##0:stmt_if.tree)
+        foreign llvm move(undef:wybe.int, ?key##0:wybe.int)
+        foreign llvm move(undef:stmt_if.tree, ?right##0:stmt_if.tree)
 
     1:
-        foreign lpvm access($#0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left#0:stmt_if.tree)
-        foreign lpvm access($#0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key#0:wybe.int)
-        foreign lpvm access(~$#0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right#0:stmt_if.tree)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access($##0:stmt_if.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:stmt_if.tree)
+        foreign lpvm access($##0:stmt_if.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
+        foreign lpvm access(~$##0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:stmt_if.tree)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 right > public {inline} (0 calls)
 0: stmt_if.tree.right<0>
-right($rec#0:stmt_if.tree, ?$#0:stmt_if.tree, ?$$#0:wybe.bool):
+right($rec##0:stmt_if.tree, ?$##0:stmt_if.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:stmt_if.tree, ?$#0:stmt_if.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:stmt_if.tree, ?$##0:stmt_if.tree)
 
     1:
-        foreign lpvm access(~$rec#0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:stmt_if.tree)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:stmt_if.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:stmt_if.tree)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 right > public {inline} (0 calls)
 1: stmt_if.tree.right<1>
-right($rec#0:stmt_if.tree, ?$rec#1:stmt_if.tree, $field#0:stmt_if.tree, ?$$#0:wybe.bool):
+right($rec##0:stmt_if.tree, ?$rec##1:stmt_if.tree, $field##0:stmt_if.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:stmt_if.tree, ?$rec#1:stmt_if.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:stmt_if.tree, ?$rec##1:stmt_if.tree)
 
     1:
-        foreign lpvm mutate(~$rec#0:stmt_if.tree, ?$rec#1:stmt_if.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field#0:stmt_if.tree)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~$rec##0:stmt_if.tree, ?$rec##1:stmt_if.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:stmt_if.tree)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: stmt_if.tree.~=<0>
-~=($left#0:stmt_if.tree, $right#0:stmt_if.tree, ?$$#0:wybe.bool):
+~=($left##0:stmt_if.tree, $right##0:stmt_if.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_if.tree.=<0>(~$left#0:stmt_if.tree, ~$right#0:stmt_if.tree, ?tmp$0#0:wybe.bool) #0
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    stmt_if.tree.=<0>(~$left##0:stmt_if.tree, ~$right##0:stmt_if.tree, ?tmp$0##0:wybe.bool) #0
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
   LLVM code       :
 
@@ -426,51 +426,51 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"stmt_if.tree.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"stmt_if.tree.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$left#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = add   i64 %"$left#0", 16 
+  %8 = add   i64 %"$left##0", 16 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
-  %"2$tmp$10#0" = icmp ne i64 %"$right#0", 0 
-  br i1 %"2$tmp$10#0", label %if.then1, label %if.else1 
+  %"2$tmp$10##0" = icmp ne i64 %"$right##0", 0 
+  br i1 %"2$tmp$10##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = icmp eq i64 %"$left#0", %"$right#0" 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
+  ret i1 %"3$$$##0" 
 if.then1:
-  %12 = inttoptr i64 %"$right#0" to i64* 
+  %12 = inttoptr i64 %"$right##0" to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %15 = add   i64 %"$right#0", 8 
+  %15 = add   i64 %"$right##0", 8 
   %16 = inttoptr i64 %15 to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
-  %19 = add   i64 %"$right#0", 16 
+  %19 = add   i64 %"$right##0", 16 
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %"4$tmp$4#0" = tail call fastcc  i1  @"stmt_if.tree.=<0>"(i64  %3, i64  %14)  
-  br i1 %"4$tmp$4#0", label %if.then2, label %if.else2 
+  %"4$tmp$4##0" = tail call fastcc  i1  @"stmt_if.tree.=<0>"(i64  %3, i64  %14)  
+  br i1 %"4$tmp$4##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$tmp$5#0" = icmp eq i64 %7, %18 
-  br i1 %"6$tmp$5#0", label %if.then3, label %if.else3 
+  %"6$tmp$5##0" = icmp eq i64 %7, %18 
+  br i1 %"6$tmp$5##0", label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %"8$$$#0" = tail call fastcc  i1  @"stmt_if.tree.=<0>"(i64  %11, i64  %22)  
-  ret i1 %"8$$$#0" 
+  %"8$$$##0" = tail call fastcc  i1  @"stmt_if.tree.=<0>"(i64  %11, i64  %22)  
+  ret i1 %"8$$$##0" 
 if.else3:
   ret i1 0 
 }
@@ -482,12 +482,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if.tree.key<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"stmt_if.tree.key<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %23 = add   i64 %"$rec#0", 8 
+  %23 = add   i64 %"$rec##0", 8 
   %24 = inttoptr i64 %23 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
   %26 = load  i64, i64* %25 
@@ -501,38 +501,38 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if.tree.key<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"stmt_if.tree.key<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %31 = trunc i64 24 to i32  
   %32 = tail call ccc  i8*  @wybe_malloc(i32  %31)  
   %33 = ptrtoint i8* %32 to i64 
   %34 = inttoptr i64 %33 to i8* 
-  %35 = inttoptr i64 %"$rec#0" to i8* 
+  %35 = inttoptr i64 %"$rec##0" to i8* 
   %36 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %34, i8*  %35, i32  %36, i32  8, i1  0)  
   %37 = add   i64 %33, 8 
   %38 = inttoptr i64 %37 to i64* 
   %39 = getelementptr  i64, i64* %38, i64 0 
-  store  i64 %"$field#0", i64* %39 
+  store  i64 %"$field##0", i64* %39 
   %40 = insertvalue {i64, i1} undef, i64 %33, 0 
   %41 = insertvalue {i64, i1} %40, i1 1, 1 
   ret {i64, i1} %41 
 if.else:
-  %42 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %42 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %43 = insertvalue {i64, i1} %42, i1 0, 1 
   ret {i64, i1} %43 
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if.tree.left<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"stmt_if.tree.left<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %44 = inttoptr i64 %"$rec#0" to i64* 
+  %44 = inttoptr i64 %"$rec##0" to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
   %47 = insertvalue {i64, i1} undef, i64 %46, 0 
@@ -545,64 +545,64 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if.tree.left<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"stmt_if.tree.left<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %51 = trunc i64 24 to i32  
   %52 = tail call ccc  i8*  @wybe_malloc(i32  %51)  
   %53 = ptrtoint i8* %52 to i64 
   %54 = inttoptr i64 %53 to i8* 
-  %55 = inttoptr i64 %"$rec#0" to i8* 
+  %55 = inttoptr i64 %"$rec##0" to i8* 
   %56 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %54, i8*  %55, i32  %56, i32  8, i1  0)  
   %57 = inttoptr i64 %53 to i64* 
   %58 = getelementptr  i64, i64* %57, i64 0 
-  store  i64 %"$field#0", i64* %58 
+  store  i64 %"$field##0", i64* %58 
   %59 = insertvalue {i64, i1} undef, i64 %53, 0 
   %60 = insertvalue {i64, i1} %59, i1 1, 1 
   ret {i64, i1} %60 
 if.else:
-  %61 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %61 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %62 = insertvalue {i64, i1} %61, i1 0, 1 
   ret {i64, i1} %62 
 }
 
 
-define external fastcc  i64 @"stmt_if.tree.node<0>"(i64  %"left#0", i64  %"key#0", i64  %"right#0")    {
+define external fastcc  i64 @"stmt_if.tree.node<0>"(i64  %"left##0", i64  %"key##0", i64  %"right##0")    {
 entry:
   %63 = trunc i64 24 to i32  
   %64 = tail call ccc  i8*  @wybe_malloc(i32  %63)  
   %65 = ptrtoint i8* %64 to i64 
   %66 = inttoptr i64 %65 to i64* 
   %67 = getelementptr  i64, i64* %66, i64 0 
-  store  i64 %"left#0", i64* %67 
+  store  i64 %"left##0", i64* %67 
   %68 = add   i64 %65, 8 
   %69 = inttoptr i64 %68 to i64* 
   %70 = getelementptr  i64, i64* %69, i64 0 
-  store  i64 %"key#0", i64* %70 
+  store  i64 %"key##0", i64* %70 
   %71 = add   i64 %65, 16 
   %72 = inttoptr i64 %71 to i64* 
   %73 = getelementptr  i64, i64* %72, i64 0 
-  store  i64 %"right#0", i64* %73 
+  store  i64 %"right##0", i64* %73 
   ret i64 %65 
 }
 
 
-define external fastcc  {i64, i64, i64, i1} @"stmt_if.tree.node<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64, i64, i1} @"stmt_if.tree.node<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %74 = inttoptr i64 %"$#0" to i64* 
+  %74 = inttoptr i64 %"$##0" to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
   %76 = load  i64, i64* %75 
-  %77 = add   i64 %"$#0", 8 
+  %77 = add   i64 %"$##0", 8 
   %78 = inttoptr i64 %77 to i64* 
   %79 = getelementptr  i64, i64* %78, i64 0 
   %80 = load  i64, i64* %79 
-  %81 = add   i64 %"$#0", 16 
+  %81 = add   i64 %"$##0", 16 
   %82 = inttoptr i64 %81 to i64* 
   %83 = getelementptr  i64, i64* %82, i64 0 
   %84 = load  i64, i64* %83 
@@ -620,12 +620,12 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if.tree.right<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"stmt_if.tree.right<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %93 = add   i64 %"$rec#0", 16 
+  %93 = add   i64 %"$rec##0", 16 
   %94 = inttoptr i64 %93 to i64* 
   %95 = getelementptr  i64, i64* %94, i64 0 
   %96 = load  i64, i64* %95 
@@ -639,35 +639,35 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if.tree.right<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"stmt_if.tree.right<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %101 = trunc i64 24 to i32  
   %102 = tail call ccc  i8*  @wybe_malloc(i32  %101)  
   %103 = ptrtoint i8* %102 to i64 
   %104 = inttoptr i64 %103 to i8* 
-  %105 = inttoptr i64 %"$rec#0" to i8* 
+  %105 = inttoptr i64 %"$rec##0" to i8* 
   %106 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %104, i8*  %105, i32  %106, i32  8, i1  0)  
   %107 = add   i64 %103, 16 
   %108 = inttoptr i64 %107 to i64* 
   %109 = getelementptr  i64, i64* %108, i64 0 
-  store  i64 %"$field#0", i64* %109 
+  store  i64 %"$field##0", i64* %109 
   %110 = insertvalue {i64, i1} undef, i64 %103, 0 
   %111 = insertvalue {i64, i1} %110, i1 1, 1 
   ret {i64, i1} %111 
 if.else:
-  %112 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %112 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %113 = insertvalue {i64, i1} %112, i1 0, 1 
   ret {i64, i1} %113 
 }
 
 
-define external fastcc  i1 @"stmt_if.tree.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"stmt_if.tree.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = tail call fastcc  i1  @"stmt_if.tree.=<0>"(i64  %"$left#0", i64  %"$right#0")  
-  %"1$$$#0" = xor i1 %"1$tmp$0#0", 1 
-  ret i1 %"1$$$#0" 
+  %"1$tmp$0##0" = tail call fastcc  i1  @"stmt_if.tree.=<0>"(i64  %"$left##0", i64  %"$right##0")  
+  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
+  ret i1 %"1$$$##0" 
 }

--- a/test-cases/final-dump/stmt_if2.exp
+++ b/test-cases/final-dump/stmt_if2.exp
@@ -25,67 +25,67 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: stmt_if2.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp$7#0:stmt_if2.tree)
-    foreign lpvm mutate(~tmp$7#0:stmt_if2.tree, ?tmp$8#0:stmt_if2.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:stmt_if2.tree)
-    foreign lpvm mutate(~tmp$8#0:stmt_if2.tree, ?tmp$9#0:stmt_if2.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp$9#0:stmt_if2.tree, ?tmp$10#0:stmt_if2.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:stmt_if2.tree)
-    stmt_if2.lookup<0>(1:wybe.int, ~tmp$10#0:stmt_if2.tree, ?tmp$3#0:wybe.bool) #3 @stmt_if2:17:5
-    case ~tmp$3#0:wybe.bool of
+    foreign lpvm alloc(24:wybe.int, ?tmp$7##0:stmt_if2.tree)
+    foreign lpvm mutate(~tmp$7##0:stmt_if2.tree, ?tmp$8##0:stmt_if2.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:stmt_if2.tree)
+    foreign lpvm mutate(~tmp$8##0:stmt_if2.tree, ?tmp$9##0:stmt_if2.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp$9##0:stmt_if2.tree, ?tmp$10##0:stmt_if2.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:stmt_if2.tree)
+    stmt_if2.lookup<0>(1:wybe.int, ~tmp$10##0:stmt_if2.tree, ?tmp$3##0:wybe.bool) #3 @stmt_if2:17:5
+    case ~tmp$3##0:wybe.bool of
     0:
-        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign c print_string("found":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+        foreign c print_string("found":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 
 gen$1 > {inline} (3 calls)
 0: stmt_if2.gen$1<0>
-gen$1([k#0:wybe.int], [key#0:wybe.int], [l#0:stmt_if2.tree], [r#0:stmt_if2.tree], tmp$4#0:wybe.bool, [tree#0:stmt_if2.tree], ?$#0:wybe.bool):
+gen$1([k##0:wybe.int], [key##0:wybe.int], [l##0:stmt_if2.tree], [r##0:stmt_if2.tree], tmp$4##0:wybe.bool, [tree##0:stmt_if2.tree], ?$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(~tmp$4#0:wybe.bool, ?$#0:wybe.bool) @stmt_if2:5:5
+    foreign llvm move(~tmp$4##0:wybe.bool, ?$##0:wybe.bool) @stmt_if2:5:5
 
 
 lookup > public (5 calls)
 0: stmt_if2.lookup<0>
-lookup(key#0:wybe.int, tree#0:stmt_if2.tree, ?$#0:wybe.bool):
+lookup(key##0:wybe.int, tree##0:stmt_if2.tree, ?$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_if2.tree.=<0>(tree#0:stmt_if2.tree, 0:stmt_if2.tree, ?tmp$13#0:wybe.bool) #1 @stmt_if2:6:9
-    case ~tmp$13#0:wybe.bool of
+    stmt_if2.tree.=<0>(tree##0:stmt_if2.tree, 0:stmt_if2.tree, ?tmp$13##0:wybe.bool) #1 @stmt_if2:6:9
+    case ~tmp$13##0:wybe.bool of
     0:
-        foreign llvm icmp_ne(tree#0:wybe.int, 0:wybe.int, ?tmp$15#0:wybe.bool)
-        case ~tmp$15#0:wybe.bool of
+        foreign llvm icmp_ne(tree##0:wybe.int, 0:wybe.int, ?tmp$15##0:wybe.bool)
+        case ~tmp$15##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$#0:wybe.bool) @stmt_if2:5:5
+            foreign llvm move(0:wybe.bool, ?$##0:wybe.bool) @stmt_if2:5:5
 
         1:
-            foreign lpvm access(tree#0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?l#0:stmt_if2.tree)
-            foreign lpvm access(tree#0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k#0:wybe.int)
-            foreign lpvm access(~tree#0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?r#0:stmt_if2.tree)
-            foreign llvm icmp_eq(k#0:wybe.int, key#0:wybe.int, ?tmp$11#0:wybe.bool) @int:nn:nn
-            case ~tmp$11#0:wybe.bool of
+            foreign lpvm access(tree##0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?l##0:stmt_if2.tree)
+            foreign lpvm access(tree##0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k##0:wybe.int)
+            foreign lpvm access(~tree##0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?r##0:stmt_if2.tree)
+            foreign llvm icmp_eq(k##0:wybe.int, key##0:wybe.int, ?tmp$11##0:wybe.bool) @int:nn:nn
+            case ~tmp$11##0:wybe.bool of
             0:
-                foreign llvm icmp_sgt(~k#0:wybe.int, key#0:wybe.int, ?tmp$10#0:wybe.bool) @int:nn:nn
-                case ~tmp$10#0:wybe.bool of
+                foreign llvm icmp_sgt(~k##0:wybe.int, key##0:wybe.int, ?tmp$10##0:wybe.bool) @int:nn:nn
+                case ~tmp$10##0:wybe.bool of
                 0:
-                    stmt_if2.lookup<0>(~key#0:wybe.int, ~r#0:stmt_if2.tree, ?$#0:wybe.bool) #10 @stmt_if2:10:24
+                    stmt_if2.lookup<0>(~key##0:wybe.int, ~r##0:stmt_if2.tree, ?$##0:wybe.bool) #10 @stmt_if2:10:24
 
                 1:
-                    stmt_if2.lookup<0>(~key#0:wybe.int, ~l#0:stmt_if2.tree, ?$#0:wybe.bool) #8 @stmt_if2:9:27
+                    stmt_if2.lookup<0>(~key##0:wybe.int, ~l##0:stmt_if2.tree, ?$##0:wybe.bool) #8 @stmt_if2:9:27
 
 
             1:
-                foreign llvm move(1:wybe.bool, ?$#0:wybe.bool) @stmt_if2:5:5
+                foreign llvm move(1:wybe.bool, ?$##0:wybe.bool) @stmt_if2:5:5
 
 
 
     1:
-        foreign llvm move(0:wybe.bool, ?$#0:wybe.bool) @stmt_if2:5:5
+        foreign llvm move(0:wybe.bool, ?$##0:wybe.bool) @stmt_if2:5:5
 
 
   LLVM code       :
@@ -124,8 +124,8 @@ entry:
   %10 = inttoptr i64 %9 to i64* 
   %11 = getelementptr  i64, i64* %10, i64 0 
   store  i64 0, i64* %11 
-  %"1$tmp$3#0" = tail call fastcc  i1  @"stmt_if2.lookup<0>"(i64  1, i64  %3)  
-  br i1 %"1$tmp$3#0", label %if.then, label %if.else 
+  %"1$tmp$3##0" = tail call fastcc  i1  @"stmt_if2.lookup<0>"(i64  1, i64  %3)  
+  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
 if.then:
   %13 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @stmt_if2.12, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %13)  
@@ -135,48 +135,48 @@ if.else:
 }
 
 
-define external fastcc  i1 @"stmt_if2.gen$1<0>"(i1  %"tmp$4#0")    {
+define external fastcc  i1 @"stmt_if2.gen$1<0>"(i1  %"tmp$4##0")    {
 entry:
-  ret i1 %"tmp$4#0" 
+  ret i1 %"tmp$4##0" 
 }
 
 
-define external fastcc  i1 @"stmt_if2.lookup<0>"(i64  %"key#0", i64  %"tree#0")    {
+define external fastcc  i1 @"stmt_if2.lookup<0>"(i64  %"key##0", i64  %"tree##0")    {
 entry:
-  %"1$tmp$13#0" = tail call fastcc  i1  @"stmt_if2.tree.=<0>"(i64  %"tree#0", i64  0)  
-  br i1 %"1$tmp$13#0", label %if.then, label %if.else 
+  %"1$tmp$13##0" = tail call fastcc  i1  @"stmt_if2.tree.=<0>"(i64  %"tree##0", i64  0)  
+  br i1 %"1$tmp$13##0", label %if.then, label %if.else 
 if.then:
   ret i1 0 
 if.else:
-  %"3$tmp$15#0" = icmp ne i64 %"tree#0", 0 
-  br i1 %"3$tmp$15#0", label %if.then1, label %if.else1 
+  %"3$tmp$15##0" = icmp ne i64 %"tree##0", 0 
+  br i1 %"3$tmp$15##0", label %if.then1, label %if.else1 
 if.then1:
-  %14 = inttoptr i64 %"tree#0" to i64* 
+  %14 = inttoptr i64 %"tree##0" to i64* 
   %15 = getelementptr  i64, i64* %14, i64 0 
   %16 = load  i64, i64* %15 
-  %17 = add   i64 %"tree#0", 8 
+  %17 = add   i64 %"tree##0", 8 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
   %20 = load  i64, i64* %19 
-  %21 = add   i64 %"tree#0", 16 
+  %21 = add   i64 %"tree##0", 16 
   %22 = inttoptr i64 %21 to i64* 
   %23 = getelementptr  i64, i64* %22, i64 0 
   %24 = load  i64, i64* %23 
-  %"4$tmp$11#0" = icmp eq i64 %20, %"key#0" 
-  br i1 %"4$tmp$11#0", label %if.then2, label %if.else2 
+  %"4$tmp$11##0" = icmp eq i64 %20, %"key##0" 
+  br i1 %"4$tmp$11##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
   ret i1 1 
 if.else2:
-  %"7$tmp$10#0" = icmp sgt i64 %20, %"key#0" 
-  br i1 %"7$tmp$10#0", label %if.then3, label %if.else3 
+  %"7$tmp$10##0" = icmp sgt i64 %20, %"key##0" 
+  br i1 %"7$tmp$10##0", label %if.then3, label %if.else3 
 if.then3:
-  %"8$$#0" = tail call fastcc  i1  @"stmt_if2.lookup<0>"(i64  %"key#0", i64  %16)  
-  ret i1 %"8$$#0" 
+  %"8$$##0" = tail call fastcc  i1  @"stmt_if2.lookup<0>"(i64  %"key##0", i64  %16)  
+  ret i1 %"8$$##0" 
 if.else3:
-  %"9$$#0" = tail call fastcc  i1  @"stmt_if2.lookup<0>"(i64  %"key#0", i64  %24)  
-  ret i1 %"9$$#0" 
+  %"9$$##0" = tail call fastcc  i1  @"stmt_if2.lookup<0>"(i64  %"key##0", i64  %24)  
+  ret i1 %"9$$##0" 
 }
 --------------------------------------------------
  Module stmt_if2.tree
@@ -201,40 +201,40 @@ if.else3:
 
 = > public (7 calls)
 0: stmt_if2.tree.=<0>
-=($left#0:stmt_if2.tree, $right#0:stmt_if2.tree, ?$$#0:wybe.bool):
+=($left##0:stmt_if2.tree, $right##0:stmt_if2.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left#0:stmt_if2.tree, ~$right#0:stmt_if2.tree, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~$left##0:stmt_if2.tree, ~$right##0:stmt_if2.tree, ?$$##0:wybe.bool)
 
     1:
-        foreign lpvm access($left#0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$left#0:stmt_if2.tree)
-        foreign lpvm access($left#0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$key#0:wybe.int)
-        foreign lpvm access(~$left#0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$right#0:stmt_if2.tree)
-        foreign llvm icmp_ne($right#0:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.bool)
-        case ~tmp$10#0:wybe.bool of
+        foreign lpvm access($left##0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$left##0:stmt_if2.tree)
+        foreign lpvm access($left##0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$key##0:wybe.int)
+        foreign lpvm access(~$left##0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$right##0:stmt_if2.tree)
+        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.bool)
+        case ~tmp$10##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign lpvm access($right#0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$left#0:stmt_if2.tree)
-            foreign lpvm access($right#0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$key#0:wybe.int)
-            foreign lpvm access(~$right#0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$right#0:stmt_if2.tree)
-            stmt_if2.tree.=<0>(~$left$left#0:stmt_if2.tree, ~$right$left#0:stmt_if2.tree, ?tmp$4#0:wybe.bool) #2
-            case ~tmp$4#0:wybe.bool of
+            foreign lpvm access($right##0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$left##0:stmt_if2.tree)
+            foreign lpvm access($right##0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$key##0:wybe.int)
+            foreign lpvm access(~$right##0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$right##0:stmt_if2.tree)
+            stmt_if2.tree.=<0>(~$left$left##0:stmt_if2.tree, ~$right$left##0:stmt_if2.tree, ?tmp$4##0:wybe.bool) #2
+            case ~tmp$4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                foreign llvm icmp_eq(~$left$key#0:wybe.int, ~$right$key#0:wybe.int, ?tmp$5#0:wybe.bool) @int:nn:nn
-                case ~tmp$5#0:wybe.bool of
+                foreign llvm icmp_eq(~$left$key##0:wybe.int, ~$right$key##0:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
+                case ~tmp$5##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                 1:
-                    stmt_if2.tree.=<0>(~$left$right#0:stmt_if2.tree, ~$right$right#0:stmt_if2.tree, ?$$#0:wybe.bool) #4
+                    stmt_if2.tree.=<0>(~$left$right##0:stmt_if2.tree, ~$right$right##0:stmt_if2.tree, ?$$##0:wybe.bool) #4
 
 
 
@@ -243,145 +243,145 @@ if.else3:
 
 empty > public {inline} (0 calls)
 0: stmt_if2.tree.empty<0>
-empty(?$#0:stmt_if2.tree):
+empty(?$##0:stmt_if2.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:stmt_if2.tree, ?$#0:stmt_if2.tree)
+    foreign llvm move(0:stmt_if2.tree, ?$##0:stmt_if2.tree)
 
 
 key > public {inline} (0 calls)
 0: stmt_if2.tree.key<0>
-key($rec#0:stmt_if2.tree, ?$#0:wybe.int, ?$$#0:wybe.bool):
+key($rec##0:stmt_if2.tree, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec#0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 key > public {inline} (0 calls)
 1: stmt_if2.tree.key<1>
-key($rec#0:stmt_if2.tree, ?$rec#1:stmt_if2.tree, $field#0:wybe.int, ?$$#0:wybe.bool):
+key($rec##0:stmt_if2.tree, ?$rec##1:stmt_if2.tree, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:stmt_if2.tree, ?$rec#1:stmt_if2.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:stmt_if2.tree, ?$rec##1:stmt_if2.tree)
 
     1:
-        foreign lpvm mutate(~$rec#0:stmt_if2.tree, ?$rec#1:stmt_if2.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~$rec##0:stmt_if2.tree, ?$rec##1:stmt_if2.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 left > public {inline} (0 calls)
 0: stmt_if2.tree.left<0>
-left($rec#0:stmt_if2.tree, ?$#0:stmt_if2.tree, ?$$#0:wybe.bool):
+left($rec##0:stmt_if2.tree, ?$##0:stmt_if2.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:stmt_if2.tree, ?$#0:stmt_if2.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:stmt_if2.tree, ?$##0:stmt_if2.tree)
 
     1:
-        foreign lpvm access(~$rec#0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:stmt_if2.tree)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:stmt_if2.tree)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 left > public {inline} (0 calls)
 1: stmt_if2.tree.left<1>
-left($rec#0:stmt_if2.tree, ?$rec#1:stmt_if2.tree, $field#0:stmt_if2.tree, ?$$#0:wybe.bool):
+left($rec##0:stmt_if2.tree, ?$rec##1:stmt_if2.tree, $field##0:stmt_if2.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:stmt_if2.tree, ?$rec#1:stmt_if2.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:stmt_if2.tree, ?$rec##1:stmt_if2.tree)
 
     1:
-        foreign lpvm mutate(~$rec#0:stmt_if2.tree, ?$rec#1:stmt_if2.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field#0:stmt_if2.tree)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~$rec##0:stmt_if2.tree, ?$rec##1:stmt_if2.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:stmt_if2.tree)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 node > public {inline} (0 calls)
 0: stmt_if2.tree.node<0>
-node(left#0:stmt_if2.tree, key#0:wybe.int, right#0:stmt_if2.tree, ?$#0:stmt_if2.tree):
+node(left##0:stmt_if2.tree, key##0:wybe.int, right##0:stmt_if2.tree, ?$##0:stmt_if2.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?$rec#0:stmt_if2.tree)
-    foreign lpvm mutate(~$rec#0:stmt_if2.tree, ?$rec#1:stmt_if2.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left#0:stmt_if2.tree)
-    foreign lpvm mutate(~$rec#1:stmt_if2.tree, ?$rec#2:stmt_if2.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key#0:wybe.int)
-    foreign lpvm mutate(~$rec#2:stmt_if2.tree, ?$#0:stmt_if2.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right#0:stmt_if2.tree)
+    foreign lpvm alloc(24:wybe.int, ?$rec##0:stmt_if2.tree)
+    foreign lpvm mutate(~$rec##0:stmt_if2.tree, ?$rec##1:stmt_if2.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:stmt_if2.tree)
+    foreign lpvm mutate(~$rec##1:stmt_if2.tree, ?$rec##2:stmt_if2.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int)
+    foreign lpvm mutate(~$rec##2:stmt_if2.tree, ?$##0:stmt_if2.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:stmt_if2.tree)
 node > public {inline} (16 calls)
 1: stmt_if2.tree.node<1>
-node(?left#0:stmt_if2.tree, ?key#0:wybe.int, ?right#0:stmt_if2.tree, $#0:stmt_if2.tree, ?$$#0:wybe.bool):
+node(?left##0:stmt_if2.tree, ?key##0:wybe.int, ?right##0:stmt_if2.tree, $##0:stmt_if2.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:stmt_if2.tree, ?left#0:stmt_if2.tree)
-        foreign llvm move(undef:wybe.int, ?key#0:wybe.int)
-        foreign llvm move(undef:stmt_if2.tree, ?right#0:stmt_if2.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:stmt_if2.tree, ?left##0:stmt_if2.tree)
+        foreign llvm move(undef:wybe.int, ?key##0:wybe.int)
+        foreign llvm move(undef:stmt_if2.tree, ?right##0:stmt_if2.tree)
 
     1:
-        foreign lpvm access($#0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left#0:stmt_if2.tree)
-        foreign lpvm access($#0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key#0:wybe.int)
-        foreign lpvm access(~$#0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right#0:stmt_if2.tree)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access($##0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:stmt_if2.tree)
+        foreign lpvm access($##0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
+        foreign lpvm access(~$##0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:stmt_if2.tree)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 right > public {inline} (0 calls)
 0: stmt_if2.tree.right<0>
-right($rec#0:stmt_if2.tree, ?$#0:stmt_if2.tree, ?$$#0:wybe.bool):
+right($rec##0:stmt_if2.tree, ?$##0:stmt_if2.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:stmt_if2.tree, ?$#0:stmt_if2.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:stmt_if2.tree, ?$##0:stmt_if2.tree)
 
     1:
-        foreign lpvm access(~$rec#0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:stmt_if2.tree)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:stmt_if2.tree)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 right > public {inline} (0 calls)
 1: stmt_if2.tree.right<1>
-right($rec#0:stmt_if2.tree, ?$rec#1:stmt_if2.tree, $field#0:stmt_if2.tree, ?$$#0:wybe.bool):
+right($rec##0:stmt_if2.tree, ?$rec##1:stmt_if2.tree, $field##0:stmt_if2.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:stmt_if2.tree, ?$rec#1:stmt_if2.tree)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:stmt_if2.tree, ?$rec##1:stmt_if2.tree)
 
     1:
-        foreign lpvm mutate(~$rec#0:stmt_if2.tree, ?$rec#1:stmt_if2.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field#0:stmt_if2.tree)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~$rec##0:stmt_if2.tree, ?$rec##1:stmt_if2.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:stmt_if2.tree)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: stmt_if2.tree.~=<0>
-~=($left#0:stmt_if2.tree, $right#0:stmt_if2.tree, ?$$#0:wybe.bool):
+~=($left##0:stmt_if2.tree, $right##0:stmt_if2.tree, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_if2.tree.=<0>(~$left#0:stmt_if2.tree, ~$right#0:stmt_if2.tree, ?tmp$0#0:wybe.bool) #0
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    stmt_if2.tree.=<0>(~$left##0:stmt_if2.tree, ~$right##0:stmt_if2.tree, ?tmp$0##0:wybe.bool) #0
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
   LLVM code       :
 
@@ -397,51 +397,51 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"stmt_if2.tree.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"stmt_if2.tree.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$left#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = add   i64 %"$left#0", 16 
+  %8 = add   i64 %"$left##0", 16 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
-  %"2$tmp$10#0" = icmp ne i64 %"$right#0", 0 
-  br i1 %"2$tmp$10#0", label %if.then1, label %if.else1 
+  %"2$tmp$10##0" = icmp ne i64 %"$right##0", 0 
+  br i1 %"2$tmp$10##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = icmp eq i64 %"$left#0", %"$right#0" 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
+  ret i1 %"3$$$##0" 
 if.then1:
-  %12 = inttoptr i64 %"$right#0" to i64* 
+  %12 = inttoptr i64 %"$right##0" to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %15 = add   i64 %"$right#0", 8 
+  %15 = add   i64 %"$right##0", 8 
   %16 = inttoptr i64 %15 to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
-  %19 = add   i64 %"$right#0", 16 
+  %19 = add   i64 %"$right##0", 16 
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %"4$tmp$4#0" = tail call fastcc  i1  @"stmt_if2.tree.=<0>"(i64  %3, i64  %14)  
-  br i1 %"4$tmp$4#0", label %if.then2, label %if.else2 
+  %"4$tmp$4##0" = tail call fastcc  i1  @"stmt_if2.tree.=<0>"(i64  %3, i64  %14)  
+  br i1 %"4$tmp$4##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$tmp$5#0" = icmp eq i64 %7, %18 
-  br i1 %"6$tmp$5#0", label %if.then3, label %if.else3 
+  %"6$tmp$5##0" = icmp eq i64 %7, %18 
+  br i1 %"6$tmp$5##0", label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %"8$$$#0" = tail call fastcc  i1  @"stmt_if2.tree.=<0>"(i64  %11, i64  %22)  
-  ret i1 %"8$$$#0" 
+  %"8$$$##0" = tail call fastcc  i1  @"stmt_if2.tree.=<0>"(i64  %11, i64  %22)  
+  ret i1 %"8$$$##0" 
 if.else3:
   ret i1 0 
 }
@@ -453,12 +453,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if2.tree.key<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"stmt_if2.tree.key<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %23 = add   i64 %"$rec#0", 8 
+  %23 = add   i64 %"$rec##0", 8 
   %24 = inttoptr i64 %23 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
   %26 = load  i64, i64* %25 
@@ -472,38 +472,38 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if2.tree.key<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"stmt_if2.tree.key<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %31 = trunc i64 24 to i32  
   %32 = tail call ccc  i8*  @wybe_malloc(i32  %31)  
   %33 = ptrtoint i8* %32 to i64 
   %34 = inttoptr i64 %33 to i8* 
-  %35 = inttoptr i64 %"$rec#0" to i8* 
+  %35 = inttoptr i64 %"$rec##0" to i8* 
   %36 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %34, i8*  %35, i32  %36, i32  8, i1  0)  
   %37 = add   i64 %33, 8 
   %38 = inttoptr i64 %37 to i64* 
   %39 = getelementptr  i64, i64* %38, i64 0 
-  store  i64 %"$field#0", i64* %39 
+  store  i64 %"$field##0", i64* %39 
   %40 = insertvalue {i64, i1} undef, i64 %33, 0 
   %41 = insertvalue {i64, i1} %40, i1 1, 1 
   ret {i64, i1} %41 
 if.else:
-  %42 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %42 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %43 = insertvalue {i64, i1} %42, i1 0, 1 
   ret {i64, i1} %43 
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if2.tree.left<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"stmt_if2.tree.left<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %44 = inttoptr i64 %"$rec#0" to i64* 
+  %44 = inttoptr i64 %"$rec##0" to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
   %47 = insertvalue {i64, i1} undef, i64 %46, 0 
@@ -516,64 +516,64 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if2.tree.left<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"stmt_if2.tree.left<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %51 = trunc i64 24 to i32  
   %52 = tail call ccc  i8*  @wybe_malloc(i32  %51)  
   %53 = ptrtoint i8* %52 to i64 
   %54 = inttoptr i64 %53 to i8* 
-  %55 = inttoptr i64 %"$rec#0" to i8* 
+  %55 = inttoptr i64 %"$rec##0" to i8* 
   %56 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %54, i8*  %55, i32  %56, i32  8, i1  0)  
   %57 = inttoptr i64 %53 to i64* 
   %58 = getelementptr  i64, i64* %57, i64 0 
-  store  i64 %"$field#0", i64* %58 
+  store  i64 %"$field##0", i64* %58 
   %59 = insertvalue {i64, i1} undef, i64 %53, 0 
   %60 = insertvalue {i64, i1} %59, i1 1, 1 
   ret {i64, i1} %60 
 if.else:
-  %61 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %61 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %62 = insertvalue {i64, i1} %61, i1 0, 1 
   ret {i64, i1} %62 
 }
 
 
-define external fastcc  i64 @"stmt_if2.tree.node<0>"(i64  %"left#0", i64  %"key#0", i64  %"right#0")    {
+define external fastcc  i64 @"stmt_if2.tree.node<0>"(i64  %"left##0", i64  %"key##0", i64  %"right##0")    {
 entry:
   %63 = trunc i64 24 to i32  
   %64 = tail call ccc  i8*  @wybe_malloc(i32  %63)  
   %65 = ptrtoint i8* %64 to i64 
   %66 = inttoptr i64 %65 to i64* 
   %67 = getelementptr  i64, i64* %66, i64 0 
-  store  i64 %"left#0", i64* %67 
+  store  i64 %"left##0", i64* %67 
   %68 = add   i64 %65, 8 
   %69 = inttoptr i64 %68 to i64* 
   %70 = getelementptr  i64, i64* %69, i64 0 
-  store  i64 %"key#0", i64* %70 
+  store  i64 %"key##0", i64* %70 
   %71 = add   i64 %65, 16 
   %72 = inttoptr i64 %71 to i64* 
   %73 = getelementptr  i64, i64* %72, i64 0 
-  store  i64 %"right#0", i64* %73 
+  store  i64 %"right##0", i64* %73 
   ret i64 %65 
 }
 
 
-define external fastcc  {i64, i64, i64, i1} @"stmt_if2.tree.node<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64, i64, i1} @"stmt_if2.tree.node<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %74 = inttoptr i64 %"$#0" to i64* 
+  %74 = inttoptr i64 %"$##0" to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
   %76 = load  i64, i64* %75 
-  %77 = add   i64 %"$#0", 8 
+  %77 = add   i64 %"$##0", 8 
   %78 = inttoptr i64 %77 to i64* 
   %79 = getelementptr  i64, i64* %78, i64 0 
   %80 = load  i64, i64* %79 
-  %81 = add   i64 %"$#0", 16 
+  %81 = add   i64 %"$##0", 16 
   %82 = inttoptr i64 %81 to i64* 
   %83 = getelementptr  i64, i64* %82, i64 0 
   %84 = load  i64, i64* %83 
@@ -591,12 +591,12 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if2.tree.right<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"stmt_if2.tree.right<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %93 = add   i64 %"$rec#0", 16 
+  %93 = add   i64 %"$rec##0", 16 
   %94 = inttoptr i64 %93 to i64* 
   %95 = getelementptr  i64, i64* %94, i64 0 
   %96 = load  i64, i64* %95 
@@ -610,35 +610,35 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if2.tree.right<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"stmt_if2.tree.right<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %101 = trunc i64 24 to i32  
   %102 = tail call ccc  i8*  @wybe_malloc(i32  %101)  
   %103 = ptrtoint i8* %102 to i64 
   %104 = inttoptr i64 %103 to i8* 
-  %105 = inttoptr i64 %"$rec#0" to i8* 
+  %105 = inttoptr i64 %"$rec##0" to i8* 
   %106 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %104, i8*  %105, i32  %106, i32  8, i1  0)  
   %107 = add   i64 %103, 16 
   %108 = inttoptr i64 %107 to i64* 
   %109 = getelementptr  i64, i64* %108, i64 0 
-  store  i64 %"$field#0", i64* %109 
+  store  i64 %"$field##0", i64* %109 
   %110 = insertvalue {i64, i1} undef, i64 %103, 0 
   %111 = insertvalue {i64, i1} %110, i1 1, 1 
   ret {i64, i1} %111 
 if.else:
-  %112 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %112 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %113 = insertvalue {i64, i1} %112, i1 0, 1 
   ret {i64, i1} %113 
 }
 
 
-define external fastcc  i1 @"stmt_if2.tree.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"stmt_if2.tree.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = tail call fastcc  i1  @"stmt_if2.tree.=<0>"(i64  %"$left#0", i64  %"$right#0")  
-  %"1$$$#0" = xor i1 %"1$tmp$0#0", 1 
-  ret i1 %"1$$$#0" 
+  %"1$tmp$0##0" = tail call fastcc  i1  @"stmt_if2.tree.=<0>"(i64  %"$left##0", i64  %"$right##0")  
+  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
+  ret i1 %"1$$$##0" 
 }

--- a/test-cases/final-dump/stmt_if2.exp
+++ b/test-cases/final-dump/stmt_if2.exp
@@ -201,13 +201,13 @@ if.else3:
 
 = > public (7 calls)
 0: stmt_if2.tree.=<0>
-=(#left##0:stmt_if2.tree, #right##0:stmt_if2.tree, ?####0:wybe.bool):
+=(#left##0:stmt_if2.tree, #right##0:stmt_if2.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~#left##0:stmt_if2.tree, ~#right##0:stmt_if2.tree, ?####0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:stmt_if2.tree, ~#right##0:stmt_if2.tree, ?#success##0:wybe.bool)
 
     1:
         foreign lpvm access(#left##0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#left##0:stmt_if2.tree)
@@ -216,7 +216,7 @@ if.else3:
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
         case ~tmp#10##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign lpvm access(#right##0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#left##0:stmt_if2.tree)
@@ -225,16 +225,16 @@ if.else3:
             stmt_if2.tree.=<0>(~#left#left##0:stmt_if2.tree, ~#right#left##0:stmt_if2.tree, ?tmp#4##0:wybe.bool) #2
             case ~tmp#4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
                 foreign llvm icmp_eq(~#left#key##0:wybe.int, ~#right#key##0:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
                 case ~tmp#5##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                 1:
-                    stmt_if2.tree.=<0>(~#left#right##0:stmt_if2.tree, ~#right#right##0:stmt_if2.tree, ?####0:wybe.bool) #4
+                    stmt_if2.tree.=<0>(~#left#right##0:stmt_if2.tree, ~#right#right##0:stmt_if2.tree, ?#success##0:wybe.bool) #4
 
 
 
@@ -251,65 +251,65 @@ empty(?#result##0:stmt_if2.tree):
 
 key > public {inline} (0 calls)
 0: stmt_if2.tree.key<0>
-key(#rec##0:stmt_if2.tree, ?#result##0:wybe.int, ?####0:wybe.bool):
+key(#rec##0:stmt_if2.tree, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign lpvm access(~#rec##0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 key > public {inline} (0 calls)
 1: stmt_if2.tree.key<1>
-key(#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, #field##0:wybe.int, ?####0:wybe.bool):
+key(#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree)
 
     1:
         foreign lpvm mutate(~#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 left > public {inline} (0 calls)
 0: stmt_if2.tree.left<0>
-left(#rec##0:stmt_if2.tree, ?#result##0:stmt_if2.tree, ?####0:wybe.bool):
+left(#rec##0:stmt_if2.tree, ?#result##0:stmt_if2.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:stmt_if2.tree, ?#result##0:stmt_if2.tree)
 
     1:
         foreign lpvm access(~#rec##0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:stmt_if2.tree)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 left > public {inline} (0 calls)
 1: stmt_if2.tree.left<1>
-left(#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, #field##0:stmt_if2.tree, ?####0:wybe.bool):
+left(#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, #field##0:stmt_if2.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree)
 
     1:
         foreign lpvm mutate(~#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:stmt_if2.tree)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -324,13 +324,13 @@ node(left##0:stmt_if2.tree, key##0:wybe.int, right##0:stmt_if2.tree, ?#result##0
     foreign lpvm mutate(~#rec##2:stmt_if2.tree, ?#result##0:stmt_if2.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:stmt_if2.tree)
 node > public {inline} (16 calls)
 1: stmt_if2.tree.node<1>
-node(?left##0:stmt_if2.tree, ?key##0:wybe.int, ?right##0:stmt_if2.tree, #result##0:stmt_if2.tree, ?####0:wybe.bool):
+node(?left##0:stmt_if2.tree, ?key##0:wybe.int, ?right##0:stmt_if2.tree, #result##0:stmt_if2.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:stmt_if2.tree, ?left##0:stmt_if2.tree)
         foreign llvm move(undef:wybe.int, ?key##0:wybe.int)
         foreign llvm move(undef:stmt_if2.tree, ?right##0:stmt_if2.tree)
@@ -339,49 +339,49 @@ node(?left##0:stmt_if2.tree, ?key##0:wybe.int, ?right##0:stmt_if2.tree, #result#
         foreign lpvm access(#result##0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:stmt_if2.tree)
         foreign lpvm access(#result##0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
         foreign lpvm access(~#result##0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:stmt_if2.tree)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 right > public {inline} (0 calls)
 0: stmt_if2.tree.right<0>
-right(#rec##0:stmt_if2.tree, ?#result##0:stmt_if2.tree, ?####0:wybe.bool):
+right(#rec##0:stmt_if2.tree, ?#result##0:stmt_if2.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:stmt_if2.tree, ?#result##0:stmt_if2.tree)
 
     1:
         foreign lpvm access(~#rec##0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:stmt_if2.tree)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 right > public {inline} (0 calls)
 1: stmt_if2.tree.right<1>
-right(#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, #field##0:stmt_if2.tree, ?####0:wybe.bool):
+right(#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, #field##0:stmt_if2.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree)
 
     1:
         foreign lpvm mutate(~#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:stmt_if2.tree)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: stmt_if2.tree.~=<0>
-~=(#left##0:stmt_if2.tree, #right##0:stmt_if2.tree, ?####0:wybe.bool):
+~=(#left##0:stmt_if2.tree, #right##0:stmt_if2.tree, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     stmt_if2.tree.=<0>(~#left##0:stmt_if2.tree, ~#right##0:stmt_if2.tree, ?tmp#0##0:wybe.bool) #0
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 
@@ -416,8 +416,8 @@ if.then:
   %"2#tmp#10##0" = icmp ne i64 %"#right##0", 0 
   br i1 %"2#tmp#10##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %"3#####0" 
+  %"3##success##0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3##success##0" 
 if.then1:
   %12 = inttoptr i64 %"#right##0" to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
@@ -440,8 +440,8 @@ if.then2:
 if.else2:
   ret i1 0 
 if.then3:
-  %"8#####0" = tail call fastcc  i1  @"stmt_if2.tree.=<0>"(i64  %11, i64  %22)  
-  ret i1 %"8#####0" 
+  %"8##success##0" = tail call fastcc  i1  @"stmt_if2.tree.=<0>"(i64  %11, i64  %22)  
+  ret i1 %"8##success##0" 
 if.else3:
   ret i1 0 
 }
@@ -639,6 +639,6 @@ if.else:
 define external fastcc  i1 @"stmt_if2.tree.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %"1#tmp#0##0" = tail call fastcc  i1  @"stmt_if2.tree.=<0>"(i64  %"#left##0", i64  %"#right##0")  
-  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
-  ret i1 %"1#####0" 
+  %"1##success##0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1##success##0" 
 }

--- a/test-cases/final-dump/stmt_if2.exp
+++ b/test-cases/final-dump/stmt_if2.exp
@@ -28,12 +28,12 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?tmp$7##0:stmt_if2.tree)
-    foreign lpvm mutate(~tmp$7##0:stmt_if2.tree, ?tmp$8##0:stmt_if2.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:stmt_if2.tree)
-    foreign lpvm mutate(~tmp$8##0:stmt_if2.tree, ?tmp$9##0:stmt_if2.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp$9##0:stmt_if2.tree, ?tmp$10##0:stmt_if2.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:stmt_if2.tree)
-    stmt_if2.lookup<0>(1:wybe.int, ~tmp$10##0:stmt_if2.tree, ?tmp$3##0:wybe.bool) #3 @stmt_if2:17:5
-    case ~tmp$3##0:wybe.bool of
+    foreign lpvm alloc(24:wybe.int, ?tmp#7##0:stmt_if2.tree)
+    foreign lpvm mutate(~tmp#7##0:stmt_if2.tree, ?tmp#8##0:stmt_if2.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:stmt_if2.tree)
+    foreign lpvm mutate(~tmp#8##0:stmt_if2.tree, ?tmp#9##0:stmt_if2.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp#9##0:stmt_if2.tree, ?tmp#10##0:stmt_if2.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 0:stmt_if2.tree)
+    stmt_if2.lookup<0>(1:wybe.int, ~tmp#10##0:stmt_if2.tree, ?tmp#3##0:wybe.bool) #3 @stmt_if2:17:5
+    case ~tmp#3##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
@@ -42,50 +42,50 @@ AFTER EVERYTHING:
 
 
 
-gen$1 > {inline} (3 calls)
-0: stmt_if2.gen$1<0>
-gen$1([k##0:wybe.int], [key##0:wybe.int], [l##0:stmt_if2.tree], [r##0:stmt_if2.tree], tmp$4##0:wybe.bool, [tree##0:stmt_if2.tree], ?$##0:wybe.bool):
+gen#1 > {inline} (3 calls)
+0: stmt_if2.gen#1<0>
+gen#1([k##0:wybe.int], [key##0:wybe.int], [l##0:stmt_if2.tree], [r##0:stmt_if2.tree], tmp#4##0:wybe.bool, [tree##0:stmt_if2.tree], ?###0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(~tmp$4##0:wybe.bool, ?$##0:wybe.bool) @stmt_if2:5:5
+    foreign llvm move(~tmp#4##0:wybe.bool, ?###0:wybe.bool) @stmt_if2:5:5
 
 
 lookup > public (5 calls)
 0: stmt_if2.lookup<0>
-lookup(key##0:wybe.int, tree##0:stmt_if2.tree, ?$##0:wybe.bool):
+lookup(key##0:wybe.int, tree##0:stmt_if2.tree, ?###0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_if2.tree.=<0>(tree##0:stmt_if2.tree, 0:stmt_if2.tree, ?tmp$13##0:wybe.bool) #1 @stmt_if2:6:9
-    case ~tmp$13##0:wybe.bool of
+    stmt_if2.tree.=<0>(tree##0:stmt_if2.tree, 0:stmt_if2.tree, ?tmp#13##0:wybe.bool) #1 @stmt_if2:6:9
+    case ~tmp#13##0:wybe.bool of
     0:
-        foreign llvm icmp_ne(tree##0:wybe.int, 0:wybe.int, ?tmp$15##0:wybe.bool)
-        case ~tmp$15##0:wybe.bool of
+        foreign llvm icmp_ne(tree##0:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.bool)
+        case ~tmp#15##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$##0:wybe.bool) @stmt_if2:5:5
+            foreign llvm move(0:wybe.bool, ?###0:wybe.bool) @stmt_if2:5:5
 
         1:
             foreign lpvm access(tree##0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?l##0:stmt_if2.tree)
             foreign lpvm access(tree##0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?k##0:wybe.int)
             foreign lpvm access(~tree##0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?r##0:stmt_if2.tree)
-            foreign llvm icmp_eq(k##0:wybe.int, key##0:wybe.int, ?tmp$11##0:wybe.bool) @int:nn:nn
-            case ~tmp$11##0:wybe.bool of
+            foreign llvm icmp_eq(k##0:wybe.int, key##0:wybe.int, ?tmp#11##0:wybe.bool) @int:nn:nn
+            case ~tmp#11##0:wybe.bool of
             0:
-                foreign llvm icmp_sgt(~k##0:wybe.int, key##0:wybe.int, ?tmp$10##0:wybe.bool) @int:nn:nn
-                case ~tmp$10##0:wybe.bool of
+                foreign llvm icmp_sgt(~k##0:wybe.int, key##0:wybe.int, ?tmp#10##0:wybe.bool) @int:nn:nn
+                case ~tmp#10##0:wybe.bool of
                 0:
-                    stmt_if2.lookup<0>(~key##0:wybe.int, ~r##0:stmt_if2.tree, ?$##0:wybe.bool) #10 @stmt_if2:10:24
+                    stmt_if2.lookup<0>(~key##0:wybe.int, ~r##0:stmt_if2.tree, ?###0:wybe.bool) #10 @stmt_if2:10:24
 
                 1:
-                    stmt_if2.lookup<0>(~key##0:wybe.int, ~l##0:stmt_if2.tree, ?$##0:wybe.bool) #8 @stmt_if2:9:27
+                    stmt_if2.lookup<0>(~key##0:wybe.int, ~l##0:stmt_if2.tree, ?###0:wybe.bool) #8 @stmt_if2:9:27
 
 
             1:
-                foreign llvm move(1:wybe.bool, ?$##0:wybe.bool) @stmt_if2:5:5
+                foreign llvm move(1:wybe.bool, ?###0:wybe.bool) @stmt_if2:5:5
 
 
 
     1:
-        foreign llvm move(0:wybe.bool, ?$##0:wybe.bool) @stmt_if2:5:5
+        foreign llvm move(0:wybe.bool, ?###0:wybe.bool) @stmt_if2:5:5
 
 
   LLVM code       :
@@ -124,8 +124,8 @@ entry:
   %10 = inttoptr i64 %9 to i64* 
   %11 = getelementptr  i64, i64* %10, i64 0 
   store  i64 0, i64* %11 
-  %"1$tmp$3##0" = tail call fastcc  i1  @"stmt_if2.lookup<0>"(i64  1, i64  %3)  
-  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
+  %"1#tmp#3##0" = tail call fastcc  i1  @"stmt_if2.lookup<0>"(i64  1, i64  %3)  
+  br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
   %13 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @stmt_if2.12, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %13)  
@@ -135,21 +135,21 @@ if.else:
 }
 
 
-define external fastcc  i1 @"stmt_if2.gen$1<0>"(i1  %"tmp$4##0")    {
+define external fastcc  i1 @"stmt_if2.gen#1<0>"(i1  %"tmp#4##0")    {
 entry:
-  ret i1 %"tmp$4##0" 
+  ret i1 %"tmp#4##0" 
 }
 
 
 define external fastcc  i1 @"stmt_if2.lookup<0>"(i64  %"key##0", i64  %"tree##0")    {
 entry:
-  %"1$tmp$13##0" = tail call fastcc  i1  @"stmt_if2.tree.=<0>"(i64  %"tree##0", i64  0)  
-  br i1 %"1$tmp$13##0", label %if.then, label %if.else 
+  %"1#tmp#13##0" = tail call fastcc  i1  @"stmt_if2.tree.=<0>"(i64  %"tree##0", i64  0)  
+  br i1 %"1#tmp#13##0", label %if.then, label %if.else 
 if.then:
   ret i1 0 
 if.else:
-  %"3$tmp$15##0" = icmp ne i64 %"tree##0", 0 
-  br i1 %"3$tmp$15##0", label %if.then1, label %if.else1 
+  %"3#tmp#15##0" = icmp ne i64 %"tree##0", 0 
+  br i1 %"3#tmp#15##0", label %if.then1, label %if.else1 
 if.then1:
   %14 = inttoptr i64 %"tree##0" to i64* 
   %15 = getelementptr  i64, i64* %14, i64 0 
@@ -162,21 +162,21 @@ if.then1:
   %22 = inttoptr i64 %21 to i64* 
   %23 = getelementptr  i64, i64* %22, i64 0 
   %24 = load  i64, i64* %23 
-  %"4$tmp$11##0" = icmp eq i64 %20, %"key##0" 
-  br i1 %"4$tmp$11##0", label %if.then2, label %if.else2 
+  %"4#tmp#11##0" = icmp eq i64 %20, %"key##0" 
+  br i1 %"4#tmp#11##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
   ret i1 1 
 if.else2:
-  %"7$tmp$10##0" = icmp sgt i64 %20, %"key##0" 
-  br i1 %"7$tmp$10##0", label %if.then3, label %if.else3 
+  %"7#tmp#10##0" = icmp sgt i64 %20, %"key##0" 
+  br i1 %"7#tmp#10##0", label %if.then3, label %if.else3 
 if.then3:
-  %"8$$##0" = tail call fastcc  i1  @"stmt_if2.lookup<0>"(i64  %"key##0", i64  %16)  
-  ret i1 %"8$$##0" 
+  %"8####0" = tail call fastcc  i1  @"stmt_if2.lookup<0>"(i64  %"key##0", i64  %16)  
+  ret i1 %"8####0" 
 if.else3:
-  %"9$$##0" = tail call fastcc  i1  @"stmt_if2.lookup<0>"(i64  %"key##0", i64  %24)  
-  ret i1 %"9$$##0" 
+  %"9####0" = tail call fastcc  i1  @"stmt_if2.lookup<0>"(i64  %"key##0", i64  %24)  
+  ret i1 %"9####0" 
 }
 --------------------------------------------------
  Module stmt_if2.tree
@@ -201,40 +201,40 @@ if.else3:
 
 = > public (7 calls)
 0: stmt_if2.tree.=<0>
-=($left##0:stmt_if2.tree, $right##0:stmt_if2.tree, ?$$##0:wybe.bool):
+=(#left##0:stmt_if2.tree, #right##0:stmt_if2.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left##0:stmt_if2.tree, ~$right##0:stmt_if2.tree, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:stmt_if2.tree, ~#right##0:stmt_if2.tree, ?####0:wybe.bool)
 
     1:
-        foreign lpvm access($left##0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$left##0:stmt_if2.tree)
-        foreign lpvm access($left##0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$key##0:wybe.int)
-        foreign lpvm access(~$left##0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$right##0:stmt_if2.tree)
-        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.bool)
-        case ~tmp$10##0:wybe.bool of
+        foreign lpvm access(#left##0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#left##0:stmt_if2.tree)
+        foreign lpvm access(#left##0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#key##0:wybe.int)
+        foreign lpvm access(~#left##0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#right##0:stmt_if2.tree)
+        foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
+        case ~tmp#10##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign lpvm access($right##0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$left##0:stmt_if2.tree)
-            foreign lpvm access($right##0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$key##0:wybe.int)
-            foreign lpvm access(~$right##0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$right##0:stmt_if2.tree)
-            stmt_if2.tree.=<0>(~$left$left##0:stmt_if2.tree, ~$right$left##0:stmt_if2.tree, ?tmp$4##0:wybe.bool) #2
-            case ~tmp$4##0:wybe.bool of
+            foreign lpvm access(#right##0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#left##0:stmt_if2.tree)
+            foreign lpvm access(#right##0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#key##0:wybe.int)
+            foreign lpvm access(~#right##0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#right##0:stmt_if2.tree)
+            stmt_if2.tree.=<0>(~#left#left##0:stmt_if2.tree, ~#right#left##0:stmt_if2.tree, ?tmp#4##0:wybe.bool) #2
+            case ~tmp#4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
             1:
-                foreign llvm icmp_eq(~$left$key##0:wybe.int, ~$right$key##0:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
-                case ~tmp$5##0:wybe.bool of
+                foreign llvm icmp_eq(~#left#key##0:wybe.int, ~#right#key##0:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
+                case ~tmp#5##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                 1:
-                    stmt_if2.tree.=<0>(~$left$right##0:stmt_if2.tree, ~$right$right##0:stmt_if2.tree, ?$$##0:wybe.bool) #4
+                    stmt_if2.tree.=<0>(~#left#right##0:stmt_if2.tree, ~#right#right##0:stmt_if2.tree, ?####0:wybe.bool) #4
 
 
 
@@ -243,145 +243,145 @@ if.else3:
 
 empty > public {inline} (0 calls)
 0: stmt_if2.tree.empty<0>
-empty(?$##0:stmt_if2.tree):
+empty(?###0:stmt_if2.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:stmt_if2.tree, ?$##0:stmt_if2.tree)
+    foreign llvm move(0:stmt_if2.tree, ?###0:stmt_if2.tree)
 
 
 key > public {inline} (0 calls)
 0: stmt_if2.tree.key<0>
-key($rec##0:stmt_if2.tree, ?$##0:wybe.int, ?$$##0:wybe.bool):
+key(#rec##0:stmt_if2.tree, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec##0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 key > public {inline} (0 calls)
 1: stmt_if2.tree.key<1>
-key($rec##0:stmt_if2.tree, ?$rec##1:stmt_if2.tree, $field##0:wybe.int, ?$$##0:wybe.bool):
+key(#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:stmt_if2.tree, ?$rec##1:stmt_if2.tree)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree)
 
     1:
-        foreign lpvm mutate(~$rec##0:stmt_if2.tree, ?$rec##1:stmt_if2.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 left > public {inline} (0 calls)
 0: stmt_if2.tree.left<0>
-left($rec##0:stmt_if2.tree, ?$##0:stmt_if2.tree, ?$$##0:wybe.bool):
+left(#rec##0:stmt_if2.tree, ?###0:stmt_if2.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:stmt_if2.tree, ?$##0:stmt_if2.tree)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:stmt_if2.tree, ?###0:stmt_if2.tree)
 
     1:
-        foreign lpvm access(~$rec##0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:stmt_if2.tree)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:stmt_if2.tree)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 left > public {inline} (0 calls)
 1: stmt_if2.tree.left<1>
-left($rec##0:stmt_if2.tree, ?$rec##1:stmt_if2.tree, $field##0:stmt_if2.tree, ?$$##0:wybe.bool):
+left(#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, #field##0:stmt_if2.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:stmt_if2.tree, ?$rec##1:stmt_if2.tree)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree)
 
     1:
-        foreign lpvm mutate(~$rec##0:stmt_if2.tree, ?$rec##1:stmt_if2.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:stmt_if2.tree)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:stmt_if2.tree)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 node > public {inline} (0 calls)
 0: stmt_if2.tree.node<0>
-node(left##0:stmt_if2.tree, key##0:wybe.int, right##0:stmt_if2.tree, ?$##0:stmt_if2.tree):
+node(left##0:stmt_if2.tree, key##0:wybe.int, right##0:stmt_if2.tree, ?###0:stmt_if2.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?$rec##0:stmt_if2.tree)
-    foreign lpvm mutate(~$rec##0:stmt_if2.tree, ?$rec##1:stmt_if2.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:stmt_if2.tree)
-    foreign lpvm mutate(~$rec##1:stmt_if2.tree, ?$rec##2:stmt_if2.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int)
-    foreign lpvm mutate(~$rec##2:stmt_if2.tree, ?$##0:stmt_if2.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:stmt_if2.tree)
+    foreign lpvm alloc(24:wybe.int, ?#rec##0:stmt_if2.tree)
+    foreign lpvm mutate(~#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:stmt_if2.tree)
+    foreign lpvm mutate(~#rec##1:stmt_if2.tree, ?#rec##2:stmt_if2.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int)
+    foreign lpvm mutate(~#rec##2:stmt_if2.tree, ?###0:stmt_if2.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:stmt_if2.tree)
 node > public {inline} (16 calls)
 1: stmt_if2.tree.node<1>
-node(?left##0:stmt_if2.tree, ?key##0:wybe.int, ?right##0:stmt_if2.tree, $##0:stmt_if2.tree, ?$$##0:wybe.bool):
+node(?left##0:stmt_if2.tree, ?key##0:wybe.int, ?right##0:stmt_if2.tree, ###0:stmt_if2.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:stmt_if2.tree, ?left##0:stmt_if2.tree)
         foreign llvm move(undef:wybe.int, ?key##0:wybe.int)
         foreign llvm move(undef:stmt_if2.tree, ?right##0:stmt_if2.tree)
 
     1:
-        foreign lpvm access($##0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:stmt_if2.tree)
-        foreign lpvm access($##0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
-        foreign lpvm access(~$##0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:stmt_if2.tree)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(###0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:stmt_if2.tree)
+        foreign lpvm access(###0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
+        foreign lpvm access(~###0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:stmt_if2.tree)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 right > public {inline} (0 calls)
 0: stmt_if2.tree.right<0>
-right($rec##0:stmt_if2.tree, ?$##0:stmt_if2.tree, ?$$##0:wybe.bool):
+right(#rec##0:stmt_if2.tree, ?###0:stmt_if2.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:stmt_if2.tree, ?$##0:stmt_if2.tree)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:stmt_if2.tree, ?###0:stmt_if2.tree)
 
     1:
-        foreign lpvm access(~$rec##0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:stmt_if2.tree)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:stmt_if2.tree)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 right > public {inline} (0 calls)
 1: stmt_if2.tree.right<1>
-right($rec##0:stmt_if2.tree, ?$rec##1:stmt_if2.tree, $field##0:stmt_if2.tree, ?$$##0:wybe.bool):
+right(#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, #field##0:stmt_if2.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:stmt_if2.tree, ?$rec##1:stmt_if2.tree)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree)
 
     1:
-        foreign lpvm mutate(~$rec##0:stmt_if2.tree, ?$rec##1:stmt_if2.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:stmt_if2.tree)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:stmt_if2.tree)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: stmt_if2.tree.~=<0>
-~=($left##0:stmt_if2.tree, $right##0:stmt_if2.tree, ?$$##0:wybe.bool):
+~=(#left##0:stmt_if2.tree, #right##0:stmt_if2.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_if2.tree.=<0>(~$left##0:stmt_if2.tree, ~$right##0:stmt_if2.tree, ?tmp$0##0:wybe.bool) #0
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    stmt_if2.tree.=<0>(~#left##0:stmt_if2.tree, ~#right##0:stmt_if2.tree, ?tmp#0##0:wybe.bool) #0
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
   LLVM code       :
 
@@ -397,51 +397,51 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"stmt_if2.tree.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"stmt_if2.tree.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#left##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = add   i64 %"$left##0", 16 
+  %8 = add   i64 %"#left##0", 16 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
-  %"2$tmp$10##0" = icmp ne i64 %"$right##0", 0 
-  br i1 %"2$tmp$10##0", label %if.then1, label %if.else1 
+  %"2#tmp#10##0" = icmp ne i64 %"#right##0", 0 
+  br i1 %"2#tmp#10##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3#####0" 
 if.then1:
-  %12 = inttoptr i64 %"$right##0" to i64* 
+  %12 = inttoptr i64 %"#right##0" to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %15 = add   i64 %"$right##0", 8 
+  %15 = add   i64 %"#right##0", 8 
   %16 = inttoptr i64 %15 to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
-  %19 = add   i64 %"$right##0", 16 
+  %19 = add   i64 %"#right##0", 16 
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %"4$tmp$4##0" = tail call fastcc  i1  @"stmt_if2.tree.=<0>"(i64  %3, i64  %14)  
-  br i1 %"4$tmp$4##0", label %if.then2, label %if.else2 
+  %"4#tmp#4##0" = tail call fastcc  i1  @"stmt_if2.tree.=<0>"(i64  %3, i64  %14)  
+  br i1 %"4#tmp#4##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$tmp$5##0" = icmp eq i64 %7, %18 
-  br i1 %"6$tmp$5##0", label %if.then3, label %if.else3 
+  %"6#tmp#5##0" = icmp eq i64 %7, %18 
+  br i1 %"6#tmp#5##0", label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %"8$$$##0" = tail call fastcc  i1  @"stmt_if2.tree.=<0>"(i64  %11, i64  %22)  
-  ret i1 %"8$$$##0" 
+  %"8#####0" = tail call fastcc  i1  @"stmt_if2.tree.=<0>"(i64  %11, i64  %22)  
+  ret i1 %"8#####0" 
 if.else3:
   ret i1 0 
 }
@@ -453,12 +453,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if2.tree.key<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"stmt_if2.tree.key<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %23 = add   i64 %"$rec##0", 8 
+  %23 = add   i64 %"#rec##0", 8 
   %24 = inttoptr i64 %23 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
   %26 = load  i64, i64* %25 
@@ -472,38 +472,38 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if2.tree.key<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"stmt_if2.tree.key<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %31 = trunc i64 24 to i32  
   %32 = tail call ccc  i8*  @wybe_malloc(i32  %31)  
   %33 = ptrtoint i8* %32 to i64 
   %34 = inttoptr i64 %33 to i8* 
-  %35 = inttoptr i64 %"$rec##0" to i8* 
+  %35 = inttoptr i64 %"#rec##0" to i8* 
   %36 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %34, i8*  %35, i32  %36, i32  8, i1  0)  
   %37 = add   i64 %33, 8 
   %38 = inttoptr i64 %37 to i64* 
   %39 = getelementptr  i64, i64* %38, i64 0 
-  store  i64 %"$field##0", i64* %39 
+  store  i64 %"#field##0", i64* %39 
   %40 = insertvalue {i64, i1} undef, i64 %33, 0 
   %41 = insertvalue {i64, i1} %40, i1 1, 1 
   ret {i64, i1} %41 
 if.else:
-  %42 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %42 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %43 = insertvalue {i64, i1} %42, i1 0, 1 
   ret {i64, i1} %43 
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if2.tree.left<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"stmt_if2.tree.left<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %44 = inttoptr i64 %"$rec##0" to i64* 
+  %44 = inttoptr i64 %"#rec##0" to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
   %47 = insertvalue {i64, i1} undef, i64 %46, 0 
@@ -516,26 +516,26 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if2.tree.left<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"stmt_if2.tree.left<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %51 = trunc i64 24 to i32  
   %52 = tail call ccc  i8*  @wybe_malloc(i32  %51)  
   %53 = ptrtoint i8* %52 to i64 
   %54 = inttoptr i64 %53 to i8* 
-  %55 = inttoptr i64 %"$rec##0" to i8* 
+  %55 = inttoptr i64 %"#rec##0" to i8* 
   %56 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %54, i8*  %55, i32  %56, i32  8, i1  0)  
   %57 = inttoptr i64 %53 to i64* 
   %58 = getelementptr  i64, i64* %57, i64 0 
-  store  i64 %"$field##0", i64* %58 
+  store  i64 %"#field##0", i64* %58 
   %59 = insertvalue {i64, i1} undef, i64 %53, 0 
   %60 = insertvalue {i64, i1} %59, i1 1, 1 
   ret {i64, i1} %60 
 if.else:
-  %61 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %61 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %62 = insertvalue {i64, i1} %61, i1 0, 1 
   ret {i64, i1} %62 
 }
@@ -561,19 +561,19 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64, i1} @"stmt_if2.tree.node<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64, i64, i1} @"stmt_if2.tree.node<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %74 = inttoptr i64 %"$##0" to i64* 
+  %74 = inttoptr i64 %"###0" to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
   %76 = load  i64, i64* %75 
-  %77 = add   i64 %"$##0", 8 
+  %77 = add   i64 %"###0", 8 
   %78 = inttoptr i64 %77 to i64* 
   %79 = getelementptr  i64, i64* %78, i64 0 
   %80 = load  i64, i64* %79 
-  %81 = add   i64 %"$##0", 16 
+  %81 = add   i64 %"###0", 16 
   %82 = inttoptr i64 %81 to i64* 
   %83 = getelementptr  i64, i64* %82, i64 0 
   %84 = load  i64, i64* %83 
@@ -591,12 +591,12 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if2.tree.right<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"stmt_if2.tree.right<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %93 = add   i64 %"$rec##0", 16 
+  %93 = add   i64 %"#rec##0", 16 
   %94 = inttoptr i64 %93 to i64* 
   %95 = getelementptr  i64, i64* %94, i64 0 
   %96 = load  i64, i64* %95 
@@ -610,35 +610,35 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"stmt_if2.tree.right<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"stmt_if2.tree.right<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %101 = trunc i64 24 to i32  
   %102 = tail call ccc  i8*  @wybe_malloc(i32  %101)  
   %103 = ptrtoint i8* %102 to i64 
   %104 = inttoptr i64 %103 to i8* 
-  %105 = inttoptr i64 %"$rec##0" to i8* 
+  %105 = inttoptr i64 %"#rec##0" to i8* 
   %106 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %104, i8*  %105, i32  %106, i32  8, i1  0)  
   %107 = add   i64 %103, 16 
   %108 = inttoptr i64 %107 to i64* 
   %109 = getelementptr  i64, i64* %108, i64 0 
-  store  i64 %"$field##0", i64* %109 
+  store  i64 %"#field##0", i64* %109 
   %110 = insertvalue {i64, i1} undef, i64 %103, 0 
   %111 = insertvalue {i64, i1} %110, i1 1, 1 
   ret {i64, i1} %111 
 if.else:
-  %112 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %112 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %113 = insertvalue {i64, i1} %112, i1 0, 1 
   ret {i64, i1} %113 
 }
 
 
-define external fastcc  i1 @"stmt_if2.tree.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"stmt_if2.tree.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = tail call fastcc  i1  @"stmt_if2.tree.=<0>"(i64  %"$left##0", i64  %"$right##0")  
-  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
-  ret i1 %"1$$$##0" 
+  %"1#tmp#0##0" = tail call fastcc  i1  @"stmt_if2.tree.=<0>"(i64  %"#left##0", i64  %"#right##0")  
+  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1#####0" 
 }

--- a/test-cases/final-dump/stmt_if2.exp
+++ b/test-cases/final-dump/stmt_if2.exp
@@ -44,15 +44,15 @@ AFTER EVERYTHING:
 
 gen#1 > {inline} (3 calls)
 0: stmt_if2.gen#1<0>
-gen#1([k##0:wybe.int], [key##0:wybe.int], [l##0:stmt_if2.tree], [r##0:stmt_if2.tree], tmp#4##0:wybe.bool, [tree##0:stmt_if2.tree], ?###0:wybe.bool):
+gen#1([k##0:wybe.int], [key##0:wybe.int], [l##0:stmt_if2.tree], [r##0:stmt_if2.tree], tmp#4##0:wybe.bool, [tree##0:stmt_if2.tree], ?#result##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(~tmp#4##0:wybe.bool, ?###0:wybe.bool) @stmt_if2:5:5
+    foreign llvm move(~tmp#4##0:wybe.bool, ?#result##0:wybe.bool) @stmt_if2:5:5
 
 
 lookup > public (5 calls)
 0: stmt_if2.lookup<0>
-lookup(key##0:wybe.int, tree##0:stmt_if2.tree, ?###0:wybe.bool):
+lookup(key##0:wybe.int, tree##0:stmt_if2.tree, ?#result##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     stmt_if2.tree.=<0>(tree##0:stmt_if2.tree, 0:stmt_if2.tree, ?tmp#13##0:wybe.bool) #1 @stmt_if2:6:9
@@ -61,7 +61,7 @@ lookup(key##0:wybe.int, tree##0:stmt_if2.tree, ?###0:wybe.bool):
         foreign llvm icmp_ne(tree##0:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.bool)
         case ~tmp#15##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?###0:wybe.bool) @stmt_if2:5:5
+            foreign llvm move(0:wybe.bool, ?#result##0:wybe.bool) @stmt_if2:5:5
 
         1:
             foreign lpvm access(tree##0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?l##0:stmt_if2.tree)
@@ -73,19 +73,19 @@ lookup(key##0:wybe.int, tree##0:stmt_if2.tree, ?###0:wybe.bool):
                 foreign llvm icmp_sgt(~k##0:wybe.int, key##0:wybe.int, ?tmp#10##0:wybe.bool) @int:nn:nn
                 case ~tmp#10##0:wybe.bool of
                 0:
-                    stmt_if2.lookup<0>(~key##0:wybe.int, ~r##0:stmt_if2.tree, ?###0:wybe.bool) #10 @stmt_if2:10:24
+                    stmt_if2.lookup<0>(~key##0:wybe.int, ~r##0:stmt_if2.tree, ?#result##0:wybe.bool) #10 @stmt_if2:10:24
 
                 1:
-                    stmt_if2.lookup<0>(~key##0:wybe.int, ~l##0:stmt_if2.tree, ?###0:wybe.bool) #8 @stmt_if2:9:27
+                    stmt_if2.lookup<0>(~key##0:wybe.int, ~l##0:stmt_if2.tree, ?#result##0:wybe.bool) #8 @stmt_if2:9:27
 
 
             1:
-                foreign llvm move(1:wybe.bool, ?###0:wybe.bool) @stmt_if2:5:5
+                foreign llvm move(1:wybe.bool, ?#result##0:wybe.bool) @stmt_if2:5:5
 
 
 
     1:
-        foreign llvm move(0:wybe.bool, ?###0:wybe.bool) @stmt_if2:5:5
+        foreign llvm move(0:wybe.bool, ?#result##0:wybe.bool) @stmt_if2:5:5
 
 
   LLVM code       :
@@ -172,11 +172,11 @@ if.else2:
   %"7#tmp#10##0" = icmp sgt i64 %20, %"key##0" 
   br i1 %"7#tmp#10##0", label %if.then3, label %if.else3 
 if.then3:
-  %"8####0" = tail call fastcc  i1  @"stmt_if2.lookup<0>"(i64  %"key##0", i64  %16)  
-  ret i1 %"8####0" 
+  %"8##result##0" = tail call fastcc  i1  @"stmt_if2.lookup<0>"(i64  %"key##0", i64  %16)  
+  ret i1 %"8##result##0" 
 if.else3:
-  %"9####0" = tail call fastcc  i1  @"stmt_if2.lookup<0>"(i64  %"key##0", i64  %24)  
-  ret i1 %"9####0" 
+  %"9##result##0" = tail call fastcc  i1  @"stmt_if2.lookup<0>"(i64  %"key##0", i64  %24)  
+  ret i1 %"9##result##0" 
 }
 --------------------------------------------------
  Module stmt_if2.tree
@@ -243,25 +243,25 @@ if.else3:
 
 empty > public {inline} (0 calls)
 0: stmt_if2.tree.empty<0>
-empty(?###0:stmt_if2.tree):
+empty(?#result##0:stmt_if2.tree):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:stmt_if2.tree, ?###0:stmt_if2.tree)
+    foreign llvm move(0:stmt_if2.tree, ?#result##0:stmt_if2.tree)
 
 
 key > public {inline} (0 calls)
 0: stmt_if2.tree.key<0>
-key(#rec##0:stmt_if2.tree, ?###0:wybe.int, ?####0:wybe.bool):
+key(#rec##0:stmt_if2.tree, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign lpvm access(~#rec##0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 key > public {inline} (0 calls)
@@ -283,17 +283,17 @@ key(#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, #field##0:wybe.int, ?####0:wy
 
 left > public {inline} (0 calls)
 0: stmt_if2.tree.left<0>
-left(#rec##0:stmt_if2.tree, ?###0:stmt_if2.tree, ?####0:wybe.bool):
+left(#rec##0:stmt_if2.tree, ?#result##0:stmt_if2.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:stmt_if2.tree, ?###0:stmt_if2.tree)
+        foreign llvm move(undef:stmt_if2.tree, ?#result##0:stmt_if2.tree)
 
     1:
-        foreign lpvm access(~#rec##0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:stmt_if2.tree)
+        foreign lpvm access(~#rec##0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:stmt_if2.tree)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 left > public {inline} (0 calls)
@@ -315,19 +315,19 @@ left(#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, #field##0:stmt_if2.tree, ?##
 
 node > public {inline} (0 calls)
 0: stmt_if2.tree.node<0>
-node(left##0:stmt_if2.tree, key##0:wybe.int, right##0:stmt_if2.tree, ?###0:stmt_if2.tree):
+node(left##0:stmt_if2.tree, key##0:wybe.int, right##0:stmt_if2.tree, ?#result##0:stmt_if2.tree):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(24:wybe.int, ?#rec##0:stmt_if2.tree)
     foreign lpvm mutate(~#rec##0:stmt_if2.tree, ?#rec##1:stmt_if2.tree, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~left##0:stmt_if2.tree)
     foreign lpvm mutate(~#rec##1:stmt_if2.tree, ?#rec##2:stmt_if2.tree, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~key##0:wybe.int)
-    foreign lpvm mutate(~#rec##2:stmt_if2.tree, ?###0:stmt_if2.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:stmt_if2.tree)
+    foreign lpvm mutate(~#rec##2:stmt_if2.tree, ?#result##0:stmt_if2.tree, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~right##0:stmt_if2.tree)
 node > public {inline} (16 calls)
 1: stmt_if2.tree.node<1>
-node(?left##0:stmt_if2.tree, ?key##0:wybe.int, ?right##0:stmt_if2.tree, ###0:stmt_if2.tree, ?####0:wybe.bool):
+node(?left##0:stmt_if2.tree, ?key##0:wybe.int, ?right##0:stmt_if2.tree, #result##0:stmt_if2.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
@@ -336,26 +336,26 @@ node(?left##0:stmt_if2.tree, ?key##0:wybe.int, ?right##0:stmt_if2.tree, ###0:stm
         foreign llvm move(undef:stmt_if2.tree, ?right##0:stmt_if2.tree)
 
     1:
-        foreign lpvm access(###0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:stmt_if2.tree)
-        foreign lpvm access(###0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
-        foreign lpvm access(~###0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:stmt_if2.tree)
+        foreign lpvm access(#result##0:stmt_if2.tree, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?left##0:stmt_if2.tree)
+        foreign lpvm access(#result##0:stmt_if2.tree, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?key##0:wybe.int)
+        foreign lpvm access(~#result##0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?right##0:stmt_if2.tree)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 right > public {inline} (0 calls)
 0: stmt_if2.tree.right<0>
-right(#rec##0:stmt_if2.tree, ?###0:stmt_if2.tree, ?####0:wybe.bool):
+right(#rec##0:stmt_if2.tree, ?#result##0:stmt_if2.tree, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:stmt_if2.tree, ?###0:stmt_if2.tree)
+        foreign llvm move(undef:stmt_if2.tree, ?#result##0:stmt_if2.tree)
 
     1:
-        foreign lpvm access(~#rec##0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:stmt_if2.tree)
+        foreign lpvm access(~#rec##0:stmt_if2.tree, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:stmt_if2.tree)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 right > public {inline} (0 calls)
@@ -561,19 +561,19 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64, i1} @"stmt_if2.tree.node<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64, i64, i1} @"stmt_if2.tree.node<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  %"1#tmp#0##0" = icmp ne i64 %"#result##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %74 = inttoptr i64 %"###0" to i64* 
+  %74 = inttoptr i64 %"#result##0" to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
   %76 = load  i64, i64* %75 
-  %77 = add   i64 %"###0", 8 
+  %77 = add   i64 %"#result##0", 8 
   %78 = inttoptr i64 %77 to i64* 
   %79 = getelementptr  i64, i64* %78, i64 0 
   %80 = load  i64, i64* %79 
-  %81 = add   i64 %"###0", 16 
+  %81 = add   i64 %"#result##0", 16 
   %82 = inttoptr i64 %81 to i64* 
   %83 = getelementptr  i64, i64* %82, i64 0 
   %84 = load  i64, i64* %83 

--- a/test-cases/final-dump/stmt_nop.exp
+++ b/test-cases/final-dump/stmt_nop.exp
@@ -11,7 +11,7 @@ AFTER EVERYTHING:
 
 *main* > public {inline} (0 calls)
 0: stmt_nop.<0>
-(io#0:wybe.phantom, [?io#0:wybe.phantom]):
+(io##0:wybe.phantom, [?io##0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
 

--- a/test-cases/final-dump/stmt_unless.exp
+++ b/test-cases/final-dump/stmt_unless.exp
@@ -54,10 +54,10 @@ gen#2(io##0:wybe.phantom, n##0:wybe.int, ?io##2:wybe.phantom):
 
 mod > public {inline} (3 calls)
 0: stmt_unless.mod<0>
-mod(x##0:wybe.int, y##0:wybe.int, ?###0:wybe.int):
+mod(x##0:wybe.int, y##0:wybe.int, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm urem(~x##0:wybe.int, ~y##0:wybe.int, ?###0:wybe.int) @stmt_unless:nn:nn
+    foreign llvm urem(~x##0:wybe.int, ~y##0:wybe.int, ?#result##0:wybe.int) @stmt_unless:nn:nn
 
   LLVM code       :
 
@@ -117,6 +117,6 @@ if.else:
 
 define external fastcc  i64 @"stmt_unless.mod<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1####0" = urem i64 %"x##0", %"y##0" 
-  ret i64 %"1####0" 
+  %"1##result##0" = urem i64 %"x##0", %"y##0" 
+  ret i64 %"1##result##0" 
 }

--- a/test-cases/final-dump/stmt_unless.exp
+++ b/test-cases/final-dump/stmt_unless.exp
@@ -15,49 +15,49 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_unless.gen$1<0>(~io##0:wybe.phantom, 10:wybe.int, ?io##1:wybe.phantom) #0 @stmt_unless:nn:nn
+    stmt_unless.gen#1<0>(~io##0:wybe.phantom, 10:wybe.int, ?io##1:wybe.phantom) #0 @stmt_unless:nn:nn
 
 
-gen$1 > (3 calls)
-0: stmt_unless.gen$1<0>
-gen$1(io##0:wybe.phantom, n##0:wybe.int, ?io##1:wybe.phantom):
+gen#1 > (3 calls)
+0: stmt_unless.gen#1<0>
+gen#1(io##0:wybe.phantom, n##0:wybe.int, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_sgt(n##0:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
-    case ~tmp$3##0:wybe.bool of
+    foreign llvm icmp_sgt(n##0:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
+    case ~tmp#3##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        stmt_unless.gen$2<0>(~io##0:wybe.phantom, ~n##0:wybe.int, ?io##1:wybe.phantom) #1
+        stmt_unless.gen#2<0>(~io##0:wybe.phantom, ~n##0:wybe.int, ?io##1:wybe.phantom) #1
 
 
 
-gen$2 > (1 calls)
-0: stmt_unless.gen$2<0>
-gen$2(io##0:wybe.phantom, n##0:wybe.int, ?io##2:wybe.phantom):
+gen#2 > (1 calls)
+0: stmt_unless.gen#2<0>
+gen#2(io##0:wybe.phantom, n##0:wybe.int, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
-    foreign llvm urem(tmp$0##0:wybe.int, 2:wybe.int, ?tmp$1##0:wybe.int) @stmt_unless:nn:nn
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.bool) @int:nn:nn
-    case ~tmp$2##0:wybe.bool of
+    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
+    foreign llvm urem(tmp#0##0:wybe.int, 2:wybe.int, ?tmp#1##0:wybe.int) @stmt_unless:nn:nn
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.bool) @int:nn:nn
+    case ~tmp#2##0:wybe.bool of
     0:
-        foreign c print_int(tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$11##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_unless.gen$1<0>(~io##1:wybe.phantom, ~tmp$0##0:wybe.int, ?io##2:wybe.phantom) #5 @stmt_unless:nn:nn
+        foreign c print_int(tmp#0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_unless.gen#1<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.int, ?io##2:wybe.phantom) #5 @stmt_unless:nn:nn
 
     1:
-        stmt_unless.gen$1<0>(~io##0:wybe.phantom, ~tmp$0##0:wybe.int, ?io##2:wybe.phantom) #3 @stmt_unless:nn:nn
+        stmt_unless.gen#1<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.int, ?io##2:wybe.phantom) #3 @stmt_unless:nn:nn
 
 
 
 mod > public {inline} (3 calls)
 0: stmt_unless.mod<0>
-mod(x##0:wybe.int, y##0:wybe.int, ?$##0:wybe.int):
+mod(x##0:wybe.int, y##0:wybe.int, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm urem(~x##0:wybe.int, ~y##0:wybe.int, ?$##0:wybe.int) @stmt_unless:nn:nn
+    foreign llvm urem(~x##0:wybe.int, ~y##0:wybe.int, ?###0:wybe.int) @stmt_unless:nn:nn
 
   LLVM code       :
 
@@ -81,42 +81,42 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"stmt_unless.<0>"()    {
 entry:
-  tail call fastcc  void  @"stmt_unless.gen$1<0>"(i64  10)  
+  tail call fastcc  void  @"stmt_unless.gen#1<0>"(i64  10)  
   ret void 
 }
 
 
-define external fastcc  void @"stmt_unless.gen$1<0>"(i64  %"n##0")    {
+define external fastcc  void @"stmt_unless.gen#1<0>"(i64  %"n##0")    {
 entry:
-  %"1$tmp$3##0" = icmp sgt i64 %"n##0", 0 
-  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
+  %"1#tmp#3##0" = icmp sgt i64 %"n##0", 0 
+  br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"stmt_unless.gen$2<0>"(i64  %"n##0")  
+  tail call fastcc  void  @"stmt_unless.gen#2<0>"(i64  %"n##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_unless.gen$2<0>"(i64  %"n##0")    {
+define external fastcc  void @"stmt_unless.gen#2<0>"(i64  %"n##0")    {
 entry:
-  %"1$tmp$0##0" = sub   i64 %"n##0", 1 
-  %"1$tmp$1##0" = urem i64 %"1$tmp$0##0", 2 
-  %"1$tmp$2##0" = icmp eq i64 %"1$tmp$1##0", 0 
-  br i1 %"1$tmp$2##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = sub   i64 %"n##0", 1 
+  %"1#tmp#1##0" = urem i64 %"1#tmp#0##0", 2 
+  %"1#tmp#2##0" = icmp eq i64 %"1#tmp#1##0", 0 
+  br i1 %"1#tmp#2##0", label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"stmt_unless.gen$1<0>"(i64  %"1$tmp$0##0")  
+  tail call fastcc  void  @"stmt_unless.gen#1<0>"(i64  %"1#tmp#0##0")  
   ret void 
 if.else:
-  tail call ccc  void  @print_int(i64  %"1$tmp$0##0")  
+  tail call ccc  void  @print_int(i64  %"1#tmp#0##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_unless.gen$1<0>"(i64  %"1$tmp$0##0")  
+  tail call fastcc  void  @"stmt_unless.gen#1<0>"(i64  %"1#tmp#0##0")  
   ret void 
 }
 
 
 define external fastcc  i64 @"stmt_unless.mod<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$$##0" = urem i64 %"x##0", %"y##0" 
-  ret i64 %"1$$##0" 
+  %"1####0" = urem i64 %"x##0", %"y##0" 
+  ret i64 %"1####0" 
 }

--- a/test-cases/final-dump/stmt_unless.exp
+++ b/test-cases/final-dump/stmt_unless.exp
@@ -12,52 +12,52 @@ AFTER EVERYTHING:
 
 *main* > public {inline} (0 calls)
 0: stmt_unless.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_unless.gen$1<0>(~io#0:wybe.phantom, 10:wybe.int, ?io#1:wybe.phantom) #0 @stmt_unless:nn:nn
+    stmt_unless.gen$1<0>(~io##0:wybe.phantom, 10:wybe.int, ?io##1:wybe.phantom) #0 @stmt_unless:nn:nn
 
 
 gen$1 > (3 calls)
 0: stmt_unless.gen$1<0>
-gen$1(io#0:wybe.phantom, n#0:wybe.int, ?io#1:wybe.phantom):
+gen$1(io##0:wybe.phantom, n##0:wybe.int, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_sgt(n#0:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.bool) @int:nn:nn
-    case ~tmp$3#0:wybe.bool of
+    foreign llvm icmp_sgt(n##0:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
+    case ~tmp$3##0:wybe.bool of
     0:
-        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        stmt_unless.gen$2<0>(~io#0:wybe.phantom, ~n#0:wybe.int, ?io#1:wybe.phantom) #1
+        stmt_unless.gen$2<0>(~io##0:wybe.phantom, ~n##0:wybe.int, ?io##1:wybe.phantom) #1
 
 
 
 gen$2 > (1 calls)
 0: stmt_unless.gen$2<0>
-gen$2(io#0:wybe.phantom, n#0:wybe.int, ?io#2:wybe.phantom):
+gen$2(io##0:wybe.phantom, n##0:wybe.int, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm sub(~n#0:wybe.int, 1:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn
-    foreign llvm urem(tmp$0#0:wybe.int, 2:wybe.int, ?tmp$1#0:wybe.int) @stmt_unless:nn:nn
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 0:wybe.int, ?tmp$2#0:wybe.bool) @int:nn:nn
-    case ~tmp$2#0:wybe.bool of
+    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
+    foreign llvm urem(tmp$0##0:wybe.int, 2:wybe.int, ?tmp$1##0:wybe.int) @stmt_unless:nn:nn
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.bool) @int:nn:nn
+    case ~tmp$2##0:wybe.bool of
     0:
-        foreign c print_int(tmp$0#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$11#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$11#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        stmt_unless.gen$1<0>(~io#1:wybe.phantom, ~tmp$0#0:wybe.int, ?io#2:wybe.phantom) #5 @stmt_unless:nn:nn
+        foreign c print_int(tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$11##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_unless.gen$1<0>(~io##1:wybe.phantom, ~tmp$0##0:wybe.int, ?io##2:wybe.phantom) #5 @stmt_unless:nn:nn
 
     1:
-        stmt_unless.gen$1<0>(~io#0:wybe.phantom, ~tmp$0#0:wybe.int, ?io#2:wybe.phantom) #3 @stmt_unless:nn:nn
+        stmt_unless.gen$1<0>(~io##0:wybe.phantom, ~tmp$0##0:wybe.int, ?io##2:wybe.phantom) #3 @stmt_unless:nn:nn
 
 
 
 mod > public {inline} (3 calls)
 0: stmt_unless.mod<0>
-mod(x#0:wybe.int, y#0:wybe.int, ?$#0:wybe.int):
+mod(x##0:wybe.int, y##0:wybe.int, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm urem(~x#0:wybe.int, ~y#0:wybe.int, ?$#0:wybe.int) @stmt_unless:nn:nn
+    foreign llvm urem(~x##0:wybe.int, ~y##0:wybe.int, ?$##0:wybe.int) @stmt_unless:nn:nn
 
   LLVM code       :
 
@@ -86,37 +86,37 @@ entry:
 }
 
 
-define external fastcc  void @"stmt_unless.gen$1<0>"(i64  %"n#0")    {
+define external fastcc  void @"stmt_unless.gen$1<0>"(i64  %"n##0")    {
 entry:
-  %"1$tmp$3#0" = icmp sgt i64 %"n#0", 0 
-  br i1 %"1$tmp$3#0", label %if.then, label %if.else 
+  %"1$tmp$3##0" = icmp sgt i64 %"n##0", 0 
+  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"stmt_unless.gen$2<0>"(i64  %"n#0")  
+  tail call fastcc  void  @"stmt_unless.gen$2<0>"(i64  %"n##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_unless.gen$2<0>"(i64  %"n#0")    {
+define external fastcc  void @"stmt_unless.gen$2<0>"(i64  %"n##0")    {
 entry:
-  %"1$tmp$0#0" = sub   i64 %"n#0", 1 
-  %"1$tmp$1#0" = urem i64 %"1$tmp$0#0", 2 
-  %"1$tmp$2#0" = icmp eq i64 %"1$tmp$1#0", 0 
-  br i1 %"1$tmp$2#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = sub   i64 %"n##0", 1 
+  %"1$tmp$1##0" = urem i64 %"1$tmp$0##0", 2 
+  %"1$tmp$2##0" = icmp eq i64 %"1$tmp$1##0", 0 
+  br i1 %"1$tmp$2##0", label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"stmt_unless.gen$1<0>"(i64  %"1$tmp$0#0")  
+  tail call fastcc  void  @"stmt_unless.gen$1<0>"(i64  %"1$tmp$0##0")  
   ret void 
 if.else:
-  tail call ccc  void  @print_int(i64  %"1$tmp$0#0")  
+  tail call ccc  void  @print_int(i64  %"1$tmp$0##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_unless.gen$1<0>"(i64  %"1$tmp$0#0")  
+  tail call fastcc  void  @"stmt_unless.gen$1<0>"(i64  %"1$tmp$0##0")  
   ret void 
 }
 
 
-define external fastcc  i64 @"stmt_unless.mod<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"stmt_unless.mod<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$$#0" = urem i64 %"x#0", %"y#0" 
-  ret i64 %"1$$#0" 
+  %"1$$##0" = urem i64 %"x##0", %"y##0" 
+  ret i64 %"1$$##0" 
 }

--- a/test-cases/final-dump/stmt_until.exp
+++ b/test-cases/final-dump/stmt_until.exp
@@ -14,36 +14,36 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_until.gen$1<0>(~io##0:wybe.phantom, 10:wybe.int, ?io##1:wybe.phantom) #0 @stmt_until:nn:nn
+    stmt_until.gen#1<0>(~io##0:wybe.phantom, 10:wybe.int, ?io##1:wybe.phantom) #0 @stmt_until:nn:nn
 
 
-gen$1 > (2 calls)
-0: stmt_until.gen$1<0>
-gen$1(io##0:wybe.phantom, n##0:wybe.int, ?io##1:wybe.phantom):
+gen#1 > (2 calls)
+0: stmt_until.gen#1<0>
+gen#1(io##0:wybe.phantom, n##0:wybe.int, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_slt(n##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign llvm icmp_slt(n##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$6##0:wybe.int) @int:nn:nn
-        foreign c print_int(tmp$6##0:wybe.int, ~io##0:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?tmp$8##0:wybe.phantom) @io:nn:nn
-        stmt_until.gen$1<0>(~tmp$8##0:wybe.phantom, ~tmp$6##0:wybe.int, ?io##1:wybe.phantom) #2 @stmt_until:nn:nn
+        foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp#6##0:wybe.int) @int:nn:nn
+        foreign c print_int(tmp#6##0:wybe.int, ~io##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @io:nn:nn
+        stmt_until.gen#1<0>(~tmp#8##0:wybe.phantom, ~tmp#6##0:wybe.int, ?io##1:wybe.phantom) #2 @stmt_until:nn:nn
 
     1:
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
 
 
-gen$2 > {inline} (1 calls)
-0: stmt_until.gen$2<0>
-gen$2(io##0:wybe.phantom, n##0:wybe.int, ?io##2:wybe.phantom):
+gen#2 > {inline} (1 calls)
+0: stmt_until.gen#2<0>
+gen#2(io##0:wybe.phantom, n##0:wybe.int, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
-    foreign c print_int(tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$5##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$5##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    stmt_until.gen$1<0>(~io##1:wybe.phantom, ~tmp$0##0:wybe.int, ?io##2:wybe.phantom) #2 @stmt_until:nn:nn
+    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
+    foreign c print_int(tmp#0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    stmt_until.gen#1<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.int, ?io##2:wybe.phantom) #2 @stmt_until:nn:nn
 
   LLVM code       :
 
@@ -67,31 +67,31 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"stmt_until.<0>"()    {
 entry:
-  tail call fastcc  void  @"stmt_until.gen$1<0>"(i64  10)  
+  tail call fastcc  void  @"stmt_until.gen#1<0>"(i64  10)  
   ret void 
 }
 
 
-define external fastcc  void @"stmt_until.gen$1<0>"(i64  %"n##0")    {
+define external fastcc  void @"stmt_until.gen#1<0>"(i64  %"n##0")    {
 entry:
-  %"1$tmp$1##0" = icmp slt i64 %"n##0", 0 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp slt i64 %"n##0", 0 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
   ret void 
 if.else:
-  %"3$tmp$6##0" = sub   i64 %"n##0", 1 
-  tail call ccc  void  @print_int(i64  %"3$tmp$6##0")  
+  %"3#tmp#6##0" = sub   i64 %"n##0", 1 
+  tail call ccc  void  @print_int(i64  %"3#tmp#6##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_until.gen$1<0>"(i64  %"3$tmp$6##0")  
+  tail call fastcc  void  @"stmt_until.gen#1<0>"(i64  %"3#tmp#6##0")  
   ret void 
 }
 
 
-define external fastcc  void @"stmt_until.gen$2<0>"(i64  %"n##0")    {
+define external fastcc  void @"stmt_until.gen#2<0>"(i64  %"n##0")    {
 entry:
-  %"1$tmp$0##0" = sub   i64 %"n##0", 1 
-  tail call ccc  void  @print_int(i64  %"1$tmp$0##0")  
+  %"1#tmp#0##0" = sub   i64 %"n##0", 1 
+  tail call ccc  void  @print_int(i64  %"1#tmp#0##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_until.gen$1<0>"(i64  %"1$tmp$0##0")  
+  tail call fastcc  void  @"stmt_until.gen#1<0>"(i64  %"1#tmp#0##0")  
   ret void 
 }

--- a/test-cases/final-dump/stmt_until.exp
+++ b/test-cases/final-dump/stmt_until.exp
@@ -11,39 +11,39 @@ AFTER EVERYTHING:
 
 *main* > public {inline} (0 calls)
 0: stmt_until.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_until.gen$1<0>(~io#0:wybe.phantom, 10:wybe.int, ?io#1:wybe.phantom) #0 @stmt_until:nn:nn
+    stmt_until.gen$1<0>(~io##0:wybe.phantom, 10:wybe.int, ?io##1:wybe.phantom) #0 @stmt_until:nn:nn
 
 
 gen$1 > (2 calls)
 0: stmt_until.gen$1<0>
-gen$1(io#0:wybe.phantom, n#0:wybe.int, ?io#1:wybe.phantom):
+gen$1(io##0:wybe.phantom, n##0:wybe.int, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_slt(n#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign llvm icmp_slt(n##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm sub(~n#0:wybe.int, 1:wybe.int, ?tmp$6#0:wybe.int) @int:nn:nn
-        foreign c print_int(tmp$6#0:wybe.int, ~io#0:wybe.phantom, ?tmp$7#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$7#0:wybe.phantom, ?tmp$8#0:wybe.phantom) @io:nn:nn
-        stmt_until.gen$1<0>(~tmp$8#0:wybe.phantom, ~tmp$6#0:wybe.int, ?io#1:wybe.phantom) #2 @stmt_until:nn:nn
+        foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$6##0:wybe.int) @int:nn:nn
+        foreign c print_int(tmp$6##0:wybe.int, ~io##0:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?tmp$8##0:wybe.phantom) @io:nn:nn
+        stmt_until.gen$1<0>(~tmp$8##0:wybe.phantom, ~tmp$6##0:wybe.int, ?io##1:wybe.phantom) #2 @stmt_until:nn:nn
 
     1:
-        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
 
 
 gen$2 > {inline} (1 calls)
 0: stmt_until.gen$2<0>
-gen$2(io#0:wybe.phantom, n#0:wybe.int, ?io#2:wybe.phantom):
+gen$2(io##0:wybe.phantom, n##0:wybe.int, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm sub(~n#0:wybe.int, 1:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn
-    foreign c print_int(tmp$0#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$5#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$5#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    stmt_until.gen$1<0>(~io#1:wybe.phantom, ~tmp$0#0:wybe.int, ?io#2:wybe.phantom) #2 @stmt_until:nn:nn
+    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
+    foreign c print_int(tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$5##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$5##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    stmt_until.gen$1<0>(~io##1:wybe.phantom, ~tmp$0##0:wybe.int, ?io##2:wybe.phantom) #2 @stmt_until:nn:nn
 
   LLVM code       :
 
@@ -72,26 +72,26 @@ entry:
 }
 
 
-define external fastcc  void @"stmt_until.gen$1<0>"(i64  %"n#0")    {
+define external fastcc  void @"stmt_until.gen$1<0>"(i64  %"n##0")    {
 entry:
-  %"1$tmp$1#0" = icmp slt i64 %"n#0", 0 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp slt i64 %"n##0", 0 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
   ret void 
 if.else:
-  %"3$tmp$6#0" = sub   i64 %"n#0", 1 
-  tail call ccc  void  @print_int(i64  %"3$tmp$6#0")  
+  %"3$tmp$6##0" = sub   i64 %"n##0", 1 
+  tail call ccc  void  @print_int(i64  %"3$tmp$6##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_until.gen$1<0>"(i64  %"3$tmp$6#0")  
+  tail call fastcc  void  @"stmt_until.gen$1<0>"(i64  %"3$tmp$6##0")  
   ret void 
 }
 
 
-define external fastcc  void @"stmt_until.gen$2<0>"(i64  %"n#0")    {
+define external fastcc  void @"stmt_until.gen$2<0>"(i64  %"n##0")    {
 entry:
-  %"1$tmp$0#0" = sub   i64 %"n#0", 1 
-  tail call ccc  void  @print_int(i64  %"1$tmp$0#0")  
+  %"1$tmp$0##0" = sub   i64 %"n##0", 1 
+  tail call ccc  void  @print_int(i64  %"1$tmp$0##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_until.gen$1<0>"(i64  %"1$tmp$0#0")  
+  tail call fastcc  void  @"stmt_until.gen$1<0>"(i64  %"1$tmp$0##0")  
   ret void 
 }

--- a/test-cases/final-dump/stmt_when.exp
+++ b/test-cases/final-dump/stmt_when.exp
@@ -54,10 +54,10 @@ gen#2(io##0:wybe.phantom, n##0:wybe.int, ?io##2:wybe.phantom):
 
 mod > public {inline} (3 calls)
 0: stmt_when.mod<0>
-mod(x##0:wybe.int, y##0:wybe.int, ?###0:wybe.int):
+mod(x##0:wybe.int, y##0:wybe.int, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm urem(~x##0:wybe.int, ~y##0:wybe.int, ?###0:wybe.int) @stmt_when:nn:nn
+    foreign llvm urem(~x##0:wybe.int, ~y##0:wybe.int, ?#result##0:wybe.int) @stmt_when:nn:nn
 
   LLVM code       :
 
@@ -117,6 +117,6 @@ if.else:
 
 define external fastcc  i64 @"stmt_when.mod<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1####0" = urem i64 %"x##0", %"y##0" 
-  ret i64 %"1####0" 
+  %"1##result##0" = urem i64 %"x##0", %"y##0" 
+  ret i64 %"1##result##0" 
 }

--- a/test-cases/final-dump/stmt_when.exp
+++ b/test-cases/final-dump/stmt_when.exp
@@ -12,52 +12,52 @@ AFTER EVERYTHING:
 
 *main* > public {inline} (0 calls)
 0: stmt_when.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_when.gen$1<0>(~io#0:wybe.phantom, 10:wybe.int, ?io#1:wybe.phantom) #0 @stmt_when:nn:nn
+    stmt_when.gen$1<0>(~io##0:wybe.phantom, 10:wybe.int, ?io##1:wybe.phantom) #0 @stmt_when:nn:nn
 
 
 gen$1 > (3 calls)
 0: stmt_when.gen$1<0>
-gen$1(io#0:wybe.phantom, n#0:wybe.int, ?io#1:wybe.phantom):
+gen$1(io##0:wybe.phantom, n##0:wybe.int, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_sgt(n#0:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.bool) @int:nn:nn
-    case ~tmp$3#0:wybe.bool of
+    foreign llvm icmp_sgt(n##0:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
+    case ~tmp$3##0:wybe.bool of
     0:
-        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        stmt_when.gen$2<0>(~io#0:wybe.phantom, ~n#0:wybe.int, ?io#1:wybe.phantom) #1
+        stmt_when.gen$2<0>(~io##0:wybe.phantom, ~n##0:wybe.int, ?io##1:wybe.phantom) #1
 
 
 
 gen$2 > (1 calls)
 0: stmt_when.gen$2<0>
-gen$2(io#0:wybe.phantom, n#0:wybe.int, ?io#2:wybe.phantom):
+gen$2(io##0:wybe.phantom, n##0:wybe.int, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm sub(~n#0:wybe.int, 1:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn
-    foreign llvm urem(tmp$0#0:wybe.int, 2:wybe.int, ?tmp$1#0:wybe.int) @stmt_when:nn:nn
-    foreign llvm icmp_eq(~tmp$1#0:wybe.int, 0:wybe.int, ?tmp$2#0:wybe.bool) @int:nn:nn
-    case ~tmp$2#0:wybe.bool of
+    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
+    foreign llvm urem(tmp$0##0:wybe.int, 2:wybe.int, ?tmp$1##0:wybe.int) @stmt_when:nn:nn
+    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.bool) @int:nn:nn
+    case ~tmp$2##0:wybe.bool of
     0:
-        stmt_when.gen$1<0>(~io#0:wybe.phantom, ~tmp$0#0:wybe.int, ?io#2:wybe.phantom) #5 @stmt_when:nn:nn
+        stmt_when.gen$1<0>(~io##0:wybe.phantom, ~tmp$0##0:wybe.int, ?io##2:wybe.phantom) #5 @stmt_when:nn:nn
 
     1:
-        foreign c print_int(tmp$0#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$11#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$11#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        stmt_when.gen$1<0>(~io#1:wybe.phantom, ~tmp$0#0:wybe.int, ?io#2:wybe.phantom) #4 @stmt_when:nn:nn
+        foreign c print_int(tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$11##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_when.gen$1<0>(~io##1:wybe.phantom, ~tmp$0##0:wybe.int, ?io##2:wybe.phantom) #4 @stmt_when:nn:nn
 
 
 
 mod > public {inline} (3 calls)
 0: stmt_when.mod<0>
-mod(x#0:wybe.int, y#0:wybe.int, ?$#0:wybe.int):
+mod(x##0:wybe.int, y##0:wybe.int, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm urem(~x#0:wybe.int, ~y#0:wybe.int, ?$#0:wybe.int) @stmt_when:nn:nn
+    foreign llvm urem(~x##0:wybe.int, ~y##0:wybe.int, ?$##0:wybe.int) @stmt_when:nn:nn
 
   LLVM code       :
 
@@ -86,37 +86,37 @@ entry:
 }
 
 
-define external fastcc  void @"stmt_when.gen$1<0>"(i64  %"n#0")    {
+define external fastcc  void @"stmt_when.gen$1<0>"(i64  %"n##0")    {
 entry:
-  %"1$tmp$3#0" = icmp sgt i64 %"n#0", 0 
-  br i1 %"1$tmp$3#0", label %if.then, label %if.else 
+  %"1$tmp$3##0" = icmp sgt i64 %"n##0", 0 
+  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"stmt_when.gen$2<0>"(i64  %"n#0")  
+  tail call fastcc  void  @"stmt_when.gen$2<0>"(i64  %"n##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_when.gen$2<0>"(i64  %"n#0")    {
+define external fastcc  void @"stmt_when.gen$2<0>"(i64  %"n##0")    {
 entry:
-  %"1$tmp$0#0" = sub   i64 %"n#0", 1 
-  %"1$tmp$1#0" = urem i64 %"1$tmp$0#0", 2 
-  %"1$tmp$2#0" = icmp eq i64 %"1$tmp$1#0", 0 
-  br i1 %"1$tmp$2#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = sub   i64 %"n##0", 1 
+  %"1$tmp$1##0" = urem i64 %"1$tmp$0##0", 2 
+  %"1$tmp$2##0" = icmp eq i64 %"1$tmp$1##0", 0 
+  br i1 %"1$tmp$2##0", label %if.then, label %if.else 
 if.then:
-  tail call ccc  void  @print_int(i64  %"1$tmp$0#0")  
+  tail call ccc  void  @print_int(i64  %"1$tmp$0##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_when.gen$1<0>"(i64  %"1$tmp$0#0")  
+  tail call fastcc  void  @"stmt_when.gen$1<0>"(i64  %"1$tmp$0##0")  
   ret void 
 if.else:
-  tail call fastcc  void  @"stmt_when.gen$1<0>"(i64  %"1$tmp$0#0")  
+  tail call fastcc  void  @"stmt_when.gen$1<0>"(i64  %"1$tmp$0##0")  
   ret void 
 }
 
 
-define external fastcc  i64 @"stmt_when.mod<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"stmt_when.mod<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$$#0" = urem i64 %"x#0", %"y#0" 
-  ret i64 %"1$$#0" 
+  %"1$$##0" = urem i64 %"x##0", %"y##0" 
+  ret i64 %"1$$##0" 
 }

--- a/test-cases/final-dump/stmt_when.exp
+++ b/test-cases/final-dump/stmt_when.exp
@@ -15,49 +15,49 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_when.gen$1<0>(~io##0:wybe.phantom, 10:wybe.int, ?io##1:wybe.phantom) #0 @stmt_when:nn:nn
+    stmt_when.gen#1<0>(~io##0:wybe.phantom, 10:wybe.int, ?io##1:wybe.phantom) #0 @stmt_when:nn:nn
 
 
-gen$1 > (3 calls)
-0: stmt_when.gen$1<0>
-gen$1(io##0:wybe.phantom, n##0:wybe.int, ?io##1:wybe.phantom):
+gen#1 > (3 calls)
+0: stmt_when.gen#1<0>
+gen#1(io##0:wybe.phantom, n##0:wybe.int, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_sgt(n##0:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
-    case ~tmp$3##0:wybe.bool of
+    foreign llvm icmp_sgt(n##0:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
+    case ~tmp#3##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        stmt_when.gen$2<0>(~io##0:wybe.phantom, ~n##0:wybe.int, ?io##1:wybe.phantom) #1
+        stmt_when.gen#2<0>(~io##0:wybe.phantom, ~n##0:wybe.int, ?io##1:wybe.phantom) #1
 
 
 
-gen$2 > (1 calls)
-0: stmt_when.gen$2<0>
-gen$2(io##0:wybe.phantom, n##0:wybe.int, ?io##2:wybe.phantom):
+gen#2 > (1 calls)
+0: stmt_when.gen#2<0>
+gen#2(io##0:wybe.phantom, n##0:wybe.int, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
-    foreign llvm urem(tmp$0##0:wybe.int, 2:wybe.int, ?tmp$1##0:wybe.int) @stmt_when:nn:nn
-    foreign llvm icmp_eq(~tmp$1##0:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.bool) @int:nn:nn
-    case ~tmp$2##0:wybe.bool of
+    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
+    foreign llvm urem(tmp#0##0:wybe.int, 2:wybe.int, ?tmp#1##0:wybe.int) @stmt_when:nn:nn
+    foreign llvm icmp_eq(~tmp#1##0:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.bool) @int:nn:nn
+    case ~tmp#2##0:wybe.bool of
     0:
-        stmt_when.gen$1<0>(~io##0:wybe.phantom, ~tmp$0##0:wybe.int, ?io##2:wybe.phantom) #5 @stmt_when:nn:nn
+        stmt_when.gen#1<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.int, ?io##2:wybe.phantom) #5 @stmt_when:nn:nn
 
     1:
-        foreign c print_int(tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$11##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$11##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_when.gen$1<0>(~io##1:wybe.phantom, ~tmp$0##0:wybe.int, ?io##2:wybe.phantom) #4 @stmt_when:nn:nn
+        foreign c print_int(tmp#0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_when.gen#1<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.int, ?io##2:wybe.phantom) #4 @stmt_when:nn:nn
 
 
 
 mod > public {inline} (3 calls)
 0: stmt_when.mod<0>
-mod(x##0:wybe.int, y##0:wybe.int, ?$##0:wybe.int):
+mod(x##0:wybe.int, y##0:wybe.int, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm urem(~x##0:wybe.int, ~y##0:wybe.int, ?$##0:wybe.int) @stmt_when:nn:nn
+    foreign llvm urem(~x##0:wybe.int, ~y##0:wybe.int, ?###0:wybe.int) @stmt_when:nn:nn
 
   LLVM code       :
 
@@ -81,42 +81,42 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"stmt_when.<0>"()    {
 entry:
-  tail call fastcc  void  @"stmt_when.gen$1<0>"(i64  10)  
+  tail call fastcc  void  @"stmt_when.gen#1<0>"(i64  10)  
   ret void 
 }
 
 
-define external fastcc  void @"stmt_when.gen$1<0>"(i64  %"n##0")    {
+define external fastcc  void @"stmt_when.gen#1<0>"(i64  %"n##0")    {
 entry:
-  %"1$tmp$3##0" = icmp sgt i64 %"n##0", 0 
-  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
+  %"1#tmp#3##0" = icmp sgt i64 %"n##0", 0 
+  br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"stmt_when.gen$2<0>"(i64  %"n##0")  
+  tail call fastcc  void  @"stmt_when.gen#2<0>"(i64  %"n##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_when.gen$2<0>"(i64  %"n##0")    {
+define external fastcc  void @"stmt_when.gen#2<0>"(i64  %"n##0")    {
 entry:
-  %"1$tmp$0##0" = sub   i64 %"n##0", 1 
-  %"1$tmp$1##0" = urem i64 %"1$tmp$0##0", 2 
-  %"1$tmp$2##0" = icmp eq i64 %"1$tmp$1##0", 0 
-  br i1 %"1$tmp$2##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = sub   i64 %"n##0", 1 
+  %"1#tmp#1##0" = urem i64 %"1#tmp#0##0", 2 
+  %"1#tmp#2##0" = icmp eq i64 %"1#tmp#1##0", 0 
+  br i1 %"1#tmp#2##0", label %if.then, label %if.else 
 if.then:
-  tail call ccc  void  @print_int(i64  %"1$tmp$0##0")  
+  tail call ccc  void  @print_int(i64  %"1#tmp#0##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_when.gen$1<0>"(i64  %"1$tmp$0##0")  
+  tail call fastcc  void  @"stmt_when.gen#1<0>"(i64  %"1#tmp#0##0")  
   ret void 
 if.else:
-  tail call fastcc  void  @"stmt_when.gen$1<0>"(i64  %"1$tmp$0##0")  
+  tail call fastcc  void  @"stmt_when.gen#1<0>"(i64  %"1#tmp#0##0")  
   ret void 
 }
 
 
 define external fastcc  i64 @"stmt_when.mod<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$$##0" = urem i64 %"x##0", %"y##0" 
-  ret i64 %"1$$##0" 
+  %"1####0" = urem i64 %"x##0", %"y##0" 
+  ret i64 %"1####0" 
 }

--- a/test-cases/final-dump/stmt_while.exp
+++ b/test-cases/final-dump/stmt_while.exp
@@ -11,39 +11,39 @@ AFTER EVERYTHING:
 
 *main* > public {inline} (0 calls)
 0: stmt_while.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_while.gen$1<0>(~io#0:wybe.phantom, 10:wybe.int, ?io#1:wybe.phantom) #0 @stmt_while:nn:nn
+    stmt_while.gen$1<0>(~io##0:wybe.phantom, 10:wybe.int, ?io##1:wybe.phantom) #0 @stmt_while:nn:nn
 
 
 gen$1 > (2 calls)
 0: stmt_while.gen$1<0>
-gen$1(io#0:wybe.phantom, n#0:wybe.int, ?io#1:wybe.phantom):
+gen$1(io##0:wybe.phantom, n##0:wybe.int, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_sgt(n#0:wybe.int, 0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign llvm icmp_sgt(n##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign llvm sub(~n#0:wybe.int, 1:wybe.int, ?tmp$6#0:wybe.int) @int:nn:nn
-        foreign c print_int(tmp$6#0:wybe.int, ~io#0:wybe.phantom, ?tmp$7#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$7#0:wybe.phantom, ?tmp$8#0:wybe.phantom) @io:nn:nn
-        stmt_while.gen$1<0>(~tmp$8#0:wybe.phantom, ~tmp$6#0:wybe.int, ?io#1:wybe.phantom) #2 @stmt_while:nn:nn
+        foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$6##0:wybe.int) @int:nn:nn
+        foreign c print_int(tmp$6##0:wybe.int, ~io##0:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?tmp$8##0:wybe.phantom) @io:nn:nn
+        stmt_while.gen$1<0>(~tmp$8##0:wybe.phantom, ~tmp$6##0:wybe.int, ?io##1:wybe.phantom) #2 @stmt_while:nn:nn
 
 
 
 gen$2 > {inline} (1 calls)
 0: stmt_while.gen$2<0>
-gen$2(io#0:wybe.phantom, n#0:wybe.int, ?io#2:wybe.phantom):
+gen$2(io##0:wybe.phantom, n##0:wybe.int, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm sub(~n#0:wybe.int, 1:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn
-    foreign c print_int(tmp$0#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$5#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$5#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    stmt_while.gen$1<0>(~io#1:wybe.phantom, ~tmp$0#0:wybe.int, ?io#2:wybe.phantom) #2 @stmt_while:nn:nn
+    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
+    foreign c print_int(tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$5##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$5##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    stmt_while.gen$1<0>(~io##1:wybe.phantom, ~tmp$0##0:wybe.int, ?io##2:wybe.phantom) #2 @stmt_while:nn:nn
 
   LLVM code       :
 
@@ -72,26 +72,26 @@ entry:
 }
 
 
-define external fastcc  void @"stmt_while.gen$1<0>"(i64  %"n#0")    {
+define external fastcc  void @"stmt_while.gen$1<0>"(i64  %"n##0")    {
 entry:
-  %"1$tmp$1#0" = icmp sgt i64 %"n#0", 0 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp sgt i64 %"n##0", 0 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$6#0" = sub   i64 %"n#0", 1 
-  tail call ccc  void  @print_int(i64  %"2$tmp$6#0")  
+  %"2$tmp$6##0" = sub   i64 %"n##0", 1 
+  tail call ccc  void  @print_int(i64  %"2$tmp$6##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_while.gen$1<0>"(i64  %"2$tmp$6#0")  
+  tail call fastcc  void  @"stmt_while.gen$1<0>"(i64  %"2$tmp$6##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_while.gen$2<0>"(i64  %"n#0")    {
+define external fastcc  void @"stmt_while.gen$2<0>"(i64  %"n##0")    {
 entry:
-  %"1$tmp$0#0" = sub   i64 %"n#0", 1 
-  tail call ccc  void  @print_int(i64  %"1$tmp$0#0")  
+  %"1$tmp$0##0" = sub   i64 %"n##0", 1 
+  tail call ccc  void  @print_int(i64  %"1$tmp$0##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_while.gen$1<0>"(i64  %"1$tmp$0#0")  
+  tail call fastcc  void  @"stmt_while.gen$1<0>"(i64  %"1$tmp$0##0")  
   ret void 
 }

--- a/test-cases/final-dump/stmt_while.exp
+++ b/test-cases/final-dump/stmt_while.exp
@@ -14,36 +14,36 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_while.gen$1<0>(~io##0:wybe.phantom, 10:wybe.int, ?io##1:wybe.phantom) #0 @stmt_while:nn:nn
+    stmt_while.gen#1<0>(~io##0:wybe.phantom, 10:wybe.int, ?io##1:wybe.phantom) #0 @stmt_while:nn:nn
 
 
-gen$1 > (2 calls)
-0: stmt_while.gen$1<0>
-gen$1(io##0:wybe.phantom, n##0:wybe.int, ?io##1:wybe.phantom):
+gen#1 > (2 calls)
+0: stmt_while.gen#1<0>
+gen#1(io##0:wybe.phantom, n##0:wybe.int, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_sgt(n##0:wybe.int, 0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign llvm icmp_sgt(n##0:wybe.int, 0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$6##0:wybe.int) @int:nn:nn
-        foreign c print_int(tmp$6##0:wybe.int, ~io##0:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?tmp$8##0:wybe.phantom) @io:nn:nn
-        stmt_while.gen$1<0>(~tmp$8##0:wybe.phantom, ~tmp$6##0:wybe.int, ?io##1:wybe.phantom) #2 @stmt_while:nn:nn
+        foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp#6##0:wybe.int) @int:nn:nn
+        foreign c print_int(tmp#6##0:wybe.int, ~io##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @io:nn:nn
+        stmt_while.gen#1<0>(~tmp#8##0:wybe.phantom, ~tmp#6##0:wybe.int, ?io##1:wybe.phantom) #2 @stmt_while:nn:nn
 
 
 
-gen$2 > {inline} (1 calls)
-0: stmt_while.gen$2<0>
-gen$2(io##0:wybe.phantom, n##0:wybe.int, ?io##2:wybe.phantom):
+gen#2 > {inline} (1 calls)
+0: stmt_while.gen#2<0>
+gen#2(io##0:wybe.phantom, n##0:wybe.int, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
-    foreign c print_int(tmp$0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$5##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$5##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    stmt_while.gen$1<0>(~io##1:wybe.phantom, ~tmp$0##0:wybe.int, ?io##2:wybe.phantom) #2 @stmt_while:nn:nn
+    foreign llvm sub(~n##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
+    foreign c print_int(tmp#0##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    stmt_while.gen#1<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.int, ?io##2:wybe.phantom) #2 @stmt_while:nn:nn
 
   LLVM code       :
 
@@ -67,31 +67,31 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"stmt_while.<0>"()    {
 entry:
-  tail call fastcc  void  @"stmt_while.gen$1<0>"(i64  10)  
+  tail call fastcc  void  @"stmt_while.gen#1<0>"(i64  10)  
   ret void 
 }
 
 
-define external fastcc  void @"stmt_while.gen$1<0>"(i64  %"n##0")    {
+define external fastcc  void @"stmt_while.gen#1<0>"(i64  %"n##0")    {
 entry:
-  %"1$tmp$1##0" = icmp sgt i64 %"n##0", 0 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp sgt i64 %"n##0", 0 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$6##0" = sub   i64 %"n##0", 1 
-  tail call ccc  void  @print_int(i64  %"2$tmp$6##0")  
+  %"2#tmp#6##0" = sub   i64 %"n##0", 1 
+  tail call ccc  void  @print_int(i64  %"2#tmp#6##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_while.gen$1<0>"(i64  %"2$tmp$6##0")  
+  tail call fastcc  void  @"stmt_while.gen#1<0>"(i64  %"2#tmp#6##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_while.gen$2<0>"(i64  %"n##0")    {
+define external fastcc  void @"stmt_while.gen#2<0>"(i64  %"n##0")    {
 entry:
-  %"1$tmp$0##0" = sub   i64 %"n##0", 1 
-  tail call ccc  void  @print_int(i64  %"1$tmp$0##0")  
+  %"1#tmp#0##0" = sub   i64 %"n##0", 1 
+  tail call ccc  void  @print_int(i64  %"1#tmp#0##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_while.gen$1<0>"(i64  %"1$tmp$0##0")  
+  tail call fastcc  void  @"stmt_while.gen#1<0>"(i64  %"1#tmp#0##0")  
   ret void 
 }

--- a/test-cases/final-dump/student.exp
+++ b/test-cases/final-dump/student.exp
@@ -176,7 +176,7 @@ entry:
 
 = > public {inline} (1 calls)
 0: student.course.=<0>
-=(#left##0:student.course, #right##0:student.course, ?####0:wybe.bool):
+=(#left##0:student.course, #right##0:student.course, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#code##0:wybe.int)
@@ -186,11 +186,11 @@ entry:
     foreign llvm icmp_eq(~#left#code##0:wybe.int, ~#right#code##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign c strcmp(~#left#name##0:wybe.string, ~#right#name##0:wybe.string, ?tmp#9##0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp#9##0:wybe.int, 0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_eq(~tmp#9##0:wybe.int, 0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -241,7 +241,7 @@ name(#rec##0:student.course, ?#rec##1:student.course, #field##0:wybe.string):
 
 ~= > public {inline} (0 calls)
 0: student.course.~=<0>
-~=(#left##0:student.course, #right##0:student.course, ?####0:wybe.bool):
+~=(#left##0:student.course, #right##0:student.course, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -252,12 +252,12 @@ name(#rec##0:student.course, ?#rec##1:student.course, #field##0:wybe.string):
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign c strcmp(~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ?tmp#8##0:wybe.int) @string:nn:nn
         foreign llvm icmp_eq(~tmp#8##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
   LLVM code       :
@@ -297,8 +297,8 @@ entry:
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#9##0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
-  %"2#####0" = icmp eq i64 %"2#tmp#9##0", 0 
-  ret i1 %"2#####0" 
+  %"2##success##0" = icmp eq i64 %"2#tmp#9##0", 0 
+  ret i1 %"2##success##0" 
 if.else:
   ret i1 0 
 }
@@ -408,11 +408,11 @@ entry:
 if.then:
   %"2#tmp#8##0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
   %"2#tmp#0##0" = icmp eq i64 %"2#tmp#8##0", 0 
-  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
-  ret i1 %"2#####0" 
+  %"2##success##0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2##success##0" 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 }
 --------------------------------------------------
  Module student.student
@@ -434,7 +434,7 @@ if.else:
 
 = > public {inline} (1 calls)
 0: student.student.=<0>
-=(#left##0:student.student, #right##0:student.student, ?####0:wybe.bool):
+=(#left##0:student.student, #right##0:student.student, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#id##0:wybe.int)
@@ -444,7 +444,7 @@ if.else:
     foreign llvm icmp_eq(~#left#id##0:wybe.int, ~#right#id##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign lpvm access(#left#major##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
@@ -454,11 +454,11 @@ if.else:
         foreign llvm icmp_eq(~tmp#11##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#13##0:wybe.bool) @int:nn:nn
         case ~tmp#13##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign c strcmp(~tmp#10##0:wybe.string, ~tmp#12##0:wybe.string, ?tmp#14##0:wybe.int) @string:nn:nn
-            foreign llvm icmp_eq(~tmp#14##0:wybe.int, 0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+            foreign llvm icmp_eq(~tmp#14##0:wybe.int, 0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -510,7 +510,7 @@ student(?id##0:wybe.int, ?major##0:student.course, #result##0:student.student):
 
 ~= > public {inline} (0 calls)
 0: student.student.~=<0>
-~=(#left##0:student.student, #right##0:student.student, ?####0:wybe.bool):
+~=(#left##0:student.student, #right##0:student.student, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -521,7 +521,7 @@ student(?id##0:wybe.int, ?major##0:student.course, #result##0:student.student):
     case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign lpvm access(tmp#4##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
@@ -532,12 +532,12 @@ student(?id##0:wybe.int, ?major##0:student.course, #result##0:student.student):
         case ~tmp#12##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign c strcmp(~tmp#9##0:wybe.string, ~tmp#11##0:wybe.string, ?tmp#13##0:wybe.int) @string:nn:nn
             foreign llvm icmp_eq(~tmp#13##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -597,8 +597,8 @@ if.else:
   ret i1 0 
 if.then1:
   %"4#tmp#14##0" = tail call ccc  i64  @strcmp(i64  %21, i64  %28)  
-  %"4#####0" = icmp eq i64 %"4#tmp#14##0", 0 
-  ret i1 %"4#####0" 
+  %"4##success##0" = icmp eq i64 %"4#tmp#14##0", 0 
+  ret i1 %"4##success##0" 
 if.else1:
   ret i1 0 
 }
@@ -723,14 +723,14 @@ if.then:
   %"2#tmp#12##0" = icmp eq i64 %93, %86 
   br i1 %"2#tmp#12##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 if.then1:
   %"4#tmp#13##0" = tail call ccc  i64  @strcmp(i64  %90, i64  %97)  
   %"4#tmp#0##0" = icmp eq i64 %"4#tmp#13##0", 0 
-  %"4#####0" = xor i1 %"4#tmp#0##0", 1 
-  ret i1 %"4#####0" 
+  %"4##success##0" = xor i1 %"4#tmp#0##0", 1 
+  ret i1 %"4##success##0" 
 if.else1:
-  %"5#####0" = xor i1 0, 1 
-  ret i1 %"5#####0" 
+  %"5##success##0" = xor i1 0, 1 
+  ret i1 %"5##success##0" 
 }

--- a/test-cases/final-dump/student.exp
+++ b/test-cases/final-dump/student.exp
@@ -196,10 +196,10 @@ entry:
 
 code > public {inline} (0 calls)
 0: student.course.code<0>
-code(#rec##0:student.course, ?###0:wybe.int):
+code(#rec##0:student.course, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 code > public {inline} (0 calls)
 1: student.course.code<1>
 code(#rec##0:student.course, ?#rec##1:student.course, #field##0:wybe.int):
@@ -210,27 +210,27 @@ code(#rec##0:student.course, ?#rec##1:student.course, #field##0:wybe.int):
 
 course > public {inline} (0 calls)
 0: student.course.course<0>
-course(code##0:wybe.int, name##0:wybe.string, ?###0:student.course):
+course(code##0:wybe.int, name##0:wybe.string, ?#result##0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:student.course)
     foreign lpvm mutate(~#rec##0:student.course, ?#rec##1:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~code##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:student.course, ?###0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~name##0:wybe.string)
+    foreign lpvm mutate(~#rec##1:student.course, ?#result##0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~name##0:wybe.string)
 course > public {inline} (6 calls)
 1: student.course.course<1>
-course(?code##0:wybe.int, ?name##0:wybe.string, ###0:student.course):
+course(?code##0:wybe.int, ?name##0:wybe.string, #result##0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?code##0:wybe.int)
-    foreign lpvm access(~###0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?name##0:wybe.string)
+    foreign lpvm access(#result##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?code##0:wybe.int)
+    foreign lpvm access(~#result##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?name##0:wybe.string)
 
 
 name > public {inline} (0 calls)
 0: student.course.name<0>
-name(#rec##0:student.course, ?###0:wybe.string):
+name(#rec##0:student.course, ?#result##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.string)
+    foreign lpvm access(~#rec##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.string)
 name > public {inline} (0 calls)
 1: student.course.name<1>
 name(#rec##0:student.course, ?#rec##1:student.course, #field##0:wybe.string):
@@ -345,12 +345,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"student.course.course<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"student.course.course<1>"(i64  %"#result##0")    {
 entry:
-  %34 = inttoptr i64 %"###0" to i64* 
+  %34 = inttoptr i64 %"#result##0" to i64* 
   %35 = getelementptr  i64, i64* %34, i64 0 
   %36 = load  i64, i64* %35 
-  %37 = add   i64 %"###0", 8 
+  %37 = add   i64 %"#result##0", 8 
   %38 = inttoptr i64 %37 to i64* 
   %39 = getelementptr  i64, i64* %38, i64 0 
   %40 = load  i64, i64* %39 
@@ -465,10 +465,10 @@ if.else:
 
 id > public {inline} (0 calls)
 0: student.student.id<0>
-id(#rec##0:student.student, ?###0:wybe.int):
+id(#rec##0:student.student, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 id > public {inline} (0 calls)
 1: student.student.id<1>
 id(#rec##0:student.student, ?#rec##1:student.student, #field##0:wybe.int):
@@ -479,10 +479,10 @@ id(#rec##0:student.student, ?#rec##1:student.student, #field##0:wybe.int):
 
 major > public {inline} (0 calls)
 0: student.student.major<0>
-major(#rec##0:student.student, ?###0:student.course):
+major(#rec##0:student.student, ?#result##0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:student.course)
+    foreign lpvm access(~#rec##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:student.course)
 major > public {inline} (0 calls)
 1: student.student.major<1>
 major(#rec##0:student.student, ?#rec##1:student.student, #field##0:student.course):
@@ -493,19 +493,19 @@ major(#rec##0:student.student, ?#rec##1:student.student, #field##0:student.cours
 
 student > public {inline} (0 calls)
 0: student.student.student<0>
-student(id##0:wybe.int, major##0:student.course, ?###0:student.student):
+student(id##0:wybe.int, major##0:student.course, ?#result##0:student.student):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:student.student)
     foreign lpvm mutate(~#rec##0:student.student, ?#rec##1:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~id##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:student.student, ?###0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~major##0:student.course)
+    foreign lpvm mutate(~#rec##1:student.student, ?#result##0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~major##0:student.course)
 student > public {inline} (6 calls)
 1: student.student.student<1>
-student(?id##0:wybe.int, ?major##0:student.course, ###0:student.student):
+student(?id##0:wybe.int, ?major##0:student.course, #result##0:student.student):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?id##0:wybe.int)
-    foreign lpvm access(~###0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?major##0:student.course)
+    foreign lpvm access(#result##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?id##0:wybe.int)
+    foreign lpvm access(~#result##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?major##0:student.course)
 
 
 ~= > public {inline} (0 calls)
@@ -672,12 +672,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"student.student.student<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64} @"student.student.student<1>"(i64  %"#result##0")    {
 entry:
-  %61 = inttoptr i64 %"###0" to i64* 
+  %61 = inttoptr i64 %"#result##0" to i64* 
   %62 = getelementptr  i64, i64* %61, i64 0 
   %63 = load  i64, i64* %62 
-  %64 = add   i64 %"###0", 8 
+  %64 = add   i64 %"#result##0", 8 
   %65 = inttoptr i64 %64 to i64* 
   %66 = getelementptr  i64, i64* %65, i64 0 
   %67 = load  i64, i64* %66 

--- a/test-cases/final-dump/student.exp
+++ b/test-cases/final-dump/student.exp
@@ -35,13 +35,13 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$4##0:student.course)
-    foreign lpvm mutate(~tmp$4##0:student.course, ?tmp$5##0:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 90048:wybe.int)
-    foreign lpvm mutate(~tmp$5##0:student.course, ?tmp$6##0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, "Declarative Programming":wybe.string)
-    foreign lpvm alloc(16:wybe.int, ?tmp$9##0:student.student)
-    foreign lpvm mutate(~tmp$9##0:student.student, ?tmp$10##0:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 12345:wybe.int)
-    foreign lpvm mutate(~tmp$10##0:student.student, ?tmp$11##0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$6##0:student.course)
-    student.printStudent<0>(~tmp$11##0:student.student, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @student:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:student.course)
+    foreign lpvm mutate(~tmp#4##0:student.course, ?tmp#5##0:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 90048:wybe.int)
+    foreign lpvm mutate(~tmp#5##0:student.course, ?tmp#6##0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, "Declarative Programming":wybe.string)
+    foreign lpvm alloc(16:wybe.int, ?tmp#9##0:student.student)
+    foreign lpvm mutate(~tmp#9##0:student.student, ?tmp#10##0:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 12345:wybe.int)
+    foreign lpvm mutate(~tmp#10##0:student.student, ?tmp#11##0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#6##0:student.course)
+    student.printStudent<0>(~tmp#11##0:student.student, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @student:nn:nn
 
 
 printStudent > public (1 calls)
@@ -50,18 +50,18 @@ printStudent(stu##0:student.student, io##0:wybe.phantom, ?io##6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign c print_string("student id: ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(stu##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$9##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$9##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~stu##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:student.course)
+    foreign lpvm access(stu##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#9##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#9##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~stu##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#1##0:student.course)
     foreign c print_string("course code: ":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(tmp$1##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.int)
-    foreign c print_int(~tmp$2##0:wybe.int, ~#io##3:wybe.phantom, ?tmp$16##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$16##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign lpvm access(tmp#1##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.int)
+    foreign c print_int(~tmp#2##0:wybe.int, ~#io##3:wybe.phantom, ?tmp#16##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
     foreign c print_string("course name: ":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~tmp$1##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.string)
-    foreign c print_string(~tmp$3##0:wybe.string, ~#io##5:wybe.phantom, ?tmp$22##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$22##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~tmp#1##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.string)
+    foreign c print_string(~tmp#3##0:wybe.string, ~#io##5:wybe.phantom, ?tmp#22##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#22##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -176,88 +176,88 @@ entry:
 
 = > public {inline} (1 calls)
 0: student.course.=<0>
-=($left##0:student.course, $right##0:student.course, ?$$##0:wybe.bool):
+=(#left##0:student.course, #right##0:student.course, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$code##0:wybe.int)
-    foreign lpvm access(~$left##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$name##0:wybe.string)
-    foreign lpvm access($right##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$code##0:wybe.int)
-    foreign lpvm access(~$right##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$name##0:wybe.string)
-    foreign llvm icmp_eq(~$left$code##0:wybe.int, ~$right$code##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#code##0:wybe.int)
+    foreign lpvm access(~#left##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#name##0:wybe.string)
+    foreign lpvm access(#right##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#code##0:wybe.int)
+    foreign lpvm access(~#right##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#name##0:wybe.string)
+    foreign llvm icmp_eq(~#left#code##0:wybe.int, ~#right#code##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign c strcmp(~$left$name##0:wybe.string, ~$right$name##0:wybe.string, ?tmp$9##0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp$9##0:wybe.int, 0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+        foreign c strcmp(~#left#name##0:wybe.string, ~#right#name##0:wybe.string, ?tmp#9##0:wybe.int) @string:nn:nn
+        foreign llvm icmp_eq(~tmp#9##0:wybe.int, 0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 code > public {inline} (0 calls)
 0: student.course.code<0>
-code($rec##0:student.course, ?$##0:wybe.int):
+code(#rec##0:student.course, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 code > public {inline} (0 calls)
 1: student.course.code<1>
-code($rec##0:student.course, ?$rec##1:student.course, $field##0:wybe.int):
+code(#rec##0:student.course, ?#rec##1:student.course, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec##0:student.course, ?$rec##1:student.course, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm mutate(~#rec##0:student.course, ?#rec##1:student.course, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 course > public {inline} (0 calls)
 0: student.course.course<0>
-course(code##0:wybe.int, name##0:wybe.string, ?$##0:student.course):
+course(code##0:wybe.int, name##0:wybe.string, ?###0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:student.course)
-    foreign lpvm mutate(~$rec##0:student.course, ?$rec##1:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~code##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:student.course, ?$##0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~name##0:wybe.string)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:student.course)
+    foreign lpvm mutate(~#rec##0:student.course, ?#rec##1:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~code##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:student.course, ?###0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~name##0:wybe.string)
 course > public {inline} (6 calls)
 1: student.course.course<1>
-course(?code##0:wybe.int, ?name##0:wybe.string, $##0:student.course):
+course(?code##0:wybe.int, ?name##0:wybe.string, ###0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?code##0:wybe.int)
-    foreign lpvm access(~$##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?name##0:wybe.string)
+    foreign lpvm access(###0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?code##0:wybe.int)
+    foreign lpvm access(~###0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?name##0:wybe.string)
 
 
 name > public {inline} (0 calls)
 0: student.course.name<0>
-name($rec##0:student.course, ?$##0:wybe.string):
+name(#rec##0:student.course, ?###0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.string)
+    foreign lpvm access(~#rec##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.string)
 name > public {inline} (0 calls)
 1: student.course.name<1>
-name($rec##0:student.course, ?$rec##1:student.course, $field##0:wybe.string):
+name(#rec##0:student.course, ?#rec##1:student.course, #field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:student.course, ?$rec##1:student.course, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.string)
+    foreign lpvm {noalias} mutate(~#rec##0:student.course, ?#rec##1:student.course, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.string)
 
 
 ~= > public {inline} (0 calls)
 0: student.course.~=<0>
-~=($left##0:student.course, $right##0:student.course, ?$$##0:wybe.bool):
+~=(#left##0:student.course, #right##0:student.course, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.string)
-    foreign lpvm access($right##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.string)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.string)
+    foreign lpvm access(#right##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.string)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign c strcmp(~tmp$4##0:wybe.string, ~tmp$6##0:wybe.string, ?tmp$8##0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp$8##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign c strcmp(~tmp#4##0:wybe.string, ~tmp#6##0:wybe.string, ?tmp#8##0:wybe.int) @string:nn:nn
+        foreign llvm icmp_eq(~tmp#8##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
   LLVM code       :
@@ -277,54 +277,54 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"student.course.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"student.course.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$9##0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
-  %"2$$$##0" = icmp eq i64 %"2$tmp$9##0", 0 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#9##0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
+  %"2#####0" = icmp eq i64 %"2#tmp#9##0", 0 
+  ret i1 %"2#####0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"student.course.code<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"student.course.code<0>"(i64  %"#rec##0")    {
 entry:
-  %15 = inttoptr i64 %"$rec##0" to i64* 
+  %15 = inttoptr i64 %"#rec##0" to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
   %17 = load  i64, i64* %16 
   ret i64 %17 
 }
 
 
-define external fastcc  i64 @"student.course.code<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"student.course.code<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %18 = trunc i64 16 to i32  
   %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
   %20 = ptrtoint i8* %19 to i64 
   %21 = inttoptr i64 %20 to i8* 
-  %22 = inttoptr i64 %"$rec##0" to i8* 
+  %22 = inttoptr i64 %"#rec##0" to i8* 
   %23 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %21, i8*  %22, i32  %23, i32  8, i1  0)  
   %24 = inttoptr i64 %20 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
-  store  i64 %"$field##0", i64* %25 
+  store  i64 %"#field##0", i64* %25 
   ret i64 %20 
 }
 
@@ -345,12 +345,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"student.course.course<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"student.course.course<1>"(i64  %"###0")    {
 entry:
-  %34 = inttoptr i64 %"$##0" to i64* 
+  %34 = inttoptr i64 %"###0" to i64* 
   %35 = getelementptr  i64, i64* %34, i64 0 
   %36 = load  i64, i64* %35 
-  %37 = add   i64 %"$##0", 8 
+  %37 = add   i64 %"###0", 8 
   %38 = inttoptr i64 %37 to i64* 
   %39 = getelementptr  i64, i64* %38, i64 0 
   %40 = load  i64, i64* %39 
@@ -360,9 +360,9 @@ entry:
 }
 
 
-define external fastcc  i64 @"student.course.name<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"student.course.name<0>"(i64  %"#rec##0")    {
 entry:
-  %43 = add   i64 %"$rec##0", 8 
+  %43 = add   i64 %"#rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -370,49 +370,49 @@ entry:
 }
 
 
-define external fastcc  i64 @"student.course.name<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"student.course.name<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec##0" to i8* 
+  %51 = inttoptr i64 %"#rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field##0", i64* %55 
+  store  i64 %"#field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"student.course.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"student.course.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left##0" to i64* 
+  %56 = inttoptr i64 %"#left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left##0", 8 
+  %59 = add   i64 %"#left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right##0" to i64* 
+  %63 = inttoptr i64 %"#right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right##0", 8 
+  %66 = add   i64 %"#right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7##0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %58, %65 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$8##0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
-  %"2$tmp$0##0" = icmp eq i64 %"2$tmp$8##0", 0 
-  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
-  ret i1 %"2$$$##0" 
+  %"2#tmp#8##0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
+  %"2#tmp#0##0" = icmp eq i64 %"2#tmp#8##0", 0 
+  %"2#####0" = xor i1 %"2#tmp#0##0", 1 
+  ret i1 %"2#####0" 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 }
 --------------------------------------------------
  Module student.student
@@ -434,110 +434,110 @@ if.else:
 
 = > public {inline} (1 calls)
 0: student.student.=<0>
-=($left##0:student.student, $right##0:student.student, ?$$##0:wybe.bool):
+=(#left##0:student.student, #right##0:student.student, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$id##0:wybe.int)
-    foreign lpvm access(~$left##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$major##0:student.course)
-    foreign lpvm access($right##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$id##0:wybe.int)
-    foreign lpvm access(~$right##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$major##0:student.course)
-    foreign llvm icmp_eq(~$left$id##0:wybe.int, ~$right$id##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#id##0:wybe.int)
+    foreign lpvm access(~#left##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#major##0:student.course)
+    foreign lpvm access(#right##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#id##0:wybe.int)
+    foreign lpvm access(~#right##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#major##0:student.course)
+    foreign llvm icmp_eq(~#left#id##0:wybe.int, ~#right#id##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign lpvm access($left$major##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.int)
-        foreign lpvm access(~$left$major##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.string)
-        foreign lpvm access($right$major##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$11##0:wybe.int)
-        foreign lpvm access(~$right$major##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$12##0:wybe.string)
-        foreign llvm icmp_eq(~tmp$11##0:wybe.int, ~tmp$9##0:wybe.int, ?tmp$13##0:wybe.bool) @int:nn:nn
-        case ~tmp$13##0:wybe.bool of
+        foreign lpvm access(#left#major##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.int)
+        foreign lpvm access(~#left#major##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.string)
+        foreign lpvm access(#right#major##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#11##0:wybe.int)
+        foreign lpvm access(~#right#major##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#12##0:wybe.string)
+        foreign llvm icmp_eq(~tmp#11##0:wybe.int, ~tmp#9##0:wybe.int, ?tmp#13##0:wybe.bool) @int:nn:nn
+        case ~tmp#13##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign c strcmp(~tmp$10##0:wybe.string, ~tmp$12##0:wybe.string, ?tmp$14##0:wybe.int) @string:nn:nn
-            foreign llvm icmp_eq(~tmp$14##0:wybe.int, 0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+            foreign c strcmp(~tmp#10##0:wybe.string, ~tmp#12##0:wybe.string, ?tmp#14##0:wybe.int) @string:nn:nn
+            foreign llvm icmp_eq(~tmp#14##0:wybe.int, 0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 
 id > public {inline} (0 calls)
 0: student.student.id<0>
-id($rec##0:student.student, ?$##0:wybe.int):
+id(#rec##0:student.student, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
 id > public {inline} (0 calls)
 1: student.student.id<1>
-id($rec##0:student.student, ?$rec##1:student.student, $field##0:wybe.int):
+id(#rec##0:student.student, ?#rec##1:student.student, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec##0:student.student, ?$rec##1:student.student, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm mutate(~#rec##0:student.student, ?#rec##1:student.student, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 major > public {inline} (0 calls)
 0: student.student.major<0>
-major($rec##0:student.student, ?$##0:student.course):
+major(#rec##0:student.student, ?###0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:student.course)
+    foreign lpvm access(~#rec##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:student.course)
 major > public {inline} (0 calls)
 1: student.student.major<1>
-major($rec##0:student.student, ?$rec##1:student.student, $field##0:student.course):
+major(#rec##0:student.student, ?#rec##1:student.student, #field##0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:student.student, ?$rec##1:student.student, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:student.course)
+    foreign lpvm {noalias} mutate(~#rec##0:student.student, ?#rec##1:student.student, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:student.course)
 
 
 student > public {inline} (0 calls)
 0: student.student.student<0>
-student(id##0:wybe.int, major##0:student.course, ?$##0:student.student):
+student(id##0:wybe.int, major##0:student.course, ?###0:student.student):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:student.student)
-    foreign lpvm mutate(~$rec##0:student.student, ?$rec##1:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~id##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:student.student, ?$##0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~major##0:student.course)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:student.student)
+    foreign lpvm mutate(~#rec##0:student.student, ?#rec##1:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~id##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:student.student, ?###0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~major##0:student.course)
 student > public {inline} (6 calls)
 1: student.student.student<1>
-student(?id##0:wybe.int, ?major##0:student.course, $##0:student.student):
+student(?id##0:wybe.int, ?major##0:student.course, ###0:student.student):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?id##0:wybe.int)
-    foreign lpvm access(~$##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?major##0:student.course)
+    foreign lpvm access(###0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?id##0:wybe.int)
+    foreign lpvm access(~###0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?major##0:student.course)
 
 
 ~= > public {inline} (0 calls)
 0: student.student.~=<0>
-~=($left##0:student.student, $right##0:student.student, ?$$##0:wybe.bool):
+~=(#left##0:student.student, #right##0:student.student, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access(~$left##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:student.course)
-    foreign lpvm access($right##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access(~$right##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:student.course)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    foreign lpvm access(#left##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(~#left##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##0:student.course)
+    foreign lpvm access(#right##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(~#right##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:student.course)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#5##0:wybe.int, ?tmp#7##0:wybe.bool) @int:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign lpvm access(tmp$4##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
-        foreign lpvm access(~tmp$4##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.string)
-        foreign lpvm access(tmp$6##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.int)
-        foreign lpvm access(~tmp$6##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$11##0:wybe.string)
-        foreign llvm icmp_eq(~tmp$10##0:wybe.int, ~tmp$8##0:wybe.int, ?tmp$12##0:wybe.bool) @int:nn:nn
-        case ~tmp$12##0:wybe.bool of
+        foreign lpvm access(tmp#4##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
+        foreign lpvm access(~tmp#4##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.string)
+        foreign lpvm access(tmp#6##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.int)
+        foreign lpvm access(~tmp#6##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#11##0:wybe.string)
+        foreign llvm icmp_eq(~tmp#10##0:wybe.int, ~tmp#8##0:wybe.int, ?tmp#12##0:wybe.bool) @int:nn:nn
+        case ~tmp#12##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign c strcmp(~tmp$9##0:wybe.string, ~tmp$11##0:wybe.string, ?tmp$13##0:wybe.int) @string:nn:nn
-            foreign llvm icmp_eq(~tmp$13##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+            foreign c strcmp(~tmp#9##0:wybe.string, ~tmp#11##0:wybe.string, ?tmp#13##0:wybe.int) @string:nn:nn
+            foreign llvm icmp_eq(~tmp#13##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
 
@@ -558,24 +558,24 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"student.student.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"student.student.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1##0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %10 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
   %15 = inttoptr i64 %7 to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
@@ -591,47 +591,47 @@ if.then:
   %26 = inttoptr i64 %25 to i64* 
   %27 = getelementptr  i64, i64* %26, i64 0 
   %28 = load  i64, i64* %27 
-  %"2$tmp$13##0" = icmp eq i64 %24, %17 
-  br i1 %"2$tmp$13##0", label %if.then1, label %if.else1 
+  %"2#tmp#13##0" = icmp eq i64 %24, %17 
+  br i1 %"2#tmp#13##0", label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %"4$tmp$14##0" = tail call ccc  i64  @strcmp(i64  %21, i64  %28)  
-  %"4$$$##0" = icmp eq i64 %"4$tmp$14##0", 0 
-  ret i1 %"4$$$##0" 
+  %"4#tmp#14##0" = tail call ccc  i64  @strcmp(i64  %21, i64  %28)  
+  %"4#####0" = icmp eq i64 %"4#tmp#14##0", 0 
+  ret i1 %"4#####0" 
 if.else1:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"student.student.id<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"student.student.id<0>"(i64  %"#rec##0")    {
 entry:
-  %29 = inttoptr i64 %"$rec##0" to i64* 
+  %29 = inttoptr i64 %"#rec##0" to i64* 
   %30 = getelementptr  i64, i64* %29, i64 0 
   %31 = load  i64, i64* %30 
   ret i64 %31 
 }
 
 
-define external fastcc  i64 @"student.student.id<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"student.student.id<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %32 = trunc i64 16 to i32  
   %33 = tail call ccc  i8*  @wybe_malloc(i32  %32)  
   %34 = ptrtoint i8* %33 to i64 
   %35 = inttoptr i64 %34 to i8* 
-  %36 = inttoptr i64 %"$rec##0" to i8* 
+  %36 = inttoptr i64 %"#rec##0" to i8* 
   %37 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %35, i8*  %36, i32  %37, i32  8, i1  0)  
   %38 = inttoptr i64 %34 to i64* 
   %39 = getelementptr  i64, i64* %38, i64 0 
-  store  i64 %"$field##0", i64* %39 
+  store  i64 %"#field##0", i64* %39 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"student.student.major<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"student.student.major<0>"(i64  %"#rec##0")    {
 entry:
-  %40 = add   i64 %"$rec##0", 8 
+  %40 = add   i64 %"#rec##0", 8 
   %41 = inttoptr i64 %40 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
   %43 = load  i64, i64* %42 
@@ -639,19 +639,19 @@ entry:
 }
 
 
-define external fastcc  i64 @"student.student.major<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"student.student.major<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %44 = trunc i64 16 to i32  
   %45 = tail call ccc  i8*  @wybe_malloc(i32  %44)  
   %46 = ptrtoint i8* %45 to i64 
   %47 = inttoptr i64 %46 to i8* 
-  %48 = inttoptr i64 %"$rec##0" to i8* 
+  %48 = inttoptr i64 %"#rec##0" to i8* 
   %49 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %47, i8*  %48, i32  %49, i32  8, i1  0)  
   %50 = add   i64 %46, 8 
   %51 = inttoptr i64 %50 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
-  store  i64 %"$field##0", i64* %52 
+  store  i64 %"#field##0", i64* %52 
   ret i64 %46 
 }
 
@@ -672,12 +672,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i64} @"student.student.student<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64} @"student.student.student<1>"(i64  %"###0")    {
 entry:
-  %61 = inttoptr i64 %"$##0" to i64* 
+  %61 = inttoptr i64 %"###0" to i64* 
   %62 = getelementptr  i64, i64* %61, i64 0 
   %63 = load  i64, i64* %62 
-  %64 = add   i64 %"$##0", 8 
+  %64 = add   i64 %"###0", 8 
   %65 = inttoptr i64 %64 to i64* 
   %66 = getelementptr  i64, i64* %65, i64 0 
   %67 = load  i64, i64* %66 
@@ -687,24 +687,24 @@ entry:
 }
 
 
-define external fastcc  i1 @"student.student.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"student.student.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %70 = inttoptr i64 %"$left##0" to i64* 
+  %70 = inttoptr i64 %"#left##0" to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
   %72 = load  i64, i64* %71 
-  %73 = add   i64 %"$left##0", 8 
+  %73 = add   i64 %"#left##0", 8 
   %74 = inttoptr i64 %73 to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
   %76 = load  i64, i64* %75 
-  %77 = inttoptr i64 %"$right##0" to i64* 
+  %77 = inttoptr i64 %"#right##0" to i64* 
   %78 = getelementptr  i64, i64* %77, i64 0 
   %79 = load  i64, i64* %78 
-  %80 = add   i64 %"$right##0", 8 
+  %80 = add   i64 %"#right##0", 8 
   %81 = inttoptr i64 %80 to i64* 
   %82 = getelementptr  i64, i64* %81, i64 0 
   %83 = load  i64, i64* %82 
-  %"1$tmp$7##0" = icmp eq i64 %72, %79 
-  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
+  %"1#tmp#7##0" = icmp eq i64 %72, %79 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
 if.then:
   %84 = inttoptr i64 %76 to i64* 
   %85 = getelementptr  i64, i64* %84, i64 0 
@@ -720,17 +720,17 @@ if.then:
   %95 = inttoptr i64 %94 to i64* 
   %96 = getelementptr  i64, i64* %95, i64 0 
   %97 = load  i64, i64* %96 
-  %"2$tmp$12##0" = icmp eq i64 %93, %86 
-  br i1 %"2$tmp$12##0", label %if.then1, label %if.else1 
+  %"2#tmp#12##0" = icmp eq i64 %93, %86 
+  br i1 %"2#tmp#12##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 if.then1:
-  %"4$tmp$13##0" = tail call ccc  i64  @strcmp(i64  %90, i64  %97)  
-  %"4$tmp$0##0" = icmp eq i64 %"4$tmp$13##0", 0 
-  %"4$$$##0" = xor i1 %"4$tmp$0##0", 1 
-  ret i1 %"4$$$##0" 
+  %"4#tmp#13##0" = tail call ccc  i64  @strcmp(i64  %90, i64  %97)  
+  %"4#tmp#0##0" = icmp eq i64 %"4#tmp#13##0", 0 
+  %"4#####0" = xor i1 %"4#tmp#0##0", 1 
+  ret i1 %"4#####0" 
 if.else1:
-  %"5$$$##0" = xor i1 0, 1 
-  ret i1 %"5$$$##0" 
+  %"5#####0" = xor i1 0, 1 
+  ret i1 %"5#####0" 
 }

--- a/test-cases/final-dump/student.exp
+++ b/test-cases/final-dump/student.exp
@@ -32,36 +32,36 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: student.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$4#0:student.course)
-    foreign lpvm mutate(~tmp$4#0:student.course, ?tmp$5#0:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 90048:wybe.int)
-    foreign lpvm mutate(~tmp$5#0:student.course, ?tmp$6#0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, "Declarative Programming":wybe.string)
-    foreign lpvm alloc(16:wybe.int, ?tmp$9#0:student.student)
-    foreign lpvm mutate(~tmp$9#0:student.student, ?tmp$10#0:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 12345:wybe.int)
-    foreign lpvm mutate(~tmp$10#0:student.student, ?tmp$11#0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$6#0:student.course)
-    student.printStudent<0>(~tmp$11#0:student.student, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #2 @student:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$4##0:student.course)
+    foreign lpvm mutate(~tmp$4##0:student.course, ?tmp$5##0:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 90048:wybe.int)
+    foreign lpvm mutate(~tmp$5##0:student.course, ?tmp$6##0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, "Declarative Programming":wybe.string)
+    foreign lpvm alloc(16:wybe.int, ?tmp$9##0:student.student)
+    foreign lpvm mutate(~tmp$9##0:student.student, ?tmp$10##0:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 12345:wybe.int)
+    foreign lpvm mutate(~tmp$10##0:student.student, ?tmp$11##0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$6##0:student.course)
+    student.printStudent<0>(~tmp$11##0:student.student, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #2 @student:nn:nn
 
 
 printStudent > public (1 calls)
 0: student.printStudent<0>
-printStudent(stu#0:student.student, io#0:wybe.phantom, ?io#6:wybe.phantom):
+printStudent(stu##0:student.student, io##0:wybe.phantom, ?io##6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("student id: ":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(stu#0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-    foreign c print_int(~tmp$0#0:wybe.int, ~#io#1:wybe.phantom, ?tmp$9#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$9#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~stu#0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1#0:student.course)
-    foreign c print_string("course code: ":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign lpvm access(tmp$1#0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$2#0:wybe.int)
-    foreign c print_int(~tmp$2#0:wybe.int, ~#io#3:wybe.phantom, ?tmp$16#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$16#0:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
-    foreign c print_string("course name: ":wybe.string, ~#io#4:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-    foreign lpvm access(~tmp$1#0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.string)
-    foreign c print_string(~tmp$3#0:wybe.string, ~#io#5:wybe.phantom, ?tmp$22#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$22#0:wybe.phantom, ?#io#6:wybe.phantom) @io:nn:nn
+    foreign c print_string("student id: ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm access(stu##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+    foreign c print_int(~tmp$0##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$9##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$9##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~stu##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$1##0:student.course)
+    foreign c print_string("course code: ":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign lpvm access(tmp$1##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.int)
+    foreign c print_int(~tmp$2##0:wybe.int, ~#io##3:wybe.phantom, ?tmp$16##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$16##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_string("course name: ":wybe.string, ~#io##4:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+    foreign lpvm access(~tmp$1##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.string)
+    foreign c print_string(~tmp$3##0:wybe.string, ~#io##5:wybe.phantom, ?tmp$22##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$22##0:wybe.phantom, ?#io##6:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -126,16 +126,16 @@ entry:
 }
 
 
-define external fastcc  void @"student.printStudent<0>"(i64  %"stu#0")    {
+define external fastcc  void @"student.printStudent<0>"(i64  %"stu##0")    {
 entry:
   %20 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @student.19, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %20)  
-  %21 = inttoptr i64 %"stu#0" to i64* 
+  %21 = inttoptr i64 %"stu##0" to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
   %23 = load  i64, i64* %22 
   tail call ccc  void  @print_int(i64  %23)  
   tail call ccc  void  @putchar(i8  10)  
-  %24 = add   i64 %"stu#0", 8 
+  %24 = add   i64 %"stu##0", 8 
   %25 = inttoptr i64 %24 to i64* 
   %26 = getelementptr  i64, i64* %25, i64 0 
   %27 = load  i64, i64* %26 
@@ -176,88 +176,88 @@ entry:
 
 = > public {inline} (1 calls)
 0: student.course.=<0>
-=($left#0:student.course, $right#0:student.course, ?$$#0:wybe.bool):
+=($left##0:student.course, $right##0:student.course, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$code#0:wybe.int)
-    foreign lpvm access(~$left#0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$name#0:wybe.string)
-    foreign lpvm access($right#0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$code#0:wybe.int)
-    foreign lpvm access(~$right#0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$name#0:wybe.string)
-    foreign llvm icmp_eq(~$left$code#0:wybe.int, ~$right$code#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$code##0:wybe.int)
+    foreign lpvm access(~$left##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$name##0:wybe.string)
+    foreign lpvm access($right##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$code##0:wybe.int)
+    foreign lpvm access(~$right##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$name##0:wybe.string)
+    foreign llvm icmp_eq(~$left$code##0:wybe.int, ~$right$code##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign c strcmp(~$left$name#0:wybe.string, ~$right$name#0:wybe.string, ?tmp$9#0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp$9#0:wybe.int, 0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+        foreign c strcmp(~$left$name##0:wybe.string, ~$right$name##0:wybe.string, ?tmp$9##0:wybe.int) @string:nn:nn
+        foreign llvm icmp_eq(~tmp$9##0:wybe.int, 0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 code > public {inline} (0 calls)
 0: student.course.code<0>
-code($rec#0:student.course, ?$#0:wybe.int):
+code($rec##0:student.course, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 code > public {inline} (0 calls)
 1: student.course.code<1>
-code($rec#0:student.course, ?$rec#1:student.course, $field#0:wybe.int):
+code($rec##0:student.course, ?$rec##1:student.course, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec#0:student.course, ?$rec#1:student.course, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm mutate(~$rec##0:student.course, ?$rec##1:student.course, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 course > public {inline} (0 calls)
 0: student.course.course<0>
-course(code#0:wybe.int, name#0:wybe.string, ?$#0:student.course):
+course(code##0:wybe.int, name##0:wybe.string, ?$##0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:student.course)
-    foreign lpvm mutate(~$rec#0:student.course, ?$rec#1:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~code#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:student.course, ?$#0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~name#0:wybe.string)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:student.course)
+    foreign lpvm mutate(~$rec##0:student.course, ?$rec##1:student.course, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~code##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:student.course, ?$##0:student.course, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~name##0:wybe.string)
 course > public {inline} (6 calls)
 1: student.course.course<1>
-course(?code#0:wybe.int, ?name#0:wybe.string, $#0:student.course):
+course(?code##0:wybe.int, ?name##0:wybe.string, $##0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?code#0:wybe.int)
-    foreign lpvm access(~$#0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?name#0:wybe.string)
+    foreign lpvm access($##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?code##0:wybe.int)
+    foreign lpvm access(~$##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?name##0:wybe.string)
 
 
 name > public {inline} (0 calls)
 0: student.course.name<0>
-name($rec#0:student.course, ?$#0:wybe.string):
+name($rec##0:student.course, ?$##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.string)
+    foreign lpvm access(~$rec##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.string)
 name > public {inline} (0 calls)
 1: student.course.name<1>
-name($rec#0:student.course, ?$rec#1:student.course, $field#0:wybe.string):
+name($rec##0:student.course, ?$rec##1:student.course, $field##0:wybe.string):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:student.course, ?$rec#1:student.course, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.string)
+    foreign lpvm {noalias} mutate(~$rec##0:student.course, ?$rec##1:student.course, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.string)
 
 
 ~= > public {inline} (0 calls)
 0: student.course.~=<0>
-~=($left#0:student.course, $right#0:student.course, ?$$#0:wybe.bool):
+~=($left##0:student.course, $right##0:student.course, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.string)
-    foreign lpvm access($right#0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.string)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.string)
+    foreign lpvm access($right##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.string)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign c strcmp(~tmp$4#0:wybe.string, ~tmp$6#0:wybe.string, ?tmp$8#0:wybe.int) @string:nn:nn
-        foreign llvm icmp_eq(~tmp$8#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign c strcmp(~tmp$4##0:wybe.string, ~tmp$6##0:wybe.string, ?tmp$8##0:wybe.int) @string:nn:nn
+        foreign llvm icmp_eq(~tmp$8##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
   LLVM code       :
@@ -277,80 +277,80 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"student.course.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"student.course.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$9#0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
-  %"2$$$#0" = icmp eq i64 %"2$tmp$9#0", 0 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$9##0" = tail call ccc  i64  @strcmp(i64  %7, i64  %14)  
+  %"2$$$##0" = icmp eq i64 %"2$tmp$9##0", 0 
+  ret i1 %"2$$$##0" 
 if.else:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"student.course.code<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"student.course.code<0>"(i64  %"$rec##0")    {
 entry:
-  %15 = inttoptr i64 %"$rec#0" to i64* 
+  %15 = inttoptr i64 %"$rec##0" to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
   %17 = load  i64, i64* %16 
   ret i64 %17 
 }
 
 
-define external fastcc  i64 @"student.course.code<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"student.course.code<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %18 = trunc i64 16 to i32  
   %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
   %20 = ptrtoint i8* %19 to i64 
   %21 = inttoptr i64 %20 to i8* 
-  %22 = inttoptr i64 %"$rec#0" to i8* 
+  %22 = inttoptr i64 %"$rec##0" to i8* 
   %23 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %21, i8*  %22, i32  %23, i32  8, i1  0)  
   %24 = inttoptr i64 %20 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
-  store  i64 %"$field#0", i64* %25 
+  store  i64 %"$field##0", i64* %25 
   ret i64 %20 
 }
 
 
-define external fastcc  i64 @"student.course.course<0>"(i64  %"code#0", i64  %"name#0")    {
+define external fastcc  i64 @"student.course.course<0>"(i64  %"code##0", i64  %"name##0")    {
 entry:
   %26 = trunc i64 16 to i32  
   %27 = tail call ccc  i8*  @wybe_malloc(i32  %26)  
   %28 = ptrtoint i8* %27 to i64 
   %29 = inttoptr i64 %28 to i64* 
   %30 = getelementptr  i64, i64* %29, i64 0 
-  store  i64 %"code#0", i64* %30 
+  store  i64 %"code##0", i64* %30 
   %31 = add   i64 %28, 8 
   %32 = inttoptr i64 %31 to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
-  store  i64 %"name#0", i64* %33 
+  store  i64 %"name##0", i64* %33 
   ret i64 %28 
 }
 
 
-define external fastcc  {i64, i64} @"student.course.course<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"student.course.course<1>"(i64  %"$##0")    {
 entry:
-  %34 = inttoptr i64 %"$#0" to i64* 
+  %34 = inttoptr i64 %"$##0" to i64* 
   %35 = getelementptr  i64, i64* %34, i64 0 
   %36 = load  i64, i64* %35 
-  %37 = add   i64 %"$#0", 8 
+  %37 = add   i64 %"$##0", 8 
   %38 = inttoptr i64 %37 to i64* 
   %39 = getelementptr  i64, i64* %38, i64 0 
   %40 = load  i64, i64* %39 
@@ -360,9 +360,9 @@ entry:
 }
 
 
-define external fastcc  i64 @"student.course.name<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"student.course.name<0>"(i64  %"$rec##0")    {
 entry:
-  %43 = add   i64 %"$rec#0", 8 
+  %43 = add   i64 %"$rec##0", 8 
   %44 = inttoptr i64 %43 to i64* 
   %45 = getelementptr  i64, i64* %44, i64 0 
   %46 = load  i64, i64* %45 
@@ -370,49 +370,49 @@ entry:
 }
 
 
-define external fastcc  i64 @"student.course.name<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"student.course.name<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %47 = trunc i64 16 to i32  
   %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
   %49 = ptrtoint i8* %48 to i64 
   %50 = inttoptr i64 %49 to i8* 
-  %51 = inttoptr i64 %"$rec#0" to i8* 
+  %51 = inttoptr i64 %"$rec##0" to i8* 
   %52 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
   %53 = add   i64 %49, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"$field#0", i64* %55 
+  store  i64 %"$field##0", i64* %55 
   ret i64 %49 
 }
 
 
-define external fastcc  i1 @"student.course.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"student.course.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %56 = inttoptr i64 %"$left#0" to i64* 
+  %56 = inttoptr i64 %"$left##0" to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
-  %59 = add   i64 %"$left#0", 8 
+  %59 = add   i64 %"$left##0", 8 
   %60 = inttoptr i64 %59 to i64* 
   %61 = getelementptr  i64, i64* %60, i64 0 
   %62 = load  i64, i64* %61 
-  %63 = inttoptr i64 %"$right#0" to i64* 
+  %63 = inttoptr i64 %"$right##0" to i64* 
   %64 = getelementptr  i64, i64* %63, i64 0 
   %65 = load  i64, i64* %64 
-  %66 = add   i64 %"$right#0", 8 
+  %66 = add   i64 %"$right##0", 8 
   %67 = inttoptr i64 %66 to i64* 
   %68 = getelementptr  i64, i64* %67, i64 0 
   %69 = load  i64, i64* %68 
-  %"1$tmp$7#0" = icmp eq i64 %58, %65 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %58, %65 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$8#0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
-  %"2$tmp$0#0" = icmp eq i64 %"2$tmp$8#0", 0 
-  %"2$$$#0" = xor i1 %"2$tmp$0#0", 1 
-  ret i1 %"2$$$#0" 
+  %"2$tmp$8##0" = tail call ccc  i64  @strcmp(i64  %62, i64  %69)  
+  %"2$tmp$0##0" = icmp eq i64 %"2$tmp$8##0", 0 
+  %"2$$$##0" = xor i1 %"2$tmp$0##0", 1 
+  ret i1 %"2$$$##0" 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 }
 --------------------------------------------------
  Module student.student
@@ -434,110 +434,110 @@ if.else:
 
 = > public {inline} (1 calls)
 0: student.student.=<0>
-=($left#0:student.student, $right#0:student.student, ?$$#0:wybe.bool):
+=($left##0:student.student, $right##0:student.student, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$id#0:wybe.int)
-    foreign lpvm access(~$left#0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$major#0:student.course)
-    foreign lpvm access($right#0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$id#0:wybe.int)
-    foreign lpvm access(~$right#0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$major#0:student.course)
-    foreign llvm icmp_eq(~$left$id#0:wybe.int, ~$right$id#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$id##0:wybe.int)
+    foreign lpvm access(~$left##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$major##0:student.course)
+    foreign lpvm access($right##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$id##0:wybe.int)
+    foreign lpvm access(~$right##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$major##0:student.course)
+    foreign llvm icmp_eq(~$left$id##0:wybe.int, ~$right$id##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign lpvm access($left$major#0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.int)
-        foreign lpvm access(~$left$major#0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.string)
-        foreign lpvm access($right$major#0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$11#0:wybe.int)
-        foreign lpvm access(~$right$major#0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$12#0:wybe.string)
-        foreign llvm icmp_eq(~tmp$11#0:wybe.int, ~tmp$9#0:wybe.int, ?tmp$13#0:wybe.bool) @int:nn:nn
-        case ~tmp$13#0:wybe.bool of
+        foreign lpvm access($left$major##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.int)
+        foreign lpvm access(~$left$major##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.string)
+        foreign lpvm access($right$major##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$11##0:wybe.int)
+        foreign lpvm access(~$right$major##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$12##0:wybe.string)
+        foreign llvm icmp_eq(~tmp$11##0:wybe.int, ~tmp$9##0:wybe.int, ?tmp$13##0:wybe.bool) @int:nn:nn
+        case ~tmp$13##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign c strcmp(~tmp$10#0:wybe.string, ~tmp$12#0:wybe.string, ?tmp$14#0:wybe.int) @string:nn:nn
-            foreign llvm icmp_eq(~tmp$14#0:wybe.int, 0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+            foreign c strcmp(~tmp$10##0:wybe.string, ~tmp$12##0:wybe.string, ?tmp$14##0:wybe.int) @string:nn:nn
+            foreign llvm icmp_eq(~tmp$14##0:wybe.int, 0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 
 id > public {inline} (0 calls)
 0: student.student.id<0>
-id($rec#0:student.student, ?$#0:wybe.int):
+id($rec##0:student.student, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 id > public {inline} (0 calls)
 1: student.student.id<1>
-id($rec#0:student.student, ?$rec#1:student.student, $field#0:wybe.int):
+id($rec##0:student.student, ?$rec##1:student.student, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm mutate(~$rec#0:student.student, ?$rec#1:student.student, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm mutate(~$rec##0:student.student, ?$rec##1:student.student, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 major > public {inline} (0 calls)
 0: student.student.major<0>
-major($rec#0:student.student, ?$#0:student.course):
+major($rec##0:student.student, ?$##0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:student.course)
+    foreign lpvm access(~$rec##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:student.course)
 major > public {inline} (0 calls)
 1: student.student.major<1>
-major($rec#0:student.student, ?$rec#1:student.student, $field#0:student.course):
+major($rec##0:student.student, ?$rec##1:student.student, $field##0:student.course):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:student.student, ?$rec#1:student.student, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:student.course)
+    foreign lpvm {noalias} mutate(~$rec##0:student.student, ?$rec##1:student.student, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:student.course)
 
 
 student > public {inline} (0 calls)
 0: student.student.student<0>
-student(id#0:wybe.int, major#0:student.course, ?$#0:student.student):
+student(id##0:wybe.int, major##0:student.course, ?$##0:student.student):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:student.student)
-    foreign lpvm mutate(~$rec#0:student.student, ?$rec#1:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~id#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:student.student, ?$#0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~major#0:student.course)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:student.student)
+    foreign lpvm mutate(~$rec##0:student.student, ?$rec##1:student.student, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~id##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:student.student, ?$##0:student.student, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~major##0:student.course)
 student > public {inline} (6 calls)
 1: student.student.student<1>
-student(?id#0:wybe.int, ?major#0:student.course, $#0:student.student):
+student(?id##0:wybe.int, ?major##0:student.course, $##0:student.student):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?id#0:wybe.int)
-    foreign lpvm access(~$#0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?major#0:student.course)
+    foreign lpvm access($##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?id##0:wybe.int)
+    foreign lpvm access(~$##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?major##0:student.course)
 
 
 ~= > public {inline} (0 calls)
 0: student.student.~=<0>
-~=($left#0:student.student, $right#0:student.student, ?$$#0:wybe.bool):
+~=($left##0:student.student, $right##0:student.student, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access(~$left#0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4#0:student.course)
-    foreign lpvm access($right#0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access(~$right#0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6#0:student.course)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$5#0:wybe.int, ?tmp$7#0:wybe.bool) @int:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    foreign lpvm access($left##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access(~$left##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$4##0:student.course)
+    foreign lpvm access($right##0:student.student, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access(~$right##0:student.student, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$6##0:student.course)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$5##0:wybe.int, ?tmp$7##0:wybe.bool) @int:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign lpvm access(tmp$4#0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.int)
-        foreign lpvm access(~tmp$4#0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.string)
-        foreign lpvm access(tmp$6#0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10#0:wybe.int)
-        foreign lpvm access(~tmp$6#0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$11#0:wybe.string)
-        foreign llvm icmp_eq(~tmp$10#0:wybe.int, ~tmp$8#0:wybe.int, ?tmp$12#0:wybe.bool) @int:nn:nn
-        case ~tmp$12#0:wybe.bool of
+        foreign lpvm access(tmp$4##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
+        foreign lpvm access(~tmp$4##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.string)
+        foreign lpvm access(tmp$6##0:student.course, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$10##0:wybe.int)
+        foreign lpvm access(~tmp$6##0:student.course, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp$11##0:wybe.string)
+        foreign llvm icmp_eq(~tmp$10##0:wybe.int, ~tmp$8##0:wybe.int, ?tmp$12##0:wybe.bool) @int:nn:nn
+        case ~tmp$12##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-            foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign c strcmp(~tmp$9#0:wybe.string, ~tmp$11#0:wybe.string, ?tmp$13#0:wybe.int) @string:nn:nn
-            foreign llvm icmp_eq(~tmp$13#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-            foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+            foreign c strcmp(~tmp$9##0:wybe.string, ~tmp$11##0:wybe.string, ?tmp$13##0:wybe.int) @string:nn:nn
+            foreign llvm icmp_eq(~tmp$13##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
@@ -558,24 +558,24 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"student.student.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"student.student.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"1$tmp$1#0" = icmp eq i64 %3, %10 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %10 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
   %15 = inttoptr i64 %7 to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
@@ -591,47 +591,47 @@ if.then:
   %26 = inttoptr i64 %25 to i64* 
   %27 = getelementptr  i64, i64* %26, i64 0 
   %28 = load  i64, i64* %27 
-  %"2$tmp$13#0" = icmp eq i64 %24, %17 
-  br i1 %"2$tmp$13#0", label %if.then1, label %if.else1 
+  %"2$tmp$13##0" = icmp eq i64 %24, %17 
+  br i1 %"2$tmp$13##0", label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %"4$tmp$14#0" = tail call ccc  i64  @strcmp(i64  %21, i64  %28)  
-  %"4$$$#0" = icmp eq i64 %"4$tmp$14#0", 0 
-  ret i1 %"4$$$#0" 
+  %"4$tmp$14##0" = tail call ccc  i64  @strcmp(i64  %21, i64  %28)  
+  %"4$$$##0" = icmp eq i64 %"4$tmp$14##0", 0 
+  ret i1 %"4$$$##0" 
 if.else1:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"student.student.id<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"student.student.id<0>"(i64  %"$rec##0")    {
 entry:
-  %29 = inttoptr i64 %"$rec#0" to i64* 
+  %29 = inttoptr i64 %"$rec##0" to i64* 
   %30 = getelementptr  i64, i64* %29, i64 0 
   %31 = load  i64, i64* %30 
   ret i64 %31 
 }
 
 
-define external fastcc  i64 @"student.student.id<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"student.student.id<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %32 = trunc i64 16 to i32  
   %33 = tail call ccc  i8*  @wybe_malloc(i32  %32)  
   %34 = ptrtoint i8* %33 to i64 
   %35 = inttoptr i64 %34 to i8* 
-  %36 = inttoptr i64 %"$rec#0" to i8* 
+  %36 = inttoptr i64 %"$rec##0" to i8* 
   %37 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %35, i8*  %36, i32  %37, i32  8, i1  0)  
   %38 = inttoptr i64 %34 to i64* 
   %39 = getelementptr  i64, i64* %38, i64 0 
-  store  i64 %"$field#0", i64* %39 
+  store  i64 %"$field##0", i64* %39 
   ret i64 %34 
 }
 
 
-define external fastcc  i64 @"student.student.major<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"student.student.major<0>"(i64  %"$rec##0")    {
 entry:
-  %40 = add   i64 %"$rec#0", 8 
+  %40 = add   i64 %"$rec##0", 8 
   %41 = inttoptr i64 %40 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
   %43 = load  i64, i64* %42 
@@ -639,45 +639,45 @@ entry:
 }
 
 
-define external fastcc  i64 @"student.student.major<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"student.student.major<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %44 = trunc i64 16 to i32  
   %45 = tail call ccc  i8*  @wybe_malloc(i32  %44)  
   %46 = ptrtoint i8* %45 to i64 
   %47 = inttoptr i64 %46 to i8* 
-  %48 = inttoptr i64 %"$rec#0" to i8* 
+  %48 = inttoptr i64 %"$rec##0" to i8* 
   %49 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %47, i8*  %48, i32  %49, i32  8, i1  0)  
   %50 = add   i64 %46, 8 
   %51 = inttoptr i64 %50 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
-  store  i64 %"$field#0", i64* %52 
+  store  i64 %"$field##0", i64* %52 
   ret i64 %46 
 }
 
 
-define external fastcc  i64 @"student.student.student<0>"(i64  %"id#0", i64  %"major#0")    {
+define external fastcc  i64 @"student.student.student<0>"(i64  %"id##0", i64  %"major##0")    {
 entry:
   %53 = trunc i64 16 to i32  
   %54 = tail call ccc  i8*  @wybe_malloc(i32  %53)  
   %55 = ptrtoint i8* %54 to i64 
   %56 = inttoptr i64 %55 to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
-  store  i64 %"id#0", i64* %57 
+  store  i64 %"id##0", i64* %57 
   %58 = add   i64 %55, 8 
   %59 = inttoptr i64 %58 to i64* 
   %60 = getelementptr  i64, i64* %59, i64 0 
-  store  i64 %"major#0", i64* %60 
+  store  i64 %"major##0", i64* %60 
   ret i64 %55 
 }
 
 
-define external fastcc  {i64, i64} @"student.student.student<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64} @"student.student.student<1>"(i64  %"$##0")    {
 entry:
-  %61 = inttoptr i64 %"$#0" to i64* 
+  %61 = inttoptr i64 %"$##0" to i64* 
   %62 = getelementptr  i64, i64* %61, i64 0 
   %63 = load  i64, i64* %62 
-  %64 = add   i64 %"$#0", 8 
+  %64 = add   i64 %"$##0", 8 
   %65 = inttoptr i64 %64 to i64* 
   %66 = getelementptr  i64, i64* %65, i64 0 
   %67 = load  i64, i64* %66 
@@ -687,24 +687,24 @@ entry:
 }
 
 
-define external fastcc  i1 @"student.student.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"student.student.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %70 = inttoptr i64 %"$left#0" to i64* 
+  %70 = inttoptr i64 %"$left##0" to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
   %72 = load  i64, i64* %71 
-  %73 = add   i64 %"$left#0", 8 
+  %73 = add   i64 %"$left##0", 8 
   %74 = inttoptr i64 %73 to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
   %76 = load  i64, i64* %75 
-  %77 = inttoptr i64 %"$right#0" to i64* 
+  %77 = inttoptr i64 %"$right##0" to i64* 
   %78 = getelementptr  i64, i64* %77, i64 0 
   %79 = load  i64, i64* %78 
-  %80 = add   i64 %"$right#0", 8 
+  %80 = add   i64 %"$right##0", 8 
   %81 = inttoptr i64 %80 to i64* 
   %82 = getelementptr  i64, i64* %81, i64 0 
   %83 = load  i64, i64* %82 
-  %"1$tmp$7#0" = icmp eq i64 %72, %79 
-  br i1 %"1$tmp$7#0", label %if.then, label %if.else 
+  %"1$tmp$7##0" = icmp eq i64 %72, %79 
+  br i1 %"1$tmp$7##0", label %if.then, label %if.else 
 if.then:
   %84 = inttoptr i64 %76 to i64* 
   %85 = getelementptr  i64, i64* %84, i64 0 
@@ -720,17 +720,17 @@ if.then:
   %95 = inttoptr i64 %94 to i64* 
   %96 = getelementptr  i64, i64* %95, i64 0 
   %97 = load  i64, i64* %96 
-  %"2$tmp$12#0" = icmp eq i64 %93, %86 
-  br i1 %"2$tmp$12#0", label %if.then1, label %if.else1 
+  %"2$tmp$12##0" = icmp eq i64 %93, %86 
+  br i1 %"2$tmp$12##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 if.then1:
-  %"4$tmp$13#0" = tail call ccc  i64  @strcmp(i64  %90, i64  %97)  
-  %"4$tmp$0#0" = icmp eq i64 %"4$tmp$13#0", 0 
-  %"4$$$#0" = xor i1 %"4$tmp$0#0", 1 
-  ret i1 %"4$$$#0" 
+  %"4$tmp$13##0" = tail call ccc  i64  @strcmp(i64  %90, i64  %97)  
+  %"4$tmp$0##0" = icmp eq i64 %"4$tmp$13##0", 0 
+  %"4$$$##0" = xor i1 %"4$tmp$0##0", 1 
+  ret i1 %"4$$$##0" 
 if.else1:
-  %"5$$$#0" = xor i1 0, 1 
-  ret i1 %"5$$$#0" 
+  %"5$$$##0" = xor i1 0, 1 
+  ret i1 %"5$$$##0" 
 }

--- a/test-cases/final-dump/submodule.exp
+++ b/test-cases/final-dump/submodule.exp
@@ -38,18 +38,18 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 hidden > {inline} (0 calls)
 0: submodule.privatetest.hidden<0>
-hidden(io#0:wybe.phantom, ?io#1:wybe.phantom):
+hidden(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("private proc in a private module":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_string("private proc in a private module":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 semi_hidden > public {inline} (0 calls)
 0: submodule.privatetest.semi_hidden<0>
-semi_hidden(io#0:wybe.phantom, ?io#1:wybe.phantom):
+semi_hidden(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("public proc in a private module":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_string("public proc in a private module":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -101,18 +101,18 @@ entry:
 
 semi_visible > {inline} (0 calls)
 0: submodule.publictest.semi_visible<0>
-semi_visible(io#0:wybe.phantom, ?io#1:wybe.phantom):
+semi_visible(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("private proc in a public module":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_string("private proc in a public module":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 visible > public {inline} (0 calls)
 0: submodule.publictest.visible<0>
-visible(io#0:wybe.phantom, ?io#1:wybe.phantom):
+visible(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("public proc in a public module":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_string("public proc in a public module":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/test_loop.exp
+++ b/test-cases/final-dump/test_loop.exp
@@ -33,10 +33,10 @@ AFTER EVERYTHING:
 
 find_modulo > {inline} (3 calls)
 0: test_loop.find_modulo<0>
-find_modulo(seq##0:test_loop.int_seq, modulus##0:wybe.int, ?i##0:wybe.int, ?$$##0:wybe.bool):
+find_modulo(seq##0:test_loop.int_seq, modulus##0:wybe.int, ?i##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    test_loop.gen$1<0>(~modulus##0:wybe.int, ~seq##0:test_loop.int_seq, ?i##0:wybe.int, ?$$##0:wybe.bool) #0 @test_loop:nn:nn
+    test_loop.gen#1<0>(~modulus##0:wybe.int, ~seq##0:test_loop.int_seq, ?i##0:wybe.int, ?####0:wybe.bool) #0 @test_loop:nn:nn
 
 
 find_test > (2 calls)
@@ -44,67 +44,67 @@ find_test > (2 calls)
 find_test(modulus##0:wybe.int, io##0:wybe.phantom, ?io##4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
- MultiSpeczDepInfo: [(8,(test_loop.gen$1<0>,fromList [NonAliasedParamCond 1 []]))]
-    foreign lpvm alloc(24:wybe.int, ?tmp$5##0:test_loop.int_seq)
-    foreign lpvm mutate(~tmp$5##0:test_loop.int_seq, ?tmp$6##0:test_loop.int_seq, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm mutate(~tmp$6##0:test_loop.int_seq, ?tmp$7##0:test_loop.int_seq, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm mutate(~tmp$7##0:test_loop.int_seq, ?tmp$8##0:test_loop.int_seq, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 10:wybe.int)
-    test_loop.gen$1<0>[6dacb8fd25](modulus##0:wybe.int, ~tmp$8##0:test_loop.int_seq, ?i##0:wybe.int, ?tmp$1##0:wybe.bool) #8 @test_loop:nn:nn
-    case ~tmp$1##0:wybe.bool of
+ MultiSpeczDepInfo: [(8,(test_loop.gen#1<0>,fromList [NonAliasedParamCond 1 []]))]
+    foreign lpvm alloc(24:wybe.int, ?tmp#5##0:test_loop.int_seq)
+    foreign lpvm mutate(~tmp#5##0:test_loop.int_seq, ?tmp#6##0:test_loop.int_seq, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 2:wybe.int)
+    foreign lpvm mutate(~tmp#6##0:test_loop.int_seq, ?tmp#7##0:test_loop.int_seq, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 2:wybe.int)
+    foreign lpvm mutate(~tmp#7##0:test_loop.int_seq, ?tmp#8##0:test_loop.int_seq, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 10:wybe.int)
+    test_loop.gen#1<0>[6dacb8fd25](modulus##0:wybe.int, ~tmp#8##0:test_loop.int_seq, ?i##0:wybe.int, ?tmp#1##0:wybe.bool) #8 @test_loop:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
         foreign c print_string("Couldn't find even number divisible by ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        foreign c print_int(~modulus##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$15##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$15##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+        foreign c print_int(~modulus##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#15##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#15##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
 
     1:
         foreign c print_string("First even number divisible by ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
         foreign c print_int(~modulus##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
         foreign c print_string(" is ":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-        foreign c print_int(~i##0:wybe.int, ~#io##3:wybe.phantom, ?tmp$19##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$19##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~#io##3:wybe.phantom, ?tmp#19##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#19##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
 
 
 
-gen$1 > (2 calls)
-0: test_loop.gen$1<0>[6dacb8fd25]
-gen$1(modulus##0:wybe.int, seq##0:test_loop.int_seq, ?i##1:wybe.int, ?$$##0:wybe.bool):
+gen#1 > (2 calls)
+0: test_loop.gen#1<0>[6dacb8fd25]
+gen#1(modulus##0:wybe.int, seq##0:test_loop.int_seq, ?i##1:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 1]
- MultiSpeczDepInfo: [(0,(test_loop.int_seq.seq_next<0>,fromList [NonAliasedParamCond 0 [1]])),(3,(test_loop.gen$1<0>,fromList [NonAliasedParamCond 1 [1]]))]
-    test_loop.int_seq.seq_next<0>(~%seq##0:test_loop.int_seq, ?%seq##1:test_loop.int_seq, ?i##0:wybe.int, ?tmp$1##0:wybe.bool) #0 @test_loop:nn:nn
-    case ~tmp$1##0:wybe.bool of
+ MultiSpeczDepInfo: [(0,(test_loop.int_seq.seq_next<0>,fromList [NonAliasedParamCond 0 [1]])),(3,(test_loop.gen#1<0>,fromList [NonAliasedParamCond 1 [1]]))]
+    test_loop.int_seq.seq_next<0>(~%seq##0:test_loop.int_seq, ?%seq##1:test_loop.int_seq, ?i##0:wybe.int, ?tmp#1##0:wybe.bool) #0 @test_loop:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(~i##0:wybe.int, ?i##1:wybe.int)
 
     1:
-        foreign llvm srem(i##0:wybe.int, modulus##0:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
-        foreign llvm icmp_eq(~tmp$0##0:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.bool) @int:nn:nn
-        case ~tmp$2##0:wybe.bool of
+        foreign llvm srem(i##0:wybe.int, modulus##0:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
+        foreign llvm icmp_eq(~tmp#0##0:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.bool) @int:nn:nn
+        case ~tmp#2##0:wybe.bool of
         0:
-            test_loop.gen$1<0>(~modulus##0:wybe.int, ~seq##1:test_loop.int_seq, ?i##1:wybe.int, ?$$##0:wybe.bool) #3 @test_loop:nn:nn
+            test_loop.gen#1<0>(~modulus##0:wybe.int, ~seq##1:test_loop.int_seq, ?i##1:wybe.int, ?####0:wybe.bool) #3 @test_loop:nn:nn
 
         1:
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
             foreign llvm move(~i##0:wybe.int, ?i##1:wybe.int)
 
 
  [6dacb8fd25] [NonAliasedParam 1] :
-    test_loop.int_seq.seq_next<0>[410bae77d3](~%seq##0:test_loop.int_seq, ?%seq##1:test_loop.int_seq, ?i##0:wybe.int, ?tmp$1##0:wybe.bool) #0 @test_loop:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    test_loop.int_seq.seq_next<0>[410bae77d3](~%seq##0:test_loop.int_seq, ?%seq##1:test_loop.int_seq, ?i##0:wybe.int, ?tmp#1##0:wybe.bool) #0 @test_loop:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(~i##0:wybe.int, ?i##1:wybe.int)
 
     1:
-        foreign llvm srem(i##0:wybe.int, modulus##0:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
-        foreign llvm icmp_eq(~tmp$0##0:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.bool) @int:nn:nn
-        case ~tmp$2##0:wybe.bool of
+        foreign llvm srem(i##0:wybe.int, modulus##0:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
+        foreign llvm icmp_eq(~tmp#0##0:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.bool) @int:nn:nn
+        case ~tmp#2##0:wybe.bool of
         0:
-            test_loop.gen$1<0>[6dacb8fd25](~modulus##0:wybe.int, ~seq##1:test_loop.int_seq, ?i##1:wybe.int, ?$$##0:wybe.bool) #3 @test_loop:nn:nn
+            test_loop.gen#1<0>[6dacb8fd25](~modulus##0:wybe.int, ~seq##1:test_loop.int_seq, ?i##1:wybe.int, ?####0:wybe.bool) #3 @test_loop:nn:nn
 
         1:
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
             foreign llvm move(~i##0:wybe.int, ?i##1:wybe.int)
 
 
@@ -151,7 +151,7 @@ entry:
 
 define external fastcc  {i64, i1} @"test_loop.find_modulo<0>"(i64  %"seq##0", i64  %"modulus##0")    {
 entry:
-  %1 = tail call fastcc  {i64, i1}  @"test_loop.gen$1<0>"(i64  %"modulus##0", i64  %"seq##0")  
+  %1 = tail call fastcc  {i64, i1}  @"test_loop.gen#1<0>"(i64  %"modulus##0", i64  %"seq##0")  
   %2 = extractvalue {i64, i1} %1, 0 
   %3 = extractvalue {i64, i1} %1, 1 
   %4 = insertvalue {i64, i1} undef, i64 %2, 0 
@@ -176,7 +176,7 @@ entry:
   %15 = inttoptr i64 %14 to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
   store  i64 10, i64* %16 
-  %17 = tail call fastcc  {i64, i1}  @"test_loop.gen$1<0>[6dacb8fd25]"(i64  %"modulus##0", i64  %8)  
+  %17 = tail call fastcc  {i64, i1}  @"test_loop.gen#1<0>[6dacb8fd25]"(i64  %"modulus##0", i64  %8)  
   %18 = extractvalue {i64, i1} %17, 0 
   %19 = extractvalue {i64, i1} %17, 1 
   br i1 %19, label %if.then, label %if.else 
@@ -198,7 +198,7 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"test_loop.gen$1<0>"(i64  %"modulus##0", i64  %"seq##0")    {
+define external fastcc  {i64, i1} @"test_loop.gen#1<0>"(i64  %"modulus##0", i64  %"seq##0")    {
 entry:
   %26 = tail call fastcc  {i64, i64, i1}  @"test_loop.int_seq.seq_next<0>"(i64  %"seq##0")  
   %27 = extractvalue {i64, i64, i1} %26, 0 
@@ -206,9 +206,9 @@ entry:
   %29 = extractvalue {i64, i64, i1} %26, 2 
   br i1 %29, label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = srem i64 %28, %"modulus##0" 
-  %"2$tmp$2##0" = icmp eq i64 %"2$tmp$0##0", 0 
-  br i1 %"2$tmp$2##0", label %if.then1, label %if.else1 
+  %"2#tmp#0##0" = srem i64 %28, %"modulus##0" 
+  %"2#tmp#2##0" = icmp eq i64 %"2#tmp#0##0", 0 
+  br i1 %"2#tmp#2##0", label %if.then1, label %if.else1 
 if.else:
   %37 = insertvalue {i64, i1} undef, i64 %28, 0 
   %38 = insertvalue {i64, i1} %37, i1 0, 1 
@@ -218,7 +218,7 @@ if.then1:
   %31 = insertvalue {i64, i1} %30, i1 1, 1 
   ret {i64, i1} %31 
 if.else1:
-  %32 = tail call fastcc  {i64, i1}  @"test_loop.gen$1<0>"(i64  %"modulus##0", i64  %27)  
+  %32 = tail call fastcc  {i64, i1}  @"test_loop.gen#1<0>"(i64  %"modulus##0", i64  %27)  
   %33 = extractvalue {i64, i1} %32, 0 
   %34 = extractvalue {i64, i1} %32, 1 
   %35 = insertvalue {i64, i1} undef, i64 %33, 0 
@@ -227,7 +227,7 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"test_loop.gen$1<0>[6dacb8fd25]"(i64  %"modulus##0", i64  %"seq##0")    {
+define external fastcc  {i64, i1} @"test_loop.gen#1<0>[6dacb8fd25]"(i64  %"modulus##0", i64  %"seq##0")    {
 entry:
   %39 = tail call fastcc  {i64, i64, i1}  @"test_loop.int_seq.seq_next<0>[410bae77d3]"(i64  %"seq##0")  
   %40 = extractvalue {i64, i64, i1} %39, 0 
@@ -235,9 +235,9 @@ entry:
   %42 = extractvalue {i64, i64, i1} %39, 2 
   br i1 %42, label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = srem i64 %41, %"modulus##0" 
-  %"2$tmp$2##0" = icmp eq i64 %"2$tmp$0##0", 0 
-  br i1 %"2$tmp$2##0", label %if.then1, label %if.else1 
+  %"2#tmp#0##0" = srem i64 %41, %"modulus##0" 
+  %"2#tmp#2##0" = icmp eq i64 %"2#tmp#0##0", 0 
+  br i1 %"2#tmp#2##0", label %if.then1, label %if.else1 
 if.else:
   %50 = insertvalue {i64, i1} undef, i64 %41, 0 
   %51 = insertvalue {i64, i1} %50, i1 0, 1 
@@ -247,7 +247,7 @@ if.then1:
   %44 = insertvalue {i64, i1} %43, i1 1, 1 
   ret {i64, i1} %44 
 if.else1:
-  %45 = tail call fastcc  {i64, i1}  @"test_loop.gen$1<0>[6dacb8fd25]"(i64  %"modulus##0", i64  %40)  
+  %45 = tail call fastcc  {i64, i1}  @"test_loop.gen#1<0>[6dacb8fd25]"(i64  %"modulus##0", i64  %40)  
   %46 = extractvalue {i64, i1} %45, 0 
   %47 = extractvalue {i64, i1} %45, 1 
   %48 = insertvalue {i64, i1} undef, i64 %46, 0 
@@ -277,156 +277,156 @@ if.else1:
 
 = > public {inline} (1 calls)
 0: test_loop.int_seq.=<0>
-=($left##0:test_loop.int_seq, $right##0:test_loop.int_seq, ?$$##0:wybe.bool):
+=(#left##0:test_loop.int_seq, #right##0:test_loop.int_seq, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$low##0:wybe.int)
-    foreign lpvm access($left##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$step##0:wybe.int)
-    foreign lpvm access(~$left##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$high##0:wybe.int)
-    foreign lpvm access($right##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$low##0:wybe.int)
-    foreign lpvm access($right##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$step##0:wybe.int)
-    foreign lpvm access(~$right##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$high##0:wybe.int)
-    foreign llvm icmp_eq(~$left$low##0:wybe.int, ~$right$low##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign lpvm access(#left##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#low##0:wybe.int)
+    foreign lpvm access(#left##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#step##0:wybe.int)
+    foreign lpvm access(~#left##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#high##0:wybe.int)
+    foreign lpvm access(#right##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#low##0:wybe.int)
+    foreign lpvm access(#right##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#step##0:wybe.int)
+    foreign lpvm access(~#right##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#right#high##0:wybe.int)
+    foreign llvm icmp_eq(~#left#low##0:wybe.int, ~#right#low##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$step##0:wybe.int, ~$right$step##0:wybe.int, ?tmp$2##0:wybe.bool) @int:nn:nn
-        case ~tmp$2##0:wybe.bool of
+        foreign llvm icmp_eq(~#left#step##0:wybe.int, ~#right#step##0:wybe.int, ?tmp#2##0:wybe.bool) @int:nn:nn
+        case ~tmp#2##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~$left$high##0:wybe.int, ~$right$high##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
+            foreign llvm icmp_eq(~#left#high##0:wybe.int, ~#right#high##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
 
 
 
 
 high > public {inline} (0 calls)
 0: test_loop.int_seq.high<0>
-high($rec##0:test_loop.int_seq, ?$##0:wybe.int):
+high(#rec##0:test_loop.int_seq, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:wybe.int)
 high > public {inline} (0 calls)
 1: test_loop.int_seq.high<1>
-high($rec##0:test_loop.int_seq, ?$rec##1:test_loop.int_seq, $field##0:wybe.int):
+high(#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:test_loop.int_seq, ?$rec##1:test_loop.int_seq, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 int_seq > public {inline} (0 calls)
 0: test_loop.int_seq.int_seq<0>
-int_seq(low##0:wybe.int, step##0:wybe.int, high##0:wybe.int, ?$##0:test_loop.int_seq):
+int_seq(low##0:wybe.int, step##0:wybe.int, high##0:wybe.int, ?###0:test_loop.int_seq):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?$rec##0:test_loop.int_seq)
-    foreign lpvm mutate(~$rec##0:test_loop.int_seq, ?$rec##1:test_loop.int_seq, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~low##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:test_loop.int_seq, ?$rec##2:test_loop.int_seq, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~step##0:wybe.int)
-    foreign lpvm mutate(~$rec##2:test_loop.int_seq, ?$##0:test_loop.int_seq, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~high##0:wybe.int)
+    foreign lpvm alloc(24:wybe.int, ?#rec##0:test_loop.int_seq)
+    foreign lpvm mutate(~#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~low##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:test_loop.int_seq, ?#rec##2:test_loop.int_seq, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~step##0:wybe.int)
+    foreign lpvm mutate(~#rec##2:test_loop.int_seq, ?###0:test_loop.int_seq, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~high##0:wybe.int)
 int_seq > public {inline} (13 calls)
 1: test_loop.int_seq.int_seq<1>
-int_seq(?low##0:wybe.int, ?step##0:wybe.int, ?high##0:wybe.int, $##0:test_loop.int_seq):
+int_seq(?low##0:wybe.int, ?step##0:wybe.int, ?high##0:wybe.int, ###0:test_loop.int_seq):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?low##0:wybe.int)
-    foreign lpvm access($##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?step##0:wybe.int)
-    foreign lpvm access(~$##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?high##0:wybe.int)
+    foreign lpvm access(###0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?low##0:wybe.int)
+    foreign lpvm access(###0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?step##0:wybe.int)
+    foreign lpvm access(~###0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?high##0:wybe.int)
 
 
 low > public {inline} (0 calls)
 0: test_loop.int_seq.low<0>
-low($rec##0:test_loop.int_seq, ?$##0:wybe.int):
+low(#rec##0:test_loop.int_seq, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:wybe.int)
 low > public {inline} (1 calls)
 1: test_loop.int_seq.low<1>
-low($rec##0:test_loop.int_seq, ?$rec##1:test_loop.int_seq, $field##0:wybe.int):
+low(#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:test_loop.int_seq, ?$rec##1:test_loop.int_seq, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 seq_next > public (0 calls)
 0: test_loop.int_seq.seq_next<0>[410bae77d3]
-seq_next(seq##0:test_loop.int_seq, ?seq##1:test_loop.int_seq, ?elt##0:wybe.int, ?$$##0:wybe.bool):
+seq_next(seq##0:test_loop.int_seq, ?seq##1:test_loop.int_seq, ?elt##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: [(seq##0,seq##1)]
  InterestingCallProperties: [InterestingUnaliased 0]
     foreign lpvm access(seq##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?elt##0:wybe.int)
     foreign lpvm access(seq##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?step##0:wybe.int)
     foreign lpvm access(seq##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?limit##0:wybe.int)
-    foreign llvm icmp_sle(elt##0:wybe.int, ~limit##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign llvm icmp_sle(elt##0:wybe.int, ~limit##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(~seq##0:test_loop.int_seq, ?seq##1:test_loop.int_seq)
 
     1:
-        foreign llvm add(elt##0:wybe.int, ~step##0:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%seq##0:test_loop.int_seq, ?%seq##1:test_loop.int_seq, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp$0##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm add(elt##0:wybe.int, ~step##0:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%seq##0:test_loop.int_seq, ?%seq##1:test_loop.int_seq, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp#0##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
  [410bae77d3] [NonAliasedParam 0] :
     foreign lpvm access(seq##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?elt##0:wybe.int)
     foreign lpvm access(seq##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?step##0:wybe.int)
     foreign lpvm access(seq##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?limit##0:wybe.int)
-    foreign llvm icmp_sle(elt##0:wybe.int, ~limit##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
-    case ~tmp$1##0:wybe.bool of
+    foreign llvm icmp_sle(elt##0:wybe.int, ~limit##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
+    case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(~seq##0:test_loop.int_seq, ?seq##1:test_loop.int_seq)
 
     1:
-        foreign llvm add(elt##0:wybe.int, ~step##0:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%seq##0:test_loop.int_seq, ?%seq##1:test_loop.int_seq, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp$0##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm add(elt##0:wybe.int, ~step##0:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%seq##0:test_loop.int_seq, ?%seq##1:test_loop.int_seq, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp#0##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 step > public {inline} (0 calls)
 0: test_loop.int_seq.step<0>
-step($rec##0:test_loop.int_seq, ?$##0:wybe.int):
+step(#rec##0:test_loop.int_seq, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+    foreign lpvm access(~#rec##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:wybe.int)
 step > public {inline} (0 calls)
 1: test_loop.int_seq.step<1>
-step($rec##0:test_loop.int_seq, ?$rec##1:test_loop.int_seq, $field##0:wybe.int):
+step(#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, #field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec##0:test_loop.int_seq, ?$rec##1:test_loop.int_seq, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+    foreign lpvm {noalias} mutate(~#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: test_loop.int_seq.~=<0>
-~=($left##0:test_loop.int_seq, $right##0:test_loop.int_seq, ?$$##0:wybe.bool):
+~=(#left##0:test_loop.int_seq, #right##0:test_loop.int_seq, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
-    foreign lpvm access($left##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
-    foreign lpvm access(~$left##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
-    foreign lpvm access($right##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
-    foreign lpvm access($right##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.int)
-    foreign lpvm access(~$right##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$9##0:wybe.bool) @int:nn:nn
-    case ~tmp$9##0:wybe.bool of
+    foreign lpvm access(#left##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
+    foreign lpvm access(#left##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#4##0:wybe.int)
+    foreign lpvm access(~#left##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
+    foreign lpvm access(#right##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.int)
+    foreign lpvm access(#right##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.int)
+    foreign lpvm access(~#right##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.int)
+    foreign llvm icmp_eq(~tmp#3##0:wybe.int, ~tmp#6##0:wybe.int, ?tmp#9##0:wybe.bool) @int:nn:nn
+    case ~tmp#9##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$7##0:wybe.int, ?tmp$10##0:wybe.bool) @int:nn:nn
-        case ~tmp$10##0:wybe.bool of
+        foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#7##0:wybe.int, ?tmp#10##0:wybe.bool) @int:nn:nn
+        case ~tmp#10##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
-            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~tmp$5##0:wybe.int, ~tmp$8##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
-            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm icmp_eq(~tmp#5##0:wybe.int, ~tmp#8##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
 
 
@@ -444,48 +444,48 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"test_loop.int_seq.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"test_loop.int_seq.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = add   i64 %"$left##0", 16 
+  %8 = add   i64 %"#left##0", 16 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
-  %12 = inttoptr i64 %"$right##0" to i64* 
+  %12 = inttoptr i64 %"#right##0" to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %15 = add   i64 %"$right##0", 8 
+  %15 = add   i64 %"#right##0", 8 
   %16 = inttoptr i64 %15 to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
-  %19 = add   i64 %"$right##0", 16 
+  %19 = add   i64 %"#right##0", 16 
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %"1$tmp$1##0" = icmp eq i64 %3, %14 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp eq i64 %3, %14 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2##0" = icmp eq i64 %7, %18 
-  br i1 %"2$tmp$2##0", label %if.then1, label %if.else1 
+  %"2#tmp#2##0" = icmp eq i64 %7, %18 
+  br i1 %"2#tmp#2##0", label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %"4$$$##0" = icmp eq i64 %11, %22 
-  ret i1 %"4$$$##0" 
+  %"4#####0" = icmp eq i64 %11, %22 
+  ret i1 %"4#####0" 
 if.else1:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"test_loop.int_seq.high<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"test_loop.int_seq.high<0>"(i64  %"#rec##0")    {
 entry:
-  %23 = add   i64 %"$rec##0", 16 
+  %23 = add   i64 %"#rec##0", 16 
   %24 = inttoptr i64 %23 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
   %26 = load  i64, i64* %25 
@@ -493,19 +493,19 @@ entry:
 }
 
 
-define external fastcc  i64 @"test_loop.int_seq.high<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"test_loop.int_seq.high<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %27 = trunc i64 24 to i32  
   %28 = tail call ccc  i8*  @wybe_malloc(i32  %27)  
   %29 = ptrtoint i8* %28 to i64 
   %30 = inttoptr i64 %29 to i8* 
-  %31 = inttoptr i64 %"$rec##0" to i8* 
+  %31 = inttoptr i64 %"#rec##0" to i8* 
   %32 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %30, i8*  %31, i32  %32, i32  8, i1  0)  
   %33 = add   i64 %29, 16 
   %34 = inttoptr i64 %33 to i64* 
   %35 = getelementptr  i64, i64* %34, i64 0 
-  store  i64 %"$field##0", i64* %35 
+  store  i64 %"#field##0", i64* %35 
   ret i64 %29 
 }
 
@@ -530,16 +530,16 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64} @"test_loop.int_seq.int_seq<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64, i64} @"test_loop.int_seq.int_seq<1>"(i64  %"###0")    {
 entry:
-  %47 = inttoptr i64 %"$##0" to i64* 
+  %47 = inttoptr i64 %"###0" to i64* 
   %48 = getelementptr  i64, i64* %47, i64 0 
   %49 = load  i64, i64* %48 
-  %50 = add   i64 %"$##0", 8 
+  %50 = add   i64 %"###0", 8 
   %51 = inttoptr i64 %50 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
   %53 = load  i64, i64* %52 
-  %54 = add   i64 %"$##0", 16 
+  %54 = add   i64 %"###0", 16 
   %55 = inttoptr i64 %54 to i64* 
   %56 = getelementptr  i64, i64* %55, i64 0 
   %57 = load  i64, i64* %56 
@@ -550,27 +550,27 @@ entry:
 }
 
 
-define external fastcc  i64 @"test_loop.int_seq.low<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"test_loop.int_seq.low<0>"(i64  %"#rec##0")    {
 entry:
-  %61 = inttoptr i64 %"$rec##0" to i64* 
+  %61 = inttoptr i64 %"#rec##0" to i64* 
   %62 = getelementptr  i64, i64* %61, i64 0 
   %63 = load  i64, i64* %62 
   ret i64 %63 
 }
 
 
-define external fastcc  i64 @"test_loop.int_seq.low<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"test_loop.int_seq.low<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %64 = trunc i64 24 to i32  
   %65 = tail call ccc  i8*  @wybe_malloc(i32  %64)  
   %66 = ptrtoint i8* %65 to i64 
   %67 = inttoptr i64 %66 to i8* 
-  %68 = inttoptr i64 %"$rec##0" to i8* 
+  %68 = inttoptr i64 %"#rec##0" to i8* 
   %69 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %67, i8*  %68, i32  %69, i32  8, i1  0)  
   %70 = inttoptr i64 %66 to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
-  store  i64 %"$field##0", i64* %71 
+  store  i64 %"#field##0", i64* %71 
   ret i64 %66 
 }
 
@@ -588,10 +588,10 @@ entry:
   %80 = inttoptr i64 %79 to i64* 
   %81 = getelementptr  i64, i64* %80, i64 0 
   %82 = load  i64, i64* %81 
-  %"1$tmp$1##0" = icmp sle i64 %74, %82 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp sle i64 %74, %82 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = add   i64 %74, %78 
+  %"2#tmp#0##0" = add   i64 %74, %78 
   %83 = trunc i64 24 to i32  
   %84 = tail call ccc  i8*  @wybe_malloc(i32  %83)  
   %85 = ptrtoint i8* %84 to i64 
@@ -601,7 +601,7 @@ if.then:
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %86, i8*  %87, i32  %88, i32  8, i1  0)  
   %89 = inttoptr i64 %85 to i64* 
   %90 = getelementptr  i64, i64* %89, i64 0 
-  store  i64 %"2$tmp$0##0", i64* %90 
+  store  i64 %"2#tmp#0##0", i64* %90 
   %91 = insertvalue {i64, i64, i1} undef, i64 %85, 0 
   %92 = insertvalue {i64, i64, i1} %91, i64 %74, 1 
   %93 = insertvalue {i64, i64, i1} %92, i1 1, 2 
@@ -627,13 +627,13 @@ entry:
   %105 = inttoptr i64 %104 to i64* 
   %106 = getelementptr  i64, i64* %105, i64 0 
   %107 = load  i64, i64* %106 
-  %"1$tmp$1##0" = icmp sle i64 %99, %107 
-  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
+  %"1#tmp#1##0" = icmp sle i64 %99, %107 
+  br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0##0" = add   i64 %99, %103 
+  %"2#tmp#0##0" = add   i64 %99, %103 
   %108 = inttoptr i64 %"seq##0" to i64* 
   %109 = getelementptr  i64, i64* %108, i64 0 
-  store  i64 %"2$tmp$0##0", i64* %109 
+  store  i64 %"2#tmp#0##0", i64* %109 
   %110 = insertvalue {i64, i64, i1} undef, i64 %"seq##0", 0 
   %111 = insertvalue {i64, i64, i1} %110, i64 %99, 1 
   %112 = insertvalue {i64, i64, i1} %111, i1 1, 2 
@@ -646,9 +646,9 @@ if.else:
 }
 
 
-define external fastcc  i64 @"test_loop.int_seq.step<0>"(i64  %"$rec##0")    {
+define external fastcc  i64 @"test_loop.int_seq.step<0>"(i64  %"#rec##0")    {
 entry:
-  %116 = add   i64 %"$rec##0", 8 
+  %116 = add   i64 %"#rec##0", 8 
   %117 = inttoptr i64 %116 to i64* 
   %118 = getelementptr  i64, i64* %117, i64 0 
   %119 = load  i64, i64* %118 
@@ -656,60 +656,60 @@ entry:
 }
 
 
-define external fastcc  i64 @"test_loop.int_seq.step<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  i64 @"test_loop.int_seq.step<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
   %120 = trunc i64 24 to i32  
   %121 = tail call ccc  i8*  @wybe_malloc(i32  %120)  
   %122 = ptrtoint i8* %121 to i64 
   %123 = inttoptr i64 %122 to i8* 
-  %124 = inttoptr i64 %"$rec##0" to i8* 
+  %124 = inttoptr i64 %"#rec##0" to i8* 
   %125 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %123, i8*  %124, i32  %125, i32  8, i1  0)  
   %126 = add   i64 %122, 8 
   %127 = inttoptr i64 %126 to i64* 
   %128 = getelementptr  i64, i64* %127, i64 0 
-  store  i64 %"$field##0", i64* %128 
+  store  i64 %"#field##0", i64* %128 
   ret i64 %122 
 }
 
 
-define external fastcc  i1 @"test_loop.int_seq.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"test_loop.int_seq.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %129 = inttoptr i64 %"$left##0" to i64* 
+  %129 = inttoptr i64 %"#left##0" to i64* 
   %130 = getelementptr  i64, i64* %129, i64 0 
   %131 = load  i64, i64* %130 
-  %132 = add   i64 %"$left##0", 8 
+  %132 = add   i64 %"#left##0", 8 
   %133 = inttoptr i64 %132 to i64* 
   %134 = getelementptr  i64, i64* %133, i64 0 
   %135 = load  i64, i64* %134 
-  %136 = add   i64 %"$left##0", 16 
+  %136 = add   i64 %"#left##0", 16 
   %137 = inttoptr i64 %136 to i64* 
   %138 = getelementptr  i64, i64* %137, i64 0 
   %139 = load  i64, i64* %138 
-  %140 = inttoptr i64 %"$right##0" to i64* 
+  %140 = inttoptr i64 %"#right##0" to i64* 
   %141 = getelementptr  i64, i64* %140, i64 0 
   %142 = load  i64, i64* %141 
-  %143 = add   i64 %"$right##0", 8 
+  %143 = add   i64 %"#right##0", 8 
   %144 = inttoptr i64 %143 to i64* 
   %145 = getelementptr  i64, i64* %144, i64 0 
   %146 = load  i64, i64* %145 
-  %147 = add   i64 %"$right##0", 16 
+  %147 = add   i64 %"#right##0", 16 
   %148 = inttoptr i64 %147 to i64* 
   %149 = getelementptr  i64, i64* %148, i64 0 
   %150 = load  i64, i64* %149 
-  %"1$tmp$9##0" = icmp eq i64 %131, %142 
-  br i1 %"1$tmp$9##0", label %if.then, label %if.else 
+  %"1#tmp#9##0" = icmp eq i64 %131, %142 
+  br i1 %"1#tmp#9##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$10##0" = icmp eq i64 %135, %146 
-  br i1 %"2$tmp$10##0", label %if.then1, label %if.else1 
+  %"2#tmp#10##0" = icmp eq i64 %135, %146 
+  br i1 %"2#tmp#10##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = xor i1 0, 1 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = xor i1 0, 1 
+  ret i1 %"3#####0" 
 if.then1:
-  %"4$tmp$0##0" = icmp eq i64 %139, %150 
-  %"4$$$##0" = xor i1 %"4$tmp$0##0", 1 
-  ret i1 %"4$$$##0" 
+  %"4#tmp#0##0" = icmp eq i64 %139, %150 
+  %"4#####0" = xor i1 %"4#tmp#0##0", 1 
+  ret i1 %"4#####0" 
 if.else1:
-  %"5$$$##0" = xor i1 0, 1 
-  ret i1 %"5$$$##0" 
+  %"5#####0" = xor i1 0, 1 
+  ret i1 %"5#####0" 
 }

--- a/test-cases/final-dump/test_loop.exp
+++ b/test-cases/final-dump/test_loop.exp
@@ -305,10 +305,10 @@ if.else1:
 
 high > public {inline} (0 calls)
 0: test_loop.int_seq.high<0>
-high(#rec##0:test_loop.int_seq, ?###0:wybe.int):
+high(#rec##0:test_loop.int_seq, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 high > public {inline} (0 calls)
 1: test_loop.int_seq.high<1>
 high(#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, #field##0:wybe.int):
@@ -319,29 +319,29 @@ high(#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, #field##0:wybe.int):
 
 int_seq > public {inline} (0 calls)
 0: test_loop.int_seq.int_seq<0>
-int_seq(low##0:wybe.int, step##0:wybe.int, high##0:wybe.int, ?###0:test_loop.int_seq):
+int_seq(low##0:wybe.int, step##0:wybe.int, high##0:wybe.int, ?#result##0:test_loop.int_seq):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(24:wybe.int, ?#rec##0:test_loop.int_seq)
     foreign lpvm mutate(~#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~low##0:wybe.int)
     foreign lpvm mutate(~#rec##1:test_loop.int_seq, ?#rec##2:test_loop.int_seq, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~step##0:wybe.int)
-    foreign lpvm mutate(~#rec##2:test_loop.int_seq, ?###0:test_loop.int_seq, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~high##0:wybe.int)
+    foreign lpvm mutate(~#rec##2:test_loop.int_seq, ?#result##0:test_loop.int_seq, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~high##0:wybe.int)
 int_seq > public {inline} (13 calls)
 1: test_loop.int_seq.int_seq<1>
-int_seq(?low##0:wybe.int, ?step##0:wybe.int, ?high##0:wybe.int, ###0:test_loop.int_seq):
+int_seq(?low##0:wybe.int, ?step##0:wybe.int, ?high##0:wybe.int, #result##0:test_loop.int_seq):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(###0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?low##0:wybe.int)
-    foreign lpvm access(###0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?step##0:wybe.int)
-    foreign lpvm access(~###0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?high##0:wybe.int)
+    foreign lpvm access(#result##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?low##0:wybe.int)
+    foreign lpvm access(#result##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?step##0:wybe.int)
+    foreign lpvm access(~#result##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?high##0:wybe.int)
 
 
 low > public {inline} (0 calls)
 0: test_loop.int_seq.low<0>
-low(#rec##0:test_loop.int_seq, ?###0:wybe.int):
+low(#rec##0:test_loop.int_seq, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 low > public {inline} (1 calls)
 1: test_loop.int_seq.low<1>
 low(#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, #field##0:wybe.int):
@@ -388,10 +388,10 @@ seq_next(seq##0:test_loop.int_seq, ?seq##1:test_loop.int_seq, ?elt##0:wybe.int, 
 
 step > public {inline} (0 calls)
 0: test_loop.int_seq.step<0>
-step(#rec##0:test_loop.int_seq, ?###0:wybe.int):
+step(#rec##0:test_loop.int_seq, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~#rec##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?###0:wybe.int)
+    foreign lpvm access(~#rec##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
 step > public {inline} (0 calls)
 1: test_loop.int_seq.step<1>
 step(#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, #field##0:wybe.int):
@@ -530,16 +530,16 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64} @"test_loop.int_seq.int_seq<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64, i64} @"test_loop.int_seq.int_seq<1>"(i64  %"#result##0")    {
 entry:
-  %47 = inttoptr i64 %"###0" to i64* 
+  %47 = inttoptr i64 %"#result##0" to i64* 
   %48 = getelementptr  i64, i64* %47, i64 0 
   %49 = load  i64, i64* %48 
-  %50 = add   i64 %"###0", 8 
+  %50 = add   i64 %"#result##0", 8 
   %51 = inttoptr i64 %50 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
   %53 = load  i64, i64* %52 
-  %54 = add   i64 %"###0", 16 
+  %54 = add   i64 %"#result##0", 16 
   %55 = inttoptr i64 %54 to i64* 
   %56 = getelementptr  i64, i64* %55, i64 0 
   %57 = load  i64, i64* %56 

--- a/test-cases/final-dump/test_loop.exp
+++ b/test-cases/final-dump/test_loop.exp
@@ -24,88 +24,88 @@ AFTER EVERYTHING:
 
 *main* > public {inline} (0 calls)
 0: test_loop.<0>
-(io#0:wybe.phantom, ?io#2:wybe.phantom):
+(io##0:wybe.phantom, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    test_loop.find_test<0>(3:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @test_loop:nn:nn
-    test_loop.find_test<0>(7:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #1 @test_loop:nn:nn
+    test_loop.find_test<0>(3:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @test_loop:nn:nn
+    test_loop.find_test<0>(7:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #1 @test_loop:nn:nn
 
 
 find_modulo > {inline} (3 calls)
 0: test_loop.find_modulo<0>
-find_modulo(seq#0:test_loop.int_seq, modulus#0:wybe.int, ?i#0:wybe.int, ?$$#0:wybe.bool):
+find_modulo(seq##0:test_loop.int_seq, modulus##0:wybe.int, ?i##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    test_loop.gen$1<0>(~modulus#0:wybe.int, ~seq#0:test_loop.int_seq, ?i#0:wybe.int, ?$$#0:wybe.bool) #0 @test_loop:nn:nn
+    test_loop.gen$1<0>(~modulus##0:wybe.int, ~seq##0:test_loop.int_seq, ?i##0:wybe.int, ?$$##0:wybe.bool) #0 @test_loop:nn:nn
 
 
 find_test > (2 calls)
 0: test_loop.find_test<0>
-find_test(modulus#0:wybe.int, io#0:wybe.phantom, ?io#4:wybe.phantom):
+find_test(modulus##0:wybe.int, io##0:wybe.phantom, ?io##4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(8,(test_loop.gen$1<0>,fromList [NonAliasedParamCond 1 []]))]
-    foreign lpvm alloc(24:wybe.int, ?tmp$5#0:test_loop.int_seq)
-    foreign lpvm mutate(~tmp$5#0:test_loop.int_seq, ?tmp$6#0:test_loop.int_seq, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm mutate(~tmp$6#0:test_loop.int_seq, ?tmp$7#0:test_loop.int_seq, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm mutate(~tmp$7#0:test_loop.int_seq, ?tmp$8#0:test_loop.int_seq, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 10:wybe.int)
-    test_loop.gen$1<0>[6dacb8fd25](modulus#0:wybe.int, ~tmp$8#0:test_loop.int_seq, ?i#0:wybe.int, ?tmp$1#0:wybe.bool) #8 @test_loop:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm alloc(24:wybe.int, ?tmp$5##0:test_loop.int_seq)
+    foreign lpvm mutate(~tmp$5##0:test_loop.int_seq, ?tmp$6##0:test_loop.int_seq, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 2:wybe.int)
+    foreign lpvm mutate(~tmp$6##0:test_loop.int_seq, ?tmp$7##0:test_loop.int_seq, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 2:wybe.int)
+    foreign lpvm mutate(~tmp$7##0:test_loop.int_seq, ?tmp$8##0:test_loop.int_seq, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, 10:wybe.int)
+    test_loop.gen$1<0>[6dacb8fd25](modulus##0:wybe.int, ~tmp$8##0:test_loop.int_seq, ?i##0:wybe.int, ?tmp$1##0:wybe.bool) #8 @test_loop:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign c print_string("Couldn't find even number divisible by ":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        foreign c print_int(~modulus#0:wybe.int, ~#io#1:wybe.phantom, ?tmp$15#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$15#0:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
+        foreign c print_string("Couldn't find even number divisible by ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        foreign c print_int(~modulus##0:wybe.int, ~#io##1:wybe.phantom, ?tmp$15##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$15##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
 
     1:
-        foreign c print_string("First even number divisible by ":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        foreign c print_int(~modulus#0:wybe.int, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-        foreign c print_string(" is ":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-        foreign c print_int(~i#0:wybe.int, ~#io#3:wybe.phantom, ?tmp$19#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$19#0:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
+        foreign c print_string("First even number divisible by ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        foreign c print_int(~modulus##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+        foreign c print_string(" is ":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~#io##3:wybe.phantom, ?tmp$19##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$19##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
 
 
 
 gen$1 > (2 calls)
 0: test_loop.gen$1<0>[6dacb8fd25]
-gen$1(modulus#0:wybe.int, seq#0:test_loop.int_seq, ?i#1:wybe.int, ?$$#0:wybe.bool):
+gen$1(modulus##0:wybe.int, seq##0:test_loop.int_seq, ?i##1:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 1]
  MultiSpeczDepInfo: [(0,(test_loop.int_seq.seq_next<0>,fromList [NonAliasedParamCond 0 [1]])),(3,(test_loop.gen$1<0>,fromList [NonAliasedParamCond 1 [1]]))]
-    test_loop.int_seq.seq_next<0>(~%seq#0:test_loop.int_seq, ?%seq#1:test_loop.int_seq, ?i#0:wybe.int, ?tmp$1#0:wybe.bool) #0 @test_loop:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    test_loop.int_seq.seq_next<0>(~%seq##0:test_loop.int_seq, ?%seq##1:test_loop.int_seq, ?i##0:wybe.int, ?tmp$1##0:wybe.bool) #0 @test_loop:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~i#0:wybe.int, ?i#1:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~i##0:wybe.int, ?i##1:wybe.int)
 
     1:
-        foreign llvm srem(i#0:wybe.int, modulus#0:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn
-        foreign llvm icmp_eq(~tmp$0#0:wybe.int, 0:wybe.int, ?tmp$2#0:wybe.bool) @int:nn:nn
-        case ~tmp$2#0:wybe.bool of
+        foreign llvm srem(i##0:wybe.int, modulus##0:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
+        foreign llvm icmp_eq(~tmp$0##0:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.bool) @int:nn:nn
+        case ~tmp$2##0:wybe.bool of
         0:
-            test_loop.gen$1<0>(~modulus#0:wybe.int, ~seq#1:test_loop.int_seq, ?i#1:wybe.int, ?$$#0:wybe.bool) #3 @test_loop:nn:nn
+            test_loop.gen$1<0>(~modulus##0:wybe.int, ~seq##1:test_loop.int_seq, ?i##1:wybe.int, ?$$##0:wybe.bool) #3 @test_loop:nn:nn
 
         1:
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(~i#0:wybe.int, ?i#1:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(~i##0:wybe.int, ?i##1:wybe.int)
 
 
  [6dacb8fd25] [NonAliasedParam 1] :
-    test_loop.int_seq.seq_next<0>[410bae77d3](~%seq#0:test_loop.int_seq, ?%seq#1:test_loop.int_seq, ?i#0:wybe.int, ?tmp$1#0:wybe.bool) #0 @test_loop:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    test_loop.int_seq.seq_next<0>[410bae77d3](~%seq##0:test_loop.int_seq, ?%seq##1:test_loop.int_seq, ?i##0:wybe.int, ?tmp$1##0:wybe.bool) #0 @test_loop:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~i#0:wybe.int, ?i#1:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~i##0:wybe.int, ?i##1:wybe.int)
 
     1:
-        foreign llvm srem(i#0:wybe.int, modulus#0:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn
-        foreign llvm icmp_eq(~tmp$0#0:wybe.int, 0:wybe.int, ?tmp$2#0:wybe.bool) @int:nn:nn
-        case ~tmp$2#0:wybe.bool of
+        foreign llvm srem(i##0:wybe.int, modulus##0:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
+        foreign llvm icmp_eq(~tmp$0##0:wybe.int, 0:wybe.int, ?tmp$2##0:wybe.bool) @int:nn:nn
+        case ~tmp$2##0:wybe.bool of
         0:
-            test_loop.gen$1<0>[6dacb8fd25](~modulus#0:wybe.int, ~seq#1:test_loop.int_seq, ?i#1:wybe.int, ?$$#0:wybe.bool) #3 @test_loop:nn:nn
+            test_loop.gen$1<0>[6dacb8fd25](~modulus##0:wybe.int, ~seq##1:test_loop.int_seq, ?i##1:wybe.int, ?$$##0:wybe.bool) #3 @test_loop:nn:nn
 
         1:
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
-            foreign llvm move(~i#0:wybe.int, ?i#1:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(~i##0:wybe.int, ?i##1:wybe.int)
 
 
 
@@ -149,9 +149,9 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"test_loop.find_modulo<0>"(i64  %"seq#0", i64  %"modulus#0")    {
+define external fastcc  {i64, i1} @"test_loop.find_modulo<0>"(i64  %"seq##0", i64  %"modulus##0")    {
 entry:
-  %1 = tail call fastcc  {i64, i1}  @"test_loop.gen$1<0>"(i64  %"modulus#0", i64  %"seq#0")  
+  %1 = tail call fastcc  {i64, i1}  @"test_loop.gen$1<0>"(i64  %"modulus##0", i64  %"seq##0")  
   %2 = extractvalue {i64, i1} %1, 0 
   %3 = extractvalue {i64, i1} %1, 1 
   %4 = insertvalue {i64, i1} undef, i64 %2, 0 
@@ -160,7 +160,7 @@ entry:
 }
 
 
-define external fastcc  void @"test_loop.find_test<0>"(i64  %"modulus#0")    {
+define external fastcc  void @"test_loop.find_test<0>"(i64  %"modulus##0")    {
 entry:
   %6 = trunc i64 24 to i32  
   %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
@@ -176,14 +176,14 @@ entry:
   %15 = inttoptr i64 %14 to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
   store  i64 10, i64* %16 
-  %17 = tail call fastcc  {i64, i1}  @"test_loop.gen$1<0>[6dacb8fd25]"(i64  %"modulus#0", i64  %8)  
+  %17 = tail call fastcc  {i64, i1}  @"test_loop.gen$1<0>[6dacb8fd25]"(i64  %"modulus##0", i64  %8)  
   %18 = extractvalue {i64, i1} %17, 0 
   %19 = extractvalue {i64, i1} %17, 1 
   br i1 %19, label %if.then, label %if.else 
 if.then:
   %21 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @test_loop.20, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %21)  
-  tail call ccc  void  @print_int(i64  %"modulus#0")  
+  tail call ccc  void  @print_int(i64  %"modulus##0")  
   %23 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @test_loop.22, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %23)  
   tail call ccc  void  @print_int(i64  %18)  
@@ -192,23 +192,23 @@ if.then:
 if.else:
   %25 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @test_loop.24, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %25)  
-  tail call ccc  void  @print_int(i64  %"modulus#0")  
+  tail call ccc  void  @print_int(i64  %"modulus##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  {i64, i1} @"test_loop.gen$1<0>"(i64  %"modulus#0", i64  %"seq#0")    {
+define external fastcc  {i64, i1} @"test_loop.gen$1<0>"(i64  %"modulus##0", i64  %"seq##0")    {
 entry:
-  %26 = tail call fastcc  {i64, i64, i1}  @"test_loop.int_seq.seq_next<0>"(i64  %"seq#0")  
+  %26 = tail call fastcc  {i64, i64, i1}  @"test_loop.int_seq.seq_next<0>"(i64  %"seq##0")  
   %27 = extractvalue {i64, i64, i1} %26, 0 
   %28 = extractvalue {i64, i64, i1} %26, 1 
   %29 = extractvalue {i64, i64, i1} %26, 2 
   br i1 %29, label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = srem i64 %28, %"modulus#0" 
-  %"2$tmp$2#0" = icmp eq i64 %"2$tmp$0#0", 0 
-  br i1 %"2$tmp$2#0", label %if.then1, label %if.else1 
+  %"2$tmp$0##0" = srem i64 %28, %"modulus##0" 
+  %"2$tmp$2##0" = icmp eq i64 %"2$tmp$0##0", 0 
+  br i1 %"2$tmp$2##0", label %if.then1, label %if.else1 
 if.else:
   %37 = insertvalue {i64, i1} undef, i64 %28, 0 
   %38 = insertvalue {i64, i1} %37, i1 0, 1 
@@ -218,7 +218,7 @@ if.then1:
   %31 = insertvalue {i64, i1} %30, i1 1, 1 
   ret {i64, i1} %31 
 if.else1:
-  %32 = tail call fastcc  {i64, i1}  @"test_loop.gen$1<0>"(i64  %"modulus#0", i64  %27)  
+  %32 = tail call fastcc  {i64, i1}  @"test_loop.gen$1<0>"(i64  %"modulus##0", i64  %27)  
   %33 = extractvalue {i64, i1} %32, 0 
   %34 = extractvalue {i64, i1} %32, 1 
   %35 = insertvalue {i64, i1} undef, i64 %33, 0 
@@ -227,17 +227,17 @@ if.else1:
 }
 
 
-define external fastcc  {i64, i1} @"test_loop.gen$1<0>[6dacb8fd25]"(i64  %"modulus#0", i64  %"seq#0")    {
+define external fastcc  {i64, i1} @"test_loop.gen$1<0>[6dacb8fd25]"(i64  %"modulus##0", i64  %"seq##0")    {
 entry:
-  %39 = tail call fastcc  {i64, i64, i1}  @"test_loop.int_seq.seq_next<0>[410bae77d3]"(i64  %"seq#0")  
+  %39 = tail call fastcc  {i64, i64, i1}  @"test_loop.int_seq.seq_next<0>[410bae77d3]"(i64  %"seq##0")  
   %40 = extractvalue {i64, i64, i1} %39, 0 
   %41 = extractvalue {i64, i64, i1} %39, 1 
   %42 = extractvalue {i64, i64, i1} %39, 2 
   br i1 %42, label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = srem i64 %41, %"modulus#0" 
-  %"2$tmp$2#0" = icmp eq i64 %"2$tmp$0#0", 0 
-  br i1 %"2$tmp$2#0", label %if.then1, label %if.else1 
+  %"2$tmp$0##0" = srem i64 %41, %"modulus##0" 
+  %"2$tmp$2##0" = icmp eq i64 %"2$tmp$0##0", 0 
+  br i1 %"2$tmp$2##0", label %if.then1, label %if.else1 
 if.else:
   %50 = insertvalue {i64, i1} undef, i64 %41, 0 
   %51 = insertvalue {i64, i1} %50, i1 0, 1 
@@ -247,7 +247,7 @@ if.then1:
   %44 = insertvalue {i64, i1} %43, i1 1, 1 
   ret {i64, i1} %44 
 if.else1:
-  %45 = tail call fastcc  {i64, i1}  @"test_loop.gen$1<0>[6dacb8fd25]"(i64  %"modulus#0", i64  %40)  
+  %45 = tail call fastcc  {i64, i1}  @"test_loop.gen$1<0>[6dacb8fd25]"(i64  %"modulus##0", i64  %40)  
   %46 = extractvalue {i64, i1} %45, 0 
   %47 = extractvalue {i64, i1} %45, 1 
   %48 = insertvalue {i64, i1} undef, i64 %46, 0 
@@ -277,156 +277,156 @@ if.else1:
 
 = > public {inline} (1 calls)
 0: test_loop.int_seq.=<0>
-=($left#0:test_loop.int_seq, $right#0:test_loop.int_seq, ?$$#0:wybe.bool):
+=($left##0:test_loop.int_seq, $right##0:test_loop.int_seq, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$low#0:wybe.int)
-    foreign lpvm access($left#0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$step#0:wybe.int)
-    foreign lpvm access(~$left#0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$high#0:wybe.int)
-    foreign lpvm access($right#0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$low#0:wybe.int)
-    foreign lpvm access($right#0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$step#0:wybe.int)
-    foreign lpvm access(~$right#0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$high#0:wybe.int)
-    foreign llvm icmp_eq(~$left$low#0:wybe.int, ~$right$low#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access($left##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$low##0:wybe.int)
+    foreign lpvm access($left##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$step##0:wybe.int)
+    foreign lpvm access(~$left##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$left$high##0:wybe.int)
+    foreign lpvm access($right##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$low##0:wybe.int)
+    foreign lpvm access($right##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$step##0:wybe.int)
+    foreign lpvm access(~$right##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$right$high##0:wybe.int)
+    foreign llvm icmp_eq(~$left$low##0:wybe.int, ~$right$low##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~$left$step#0:wybe.int, ~$right$step#0:wybe.int, ?tmp$2#0:wybe.bool) @int:nn:nn
-        case ~tmp$2#0:wybe.bool of
+        foreign llvm icmp_eq(~$left$step##0:wybe.int, ~$right$step##0:wybe.int, ?tmp$2##0:wybe.bool) @int:nn:nn
+        case ~tmp$2##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~$left$high#0:wybe.int, ~$right$high#0:wybe.int, ?$$#0:wybe.bool) @int:nn:nn
+            foreign llvm icmp_eq(~$left$high##0:wybe.int, ~$right$high##0:wybe.int, ?$$##0:wybe.bool) @int:nn:nn
 
 
 
 
 high > public {inline} (0 calls)
 0: test_loop.int_seq.high<0>
-high($rec#0:test_loop.int_seq, ?$#0:wybe.int):
+high($rec##0:test_loop.int_seq, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 high > public {inline} (0 calls)
 1: test_loop.int_seq.high<1>
-high($rec#0:test_loop.int_seq, ?$rec#1:test_loop.int_seq, $field#0:wybe.int):
+high($rec##0:test_loop.int_seq, ?$rec##1:test_loop.int_seq, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:test_loop.int_seq, ?$rec#1:test_loop.int_seq, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:test_loop.int_seq, ?$rec##1:test_loop.int_seq, 16:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 int_seq > public {inline} (0 calls)
 0: test_loop.int_seq.int_seq<0>
-int_seq(low#0:wybe.int, step#0:wybe.int, high#0:wybe.int, ?$#0:test_loop.int_seq):
+int_seq(low##0:wybe.int, step##0:wybe.int, high##0:wybe.int, ?$##0:test_loop.int_seq):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?$rec#0:test_loop.int_seq)
-    foreign lpvm mutate(~$rec#0:test_loop.int_seq, ?$rec#1:test_loop.int_seq, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~low#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:test_loop.int_seq, ?$rec#2:test_loop.int_seq, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~step#0:wybe.int)
-    foreign lpvm mutate(~$rec#2:test_loop.int_seq, ?$#0:test_loop.int_seq, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~high#0:wybe.int)
+    foreign lpvm alloc(24:wybe.int, ?$rec##0:test_loop.int_seq)
+    foreign lpvm mutate(~$rec##0:test_loop.int_seq, ?$rec##1:test_loop.int_seq, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~low##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:test_loop.int_seq, ?$rec##2:test_loop.int_seq, 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~step##0:wybe.int)
+    foreign lpvm mutate(~$rec##2:test_loop.int_seq, ?$##0:test_loop.int_seq, 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~high##0:wybe.int)
 int_seq > public {inline} (13 calls)
 1: test_loop.int_seq.int_seq<1>
-int_seq(?low#0:wybe.int, ?step#0:wybe.int, ?high#0:wybe.int, $#0:test_loop.int_seq):
+int_seq(?low##0:wybe.int, ?step##0:wybe.int, ?high##0:wybe.int, $##0:test_loop.int_seq):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($#0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?low#0:wybe.int)
-    foreign lpvm access($#0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?step#0:wybe.int)
-    foreign lpvm access(~$#0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?high#0:wybe.int)
+    foreign lpvm access($##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?low##0:wybe.int)
+    foreign lpvm access($##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?step##0:wybe.int)
+    foreign lpvm access(~$##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?high##0:wybe.int)
 
 
 low > public {inline} (0 calls)
 0: test_loop.int_seq.low<0>
-low($rec#0:test_loop.int_seq, ?$#0:wybe.int):
+low($rec##0:test_loop.int_seq, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 low > public {inline} (1 calls)
 1: test_loop.int_seq.low<1>
-low($rec#0:test_loop.int_seq, ?$rec#1:test_loop.int_seq, $field#0:wybe.int):
+low($rec##0:test_loop.int_seq, ?$rec##1:test_loop.int_seq, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:test_loop.int_seq, ?$rec#1:test_loop.int_seq, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:test_loop.int_seq, ?$rec##1:test_loop.int_seq, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 seq_next > public (0 calls)
 0: test_loop.int_seq.seq_next<0>[410bae77d3]
-seq_next(seq#0:test_loop.int_seq, ?seq#1:test_loop.int_seq, ?elt#0:wybe.int, ?$$#0:wybe.bool):
- AliasPairs: [(seq#0,seq#1)]
+seq_next(seq##0:test_loop.int_seq, ?seq##1:test_loop.int_seq, ?elt##0:wybe.int, ?$$##0:wybe.bool):
+ AliasPairs: [(seq##0,seq##1)]
  InterestingCallProperties: [InterestingUnaliased 0]
-    foreign lpvm access(seq#0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?elt#0:wybe.int)
-    foreign lpvm access(seq#0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?step#0:wybe.int)
-    foreign lpvm access(seq#0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?limit#0:wybe.int)
-    foreign llvm icmp_sle(elt#0:wybe.int, ~limit#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access(seq##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?elt##0:wybe.int)
+    foreign lpvm access(seq##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?step##0:wybe.int)
+    foreign lpvm access(seq##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?limit##0:wybe.int)
+    foreign llvm icmp_sle(elt##0:wybe.int, ~limit##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~seq#0:test_loop.int_seq, ?seq#1:test_loop.int_seq)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~seq##0:test_loop.int_seq, ?seq##1:test_loop.int_seq)
 
     1:
-        foreign llvm add(elt#0:wybe.int, ~step#0:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%seq#0:test_loop.int_seq, ?%seq#1:test_loop.int_seq, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp$0#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm add(elt##0:wybe.int, ~step##0:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%seq##0:test_loop.int_seq, ?%seq##1:test_loop.int_seq, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp$0##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign lpvm access(seq#0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?elt#0:wybe.int)
-    foreign lpvm access(seq#0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?step#0:wybe.int)
-    foreign lpvm access(seq#0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?limit#0:wybe.int)
-    foreign llvm icmp_sle(elt#0:wybe.int, ~limit#0:wybe.int, ?tmp$1#0:wybe.bool) @int:nn:nn
-    case ~tmp$1#0:wybe.bool of
+    foreign lpvm access(seq##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?elt##0:wybe.int)
+    foreign lpvm access(seq##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?step##0:wybe.int)
+    foreign lpvm access(seq##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?limit##0:wybe.int)
+    foreign llvm icmp_sle(elt##0:wybe.int, ~limit##0:wybe.int, ?tmp$1##0:wybe.bool) @int:nn:nn
+    case ~tmp$1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~seq#0:test_loop.int_seq, ?seq#1:test_loop.int_seq)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~seq##0:test_loop.int_seq, ?seq##1:test_loop.int_seq)
 
     1:
-        foreign llvm add(elt#0:wybe.int, ~step#0:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn
-        foreign lpvm {noalias} mutate(~%seq#0:test_loop.int_seq, ?%seq#1:test_loop.int_seq, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp$0#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm add(elt##0:wybe.int, ~step##0:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
+        foreign lpvm {noalias} mutate(~%seq##0:test_loop.int_seq, ?%seq##1:test_loop.int_seq, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp$0##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 step > public {inline} (0 calls)
 0: test_loop.int_seq.step<0>
-step($rec#0:test_loop.int_seq, ?$#0:wybe.int):
+step($rec##0:test_loop.int_seq, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access(~$rec#0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$#0:wybe.int)
+    foreign lpvm access(~$rec##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?$##0:wybe.int)
 step > public {inline} (0 calls)
 1: test_loop.int_seq.step<1>
-step($rec#0:test_loop.int_seq, ?$rec#1:test_loop.int_seq, $field#0:wybe.int):
+step($rec##0:test_loop.int_seq, ?$rec##1:test_loop.int_seq, $field##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm {noalias} mutate(~$rec#0:test_loop.int_seq, ?$rec#1:test_loop.int_seq, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
+    foreign lpvm {noalias} mutate(~$rec##0:test_loop.int_seq, ?$rec##1:test_loop.int_seq, 8:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
 
 
 ~= > public {inline} (0 calls)
 0: test_loop.int_seq.~=<0>
-~=($left#0:test_loop.int_seq, $right#0:test_loop.int_seq, ?$$#0:wybe.bool):
+~=($left##0:test_loop.int_seq, $right##0:test_loop.int_seq, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm access($left#0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$3#0:wybe.int)
-    foreign lpvm access($left#0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$4#0:wybe.int)
-    foreign lpvm access(~$left#0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.int)
-    foreign lpvm access($right#0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$6#0:wybe.int)
-    foreign lpvm access($right#0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$7#0:wybe.int)
-    foreign lpvm access(~$right#0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$8#0:wybe.int)
-    foreign llvm icmp_eq(~tmp$3#0:wybe.int, ~tmp$6#0:wybe.int, ?tmp$9#0:wybe.bool) @int:nn:nn
-    case ~tmp$9#0:wybe.bool of
+    foreign lpvm access($left##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$3##0:wybe.int)
+    foreign lpvm access($left##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$4##0:wybe.int)
+    foreign lpvm access(~$left##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.int)
+    foreign lpvm access($right##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$6##0:wybe.int)
+    foreign lpvm access($right##0:test_loop.int_seq, 8:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$7##0:wybe.int)
+    foreign lpvm access(~$right##0:test_loop.int_seq, 16:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp$8##0:wybe.int)
+    foreign llvm icmp_eq(~tmp$3##0:wybe.int, ~tmp$6##0:wybe.int, ?tmp$9##0:wybe.bool) @int:nn:nn
+    case ~tmp$9##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-        foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+        foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm icmp_eq(~tmp$4#0:wybe.int, ~tmp$7#0:wybe.int, ?tmp$10#0:wybe.bool) @int:nn:nn
-        case ~tmp$10#0:wybe.bool of
+        foreign llvm icmp_eq(~tmp$4##0:wybe.int, ~tmp$7##0:wybe.int, ?tmp$10##0:wybe.bool) @int:nn:nn
+        case ~tmp$10##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?tmp$0#0:wybe.bool)
-            foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?tmp$0##0:wybe.bool)
+            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~tmp$5#0:wybe.int, ~tmp$8#0:wybe.int, ?tmp$0#0:wybe.bool) @int:nn:nn
-            foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm icmp_eq(~tmp$5##0:wybe.int, ~tmp$8##0:wybe.int, ?tmp$0##0:wybe.bool) @int:nn:nn
+            foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
@@ -444,48 +444,48 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"test_loop.int_seq.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"test_loop.int_seq.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = add   i64 %"$left#0", 16 
+  %8 = add   i64 %"$left##0", 16 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
-  %12 = inttoptr i64 %"$right#0" to i64* 
+  %12 = inttoptr i64 %"$right##0" to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %15 = add   i64 %"$right#0", 8 
+  %15 = add   i64 %"$right##0", 8 
   %16 = inttoptr i64 %15 to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
-  %19 = add   i64 %"$right#0", 16 
+  %19 = add   i64 %"$right##0", 16 
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %"1$tmp$1#0" = icmp eq i64 %3, %14 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp eq i64 %3, %14 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$2#0" = icmp eq i64 %7, %18 
-  br i1 %"2$tmp$2#0", label %if.then1, label %if.else1 
+  %"2$tmp$2##0" = icmp eq i64 %7, %18 
+  br i1 %"2$tmp$2##0", label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
-  %"4$$$#0" = icmp eq i64 %11, %22 
-  ret i1 %"4$$$#0" 
+  %"4$$$##0" = icmp eq i64 %11, %22 
+  ret i1 %"4$$$##0" 
 if.else1:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"test_loop.int_seq.high<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"test_loop.int_seq.high<0>"(i64  %"$rec##0")    {
 entry:
-  %23 = add   i64 %"$rec#0", 16 
+  %23 = add   i64 %"$rec##0", 16 
   %24 = inttoptr i64 %23 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
   %26 = load  i64, i64* %25 
@@ -493,53 +493,53 @@ entry:
 }
 
 
-define external fastcc  i64 @"test_loop.int_seq.high<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"test_loop.int_seq.high<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %27 = trunc i64 24 to i32  
   %28 = tail call ccc  i8*  @wybe_malloc(i32  %27)  
   %29 = ptrtoint i8* %28 to i64 
   %30 = inttoptr i64 %29 to i8* 
-  %31 = inttoptr i64 %"$rec#0" to i8* 
+  %31 = inttoptr i64 %"$rec##0" to i8* 
   %32 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %30, i8*  %31, i32  %32, i32  8, i1  0)  
   %33 = add   i64 %29, 16 
   %34 = inttoptr i64 %33 to i64* 
   %35 = getelementptr  i64, i64* %34, i64 0 
-  store  i64 %"$field#0", i64* %35 
+  store  i64 %"$field##0", i64* %35 
   ret i64 %29 
 }
 
 
-define external fastcc  i64 @"test_loop.int_seq.int_seq<0>"(i64  %"low#0", i64  %"step#0", i64  %"high#0")    {
+define external fastcc  i64 @"test_loop.int_seq.int_seq<0>"(i64  %"low##0", i64  %"step##0", i64  %"high##0")    {
 entry:
   %36 = trunc i64 24 to i32  
   %37 = tail call ccc  i8*  @wybe_malloc(i32  %36)  
   %38 = ptrtoint i8* %37 to i64 
   %39 = inttoptr i64 %38 to i64* 
   %40 = getelementptr  i64, i64* %39, i64 0 
-  store  i64 %"low#0", i64* %40 
+  store  i64 %"low##0", i64* %40 
   %41 = add   i64 %38, 8 
   %42 = inttoptr i64 %41 to i64* 
   %43 = getelementptr  i64, i64* %42, i64 0 
-  store  i64 %"step#0", i64* %43 
+  store  i64 %"step##0", i64* %43 
   %44 = add   i64 %38, 16 
   %45 = inttoptr i64 %44 to i64* 
   %46 = getelementptr  i64, i64* %45, i64 0 
-  store  i64 %"high#0", i64* %46 
+  store  i64 %"high##0", i64* %46 
   ret i64 %38 
 }
 
 
-define external fastcc  {i64, i64, i64} @"test_loop.int_seq.int_seq<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64, i64} @"test_loop.int_seq.int_seq<1>"(i64  %"$##0")    {
 entry:
-  %47 = inttoptr i64 %"$#0" to i64* 
+  %47 = inttoptr i64 %"$##0" to i64* 
   %48 = getelementptr  i64, i64* %47, i64 0 
   %49 = load  i64, i64* %48 
-  %50 = add   i64 %"$#0", 8 
+  %50 = add   i64 %"$##0", 8 
   %51 = inttoptr i64 %50 to i64* 
   %52 = getelementptr  i64, i64* %51, i64 0 
   %53 = load  i64, i64* %52 
-  %54 = add   i64 %"$#0", 16 
+  %54 = add   i64 %"$##0", 16 
   %55 = inttoptr i64 %54 to i64* 
   %56 = getelementptr  i64, i64* %55, i64 0 
   %57 = load  i64, i64* %56 
@@ -550,105 +550,105 @@ entry:
 }
 
 
-define external fastcc  i64 @"test_loop.int_seq.low<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"test_loop.int_seq.low<0>"(i64  %"$rec##0")    {
 entry:
-  %61 = inttoptr i64 %"$rec#0" to i64* 
+  %61 = inttoptr i64 %"$rec##0" to i64* 
   %62 = getelementptr  i64, i64* %61, i64 0 
   %63 = load  i64, i64* %62 
   ret i64 %63 
 }
 
 
-define external fastcc  i64 @"test_loop.int_seq.low<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"test_loop.int_seq.low<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %64 = trunc i64 24 to i32  
   %65 = tail call ccc  i8*  @wybe_malloc(i32  %64)  
   %66 = ptrtoint i8* %65 to i64 
   %67 = inttoptr i64 %66 to i8* 
-  %68 = inttoptr i64 %"$rec#0" to i8* 
+  %68 = inttoptr i64 %"$rec##0" to i8* 
   %69 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %67, i8*  %68, i32  %69, i32  8, i1  0)  
   %70 = inttoptr i64 %66 to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
-  store  i64 %"$field#0", i64* %71 
+  store  i64 %"$field##0", i64* %71 
   ret i64 %66 
 }
 
 
-define external fastcc  {i64, i64, i1} @"test_loop.int_seq.seq_next<0>"(i64  %"seq#0")    {
+define external fastcc  {i64, i64, i1} @"test_loop.int_seq.seq_next<0>"(i64  %"seq##0")    {
 entry:
-  %72 = inttoptr i64 %"seq#0" to i64* 
+  %72 = inttoptr i64 %"seq##0" to i64* 
   %73 = getelementptr  i64, i64* %72, i64 0 
   %74 = load  i64, i64* %73 
-  %75 = add   i64 %"seq#0", 8 
+  %75 = add   i64 %"seq##0", 8 
   %76 = inttoptr i64 %75 to i64* 
   %77 = getelementptr  i64, i64* %76, i64 0 
   %78 = load  i64, i64* %77 
-  %79 = add   i64 %"seq#0", 16 
+  %79 = add   i64 %"seq##0", 16 
   %80 = inttoptr i64 %79 to i64* 
   %81 = getelementptr  i64, i64* %80, i64 0 
   %82 = load  i64, i64* %81 
-  %"1$tmp$1#0" = icmp sle i64 %74, %82 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp sle i64 %74, %82 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = add   i64 %74, %78 
+  %"2$tmp$0##0" = add   i64 %74, %78 
   %83 = trunc i64 24 to i32  
   %84 = tail call ccc  i8*  @wybe_malloc(i32  %83)  
   %85 = ptrtoint i8* %84 to i64 
   %86 = inttoptr i64 %85 to i8* 
-  %87 = inttoptr i64 %"seq#0" to i8* 
+  %87 = inttoptr i64 %"seq##0" to i8* 
   %88 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %86, i8*  %87, i32  %88, i32  8, i1  0)  
   %89 = inttoptr i64 %85 to i64* 
   %90 = getelementptr  i64, i64* %89, i64 0 
-  store  i64 %"2$tmp$0#0", i64* %90 
+  store  i64 %"2$tmp$0##0", i64* %90 
   %91 = insertvalue {i64, i64, i1} undef, i64 %85, 0 
   %92 = insertvalue {i64, i64, i1} %91, i64 %74, 1 
   %93 = insertvalue {i64, i64, i1} %92, i1 1, 2 
   ret {i64, i64, i1} %93 
 if.else:
-  %94 = insertvalue {i64, i64, i1} undef, i64 %"seq#0", 0 
+  %94 = insertvalue {i64, i64, i1} undef, i64 %"seq##0", 0 
   %95 = insertvalue {i64, i64, i1} %94, i64 %74, 1 
   %96 = insertvalue {i64, i64, i1} %95, i1 0, 2 
   ret {i64, i64, i1} %96 
 }
 
 
-define external fastcc  {i64, i64, i1} @"test_loop.int_seq.seq_next<0>[410bae77d3]"(i64  %"seq#0")    {
+define external fastcc  {i64, i64, i1} @"test_loop.int_seq.seq_next<0>[410bae77d3]"(i64  %"seq##0")    {
 entry:
-  %97 = inttoptr i64 %"seq#0" to i64* 
+  %97 = inttoptr i64 %"seq##0" to i64* 
   %98 = getelementptr  i64, i64* %97, i64 0 
   %99 = load  i64, i64* %98 
-  %100 = add   i64 %"seq#0", 8 
+  %100 = add   i64 %"seq##0", 8 
   %101 = inttoptr i64 %100 to i64* 
   %102 = getelementptr  i64, i64* %101, i64 0 
   %103 = load  i64, i64* %102 
-  %104 = add   i64 %"seq#0", 16 
+  %104 = add   i64 %"seq##0", 16 
   %105 = inttoptr i64 %104 to i64* 
   %106 = getelementptr  i64, i64* %105, i64 0 
   %107 = load  i64, i64* %106 
-  %"1$tmp$1#0" = icmp sle i64 %99, %107 
-  br i1 %"1$tmp$1#0", label %if.then, label %if.else 
+  %"1$tmp$1##0" = icmp sle i64 %99, %107 
+  br i1 %"1$tmp$1##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$0#0" = add   i64 %99, %103 
-  %108 = inttoptr i64 %"seq#0" to i64* 
+  %"2$tmp$0##0" = add   i64 %99, %103 
+  %108 = inttoptr i64 %"seq##0" to i64* 
   %109 = getelementptr  i64, i64* %108, i64 0 
-  store  i64 %"2$tmp$0#0", i64* %109 
-  %110 = insertvalue {i64, i64, i1} undef, i64 %"seq#0", 0 
+  store  i64 %"2$tmp$0##0", i64* %109 
+  %110 = insertvalue {i64, i64, i1} undef, i64 %"seq##0", 0 
   %111 = insertvalue {i64, i64, i1} %110, i64 %99, 1 
   %112 = insertvalue {i64, i64, i1} %111, i1 1, 2 
   ret {i64, i64, i1} %112 
 if.else:
-  %113 = insertvalue {i64, i64, i1} undef, i64 %"seq#0", 0 
+  %113 = insertvalue {i64, i64, i1} undef, i64 %"seq##0", 0 
   %114 = insertvalue {i64, i64, i1} %113, i64 %99, 1 
   %115 = insertvalue {i64, i64, i1} %114, i1 0, 2 
   ret {i64, i64, i1} %115 
 }
 
 
-define external fastcc  i64 @"test_loop.int_seq.step<0>"(i64  %"$rec#0")    {
+define external fastcc  i64 @"test_loop.int_seq.step<0>"(i64  %"$rec##0")    {
 entry:
-  %116 = add   i64 %"$rec#0", 8 
+  %116 = add   i64 %"$rec##0", 8 
   %117 = inttoptr i64 %116 to i64* 
   %118 = getelementptr  i64, i64* %117, i64 0 
   %119 = load  i64, i64* %118 
@@ -656,60 +656,60 @@ entry:
 }
 
 
-define external fastcc  i64 @"test_loop.int_seq.step<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  i64 @"test_loop.int_seq.step<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
   %120 = trunc i64 24 to i32  
   %121 = tail call ccc  i8*  @wybe_malloc(i32  %120)  
   %122 = ptrtoint i8* %121 to i64 
   %123 = inttoptr i64 %122 to i8* 
-  %124 = inttoptr i64 %"$rec#0" to i8* 
+  %124 = inttoptr i64 %"$rec##0" to i8* 
   %125 = trunc i64 24 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %123, i8*  %124, i32  %125, i32  8, i1  0)  
   %126 = add   i64 %122, 8 
   %127 = inttoptr i64 %126 to i64* 
   %128 = getelementptr  i64, i64* %127, i64 0 
-  store  i64 %"$field#0", i64* %128 
+  store  i64 %"$field##0", i64* %128 
   ret i64 %122 
 }
 
 
-define external fastcc  i1 @"test_loop.int_seq.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"test_loop.int_seq.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %129 = inttoptr i64 %"$left#0" to i64* 
+  %129 = inttoptr i64 %"$left##0" to i64* 
   %130 = getelementptr  i64, i64* %129, i64 0 
   %131 = load  i64, i64* %130 
-  %132 = add   i64 %"$left#0", 8 
+  %132 = add   i64 %"$left##0", 8 
   %133 = inttoptr i64 %132 to i64* 
   %134 = getelementptr  i64, i64* %133, i64 0 
   %135 = load  i64, i64* %134 
-  %136 = add   i64 %"$left#0", 16 
+  %136 = add   i64 %"$left##0", 16 
   %137 = inttoptr i64 %136 to i64* 
   %138 = getelementptr  i64, i64* %137, i64 0 
   %139 = load  i64, i64* %138 
-  %140 = inttoptr i64 %"$right#0" to i64* 
+  %140 = inttoptr i64 %"$right##0" to i64* 
   %141 = getelementptr  i64, i64* %140, i64 0 
   %142 = load  i64, i64* %141 
-  %143 = add   i64 %"$right#0", 8 
+  %143 = add   i64 %"$right##0", 8 
   %144 = inttoptr i64 %143 to i64* 
   %145 = getelementptr  i64, i64* %144, i64 0 
   %146 = load  i64, i64* %145 
-  %147 = add   i64 %"$right#0", 16 
+  %147 = add   i64 %"$right##0", 16 
   %148 = inttoptr i64 %147 to i64* 
   %149 = getelementptr  i64, i64* %148, i64 0 
   %150 = load  i64, i64* %149 
-  %"1$tmp$9#0" = icmp eq i64 %131, %142 
-  br i1 %"1$tmp$9#0", label %if.then, label %if.else 
+  %"1$tmp$9##0" = icmp eq i64 %131, %142 
+  br i1 %"1$tmp$9##0", label %if.then, label %if.else 
 if.then:
-  %"2$tmp$10#0" = icmp eq i64 %135, %146 
-  br i1 %"2$tmp$10#0", label %if.then1, label %if.else1 
+  %"2$tmp$10##0" = icmp eq i64 %135, %146 
+  br i1 %"2$tmp$10##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = xor i1 0, 1 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = xor i1 0, 1 
+  ret i1 %"3$$$##0" 
 if.then1:
-  %"4$tmp$0#0" = icmp eq i64 %139, %150 
-  %"4$$$#0" = xor i1 %"4$tmp$0#0", 1 
-  ret i1 %"4$$$#0" 
+  %"4$tmp$0##0" = icmp eq i64 %139, %150 
+  %"4$$$##0" = xor i1 %"4$tmp$0##0", 1 
+  ret i1 %"4$$$##0" 
 if.else1:
-  %"5$$$#0" = xor i1 0, 1 
-  ret i1 %"5$$$#0" 
+  %"5$$$##0" = xor i1 0, 1 
+  ret i1 %"5$$$##0" 
 }

--- a/test-cases/final-dump/test_loop.exp
+++ b/test-cases/final-dump/test_loop.exp
@@ -33,10 +33,10 @@ AFTER EVERYTHING:
 
 find_modulo > {inline} (3 calls)
 0: test_loop.find_modulo<0>
-find_modulo(seq##0:test_loop.int_seq, modulus##0:wybe.int, ?i##0:wybe.int, ?####0:wybe.bool):
+find_modulo(seq##0:test_loop.int_seq, modulus##0:wybe.int, ?i##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    test_loop.gen#1<0>(~modulus##0:wybe.int, ~seq##0:test_loop.int_seq, ?i##0:wybe.int, ?####0:wybe.bool) #0 @test_loop:nn:nn
+    test_loop.gen#1<0>(~modulus##0:wybe.int, ~seq##0:test_loop.int_seq, ?i##0:wybe.int, ?#success##0:wybe.bool) #0 @test_loop:nn:nn
 
 
 find_test > (2 calls)
@@ -67,14 +67,14 @@ find_test(modulus##0:wybe.int, io##0:wybe.phantom, ?io##4:wybe.phantom):
 
 gen#1 > (2 calls)
 0: test_loop.gen#1<0>[6dacb8fd25]
-gen#1(modulus##0:wybe.int, seq##0:test_loop.int_seq, ?i##1:wybe.int, ?####0:wybe.bool):
+gen#1(modulus##0:wybe.int, seq##0:test_loop.int_seq, ?i##1:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 1]
  MultiSpeczDepInfo: [(0,(test_loop.int_seq.seq_next<0>,fromList [NonAliasedParamCond 0 [1]])),(3,(test_loop.gen#1<0>,fromList [NonAliasedParamCond 1 [1]]))]
     test_loop.int_seq.seq_next<0>(~%seq##0:test_loop.int_seq, ?%seq##1:test_loop.int_seq, ?i##0:wybe.int, ?tmp#1##0:wybe.bool) #0 @test_loop:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~i##0:wybe.int, ?i##1:wybe.int)
 
     1:
@@ -82,10 +82,10 @@ gen#1(modulus##0:wybe.int, seq##0:test_loop.int_seq, ?i##1:wybe.int, ?####0:wybe
         foreign llvm icmp_eq(~tmp#0##0:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.bool) @int:nn:nn
         case ~tmp#2##0:wybe.bool of
         0:
-            test_loop.gen#1<0>(~modulus##0:wybe.int, ~seq##1:test_loop.int_seq, ?i##1:wybe.int, ?####0:wybe.bool) #3 @test_loop:nn:nn
+            test_loop.gen#1<0>(~modulus##0:wybe.int, ~seq##1:test_loop.int_seq, ?i##1:wybe.int, ?#success##0:wybe.bool) #3 @test_loop:nn:nn
 
         1:
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(~i##0:wybe.int, ?i##1:wybe.int)
 
 
@@ -93,7 +93,7 @@ gen#1(modulus##0:wybe.int, seq##0:test_loop.int_seq, ?i##1:wybe.int, ?####0:wybe
     test_loop.int_seq.seq_next<0>[410bae77d3](~%seq##0:test_loop.int_seq, ?%seq##1:test_loop.int_seq, ?i##0:wybe.int, ?tmp#1##0:wybe.bool) #0 @test_loop:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~i##0:wybe.int, ?i##1:wybe.int)
 
     1:
@@ -101,10 +101,10 @@ gen#1(modulus##0:wybe.int, seq##0:test_loop.int_seq, ?i##1:wybe.int, ?####0:wybe
         foreign llvm icmp_eq(~tmp#0##0:wybe.int, 0:wybe.int, ?tmp#2##0:wybe.bool) @int:nn:nn
         case ~tmp#2##0:wybe.bool of
         0:
-            test_loop.gen#1<0>[6dacb8fd25](~modulus##0:wybe.int, ~seq##1:test_loop.int_seq, ?i##1:wybe.int, ?####0:wybe.bool) #3 @test_loop:nn:nn
+            test_loop.gen#1<0>[6dacb8fd25](~modulus##0:wybe.int, ~seq##1:test_loop.int_seq, ?i##1:wybe.int, ?#success##0:wybe.bool) #3 @test_loop:nn:nn
 
         1:
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
             foreign llvm move(~i##0:wybe.int, ?i##1:wybe.int)
 
 
@@ -277,7 +277,7 @@ if.else1:
 
 = > public {inline} (1 calls)
 0: test_loop.int_seq.=<0>
-=(#left##0:test_loop.int_seq, #right##0:test_loop.int_seq, ?####0:wybe.bool):
+=(#left##0:test_loop.int_seq, #right##0:test_loop.int_seq, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?#left#low##0:wybe.int)
@@ -289,16 +289,16 @@ if.else1:
     foreign llvm icmp_eq(~#left#low##0:wybe.int, ~#right#low##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~#left#step##0:wybe.int, ~#right#step##0:wybe.int, ?tmp#2##0:wybe.bool) @int:nn:nn
         case ~tmp#2##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
-            foreign llvm icmp_eq(~#left#high##0:wybe.int, ~#right#high##0:wybe.int, ?####0:wybe.bool) @int:nn:nn
+            foreign llvm icmp_eq(~#left#high##0:wybe.int, ~#right#high##0:wybe.int, ?#success##0:wybe.bool) @int:nn:nn
 
 
 
@@ -352,7 +352,7 @@ low(#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, #field##0:wybe.int):
 
 seq_next > public (0 calls)
 0: test_loop.int_seq.seq_next<0>[410bae77d3]
-seq_next(seq##0:test_loop.int_seq, ?seq##1:test_loop.int_seq, ?elt##0:wybe.int, ?####0:wybe.bool):
+seq_next(seq##0:test_loop.int_seq, ?seq##1:test_loop.int_seq, ?elt##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: [(seq##0,seq##1)]
  InterestingCallProperties: [InterestingUnaliased 0]
     foreign lpvm access(seq##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?elt##0:wybe.int)
@@ -361,13 +361,13 @@ seq_next(seq##0:test_loop.int_seq, ?seq##1:test_loop.int_seq, ?elt##0:wybe.int, 
     foreign llvm icmp_sle(elt##0:wybe.int, ~limit##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~seq##0:test_loop.int_seq, ?seq##1:test_loop.int_seq)
 
     1:
         foreign llvm add(elt##0:wybe.int, ~step##0:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
         foreign lpvm {noalias} mutate(~%seq##0:test_loop.int_seq, ?%seq##1:test_loop.int_seq, 0:wybe.int, 0:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp#0##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
  [410bae77d3] [NonAliasedParam 0] :
     foreign lpvm access(seq##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?elt##0:wybe.int)
@@ -376,13 +376,13 @@ seq_next(seq##0:test_loop.int_seq, ?seq##1:test_loop.int_seq, ?elt##0:wybe.int, 
     foreign llvm icmp_sle(elt##0:wybe.int, ~limit##0:wybe.int, ?tmp#1##0:wybe.bool) @int:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~seq##0:test_loop.int_seq, ?seq##1:test_loop.int_seq)
 
     1:
         foreign llvm add(elt##0:wybe.int, ~step##0:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
         foreign lpvm {noalias} mutate(~%seq##0:test_loop.int_seq, ?%seq##1:test_loop.int_seq, 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~tmp#0##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -402,7 +402,7 @@ step(#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, #field##0:wybe.int):
 
 ~= > public {inline} (0 calls)
 0: test_loop.int_seq.~=<0>
-~=(#left##0:test_loop.int_seq, #right##0:test_loop.int_seq, ?####0:wybe.bool):
+~=(#left##0:test_loop.int_seq, #right##0:test_loop.int_seq, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm access(#left##0:test_loop.int_seq, 0:wybe.int, 24:wybe.int, 0:wybe.int, ?tmp#3##0:wybe.int)
@@ -415,18 +415,18 @@ step(#rec##0:test_loop.int_seq, ?#rec##1:test_loop.int_seq, #field##0:wybe.int):
     case ~tmp#9##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
     1:
         foreign llvm icmp_eq(~tmp#4##0:wybe.int, ~tmp#7##0:wybe.int, ?tmp#10##0:wybe.bool) @int:nn:nn
         case ~tmp#10##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?tmp#0##0:wybe.bool)
-            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign llvm icmp_eq(~tmp#5##0:wybe.int, ~tmp#8##0:wybe.int, ?tmp#0##0:wybe.bool) @int:nn:nn
-            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -476,8 +476,8 @@ if.then:
 if.else:
   ret i1 0 
 if.then1:
-  %"4#####0" = icmp eq i64 %11, %22 
-  ret i1 %"4#####0" 
+  %"4##success##0" = icmp eq i64 %11, %22 
+  ret i1 %"4##success##0" 
 if.else1:
   ret i1 0 
 }
@@ -703,13 +703,13 @@ if.then:
   %"2#tmp#10##0" = icmp eq i64 %135, %146 
   br i1 %"2#tmp#10##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = xor i1 0, 1 
-  ret i1 %"3#####0" 
+  %"3##success##0" = xor i1 0, 1 
+  ret i1 %"3##success##0" 
 if.then1:
   %"4#tmp#0##0" = icmp eq i64 %139, %150 
-  %"4#####0" = xor i1 %"4#tmp#0##0", 1 
-  ret i1 %"4#####0" 
+  %"4##success##0" = xor i1 %"4#tmp#0##0", 1 
+  ret i1 %"4##success##0" 
 if.else1:
-  %"5#####0" = xor i1 0, 1 
-  ret i1 %"5#####0" 
+  %"5##success##0" = xor i1 0, 1 
+  ret i1 %"5##success##0" 
 }

--- a/test-cases/final-dump/tests.exp
+++ b/test-cases/final-dump/tests.exp
@@ -29,50 +29,50 @@ AFTER EVERYTHING:
 
 lookup > public (6 calls)
 0: tests.lookup<0>
-lookup(key##0:wybe.int, map##0:tests.map, ?result##0:wybe.int, ?$$##0:wybe.bool):
+lookup(key##0:wybe.int, map##0:tests.map, ?result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(map##0:wybe.int, 0:wybe.int, ?tmp$15##0:wybe.bool)
-    case ~tmp$15##0:wybe.bool of
+    foreign llvm icmp_ne(map##0:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.bool)
+    case ~tmp#15##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?result##0:wybe.int)
 
     1:
-        foreign lpvm access(map##0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
-        foreign llvm icmp_eq(key##0:wybe.int, tmp$0##0:wybe.int, ?tmp$13##0:wybe.bool) @int:nn:nn
-        case ~tmp$13##0:wybe.bool of
+        foreign lpvm access(map##0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+        foreign llvm icmp_eq(key##0:wybe.int, tmp#0##0:wybe.int, ?tmp#13##0:wybe.bool) @int:nn:nn
+        case ~tmp#13##0:wybe.bool of
         0:
-            foreign llvm icmp_slt(key##0:wybe.int, ~tmp$0##0:wybe.int, ?tmp$11##0:wybe.bool) @int:nn:nn
-            case ~tmp$11##0:wybe.bool of
+            foreign llvm icmp_slt(key##0:wybe.int, ~tmp#0##0:wybe.int, ?tmp#11##0:wybe.bool) @int:nn:nn
+            case ~tmp#11##0:wybe.bool of
             0:
-                foreign lpvm access(~map##0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$4##0:tests.map)
-                tests.lookup<0>(~key##0:wybe.int, ~tmp$4##0:tests.map, ?result##0:wybe.int, ?$$##0:wybe.bool) #8 @tests:nn:nn
+                foreign lpvm access(~map##0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#4##0:tests.map)
+                tests.lookup<0>(~key##0:wybe.int, ~tmp#4##0:tests.map, ?result##0:wybe.int, ?####0:wybe.bool) #8 @tests:nn:nn
 
             1:
-                foreign lpvm access(~map##0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$3##0:tests.map)
-                tests.lookup<0>(~key##0:wybe.int, ~tmp$3##0:tests.map, ?result##0:wybe.int, ?$$##0:wybe.bool) #6 @tests:nn:nn
+                foreign lpvm access(~map##0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#3##0:tests.map)
+                tests.lookup<0>(~key##0:wybe.int, ~tmp#3##0:tests.map, ?result##0:wybe.int, ?####0:wybe.bool) #6 @tests:nn:nn
 
 
         1:
             foreign lpvm access(~map##0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?result##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 
 lt > public (1 calls)
 0: tests.lt<0>
-lt(x##0:wybe.int, y##0:wybe.int, ?$$##0:wybe.bool):
+lt(x##0:wybe.int, y##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_slt(~x##0:wybe.int, ~y##0:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
-    case ~tmp$3##0:wybe.bool of
+    foreign llvm icmp_slt(~x##0:wybe.int, ~y##0:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
+    case ~tmp#3##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
     1:
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
@@ -86,10 +86,10 @@ lt2(x##0:wybe.int, y##0:wybe.int, ?res##0:wybe.bool):
 
 lt3 > public {inline} (0 calls)
 0: tests.lt3<0>
-lt3(x##0:wybe.int, y##0:wybe.int, ?$$##0:wybe.bool):
+lt3(x##0:wybe.int, y##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    tests.lt<0>(~y##0:wybe.int, ~x##0:wybe.int, ?$$##0:wybe.bool) #1 @tests:nn:nn
+    tests.lt<0>(~y##0:wybe.int, ~x##0:wybe.int, ?####0:wybe.bool) #1 @tests:nn:nn
 
   LLVM code       :
 
@@ -107,15 +107,15 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  {i64, i1} @"tests.lookup<0>"(i64  %"key##0", i64  %"map##0")    {
 entry:
-  %"1$tmp$15##0" = icmp ne i64 %"map##0", 0 
-  br i1 %"1$tmp$15##0", label %if.then, label %if.else 
+  %"1#tmp#15##0" = icmp ne i64 %"map##0", 0 
+  br i1 %"1#tmp#15##0", label %if.then, label %if.else 
 if.then:
   %1 = add   i64 %"map##0", 8 
   %2 = inttoptr i64 %1 to i64* 
   %3 = getelementptr  i64, i64* %2, i64 0 
   %4 = load  i64, i64* %3 
-  %"2$tmp$13##0" = icmp eq i64 %"key##0", %4 
-  br i1 %"2$tmp$13##0", label %if.then1, label %if.else1 
+  %"2#tmp#13##0" = icmp eq i64 %"key##0", %4 
+  br i1 %"2#tmp#13##0", label %if.then1, label %if.else1 
 if.else:
   %28 = insertvalue {i64, i1} undef, i64 undef, 0 
   %29 = insertvalue {i64, i1} %28, i1 0, 1 
@@ -129,8 +129,8 @@ if.then1:
   %10 = insertvalue {i64, i1} %9, i1 1, 1 
   ret {i64, i1} %10 
 if.else1:
-  %"5$tmp$11##0" = icmp slt i64 %"key##0", %4 
-  br i1 %"5$tmp$11##0", label %if.then2, label %if.else2 
+  %"5#tmp#11##0" = icmp slt i64 %"key##0", %4 
+  br i1 %"5#tmp#11##0", label %if.then2, label %if.else2 
 if.then2:
   %11 = inttoptr i64 %"map##0" to i64* 
   %12 = getelementptr  i64, i64* %11, i64 0 
@@ -157,8 +157,8 @@ if.else2:
 
 define external fastcc  i1 @"tests.lt<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$tmp$3##0" = icmp slt i64 %"x##0", %"y##0" 
-  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
+  %"1#tmp#3##0" = icmp slt i64 %"x##0", %"y##0" 
+  br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
   ret i1 1 
 if.else:
@@ -168,15 +168,15 @@ if.else:
 
 define external fastcc  i1 @"tests.lt2<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$res##0" = tail call fastcc  i1  @"tests.lt<0>"(i64  %"x##0", i64  %"y##0")  
-  ret i1 %"1$res##0" 
+  %"1#res##0" = tail call fastcc  i1  @"tests.lt<0>"(i64  %"x##0", i64  %"y##0")  
+  ret i1 %"1#res##0" 
 }
 
 
 define external fastcc  i1 @"tests.lt3<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$$$##0" = tail call fastcc  i1  @"tests.lt<0>"(i64  %"y##0", i64  %"x##0")  
-  ret i1 %"1$$$##0" 
+  %"1#####0" = tail call fastcc  i1  @"tests.lt<0>"(i64  %"y##0", i64  %"x##0")  
+  ret i1 %"1#####0" 
 }
 --------------------------------------------------
  Module tests.map
@@ -203,48 +203,48 @@ entry:
 
 = > public (9 calls)
 0: tests.map.=<0>
-=($left##0:tests.map, $right##0:tests.map, ?$$##0:wybe.bool):
+=(#left##0:tests.map, #right##0:tests.map, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left##0:tests.map, ~$right##0:tests.map, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:tests.map, ~#right##0:tests.map, ?####0:wybe.bool)
 
     1:
-        foreign lpvm access($left##0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$left##0:tests.map)
-        foreign lpvm access($left##0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$key##0:wybe.int)
-        foreign lpvm access($left##0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$value##0:wybe.int)
-        foreign lpvm access(~$left##0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$right##0:tests.map)
-        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$11##0:wybe.bool)
-        case ~tmp$11##0:wybe.bool of
+        foreign lpvm access(#left##0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#left##0:tests.map)
+        foreign lpvm access(#left##0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#key##0:wybe.int)
+        foreign lpvm access(#left##0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#value##0:wybe.int)
+        foreign lpvm access(~#left##0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#right##0:tests.map)
+        foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#11##0:wybe.bool)
+        case ~tmp#11##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign lpvm access($right##0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$left##0:tests.map)
-            foreign lpvm access($right##0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$key##0:wybe.int)
-            foreign lpvm access($right##0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$value##0:wybe.int)
-            foreign lpvm access(~$right##0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$right##0:tests.map)
-            tests.map.=<0>(~$left$left##0:tests.map, ~$right$left##0:tests.map, ?tmp$4##0:wybe.bool) #2
-            case ~tmp$4##0:wybe.bool of
+            foreign lpvm access(#right##0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#left##0:tests.map)
+            foreign lpvm access(#right##0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#key##0:wybe.int)
+            foreign lpvm access(#right##0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#value##0:wybe.int)
+            foreign lpvm access(~#right##0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#right##0:tests.map)
+            tests.map.=<0>(~#left#left##0:tests.map, ~#right#left##0:tests.map, ?tmp#4##0:wybe.bool) #2
+            case ~tmp#4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
             1:
-                foreign llvm icmp_eq(~$left$key##0:wybe.int, ~$right$key##0:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
-                case ~tmp$5##0:wybe.bool of
+                foreign llvm icmp_eq(~#left#key##0:wybe.int, ~#right#key##0:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
+                case ~tmp#5##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                 1:
-                    foreign llvm icmp_eq(~$left$value##0:wybe.int, ~$right$value##0:wybe.int, ?tmp$6##0:wybe.bool) @int:nn:nn
-                    case ~tmp$6##0:wybe.bool of
+                    foreign llvm icmp_eq(~#left#value##0:wybe.int, ~#right#value##0:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
+                    case ~tmp#6##0:wybe.bool of
                     0:
-                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
                     1:
-                        tests.map.=<0>(~$left$right##0:tests.map, ~$right$right##0:tests.map, ?$$##0:wybe.bool) #5
+                        tests.map.=<0>(~#left#right##0:tests.map, ~#right#right##0:tests.map, ?####0:wybe.bool) #5
 
 
 
@@ -254,180 +254,180 @@ entry:
 
 empty > public {inline} (0 calls)
 0: tests.map.empty<0>
-empty(?$##0:tests.map):
+empty(?###0:tests.map):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:tests.map, ?$##0:tests.map)
+    foreign llvm move(0:tests.map, ?###0:tests.map)
 
 
 key > public {inline} (0 calls)
 0: tests.map.key<0>
-key($rec##0:tests.map, ?$##0:wybe.int, ?$$##0:wybe.bool):
+key(#rec##0:tests.map, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec##0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 key > public {inline} (0 calls)
 1: tests.map.key<1>
-key($rec##0:tests.map, ?$rec##1:tests.map, $field##0:wybe.int, ?$$##0:wybe.bool):
+key(#rec##0:tests.map, ?#rec##1:tests.map, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:tests.map, ?$rec##1:tests.map)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:tests.map, ?#rec##1:tests.map)
 
     1:
-        foreign lpvm mutate(~$rec##0:tests.map, ?$rec##1:tests.map, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~#rec##0:tests.map, ?#rec##1:tests.map, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 left > public {inline} (0 calls)
 0: tests.map.left<0>
-left($rec##0:tests.map, ?$##0:tests.map, ?$$##0:wybe.bool):
+left(#rec##0:tests.map, ?###0:tests.map, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:tests.map, ?$##0:tests.map)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:tests.map, ?###0:tests.map)
 
     1:
-        foreign lpvm access(~$rec##0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:tests.map)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:tests.map)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 left > public {inline} (0 calls)
 1: tests.map.left<1>
-left($rec##0:tests.map, ?$rec##1:tests.map, $field##0:tests.map, ?$$##0:wybe.bool):
+left(#rec##0:tests.map, ?#rec##1:tests.map, #field##0:tests.map, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:tests.map, ?$rec##1:tests.map)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:tests.map, ?#rec##1:tests.map)
 
     1:
-        foreign lpvm mutate(~$rec##0:tests.map, ?$rec##1:tests.map, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:tests.map)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~#rec##0:tests.map, ?#rec##1:tests.map, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:tests.map)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 node > public {inline} (0 calls)
 0: tests.map.node<0>
-node(left##0:tests.map, key##0:wybe.int, value##0:wybe.int, right##0:tests.map, ?$##0:tests.map):
+node(left##0:tests.map, key##0:wybe.int, value##0:wybe.int, right##0:tests.map, ?###0:tests.map):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(32:wybe.int, ?$rec##0:tests.map)
-    foreign lpvm mutate(~$rec##0:tests.map, ?$rec##1:tests.map, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~left##0:tests.map)
-    foreign lpvm mutate(~$rec##1:tests.map, ?$rec##2:tests.map, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~key##0:wybe.int)
-    foreign lpvm mutate(~$rec##2:tests.map, ?$rec##3:tests.map, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~value##0:wybe.int)
-    foreign lpvm mutate(~$rec##3:tests.map, ?$##0:tests.map, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~right##0:tests.map)
+    foreign lpvm alloc(32:wybe.int, ?#rec##0:tests.map)
+    foreign lpvm mutate(~#rec##0:tests.map, ?#rec##1:tests.map, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~left##0:tests.map)
+    foreign lpvm mutate(~#rec##1:tests.map, ?#rec##2:tests.map, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~key##0:wybe.int)
+    foreign lpvm mutate(~#rec##2:tests.map, ?#rec##3:tests.map, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~value##0:wybe.int)
+    foreign lpvm mutate(~#rec##3:tests.map, ?###0:tests.map, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~right##0:tests.map)
 node > public {inline} (20 calls)
 1: tests.map.node<1>
-node(?left##0:tests.map, ?key##0:wybe.int, ?value##0:wybe.int, ?right##0:tests.map, $##0:tests.map, ?$$##0:wybe.bool):
+node(?left##0:tests.map, ?key##0:wybe.int, ?value##0:wybe.int, ?right##0:tests.map, ###0:tests.map, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:tests.map, ?left##0:tests.map)
         foreign llvm move(undef:wybe.int, ?key##0:wybe.int)
         foreign llvm move(undef:wybe.int, ?value##0:wybe.int)
         foreign llvm move(undef:tests.map, ?right##0:tests.map)
 
     1:
-        foreign lpvm access($##0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?left##0:tests.map)
-        foreign lpvm access($##0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?key##0:wybe.int)
-        foreign lpvm access($##0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?value##0:wybe.int)
-        foreign lpvm access(~$##0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?right##0:tests.map)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(###0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?left##0:tests.map)
+        foreign lpvm access(###0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?key##0:wybe.int)
+        foreign lpvm access(###0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?value##0:wybe.int)
+        foreign lpvm access(~###0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?right##0:tests.map)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 right > public {inline} (0 calls)
 0: tests.map.right<0>
-right($rec##0:tests.map, ?$##0:tests.map, ?$$##0:wybe.bool):
+right(#rec##0:tests.map, ?###0:tests.map, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:tests.map, ?$##0:tests.map)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:tests.map, ?###0:tests.map)
 
     1:
-        foreign lpvm access(~$rec##0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:tests.map)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:tests.map)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 right > public {inline} (0 calls)
 1: tests.map.right<1>
-right($rec##0:tests.map, ?$rec##1:tests.map, $field##0:tests.map, ?$$##0:wybe.bool):
+right(#rec##0:tests.map, ?#rec##1:tests.map, #field##0:tests.map, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:tests.map, ?$rec##1:tests.map)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:tests.map, ?#rec##1:tests.map)
 
     1:
-        foreign lpvm mutate(~$rec##0:tests.map, ?$rec##1:tests.map, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:tests.map)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~#rec##0:tests.map, ?#rec##1:tests.map, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:tests.map)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 value > public {inline} (0 calls)
 0: tests.map.value<0>
-value($rec##0:tests.map, ?$##0:wybe.int, ?$$##0:wybe.bool):
+value(#rec##0:tests.map, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec##0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 value > public {inline} (0 calls)
 1: tests.map.value<1>
-value($rec##0:tests.map, ?$rec##1:tests.map, $field##0:wybe.int, ?$$##0:wybe.bool):
+value(#rec##0:tests.map, ?#rec##1:tests.map, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:tests.map, ?$rec##1:tests.map)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:tests.map, ?#rec##1:tests.map)
 
     1:
-        foreign lpvm mutate(~$rec##0:tests.map, ?$rec##1:tests.map, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~#rec##0:tests.map, ?#rec##1:tests.map, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: tests.map.~=<0>
-~=($left##0:tests.map, $right##0:tests.map, ?$$##0:wybe.bool):
+~=(#left##0:tests.map, #right##0:tests.map, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    tests.map.=<0>(~$left##0:tests.map, ~$right##0:tests.map, ?tmp$0##0:wybe.bool) #0
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    tests.map.=<0>(~#left##0:tests.map, ~#right##0:tests.map, ?tmp#0##0:wybe.bool) #0
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
   LLVM code       :
 
@@ -443,64 +443,64 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"tests.map.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"tests.map.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#left##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = add   i64 %"$left##0", 16 
+  %8 = add   i64 %"#left##0", 16 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
-  %12 = add   i64 %"$left##0", 24 
+  %12 = add   i64 %"#left##0", 24 
   %13 = inttoptr i64 %12 to i64* 
   %14 = getelementptr  i64, i64* %13, i64 0 
   %15 = load  i64, i64* %14 
-  %"2$tmp$11##0" = icmp ne i64 %"$right##0", 0 
-  br i1 %"2$tmp$11##0", label %if.then1, label %if.else1 
+  %"2#tmp#11##0" = icmp ne i64 %"#right##0", 0 
+  br i1 %"2#tmp#11##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3#####0" 
 if.then1:
-  %16 = inttoptr i64 %"$right##0" to i64* 
+  %16 = inttoptr i64 %"#right##0" to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
-  %19 = add   i64 %"$right##0", 8 
+  %19 = add   i64 %"#right##0", 8 
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %23 = add   i64 %"$right##0", 16 
+  %23 = add   i64 %"#right##0", 16 
   %24 = inttoptr i64 %23 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
   %26 = load  i64, i64* %25 
-  %27 = add   i64 %"$right##0", 24 
+  %27 = add   i64 %"#right##0", 24 
   %28 = inttoptr i64 %27 to i64* 
   %29 = getelementptr  i64, i64* %28, i64 0 
   %30 = load  i64, i64* %29 
-  %"4$tmp$4##0" = tail call fastcc  i1  @"tests.map.=<0>"(i64  %3, i64  %18)  
-  br i1 %"4$tmp$4##0", label %if.then2, label %if.else2 
+  %"4#tmp#4##0" = tail call fastcc  i1  @"tests.map.=<0>"(i64  %3, i64  %18)  
+  br i1 %"4#tmp#4##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$tmp$5##0" = icmp eq i64 %7, %22 
-  br i1 %"6$tmp$5##0", label %if.then3, label %if.else3 
+  %"6#tmp#5##0" = icmp eq i64 %7, %22 
+  br i1 %"6#tmp#5##0", label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %"8$tmp$6##0" = icmp eq i64 %11, %26 
-  br i1 %"8$tmp$6##0", label %if.then4, label %if.else4 
+  %"8#tmp#6##0" = icmp eq i64 %11, %26 
+  br i1 %"8#tmp#6##0", label %if.then4, label %if.else4 
 if.else3:
   ret i1 0 
 if.then4:
-  %"10$$$##0" = tail call fastcc  i1  @"tests.map.=<0>"(i64  %15, i64  %30)  
-  ret i1 %"10$$$##0" 
+  %"10#####0" = tail call fastcc  i1  @"tests.map.=<0>"(i64  %15, i64  %30)  
+  ret i1 %"10#####0" 
 if.else4:
   ret i1 0 
 }
@@ -512,12 +512,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"tests.map.key<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"tests.map.key<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %31 = add   i64 %"$rec##0", 8 
+  %31 = add   i64 %"#rec##0", 8 
   %32 = inttoptr i64 %31 to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
@@ -531,38 +531,38 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"tests.map.key<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"tests.map.key<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %39 = trunc i64 32 to i32  
   %40 = tail call ccc  i8*  @wybe_malloc(i32  %39)  
   %41 = ptrtoint i8* %40 to i64 
   %42 = inttoptr i64 %41 to i8* 
-  %43 = inttoptr i64 %"$rec##0" to i8* 
+  %43 = inttoptr i64 %"#rec##0" to i8* 
   %44 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %42, i8*  %43, i32  %44, i32  8, i1  0)  
   %45 = add   i64 %41, 8 
   %46 = inttoptr i64 %45 to i64* 
   %47 = getelementptr  i64, i64* %46, i64 0 
-  store  i64 %"$field##0", i64* %47 
+  store  i64 %"#field##0", i64* %47 
   %48 = insertvalue {i64, i1} undef, i64 %41, 0 
   %49 = insertvalue {i64, i1} %48, i1 1, 1 
   ret {i64, i1} %49 
 if.else:
-  %50 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %50 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %51 = insertvalue {i64, i1} %50, i1 0, 1 
   ret {i64, i1} %51 
 }
 
 
-define external fastcc  {i64, i1} @"tests.map.left<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"tests.map.left<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %52 = inttoptr i64 %"$rec##0" to i64* 
+  %52 = inttoptr i64 %"#rec##0" to i64* 
   %53 = getelementptr  i64, i64* %52, i64 0 
   %54 = load  i64, i64* %53 
   %55 = insertvalue {i64, i1} undef, i64 %54, 0 
@@ -575,26 +575,26 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"tests.map.left<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"tests.map.left<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %59 = trunc i64 32 to i32  
   %60 = tail call ccc  i8*  @wybe_malloc(i32  %59)  
   %61 = ptrtoint i8* %60 to i64 
   %62 = inttoptr i64 %61 to i8* 
-  %63 = inttoptr i64 %"$rec##0" to i8* 
+  %63 = inttoptr i64 %"#rec##0" to i8* 
   %64 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %62, i8*  %63, i32  %64, i32  8, i1  0)  
   %65 = inttoptr i64 %61 to i64* 
   %66 = getelementptr  i64, i64* %65, i64 0 
-  store  i64 %"$field##0", i64* %66 
+  store  i64 %"#field##0", i64* %66 
   %67 = insertvalue {i64, i1} undef, i64 %61, 0 
   %68 = insertvalue {i64, i1} %67, i1 1, 1 
   ret {i64, i1} %68 
 if.else:
-  %69 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %69 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %70 = insertvalue {i64, i1} %69, i1 0, 1 
   ret {i64, i1} %70 
 }
@@ -624,23 +624,23 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64, i64, i1} @"tests.map.node<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64, i64, i64, i1} @"tests.map.node<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %85 = inttoptr i64 %"$##0" to i64* 
+  %85 = inttoptr i64 %"###0" to i64* 
   %86 = getelementptr  i64, i64* %85, i64 0 
   %87 = load  i64, i64* %86 
-  %88 = add   i64 %"$##0", 8 
+  %88 = add   i64 %"###0", 8 
   %89 = inttoptr i64 %88 to i64* 
   %90 = getelementptr  i64, i64* %89, i64 0 
   %91 = load  i64, i64* %90 
-  %92 = add   i64 %"$##0", 16 
+  %92 = add   i64 %"###0", 16 
   %93 = inttoptr i64 %92 to i64* 
   %94 = getelementptr  i64, i64* %93, i64 0 
   %95 = load  i64, i64* %94 
-  %96 = add   i64 %"$##0", 24 
+  %96 = add   i64 %"###0", 24 
   %97 = inttoptr i64 %96 to i64* 
   %98 = getelementptr  i64, i64* %97, i64 0 
   %99 = load  i64, i64* %98 
@@ -660,12 +660,12 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"tests.map.right<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"tests.map.right<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %110 = add   i64 %"$rec##0", 24 
+  %110 = add   i64 %"#rec##0", 24 
   %111 = inttoptr i64 %110 to i64* 
   %112 = getelementptr  i64, i64* %111, i64 0 
   %113 = load  i64, i64* %112 
@@ -679,38 +679,38 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"tests.map.right<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"tests.map.right<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %118 = trunc i64 32 to i32  
   %119 = tail call ccc  i8*  @wybe_malloc(i32  %118)  
   %120 = ptrtoint i8* %119 to i64 
   %121 = inttoptr i64 %120 to i8* 
-  %122 = inttoptr i64 %"$rec##0" to i8* 
+  %122 = inttoptr i64 %"#rec##0" to i8* 
   %123 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %121, i8*  %122, i32  %123, i32  8, i1  0)  
   %124 = add   i64 %120, 24 
   %125 = inttoptr i64 %124 to i64* 
   %126 = getelementptr  i64, i64* %125, i64 0 
-  store  i64 %"$field##0", i64* %126 
+  store  i64 %"#field##0", i64* %126 
   %127 = insertvalue {i64, i1} undef, i64 %120, 0 
   %128 = insertvalue {i64, i1} %127, i1 1, 1 
   ret {i64, i1} %128 
 if.else:
-  %129 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %129 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %130 = insertvalue {i64, i1} %129, i1 0, 1 
   ret {i64, i1} %130 
 }
 
 
-define external fastcc  {i64, i1} @"tests.map.value<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"tests.map.value<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %131 = add   i64 %"$rec##0", 16 
+  %131 = add   i64 %"#rec##0", 16 
   %132 = inttoptr i64 %131 to i64* 
   %133 = getelementptr  i64, i64* %132, i64 0 
   %134 = load  i64, i64* %133 
@@ -724,35 +724,35 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"tests.map.value<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"tests.map.value<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %139 = trunc i64 32 to i32  
   %140 = tail call ccc  i8*  @wybe_malloc(i32  %139)  
   %141 = ptrtoint i8* %140 to i64 
   %142 = inttoptr i64 %141 to i8* 
-  %143 = inttoptr i64 %"$rec##0" to i8* 
+  %143 = inttoptr i64 %"#rec##0" to i8* 
   %144 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %142, i8*  %143, i32  %144, i32  8, i1  0)  
   %145 = add   i64 %141, 16 
   %146 = inttoptr i64 %145 to i64* 
   %147 = getelementptr  i64, i64* %146, i64 0 
-  store  i64 %"$field##0", i64* %147 
+  store  i64 %"#field##0", i64* %147 
   %148 = insertvalue {i64, i1} undef, i64 %141, 0 
   %149 = insertvalue {i64, i1} %148, i1 1, 1 
   ret {i64, i1} %149 
 if.else:
-  %150 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %150 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %151 = insertvalue {i64, i1} %150, i1 0, 1 
   ret {i64, i1} %151 
 }
 
 
-define external fastcc  i1 @"tests.map.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"tests.map.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = tail call fastcc  i1  @"tests.map.=<0>"(i64  %"$left##0", i64  %"$right##0")  
-  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
-  ret i1 %"1$$$##0" 
+  %"1#tmp#0##0" = tail call fastcc  i1  @"tests.map.=<0>"(i64  %"#left##0", i64  %"#right##0")  
+  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1#####0" 
 }

--- a/test-cases/final-dump/tests.exp
+++ b/test-cases/final-dump/tests.exp
@@ -254,25 +254,25 @@ entry:
 
 empty > public {inline} (0 calls)
 0: tests.map.empty<0>
-empty(?###0:tests.map):
+empty(?#result##0:tests.map):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:tests.map, ?###0:tests.map)
+    foreign llvm move(0:tests.map, ?#result##0:tests.map)
 
 
 key > public {inline} (0 calls)
 0: tests.map.key<0>
-key(#rec##0:tests.map, ?###0:wybe.int, ?####0:wybe.bool):
+key(#rec##0:tests.map, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign lpvm access(~#rec##0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 key > public {inline} (0 calls)
@@ -294,17 +294,17 @@ key(#rec##0:tests.map, ?#rec##1:tests.map, #field##0:wybe.int, ?####0:wybe.bool)
 
 left > public {inline} (0 calls)
 0: tests.map.left<0>
-left(#rec##0:tests.map, ?###0:tests.map, ?####0:wybe.bool):
+left(#rec##0:tests.map, ?#result##0:tests.map, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:tests.map, ?###0:tests.map)
+        foreign llvm move(undef:tests.map, ?#result##0:tests.map)
 
     1:
-        foreign lpvm access(~#rec##0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:tests.map)
+        foreign lpvm access(~#rec##0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:tests.map)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 left > public {inline} (0 calls)
@@ -326,20 +326,20 @@ left(#rec##0:tests.map, ?#rec##1:tests.map, #field##0:tests.map, ?####0:wybe.boo
 
 node > public {inline} (0 calls)
 0: tests.map.node<0>
-node(left##0:tests.map, key##0:wybe.int, value##0:wybe.int, right##0:tests.map, ?###0:tests.map):
+node(left##0:tests.map, key##0:wybe.int, value##0:wybe.int, right##0:tests.map, ?#result##0:tests.map):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(32:wybe.int, ?#rec##0:tests.map)
     foreign lpvm mutate(~#rec##0:tests.map, ?#rec##1:tests.map, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~left##0:tests.map)
     foreign lpvm mutate(~#rec##1:tests.map, ?#rec##2:tests.map, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~key##0:wybe.int)
     foreign lpvm mutate(~#rec##2:tests.map, ?#rec##3:tests.map, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~value##0:wybe.int)
-    foreign lpvm mutate(~#rec##3:tests.map, ?###0:tests.map, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~right##0:tests.map)
+    foreign lpvm mutate(~#rec##3:tests.map, ?#result##0:tests.map, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~right##0:tests.map)
 node > public {inline} (20 calls)
 1: tests.map.node<1>
-node(?left##0:tests.map, ?key##0:wybe.int, ?value##0:wybe.int, ?right##0:tests.map, ###0:tests.map, ?####0:wybe.bool):
+node(?left##0:tests.map, ?key##0:wybe.int, ?value##0:wybe.int, ?right##0:tests.map, #result##0:tests.map, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
@@ -349,27 +349,27 @@ node(?left##0:tests.map, ?key##0:wybe.int, ?value##0:wybe.int, ?right##0:tests.m
         foreign llvm move(undef:tests.map, ?right##0:tests.map)
 
     1:
-        foreign lpvm access(###0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?left##0:tests.map)
-        foreign lpvm access(###0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?key##0:wybe.int)
-        foreign lpvm access(###0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?value##0:wybe.int)
-        foreign lpvm access(~###0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?right##0:tests.map)
+        foreign lpvm access(#result##0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?left##0:tests.map)
+        foreign lpvm access(#result##0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?key##0:wybe.int)
+        foreign lpvm access(#result##0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?value##0:wybe.int)
+        foreign lpvm access(~#result##0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?right##0:tests.map)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 right > public {inline} (0 calls)
 0: tests.map.right<0>
-right(#rec##0:tests.map, ?###0:tests.map, ?####0:wybe.bool):
+right(#rec##0:tests.map, ?#result##0:tests.map, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:tests.map, ?###0:tests.map)
+        foreign llvm move(undef:tests.map, ?#result##0:tests.map)
 
     1:
-        foreign lpvm access(~#rec##0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:tests.map)
+        foreign lpvm access(~#rec##0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:tests.map)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 right > public {inline} (0 calls)
@@ -391,17 +391,17 @@ right(#rec##0:tests.map, ?#rec##1:tests.map, #field##0:tests.map, ?####0:wybe.bo
 
 value > public {inline} (0 calls)
 0: tests.map.value<0>
-value(#rec##0:tests.map, ?###0:wybe.int, ?####0:wybe.bool):
+value(#rec##0:tests.map, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign lpvm access(~#rec##0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 value > public {inline} (0 calls)
@@ -624,23 +624,23 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i64, i64, i1} @"tests.map.node<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64, i64, i64, i1} @"tests.map.node<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  %"1#tmp#0##0" = icmp ne i64 %"#result##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %85 = inttoptr i64 %"###0" to i64* 
+  %85 = inttoptr i64 %"#result##0" to i64* 
   %86 = getelementptr  i64, i64* %85, i64 0 
   %87 = load  i64, i64* %86 
-  %88 = add   i64 %"###0", 8 
+  %88 = add   i64 %"#result##0", 8 
   %89 = inttoptr i64 %88 to i64* 
   %90 = getelementptr  i64, i64* %89, i64 0 
   %91 = load  i64, i64* %90 
-  %92 = add   i64 %"###0", 16 
+  %92 = add   i64 %"#result##0", 16 
   %93 = inttoptr i64 %92 to i64* 
   %94 = getelementptr  i64, i64* %93, i64 0 
   %95 = load  i64, i64* %94 
-  %96 = add   i64 %"###0", 24 
+  %96 = add   i64 %"#result##0", 24 
   %97 = inttoptr i64 %96 to i64* 
   %98 = getelementptr  i64, i64* %97, i64 0 
   %99 = load  i64, i64* %98 

--- a/test-cases/final-dump/tests.exp
+++ b/test-cases/final-dump/tests.exp
@@ -29,13 +29,13 @@ AFTER EVERYTHING:
 
 lookup > public (6 calls)
 0: tests.lookup<0>
-lookup(key##0:wybe.int, map##0:tests.map, ?result##0:wybe.int, ?####0:wybe.bool):
+lookup(key##0:wybe.int, map##0:tests.map, ?result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(map##0:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.bool)
     case ~tmp#15##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?result##0:wybe.int)
 
     1:
@@ -47,32 +47,32 @@ lookup(key##0:wybe.int, map##0:tests.map, ?result##0:wybe.int, ?####0:wybe.bool)
             case ~tmp#11##0:wybe.bool of
             0:
                 foreign lpvm access(~map##0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#4##0:tests.map)
-                tests.lookup<0>(~key##0:wybe.int, ~tmp#4##0:tests.map, ?result##0:wybe.int, ?####0:wybe.bool) #8 @tests:nn:nn
+                tests.lookup<0>(~key##0:wybe.int, ~tmp#4##0:tests.map, ?result##0:wybe.int, ?#success##0:wybe.bool) #8 @tests:nn:nn
 
             1:
                 foreign lpvm access(~map##0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp#3##0:tests.map)
-                tests.lookup<0>(~key##0:wybe.int, ~tmp#3##0:tests.map, ?result##0:wybe.int, ?####0:wybe.bool) #6 @tests:nn:nn
+                tests.lookup<0>(~key##0:wybe.int, ~tmp#3##0:tests.map, ?result##0:wybe.int, ?#success##0:wybe.bool) #6 @tests:nn:nn
 
 
         1:
             foreign lpvm access(~map##0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?result##0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 
 lt > public (1 calls)
 0: tests.lt<0>
-lt(x##0:wybe.int, y##0:wybe.int, ?####0:wybe.bool):
+lt(x##0:wybe.int, y##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_slt(~x##0:wybe.int, ~y##0:wybe.int, ?tmp#3##0:wybe.bool) @int:nn:nn
     case ~tmp#3##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
     1:
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -86,10 +86,10 @@ lt2(x##0:wybe.int, y##0:wybe.int, ?res##0:wybe.bool):
 
 lt3 > public {inline} (0 calls)
 0: tests.lt3<0>
-lt3(x##0:wybe.int, y##0:wybe.int, ?####0:wybe.bool):
+lt3(x##0:wybe.int, y##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    tests.lt<0>(~y##0:wybe.int, ~x##0:wybe.int, ?####0:wybe.bool) #1 @tests:nn:nn
+    tests.lt<0>(~y##0:wybe.int, ~x##0:wybe.int, ?#success##0:wybe.bool) #1 @tests:nn:nn
 
   LLVM code       :
 
@@ -175,8 +175,8 @@ entry:
 
 define external fastcc  i1 @"tests.lt3<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1#####0" = tail call fastcc  i1  @"tests.lt<0>"(i64  %"y##0", i64  %"x##0")  
-  ret i1 %"1#####0" 
+  %"1##success##0" = tail call fastcc  i1  @"tests.lt<0>"(i64  %"y##0", i64  %"x##0")  
+  ret i1 %"1##success##0" 
 }
 --------------------------------------------------
  Module tests.map
@@ -203,13 +203,13 @@ entry:
 
 = > public (9 calls)
 0: tests.map.=<0>
-=(#left##0:tests.map, #right##0:tests.map, ?####0:wybe.bool):
+=(#left##0:tests.map, #right##0:tests.map, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~#left##0:tests.map, ~#right##0:tests.map, ?####0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:tests.map, ~#right##0:tests.map, ?#success##0:wybe.bool)
 
     1:
         foreign lpvm access(#left##0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#left#left##0:tests.map)
@@ -219,7 +219,7 @@ entry:
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#11##0:wybe.bool)
         case ~tmp#11##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign lpvm access(#right##0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#right#left##0:tests.map)
@@ -229,22 +229,22 @@ entry:
             tests.map.=<0>(~#left#left##0:tests.map, ~#right#left##0:tests.map, ?tmp#4##0:wybe.bool) #2
             case ~tmp#4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
                 foreign llvm icmp_eq(~#left#key##0:wybe.int, ~#right#key##0:wybe.int, ?tmp#5##0:wybe.bool) @int:nn:nn
                 case ~tmp#5##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                 1:
                     foreign llvm icmp_eq(~#left#value##0:wybe.int, ~#right#value##0:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
                     case ~tmp#6##0:wybe.bool of
                     0:
-                        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
                     1:
-                        tests.map.=<0>(~#left#right##0:tests.map, ~#right#right##0:tests.map, ?####0:wybe.bool) #5
+                        tests.map.=<0>(~#left#right##0:tests.map, ~#right#right##0:tests.map, ?#success##0:wybe.bool) #5
 
 
 
@@ -262,65 +262,65 @@ empty(?#result##0:tests.map):
 
 key > public {inline} (0 calls)
 0: tests.map.key<0>
-key(#rec##0:tests.map, ?#result##0:wybe.int, ?####0:wybe.bool):
+key(#rec##0:tests.map, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign lpvm access(~#rec##0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 key > public {inline} (0 calls)
 1: tests.map.key<1>
-key(#rec##0:tests.map, ?#rec##1:tests.map, #field##0:wybe.int, ?####0:wybe.bool):
+key(#rec##0:tests.map, ?#rec##1:tests.map, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:tests.map, ?#rec##1:tests.map)
 
     1:
         foreign lpvm mutate(~#rec##0:tests.map, ?#rec##1:tests.map, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 left > public {inline} (0 calls)
 0: tests.map.left<0>
-left(#rec##0:tests.map, ?#result##0:tests.map, ?####0:wybe.bool):
+left(#rec##0:tests.map, ?#result##0:tests.map, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:tests.map, ?#result##0:tests.map)
 
     1:
         foreign lpvm access(~#rec##0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:tests.map)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 left > public {inline} (0 calls)
 1: tests.map.left<1>
-left(#rec##0:tests.map, ?#rec##1:tests.map, #field##0:tests.map, ?####0:wybe.bool):
+left(#rec##0:tests.map, ?#rec##1:tests.map, #field##0:tests.map, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:tests.map, ?#rec##1:tests.map)
 
     1:
         foreign lpvm mutate(~#rec##0:tests.map, ?#rec##1:tests.map, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:tests.map)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -336,13 +336,13 @@ node(left##0:tests.map, key##0:wybe.int, value##0:wybe.int, right##0:tests.map, 
     foreign lpvm mutate(~#rec##3:tests.map, ?#result##0:tests.map, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~right##0:tests.map)
 node > public {inline} (20 calls)
 1: tests.map.node<1>
-node(?left##0:tests.map, ?key##0:wybe.int, ?value##0:wybe.int, ?right##0:tests.map, #result##0:tests.map, ?####0:wybe.bool):
+node(?left##0:tests.map, ?key##0:wybe.int, ?value##0:wybe.int, ?right##0:tests.map, #result##0:tests.map, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:tests.map, ?left##0:tests.map)
         foreign llvm move(undef:wybe.int, ?key##0:wybe.int)
         foreign llvm move(undef:wybe.int, ?value##0:wybe.int)
@@ -353,81 +353,81 @@ node(?left##0:tests.map, ?key##0:wybe.int, ?value##0:wybe.int, ?right##0:tests.m
         foreign lpvm access(#result##0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?key##0:wybe.int)
         foreign lpvm access(#result##0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?value##0:wybe.int)
         foreign lpvm access(~#result##0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?right##0:tests.map)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 right > public {inline} (0 calls)
 0: tests.map.right<0>
-right(#rec##0:tests.map, ?#result##0:tests.map, ?####0:wybe.bool):
+right(#rec##0:tests.map, ?#result##0:tests.map, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:tests.map, ?#result##0:tests.map)
 
     1:
         foreign lpvm access(~#rec##0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:tests.map)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 right > public {inline} (0 calls)
 1: tests.map.right<1>
-right(#rec##0:tests.map, ?#rec##1:tests.map, #field##0:tests.map, ?####0:wybe.bool):
+right(#rec##0:tests.map, ?#rec##1:tests.map, #field##0:tests.map, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:tests.map, ?#rec##1:tests.map)
 
     1:
         foreign lpvm mutate(~#rec##0:tests.map, ?#rec##1:tests.map, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:tests.map)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 value > public {inline} (0 calls)
 0: tests.map.value<0>
-value(#rec##0:tests.map, ?#result##0:wybe.int, ?####0:wybe.bool):
+value(#rec##0:tests.map, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign lpvm access(~#rec##0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 value > public {inline} (0 calls)
 1: tests.map.value<1>
-value(#rec##0:tests.map, ?#rec##1:tests.map, #field##0:wybe.int, ?####0:wybe.bool):
+value(#rec##0:tests.map, ?#rec##1:tests.map, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:tests.map, ?#rec##1:tests.map)
 
     1:
         foreign lpvm mutate(~#rec##0:tests.map, ?#rec##1:tests.map, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: tests.map.~=<0>
-~=(#left##0:tests.map, #right##0:tests.map, ?####0:wybe.bool):
+~=(#left##0:tests.map, #right##0:tests.map, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     tests.map.=<0>(~#left##0:tests.map, ~#right##0:tests.map, ?tmp#0##0:wybe.bool) #0
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 
@@ -466,8 +466,8 @@ if.then:
   %"2#tmp#11##0" = icmp ne i64 %"#right##0", 0 
   br i1 %"2#tmp#11##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %"3#####0" 
+  %"3##success##0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3##success##0" 
 if.then1:
   %16 = inttoptr i64 %"#right##0" to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
@@ -499,8 +499,8 @@ if.then3:
 if.else3:
   ret i1 0 
 if.then4:
-  %"10#####0" = tail call fastcc  i1  @"tests.map.=<0>"(i64  %15, i64  %30)  
-  ret i1 %"10#####0" 
+  %"10##success##0" = tail call fastcc  i1  @"tests.map.=<0>"(i64  %15, i64  %30)  
+  ret i1 %"10##success##0" 
 if.else4:
   ret i1 0 
 }
@@ -753,6 +753,6 @@ if.else:
 define external fastcc  i1 @"tests.map.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %"1#tmp#0##0" = tail call fastcc  i1  @"tests.map.=<0>"(i64  %"#left##0", i64  %"#right##0")  
-  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
-  ret i1 %"1#####0" 
+  %"1##success##0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1##success##0" 
 }

--- a/test-cases/final-dump/tests.exp
+++ b/test-cases/final-dump/tests.exp
@@ -29,67 +29,67 @@ AFTER EVERYTHING:
 
 lookup > public (6 calls)
 0: tests.lookup<0>
-lookup(key#0:wybe.int, map#0:tests.map, ?result#0:wybe.int, ?$$#0:wybe.bool):
+lookup(key##0:wybe.int, map##0:tests.map, ?result##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(map#0:wybe.int, 0:wybe.int, ?tmp$15#0:wybe.bool)
-    case ~tmp$15#0:wybe.bool of
+    foreign llvm icmp_ne(map##0:wybe.int, 0:wybe.int, ?tmp$15##0:wybe.bool)
+    case ~tmp$15##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?result#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?result##0:wybe.int)
 
     1:
-        foreign lpvm access(map#0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.int)
-        foreign llvm icmp_eq(key#0:wybe.int, tmp$0#0:wybe.int, ?tmp$13#0:wybe.bool) @int:nn:nn
-        case ~tmp$13#0:wybe.bool of
+        foreign lpvm access(map##0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.int)
+        foreign llvm icmp_eq(key##0:wybe.int, tmp$0##0:wybe.int, ?tmp$13##0:wybe.bool) @int:nn:nn
+        case ~tmp$13##0:wybe.bool of
         0:
-            foreign llvm icmp_slt(key#0:wybe.int, ~tmp$0#0:wybe.int, ?tmp$11#0:wybe.bool) @int:nn:nn
-            case ~tmp$11#0:wybe.bool of
+            foreign llvm icmp_slt(key##0:wybe.int, ~tmp$0##0:wybe.int, ?tmp$11##0:wybe.bool) @int:nn:nn
+            case ~tmp$11##0:wybe.bool of
             0:
-                foreign lpvm access(~map#0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$4#0:tests.map)
-                tests.lookup<0>(~key#0:wybe.int, ~tmp$4#0:tests.map, ?result#0:wybe.int, ?$$#0:wybe.bool) #8 @tests:nn:nn
+                foreign lpvm access(~map##0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$4##0:tests.map)
+                tests.lookup<0>(~key##0:wybe.int, ~tmp$4##0:tests.map, ?result##0:wybe.int, ?$$##0:wybe.bool) #8 @tests:nn:nn
 
             1:
-                foreign lpvm access(~map#0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$3#0:tests.map)
-                tests.lookup<0>(~key#0:wybe.int, ~tmp$3#0:tests.map, ?result#0:wybe.int, ?$$#0:wybe.bool) #6 @tests:nn:nn
+                foreign lpvm access(~map##0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?tmp$3##0:tests.map)
+                tests.lookup<0>(~key##0:wybe.int, ~tmp$3##0:tests.map, ?result##0:wybe.int, ?$$##0:wybe.bool) #6 @tests:nn:nn
 
 
         1:
-            foreign lpvm access(~map#0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?result#0:wybe.int)
-            foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+            foreign lpvm access(~map##0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?result##0:wybe.int)
+            foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 
 lt > public (1 calls)
 0: tests.lt<0>
-lt(x#0:wybe.int, y#0:wybe.int, ?$$#0:wybe.bool):
+lt(x##0:wybe.int, y##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_slt(~x#0:wybe.int, ~y#0:wybe.int, ?tmp$3#0:wybe.bool) @int:nn:nn
-    case ~tmp$3#0:wybe.bool of
+    foreign llvm icmp_slt(~x##0:wybe.int, ~y##0:wybe.int, ?tmp$3##0:wybe.bool) @int:nn:nn
+    case ~tmp$3##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
     1:
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 lt2 > public {inline} (1 calls)
 0: tests.lt2<0>
-lt2(x#0:wybe.int, y#0:wybe.int, ?res#0:wybe.bool):
+lt2(x##0:wybe.int, y##0:wybe.int, ?res##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    tests.lt<0>(~x#0:wybe.int, ~y#0:wybe.int, ?res#0:wybe.bool) #0 @tests:nn:nn
+    tests.lt<0>(~x##0:wybe.int, ~y##0:wybe.int, ?res##0:wybe.bool) #0 @tests:nn:nn
 
 
 lt3 > public {inline} (0 calls)
 0: tests.lt3<0>
-lt3(x#0:wybe.int, y#0:wybe.int, ?$$#0:wybe.bool):
+lt3(x##0:wybe.int, y##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    tests.lt<0>(~y#0:wybe.int, ~x#0:wybe.int, ?$$#0:wybe.bool) #1 @tests:nn:nn
+    tests.lt<0>(~y##0:wybe.int, ~x##0:wybe.int, ?$$##0:wybe.bool) #1 @tests:nn:nn
 
   LLVM code       :
 
@@ -105,23 +105,23 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  {i64, i1} @"tests.lookup<0>"(i64  %"key#0", i64  %"map#0")    {
+define external fastcc  {i64, i1} @"tests.lookup<0>"(i64  %"key##0", i64  %"map##0")    {
 entry:
-  %"1$tmp$15#0" = icmp ne i64 %"map#0", 0 
-  br i1 %"1$tmp$15#0", label %if.then, label %if.else 
+  %"1$tmp$15##0" = icmp ne i64 %"map##0", 0 
+  br i1 %"1$tmp$15##0", label %if.then, label %if.else 
 if.then:
-  %1 = add   i64 %"map#0", 8 
+  %1 = add   i64 %"map##0", 8 
   %2 = inttoptr i64 %1 to i64* 
   %3 = getelementptr  i64, i64* %2, i64 0 
   %4 = load  i64, i64* %3 
-  %"2$tmp$13#0" = icmp eq i64 %"key#0", %4 
-  br i1 %"2$tmp$13#0", label %if.then1, label %if.else1 
+  %"2$tmp$13##0" = icmp eq i64 %"key##0", %4 
+  br i1 %"2$tmp$13##0", label %if.then1, label %if.else1 
 if.else:
   %28 = insertvalue {i64, i1} undef, i64 undef, 0 
   %29 = insertvalue {i64, i1} %28, i1 0, 1 
   ret {i64, i1} %29 
 if.then1:
-  %5 = add   i64 %"map#0", 16 
+  %5 = add   i64 %"map##0", 16 
   %6 = inttoptr i64 %5 to i64* 
   %7 = getelementptr  i64, i64* %6, i64 0 
   %8 = load  i64, i64* %7 
@@ -129,24 +129,24 @@ if.then1:
   %10 = insertvalue {i64, i1} %9, i1 1, 1 
   ret {i64, i1} %10 
 if.else1:
-  %"5$tmp$11#0" = icmp slt i64 %"key#0", %4 
-  br i1 %"5$tmp$11#0", label %if.then2, label %if.else2 
+  %"5$tmp$11##0" = icmp slt i64 %"key##0", %4 
+  br i1 %"5$tmp$11##0", label %if.then2, label %if.else2 
 if.then2:
-  %11 = inttoptr i64 %"map#0" to i64* 
+  %11 = inttoptr i64 %"map##0" to i64* 
   %12 = getelementptr  i64, i64* %11, i64 0 
   %13 = load  i64, i64* %12 
-  %14 = tail call fastcc  {i64, i1}  @"tests.lookup<0>"(i64  %"key#0", i64  %13)  
+  %14 = tail call fastcc  {i64, i1}  @"tests.lookup<0>"(i64  %"key##0", i64  %13)  
   %15 = extractvalue {i64, i1} %14, 0 
   %16 = extractvalue {i64, i1} %14, 1 
   %17 = insertvalue {i64, i1} undef, i64 %15, 0 
   %18 = insertvalue {i64, i1} %17, i1 %16, 1 
   ret {i64, i1} %18 
 if.else2:
-  %19 = add   i64 %"map#0", 24 
+  %19 = add   i64 %"map##0", 24 
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %23 = tail call fastcc  {i64, i1}  @"tests.lookup<0>"(i64  %"key#0", i64  %22)  
+  %23 = tail call fastcc  {i64, i1}  @"tests.lookup<0>"(i64  %"key##0", i64  %22)  
   %24 = extractvalue {i64, i1} %23, 0 
   %25 = extractvalue {i64, i1} %23, 1 
   %26 = insertvalue {i64, i1} undef, i64 %24, 0 
@@ -155,10 +155,10 @@ if.else2:
 }
 
 
-define external fastcc  i1 @"tests.lt<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i1 @"tests.lt<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$tmp$3#0" = icmp slt i64 %"x#0", %"y#0" 
-  br i1 %"1$tmp$3#0", label %if.then, label %if.else 
+  %"1$tmp$3##0" = icmp slt i64 %"x##0", %"y##0" 
+  br i1 %"1$tmp$3##0", label %if.then, label %if.else 
 if.then:
   ret i1 1 
 if.else:
@@ -166,17 +166,17 @@ if.else:
 }
 
 
-define external fastcc  i1 @"tests.lt2<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i1 @"tests.lt2<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$res#0" = tail call fastcc  i1  @"tests.lt<0>"(i64  %"x#0", i64  %"y#0")  
-  ret i1 %"1$res#0" 
+  %"1$res##0" = tail call fastcc  i1  @"tests.lt<0>"(i64  %"x##0", i64  %"y##0")  
+  ret i1 %"1$res##0" 
 }
 
 
-define external fastcc  i1 @"tests.lt3<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i1 @"tests.lt3<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$$$#0" = tail call fastcc  i1  @"tests.lt<0>"(i64  %"y#0", i64  %"x#0")  
-  ret i1 %"1$$$#0" 
+  %"1$$$##0" = tail call fastcc  i1  @"tests.lt<0>"(i64  %"y##0", i64  %"x##0")  
+  ret i1 %"1$$$##0" 
 }
 --------------------------------------------------
  Module tests.map
@@ -203,48 +203,48 @@ entry:
 
 = > public (9 calls)
 0: tests.map.=<0>
-=($left#0:tests.map, $right#0:tests.map, ?$$#0:wybe.bool):
+=($left##0:tests.map, $right##0:tests.map, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left#0:tests.map, ~$right#0:tests.map, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~$left##0:tests.map, ~$right##0:tests.map, ?$$##0:wybe.bool)
 
     1:
-        foreign lpvm access($left#0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$left#0:tests.map)
-        foreign lpvm access($left#0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$key#0:wybe.int)
-        foreign lpvm access($left#0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$value#0:wybe.int)
-        foreign lpvm access(~$left#0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$right#0:tests.map)
-        foreign llvm icmp_ne($right#0:wybe.int, 0:wybe.int, ?tmp$11#0:wybe.bool)
-        case ~tmp$11#0:wybe.bool of
+        foreign lpvm access($left##0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$left##0:tests.map)
+        foreign lpvm access($left##0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$key##0:wybe.int)
+        foreign lpvm access($left##0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$value##0:wybe.int)
+        foreign lpvm access(~$left##0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$left$right##0:tests.map)
+        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$11##0:wybe.bool)
+        case ~tmp$11##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign lpvm access($right#0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$left#0:tests.map)
-            foreign lpvm access($right#0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$key#0:wybe.int)
-            foreign lpvm access($right#0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$value#0:wybe.int)
-            foreign lpvm access(~$right#0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$right#0:tests.map)
-            tests.map.=<0>(~$left$left#0:tests.map, ~$right$left#0:tests.map, ?tmp$4#0:wybe.bool) #2
-            case ~tmp$4#0:wybe.bool of
+            foreign lpvm access($right##0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$left##0:tests.map)
+            foreign lpvm access($right##0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$key##0:wybe.int)
+            foreign lpvm access($right##0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$value##0:wybe.int)
+            foreign lpvm access(~$right##0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$right$right##0:tests.map)
+            tests.map.=<0>(~$left$left##0:tests.map, ~$right$left##0:tests.map, ?tmp$4##0:wybe.bool) #2
+            case ~tmp$4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                foreign llvm icmp_eq(~$left$key#0:wybe.int, ~$right$key#0:wybe.int, ?tmp$5#0:wybe.bool) @int:nn:nn
-                case ~tmp$5#0:wybe.bool of
+                foreign llvm icmp_eq(~$left$key##0:wybe.int, ~$right$key##0:wybe.int, ?tmp$5##0:wybe.bool) @int:nn:nn
+                case ~tmp$5##0:wybe.bool of
                 0:
-                    foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                    foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                 1:
-                    foreign llvm icmp_eq(~$left$value#0:wybe.int, ~$right$value#0:wybe.int, ?tmp$6#0:wybe.bool) @int:nn:nn
-                    case ~tmp$6#0:wybe.bool of
+                    foreign llvm icmp_eq(~$left$value##0:wybe.int, ~$right$value##0:wybe.int, ?tmp$6##0:wybe.bool) @int:nn:nn
+                    case ~tmp$6##0:wybe.bool of
                     0:
-                        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
                     1:
-                        tests.map.=<0>(~$left$right#0:tests.map, ~$right$right#0:tests.map, ?$$#0:wybe.bool) #5
+                        tests.map.=<0>(~$left$right##0:tests.map, ~$right$right##0:tests.map, ?$$##0:wybe.bool) #5
 
 
 
@@ -254,180 +254,180 @@ entry:
 
 empty > public {inline} (0 calls)
 0: tests.map.empty<0>
-empty(?$#0:tests.map):
+empty(?$##0:tests.map):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:tests.map, ?$#0:tests.map)
+    foreign llvm move(0:tests.map, ?$##0:tests.map)
 
 
 key > public {inline} (0 calls)
 0: tests.map.key<0>
-key($rec#0:tests.map, ?$#0:wybe.int, ?$$#0:wybe.bool):
+key($rec##0:tests.map, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec#0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 key > public {inline} (0 calls)
 1: tests.map.key<1>
-key($rec#0:tests.map, ?$rec#1:tests.map, $field#0:wybe.int, ?$$#0:wybe.bool):
+key($rec##0:tests.map, ?$rec##1:tests.map, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:tests.map, ?$rec#1:tests.map)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:tests.map, ?$rec##1:tests.map)
 
     1:
-        foreign lpvm mutate(~$rec#0:tests.map, ?$rec#1:tests.map, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~$rec##0:tests.map, ?$rec##1:tests.map, 8:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 left > public {inline} (0 calls)
 0: tests.map.left<0>
-left($rec#0:tests.map, ?$#0:tests.map, ?$$#0:wybe.bool):
+left($rec##0:tests.map, ?$##0:tests.map, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:tests.map, ?$#0:tests.map)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:tests.map, ?$##0:tests.map)
 
     1:
-        foreign lpvm access(~$rec#0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$#0:tests.map)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:tests.map)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 left > public {inline} (0 calls)
 1: tests.map.left<1>
-left($rec#0:tests.map, ?$rec#1:tests.map, $field#0:tests.map, ?$$#0:wybe.bool):
+left($rec##0:tests.map, ?$rec##1:tests.map, $field##0:tests.map, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:tests.map, ?$rec#1:tests.map)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:tests.map, ?$rec##1:tests.map)
 
     1:
-        foreign lpvm mutate(~$rec#0:tests.map, ?$rec#1:tests.map, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field#0:tests.map)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~$rec##0:tests.map, ?$rec##1:tests.map, 0:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:tests.map)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 node > public {inline} (0 calls)
 0: tests.map.node<0>
-node(left#0:tests.map, key#0:wybe.int, value#0:wybe.int, right#0:tests.map, ?$#0:tests.map):
+node(left##0:tests.map, key##0:wybe.int, value##0:wybe.int, right##0:tests.map, ?$##0:tests.map):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(32:wybe.int, ?$rec#0:tests.map)
-    foreign lpvm mutate(~$rec#0:tests.map, ?$rec#1:tests.map, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~left#0:tests.map)
-    foreign lpvm mutate(~$rec#1:tests.map, ?$rec#2:tests.map, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~key#0:wybe.int)
-    foreign lpvm mutate(~$rec#2:tests.map, ?$rec#3:tests.map, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~value#0:wybe.int)
-    foreign lpvm mutate(~$rec#3:tests.map, ?$#0:tests.map, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~right#0:tests.map)
+    foreign lpvm alloc(32:wybe.int, ?$rec##0:tests.map)
+    foreign lpvm mutate(~$rec##0:tests.map, ?$rec##1:tests.map, 0:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~left##0:tests.map)
+    foreign lpvm mutate(~$rec##1:tests.map, ?$rec##2:tests.map, 8:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~key##0:wybe.int)
+    foreign lpvm mutate(~$rec##2:tests.map, ?$rec##3:tests.map, 16:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~value##0:wybe.int)
+    foreign lpvm mutate(~$rec##3:tests.map, ?$##0:tests.map, 24:wybe.int, 1:wybe.int, 32:wybe.int, 0:wybe.int, ~right##0:tests.map)
 node > public {inline} (20 calls)
 1: tests.map.node<1>
-node(?left#0:tests.map, ?key#0:wybe.int, ?value#0:wybe.int, ?right#0:tests.map, $#0:tests.map, ?$$#0:wybe.bool):
+node(?left##0:tests.map, ?key##0:wybe.int, ?value##0:wybe.int, ?right##0:tests.map, $##0:tests.map, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:tests.map, ?left#0:tests.map)
-        foreign llvm move(undef:wybe.int, ?key#0:wybe.int)
-        foreign llvm move(undef:wybe.int, ?value#0:wybe.int)
-        foreign llvm move(undef:tests.map, ?right#0:tests.map)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:tests.map, ?left##0:tests.map)
+        foreign llvm move(undef:wybe.int, ?key##0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?value##0:wybe.int)
+        foreign llvm move(undef:tests.map, ?right##0:tests.map)
 
     1:
-        foreign lpvm access($#0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?left#0:tests.map)
-        foreign lpvm access($#0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?key#0:wybe.int)
-        foreign lpvm access($#0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?value#0:wybe.int)
-        foreign lpvm access(~$#0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?right#0:tests.map)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access($##0:tests.map, 0:wybe.int, 32:wybe.int, 0:wybe.int, ?left##0:tests.map)
+        foreign lpvm access($##0:tests.map, 8:wybe.int, 32:wybe.int, 0:wybe.int, ?key##0:wybe.int)
+        foreign lpvm access($##0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?value##0:wybe.int)
+        foreign lpvm access(~$##0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?right##0:tests.map)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 right > public {inline} (0 calls)
 0: tests.map.right<0>
-right($rec#0:tests.map, ?$#0:tests.map, ?$$#0:wybe.bool):
+right($rec##0:tests.map, ?$##0:tests.map, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:tests.map, ?$#0:tests.map)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:tests.map, ?$##0:tests.map)
 
     1:
-        foreign lpvm access(~$rec#0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$#0:tests.map)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:tests.map, 24:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:tests.map)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 right > public {inline} (0 calls)
 1: tests.map.right<1>
-right($rec#0:tests.map, ?$rec#1:tests.map, $field#0:tests.map, ?$$#0:wybe.bool):
+right($rec##0:tests.map, ?$rec##1:tests.map, $field##0:tests.map, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:tests.map, ?$rec#1:tests.map)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:tests.map, ?$rec##1:tests.map)
 
     1:
-        foreign lpvm mutate(~$rec#0:tests.map, ?$rec#1:tests.map, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field#0:tests.map)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~$rec##0:tests.map, ?$rec##1:tests.map, 24:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:tests.map)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 value > public {inline} (0 calls)
 0: tests.map.value<0>
-value($rec#0:tests.map, ?$#0:wybe.int, ?$$#0:wybe.bool):
+value($rec##0:tests.map, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec#0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:tests.map, 16:wybe.int, 32:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 value > public {inline} (0 calls)
 1: tests.map.value<1>
-value($rec#0:tests.map, ?$rec#1:tests.map, $field#0:wybe.int, ?$$#0:wybe.bool):
+value($rec##0:tests.map, ?$rec##1:tests.map, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:tests.map, ?$rec#1:tests.map)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:tests.map, ?$rec##1:tests.map)
 
     1:
-        foreign lpvm mutate(~$rec#0:tests.map, ?$rec#1:tests.map, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~$rec##0:tests.map, ?$rec##1:tests.map, 16:wybe.int, 0:wybe.int, 32:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: tests.map.~=<0>
-~=($left#0:tests.map, $right#0:tests.map, ?$$#0:wybe.bool):
+~=($left##0:tests.map, $right##0:tests.map, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    tests.map.=<0>(~$left#0:tests.map, ~$right#0:tests.map, ?tmp$0#0:wybe.bool) #0
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    tests.map.=<0>(~$left##0:tests.map, ~$right##0:tests.map, ?tmp$0##0:wybe.bool) #0
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
   LLVM code       :
 
@@ -443,64 +443,64 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"tests.map.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"tests.map.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$left#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %8 = add   i64 %"$left#0", 16 
+  %8 = add   i64 %"$left##0", 16 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   %11 = load  i64, i64* %10 
-  %12 = add   i64 %"$left#0", 24 
+  %12 = add   i64 %"$left##0", 24 
   %13 = inttoptr i64 %12 to i64* 
   %14 = getelementptr  i64, i64* %13, i64 0 
   %15 = load  i64, i64* %14 
-  %"2$tmp$11#0" = icmp ne i64 %"$right#0", 0 
-  br i1 %"2$tmp$11#0", label %if.then1, label %if.else1 
+  %"2$tmp$11##0" = icmp ne i64 %"$right##0", 0 
+  br i1 %"2$tmp$11##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = icmp eq i64 %"$left#0", %"$right#0" 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
+  ret i1 %"3$$$##0" 
 if.then1:
-  %16 = inttoptr i64 %"$right#0" to i64* 
+  %16 = inttoptr i64 %"$right##0" to i64* 
   %17 = getelementptr  i64, i64* %16, i64 0 
   %18 = load  i64, i64* %17 
-  %19 = add   i64 %"$right#0", 8 
+  %19 = add   i64 %"$right##0", 8 
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   %22 = load  i64, i64* %21 
-  %23 = add   i64 %"$right#0", 16 
+  %23 = add   i64 %"$right##0", 16 
   %24 = inttoptr i64 %23 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
   %26 = load  i64, i64* %25 
-  %27 = add   i64 %"$right#0", 24 
+  %27 = add   i64 %"$right##0", 24 
   %28 = inttoptr i64 %27 to i64* 
   %29 = getelementptr  i64, i64* %28, i64 0 
   %30 = load  i64, i64* %29 
-  %"4$tmp$4#0" = tail call fastcc  i1  @"tests.map.=<0>"(i64  %3, i64  %18)  
-  br i1 %"4$tmp$4#0", label %if.then2, label %if.else2 
+  %"4$tmp$4##0" = tail call fastcc  i1  @"tests.map.=<0>"(i64  %3, i64  %18)  
+  br i1 %"4$tmp$4##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$tmp$5#0" = icmp eq i64 %7, %22 
-  br i1 %"6$tmp$5#0", label %if.then3, label %if.else3 
+  %"6$tmp$5##0" = icmp eq i64 %7, %22 
+  br i1 %"6$tmp$5##0", label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %"8$tmp$6#0" = icmp eq i64 %11, %26 
-  br i1 %"8$tmp$6#0", label %if.then4, label %if.else4 
+  %"8$tmp$6##0" = icmp eq i64 %11, %26 
+  br i1 %"8$tmp$6##0", label %if.then4, label %if.else4 
 if.else3:
   ret i1 0 
 if.then4:
-  %"10$$$#0" = tail call fastcc  i1  @"tests.map.=<0>"(i64  %15, i64  %30)  
-  ret i1 %"10$$$#0" 
+  %"10$$$##0" = tail call fastcc  i1  @"tests.map.=<0>"(i64  %15, i64  %30)  
+  ret i1 %"10$$$##0" 
 if.else4:
   ret i1 0 
 }
@@ -512,12 +512,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"tests.map.key<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"tests.map.key<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %31 = add   i64 %"$rec#0", 8 
+  %31 = add   i64 %"$rec##0", 8 
   %32 = inttoptr i64 %31 to i64* 
   %33 = getelementptr  i64, i64* %32, i64 0 
   %34 = load  i64, i64* %33 
@@ -531,38 +531,38 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"tests.map.key<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"tests.map.key<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %39 = trunc i64 32 to i32  
   %40 = tail call ccc  i8*  @wybe_malloc(i32  %39)  
   %41 = ptrtoint i8* %40 to i64 
   %42 = inttoptr i64 %41 to i8* 
-  %43 = inttoptr i64 %"$rec#0" to i8* 
+  %43 = inttoptr i64 %"$rec##0" to i8* 
   %44 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %42, i8*  %43, i32  %44, i32  8, i1  0)  
   %45 = add   i64 %41, 8 
   %46 = inttoptr i64 %45 to i64* 
   %47 = getelementptr  i64, i64* %46, i64 0 
-  store  i64 %"$field#0", i64* %47 
+  store  i64 %"$field##0", i64* %47 
   %48 = insertvalue {i64, i1} undef, i64 %41, 0 
   %49 = insertvalue {i64, i1} %48, i1 1, 1 
   ret {i64, i1} %49 
 if.else:
-  %50 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %50 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %51 = insertvalue {i64, i1} %50, i1 0, 1 
   ret {i64, i1} %51 
 }
 
 
-define external fastcc  {i64, i1} @"tests.map.left<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"tests.map.left<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %52 = inttoptr i64 %"$rec#0" to i64* 
+  %52 = inttoptr i64 %"$rec##0" to i64* 
   %53 = getelementptr  i64, i64* %52, i64 0 
   %54 = load  i64, i64* %53 
   %55 = insertvalue {i64, i1} undef, i64 %54, 0 
@@ -575,72 +575,72 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"tests.map.left<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"tests.map.left<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %59 = trunc i64 32 to i32  
   %60 = tail call ccc  i8*  @wybe_malloc(i32  %59)  
   %61 = ptrtoint i8* %60 to i64 
   %62 = inttoptr i64 %61 to i8* 
-  %63 = inttoptr i64 %"$rec#0" to i8* 
+  %63 = inttoptr i64 %"$rec##0" to i8* 
   %64 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %62, i8*  %63, i32  %64, i32  8, i1  0)  
   %65 = inttoptr i64 %61 to i64* 
   %66 = getelementptr  i64, i64* %65, i64 0 
-  store  i64 %"$field#0", i64* %66 
+  store  i64 %"$field##0", i64* %66 
   %67 = insertvalue {i64, i1} undef, i64 %61, 0 
   %68 = insertvalue {i64, i1} %67, i1 1, 1 
   ret {i64, i1} %68 
 if.else:
-  %69 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %69 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %70 = insertvalue {i64, i1} %69, i1 0, 1 
   ret {i64, i1} %70 
 }
 
 
-define external fastcc  i64 @"tests.map.node<0>"(i64  %"left#0", i64  %"key#0", i64  %"value#0", i64  %"right#0")    {
+define external fastcc  i64 @"tests.map.node<0>"(i64  %"left##0", i64  %"key##0", i64  %"value##0", i64  %"right##0")    {
 entry:
   %71 = trunc i64 32 to i32  
   %72 = tail call ccc  i8*  @wybe_malloc(i32  %71)  
   %73 = ptrtoint i8* %72 to i64 
   %74 = inttoptr i64 %73 to i64* 
   %75 = getelementptr  i64, i64* %74, i64 0 
-  store  i64 %"left#0", i64* %75 
+  store  i64 %"left##0", i64* %75 
   %76 = add   i64 %73, 8 
   %77 = inttoptr i64 %76 to i64* 
   %78 = getelementptr  i64, i64* %77, i64 0 
-  store  i64 %"key#0", i64* %78 
+  store  i64 %"key##0", i64* %78 
   %79 = add   i64 %73, 16 
   %80 = inttoptr i64 %79 to i64* 
   %81 = getelementptr  i64, i64* %80, i64 0 
-  store  i64 %"value#0", i64* %81 
+  store  i64 %"value##0", i64* %81 
   %82 = add   i64 %73, 24 
   %83 = inttoptr i64 %82 to i64* 
   %84 = getelementptr  i64, i64* %83, i64 0 
-  store  i64 %"right#0", i64* %84 
+  store  i64 %"right##0", i64* %84 
   ret i64 %73 
 }
 
 
-define external fastcc  {i64, i64, i64, i64, i1} @"tests.map.node<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64, i64, i64, i1} @"tests.map.node<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %85 = inttoptr i64 %"$#0" to i64* 
+  %85 = inttoptr i64 %"$##0" to i64* 
   %86 = getelementptr  i64, i64* %85, i64 0 
   %87 = load  i64, i64* %86 
-  %88 = add   i64 %"$#0", 8 
+  %88 = add   i64 %"$##0", 8 
   %89 = inttoptr i64 %88 to i64* 
   %90 = getelementptr  i64, i64* %89, i64 0 
   %91 = load  i64, i64* %90 
-  %92 = add   i64 %"$#0", 16 
+  %92 = add   i64 %"$##0", 16 
   %93 = inttoptr i64 %92 to i64* 
   %94 = getelementptr  i64, i64* %93, i64 0 
   %95 = load  i64, i64* %94 
-  %96 = add   i64 %"$#0", 24 
+  %96 = add   i64 %"$##0", 24 
   %97 = inttoptr i64 %96 to i64* 
   %98 = getelementptr  i64, i64* %97, i64 0 
   %99 = load  i64, i64* %98 
@@ -660,12 +660,12 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"tests.map.right<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"tests.map.right<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %110 = add   i64 %"$rec#0", 24 
+  %110 = add   i64 %"$rec##0", 24 
   %111 = inttoptr i64 %110 to i64* 
   %112 = getelementptr  i64, i64* %111, i64 0 
   %113 = load  i64, i64* %112 
@@ -679,38 +679,38 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"tests.map.right<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"tests.map.right<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %118 = trunc i64 32 to i32  
   %119 = tail call ccc  i8*  @wybe_malloc(i32  %118)  
   %120 = ptrtoint i8* %119 to i64 
   %121 = inttoptr i64 %120 to i8* 
-  %122 = inttoptr i64 %"$rec#0" to i8* 
+  %122 = inttoptr i64 %"$rec##0" to i8* 
   %123 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %121, i8*  %122, i32  %123, i32  8, i1  0)  
   %124 = add   i64 %120, 24 
   %125 = inttoptr i64 %124 to i64* 
   %126 = getelementptr  i64, i64* %125, i64 0 
-  store  i64 %"$field#0", i64* %126 
+  store  i64 %"$field##0", i64* %126 
   %127 = insertvalue {i64, i1} undef, i64 %120, 0 
   %128 = insertvalue {i64, i1} %127, i1 1, 1 
   ret {i64, i1} %128 
 if.else:
-  %129 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %129 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %130 = insertvalue {i64, i1} %129, i1 0, 1 
   ret {i64, i1} %130 
 }
 
 
-define external fastcc  {i64, i1} @"tests.map.value<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"tests.map.value<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %131 = add   i64 %"$rec#0", 16 
+  %131 = add   i64 %"$rec##0", 16 
   %132 = inttoptr i64 %131 to i64* 
   %133 = getelementptr  i64, i64* %132, i64 0 
   %134 = load  i64, i64* %133 
@@ -724,35 +724,35 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"tests.map.value<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"tests.map.value<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %139 = trunc i64 32 to i32  
   %140 = tail call ccc  i8*  @wybe_malloc(i32  %139)  
   %141 = ptrtoint i8* %140 to i64 
   %142 = inttoptr i64 %141 to i8* 
-  %143 = inttoptr i64 %"$rec#0" to i8* 
+  %143 = inttoptr i64 %"$rec##0" to i8* 
   %144 = trunc i64 32 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %142, i8*  %143, i32  %144, i32  8, i1  0)  
   %145 = add   i64 %141, 16 
   %146 = inttoptr i64 %145 to i64* 
   %147 = getelementptr  i64, i64* %146, i64 0 
-  store  i64 %"$field#0", i64* %147 
+  store  i64 %"$field##0", i64* %147 
   %148 = insertvalue {i64, i1} undef, i64 %141, 0 
   %149 = insertvalue {i64, i1} %148, i1 1, 1 
   ret {i64, i1} %149 
 if.else:
-  %150 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %150 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %151 = insertvalue {i64, i1} %150, i1 0, 1 
   ret {i64, i1} %151 
 }
 
 
-define external fastcc  i1 @"tests.map.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"tests.map.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = tail call fastcc  i1  @"tests.map.=<0>"(i64  %"$left#0", i64  %"$right#0")  
-  %"1$$$#0" = xor i1 %"1$tmp$0#0", 1 
-  ret i1 %"1$$$#0" 
+  %"1$tmp$0##0" = tail call fastcc  i1  @"tests.map.=<0>"(i64  %"$left##0", i64  %"$right##0")  
+  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
+  ret i1 %"1$$$##0" 
 }

--- a/test-cases/final-dump/thistype.exp
+++ b/test-cases/final-dump/thistype.exp
@@ -82,14 +82,14 @@ AFTER EVERYTHING:
 
 concat > public (2 calls)
 0: thistype.concat<0>[410bae77d3]
-concat(x##0:thistype, y##0:thistype, ?###0:thistype):
- AliasPairs: [(###0,y##0)]
+concat(x##0:thistype, y##0:thistype, ?#result##0:thistype):
+ AliasPairs: [(#result##0,y##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(thistype.concat<0>,fromList [NonAliasedParamCond 0 [0]]))]
     foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
     case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~y##0:thistype, ?###0:thistype) @thistype:nn:nn
+        foreign llvm move(~y##0:thistype, ?#result##0:thistype) @thistype:nn:nn
 
     1:
         foreign lpvm access(x##0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
@@ -97,35 +97,35 @@ concat(x##0:thistype, y##0:thistype, ?###0:thistype):
         thistype.concat<0>(~t##0:thistype, ~y##0:thistype, ?tmp#2##0:thistype) #1 @thistype:nn:nn
         foreign lpvm alloc(16:wybe.int, ?tmp#8##0:thistype)
         foreign lpvm mutate(~tmp#8##0:thistype, ?tmp#9##0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-        foreign lpvm mutate(~tmp#9##0:thistype, ?###0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:thistype)
+        foreign lpvm mutate(~tmp#9##0:thistype, ?#result##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:thistype)
 
  [410bae77d3] [NonAliasedParam 0] :
     foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
     case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~y##0:thistype, ?###0:thistype) @thistype:nn:nn
+        foreign llvm move(~y##0:thistype, ?#result##0:thistype) @thistype:nn:nn
 
     1:
         foreign lpvm access(x##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:thistype)
         thistype.concat<0>[410bae77d3](~t##0:thistype, ~y##0:thistype, ?tmp#2##0:thistype) #1 @thistype:nn:nn
-        foreign lpvm mutate(~x##0:thistype, ?###0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:thistype)
+        foreign lpvm mutate(~x##0:thistype, ?#result##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:thistype)
 
 
 
 cons > public {inline} (6 calls)
 0: thistype.cons<0>
-cons(head##0:wybe.int, tail##0:thistype, ?###0:thistype):
+cons(head##0:wybe.int, tail##0:thistype, ?#result##0:thistype):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:thistype)
     foreign lpvm mutate(~#rec##0:thistype, ?#rec##1:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:thistype, ?###0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:thistype)
+    foreign lpvm mutate(~#rec##1:thistype, ?#result##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:thistype)
 cons > public {inline} (18 calls)
 1: thistype.cons<1>
-cons(?head##0:wybe.int, ?tail##0:thistype, ###0:thistype, ?####0:wybe.bool):
+cons(?head##0:wybe.int, ?tail##0:thistype, #result##0:thistype, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
@@ -133,25 +133,25 @@ cons(?head##0:wybe.int, ?tail##0:thistype, ###0:thistype, ?####0:wybe.bool):
         foreign llvm move(undef:thistype, ?tail##0:thistype)
 
     1:
-        foreign lpvm access(###0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
-        foreign lpvm access(~###0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:thistype)
+        foreign lpvm access(#result##0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
+        foreign lpvm access(~#result##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:thistype)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 head > public {inline} (0 calls)
 0: thistype.head<0>
-head(#rec##0:thistype, ?###0:wybe.int, ?####0:wybe.bool):
+head(#rec##0:thistype, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign lpvm access(~#rec##0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 head > public {inline} (0 calls)
@@ -173,42 +173,42 @@ head(#rec##0:thistype, ?#rec##1:thistype, #field##0:wybe.int, ?####0:wybe.bool):
 
 length > public (2 calls)
 0: thistype.length<0>
-length(x##0:thistype, ?###0:wybe.int):
+length(x##0:thistype, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
     case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.int, ?###0:wybe.int) @thistype:nn:nn
+        foreign llvm move(0:wybe.int, ?#result##0:wybe.int) @thistype:nn:nn
 
     1:
         foreign lpvm access(~x##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:thistype)
         thistype.length<0>(~t##0:thistype, ?tmp#2##0:wybe.int) #1 @thistype:nn:nn
-        foreign llvm add(~tmp#2##0:wybe.int, 1:wybe.int, ?###0:wybe.int) @int:nn:nn
+        foreign llvm add(~tmp#2##0:wybe.int, 1:wybe.int, ?#result##0:wybe.int) @int:nn:nn
 
 
 
 nil > public {inline} (2 calls)
 0: thistype.nil<0>
-nil(?###0:thistype):
+nil(?#result##0:thistype):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:thistype, ?###0:thistype)
+    foreign llvm move(0:thistype, ?#result##0:thistype)
 
 
 tail > public {inline} (0 calls)
 0: thistype.tail<0>
-tail(#rec##0:thistype, ?###0:thistype, ?####0:wybe.bool):
+tail(#rec##0:thistype, ?#result##0:thistype, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:thistype, ?###0:thistype)
+        foreign llvm move(undef:thistype, ?#result##0:thistype)
 
     1:
-        foreign lpvm access(~#rec##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:thistype)
+        foreign lpvm access(~#rec##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:thistype)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 tail > public {inline} (0 calls)
@@ -418,15 +418,15 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"thistype.cons<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64, i1} @"thistype.cons<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  %"1#tmp#0##0" = icmp ne i64 %"#result##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %85 = inttoptr i64 %"###0" to i64* 
+  %85 = inttoptr i64 %"#result##0" to i64* 
   %86 = getelementptr  i64, i64* %85, i64 0 
   %87 = load  i64, i64* %86 
-  %88 = add   i64 %"###0", 8 
+  %88 = add   i64 %"#result##0", 8 
   %89 = inttoptr i64 %88 to i64* 
   %90 = getelementptr  i64, i64* %89, i64 0 
   %91 = load  i64, i64* %90 
@@ -495,8 +495,8 @@ if.then:
   %119 = getelementptr  i64, i64* %118, i64 0 
   %120 = load  i64, i64* %119 
   %"2#tmp#2##0" = tail call fastcc  i64  @"thistype.length<0>"(i64  %120)  
-  %"2####0" = add   i64 %"2#tmp#2##0", 1 
-  ret i64 %"2####0" 
+  %"2##result##0" = add   i64 %"2#tmp#2##0", 1 
+  ret i64 %"2##result##0" 
 if.else:
   ret i64 0 
 }

--- a/test-cases/final-dump/thistype.exp
+++ b/test-cases/final-dump/thistype.exp
@@ -22,59 +22,59 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: thistype.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(7,(thistype.concat<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm alloc(16:wybe.int, ?tmp$11#0:thistype)
-    foreign lpvm mutate(~tmp$11#0:thistype, ?tmp$12#0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-    foreign lpvm mutate(~tmp$12#0:thistype, ?tmp$2#0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:thistype)
-    foreign lpvm alloc(16:wybe.int, ?tmp$15#0:thistype)
-    foreign lpvm mutate(~tmp$15#0:thistype, ?tmp$16#0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm mutate(~tmp$16#0:thistype, ?tmp$1#0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:thistype)
-    foreign lpvm alloc(16:wybe.int, ?tmp$19#0:thistype)
-    foreign lpvm mutate(~tmp$19#0:thistype, ?tmp$20#0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp$20#0:thistype, ?tmp$0#0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$1#0:thistype)
-    foreign lpvm alloc(16:wybe.int, ?tmp$23#0:thistype)
-    foreign lpvm mutate(~tmp$23#0:thistype, ?tmp$24#0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
-    foreign lpvm mutate(~tmp$24#0:thistype, ?tmp$5#0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:thistype)
-    foreign lpvm alloc(16:wybe.int, ?tmp$27#0:thistype)
-    foreign lpvm mutate(~tmp$27#0:thistype, ?tmp$28#0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm mutate(~tmp$28#0:thistype, ?tmp$4#0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$5#0:thistype)
-    thistype.concat<0>[410bae77d3](~tmp$0#0:thistype, ~tmp$4#0:thistype, ?tmp$8#0:thistype) #7 @thistype:nn:nn
-    thistype.length<0>(~tmp$8#0:thistype, ?tmp$7#0:wybe.int) #8 @thistype:nn:nn
-    foreign c print_int(~tmp$7#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$31#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$31#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$11##0:thistype)
+    foreign lpvm mutate(~tmp$11##0:thistype, ?tmp$12##0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+    foreign lpvm mutate(~tmp$12##0:thistype, ?tmp$2##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:thistype)
+    foreign lpvm alloc(16:wybe.int, ?tmp$15##0:thistype)
+    foreign lpvm mutate(~tmp$15##0:thistype, ?tmp$16##0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+    foreign lpvm mutate(~tmp$16##0:thistype, ?tmp$1##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:thistype)
+    foreign lpvm alloc(16:wybe.int, ?tmp$19##0:thistype)
+    foreign lpvm mutate(~tmp$19##0:thistype, ?tmp$20##0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp$20##0:thistype, ?tmp$0##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$1##0:thistype)
+    foreign lpvm alloc(16:wybe.int, ?tmp$23##0:thistype)
+    foreign lpvm mutate(~tmp$23##0:thistype, ?tmp$24##0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
+    foreign lpvm mutate(~tmp$24##0:thistype, ?tmp$5##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:thistype)
+    foreign lpvm alloc(16:wybe.int, ?tmp$27##0:thistype)
+    foreign lpvm mutate(~tmp$27##0:thistype, ?tmp$28##0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
+    foreign lpvm mutate(~tmp$28##0:thistype, ?tmp$4##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$5##0:thistype)
+    thistype.concat<0>[410bae77d3](~tmp$0##0:thistype, ~tmp$4##0:thistype, ?tmp$8##0:thistype) #7 @thistype:nn:nn
+    thistype.length<0>(~tmp$8##0:thistype, ?tmp$7##0:wybe.int) #8 @thistype:nn:nn
+    foreign c print_int(~tmp$7##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$31##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$31##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 = > public (2 calls)
 0: thistype.=<0>
-=($left#0:thistype, $right#0:thistype, ?$$#0:wybe.bool):
+=($left##0:thistype, $right##0:thistype, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left#0:thistype, ~$right#0:thistype, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~$left##0:thistype, ~$right##0:thistype, ?$$##0:wybe.bool)
 
     1:
-        foreign lpvm access($left#0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$head#0:wybe.int)
-        foreign lpvm access(~$left#0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$tail#0:thistype)
-        foreign llvm icmp_ne($right#0:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.bool)
-        case ~tmp$9#0:wybe.bool of
+        foreign lpvm access($left##0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$head##0:wybe.int)
+        foreign lpvm access(~$left##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$tail##0:thistype)
+        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
+        case ~tmp$9##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign lpvm access($right#0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$head#0:wybe.int)
-            foreign lpvm access(~$right#0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$tail#0:thistype)
-            foreign llvm icmp_eq(~$left$head#0:wybe.int, ~$right$head#0:wybe.int, ?tmp$4#0:wybe.bool) @int:nn:nn
-            case ~tmp$4#0:wybe.bool of
+            foreign lpvm access($right##0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$head##0:wybe.int)
+            foreign lpvm access(~$right##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$tail##0:thistype)
+            foreign llvm icmp_eq(~$left$head##0:wybe.int, ~$right$head##0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
+            case ~tmp$4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                thistype.=<0>(~$left$tail#0:thistype, ~$right$tail#0:thistype, ?$$#0:wybe.bool) #3
+                thistype.=<0>(~$left$tail##0:thistype, ~$right$tail##0:thistype, ?$$##0:wybe.bool) #3
 
 
 
@@ -82,159 +82,159 @@ AFTER EVERYTHING:
 
 concat > public (2 calls)
 0: thistype.concat<0>[410bae77d3]
-concat(x#0:thistype, y#0:thistype, ?$#0:thistype):
- AliasPairs: [($#0,y#0)]
+concat(x##0:thistype, y##0:thistype, ?$##0:thistype):
+ AliasPairs: [($##0,y##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(thistype.concat<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(x#0:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.bool)
-    case ~tmp$5#0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
+    case ~tmp$5##0:wybe.bool of
     0:
-        foreign llvm move(~y#0:thistype, ?$#0:thistype) @thistype:nn:nn
+        foreign llvm move(~y##0:thistype, ?$##0:thistype) @thistype:nn:nn
 
     1:
-        foreign lpvm access(x#0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:wybe.int)
-        foreign lpvm access(~x#0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:thistype)
-        thistype.concat<0>(~t#0:thistype, ~y#0:thistype, ?tmp$2#0:thistype) #1 @thistype:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$8#0:thistype)
-        foreign lpvm mutate(~tmp$8#0:thistype, ?tmp$9#0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h#0:wybe.int)
-        foreign lpvm mutate(~tmp$9#0:thistype, ?$#0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:thistype)
+        foreign lpvm access(x##0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+        foreign lpvm access(~x##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:thistype)
+        thistype.concat<0>(~t##0:thistype, ~y##0:thistype, ?tmp$2##0:thistype) #1 @thistype:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp$8##0:thistype)
+        foreign lpvm mutate(~tmp$8##0:thistype, ?tmp$9##0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+        foreign lpvm mutate(~tmp$9##0:thistype, ?$##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:thistype)
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_ne(x#0:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.bool)
-    case ~tmp$5#0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
+    case ~tmp$5##0:wybe.bool of
     0:
-        foreign llvm move(~y#0:thistype, ?$#0:thistype) @thistype:nn:nn
+        foreign llvm move(~y##0:thistype, ?$##0:thistype) @thistype:nn:nn
 
     1:
-        foreign lpvm access(x#0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:thistype)
-        thistype.concat<0>[410bae77d3](~t#0:thistype, ~y#0:thistype, ?tmp$2#0:thistype) #1 @thistype:nn:nn
-        foreign lpvm mutate(~x#0:thistype, ?$#0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:thistype)
+        foreign lpvm access(x##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:thistype)
+        thistype.concat<0>[410bae77d3](~t##0:thistype, ~y##0:thistype, ?tmp$2##0:thistype) #1 @thistype:nn:nn
+        foreign lpvm mutate(~x##0:thistype, ?$##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:thistype)
 
 
 
 cons > public {inline} (6 calls)
 0: thistype.cons<0>
-cons(head#0:wybe.int, tail#0:thistype, ?$#0:thistype):
+cons(head##0:wybe.int, tail##0:thistype, ?$##0:thistype):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:thistype)
-    foreign lpvm mutate(~$rec#0:thistype, ?$rec#1:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:thistype, ?$#0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail#0:thistype)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:thistype)
+    foreign lpvm mutate(~$rec##0:thistype, ?$rec##1:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:thistype, ?$##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:thistype)
 cons > public {inline} (18 calls)
 1: thistype.cons<1>
-cons(?head#0:wybe.int, ?tail#0:thistype, $#0:thistype, ?$$#0:wybe.bool):
+cons(?head##0:wybe.int, ?tail##0:thistype, $##0:thistype, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?head#0:wybe.int)
-        foreign llvm move(undef:thistype, ?tail#0:thistype)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?head##0:wybe.int)
+        foreign llvm move(undef:thistype, ?tail##0:thistype)
 
     1:
-        foreign lpvm access($#0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head#0:wybe.int)
-        foreign lpvm access(~$#0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail#0:thistype)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access($##0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
+        foreign lpvm access(~$##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:thistype)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 head > public {inline} (0 calls)
 0: thistype.head<0>
-head($rec#0:thistype, ?$#0:wybe.int, ?$$#0:wybe.bool):
+head($rec##0:thistype, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec#0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 head > public {inline} (0 calls)
 1: thistype.head<1>
-head($rec#0:thistype, ?$rec#1:thistype, $field#0:wybe.int, ?$$#0:wybe.bool):
+head($rec##0:thistype, ?$rec##1:thistype, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:thistype, ?$rec#1:thistype)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:thistype, ?$rec##1:thistype)
 
     1:
-        foreign lpvm mutate(~$rec#0:thistype, ?$rec#1:thistype, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~$rec##0:thistype, ?$rec##1:thistype, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 length > public (2 calls)
 0: thistype.length<0>
-length(x#0:thistype, ?$#0:wybe.int):
+length(x##0:thistype, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(x#0:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.bool)
-    case ~tmp$5#0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
+    case ~tmp$5##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.int, ?$#0:wybe.int) @thistype:nn:nn
+        foreign llvm move(0:wybe.int, ?$##0:wybe.int) @thistype:nn:nn
 
     1:
-        foreign lpvm access(~x#0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:thistype)
-        thistype.length<0>(~t#0:thistype, ?tmp$2#0:wybe.int) #1 @thistype:nn:nn
-        foreign llvm add(~tmp$2#0:wybe.int, 1:wybe.int, ?$#0:wybe.int) @int:nn:nn
+        foreign lpvm access(~x##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:thistype)
+        thistype.length<0>(~t##0:thistype, ?tmp$2##0:wybe.int) #1 @thistype:nn:nn
+        foreign llvm add(~tmp$2##0:wybe.int, 1:wybe.int, ?$##0:wybe.int) @int:nn:nn
 
 
 
 nil > public {inline} (2 calls)
 0: thistype.nil<0>
-nil(?$#0:thistype):
+nil(?$##0:thistype):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:thistype, ?$#0:thistype)
+    foreign llvm move(0:thistype, ?$##0:thistype)
 
 
 tail > public {inline} (0 calls)
 0: thistype.tail<0>
-tail($rec#0:thistype, ?$#0:thistype, ?$$#0:wybe.bool):
+tail($rec##0:thistype, ?$##0:thistype, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:thistype, ?$#0:thistype)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:thistype, ?$##0:thistype)
 
     1:
-        foreign lpvm access(~$rec#0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:thistype)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:thistype)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 tail > public {inline} (0 calls)
 1: thistype.tail<1>
-tail($rec#0:thistype, ?$rec#1:thistype, $field#0:thistype, ?$$#0:wybe.bool):
+tail($rec##0:thistype, ?$rec##1:thistype, $field##0:thistype, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:thistype, ?$rec#1:thistype)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:thistype, ?$rec##1:thistype)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec#0:thistype, ?$rec#1:thistype, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:thistype)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm {noalias} mutate(~$rec##0:thistype, ?$rec##1:thistype, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:thistype)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: thistype.~=<0>
-~=($left#0:thistype, $right#0:thistype, ?$$#0:wybe.bool):
+~=($left##0:thistype, $right##0:thistype, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    thistype.=<0>(~$left#0:thistype, ~$right#0:thistype, ?tmp$0#0:wybe.bool) #0
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    thistype.=<0>(~$left##0:thistype, ~$right##0:thistype, ?tmp$0##0:wybe.bool) #0
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
   LLVM code       :
 
@@ -308,64 +308,64 @@ entry:
   %39 = inttoptr i64 %38 to i64* 
   %40 = getelementptr  i64, i64* %39, i64 0 
   store  i64 %27, i64* %40 
-  %"1$tmp$8#0" = tail call fastcc  i64  @"thistype.concat<0>[410bae77d3]"(i64  %19, i64  %35)  
-  %"1$tmp$7#0" = tail call fastcc  i64  @"thistype.length<0>"(i64  %"1$tmp$8#0")  
-  tail call ccc  void  @print_int(i64  %"1$tmp$7#0")  
+  %"1$tmp$8##0" = tail call fastcc  i64  @"thistype.concat<0>[410bae77d3]"(i64  %19, i64  %35)  
+  %"1$tmp$7##0" = tail call fastcc  i64  @"thistype.length<0>"(i64  %"1$tmp$8##0")  
+  tail call ccc  void  @print_int(i64  %"1$tmp$7##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  i1 @"thistype.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"thistype.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$left#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %41 = inttoptr i64 %"$left#0" to i64* 
+  %41 = inttoptr i64 %"$left##0" to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
   %43 = load  i64, i64* %42 
-  %44 = add   i64 %"$left#0", 8 
+  %44 = add   i64 %"$left##0", 8 
   %45 = inttoptr i64 %44 to i64* 
   %46 = getelementptr  i64, i64* %45, i64 0 
   %47 = load  i64, i64* %46 
-  %"2$tmp$9#0" = icmp ne i64 %"$right#0", 0 
-  br i1 %"2$tmp$9#0", label %if.then1, label %if.else1 
+  %"2$tmp$9##0" = icmp ne i64 %"$right##0", 0 
+  br i1 %"2$tmp$9##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = icmp eq i64 %"$left#0", %"$right#0" 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
+  ret i1 %"3$$$##0" 
 if.then1:
-  %48 = inttoptr i64 %"$right#0" to i64* 
+  %48 = inttoptr i64 %"$right##0" to i64* 
   %49 = getelementptr  i64, i64* %48, i64 0 
   %50 = load  i64, i64* %49 
-  %51 = add   i64 %"$right#0", 8 
+  %51 = add   i64 %"$right##0", 8 
   %52 = inttoptr i64 %51 to i64* 
   %53 = getelementptr  i64, i64* %52, i64 0 
   %54 = load  i64, i64* %53 
-  %"4$tmp$4#0" = icmp eq i64 %43, %50 
-  br i1 %"4$tmp$4#0", label %if.then2, label %if.else2 
+  %"4$tmp$4##0" = icmp eq i64 %43, %50 
+  br i1 %"4$tmp$4##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$$$#0" = tail call fastcc  i1  @"thistype.=<0>"(i64  %47, i64  %54)  
-  ret i1 %"6$$$#0" 
+  %"6$$$##0" = tail call fastcc  i1  @"thistype.=<0>"(i64  %47, i64  %54)  
+  ret i1 %"6$$$##0" 
 if.else2:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"thistype.concat<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"thistype.concat<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$tmp$5#0" = icmp ne i64 %"x#0", 0 
-  br i1 %"1$tmp$5#0", label %if.then, label %if.else 
+  %"1$tmp$5##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
 if.then:
-  %55 = inttoptr i64 %"x#0" to i64* 
+  %55 = inttoptr i64 %"x##0" to i64* 
   %56 = getelementptr  i64, i64* %55, i64 0 
   %57 = load  i64, i64* %56 
-  %58 = add   i64 %"x#0", 8 
+  %58 = add   i64 %"x##0", 8 
   %59 = inttoptr i64 %58 to i64* 
   %60 = getelementptr  i64, i64* %59, i64 0 
   %61 = load  i64, i64* %60 
-  %"2$tmp$2#0" = tail call fastcc  i64  @"thistype.concat<0>"(i64  %61, i64  %"y#0")  
+  %"2$tmp$2##0" = tail call fastcc  i64  @"thistype.concat<0>"(i64  %61, i64  %"y##0")  
   %62 = trunc i64 16 to i32  
   %63 = tail call ccc  i8*  @wybe_malloc(i32  %62)  
   %64 = ptrtoint i8* %63 to i64 
@@ -375,58 +375,58 @@ if.then:
   %67 = add   i64 %64, 8 
   %68 = inttoptr i64 %67 to i64* 
   %69 = getelementptr  i64, i64* %68, i64 0 
-  store  i64 %"2$tmp$2#0", i64* %69 
+  store  i64 %"2$tmp$2##0", i64* %69 
   ret i64 %64 
 if.else:
-  ret i64 %"y#0" 
+  ret i64 %"y##0" 
 }
 
 
-define external fastcc  i64 @"thistype.concat<0>[410bae77d3]"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"thistype.concat<0>[410bae77d3]"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$tmp$5#0" = icmp ne i64 %"x#0", 0 
-  br i1 %"1$tmp$5#0", label %if.then, label %if.else 
+  %"1$tmp$5##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
 if.then:
-  %70 = add   i64 %"x#0", 8 
+  %70 = add   i64 %"x##0", 8 
   %71 = inttoptr i64 %70 to i64* 
   %72 = getelementptr  i64, i64* %71, i64 0 
   %73 = load  i64, i64* %72 
-  %"2$tmp$2#0" = tail call fastcc  i64  @"thistype.concat<0>[410bae77d3]"(i64  %73, i64  %"y#0")  
-  %74 = add   i64 %"x#0", 8 
+  %"2$tmp$2##0" = tail call fastcc  i64  @"thistype.concat<0>[410bae77d3]"(i64  %73, i64  %"y##0")  
+  %74 = add   i64 %"x##0", 8 
   %75 = inttoptr i64 %74 to i64* 
   %76 = getelementptr  i64, i64* %75, i64 0 
-  store  i64 %"2$tmp$2#0", i64* %76 
-  ret i64 %"x#0" 
+  store  i64 %"2$tmp$2##0", i64* %76 
+  ret i64 %"x##0" 
 if.else:
-  ret i64 %"y#0" 
+  ret i64 %"y##0" 
 }
 
 
-define external fastcc  i64 @"thistype.cons<0>"(i64  %"head#0", i64  %"tail#0")    {
+define external fastcc  i64 @"thistype.cons<0>"(i64  %"head##0", i64  %"tail##0")    {
 entry:
   %77 = trunc i64 16 to i32  
   %78 = tail call ccc  i8*  @wybe_malloc(i32  %77)  
   %79 = ptrtoint i8* %78 to i64 
   %80 = inttoptr i64 %79 to i64* 
   %81 = getelementptr  i64, i64* %80, i64 0 
-  store  i64 %"head#0", i64* %81 
+  store  i64 %"head##0", i64* %81 
   %82 = add   i64 %79, 8 
   %83 = inttoptr i64 %82 to i64* 
   %84 = getelementptr  i64, i64* %83, i64 0 
-  store  i64 %"tail#0", i64* %84 
+  store  i64 %"tail##0", i64* %84 
   ret i64 %79 
 }
 
 
-define external fastcc  {i64, i64, i1} @"thistype.cons<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64, i1} @"thistype.cons<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %85 = inttoptr i64 %"$#0" to i64* 
+  %85 = inttoptr i64 %"$##0" to i64* 
   %86 = getelementptr  i64, i64* %85, i64 0 
   %87 = load  i64, i64* %86 
-  %88 = add   i64 %"$#0", 8 
+  %88 = add   i64 %"$##0", 8 
   %89 = inttoptr i64 %88 to i64* 
   %90 = getelementptr  i64, i64* %89, i64 0 
   %91 = load  i64, i64* %90 
@@ -442,12 +442,12 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"thistype.head<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"thistype.head<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %98 = inttoptr i64 %"$rec#0" to i64* 
+  %98 = inttoptr i64 %"$rec##0" to i64* 
   %99 = getelementptr  i64, i64* %98, i64 0 
   %100 = load  i64, i64* %99 
   %101 = insertvalue {i64, i1} undef, i64 %100, 0 
@@ -460,43 +460,43 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"thistype.head<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"thistype.head<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %105 = trunc i64 16 to i32  
   %106 = tail call ccc  i8*  @wybe_malloc(i32  %105)  
   %107 = ptrtoint i8* %106 to i64 
   %108 = inttoptr i64 %107 to i8* 
-  %109 = inttoptr i64 %"$rec#0" to i8* 
+  %109 = inttoptr i64 %"$rec##0" to i8* 
   %110 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %108, i8*  %109, i32  %110, i32  8, i1  0)  
   %111 = inttoptr i64 %107 to i64* 
   %112 = getelementptr  i64, i64* %111, i64 0 
-  store  i64 %"$field#0", i64* %112 
+  store  i64 %"$field##0", i64* %112 
   %113 = insertvalue {i64, i1} undef, i64 %107, 0 
   %114 = insertvalue {i64, i1} %113, i1 1, 1 
   ret {i64, i1} %114 
 if.else:
-  %115 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %115 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %116 = insertvalue {i64, i1} %115, i1 0, 1 
   ret {i64, i1} %116 
 }
 
 
-define external fastcc  i64 @"thistype.length<0>"(i64  %"x#0")    {
+define external fastcc  i64 @"thistype.length<0>"(i64  %"x##0")    {
 entry:
-  %"1$tmp$5#0" = icmp ne i64 %"x#0", 0 
-  br i1 %"1$tmp$5#0", label %if.then, label %if.else 
+  %"1$tmp$5##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
 if.then:
-  %117 = add   i64 %"x#0", 8 
+  %117 = add   i64 %"x##0", 8 
   %118 = inttoptr i64 %117 to i64* 
   %119 = getelementptr  i64, i64* %118, i64 0 
   %120 = load  i64, i64* %119 
-  %"2$tmp$2#0" = tail call fastcc  i64  @"thistype.length<0>"(i64  %120)  
-  %"2$$#0" = add   i64 %"2$tmp$2#0", 1 
-  ret i64 %"2$$#0" 
+  %"2$tmp$2##0" = tail call fastcc  i64  @"thistype.length<0>"(i64  %120)  
+  %"2$$##0" = add   i64 %"2$tmp$2##0", 1 
+  ret i64 %"2$$##0" 
 if.else:
   ret i64 0 
 }
@@ -508,12 +508,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"thistype.tail<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"thistype.tail<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %121 = add   i64 %"$rec#0", 8 
+  %121 = add   i64 %"$rec##0", 8 
   %122 = inttoptr i64 %121 to i64* 
   %123 = getelementptr  i64, i64* %122, i64 0 
   %124 = load  i64, i64* %123 
@@ -527,35 +527,35 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"thistype.tail<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"thistype.tail<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %129 = trunc i64 16 to i32  
   %130 = tail call ccc  i8*  @wybe_malloc(i32  %129)  
   %131 = ptrtoint i8* %130 to i64 
   %132 = inttoptr i64 %131 to i8* 
-  %133 = inttoptr i64 %"$rec#0" to i8* 
+  %133 = inttoptr i64 %"$rec##0" to i8* 
   %134 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %132, i8*  %133, i32  %134, i32  8, i1  0)  
   %135 = add   i64 %131, 8 
   %136 = inttoptr i64 %135 to i64* 
   %137 = getelementptr  i64, i64* %136, i64 0 
-  store  i64 %"$field#0", i64* %137 
+  store  i64 %"$field##0", i64* %137 
   %138 = insertvalue {i64, i1} undef, i64 %131, 0 
   %139 = insertvalue {i64, i1} %138, i1 1, 1 
   ret {i64, i1} %139 
 if.else:
-  %140 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %140 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %141 = insertvalue {i64, i1} %140, i1 0, 1 
   ret {i64, i1} %141 
 }
 
 
-define external fastcc  i1 @"thistype.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"thistype.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = tail call fastcc  i1  @"thistype.=<0>"(i64  %"$left#0", i64  %"$right#0")  
-  %"1$$$#0" = xor i1 %"1$tmp$0#0", 1 
-  ret i1 %"1$$$#0" 
+  %"1$tmp$0##0" = tail call fastcc  i1  @"thistype.=<0>"(i64  %"$left##0", i64  %"$right##0")  
+  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
+  ret i1 %"1$$$##0" 
 }

--- a/test-cases/final-dump/thistype.exp
+++ b/test-cases/final-dump/thistype.exp
@@ -49,13 +49,13 @@ AFTER EVERYTHING:
 
 = > public (2 calls)
 0: thistype.=<0>
-=(#left##0:thistype, #right##0:thistype, ?####0:wybe.bool):
+=(#left##0:thistype, #right##0:thistype, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~#left##0:thistype, ~#right##0:thistype, ?####0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:thistype, ~#right##0:thistype, ?#success##0:wybe.bool)
 
     1:
         foreign lpvm access(#left##0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#head##0:wybe.int)
@@ -63,7 +63,7 @@ AFTER EVERYTHING:
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
         case ~tmp#9##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign lpvm access(#right##0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#head##0:wybe.int)
@@ -71,10 +71,10 @@ AFTER EVERYTHING:
             foreign llvm icmp_eq(~#left#head##0:wybe.int, ~#right#head##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
             case ~tmp#4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
-                thistype.=<0>(~#left#tail##0:thistype, ~#right#tail##0:thistype, ?####0:wybe.bool) #3
+                thistype.=<0>(~#left#tail##0:thistype, ~#right#tail##0:thistype, ?#success##0:wybe.bool) #3
 
 
 
@@ -122,52 +122,52 @@ cons(head##0:wybe.int, tail##0:thistype, ?#result##0:thistype):
     foreign lpvm mutate(~#rec##1:thistype, ?#result##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:thistype)
 cons > public {inline} (18 calls)
 1: thistype.cons<1>
-cons(?head##0:wybe.int, ?tail##0:thistype, #result##0:thistype, ?####0:wybe.bool):
+cons(?head##0:wybe.int, ?tail##0:thistype, #result##0:thistype, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?head##0:wybe.int)
         foreign llvm move(undef:thistype, ?tail##0:thistype)
 
     1:
         foreign lpvm access(#result##0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
         foreign lpvm access(~#result##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:thistype)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 head > public {inline} (0 calls)
 0: thistype.head<0>
-head(#rec##0:thistype, ?#result##0:wybe.int, ?####0:wybe.bool):
+head(#rec##0:thistype, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign lpvm access(~#rec##0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 head > public {inline} (0 calls)
 1: thistype.head<1>
-head(#rec##0:thistype, ?#rec##1:thistype, #field##0:wybe.int, ?####0:wybe.bool):
+head(#rec##0:thistype, ?#rec##1:thistype, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:thistype, ?#rec##1:thistype)
 
     1:
         foreign lpvm mutate(~#rec##0:thistype, ?#rec##1:thistype, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -198,43 +198,43 @@ nil(?#result##0:thistype):
 
 tail > public {inline} (0 calls)
 0: thistype.tail<0>
-tail(#rec##0:thistype, ?#result##0:thistype, ?####0:wybe.bool):
+tail(#rec##0:thistype, ?#result##0:thistype, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:thistype, ?#result##0:thistype)
 
     1:
         foreign lpvm access(~#rec##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:thistype)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 tail > public {inline} (0 calls)
 1: thistype.tail<1>
-tail(#rec##0:thistype, ?#rec##1:thistype, #field##0:thistype, ?####0:wybe.bool):
+tail(#rec##0:thistype, ?#rec##1:thistype, #field##0:thistype, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:thistype, ?#rec##1:thistype)
 
     1:
         foreign lpvm {noalias} mutate(~#rec##0:thistype, ?#rec##1:thistype, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:thistype)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: thistype.~=<0>
-~=(#left##0:thistype, #right##0:thistype, ?####0:wybe.bool):
+~=(#left##0:thistype, #right##0:thistype, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     thistype.=<0>(~#left##0:thistype, ~#right##0:thistype, ?tmp#0##0:wybe.bool) #0
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 
@@ -331,8 +331,8 @@ if.then:
   %"2#tmp#9##0" = icmp ne i64 %"#right##0", 0 
   br i1 %"2#tmp#9##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %"3#####0" 
+  %"3##success##0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3##success##0" 
 if.then1:
   %48 = inttoptr i64 %"#right##0" to i64* 
   %49 = getelementptr  i64, i64* %48, i64 0 
@@ -346,8 +346,8 @@ if.then1:
 if.else1:
   ret i1 0 
 if.then2:
-  %"6#####0" = tail call fastcc  i1  @"thistype.=<0>"(i64  %47, i64  %54)  
-  ret i1 %"6#####0" 
+  %"6##success##0" = tail call fastcc  i1  @"thistype.=<0>"(i64  %47, i64  %54)  
+  ret i1 %"6##success##0" 
 if.else2:
   ret i1 0 
 }
@@ -556,6 +556,6 @@ if.else:
 define external fastcc  i1 @"thistype.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %"1#tmp#0##0" = tail call fastcc  i1  @"thistype.=<0>"(i64  %"#left##0", i64  %"#right##0")  
-  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
-  ret i1 %"1#####0" 
+  %"1##success##0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1##success##0" 
 }

--- a/test-cases/final-dump/thistype.exp
+++ b/test-cases/final-dump/thistype.exp
@@ -26,55 +26,55 @@ AFTER EVERYTHING:
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(7,(thistype.concat<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm alloc(16:wybe.int, ?tmp$11##0:thistype)
-    foreign lpvm mutate(~tmp$11##0:thistype, ?tmp$12##0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-    foreign lpvm mutate(~tmp$12##0:thistype, ?tmp$2##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:thistype)
-    foreign lpvm alloc(16:wybe.int, ?tmp$15##0:thistype)
-    foreign lpvm mutate(~tmp$15##0:thistype, ?tmp$16##0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm mutate(~tmp$16##0:thistype, ?tmp$1##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:thistype)
-    foreign lpvm alloc(16:wybe.int, ?tmp$19##0:thistype)
-    foreign lpvm mutate(~tmp$19##0:thistype, ?tmp$20##0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp$20##0:thistype, ?tmp$0##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$1##0:thistype)
-    foreign lpvm alloc(16:wybe.int, ?tmp$23##0:thistype)
-    foreign lpvm mutate(~tmp$23##0:thistype, ?tmp$24##0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
-    foreign lpvm mutate(~tmp$24##0:thistype, ?tmp$5##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:thistype)
-    foreign lpvm alloc(16:wybe.int, ?tmp$27##0:thistype)
-    foreign lpvm mutate(~tmp$27##0:thistype, ?tmp$28##0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm mutate(~tmp$28##0:thistype, ?tmp$4##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$5##0:thistype)
-    thistype.concat<0>[410bae77d3](~tmp$0##0:thistype, ~tmp$4##0:thistype, ?tmp$8##0:thistype) #7 @thistype:nn:nn
-    thistype.length<0>(~tmp$8##0:thistype, ?tmp$7##0:wybe.int) #8 @thistype:nn:nn
-    foreign c print_int(~tmp$7##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$31##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$31##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:thistype)
+    foreign lpvm mutate(~tmp#11##0:thistype, ?tmp#12##0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+    foreign lpvm mutate(~tmp#12##0:thistype, ?tmp#2##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:thistype)
+    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:thistype)
+    foreign lpvm mutate(~tmp#15##0:thistype, ?tmp#16##0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+    foreign lpvm mutate(~tmp#16##0:thistype, ?tmp#1##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:thistype)
+    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:thistype)
+    foreign lpvm mutate(~tmp#19##0:thistype, ?tmp#20##0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp#20##0:thistype, ?tmp#0##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:thistype)
+    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:thistype)
+    foreign lpvm mutate(~tmp#23##0:thistype, ?tmp#24##0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
+    foreign lpvm mutate(~tmp#24##0:thistype, ?tmp#5##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:thistype)
+    foreign lpvm alloc(16:wybe.int, ?tmp#27##0:thistype)
+    foreign lpvm mutate(~tmp#27##0:thistype, ?tmp#28##0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
+    foreign lpvm mutate(~tmp#28##0:thistype, ?tmp#4##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##0:thistype)
+    thistype.concat<0>[410bae77d3](~tmp#0##0:thistype, ~tmp#4##0:thistype, ?tmp#8##0:thistype) #7 @thistype:nn:nn
+    thistype.length<0>(~tmp#8##0:thistype, ?tmp#7##0:wybe.int) #8 @thistype:nn:nn
+    foreign c print_int(~tmp#7##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#31##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#31##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 = > public (2 calls)
 0: thistype.=<0>
-=($left##0:thistype, $right##0:thistype, ?$$##0:wybe.bool):
+=(#left##0:thistype, #right##0:thistype, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left##0:thistype, ~$right##0:thistype, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:thistype, ~#right##0:thistype, ?####0:wybe.bool)
 
     1:
-        foreign lpvm access($left##0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$head##0:wybe.int)
-        foreign lpvm access(~$left##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$tail##0:thistype)
-        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
-        case ~tmp$9##0:wybe.bool of
+        foreign lpvm access(#left##0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#head##0:wybe.int)
+        foreign lpvm access(~#left##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#tail##0:thistype)
+        foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
+        case ~tmp#9##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign lpvm access($right##0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$head##0:wybe.int)
-            foreign lpvm access(~$right##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$tail##0:thistype)
-            foreign llvm icmp_eq(~$left$head##0:wybe.int, ~$right$head##0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
-            case ~tmp$4##0:wybe.bool of
+            foreign lpvm access(#right##0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#head##0:wybe.int)
+            foreign lpvm access(~#right##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#tail##0:thistype)
+            foreign llvm icmp_eq(~#left#head##0:wybe.int, ~#right#head##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
+            case ~tmp#4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
             1:
-                thistype.=<0>(~$left$tail##0:thistype, ~$right$tail##0:thistype, ?$$##0:wybe.bool) #3
+                thistype.=<0>(~#left#tail##0:thistype, ~#right#tail##0:thistype, ?####0:wybe.bool) #3
 
 
 
@@ -82,159 +82,159 @@ AFTER EVERYTHING:
 
 concat > public (2 calls)
 0: thistype.concat<0>[410bae77d3]
-concat(x##0:thistype, y##0:thistype, ?$##0:thistype):
- AliasPairs: [($##0,y##0)]
+concat(x##0:thistype, y##0:thistype, ?###0:thistype):
+ AliasPairs: [(###0,y##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(thistype.concat<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
-    case ~tmp$5##0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
+    case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~y##0:thistype, ?$##0:thistype) @thistype:nn:nn
+        foreign llvm move(~y##0:thistype, ?###0:thistype) @thistype:nn:nn
 
     1:
         foreign lpvm access(x##0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
         foreign lpvm access(~x##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:thistype)
-        thistype.concat<0>(~t##0:thistype, ~y##0:thistype, ?tmp$2##0:thistype) #1 @thistype:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$8##0:thistype)
-        foreign lpvm mutate(~tmp$8##0:thistype, ?tmp$9##0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-        foreign lpvm mutate(~tmp$9##0:thistype, ?$##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:thistype)
+        thistype.concat<0>(~t##0:thistype, ~y##0:thistype, ?tmp#2##0:thistype) #1 @thistype:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:thistype)
+        foreign lpvm mutate(~tmp#8##0:thistype, ?tmp#9##0:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+        foreign lpvm mutate(~tmp#9##0:thistype, ?###0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:thistype)
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
-    case ~tmp$5##0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
+    case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~y##0:thistype, ?$##0:thistype) @thistype:nn:nn
+        foreign llvm move(~y##0:thistype, ?###0:thistype) @thistype:nn:nn
 
     1:
         foreign lpvm access(x##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:thistype)
-        thistype.concat<0>[410bae77d3](~t##0:thistype, ~y##0:thistype, ?tmp$2##0:thistype) #1 @thistype:nn:nn
-        foreign lpvm mutate(~x##0:thistype, ?$##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:thistype)
+        thistype.concat<0>[410bae77d3](~t##0:thistype, ~y##0:thistype, ?tmp#2##0:thistype) #1 @thistype:nn:nn
+        foreign lpvm mutate(~x##0:thistype, ?###0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:thistype)
 
 
 
 cons > public {inline} (6 calls)
 0: thistype.cons<0>
-cons(head##0:wybe.int, tail##0:thistype, ?$##0:thistype):
+cons(head##0:wybe.int, tail##0:thistype, ?###0:thistype):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:thistype)
-    foreign lpvm mutate(~$rec##0:thistype, ?$rec##1:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:thistype, ?$##0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:thistype)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:thistype)
+    foreign lpvm mutate(~#rec##0:thistype, ?#rec##1:thistype, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:thistype, ?###0:thistype, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:thistype)
 cons > public {inline} (18 calls)
 1: thistype.cons<1>
-cons(?head##0:wybe.int, ?tail##0:thistype, $##0:thistype, ?$$##0:wybe.bool):
+cons(?head##0:wybe.int, ?tail##0:thistype, ###0:thistype, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?head##0:wybe.int)
         foreign llvm move(undef:thistype, ?tail##0:thistype)
 
     1:
-        foreign lpvm access($##0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
-        foreign lpvm access(~$##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:thistype)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(###0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
+        foreign lpvm access(~###0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:thistype)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 head > public {inline} (0 calls)
 0: thistype.head<0>
-head($rec##0:thistype, ?$##0:wybe.int, ?$$##0:wybe.bool):
+head(#rec##0:thistype, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec##0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:thistype, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 head > public {inline} (0 calls)
 1: thistype.head<1>
-head($rec##0:thistype, ?$rec##1:thistype, $field##0:wybe.int, ?$$##0:wybe.bool):
+head(#rec##0:thistype, ?#rec##1:thistype, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:thistype, ?$rec##1:thistype)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:thistype, ?#rec##1:thistype)
 
     1:
-        foreign lpvm mutate(~$rec##0:thistype, ?$rec##1:thistype, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~#rec##0:thistype, ?#rec##1:thistype, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 length > public (2 calls)
 0: thistype.length<0>
-length(x##0:thistype, ?$##0:wybe.int):
+length(x##0:thistype, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
-    case ~tmp$5##0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
+    case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.int, ?$##0:wybe.int) @thistype:nn:nn
+        foreign llvm move(0:wybe.int, ?###0:wybe.int) @thistype:nn:nn
 
     1:
         foreign lpvm access(~x##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:thistype)
-        thistype.length<0>(~t##0:thistype, ?tmp$2##0:wybe.int) #1 @thistype:nn:nn
-        foreign llvm add(~tmp$2##0:wybe.int, 1:wybe.int, ?$##0:wybe.int) @int:nn:nn
+        thistype.length<0>(~t##0:thistype, ?tmp#2##0:wybe.int) #1 @thistype:nn:nn
+        foreign llvm add(~tmp#2##0:wybe.int, 1:wybe.int, ?###0:wybe.int) @int:nn:nn
 
 
 
 nil > public {inline} (2 calls)
 0: thistype.nil<0>
-nil(?$##0:thistype):
+nil(?###0:thistype):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:thistype, ?$##0:thistype)
+    foreign llvm move(0:thistype, ?###0:thistype)
 
 
 tail > public {inline} (0 calls)
 0: thistype.tail<0>
-tail($rec##0:thistype, ?$##0:thistype, ?$$##0:wybe.bool):
+tail(#rec##0:thistype, ?###0:thistype, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:thistype, ?$##0:thistype)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:thistype, ?###0:thistype)
 
     1:
-        foreign lpvm access(~$rec##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:thistype)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:thistype, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:thistype)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 tail > public {inline} (0 calls)
 1: thistype.tail<1>
-tail($rec##0:thistype, ?$rec##1:thistype, $field##0:thistype, ?$$##0:wybe.bool):
+tail(#rec##0:thistype, ?#rec##1:thistype, #field##0:thistype, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:thistype, ?$rec##1:thistype)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:thistype, ?#rec##1:thistype)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec##0:thistype, ?$rec##1:thistype, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:thistype)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm {noalias} mutate(~#rec##0:thistype, ?#rec##1:thistype, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:thistype)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: thistype.~=<0>
-~=($left##0:thistype, $right##0:thistype, ?$$##0:wybe.bool):
+~=(#left##0:thistype, #right##0:thistype, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    thistype.=<0>(~$left##0:thistype, ~$right##0:thistype, ?tmp$0##0:wybe.bool) #0
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    thistype.=<0>(~#left##0:thistype, ~#right##0:thistype, ?tmp#0##0:wybe.bool) #0
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
   LLVM code       :
 
@@ -308,46 +308,46 @@ entry:
   %39 = inttoptr i64 %38 to i64* 
   %40 = getelementptr  i64, i64* %39, i64 0 
   store  i64 %27, i64* %40 
-  %"1$tmp$8##0" = tail call fastcc  i64  @"thistype.concat<0>[410bae77d3]"(i64  %19, i64  %35)  
-  %"1$tmp$7##0" = tail call fastcc  i64  @"thistype.length<0>"(i64  %"1$tmp$8##0")  
-  tail call ccc  void  @print_int(i64  %"1$tmp$7##0")  
+  %"1#tmp#8##0" = tail call fastcc  i64  @"thistype.concat<0>[410bae77d3]"(i64  %19, i64  %35)  
+  %"1#tmp#7##0" = tail call fastcc  i64  @"thistype.length<0>"(i64  %"1#tmp#8##0")  
+  tail call ccc  void  @print_int(i64  %"1#tmp#7##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  i1 @"thistype.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"thistype.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#left##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %41 = inttoptr i64 %"$left##0" to i64* 
+  %41 = inttoptr i64 %"#left##0" to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
   %43 = load  i64, i64* %42 
-  %44 = add   i64 %"$left##0", 8 
+  %44 = add   i64 %"#left##0", 8 
   %45 = inttoptr i64 %44 to i64* 
   %46 = getelementptr  i64, i64* %45, i64 0 
   %47 = load  i64, i64* %46 
-  %"2$tmp$9##0" = icmp ne i64 %"$right##0", 0 
-  br i1 %"2$tmp$9##0", label %if.then1, label %if.else1 
+  %"2#tmp#9##0" = icmp ne i64 %"#right##0", 0 
+  br i1 %"2#tmp#9##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3#####0" 
 if.then1:
-  %48 = inttoptr i64 %"$right##0" to i64* 
+  %48 = inttoptr i64 %"#right##0" to i64* 
   %49 = getelementptr  i64, i64* %48, i64 0 
   %50 = load  i64, i64* %49 
-  %51 = add   i64 %"$right##0", 8 
+  %51 = add   i64 %"#right##0", 8 
   %52 = inttoptr i64 %51 to i64* 
   %53 = getelementptr  i64, i64* %52, i64 0 
   %54 = load  i64, i64* %53 
-  %"4$tmp$4##0" = icmp eq i64 %43, %50 
-  br i1 %"4$tmp$4##0", label %if.then2, label %if.else2 
+  %"4#tmp#4##0" = icmp eq i64 %43, %50 
+  br i1 %"4#tmp#4##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$$$##0" = tail call fastcc  i1  @"thistype.=<0>"(i64  %47, i64  %54)  
-  ret i1 %"6$$$##0" 
+  %"6#####0" = tail call fastcc  i1  @"thistype.=<0>"(i64  %47, i64  %54)  
+  ret i1 %"6#####0" 
 if.else2:
   ret i1 0 
 }
@@ -355,8 +355,8 @@ if.else2:
 
 define external fastcc  i64 @"thistype.concat<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$tmp$5##0" = icmp ne i64 %"x##0", 0 
-  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
+  %"1#tmp#5##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
   %55 = inttoptr i64 %"x##0" to i64* 
   %56 = getelementptr  i64, i64* %55, i64 0 
@@ -365,7 +365,7 @@ if.then:
   %59 = inttoptr i64 %58 to i64* 
   %60 = getelementptr  i64, i64* %59, i64 0 
   %61 = load  i64, i64* %60 
-  %"2$tmp$2##0" = tail call fastcc  i64  @"thistype.concat<0>"(i64  %61, i64  %"y##0")  
+  %"2#tmp#2##0" = tail call fastcc  i64  @"thistype.concat<0>"(i64  %61, i64  %"y##0")  
   %62 = trunc i64 16 to i32  
   %63 = tail call ccc  i8*  @wybe_malloc(i32  %62)  
   %64 = ptrtoint i8* %63 to i64 
@@ -375,7 +375,7 @@ if.then:
   %67 = add   i64 %64, 8 
   %68 = inttoptr i64 %67 to i64* 
   %69 = getelementptr  i64, i64* %68, i64 0 
-  store  i64 %"2$tmp$2##0", i64* %69 
+  store  i64 %"2#tmp#2##0", i64* %69 
   ret i64 %64 
 if.else:
   ret i64 %"y##0" 
@@ -384,18 +384,18 @@ if.else:
 
 define external fastcc  i64 @"thistype.concat<0>[410bae77d3]"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$tmp$5##0" = icmp ne i64 %"x##0", 0 
-  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
+  %"1#tmp#5##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
   %70 = add   i64 %"x##0", 8 
   %71 = inttoptr i64 %70 to i64* 
   %72 = getelementptr  i64, i64* %71, i64 0 
   %73 = load  i64, i64* %72 
-  %"2$tmp$2##0" = tail call fastcc  i64  @"thistype.concat<0>[410bae77d3]"(i64  %73, i64  %"y##0")  
+  %"2#tmp#2##0" = tail call fastcc  i64  @"thistype.concat<0>[410bae77d3]"(i64  %73, i64  %"y##0")  
   %74 = add   i64 %"x##0", 8 
   %75 = inttoptr i64 %74 to i64* 
   %76 = getelementptr  i64, i64* %75, i64 0 
-  store  i64 %"2$tmp$2##0", i64* %76 
+  store  i64 %"2#tmp#2##0", i64* %76 
   ret i64 %"x##0" 
 if.else:
   ret i64 %"y##0" 
@@ -418,15 +418,15 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"thistype.cons<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64, i1} @"thistype.cons<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %85 = inttoptr i64 %"$##0" to i64* 
+  %85 = inttoptr i64 %"###0" to i64* 
   %86 = getelementptr  i64, i64* %85, i64 0 
   %87 = load  i64, i64* %86 
-  %88 = add   i64 %"$##0", 8 
+  %88 = add   i64 %"###0", 8 
   %89 = inttoptr i64 %88 to i64* 
   %90 = getelementptr  i64, i64* %89, i64 0 
   %91 = load  i64, i64* %90 
@@ -442,12 +442,12 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"thistype.head<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"thistype.head<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %98 = inttoptr i64 %"$rec##0" to i64* 
+  %98 = inttoptr i64 %"#rec##0" to i64* 
   %99 = getelementptr  i64, i64* %98, i64 0 
   %100 = load  i64, i64* %99 
   %101 = insertvalue {i64, i1} undef, i64 %100, 0 
@@ -460,26 +460,26 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"thistype.head<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"thistype.head<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %105 = trunc i64 16 to i32  
   %106 = tail call ccc  i8*  @wybe_malloc(i32  %105)  
   %107 = ptrtoint i8* %106 to i64 
   %108 = inttoptr i64 %107 to i8* 
-  %109 = inttoptr i64 %"$rec##0" to i8* 
+  %109 = inttoptr i64 %"#rec##0" to i8* 
   %110 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %108, i8*  %109, i32  %110, i32  8, i1  0)  
   %111 = inttoptr i64 %107 to i64* 
   %112 = getelementptr  i64, i64* %111, i64 0 
-  store  i64 %"$field##0", i64* %112 
+  store  i64 %"#field##0", i64* %112 
   %113 = insertvalue {i64, i1} undef, i64 %107, 0 
   %114 = insertvalue {i64, i1} %113, i1 1, 1 
   ret {i64, i1} %114 
 if.else:
-  %115 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %115 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %116 = insertvalue {i64, i1} %115, i1 0, 1 
   ret {i64, i1} %116 
 }
@@ -487,16 +487,16 @@ if.else:
 
 define external fastcc  i64 @"thistype.length<0>"(i64  %"x##0")    {
 entry:
-  %"1$tmp$5##0" = icmp ne i64 %"x##0", 0 
-  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
+  %"1#tmp#5##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
   %117 = add   i64 %"x##0", 8 
   %118 = inttoptr i64 %117 to i64* 
   %119 = getelementptr  i64, i64* %118, i64 0 
   %120 = load  i64, i64* %119 
-  %"2$tmp$2##0" = tail call fastcc  i64  @"thistype.length<0>"(i64  %120)  
-  %"2$$##0" = add   i64 %"2$tmp$2##0", 1 
-  ret i64 %"2$$##0" 
+  %"2#tmp#2##0" = tail call fastcc  i64  @"thistype.length<0>"(i64  %120)  
+  %"2####0" = add   i64 %"2#tmp#2##0", 1 
+  ret i64 %"2####0" 
 if.else:
   ret i64 0 
 }
@@ -508,12 +508,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"thistype.tail<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"thistype.tail<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %121 = add   i64 %"$rec##0", 8 
+  %121 = add   i64 %"#rec##0", 8 
   %122 = inttoptr i64 %121 to i64* 
   %123 = getelementptr  i64, i64* %122, i64 0 
   %124 = load  i64, i64* %123 
@@ -527,35 +527,35 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"thistype.tail<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"thistype.tail<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %129 = trunc i64 16 to i32  
   %130 = tail call ccc  i8*  @wybe_malloc(i32  %129)  
   %131 = ptrtoint i8* %130 to i64 
   %132 = inttoptr i64 %131 to i8* 
-  %133 = inttoptr i64 %"$rec##0" to i8* 
+  %133 = inttoptr i64 %"#rec##0" to i8* 
   %134 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %132, i8*  %133, i32  %134, i32  8, i1  0)  
   %135 = add   i64 %131, 8 
   %136 = inttoptr i64 %135 to i64* 
   %137 = getelementptr  i64, i64* %136, i64 0 
-  store  i64 %"$field##0", i64* %137 
+  store  i64 %"#field##0", i64* %137 
   %138 = insertvalue {i64, i1} undef, i64 %131, 0 
   %139 = insertvalue {i64, i1} %138, i1 1, 1 
   ret {i64, i1} %139 
 if.else:
-  %140 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %140 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %141 = insertvalue {i64, i1} %140, i1 0, 1 
   ret {i64, i1} %141 
 }
 
 
-define external fastcc  i1 @"thistype.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"thistype.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = tail call fastcc  i1  @"thistype.=<0>"(i64  %"$left##0", i64  %"$right##0")  
-  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
-  ret i1 %"1$$$##0" 
+  %"1#tmp#0##0" = tail call fastcc  i1  @"thistype.=<0>"(i64  %"#left##0", i64  %"#right##0")  
+  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1#####0" 
 }

--- a/test-cases/final-dump/type_enum.exp
+++ b/test-cases/final-dump/type_enum.exp
@@ -47,51 +47,51 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 = > public {inline} (1 calls)
 0: type_enum.season.=<0>
-=($left#0:type_enum.season, $right#0:type_enum.season, ?$$#0:wybe.bool):
+=($left##0:type_enum.season, $right##0:type_enum.season, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(~$left#0:type_enum.season, ~$right#0:type_enum.season, ?$$#0:wybe.bool)
+    foreign llvm icmp_eq(~$left##0:type_enum.season, ~$right##0:type_enum.season, ?$$##0:wybe.bool)
 
 
 autumn > public {inline} (0 calls)
 0: type_enum.season.autumn<0>
-autumn(?$#0:type_enum.season):
+autumn(?$##0:type_enum.season):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(3:type_enum.season, ?$#0:type_enum.season)
+    foreign llvm move(3:type_enum.season, ?$##0:type_enum.season)
 
 
 spring > public {inline} (0 calls)
 0: type_enum.season.spring<0>
-spring(?$#0:type_enum.season):
+spring(?$##0:type_enum.season):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(1:type_enum.season, ?$#0:type_enum.season)
+    foreign llvm move(1:type_enum.season, ?$##0:type_enum.season)
 
 
 summer > public {inline} (0 calls)
 0: type_enum.season.summer<0>
-summer(?$#0:type_enum.season):
+summer(?$##0:type_enum.season):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(2:type_enum.season, ?$#0:type_enum.season)
+    foreign llvm move(2:type_enum.season, ?$##0:type_enum.season)
 
 
 winter > public {inline} (0 calls)
 0: type_enum.season.winter<0>
-winter(?$#0:type_enum.season):
+winter(?$##0:type_enum.season):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:type_enum.season, ?$#0:type_enum.season)
+    foreign llvm move(0:type_enum.season, ?$##0:type_enum.season)
 
 
 ~= > public {inline} (0 calls)
 0: type_enum.season.~=<0>
-~=($left#0:type_enum.season, $right#0:type_enum.season, ?$$#0:wybe.bool):
+~=($left##0:type_enum.season, $right##0:type_enum.season, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(~$left#0:type_enum.season, ~$right#0:type_enum.season, ?tmp$0#0:wybe.bool)
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    foreign llvm icmp_eq(~$left##0:type_enum.season, ~$right##0:type_enum.season, ?tmp$0##0:wybe.bool)
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
   LLVM code       :
 
@@ -107,10 +107,10 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"type_enum.season.=<0>"(i2  %"$left#0", i2  %"$right#0")    {
+define external fastcc  i1 @"type_enum.season.=<0>"(i2  %"$left##0", i2  %"$right##0")    {
 entry:
-  %"1$$$#0" = icmp eq i2 %"$left#0", %"$right#0" 
-  ret i1 %"1$$$#0" 
+  %"1$$$##0" = icmp eq i2 %"$left##0", %"$right##0" 
+  ret i1 %"1$$$##0" 
 }
 
 
@@ -138,9 +138,9 @@ entry:
 }
 
 
-define external fastcc  i1 @"type_enum.season.~=<0>"(i2  %"$left#0", i2  %"$right#0")    {
+define external fastcc  i1 @"type_enum.season.~=<0>"(i2  %"$left##0", i2  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = icmp eq i2 %"$left#0", %"$right#0" 
-  %"1$$$#0" = xor i1 %"1$tmp$0#0", 1 
-  ret i1 %"1$$$#0" 
+  %"1$tmp$0##0" = icmp eq i2 %"$left##0", %"$right##0" 
+  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
+  ret i1 %"1$$$##0" 
 }

--- a/test-cases/final-dump/type_enum.exp
+++ b/test-cases/final-dump/type_enum.exp
@@ -47,10 +47,10 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 = > public {inline} (1 calls)
 0: type_enum.season.=<0>
-=(#left##0:type_enum.season, #right##0:type_enum.season, ?####0:wybe.bool):
+=(#left##0:type_enum.season, #right##0:type_enum.season, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(~#left##0:type_enum.season, ~#right##0:type_enum.season, ?####0:wybe.bool)
+    foreign llvm icmp_eq(~#left##0:type_enum.season, ~#right##0:type_enum.season, ?#success##0:wybe.bool)
 
 
 autumn > public {inline} (0 calls)
@@ -87,11 +87,11 @@ winter(?#result##0:type_enum.season):
 
 ~= > public {inline} (0 calls)
 0: type_enum.season.~=<0>
-~=(#left##0:type_enum.season, #right##0:type_enum.season, ?####0:wybe.bool):
+~=(#left##0:type_enum.season, #right##0:type_enum.season, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_eq(~#left##0:type_enum.season, ~#right##0:type_enum.season, ?tmp#0##0:wybe.bool)
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 
@@ -109,8 +109,8 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  i1 @"type_enum.season.=<0>"(i2  %"#left##0", i2  %"#right##0")    {
 entry:
-  %"1#####0" = icmp eq i2 %"#left##0", %"#right##0" 
-  ret i1 %"1#####0" 
+  %"1##success##0" = icmp eq i2 %"#left##0", %"#right##0" 
+  ret i1 %"1##success##0" 
 }
 
 
@@ -141,6 +141,6 @@ entry:
 define external fastcc  i1 @"type_enum.season.~=<0>"(i2  %"#left##0", i2  %"#right##0")    {
 entry:
   %"1#tmp#0##0" = icmp eq i2 %"#left##0", %"#right##0" 
-  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
-  ret i1 %"1#####0" 
+  %"1##success##0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1##success##0" 
 }

--- a/test-cases/final-dump/type_enum.exp
+++ b/test-cases/final-dump/type_enum.exp
@@ -47,51 +47,51 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 = > public {inline} (1 calls)
 0: type_enum.season.=<0>
-=($left##0:type_enum.season, $right##0:type_enum.season, ?$$##0:wybe.bool):
+=(#left##0:type_enum.season, #right##0:type_enum.season, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(~$left##0:type_enum.season, ~$right##0:type_enum.season, ?$$##0:wybe.bool)
+    foreign llvm icmp_eq(~#left##0:type_enum.season, ~#right##0:type_enum.season, ?####0:wybe.bool)
 
 
 autumn > public {inline} (0 calls)
 0: type_enum.season.autumn<0>
-autumn(?$##0:type_enum.season):
+autumn(?###0:type_enum.season):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(3:type_enum.season, ?$##0:type_enum.season)
+    foreign llvm move(3:type_enum.season, ?###0:type_enum.season)
 
 
 spring > public {inline} (0 calls)
 0: type_enum.season.spring<0>
-spring(?$##0:type_enum.season):
+spring(?###0:type_enum.season):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(1:type_enum.season, ?$##0:type_enum.season)
+    foreign llvm move(1:type_enum.season, ?###0:type_enum.season)
 
 
 summer > public {inline} (0 calls)
 0: type_enum.season.summer<0>
-summer(?$##0:type_enum.season):
+summer(?###0:type_enum.season):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(2:type_enum.season, ?$##0:type_enum.season)
+    foreign llvm move(2:type_enum.season, ?###0:type_enum.season)
 
 
 winter > public {inline} (0 calls)
 0: type_enum.season.winter<0>
-winter(?$##0:type_enum.season):
+winter(?###0:type_enum.season):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:type_enum.season, ?$##0:type_enum.season)
+    foreign llvm move(0:type_enum.season, ?###0:type_enum.season)
 
 
 ~= > public {inline} (0 calls)
 0: type_enum.season.~=<0>
-~=($left##0:type_enum.season, $right##0:type_enum.season, ?$$##0:wybe.bool):
+~=(#left##0:type_enum.season, #right##0:type_enum.season, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(~$left##0:type_enum.season, ~$right##0:type_enum.season, ?tmp$0##0:wybe.bool)
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    foreign llvm icmp_eq(~#left##0:type_enum.season, ~#right##0:type_enum.season, ?tmp#0##0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
   LLVM code       :
 
@@ -107,10 +107,10 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"type_enum.season.=<0>"(i2  %"$left##0", i2  %"$right##0")    {
+define external fastcc  i1 @"type_enum.season.=<0>"(i2  %"#left##0", i2  %"#right##0")    {
 entry:
-  %"1$$$##0" = icmp eq i2 %"$left##0", %"$right##0" 
-  ret i1 %"1$$$##0" 
+  %"1#####0" = icmp eq i2 %"#left##0", %"#right##0" 
+  ret i1 %"1#####0" 
 }
 
 
@@ -138,9 +138,9 @@ entry:
 }
 
 
-define external fastcc  i1 @"type_enum.season.~=<0>"(i2  %"$left##0", i2  %"$right##0")    {
+define external fastcc  i1 @"type_enum.season.~=<0>"(i2  %"#left##0", i2  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = icmp eq i2 %"$left##0", %"$right##0" 
-  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
-  ret i1 %"1$$$##0" 
+  %"1#tmp#0##0" = icmp eq i2 %"#left##0", %"#right##0" 
+  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1#####0" 
 }

--- a/test-cases/final-dump/type_enum.exp
+++ b/test-cases/final-dump/type_enum.exp
@@ -55,34 +55,34 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 autumn > public {inline} (0 calls)
 0: type_enum.season.autumn<0>
-autumn(?###0:type_enum.season):
+autumn(?#result##0:type_enum.season):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(3:type_enum.season, ?###0:type_enum.season)
+    foreign llvm move(3:type_enum.season, ?#result##0:type_enum.season)
 
 
 spring > public {inline} (0 calls)
 0: type_enum.season.spring<0>
-spring(?###0:type_enum.season):
+spring(?#result##0:type_enum.season):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(1:type_enum.season, ?###0:type_enum.season)
+    foreign llvm move(1:type_enum.season, ?#result##0:type_enum.season)
 
 
 summer > public {inline} (0 calls)
 0: type_enum.season.summer<0>
-summer(?###0:type_enum.season):
+summer(?#result##0:type_enum.season):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(2:type_enum.season, ?###0:type_enum.season)
+    foreign llvm move(2:type_enum.season, ?#result##0:type_enum.season)
 
 
 winter > public {inline} (0 calls)
 0: type_enum.season.winter<0>
-winter(?###0:type_enum.season):
+winter(?#result##0:type_enum.season):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:type_enum.season, ?###0:type_enum.season)
+    foreign llvm move(0:type_enum.season, ?#result##0:type_enum.season)
 
 
 ~= > public {inline} (0 calls)

--- a/test-cases/final-dump/type_generics.exp
+++ b/test-cases/final-dump/type_generics.exp
@@ -11,139 +11,139 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: type_generics.<0>
-(io#0:wybe.phantom, ?io#6:wybe.phantom):
+(io##0:wybe.phantom, ?io##6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    type_generics.foo<0>(1:?t, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) #0 @type_generics:nn:nn
-    type_generics.foo<0>(1:?t, ~#io#1:wybe.phantom, ?#io#2:wybe.phantom) #2 @type_generics:nn:nn
-    type_generics.foo<0>(1.0:?t, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) #3 @type_generics:nn:nn
-    type_generics.foo<0>(1.0:?t, ~#io#3:wybe.phantom, ?#io#4:wybe.phantom) #4 @type_generics:nn:nn
-    type_generics.foo2<0>(1:?T, ?y#0:?T, ?tmp$7#0:wybe.bool) #5 @type_generics:nn:nn
-    case ~tmp$7#0:wybe.bool of
+    type_generics.foo<0>(1:?t, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @type_generics:nn:nn
+    type_generics.foo<0>(1:?t, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #2 @type_generics:nn:nn
+    type_generics.foo<0>(1.0:?t, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @type_generics:nn:nn
+    type_generics.foo<0>(1.0:?t, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @type_generics:nn:nn
+    type_generics.foo2<0>(1:?T, ?y##0:?T, ?tmp$7##0:wybe.bool) #5 @type_generics:nn:nn
+    case ~tmp$7##0:wybe.bool of
     0:
-        type_generics.gen$1<0>(~io#4:wybe.phantom, _:wybe.bool, _:wybe.float, ?io#6:wybe.phantom) #8
+        type_generics.gen$1<0>(~io##4:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##6:wybe.phantom) #8
 
     1:
-        foreign c print_int(~y#0:wybe.int, ~#io#4:wybe.phantom, ?tmp$10#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$10#0:wybe.phantom, ?#io#5:wybe.phantom) @io:nn:nn
-        type_generics.gen$1<0>(~io#5:wybe.phantom, _:wybe.bool, _:wybe.float, ?io#6:wybe.phantom) #7
+        foreign c print_int(~y##0:wybe.int, ~#io##4:wybe.phantom, ?tmp$10##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$10##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+        type_generics.gen$1<0>(~io##5:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##6:wybe.phantom) #7
 
 
 
 foo > (12 calls)
 0: type_generics.foo<0>
-foo(x#0:?t, io#0:wybe.phantom, ?io#1:wybe.phantom):
+foo(x##0:?t, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$5#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$5#0:wybe.list(?T), ?tmp$6#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:?T)
-    foreign lpvm mutate(~tmp$6#0:wybe.list(?T), ?tmp$0#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    wybe.list.length1<0>(~tmp$0#0:wybe.list(?T), 0:wybe.int, ?tmp$2#0:wybe.int) #4 @list:nn:nn
-    foreign c print_int(~tmp$2#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$10#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$10#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$5##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$5##0:wybe.list(?T), ?tmp$6##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:?T)
+    foreign lpvm mutate(~tmp$6##0:wybe.list(?T), ?tmp$0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
+    wybe.list.length1<0>(~tmp$0##0:wybe.list(?T), 0:wybe.int, ?tmp$2##0:wybe.int) #4 @list:nn:nn
+    foreign c print_int(~tmp$2##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$10##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 foo2 > (18 calls)
 0: type_generics.foo2<0>
-foo2(x#0:?T, ?y#0:?T, ?$$#0:wybe.bool):
+foo2(x##0:?T, ?y##0:?T, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$6#0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$6#0:wybe.list(?T), ?tmp$7#0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x#0:?T)
-    foreign lpvm mutate(~tmp$7#0:wybe.list(?T), ?tmp$0#0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign llvm icmp_ne(tmp$0#0:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.bool)
-    case ~tmp$9#0:wybe.bool of
+    foreign lpvm alloc(16:wybe.int, ?tmp$6##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp$6##0:wybe.list(?T), ?tmp$7##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:?T)
+    foreign lpvm mutate(~tmp$7##0:wybe.list(?T), ?tmp$0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
+    foreign llvm icmp_ne(tmp$0##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
+    case ~tmp$9##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:?T, ?y#0:?T)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:?T, ?y##0:?T)
 
     1:
-        foreign lpvm access(~tmp$0#0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?y#0:?T)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~tmp$0##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:?T)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 gen$1 > (2 calls)
 0: type_generics.gen$1<0>
-gen$1(io#0:wybe.phantom, [tmp$0#0:wybe.bool], [x#0:wybe.float], ?io#2:wybe.phantom):
+gen$1(io##0:wybe.phantom, [tmp$0##0:wybe.bool], [x##0:wybe.float], ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    type_generics.foo2<0>(1:?T, ?y#0:?T, ?tmp$6#0:wybe.bool) #0 @type_generics:nn:nn
-    case ~tmp$6#0:wybe.bool of
+    type_generics.foo2<0>(1:?T, ?y##0:?T, ?tmp$6##0:wybe.bool) #0 @type_generics:nn:nn
+    case ~tmp$6##0:wybe.bool of
     0:
-        type_generics.gen$2<0>(_:wybe.int, ~io#0:wybe.phantom, _:wybe.bool, _:wybe.float, ?io#2:wybe.phantom) #3
+        type_generics.gen$2<0>(_:wybe.int, ~io##0:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##2:wybe.phantom) #3
 
     1:
-        foreign c print_int(~y#0:wybe.int, ~#io#0:wybe.phantom, ?tmp$9#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$9#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        type_generics.gen$2<0>(_:wybe.int, ~io#1:wybe.phantom, _:wybe.bool, _:wybe.float, ?io#2:wybe.phantom) #2
+        foreign c print_int(~y##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$9##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$9##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        type_generics.gen$2<0>(_:wybe.int, ~io##1:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##2:wybe.phantom) #2
 
 
 
 gen$2 > (2 calls)
 0: type_generics.gen$2<0>
-gen$2([i#0:wybe.int], io#0:wybe.phantom, [tmp$0#0:wybe.bool], [x#0:wybe.float], ?io#2:wybe.phantom):
+gen$2([i##0:wybe.int], io##0:wybe.phantom, [tmp$0##0:wybe.bool], [x##0:wybe.float], ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    type_generics.foo2<0>(1.0:?T, ?fx#0:?T, ?tmp$5#0:wybe.bool) #0 @type_generics:nn:nn
-    case ~tmp$5#0:wybe.bool of
+    type_generics.foo2<0>(1.0:?T, ?fx##0:?T, ?tmp$5##0:wybe.bool) #0 @type_generics:nn:nn
+    case ~tmp$5##0:wybe.bool of
     0:
-        type_generics.gen$3<0>(_:wybe.float, _:wybe.int, ~io#0:wybe.phantom, _:wybe.bool, _:wybe.float, ?io#2:wybe.phantom) #3
+        type_generics.gen$3<0>(_:wybe.float, _:wybe.int, ~io##0:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##2:wybe.phantom) #3
 
     1:
-        foreign c print_float(~fx#0:wybe.float, ~#io#0:wybe.phantom, ?tmp$8#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$8#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        type_generics.gen$3<0>(_:wybe.float, _:wybe.int, ~io#1:wybe.phantom, _:wybe.bool, _:wybe.float, ?io#2:wybe.phantom) #2
+        foreign c print_float(~fx##0:wybe.float, ~#io##0:wybe.phantom, ?tmp$8##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$8##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        type_generics.gen$3<0>(_:wybe.float, _:wybe.int, ~io##1:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##2:wybe.phantom) #2
 
 
 
 gen$3 > (2 calls)
 0: type_generics.gen$3<0>
-gen$3([f#0:wybe.float], [i#0:wybe.int], io#0:wybe.phantom, [tmp$0#0:wybe.bool], [x#0:wybe.float], ?io#2:wybe.phantom):
+gen$3([f##0:wybe.float], [i##0:wybe.int], io##0:wybe.phantom, [tmp$0##0:wybe.bool], [x##0:wybe.float], ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    type_generics.foo2<0>(1.0:?T, ?x#1:?T, ?tmp$4#0:wybe.bool) #0 @type_generics:nn:nn
-    case ~tmp$4#0:wybe.bool of
+    type_generics.foo2<0>(1.0:?T, ?x##1:?T, ?tmp$4##0:wybe.bool) #0 @type_generics:nn:nn
+    case ~tmp$4##0:wybe.bool of
     0:
-        type_generics.gen$4<0>(_:wybe.float, _:wybe.int, ~io#0:wybe.phantom, _:wybe.bool, _:wybe.float, ?io#2:wybe.phantom) #3
+        type_generics.gen$4<0>(_:wybe.float, _:wybe.int, ~io##0:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##2:wybe.phantom) #3
 
     1:
-        foreign c print_float(~x#1:wybe.float, ~#io#0:wybe.phantom, ?tmp$7#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$7#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        type_generics.gen$4<0>(_:wybe.float, _:wybe.int, ~io#1:wybe.phantom, _:wybe.bool, _:wybe.float, ?io#2:wybe.phantom) #2
+        foreign c print_float(~x##1:wybe.float, ~#io##0:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        type_generics.gen$4<0>(_:wybe.float, _:wybe.int, ~io##1:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##2:wybe.phantom) #2
 
 
 
 gen$4 > (2 calls)
 0: type_generics.gen$4<0>
-gen$4([f#0:wybe.float], [i#0:wybe.int], io#0:wybe.phantom, [tmp$0#0:wybe.bool], [x#0:wybe.float], ?io#2:wybe.phantom):
+gen$4([f##0:wybe.float], [i##0:wybe.int], io##0:wybe.phantom, [tmp$0##0:wybe.bool], [x##0:wybe.float], ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    type_generics.foo2<0>('a':?T, ?z#0:?T, ?tmp$3#0:wybe.bool) #0 @type_generics:nn:nn
-    case ~tmp$3#0:wybe.bool of
+    type_generics.foo2<0>('a':?T, ?z##0:?T, ?tmp$3##0:wybe.bool) #0 @type_generics:nn:nn
+    case ~tmp$3##0:wybe.bool of
     0:
-        type_generics.gen$5<0>(_:wybe.float, _:wybe.int, ~io#0:wybe.phantom, _:wybe.bool, _:wybe.float, ?io#2:wybe.phantom) #3
+        type_generics.gen$5<0>(_:wybe.float, _:wybe.int, ~io##0:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##2:wybe.phantom) #3
 
     1:
-        foreign c putchar(~z#0:wybe.char, ~#io#0:wybe.phantom, ?tmp$6#0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$6#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-        type_generics.gen$5<0>(_:wybe.float, _:wybe.int, ~io#1:wybe.phantom, _:wybe.bool, _:wybe.float, ?io#2:wybe.phantom) #2
+        foreign c putchar(~z##0:wybe.char, ~#io##0:wybe.phantom, ?tmp$6##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        type_generics.gen$5<0>(_:wybe.float, _:wybe.int, ~io##1:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##2:wybe.phantom) #2
 
 
 
 gen$5 > (2 calls)
 0: type_generics.gen$5<0>
-gen$5([f#0:wybe.float], [i#0:wybe.int], io#0:wybe.phantom, [tmp$0#0:wybe.bool], [x#0:wybe.float], ?io#1:wybe.phantom):
+gen$5([f##0:wybe.float], [i##0:wybe.int], io##0:wybe.phantom, [tmp$0##0:wybe.bool], [x##0:wybe.float], ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    type_generics.foo2<0>(0:?T, ?b#0:?T, ?tmp$2#0:wybe.bool) #1 @type_generics:nn:nn
-    case ~tmp$2#0:wybe.bool of
+    type_generics.foo2<0>(0:?T, ?b##0:?T, ?tmp$2##0:wybe.bool) #1 @type_generics:nn:nn
+    case ~tmp$2##0:wybe.bool of
     0:
-        foreign llvm move(~io#0:wybe.phantom, ?io#1:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        wybe.io.print<5>(~b#0:wybe.bool, ~#io#0:wybe.phantom, ?tmp$5#0:wybe.phantom) #3 @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$5#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+        wybe.io.print<5>(~b##0:wybe.bool, ~#io##0:wybe.phantom, ?tmp$5##0:wybe.phantom) #3 @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp$5##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
   LLVM code       :
@@ -198,39 +198,39 @@ if.else:
 }
 
 
-define external fastcc  void @"type_generics.foo<0>"(i64  %"x#0")    {
+define external fastcc  void @"type_generics.foo<0>"(i64  %"x##0")    {
 entry:
   %6 = trunc i64 16 to i32  
   %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
   %8 = ptrtoint i8* %7 to i64 
   %9 = inttoptr i64 %8 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 %"x#0", i64* %10 
+  store  i64 %"x##0", i64* %10 
   %11 = add   i64 %8, 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   store  i64 0, i64* %13 
-  %"1$tmp$2#0" = tail call fastcc  i64  @"wybe.list.length1<0>"(i64  %8, i64  0)  
-  tail call ccc  void  @print_int(i64  %"1$tmp$2#0")  
+  %"1$tmp$2##0" = tail call fastcc  i64  @"wybe.list.length1<0>"(i64  %8, i64  0)  
+  tail call ccc  void  @print_int(i64  %"1$tmp$2##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
 
 
-define external fastcc  {i64, i1} @"type_generics.foo2<0>"(i64  %"x#0")    {
+define external fastcc  {i64, i1} @"type_generics.foo2<0>"(i64  %"x##0")    {
 entry:
   %14 = trunc i64 16 to i32  
   %15 = tail call ccc  i8*  @wybe_malloc(i32  %14)  
   %16 = ptrtoint i8* %15 to i64 
   %17 = inttoptr i64 %16 to i64* 
   %18 = getelementptr  i64, i64* %17, i64 0 
-  store  i64 %"x#0", i64* %18 
+  store  i64 %"x##0", i64* %18 
   %19 = add   i64 %16, 8 
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   store  i64 0, i64* %21 
-  %"1$tmp$9#0" = icmp ne i64 %16, 0 
-  br i1 %"1$tmp$9#0", label %if.then, label %if.else 
+  %"1$tmp$9##0" = icmp ne i64 %16, 0 
+  br i1 %"1$tmp$9##0", label %if.then, label %if.else 
 if.then:
   %22 = inttoptr i64 %16 to i64* 
   %23 = getelementptr  i64, i64* %22, i64 0 

--- a/test-cases/final-dump/type_generics.exp
+++ b/test-cases/final-dump/type_generics.exp
@@ -18,15 +18,15 @@ AFTER EVERYTHING:
     type_generics.foo<0>(1:?t, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #2 @type_generics:nn:nn
     type_generics.foo<0>(1.0:?t, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @type_generics:nn:nn
     type_generics.foo<0>(1.0:?t, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @type_generics:nn:nn
-    type_generics.foo2<0>(1:?T, ?y##0:?T, ?tmp$7##0:wybe.bool) #5 @type_generics:nn:nn
-    case ~tmp$7##0:wybe.bool of
+    type_generics.foo2<0>(1:?T, ?y##0:?T, ?tmp#7##0:wybe.bool) #5 @type_generics:nn:nn
+    case ~tmp#7##0:wybe.bool of
     0:
-        type_generics.gen$1<0>(~io##4:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##6:wybe.phantom) #8
+        type_generics.gen#1<0>(~io##4:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##6:wybe.phantom) #8
 
     1:
-        foreign c print_int(~y##0:wybe.int, ~#io##4:wybe.phantom, ?tmp$10##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$10##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
-        type_generics.gen$1<0>(~io##5:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##6:wybe.phantom) #7
+        foreign c print_int(~y##0:wybe.int, ~#io##4:wybe.phantom, ?tmp#10##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
+        type_generics.gen#1<0>(~io##5:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##6:wybe.phantom) #7
 
 
 
@@ -35,115 +35,115 @@ foo > (12 calls)
 foo(x##0:?t, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$5##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$5##0:wybe.list(?T), ?tmp$6##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:?T)
-    foreign lpvm mutate(~tmp$6##0:wybe.list(?T), ?tmp$0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    wybe.list.length1<0>(~tmp$0##0:wybe.list(?T), 0:wybe.int, ?tmp$2##0:wybe.int) #4 @list:nn:nn
-    foreign c print_int(~tmp$2##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$10##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#5##0:wybe.list(?T), ?tmp#6##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:?T)
+    foreign lpvm mutate(~tmp#6##0:wybe.list(?T), ?tmp#0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
+    wybe.list.length1<0>(~tmp#0##0:wybe.list(?T), 0:wybe.int, ?tmp#2##0:wybe.int) #4 @list:nn:nn
+    foreign c print_int(~tmp#2##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 foo2 > (18 calls)
 0: type_generics.foo2<0>
-foo2(x##0:?T, ?y##0:?T, ?$$##0:wybe.bool):
+foo2(x##0:?T, ?y##0:?T, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp$6##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp$6##0:wybe.list(?T), ?tmp$7##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:?T)
-    foreign lpvm mutate(~tmp$7##0:wybe.list(?T), ?tmp$0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign llvm icmp_ne(tmp$0##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
-    case ~tmp$9##0:wybe.bool of
+    foreign lpvm alloc(16:wybe.int, ?tmp#6##0:wybe.list(?T))
+    foreign lpvm mutate(~tmp#6##0:wybe.list(?T), ?tmp#7##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:?T)
+    foreign lpvm mutate(~tmp#7##0:wybe.list(?T), ?tmp#0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
+    foreign llvm icmp_ne(tmp#0##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
+    case ~tmp#9##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:?T, ?y##0:?T)
 
     1:
-        foreign lpvm access(~tmp$0##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:?T)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~tmp#0##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:?T)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
-gen$1 > (2 calls)
-0: type_generics.gen$1<0>
-gen$1(io##0:wybe.phantom, [tmp$0##0:wybe.bool], [x##0:wybe.float], ?io##2:wybe.phantom):
+gen#1 > (2 calls)
+0: type_generics.gen#1<0>
+gen#1(io##0:wybe.phantom, [tmp#0##0:wybe.bool], [x##0:wybe.float], ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    type_generics.foo2<0>(1:?T, ?y##0:?T, ?tmp$6##0:wybe.bool) #0 @type_generics:nn:nn
-    case ~tmp$6##0:wybe.bool of
+    type_generics.foo2<0>(1:?T, ?y##0:?T, ?tmp#6##0:wybe.bool) #0 @type_generics:nn:nn
+    case ~tmp#6##0:wybe.bool of
     0:
-        type_generics.gen$2<0>(_:wybe.int, ~io##0:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##2:wybe.phantom) #3
+        type_generics.gen#2<0>(_:wybe.int, ~io##0:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##2:wybe.phantom) #3
 
     1:
-        foreign c print_int(~y##0:wybe.int, ~#io##0:wybe.phantom, ?tmp$9##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$9##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        type_generics.gen$2<0>(_:wybe.int, ~io##1:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##2:wybe.phantom) #2
+        foreign c print_int(~y##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#9##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        type_generics.gen#2<0>(_:wybe.int, ~io##1:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##2:wybe.phantom) #2
 
 
 
-gen$2 > (2 calls)
-0: type_generics.gen$2<0>
-gen$2([i##0:wybe.int], io##0:wybe.phantom, [tmp$0##0:wybe.bool], [x##0:wybe.float], ?io##2:wybe.phantom):
+gen#2 > (2 calls)
+0: type_generics.gen#2<0>
+gen#2([i##0:wybe.int], io##0:wybe.phantom, [tmp#0##0:wybe.bool], [x##0:wybe.float], ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    type_generics.foo2<0>(1.0:?T, ?fx##0:?T, ?tmp$5##0:wybe.bool) #0 @type_generics:nn:nn
-    case ~tmp$5##0:wybe.bool of
+    type_generics.foo2<0>(1.0:?T, ?fx##0:?T, ?tmp#5##0:wybe.bool) #0 @type_generics:nn:nn
+    case ~tmp#5##0:wybe.bool of
     0:
-        type_generics.gen$3<0>(_:wybe.float, _:wybe.int, ~io##0:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##2:wybe.phantom) #3
+        type_generics.gen#3<0>(_:wybe.float, _:wybe.int, ~io##0:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##2:wybe.phantom) #3
 
     1:
-        foreign c print_float(~fx##0:wybe.float, ~#io##0:wybe.phantom, ?tmp$8##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$8##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        type_generics.gen$3<0>(_:wybe.float, _:wybe.int, ~io##1:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##2:wybe.phantom) #2
+        foreign c print_float(~fx##0:wybe.float, ~#io##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#8##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        type_generics.gen#3<0>(_:wybe.float, _:wybe.int, ~io##1:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##2:wybe.phantom) #2
 
 
 
-gen$3 > (2 calls)
-0: type_generics.gen$3<0>
-gen$3([f##0:wybe.float], [i##0:wybe.int], io##0:wybe.phantom, [tmp$0##0:wybe.bool], [x##0:wybe.float], ?io##2:wybe.phantom):
+gen#3 > (2 calls)
+0: type_generics.gen#3<0>
+gen#3([f##0:wybe.float], [i##0:wybe.int], io##0:wybe.phantom, [tmp#0##0:wybe.bool], [x##0:wybe.float], ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    type_generics.foo2<0>(1.0:?T, ?x##1:?T, ?tmp$4##0:wybe.bool) #0 @type_generics:nn:nn
-    case ~tmp$4##0:wybe.bool of
+    type_generics.foo2<0>(1.0:?T, ?x##1:?T, ?tmp#4##0:wybe.bool) #0 @type_generics:nn:nn
+    case ~tmp#4##0:wybe.bool of
     0:
-        type_generics.gen$4<0>(_:wybe.float, _:wybe.int, ~io##0:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##2:wybe.phantom) #3
+        type_generics.gen#4<0>(_:wybe.float, _:wybe.int, ~io##0:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##2:wybe.phantom) #3
 
     1:
-        foreign c print_float(~x##1:wybe.float, ~#io##0:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        type_generics.gen$4<0>(_:wybe.float, _:wybe.int, ~io##1:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##2:wybe.phantom) #2
+        foreign c print_float(~x##1:wybe.float, ~#io##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        type_generics.gen#4<0>(_:wybe.float, _:wybe.int, ~io##1:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##2:wybe.phantom) #2
 
 
 
-gen$4 > (2 calls)
-0: type_generics.gen$4<0>
-gen$4([f##0:wybe.float], [i##0:wybe.int], io##0:wybe.phantom, [tmp$0##0:wybe.bool], [x##0:wybe.float], ?io##2:wybe.phantom):
+gen#4 > (2 calls)
+0: type_generics.gen#4<0>
+gen#4([f##0:wybe.float], [i##0:wybe.int], io##0:wybe.phantom, [tmp#0##0:wybe.bool], [x##0:wybe.float], ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    type_generics.foo2<0>('a':?T, ?z##0:?T, ?tmp$3##0:wybe.bool) #0 @type_generics:nn:nn
-    case ~tmp$3##0:wybe.bool of
+    type_generics.foo2<0>('a':?T, ?z##0:?T, ?tmp#3##0:wybe.bool) #0 @type_generics:nn:nn
+    case ~tmp#3##0:wybe.bool of
     0:
-        type_generics.gen$5<0>(_:wybe.float, _:wybe.int, ~io##0:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##2:wybe.phantom) #3
+        type_generics.gen#5<0>(_:wybe.float, _:wybe.int, ~io##0:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##2:wybe.phantom) #3
 
     1:
-        foreign c putchar(~z##0:wybe.char, ~#io##0:wybe.phantom, ?tmp$6##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        type_generics.gen$5<0>(_:wybe.float, _:wybe.int, ~io##1:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##2:wybe.phantom) #2
+        foreign c putchar(~z##0:wybe.char, ~#io##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        type_generics.gen#5<0>(_:wybe.float, _:wybe.int, ~io##1:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##2:wybe.phantom) #2
 
 
 
-gen$5 > (2 calls)
-0: type_generics.gen$5<0>
-gen$5([f##0:wybe.float], [i##0:wybe.int], io##0:wybe.phantom, [tmp$0##0:wybe.bool], [x##0:wybe.float], ?io##1:wybe.phantom):
+gen#5 > (2 calls)
+0: type_generics.gen#5<0>
+gen#5([f##0:wybe.float], [i##0:wybe.int], io##0:wybe.phantom, [tmp#0##0:wybe.bool], [x##0:wybe.float], ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    type_generics.foo2<0>(0:?T, ?b##0:?T, ?tmp$2##0:wybe.bool) #1 @type_generics:nn:nn
-    case ~tmp$2##0:wybe.bool of
+    type_generics.foo2<0>(0:?T, ?b##0:?T, ?tmp#2##0:wybe.bool) #1 @type_generics:nn:nn
+    case ~tmp#2##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        wybe.io.print<5>(~b##0:wybe.bool, ~#io##0:wybe.phantom, ?tmp$5##0:wybe.phantom) #3 @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp$5##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        wybe.io.print<5>(~b##0:wybe.bool, ~#io##0:wybe.phantom, ?tmp#5##0:wybe.phantom) #3 @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
   LLVM code       :
@@ -190,10 +190,10 @@ entry:
 if.then:
   tail call ccc  void  @print_int(i64  %4)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"type_generics.gen$1<0>"()  
+  tail call fastcc  void  @"type_generics.gen#1<0>"()  
   ret void 
 if.else:
-  tail call fastcc  void  @"type_generics.gen$1<0>"()  
+  tail call fastcc  void  @"type_generics.gen#1<0>"()  
   ret void 
 }
 
@@ -210,8 +210,8 @@ entry:
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   store  i64 0, i64* %13 
-  %"1$tmp$2##0" = tail call fastcc  i64  @"wybe.list.length1<0>"(i64  %8, i64  0)  
-  tail call ccc  void  @print_int(i64  %"1$tmp$2##0")  
+  %"1#tmp#2##0" = tail call fastcc  i64  @"wybe.list.length1<0>"(i64  %8, i64  0)  
+  tail call ccc  void  @print_int(i64  %"1#tmp#2##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -229,8 +229,8 @@ entry:
   %20 = inttoptr i64 %19 to i64* 
   %21 = getelementptr  i64, i64* %20, i64 0 
   store  i64 0, i64* %21 
-  %"1$tmp$9##0" = icmp ne i64 %16, 0 
-  br i1 %"1$tmp$9##0", label %if.then, label %if.else 
+  %"1#tmp#9##0" = icmp ne i64 %16, 0 
+  br i1 %"1#tmp#9##0", label %if.then, label %if.else 
 if.then:
   %22 = inttoptr i64 %16 to i64* 
   %23 = getelementptr  i64, i64* %22, i64 0 
@@ -245,7 +245,7 @@ if.else:
 }
 
 
-define external fastcc  void @"type_generics.gen$1<0>"()    {
+define external fastcc  void @"type_generics.gen#1<0>"()    {
 entry:
   %29 = tail call fastcc  {i64, i1}  @"type_generics.foo2<0>"(i64  1)  
   %30 = extractvalue {i64, i1} %29, 0 
@@ -254,15 +254,15 @@ entry:
 if.then:
   tail call ccc  void  @print_int(i64  %30)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"type_generics.gen$2<0>"()  
+  tail call fastcc  void  @"type_generics.gen#2<0>"()  
   ret void 
 if.else:
-  tail call fastcc  void  @"type_generics.gen$2<0>"()  
+  tail call fastcc  void  @"type_generics.gen#2<0>"()  
   ret void 
 }
 
 
-define external fastcc  void @"type_generics.gen$2<0>"()    {
+define external fastcc  void @"type_generics.gen#2<0>"()    {
 entry:
   %32 = bitcast double 1.000000e0 to i64 
   %33 = tail call fastcc  {i64, i1}  @"type_generics.foo2<0>"(i64  %32)  
@@ -273,15 +273,15 @@ if.then:
   %36 = bitcast i64 %34 to double 
   tail call ccc  void  @print_float(double  %36)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"type_generics.gen$3<0>"()  
+  tail call fastcc  void  @"type_generics.gen#3<0>"()  
   ret void 
 if.else:
-  tail call fastcc  void  @"type_generics.gen$3<0>"()  
+  tail call fastcc  void  @"type_generics.gen#3<0>"()  
   ret void 
 }
 
 
-define external fastcc  void @"type_generics.gen$3<0>"()    {
+define external fastcc  void @"type_generics.gen#3<0>"()    {
 entry:
   %37 = bitcast double 1.000000e0 to i64 
   %38 = tail call fastcc  {i64, i1}  @"type_generics.foo2<0>"(i64  %37)  
@@ -292,15 +292,15 @@ if.then:
   %41 = bitcast i64 %39 to double 
   tail call ccc  void  @print_float(double  %41)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"type_generics.gen$4<0>"()  
+  tail call fastcc  void  @"type_generics.gen#4<0>"()  
   ret void 
 if.else:
-  tail call fastcc  void  @"type_generics.gen$4<0>"()  
+  tail call fastcc  void  @"type_generics.gen#4<0>"()  
   ret void 
 }
 
 
-define external fastcc  void @"type_generics.gen$4<0>"()    {
+define external fastcc  void @"type_generics.gen#4<0>"()    {
 entry:
   %42 = tail call fastcc  {i64, i1}  @"type_generics.foo2<0>"(i64  97)  
   %43 = extractvalue {i64, i1} %42, 0 
@@ -310,15 +310,15 @@ if.then:
   %45 = trunc i64 %43 to i8  
   tail call ccc  void  @putchar(i8  %45)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"type_generics.gen$5<0>"()  
+  tail call fastcc  void  @"type_generics.gen#5<0>"()  
   ret void 
 if.else:
-  tail call fastcc  void  @"type_generics.gen$5<0>"()  
+  tail call fastcc  void  @"type_generics.gen#5<0>"()  
   ret void 
 }
 
 
-define external fastcc  void @"type_generics.gen$5<0>"()    {
+define external fastcc  void @"type_generics.gen#5<0>"()    {
 entry:
   %46 = tail call fastcc  {i64, i1}  @"type_generics.foo2<0>"(i64  0)  
   %47 = extractvalue {i64, i1} %46, 0 

--- a/test-cases/final-dump/type_generics.exp
+++ b/test-cases/final-dump/type_generics.exp
@@ -45,7 +45,7 @@ foo(x##0:?t, io##0:wybe.phantom, ?io##1:wybe.phantom):
 
 foo2 > (18 calls)
 0: type_generics.foo2<0>
-foo2(x##0:?T, ?y##0:?T, ?####0:wybe.bool):
+foo2(x##0:?T, ?y##0:?T, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp#6##0:wybe.list(?T))
@@ -54,12 +54,12 @@ foo2(x##0:?T, ?y##0:?T, ?####0:wybe.bool):
     foreign llvm icmp_ne(tmp#0##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
     case ~tmp#9##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:?T, ?y##0:?T)
 
     1:
         foreign lpvm access(~tmp#0##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:?T)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 

--- a/test-cases/final-dump/type_int.exp
+++ b/test-cases/final-dump/type_int.exp
@@ -63,18 +63,18 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 * > public {inline} (0 calls)
 0: type_int.myint.*<0>
-*(x##0:type_int.myint, y##0:type_int.myint, ?###0:type_int.myint):
+*(x##0:type_int.myint, y##0:type_int.myint, ?#result##0:type_int.myint):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm mul(~x##0:type_int.myint, ~y##0:type_int.myint, ?###0:type_int.myint) @type_int:nn:nn
+    foreign llvm mul(~x##0:type_int.myint, ~y##0:type_int.myint, ?#result##0:type_int.myint) @type_int:nn:nn
 
 
 + > public {inline} (0 calls)
 0: type_int.myint.+<0>
-+(x##0:type_int.myint, y##0:type_int.myint, ?###0:type_int.myint):
++(x##0:type_int.myint, y##0:type_int.myint, ?#result##0:type_int.myint):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~x##0:type_int.myint, ~y##0:type_int.myint, ?###0:type_int.myint) @type_int:nn:nn
+    foreign llvm add(~x##0:type_int.myint, ~y##0:type_int.myint, ?#result##0:type_int.myint) @type_int:nn:nn
 + > public {inline} (0 calls)
 1: type_int.myint.+<1>
 +(?x##0:type_int.myint, y##0:type_int.myint, z##0:type_int.myint):
@@ -91,10 +91,10 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 - > public {inline} (0 calls)
 0: type_int.myint.-<0>
--(x##0:type_int.myint, y##0:type_int.myint, ?###0:type_int.myint):
+-(x##0:type_int.myint, y##0:type_int.myint, ?#result##0:type_int.myint):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm sub(~x##0:type_int.myint, ~y##0:type_int.myint, ?###0:type_int.myint) @type_int:nn:nn
+    foreign llvm sub(~x##0:type_int.myint, ~y##0:type_int.myint, ?#result##0:type_int.myint) @type_int:nn:nn
 - > public {inline} (0 calls)
 1: type_int.myint.-<1>
 -(?x##0:type_int.myint, y##0:type_int.myint, z##0:type_int.myint):
@@ -111,58 +111,58 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 / > public {inline} (0 calls)
 0: type_int.myint./<0>
-/(x##0:type_int.myint, y##0:type_int.myint, ?###0:type_int.myint):
+/(x##0:type_int.myint, y##0:type_int.myint, ?#result##0:type_int.myint):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm sdiv(~x##0:type_int.myint, ~y##0:type_int.myint, ?###0:type_int.myint) @type_int:nn:nn
+    foreign llvm sdiv(~x##0:type_int.myint, ~y##0:type_int.myint, ?#result##0:type_int.myint) @type_int:nn:nn
 
 
 < > public {inline} (0 calls)
 0: type_int.myint.<<0>
-<(x##0:type_int.myint, y##0:type_int.myint, ?###0:wybe.bool):
+<(x##0:type_int.myint, y##0:type_int.myint, ?#result##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_slt(~x##0:type_int.myint, ~y##0:type_int.myint, ?###0:wybe.bool) @type_int:nn:nn
+    foreign llvm icmp_slt(~x##0:type_int.myint, ~y##0:type_int.myint, ?#result##0:wybe.bool) @type_int:nn:nn
 
 
 <= > public {inline} (0 calls)
 0: type_int.myint.<=<0>
-<=(x##0:type_int.myint, y##0:type_int.myint, ?###0:wybe.bool):
+<=(x##0:type_int.myint, y##0:type_int.myint, ?#result##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_sle(~x##0:type_int.myint, ~y##0:type_int.myint, ?###0:wybe.bool) @type_int:nn:nn
+    foreign llvm icmp_sle(~x##0:type_int.myint, ~y##0:type_int.myint, ?#result##0:wybe.bool) @type_int:nn:nn
 
 
 = > public {inline} (0 calls)
 0: type_int.myint.=<0>
-=(x##0:type_int.myint, y##0:type_int.myint, ?###0:wybe.bool):
+=(x##0:type_int.myint, y##0:type_int.myint, ?#result##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(~x##0:type_int.myint, ~y##0:type_int.myint, ?###0:wybe.bool) @type_int:nn:nn
+    foreign llvm icmp_eq(~x##0:type_int.myint, ~y##0:type_int.myint, ?#result##0:wybe.bool) @type_int:nn:nn
 
 
 > > public {inline} (0 calls)
 0: type_int.myint.><0>
->(x##0:type_int.myint, y##0:type_int.myint, ?###0:wybe.bool):
+>(x##0:type_int.myint, y##0:type_int.myint, ?#result##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_sgt(~x##0:type_int.myint, ~y##0:type_int.myint, ?###0:wybe.bool) @type_int:nn:nn
+    foreign llvm icmp_sgt(~x##0:type_int.myint, ~y##0:type_int.myint, ?#result##0:wybe.bool) @type_int:nn:nn
 
 
 >= > public {inline} (0 calls)
 0: type_int.myint.>=<0>
->=(x##0:type_int.myint, y##0:type_int.myint, ?###0:wybe.bool):
+>=(x##0:type_int.myint, y##0:type_int.myint, ?#result##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_sge(~x##0:type_int.myint, ~y##0:type_int.myint, ?###0:wybe.bool) @type_int:nn:nn
+    foreign llvm icmp_sge(~x##0:type_int.myint, ~y##0:type_int.myint, ?#result##0:wybe.bool) @type_int:nn:nn
 
 
 ~= > public {inline} (0 calls)
 0: type_int.myint.~=<0>
-~=(x##0:type_int.myint, y##0:type_int.myint, ?###0:wybe.bool):
+~=(x##0:type_int.myint, y##0:type_int.myint, ?#result##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(~x##0:type_int.myint, ~y##0:type_int.myint, ?###0:wybe.bool) @type_int:nn:nn
+    foreign llvm icmp_ne(~x##0:type_int.myint, ~y##0:type_int.myint, ?#result##0:wybe.bool) @type_int:nn:nn
 
   LLVM code       :
 
@@ -180,15 +180,15 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  i64 @"type_int.myint.*<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1####0" = mul   i64 %"x##0", %"y##0" 
-  ret i64 %"1####0" 
+  %"1##result##0" = mul   i64 %"x##0", %"y##0" 
+  ret i64 %"1##result##0" 
 }
 
 
 define external fastcc  i64 @"type_int.myint.+<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1####0" = add   i64 %"x##0", %"y##0" 
-  ret i64 %"1####0" 
+  %"1##result##0" = add   i64 %"x##0", %"y##0" 
+  ret i64 %"1##result##0" 
 }
 
 
@@ -208,8 +208,8 @@ entry:
 
 define external fastcc  i64 @"type_int.myint.-<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1####0" = sub   i64 %"x##0", %"y##0" 
-  ret i64 %"1####0" 
+  %"1##result##0" = sub   i64 %"x##0", %"y##0" 
+  ret i64 %"1##result##0" 
 }
 
 
@@ -229,48 +229,48 @@ entry:
 
 define external fastcc  i64 @"type_int.myint./<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1####0" = sdiv exact i64 %"x##0", %"y##0" 
-  ret i64 %"1####0" 
+  %"1##result##0" = sdiv exact i64 %"x##0", %"y##0" 
+  ret i64 %"1##result##0" 
 }
 
 
 define external fastcc  i1 @"type_int.myint.<<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1####0" = icmp slt i64 %"x##0", %"y##0" 
-  ret i1 %"1####0" 
+  %"1##result##0" = icmp slt i64 %"x##0", %"y##0" 
+  ret i1 %"1##result##0" 
 }
 
 
 define external fastcc  i1 @"type_int.myint.<=<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1####0" = icmp sle i64 %"x##0", %"y##0" 
-  ret i1 %"1####0" 
+  %"1##result##0" = icmp sle i64 %"x##0", %"y##0" 
+  ret i1 %"1##result##0" 
 }
 
 
 define external fastcc  i1 @"type_int.myint.=<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1####0" = icmp eq i64 %"x##0", %"y##0" 
-  ret i1 %"1####0" 
+  %"1##result##0" = icmp eq i64 %"x##0", %"y##0" 
+  ret i1 %"1##result##0" 
 }
 
 
 define external fastcc  i1 @"type_int.myint.><0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1####0" = icmp sgt i64 %"x##0", %"y##0" 
-  ret i1 %"1####0" 
+  %"1##result##0" = icmp sgt i64 %"x##0", %"y##0" 
+  ret i1 %"1##result##0" 
 }
 
 
 define external fastcc  i1 @"type_int.myint.>=<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1####0" = icmp sge i64 %"x##0", %"y##0" 
-  ret i1 %"1####0" 
+  %"1##result##0" = icmp sge i64 %"x##0", %"y##0" 
+  ret i1 %"1##result##0" 
 }
 
 
 define external fastcc  i1 @"type_int.myint.~=<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1####0" = icmp ne i64 %"x##0", %"y##0" 
-  ret i1 %"1####0" 
+  %"1##result##0" = icmp ne i64 %"x##0", %"y##0" 
+  ret i1 %"1##result##0" 
 }

--- a/test-cases/final-dump/type_int.exp
+++ b/test-cases/final-dump/type_int.exp
@@ -63,18 +63,18 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 * > public {inline} (0 calls)
 0: type_int.myint.*<0>
-*(x##0:type_int.myint, y##0:type_int.myint, ?$##0:type_int.myint):
+*(x##0:type_int.myint, y##0:type_int.myint, ?###0:type_int.myint):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm mul(~x##0:type_int.myint, ~y##0:type_int.myint, ?$##0:type_int.myint) @type_int:nn:nn
+    foreign llvm mul(~x##0:type_int.myint, ~y##0:type_int.myint, ?###0:type_int.myint) @type_int:nn:nn
 
 
 + > public {inline} (0 calls)
 0: type_int.myint.+<0>
-+(x##0:type_int.myint, y##0:type_int.myint, ?$##0:type_int.myint):
++(x##0:type_int.myint, y##0:type_int.myint, ?###0:type_int.myint):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~x##0:type_int.myint, ~y##0:type_int.myint, ?$##0:type_int.myint) @type_int:nn:nn
+    foreign llvm add(~x##0:type_int.myint, ~y##0:type_int.myint, ?###0:type_int.myint) @type_int:nn:nn
 + > public {inline} (0 calls)
 1: type_int.myint.+<1>
 +(?x##0:type_int.myint, y##0:type_int.myint, z##0:type_int.myint):
@@ -91,10 +91,10 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 - > public {inline} (0 calls)
 0: type_int.myint.-<0>
--(x##0:type_int.myint, y##0:type_int.myint, ?$##0:type_int.myint):
+-(x##0:type_int.myint, y##0:type_int.myint, ?###0:type_int.myint):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm sub(~x##0:type_int.myint, ~y##0:type_int.myint, ?$##0:type_int.myint) @type_int:nn:nn
+    foreign llvm sub(~x##0:type_int.myint, ~y##0:type_int.myint, ?###0:type_int.myint) @type_int:nn:nn
 - > public {inline} (0 calls)
 1: type_int.myint.-<1>
 -(?x##0:type_int.myint, y##0:type_int.myint, z##0:type_int.myint):
@@ -111,58 +111,58 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 / > public {inline} (0 calls)
 0: type_int.myint./<0>
-/(x##0:type_int.myint, y##0:type_int.myint, ?$##0:type_int.myint):
+/(x##0:type_int.myint, y##0:type_int.myint, ?###0:type_int.myint):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm sdiv(~x##0:type_int.myint, ~y##0:type_int.myint, ?$##0:type_int.myint) @type_int:nn:nn
+    foreign llvm sdiv(~x##0:type_int.myint, ~y##0:type_int.myint, ?###0:type_int.myint) @type_int:nn:nn
 
 
 < > public {inline} (0 calls)
 0: type_int.myint.<<0>
-<(x##0:type_int.myint, y##0:type_int.myint, ?$##0:wybe.bool):
+<(x##0:type_int.myint, y##0:type_int.myint, ?###0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_slt(~x##0:type_int.myint, ~y##0:type_int.myint, ?$##0:wybe.bool) @type_int:nn:nn
+    foreign llvm icmp_slt(~x##0:type_int.myint, ~y##0:type_int.myint, ?###0:wybe.bool) @type_int:nn:nn
 
 
 <= > public {inline} (0 calls)
 0: type_int.myint.<=<0>
-<=(x##0:type_int.myint, y##0:type_int.myint, ?$##0:wybe.bool):
+<=(x##0:type_int.myint, y##0:type_int.myint, ?###0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_sle(~x##0:type_int.myint, ~y##0:type_int.myint, ?$##0:wybe.bool) @type_int:nn:nn
+    foreign llvm icmp_sle(~x##0:type_int.myint, ~y##0:type_int.myint, ?###0:wybe.bool) @type_int:nn:nn
 
 
 = > public {inline} (0 calls)
 0: type_int.myint.=<0>
-=(x##0:type_int.myint, y##0:type_int.myint, ?$##0:wybe.bool):
+=(x##0:type_int.myint, y##0:type_int.myint, ?###0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(~x##0:type_int.myint, ~y##0:type_int.myint, ?$##0:wybe.bool) @type_int:nn:nn
+    foreign llvm icmp_eq(~x##0:type_int.myint, ~y##0:type_int.myint, ?###0:wybe.bool) @type_int:nn:nn
 
 
 > > public {inline} (0 calls)
 0: type_int.myint.><0>
->(x##0:type_int.myint, y##0:type_int.myint, ?$##0:wybe.bool):
+>(x##0:type_int.myint, y##0:type_int.myint, ?###0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_sgt(~x##0:type_int.myint, ~y##0:type_int.myint, ?$##0:wybe.bool) @type_int:nn:nn
+    foreign llvm icmp_sgt(~x##0:type_int.myint, ~y##0:type_int.myint, ?###0:wybe.bool) @type_int:nn:nn
 
 
 >= > public {inline} (0 calls)
 0: type_int.myint.>=<0>
->=(x##0:type_int.myint, y##0:type_int.myint, ?$##0:wybe.bool):
+>=(x##0:type_int.myint, y##0:type_int.myint, ?###0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_sge(~x##0:type_int.myint, ~y##0:type_int.myint, ?$##0:wybe.bool) @type_int:nn:nn
+    foreign llvm icmp_sge(~x##0:type_int.myint, ~y##0:type_int.myint, ?###0:wybe.bool) @type_int:nn:nn
 
 
 ~= > public {inline} (0 calls)
 0: type_int.myint.~=<0>
-~=(x##0:type_int.myint, y##0:type_int.myint, ?$##0:wybe.bool):
+~=(x##0:type_int.myint, y##0:type_int.myint, ?###0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(~x##0:type_int.myint, ~y##0:type_int.myint, ?$##0:wybe.bool) @type_int:nn:nn
+    foreign llvm icmp_ne(~x##0:type_int.myint, ~y##0:type_int.myint, ?###0:wybe.bool) @type_int:nn:nn
 
   LLVM code       :
 
@@ -180,97 +180,97 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  i64 @"type_int.myint.*<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$$##0" = mul   i64 %"x##0", %"y##0" 
-  ret i64 %"1$$##0" 
+  %"1####0" = mul   i64 %"x##0", %"y##0" 
+  ret i64 %"1####0" 
 }
 
 
 define external fastcc  i64 @"type_int.myint.+<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$$##0" = add   i64 %"x##0", %"y##0" 
-  ret i64 %"1$$##0" 
+  %"1####0" = add   i64 %"x##0", %"y##0" 
+  ret i64 %"1####0" 
 }
 
 
 define external fastcc  i64 @"type_int.myint.+<1>"(i64  %"y##0", i64  %"z##0")    {
 entry:
-  %"1$x##0" = sub   i64 %"z##0", %"y##0" 
-  ret i64 %"1$x##0" 
+  %"1#x##0" = sub   i64 %"z##0", %"y##0" 
+  ret i64 %"1#x##0" 
 }
 
 
 define external fastcc  i64 @"type_int.myint.+<2>"(i64  %"x##0", i64  %"z##0")    {
 entry:
-  %"1$y##0" = sub   i64 %"z##0", %"x##0" 
-  ret i64 %"1$y##0" 
+  %"1#y##0" = sub   i64 %"z##0", %"x##0" 
+  ret i64 %"1#y##0" 
 }
 
 
 define external fastcc  i64 @"type_int.myint.-<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$$##0" = sub   i64 %"x##0", %"y##0" 
-  ret i64 %"1$$##0" 
+  %"1####0" = sub   i64 %"x##0", %"y##0" 
+  ret i64 %"1####0" 
 }
 
 
 define external fastcc  i64 @"type_int.myint.-<1>"(i64  %"y##0", i64  %"z##0")    {
 entry:
-  %"1$x##0" = add   i64 %"y##0", %"z##0" 
-  ret i64 %"1$x##0" 
+  %"1#x##0" = add   i64 %"y##0", %"z##0" 
+  ret i64 %"1#x##0" 
 }
 
 
 define external fastcc  i64 @"type_int.myint.-<2>"(i64  %"x##0", i64  %"z##0")    {
 entry:
-  %"1$y##0" = sub   i64 %"z##0", %"x##0" 
-  ret i64 %"1$y##0" 
+  %"1#y##0" = sub   i64 %"z##0", %"x##0" 
+  ret i64 %"1#y##0" 
 }
 
 
 define external fastcc  i64 @"type_int.myint./<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$$##0" = sdiv exact i64 %"x##0", %"y##0" 
-  ret i64 %"1$$##0" 
+  %"1####0" = sdiv exact i64 %"x##0", %"y##0" 
+  ret i64 %"1####0" 
 }
 
 
 define external fastcc  i1 @"type_int.myint.<<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$$##0" = icmp slt i64 %"x##0", %"y##0" 
-  ret i1 %"1$$##0" 
+  %"1####0" = icmp slt i64 %"x##0", %"y##0" 
+  ret i1 %"1####0" 
 }
 
 
 define external fastcc  i1 @"type_int.myint.<=<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$$##0" = icmp sle i64 %"x##0", %"y##0" 
-  ret i1 %"1$$##0" 
+  %"1####0" = icmp sle i64 %"x##0", %"y##0" 
+  ret i1 %"1####0" 
 }
 
 
 define external fastcc  i1 @"type_int.myint.=<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$$##0" = icmp eq i64 %"x##0", %"y##0" 
-  ret i1 %"1$$##0" 
+  %"1####0" = icmp eq i64 %"x##0", %"y##0" 
+  ret i1 %"1####0" 
 }
 
 
 define external fastcc  i1 @"type_int.myint.><0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$$##0" = icmp sgt i64 %"x##0", %"y##0" 
-  ret i1 %"1$$##0" 
+  %"1####0" = icmp sgt i64 %"x##0", %"y##0" 
+  ret i1 %"1####0" 
 }
 
 
 define external fastcc  i1 @"type_int.myint.>=<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$$##0" = icmp sge i64 %"x##0", %"y##0" 
-  ret i1 %"1$$##0" 
+  %"1####0" = icmp sge i64 %"x##0", %"y##0" 
+  ret i1 %"1####0" 
 }
 
 
 define external fastcc  i1 @"type_int.myint.~=<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$$##0" = icmp ne i64 %"x##0", %"y##0" 
-  ret i1 %"1$$##0" 
+  %"1####0" = icmp ne i64 %"x##0", %"y##0" 
+  ret i1 %"1####0" 
 }

--- a/test-cases/final-dump/type_int.exp
+++ b/test-cases/final-dump/type_int.exp
@@ -63,106 +63,106 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 * > public {inline} (0 calls)
 0: type_int.myint.*<0>
-*(x#0:type_int.myint, y#0:type_int.myint, ?$#0:type_int.myint):
+*(x##0:type_int.myint, y##0:type_int.myint, ?$##0:type_int.myint):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm mul(~x#0:type_int.myint, ~y#0:type_int.myint, ?$#0:type_int.myint) @type_int:nn:nn
+    foreign llvm mul(~x##0:type_int.myint, ~y##0:type_int.myint, ?$##0:type_int.myint) @type_int:nn:nn
 
 
 + > public {inline} (0 calls)
 0: type_int.myint.+<0>
-+(x#0:type_int.myint, y#0:type_int.myint, ?$#0:type_int.myint):
++(x##0:type_int.myint, y##0:type_int.myint, ?$##0:type_int.myint):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~x#0:type_int.myint, ~y#0:type_int.myint, ?$#0:type_int.myint) @type_int:nn:nn
+    foreign llvm add(~x##0:type_int.myint, ~y##0:type_int.myint, ?$##0:type_int.myint) @type_int:nn:nn
 + > public {inline} (0 calls)
 1: type_int.myint.+<1>
-+(?x#0:type_int.myint, y#0:type_int.myint, z#0:type_int.myint):
++(?x##0:type_int.myint, y##0:type_int.myint, z##0:type_int.myint):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm sub(~z#0:type_int.myint, ~y#0:type_int.myint, ?x#0:type_int.myint) @type_int:nn:nn
+    foreign llvm sub(~z##0:type_int.myint, ~y##0:type_int.myint, ?x##0:type_int.myint) @type_int:nn:nn
 + > public {inline} (0 calls)
 2: type_int.myint.+<2>
-+(x#0:type_int.myint, ?y#0:type_int.myint, z#0:type_int.myint):
++(x##0:type_int.myint, ?y##0:type_int.myint, z##0:type_int.myint):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm sub(~z#0:type_int.myint, ~x#0:type_int.myint, ?y#0:type_int.myint) @type_int:nn:nn
+    foreign llvm sub(~z##0:type_int.myint, ~x##0:type_int.myint, ?y##0:type_int.myint) @type_int:nn:nn
 
 
 - > public {inline} (0 calls)
 0: type_int.myint.-<0>
--(x#0:type_int.myint, y#0:type_int.myint, ?$#0:type_int.myint):
+-(x##0:type_int.myint, y##0:type_int.myint, ?$##0:type_int.myint):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm sub(~x#0:type_int.myint, ~y#0:type_int.myint, ?$#0:type_int.myint) @type_int:nn:nn
+    foreign llvm sub(~x##0:type_int.myint, ~y##0:type_int.myint, ?$##0:type_int.myint) @type_int:nn:nn
 - > public {inline} (0 calls)
 1: type_int.myint.-<1>
--(?x#0:type_int.myint, y#0:type_int.myint, z#0:type_int.myint):
+-(?x##0:type_int.myint, y##0:type_int.myint, z##0:type_int.myint):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~y#0:type_int.myint, ~z#0:type_int.myint, ?x#0:type_int.myint) @type_int:nn:nn
+    foreign llvm add(~y##0:type_int.myint, ~z##0:type_int.myint, ?x##0:type_int.myint) @type_int:nn:nn
 - > public {inline} (0 calls)
 2: type_int.myint.-<2>
--(x#0:type_int.myint, ?y#0:type_int.myint, z#0:type_int.myint):
+-(x##0:type_int.myint, ?y##0:type_int.myint, z##0:type_int.myint):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm sub(~z#0:type_int.myint, ~x#0:type_int.myint, ?y#0:type_int.myint) @type_int:nn:nn
+    foreign llvm sub(~z##0:type_int.myint, ~x##0:type_int.myint, ?y##0:type_int.myint) @type_int:nn:nn
 
 
 / > public {inline} (0 calls)
 0: type_int.myint./<0>
-/(x#0:type_int.myint, y#0:type_int.myint, ?$#0:type_int.myint):
+/(x##0:type_int.myint, y##0:type_int.myint, ?$##0:type_int.myint):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm sdiv(~x#0:type_int.myint, ~y#0:type_int.myint, ?$#0:type_int.myint) @type_int:nn:nn
+    foreign llvm sdiv(~x##0:type_int.myint, ~y##0:type_int.myint, ?$##0:type_int.myint) @type_int:nn:nn
 
 
 < > public {inline} (0 calls)
 0: type_int.myint.<<0>
-<(x#0:type_int.myint, y#0:type_int.myint, ?$#0:wybe.bool):
+<(x##0:type_int.myint, y##0:type_int.myint, ?$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_slt(~x#0:type_int.myint, ~y#0:type_int.myint, ?$#0:wybe.bool) @type_int:nn:nn
+    foreign llvm icmp_slt(~x##0:type_int.myint, ~y##0:type_int.myint, ?$##0:wybe.bool) @type_int:nn:nn
 
 
 <= > public {inline} (0 calls)
 0: type_int.myint.<=<0>
-<=(x#0:type_int.myint, y#0:type_int.myint, ?$#0:wybe.bool):
+<=(x##0:type_int.myint, y##0:type_int.myint, ?$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_sle(~x#0:type_int.myint, ~y#0:type_int.myint, ?$#0:wybe.bool) @type_int:nn:nn
+    foreign llvm icmp_sle(~x##0:type_int.myint, ~y##0:type_int.myint, ?$##0:wybe.bool) @type_int:nn:nn
 
 
 = > public {inline} (0 calls)
 0: type_int.myint.=<0>
-=(x#0:type_int.myint, y#0:type_int.myint, ?$#0:wybe.bool):
+=(x##0:type_int.myint, y##0:type_int.myint, ?$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(~x#0:type_int.myint, ~y#0:type_int.myint, ?$#0:wybe.bool) @type_int:nn:nn
+    foreign llvm icmp_eq(~x##0:type_int.myint, ~y##0:type_int.myint, ?$##0:wybe.bool) @type_int:nn:nn
 
 
 > > public {inline} (0 calls)
 0: type_int.myint.><0>
->(x#0:type_int.myint, y#0:type_int.myint, ?$#0:wybe.bool):
+>(x##0:type_int.myint, y##0:type_int.myint, ?$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_sgt(~x#0:type_int.myint, ~y#0:type_int.myint, ?$#0:wybe.bool) @type_int:nn:nn
+    foreign llvm icmp_sgt(~x##0:type_int.myint, ~y##0:type_int.myint, ?$##0:wybe.bool) @type_int:nn:nn
 
 
 >= > public {inline} (0 calls)
 0: type_int.myint.>=<0>
->=(x#0:type_int.myint, y#0:type_int.myint, ?$#0:wybe.bool):
+>=(x##0:type_int.myint, y##0:type_int.myint, ?$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_sge(~x#0:type_int.myint, ~y#0:type_int.myint, ?$#0:wybe.bool) @type_int:nn:nn
+    foreign llvm icmp_sge(~x##0:type_int.myint, ~y##0:type_int.myint, ?$##0:wybe.bool) @type_int:nn:nn
 
 
 ~= > public {inline} (0 calls)
 0: type_int.myint.~=<0>
-~=(x#0:type_int.myint, y#0:type_int.myint, ?$#0:wybe.bool):
+~=(x##0:type_int.myint, y##0:type_int.myint, ?$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(~x#0:type_int.myint, ~y#0:type_int.myint, ?$#0:wybe.bool) @type_int:nn:nn
+    foreign llvm icmp_ne(~x##0:type_int.myint, ~y##0:type_int.myint, ?$##0:wybe.bool) @type_int:nn:nn
 
   LLVM code       :
 
@@ -178,99 +178,99 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i64 @"type_int.myint.*<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"type_int.myint.*<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$$#0" = mul   i64 %"x#0", %"y#0" 
-  ret i64 %"1$$#0" 
+  %"1$$##0" = mul   i64 %"x##0", %"y##0" 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  i64 @"type_int.myint.+<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"type_int.myint.+<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$$#0" = add   i64 %"x#0", %"y#0" 
-  ret i64 %"1$$#0" 
+  %"1$$##0" = add   i64 %"x##0", %"y##0" 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  i64 @"type_int.myint.+<1>"(i64  %"y#0", i64  %"z#0")    {
+define external fastcc  i64 @"type_int.myint.+<1>"(i64  %"y##0", i64  %"z##0")    {
 entry:
-  %"1$x#0" = sub   i64 %"z#0", %"y#0" 
-  ret i64 %"1$x#0" 
+  %"1$x##0" = sub   i64 %"z##0", %"y##0" 
+  ret i64 %"1$x##0" 
 }
 
 
-define external fastcc  i64 @"type_int.myint.+<2>"(i64  %"x#0", i64  %"z#0")    {
+define external fastcc  i64 @"type_int.myint.+<2>"(i64  %"x##0", i64  %"z##0")    {
 entry:
-  %"1$y#0" = sub   i64 %"z#0", %"x#0" 
-  ret i64 %"1$y#0" 
+  %"1$y##0" = sub   i64 %"z##0", %"x##0" 
+  ret i64 %"1$y##0" 
 }
 
 
-define external fastcc  i64 @"type_int.myint.-<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"type_int.myint.-<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$$#0" = sub   i64 %"x#0", %"y#0" 
-  ret i64 %"1$$#0" 
+  %"1$$##0" = sub   i64 %"x##0", %"y##0" 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  i64 @"type_int.myint.-<1>"(i64  %"y#0", i64  %"z#0")    {
+define external fastcc  i64 @"type_int.myint.-<1>"(i64  %"y##0", i64  %"z##0")    {
 entry:
-  %"1$x#0" = add   i64 %"y#0", %"z#0" 
-  ret i64 %"1$x#0" 
+  %"1$x##0" = add   i64 %"y##0", %"z##0" 
+  ret i64 %"1$x##0" 
 }
 
 
-define external fastcc  i64 @"type_int.myint.-<2>"(i64  %"x#0", i64  %"z#0")    {
+define external fastcc  i64 @"type_int.myint.-<2>"(i64  %"x##0", i64  %"z##0")    {
 entry:
-  %"1$y#0" = sub   i64 %"z#0", %"x#0" 
-  ret i64 %"1$y#0" 
+  %"1$y##0" = sub   i64 %"z##0", %"x##0" 
+  ret i64 %"1$y##0" 
 }
 
 
-define external fastcc  i64 @"type_int.myint./<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"type_int.myint./<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$$#0" = sdiv exact i64 %"x#0", %"y#0" 
-  ret i64 %"1$$#0" 
+  %"1$$##0" = sdiv exact i64 %"x##0", %"y##0" 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  i1 @"type_int.myint.<<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i1 @"type_int.myint.<<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$$#0" = icmp slt i64 %"x#0", %"y#0" 
-  ret i1 %"1$$#0" 
+  %"1$$##0" = icmp slt i64 %"x##0", %"y##0" 
+  ret i1 %"1$$##0" 
 }
 
 
-define external fastcc  i1 @"type_int.myint.<=<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i1 @"type_int.myint.<=<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$$#0" = icmp sle i64 %"x#0", %"y#0" 
-  ret i1 %"1$$#0" 
+  %"1$$##0" = icmp sle i64 %"x##0", %"y##0" 
+  ret i1 %"1$$##0" 
 }
 
 
-define external fastcc  i1 @"type_int.myint.=<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i1 @"type_int.myint.=<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$$#0" = icmp eq i64 %"x#0", %"y#0" 
-  ret i1 %"1$$#0" 
+  %"1$$##0" = icmp eq i64 %"x##0", %"y##0" 
+  ret i1 %"1$$##0" 
 }
 
 
-define external fastcc  i1 @"type_int.myint.><0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i1 @"type_int.myint.><0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$$#0" = icmp sgt i64 %"x#0", %"y#0" 
-  ret i1 %"1$$#0" 
+  %"1$$##0" = icmp sgt i64 %"x##0", %"y##0" 
+  ret i1 %"1$$##0" 
 }
 
 
-define external fastcc  i1 @"type_int.myint.>=<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i1 @"type_int.myint.>=<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$$#0" = icmp sge i64 %"x#0", %"y#0" 
-  ret i1 %"1$$#0" 
+  %"1$$##0" = icmp sge i64 %"x##0", %"y##0" 
+  ret i1 %"1$$##0" 
 }
 
 
-define external fastcc  i1 @"type_int.myint.~=<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i1 @"type_int.myint.~=<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$$#0" = icmp ne i64 %"x#0", %"y#0" 
-  ret i1 %"1$$#0" 
+  %"1$$##0" = icmp ne i64 %"x##0", %"y##0" 
+  ret i1 %"1$$##0" 
 }

--- a/test-cases/final-dump/type_list.exp
+++ b/test-cases/final-dump/type_list.exp
@@ -257,13 +257,13 @@ if.else:
 
 = > public (2 calls)
 0: type_list.intlist.=<0>
-=(#left##0:type_list.intlist, #right##0:type_list.intlist, ?####0:wybe.bool):
+=(#left##0:type_list.intlist, #right##0:type_list.intlist, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~#left##0:type_list.intlist, ~#right##0:type_list.intlist, ?####0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:type_list.intlist, ~#right##0:type_list.intlist, ?#success##0:wybe.bool)
 
     1:
         foreign lpvm access(#left##0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#head##0:wybe.int)
@@ -271,7 +271,7 @@ if.else:
         foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
         case ~tmp#9##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
         1:
             foreign lpvm access(#right##0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#head##0:wybe.int)
@@ -279,10 +279,10 @@ if.else:
             foreign llvm icmp_eq(~#left#head##0:wybe.int, ~#right#head##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
             case ~tmp#4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
 
             1:
-                type_list.intlist.=<0>(~#left#tail##0:type_list.intlist, ~#right#tail##0:type_list.intlist, ?####0:wybe.bool) #3
+                type_list.intlist.=<0>(~#left#tail##0:type_list.intlist, ~#right#tail##0:type_list.intlist, ?#success##0:wybe.bool) #3
 
 
 
@@ -298,52 +298,52 @@ cons(head##0:wybe.int, tail##0:type_list.intlist, ?#result##0:type_list.intlist)
     foreign lpvm mutate(~#rec##1:type_list.intlist, ?#result##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:type_list.intlist)
 cons > public {inline} (12 calls)
 1: type_list.intlist.cons<1>
-cons(?head##0:wybe.int, ?tail##0:type_list.intlist, #result##0:type_list.intlist, ?####0:wybe.bool):
+cons(?head##0:wybe.int, ?tail##0:type_list.intlist, #result##0:type_list.intlist, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?head##0:wybe.int)
         foreign llvm move(undef:type_list.intlist, ?tail##0:type_list.intlist)
 
     1:
         foreign lpvm access(#result##0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
         foreign lpvm access(~#result##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:type_list.intlist)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 head > public {inline} (0 calls)
 0: type_list.intlist.head<0>
-head(#rec##0:type_list.intlist, ?#result##0:wybe.int, ?####0:wybe.bool):
+head(#rec##0:type_list.intlist, ?#result##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
         foreign lpvm access(~#rec##0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 head > public {inline} (0 calls)
 1: type_list.intlist.head<1>
-head(#rec##0:type_list.intlist, ?#rec##1:type_list.intlist, #field##0:wybe.int, ?####0:wybe.bool):
+head(#rec##0:type_list.intlist, ?#rec##1:type_list.intlist, #field##0:wybe.int, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:type_list.intlist, ?#rec##1:type_list.intlist)
 
     1:
         foreign lpvm mutate(~#rec##0:type_list.intlist, ?#rec##1:type_list.intlist, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
@@ -357,43 +357,43 @@ nil(?#result##0:type_list.intlist):
 
 tail > public {inline} (0 calls)
 0: type_list.intlist.tail<0>
-tail(#rec##0:type_list.intlist, ?#result##0:type_list.intlist, ?####0:wybe.bool):
+tail(#rec##0:type_list.intlist, ?#result##0:type_list.intlist, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:type_list.intlist, ?#result##0:type_list.intlist)
 
     1:
         foreign lpvm access(~#rec##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:type_list.intlist)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 tail > public {inline} (0 calls)
 1: type_list.intlist.tail<1>
-tail(#rec##0:type_list.intlist, ?#rec##1:type_list.intlist, #field##0:type_list.intlist, ?####0:wybe.bool):
+tail(#rec##0:type_list.intlist, ?#rec##1:type_list.intlist, #field##0:type_list.intlist, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~#rec##0:type_list.intlist, ?#rec##1:type_list.intlist)
 
     1:
         foreign lpvm {noalias} mutate(~#rec##0:type_list.intlist, ?#rec##1:type_list.intlist, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:type_list.intlist)
-        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: type_list.intlist.~=<0>
-~=(#left##0:type_list.intlist, #right##0:type_list.intlist, ?####0:wybe.bool):
+~=(#left##0:type_list.intlist, #right##0:type_list.intlist, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     type_list.intlist.=<0>(~#left##0:type_list.intlist, ~#right##0:type_list.intlist, ?tmp#0##0:wybe.bool) #0
-    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?#success##0:wybe.bool)
 
   LLVM code       :
 
@@ -424,8 +424,8 @@ if.then:
   %"2#tmp#9##0" = icmp ne i64 %"#right##0", 0 
   br i1 %"2#tmp#9##0", label %if.then1, label %if.else1 
 if.else:
-  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
-  ret i1 %"3#####0" 
+  %"3##success##0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3##success##0" 
 if.then1:
   %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
@@ -439,8 +439,8 @@ if.then1:
 if.else1:
   ret i1 0 
 if.then2:
-  %"6#####0" = tail call fastcc  i1  @"type_list.intlist.=<0>"(i64  %7, i64  %14)  
-  ret i1 %"6#####0" 
+  %"6##success##0" = tail call fastcc  i1  @"type_list.intlist.=<0>"(i64  %7, i64  %14)  
+  ret i1 %"6##success##0" 
 if.else2:
   ret i1 0 
 }
@@ -583,6 +583,6 @@ if.else:
 define external fastcc  i1 @"type_list.intlist.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
   %"1#tmp#0##0" = tail call fastcc  i1  @"type_list.intlist.=<0>"(i64  %"#left##0", i64  %"#right##0")  
-  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
-  ret i1 %"1#####0" 
+  %"1##success##0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1##success##0" 
 }

--- a/test-cases/final-dump/type_list.exp
+++ b/test-cases/final-dump/type_list.exp
@@ -50,14 +50,14 @@ AFTER EVERYTHING:
 
 ,, > public (2 calls)
 0: type_list.,,<0>[410bae77d3]
-,,(x##0:type_list.intlist, y##0:type_list.intlist, ?###0:type_list.intlist):
- AliasPairs: [(###0,y##0)]
+,,(x##0:type_list.intlist, y##0:type_list.intlist, ?#result##0:type_list.intlist):
+ AliasPairs: [(#result##0,y##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(type_list.,,<0>,fromList [NonAliasedParamCond 0 [0]]))]
     foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
     case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~y##0:type_list.intlist, ?###0:type_list.intlist) @type_list:nn:nn
+        foreign llvm move(~y##0:type_list.intlist, ?#result##0:type_list.intlist) @type_list:nn:nn
 
     1:
         foreign lpvm access(x##0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
@@ -65,35 +65,35 @@ AFTER EVERYTHING:
         type_list.,,<0>(~t##0:type_list.intlist, ~y##0:type_list.intlist, ?tmp#2##0:type_list.intlist) #1 @type_list:nn:nn
         foreign lpvm alloc(16:wybe.int, ?tmp#8##0:type_list.intlist)
         foreign lpvm mutate(~tmp#8##0:type_list.intlist, ?tmp#9##0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-        foreign lpvm mutate(~tmp#9##0:type_list.intlist, ?###0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:type_list.intlist)
+        foreign lpvm mutate(~tmp#9##0:type_list.intlist, ?#result##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:type_list.intlist)
 
  [410bae77d3] [NonAliasedParam 0] :
     foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
     case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~y##0:type_list.intlist, ?###0:type_list.intlist) @type_list:nn:nn
+        foreign llvm move(~y##0:type_list.intlist, ?#result##0:type_list.intlist) @type_list:nn:nn
 
     1:
         foreign lpvm access(x##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:type_list.intlist)
         type_list.,,<0>[410bae77d3](~t##0:type_list.intlist, ~y##0:type_list.intlist, ?tmp#2##0:type_list.intlist) #1 @type_list:nn:nn
-        foreign lpvm mutate(~x##0:type_list.intlist, ?###0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:type_list.intlist)
+        foreign lpvm mutate(~x##0:type_list.intlist, ?#result##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:type_list.intlist)
 
 
 
 length > public (2 calls)
 0: type_list.length<0>
-length(x##0:type_list.intlist, ?###0:wybe.int):
+length(x##0:type_list.intlist, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
     case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.int, ?###0:wybe.int) @type_list:nn:nn
+        foreign llvm move(0:wybe.int, ?#result##0:wybe.int) @type_list:nn:nn
 
     1:
         foreign lpvm access(~x##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:type_list.intlist)
         type_list.length<0>(~t##0:type_list.intlist, ?tmp#2##0:wybe.int) #1 @type_list:nn:nn
-        foreign llvm add(~tmp#2##0:wybe.int, 1:wybe.int, ?###0:wybe.int) @int:nn:nn
+        foreign llvm add(~tmp#2##0:wybe.int, 1:wybe.int, ?#result##0:wybe.int) @int:nn:nn
 
 
   LLVM code       :
@@ -231,8 +231,8 @@ if.then:
   %65 = getelementptr  i64, i64* %64, i64 0 
   %66 = load  i64, i64* %65 
   %"2#tmp#2##0" = tail call fastcc  i64  @"type_list.length<0>"(i64  %66)  
-  %"2####0" = add   i64 %"2#tmp#2##0", 1 
-  ret i64 %"2####0" 
+  %"2##result##0" = add   i64 %"2#tmp#2##0", 1 
+  ret i64 %"2##result##0" 
 if.else:
   ret i64 0 
 }
@@ -290,18 +290,18 @@ if.else:
 
 cons > public {inline} (0 calls)
 0: type_list.intlist.cons<0>
-cons(head##0:wybe.int, tail##0:type_list.intlist, ?###0:type_list.intlist):
+cons(head##0:wybe.int, tail##0:type_list.intlist, ?#result##0:type_list.intlist):
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?#rec##0:type_list.intlist)
     foreign lpvm mutate(~#rec##0:type_list.intlist, ?#rec##1:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:type_list.intlist, ?###0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:type_list.intlist)
+    foreign lpvm mutate(~#rec##1:type_list.intlist, ?#result##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:type_list.intlist)
 cons > public {inline} (12 calls)
 1: type_list.intlist.cons<1>
-cons(?head##0:wybe.int, ?tail##0:type_list.intlist, ###0:type_list.intlist, ?####0:wybe.bool):
+cons(?head##0:wybe.int, ?tail##0:type_list.intlist, #result##0:type_list.intlist, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
@@ -309,25 +309,25 @@ cons(?head##0:wybe.int, ?tail##0:type_list.intlist, ###0:type_list.intlist, ?###
         foreign llvm move(undef:type_list.intlist, ?tail##0:type_list.intlist)
 
     1:
-        foreign lpvm access(###0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
-        foreign lpvm access(~###0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:type_list.intlist)
+        foreign lpvm access(#result##0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
+        foreign lpvm access(~#result##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:type_list.intlist)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 head > public {inline} (0 calls)
 0: type_list.intlist.head<0>
-head(#rec##0:type_list.intlist, ?###0:wybe.int, ?####0:wybe.bool):
+head(#rec##0:type_list.intlist, ?#result##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
+        foreign llvm move(undef:wybe.int, ?#result##0:wybe.int)
 
     1:
-        foreign lpvm access(~#rec##0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign lpvm access(~#rec##0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:wybe.int)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 head > public {inline} (0 calls)
@@ -349,25 +349,25 @@ head(#rec##0:type_list.intlist, ?#rec##1:type_list.intlist, #field##0:wybe.int, 
 
 nil > public {inline} (0 calls)
 0: type_list.intlist.nil<0>
-nil(?###0:type_list.intlist):
+nil(?#result##0:type_list.intlist):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:type_list.intlist, ?###0:type_list.intlist)
+    foreign llvm move(0:type_list.intlist, ?#result##0:type_list.intlist)
 
 
 tail > public {inline} (0 calls)
 0: type_list.intlist.tail<0>
-tail(#rec##0:type_list.intlist, ?###0:type_list.intlist, ?####0:wybe.bool):
+tail(#rec##0:type_list.intlist, ?#result##0:type_list.intlist, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
-        foreign llvm move(undef:type_list.intlist, ?###0:type_list.intlist)
+        foreign llvm move(undef:type_list.intlist, ?#result##0:type_list.intlist)
 
     1:
-        foreign lpvm access(~#rec##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:type_list.intlist)
+        foreign lpvm access(~#rec##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:type_list.intlist)
         foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 tail > public {inline} (0 calls)
@@ -462,15 +462,15 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"type_list.intlist.cons<1>"(i64  %"###0")    {
+define external fastcc  {i64, i64, i1} @"type_list.intlist.cons<1>"(i64  %"#result##0")    {
 entry:
-  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  %"1#tmp#0##0" = icmp ne i64 %"#result##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %23 = inttoptr i64 %"###0" to i64* 
+  %23 = inttoptr i64 %"#result##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"###0", 8 
+  %26 = add   i64 %"#result##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 

--- a/test-cases/final-dump/type_list.exp
+++ b/test-cases/final-dump/type_list.exp
@@ -24,76 +24,76 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: type_list.<0>
-(io#0:wybe.phantom, ?io#1:wybe.phantom):
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(7,(type_list.,,<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm alloc(16:wybe.int, ?tmp$11#0:type_list.intlist)
-    foreign lpvm mutate(~tmp$11#0:type_list.intlist, ?tmp$12#0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-    foreign lpvm mutate(~tmp$12#0:type_list.intlist, ?tmp$13#0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:type_list.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp$16#0:type_list.intlist)
-    foreign lpvm mutate(~tmp$16#0:type_list.intlist, ?tmp$17#0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm mutate(~tmp$17#0:type_list.intlist, ?tmp$18#0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$13#0:type_list.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp$21#0:type_list.intlist)
-    foreign lpvm mutate(~tmp$21#0:type_list.intlist, ?tmp$22#0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp$22#0:type_list.intlist, ?tmp$23#0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$18#0:type_list.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp$26#0:type_list.intlist)
-    foreign lpvm mutate(~tmp$26#0:type_list.intlist, ?tmp$27#0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
-    foreign lpvm mutate(~tmp$27#0:type_list.intlist, ?tmp$28#0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:type_list.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp$31#0:type_list.intlist)
-    foreign lpvm mutate(~tmp$31#0:type_list.intlist, ?tmp$32#0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm mutate(~tmp$32#0:type_list.intlist, ?tmp$33#0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$28#0:type_list.intlist)
-    type_list.,,<0>[410bae77d3](~tmp$23#0:type_list.intlist, ~tmp$33#0:type_list.intlist, ?tmp$8#0:type_list.intlist) #7 @type_list:nn:nn
-    type_list.length<0>(~tmp$8#0:type_list.intlist, ?tmp$7#0:wybe.int) #8 @type_list:nn:nn
-    foreign c print_int(~tmp$7#0:wybe.int, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp$11##0:type_list.intlist)
+    foreign lpvm mutate(~tmp$11##0:type_list.intlist, ?tmp$12##0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+    foreign lpvm mutate(~tmp$12##0:type_list.intlist, ?tmp$13##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:type_list.intlist)
+    foreign lpvm alloc(16:wybe.int, ?tmp$16##0:type_list.intlist)
+    foreign lpvm mutate(~tmp$16##0:type_list.intlist, ?tmp$17##0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+    foreign lpvm mutate(~tmp$17##0:type_list.intlist, ?tmp$18##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$13##0:type_list.intlist)
+    foreign lpvm alloc(16:wybe.int, ?tmp$21##0:type_list.intlist)
+    foreign lpvm mutate(~tmp$21##0:type_list.intlist, ?tmp$22##0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp$22##0:type_list.intlist, ?tmp$23##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$18##0:type_list.intlist)
+    foreign lpvm alloc(16:wybe.int, ?tmp$26##0:type_list.intlist)
+    foreign lpvm mutate(~tmp$26##0:type_list.intlist, ?tmp$27##0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
+    foreign lpvm mutate(~tmp$27##0:type_list.intlist, ?tmp$28##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:type_list.intlist)
+    foreign lpvm alloc(16:wybe.int, ?tmp$31##0:type_list.intlist)
+    foreign lpvm mutate(~tmp$31##0:type_list.intlist, ?tmp$32##0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
+    foreign lpvm mutate(~tmp$32##0:type_list.intlist, ?tmp$33##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$28##0:type_list.intlist)
+    type_list.,,<0>[410bae77d3](~tmp$23##0:type_list.intlist, ~tmp$33##0:type_list.intlist, ?tmp$8##0:type_list.intlist) #7 @type_list:nn:nn
+    type_list.length<0>(~tmp$8##0:type_list.intlist, ?tmp$7##0:wybe.int) #8 @type_list:nn:nn
+    foreign c print_int(~tmp$7##0:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 ,, > public (2 calls)
 0: type_list.,,<0>[410bae77d3]
-,,(x#0:type_list.intlist, y#0:type_list.intlist, ?$#0:type_list.intlist):
- AliasPairs: [($#0,y#0)]
+,,(x##0:type_list.intlist, y##0:type_list.intlist, ?$##0:type_list.intlist):
+ AliasPairs: [($##0,y##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(type_list.,,<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(x#0:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.bool)
-    case ~tmp$5#0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
+    case ~tmp$5##0:wybe.bool of
     0:
-        foreign llvm move(~y#0:type_list.intlist, ?$#0:type_list.intlist) @type_list:nn:nn
+        foreign llvm move(~y##0:type_list.intlist, ?$##0:type_list.intlist) @type_list:nn:nn
 
     1:
-        foreign lpvm access(x#0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h#0:wybe.int)
-        foreign lpvm access(~x#0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:type_list.intlist)
-        type_list.,,<0>(~t#0:type_list.intlist, ~y#0:type_list.intlist, ?tmp$2#0:type_list.intlist) #1 @type_list:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$8#0:type_list.intlist)
-        foreign lpvm mutate(~tmp$8#0:type_list.intlist, ?tmp$9#0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h#0:wybe.int)
-        foreign lpvm mutate(~tmp$9#0:type_list.intlist, ?$#0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:type_list.intlist)
+        foreign lpvm access(x##0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+        foreign lpvm access(~x##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:type_list.intlist)
+        type_list.,,<0>(~t##0:type_list.intlist, ~y##0:type_list.intlist, ?tmp$2##0:type_list.intlist) #1 @type_list:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp$8##0:type_list.intlist)
+        foreign lpvm mutate(~tmp$8##0:type_list.intlist, ?tmp$9##0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+        foreign lpvm mutate(~tmp$9##0:type_list.intlist, ?$##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:type_list.intlist)
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_ne(x#0:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.bool)
-    case ~tmp$5#0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
+    case ~tmp$5##0:wybe.bool of
     0:
-        foreign llvm move(~y#0:type_list.intlist, ?$#0:type_list.intlist) @type_list:nn:nn
+        foreign llvm move(~y##0:type_list.intlist, ?$##0:type_list.intlist) @type_list:nn:nn
 
     1:
-        foreign lpvm access(x#0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:type_list.intlist)
-        type_list.,,<0>[410bae77d3](~t#0:type_list.intlist, ~y#0:type_list.intlist, ?tmp$2#0:type_list.intlist) #1 @type_list:nn:nn
-        foreign lpvm mutate(~x#0:type_list.intlist, ?$#0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2#0:type_list.intlist)
+        foreign lpvm access(x##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:type_list.intlist)
+        type_list.,,<0>[410bae77d3](~t##0:type_list.intlist, ~y##0:type_list.intlist, ?tmp$2##0:type_list.intlist) #1 @type_list:nn:nn
+        foreign lpvm mutate(~x##0:type_list.intlist, ?$##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:type_list.intlist)
 
 
 
 length > public (2 calls)
 0: type_list.length<0>
-length(x#0:type_list.intlist, ?$#0:wybe.int):
+length(x##0:type_list.intlist, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(x#0:wybe.int, 0:wybe.int, ?tmp$5#0:wybe.bool)
-    case ~tmp$5#0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
+    case ~tmp$5##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.int, ?$#0:wybe.int) @type_list:nn:nn
+        foreign llvm move(0:wybe.int, ?$##0:wybe.int) @type_list:nn:nn
 
     1:
-        foreign lpvm access(~x#0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t#0:type_list.intlist)
-        type_list.length<0>(~t#0:type_list.intlist, ?tmp$2#0:wybe.int) #1 @type_list:nn:nn
-        foreign llvm add(~tmp$2#0:wybe.int, 1:wybe.int, ?$#0:wybe.int) @int:nn:nn
+        foreign lpvm access(~x##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:type_list.intlist)
+        type_list.length<0>(~t##0:type_list.intlist, ?tmp$2##0:wybe.int) #1 @type_list:nn:nn
+        foreign llvm add(~tmp$2##0:wybe.int, 1:wybe.int, ?$##0:wybe.int) @int:nn:nn
 
 
   LLVM code       :
@@ -165,26 +165,26 @@ entry:
   %39 = inttoptr i64 %38 to i64* 
   %40 = getelementptr  i64, i64* %39, i64 0 
   store  i64 %27, i64* %40 
-  %"1$tmp$8#0" = tail call fastcc  i64  @"type_list.,,<0>[410bae77d3]"(i64  %19, i64  %35)  
-  %"1$tmp$7#0" = tail call fastcc  i64  @"type_list.length<0>"(i64  %"1$tmp$8#0")  
-  tail call ccc  void  @print_int(i64  %"1$tmp$7#0")  
+  %"1$tmp$8##0" = tail call fastcc  i64  @"type_list.,,<0>[410bae77d3]"(i64  %19, i64  %35)  
+  %"1$tmp$7##0" = tail call fastcc  i64  @"type_list.length<0>"(i64  %"1$tmp$8##0")  
+  tail call ccc  void  @print_int(i64  %"1$tmp$7##0")  
   ret void 
 }
 
 
-define external fastcc  i64 @"type_list.,,<0>"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"type_list.,,<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$tmp$5#0" = icmp ne i64 %"x#0", 0 
-  br i1 %"1$tmp$5#0", label %if.then, label %if.else 
+  %"1$tmp$5##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
 if.then:
-  %41 = inttoptr i64 %"x#0" to i64* 
+  %41 = inttoptr i64 %"x##0" to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
   %43 = load  i64, i64* %42 
-  %44 = add   i64 %"x#0", 8 
+  %44 = add   i64 %"x##0", 8 
   %45 = inttoptr i64 %44 to i64* 
   %46 = getelementptr  i64, i64* %45, i64 0 
   %47 = load  i64, i64* %46 
-  %"2$tmp$2#0" = tail call fastcc  i64  @"type_list.,,<0>"(i64  %47, i64  %"y#0")  
+  %"2$tmp$2##0" = tail call fastcc  i64  @"type_list.,,<0>"(i64  %47, i64  %"y##0")  
   %48 = trunc i64 16 to i32  
   %49 = tail call ccc  i8*  @wybe_malloc(i32  %48)  
   %50 = ptrtoint i8* %49 to i64 
@@ -194,45 +194,45 @@ if.then:
   %53 = add   i64 %50, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"2$tmp$2#0", i64* %55 
+  store  i64 %"2$tmp$2##0", i64* %55 
   ret i64 %50 
 if.else:
-  ret i64 %"y#0" 
+  ret i64 %"y##0" 
 }
 
 
-define external fastcc  i64 @"type_list.,,<0>[410bae77d3]"(i64  %"x#0", i64  %"y#0")    {
+define external fastcc  i64 @"type_list.,,<0>[410bae77d3]"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$tmp$5#0" = icmp ne i64 %"x#0", 0 
-  br i1 %"1$tmp$5#0", label %if.then, label %if.else 
+  %"1$tmp$5##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
 if.then:
-  %56 = add   i64 %"x#0", 8 
+  %56 = add   i64 %"x##0", 8 
   %57 = inttoptr i64 %56 to i64* 
   %58 = getelementptr  i64, i64* %57, i64 0 
   %59 = load  i64, i64* %58 
-  %"2$tmp$2#0" = tail call fastcc  i64  @"type_list.,,<0>[410bae77d3]"(i64  %59, i64  %"y#0")  
-  %60 = add   i64 %"x#0", 8 
+  %"2$tmp$2##0" = tail call fastcc  i64  @"type_list.,,<0>[410bae77d3]"(i64  %59, i64  %"y##0")  
+  %60 = add   i64 %"x##0", 8 
   %61 = inttoptr i64 %60 to i64* 
   %62 = getelementptr  i64, i64* %61, i64 0 
-  store  i64 %"2$tmp$2#0", i64* %62 
-  ret i64 %"x#0" 
+  store  i64 %"2$tmp$2##0", i64* %62 
+  ret i64 %"x##0" 
 if.else:
-  ret i64 %"y#0" 
+  ret i64 %"y##0" 
 }
 
 
-define external fastcc  i64 @"type_list.length<0>"(i64  %"x#0")    {
+define external fastcc  i64 @"type_list.length<0>"(i64  %"x##0")    {
 entry:
-  %"1$tmp$5#0" = icmp ne i64 %"x#0", 0 
-  br i1 %"1$tmp$5#0", label %if.then, label %if.else 
+  %"1$tmp$5##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
 if.then:
-  %63 = add   i64 %"x#0", 8 
+  %63 = add   i64 %"x##0", 8 
   %64 = inttoptr i64 %63 to i64* 
   %65 = getelementptr  i64, i64* %64, i64 0 
   %66 = load  i64, i64* %65 
-  %"2$tmp$2#0" = tail call fastcc  i64  @"type_list.length<0>"(i64  %66)  
-  %"2$$#0" = add   i64 %"2$tmp$2#0", 1 
-  ret i64 %"2$$#0" 
+  %"2$tmp$2##0" = tail call fastcc  i64  @"type_list.length<0>"(i64  %66)  
+  %"2$$##0" = add   i64 %"2$tmp$2##0", 1 
+  ret i64 %"2$$##0" 
 if.else:
   ret i64 0 
 }
@@ -257,32 +257,32 @@ if.else:
 
 = > public (2 calls)
 0: type_list.intlist.=<0>
-=($left#0:type_list.intlist, $right#0:type_list.intlist, ?$$#0:wybe.bool):
+=($left##0:type_list.intlist, $right##0:type_list.intlist, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left#0:type_list.intlist, ~$right#0:type_list.intlist, ?$$#0:wybe.bool)
+        foreign llvm icmp_eq(~$left##0:type_list.intlist, ~$right##0:type_list.intlist, ?$$##0:wybe.bool)
 
     1:
-        foreign lpvm access($left#0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$head#0:wybe.int)
-        foreign lpvm access(~$left#0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$tail#0:type_list.intlist)
-        foreign llvm icmp_ne($right#0:wybe.int, 0:wybe.int, ?tmp$9#0:wybe.bool)
-        case ~tmp$9#0:wybe.bool of
+        foreign lpvm access($left##0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$head##0:wybe.int)
+        foreign lpvm access(~$left##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$tail##0:type_list.intlist)
+        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
+        case ~tmp$9##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
         1:
-            foreign lpvm access($right#0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$head#0:wybe.int)
-            foreign lpvm access(~$right#0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$tail#0:type_list.intlist)
-            foreign llvm icmp_eq(~$left$head#0:wybe.int, ~$right$head#0:wybe.int, ?tmp$4#0:wybe.bool) @int:nn:nn
-            case ~tmp$4#0:wybe.bool of
+            foreign lpvm access($right##0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$head##0:wybe.int)
+            foreign lpvm access(~$right##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$tail##0:type_list.intlist)
+            foreign llvm icmp_eq(~$left$head##0:wybe.int, ~$right$head##0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
+            case ~tmp$4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
 
             1:
-                type_list.intlist.=<0>(~$left$tail#0:type_list.intlist, ~$right$tail#0:type_list.intlist, ?$$#0:wybe.bool) #3
+                type_list.intlist.=<0>(~$left$tail##0:type_list.intlist, ~$right$tail##0:type_list.intlist, ?$$##0:wybe.bool) #3
 
 
 
@@ -290,110 +290,110 @@ if.else:
 
 cons > public {inline} (0 calls)
 0: type_list.intlist.cons<0>
-cons(head#0:wybe.int, tail#0:type_list.intlist, ?$#0:type_list.intlist):
+cons(head##0:wybe.int, tail##0:type_list.intlist, ?$##0:type_list.intlist):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec#0:type_list.intlist)
-    foreign lpvm mutate(~$rec#0:type_list.intlist, ?$rec#1:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head#0:wybe.int)
-    foreign lpvm mutate(~$rec#1:type_list.intlist, ?$#0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail#0:type_list.intlist)
+    foreign lpvm alloc(16:wybe.int, ?$rec##0:type_list.intlist)
+    foreign lpvm mutate(~$rec##0:type_list.intlist, ?$rec##1:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
+    foreign lpvm mutate(~$rec##1:type_list.intlist, ?$##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:type_list.intlist)
 cons > public {inline} (12 calls)
 1: type_list.intlist.cons<1>
-cons(?head#0:wybe.int, ?tail#0:type_list.intlist, $#0:type_list.intlist, ?$$#0:wybe.bool):
+cons(?head##0:wybe.int, ?tail##0:type_list.intlist, $##0:type_list.intlist, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?head#0:wybe.int)
-        foreign llvm move(undef:type_list.intlist, ?tail#0:type_list.intlist)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?head##0:wybe.int)
+        foreign llvm move(undef:type_list.intlist, ?tail##0:type_list.intlist)
 
     1:
-        foreign lpvm access($#0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head#0:wybe.int)
-        foreign lpvm access(~$#0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail#0:type_list.intlist)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access($##0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
+        foreign lpvm access(~$##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:type_list.intlist)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 head > public {inline} (0 calls)
 0: type_list.intlist.head<0>
-head($rec#0:type_list.intlist, ?$#0:wybe.int, ?$$#0:wybe.bool):
+head($rec##0:type_list.intlist, ?$##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$#0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec#0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 head > public {inline} (0 calls)
 1: type_list.intlist.head<1>
-head($rec#0:type_list.intlist, ?$rec#1:type_list.intlist, $field#0:wybe.int, ?$$#0:wybe.bool):
+head($rec##0:type_list.intlist, ?$rec##1:type_list.intlist, $field##0:wybe.int, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:type_list.intlist, ?$rec#1:type_list.intlist)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:type_list.intlist, ?$rec##1:type_list.intlist)
 
     1:
-        foreign lpvm mutate(~$rec#0:type_list.intlist, ?$rec#1:type_list.intlist, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm mutate(~$rec##0:type_list.intlist, ?$rec##1:type_list.intlist, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 nil > public {inline} (0 calls)
 0: type_list.intlist.nil<0>
-nil(?$#0:type_list.intlist):
+nil(?$##0:type_list.intlist):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:type_list.intlist, ?$#0:type_list.intlist)
+    foreign llvm move(0:type_list.intlist, ?$##0:type_list.intlist)
 
 
 tail > public {inline} (0 calls)
 0: type_list.intlist.tail<0>
-tail($rec#0:type_list.intlist, ?$#0:type_list.intlist, ?$$#0:wybe.bool):
+tail($rec##0:type_list.intlist, ?$##0:type_list.intlist, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(undef:type_list.intlist, ?$#0:type_list.intlist)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(undef:type_list.intlist, ?$##0:type_list.intlist)
 
     1:
-        foreign lpvm access(~$rec#0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$#0:type_list.intlist)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm access(~$rec##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:type_list.intlist)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 tail > public {inline} (0 calls)
 1: type_list.intlist.tail<1>
-tail($rec#0:type_list.intlist, ?$rec#1:type_list.intlist, $field#0:type_list.intlist, ?$$#0:wybe.bool):
+tail($rec##0:type_list.intlist, ?$rec##1:type_list.intlist, $field##0:type_list.intlist, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec#0:wybe.int, 0:wybe.int, ?tmp$0#0:wybe.bool)
-    case ~tmp$0#0:wybe.bool of
+    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
+    case ~tmp$0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$#0:wybe.bool)
-        foreign llvm move(~$rec#0:type_list.intlist, ?$rec#1:type_list.intlist)
+        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(~$rec##0:type_list.intlist, ?$rec##1:type_list.intlist)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec#0:type_list.intlist, ?$rec#1:type_list.intlist, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field#0:type_list.intlist)
-        foreign llvm move(1:wybe.bool, ?$$#0:wybe.bool)
+        foreign lpvm {noalias} mutate(~$rec##0:type_list.intlist, ?$rec##1:type_list.intlist, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:type_list.intlist)
+        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: type_list.intlist.~=<0>
-~=($left#0:type_list.intlist, $right#0:type_list.intlist, ?$$#0:wybe.bool):
+~=($left##0:type_list.intlist, $right##0:type_list.intlist, ?$$##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    type_list.intlist.=<0>(~$left#0:type_list.intlist, ~$right#0:type_list.intlist, ?tmp$0#0:wybe.bool) #0
-    foreign llvm xor(~tmp$0#0:wybe.bool, 1:wybe.bool, ?$$#0:wybe.bool)
+    type_list.intlist.=<0>(~$left##0:type_list.intlist, ~$right##0:type_list.intlist, ?tmp$0##0:wybe.bool) #0
+    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
 
   LLVM code       :
 
@@ -409,68 +409,68 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"type_list.intlist.=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"type_list.intlist.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$left#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left#0" to i64* 
+  %1 = inttoptr i64 %"$left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left#0", 8 
+  %4 = add   i64 %"$left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %"2$tmp$9#0" = icmp ne i64 %"$right#0", 0 
-  br i1 %"2$tmp$9#0", label %if.then1, label %if.else1 
+  %"2$tmp$9##0" = icmp ne i64 %"$right##0", 0 
+  br i1 %"2$tmp$9##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$#0" = icmp eq i64 %"$left#0", %"$right#0" 
-  ret i1 %"3$$$#0" 
+  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
+  ret i1 %"3$$$##0" 
 if.then1:
-  %8 = inttoptr i64 %"$right#0" to i64* 
+  %8 = inttoptr i64 %"$right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right#0", 8 
+  %11 = add   i64 %"$right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"4$tmp$4#0" = icmp eq i64 %3, %10 
-  br i1 %"4$tmp$4#0", label %if.then2, label %if.else2 
+  %"4$tmp$4##0" = icmp eq i64 %3, %10 
+  br i1 %"4$tmp$4##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$$$#0" = tail call fastcc  i1  @"type_list.intlist.=<0>"(i64  %7, i64  %14)  
-  ret i1 %"6$$$#0" 
+  %"6$$$##0" = tail call fastcc  i1  @"type_list.intlist.=<0>"(i64  %7, i64  %14)  
+  ret i1 %"6$$$##0" 
 if.else2:
   ret i1 0 
 }
 
 
-define external fastcc  i64 @"type_list.intlist.cons<0>"(i64  %"head#0", i64  %"tail#0")    {
+define external fastcc  i64 @"type_list.intlist.cons<0>"(i64  %"head##0", i64  %"tail##0")    {
 entry:
   %15 = trunc i64 16 to i32  
   %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
   %17 = ptrtoint i8* %16 to i64 
   %18 = inttoptr i64 %17 to i64* 
   %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %"head#0", i64* %19 
+  store  i64 %"head##0", i64* %19 
   %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"tail#0", i64* %22 
+  store  i64 %"tail##0", i64* %22 
   ret i64 %17 
 }
 
 
-define external fastcc  {i64, i64, i1} @"type_list.intlist.cons<1>"(i64  %"$#0")    {
+define external fastcc  {i64, i64, i1} @"type_list.intlist.cons<1>"(i64  %"$##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %23 = inttoptr i64 %"$#0" to i64* 
+  %23 = inttoptr i64 %"$##0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$#0", 8 
+  %26 = add   i64 %"$##0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -486,12 +486,12 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"type_list.intlist.head<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"type_list.intlist.head<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %36 = inttoptr i64 %"$rec#0" to i64* 
+  %36 = inttoptr i64 %"$rec##0" to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
   %39 = insertvalue {i64, i1} undef, i64 %38, 0 
@@ -504,26 +504,26 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"type_list.intlist.head<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"type_list.intlist.head<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %43 = trunc i64 16 to i32  
   %44 = tail call ccc  i8*  @wybe_malloc(i32  %43)  
   %45 = ptrtoint i8* %44 to i64 
   %46 = inttoptr i64 %45 to i8* 
-  %47 = inttoptr i64 %"$rec#0" to i8* 
+  %47 = inttoptr i64 %"$rec##0" to i8* 
   %48 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %46, i8*  %47, i32  %48, i32  8, i1  0)  
   %49 = inttoptr i64 %45 to i64* 
   %50 = getelementptr  i64, i64* %49, i64 0 
-  store  i64 %"$field#0", i64* %50 
+  store  i64 %"$field##0", i64* %50 
   %51 = insertvalue {i64, i1} undef, i64 %45, 0 
   %52 = insertvalue {i64, i1} %51, i1 1, 1 
   ret {i64, i1} %52 
 if.else:
-  %53 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %53 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %54 = insertvalue {i64, i1} %53, i1 0, 1 
   ret {i64, i1} %54 
 }
@@ -535,12 +535,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"type_list.intlist.tail<0>"(i64  %"$rec#0")    {
+define external fastcc  {i64, i1} @"type_list.intlist.tail<0>"(i64  %"$rec##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
-  %55 = add   i64 %"$rec#0", 8 
+  %55 = add   i64 %"$rec##0", 8 
   %56 = inttoptr i64 %55 to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
@@ -554,35 +554,35 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"type_list.intlist.tail<1>"(i64  %"$rec#0", i64  %"$field#0")    {
+define external fastcc  {i64, i1} @"type_list.intlist.tail<1>"(i64  %"$rec##0", i64  %"$field##0")    {
 entry:
-  %"1$tmp$0#0" = icmp ne i64 %"$rec#0", 0 
-  br i1 %"1$tmp$0#0", label %if.then, label %if.else 
+  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
+  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
 if.then:
   %63 = trunc i64 16 to i32  
   %64 = tail call ccc  i8*  @wybe_malloc(i32  %63)  
   %65 = ptrtoint i8* %64 to i64 
   %66 = inttoptr i64 %65 to i8* 
-  %67 = inttoptr i64 %"$rec#0" to i8* 
+  %67 = inttoptr i64 %"$rec##0" to i8* 
   %68 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %66, i8*  %67, i32  %68, i32  8, i1  0)  
   %69 = add   i64 %65, 8 
   %70 = inttoptr i64 %69 to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
-  store  i64 %"$field#0", i64* %71 
+  store  i64 %"$field##0", i64* %71 
   %72 = insertvalue {i64, i1} undef, i64 %65, 0 
   %73 = insertvalue {i64, i1} %72, i1 1, 1 
   ret {i64, i1} %73 
 if.else:
-  %74 = insertvalue {i64, i1} undef, i64 %"$rec#0", 0 
+  %74 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
   %75 = insertvalue {i64, i1} %74, i1 0, 1 
   ret {i64, i1} %75 
 }
 
 
-define external fastcc  i1 @"type_list.intlist.~=<0>"(i64  %"$left#0", i64  %"$right#0")    {
+define external fastcc  i1 @"type_list.intlist.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
 entry:
-  %"1$tmp$0#0" = tail call fastcc  i1  @"type_list.intlist.=<0>"(i64  %"$left#0", i64  %"$right#0")  
-  %"1$$$#0" = xor i1 %"1$tmp$0#0", 1 
-  ret i1 %"1$$$#0" 
+  %"1$tmp$0##0" = tail call fastcc  i1  @"type_list.intlist.=<0>"(i64  %"$left##0", i64  %"$right##0")  
+  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
+  ret i1 %"1$$$##0" 
 }

--- a/test-cases/final-dump/type_list.exp
+++ b/test-cases/final-dump/type_list.exp
@@ -28,72 +28,72 @@ AFTER EVERYTHING:
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(7,(type_list.,,<0>,fromList [NonAliasedParamCond 0 []]))]
-    foreign lpvm alloc(16:wybe.int, ?tmp$11##0:type_list.intlist)
-    foreign lpvm mutate(~tmp$11##0:type_list.intlist, ?tmp$12##0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
-    foreign lpvm mutate(~tmp$12##0:type_list.intlist, ?tmp$13##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:type_list.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp$16##0:type_list.intlist)
-    foreign lpvm mutate(~tmp$16##0:type_list.intlist, ?tmp$17##0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
-    foreign lpvm mutate(~tmp$17##0:type_list.intlist, ?tmp$18##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$13##0:type_list.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp$21##0:type_list.intlist)
-    foreign lpvm mutate(~tmp$21##0:type_list.intlist, ?tmp$22##0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp$22##0:type_list.intlist, ?tmp$23##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$18##0:type_list.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp$26##0:type_list.intlist)
-    foreign lpvm mutate(~tmp$26##0:type_list.intlist, ?tmp$27##0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
-    foreign lpvm mutate(~tmp$27##0:type_list.intlist, ?tmp$28##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:type_list.intlist)
-    foreign lpvm alloc(16:wybe.int, ?tmp$31##0:type_list.intlist)
-    foreign lpvm mutate(~tmp$31##0:type_list.intlist, ?tmp$32##0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
-    foreign lpvm mutate(~tmp$32##0:type_list.intlist, ?tmp$33##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$28##0:type_list.intlist)
-    type_list.,,<0>[410bae77d3](~tmp$23##0:type_list.intlist, ~tmp$33##0:type_list.intlist, ?tmp$8##0:type_list.intlist) #7 @type_list:nn:nn
-    type_list.length<0>(~tmp$8##0:type_list.intlist, ?tmp$7##0:wybe.int) #8 @type_list:nn:nn
-    foreign c print_int(~tmp$7##0:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:type_list.intlist)
+    foreign lpvm mutate(~tmp#11##0:type_list.intlist, ?tmp#12##0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:wybe.int)
+    foreign lpvm mutate(~tmp#12##0:type_list.intlist, ?tmp#13##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:type_list.intlist)
+    foreign lpvm alloc(16:wybe.int, ?tmp#16##0:type_list.intlist)
+    foreign lpvm mutate(~tmp#16##0:type_list.intlist, ?tmp#17##0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:wybe.int)
+    foreign lpvm mutate(~tmp#17##0:type_list.intlist, ?tmp#18##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#13##0:type_list.intlist)
+    foreign lpvm alloc(16:wybe.int, ?tmp#21##0:type_list.intlist)
+    foreign lpvm mutate(~tmp#21##0:type_list.intlist, ?tmp#22##0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp#22##0:type_list.intlist, ?tmp#23##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#18##0:type_list.intlist)
+    foreign lpvm alloc(16:wybe.int, ?tmp#26##0:type_list.intlist)
+    foreign lpvm mutate(~tmp#26##0:type_list.intlist, ?tmp#27##0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 200:wybe.int)
+    foreign lpvm mutate(~tmp#27##0:type_list.intlist, ?tmp#28##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:type_list.intlist)
+    foreign lpvm alloc(16:wybe.int, ?tmp#31##0:type_list.intlist)
+    foreign lpvm mutate(~tmp#31##0:type_list.intlist, ?tmp#32##0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 100:wybe.int)
+    foreign lpvm mutate(~tmp#32##0:type_list.intlist, ?tmp#33##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#28##0:type_list.intlist)
+    type_list.,,<0>[410bae77d3](~tmp#23##0:type_list.intlist, ~tmp#33##0:type_list.intlist, ?tmp#8##0:type_list.intlist) #7 @type_list:nn:nn
+    type_list.length<0>(~tmp#8##0:type_list.intlist, ?tmp#7##0:wybe.int) #8 @type_list:nn:nn
+    foreign c print_int(~tmp#7##0:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 ,, > public (2 calls)
 0: type_list.,,<0>[410bae77d3]
-,,(x##0:type_list.intlist, y##0:type_list.intlist, ?$##0:type_list.intlist):
- AliasPairs: [($##0,y##0)]
+,,(x##0:type_list.intlist, y##0:type_list.intlist, ?###0:type_list.intlist):
+ AliasPairs: [(###0,y##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(type_list.,,<0>,fromList [NonAliasedParamCond 0 [0]]))]
-    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
-    case ~tmp$5##0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
+    case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~y##0:type_list.intlist, ?$##0:type_list.intlist) @type_list:nn:nn
+        foreign llvm move(~y##0:type_list.intlist, ?###0:type_list.intlist) @type_list:nn:nn
 
     1:
         foreign lpvm access(x##0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
         foreign lpvm access(~x##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:type_list.intlist)
-        type_list.,,<0>(~t##0:type_list.intlist, ~y##0:type_list.intlist, ?tmp$2##0:type_list.intlist) #1 @type_list:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp$8##0:type_list.intlist)
-        foreign lpvm mutate(~tmp$8##0:type_list.intlist, ?tmp$9##0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
-        foreign lpvm mutate(~tmp$9##0:type_list.intlist, ?$##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:type_list.intlist)
+        type_list.,,<0>(~t##0:type_list.intlist, ~y##0:type_list.intlist, ?tmp#2##0:type_list.intlist) #1 @type_list:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:type_list.intlist)
+        foreign lpvm mutate(~tmp#8##0:type_list.intlist, ?tmp#9##0:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:wybe.int)
+        foreign lpvm mutate(~tmp#9##0:type_list.intlist, ?###0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:type_list.intlist)
 
  [410bae77d3] [NonAliasedParam 0] :
-    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
-    case ~tmp$5##0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
+    case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~y##0:type_list.intlist, ?$##0:type_list.intlist) @type_list:nn:nn
+        foreign llvm move(~y##0:type_list.intlist, ?###0:type_list.intlist) @type_list:nn:nn
 
     1:
         foreign lpvm access(x##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:type_list.intlist)
-        type_list.,,<0>[410bae77d3](~t##0:type_list.intlist, ~y##0:type_list.intlist, ?tmp$2##0:type_list.intlist) #1 @type_list:nn:nn
-        foreign lpvm mutate(~x##0:type_list.intlist, ?$##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp$2##0:type_list.intlist)
+        type_list.,,<0>[410bae77d3](~t##0:type_list.intlist, ~y##0:type_list.intlist, ?tmp#2##0:type_list.intlist) #1 @type_list:nn:nn
+        foreign lpvm mutate(~x##0:type_list.intlist, ?###0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:type_list.intlist)
 
 
 
 length > public (2 calls)
 0: type_list.length<0>
-length(x##0:type_list.intlist, ?$##0:wybe.int):
+length(x##0:type_list.intlist, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp$5##0:wybe.bool)
-    case ~tmp$5##0:wybe.bool of
+    foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
+    case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.int, ?$##0:wybe.int) @type_list:nn:nn
+        foreign llvm move(0:wybe.int, ?###0:wybe.int) @type_list:nn:nn
 
     1:
         foreign lpvm access(~x##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:type_list.intlist)
-        type_list.length<0>(~t##0:type_list.intlist, ?tmp$2##0:wybe.int) #1 @type_list:nn:nn
-        foreign llvm add(~tmp$2##0:wybe.int, 1:wybe.int, ?$##0:wybe.int) @int:nn:nn
+        type_list.length<0>(~t##0:type_list.intlist, ?tmp#2##0:wybe.int) #1 @type_list:nn:nn
+        foreign llvm add(~tmp#2##0:wybe.int, 1:wybe.int, ?###0:wybe.int) @int:nn:nn
 
 
   LLVM code       :
@@ -165,17 +165,17 @@ entry:
   %39 = inttoptr i64 %38 to i64* 
   %40 = getelementptr  i64, i64* %39, i64 0 
   store  i64 %27, i64* %40 
-  %"1$tmp$8##0" = tail call fastcc  i64  @"type_list.,,<0>[410bae77d3]"(i64  %19, i64  %35)  
-  %"1$tmp$7##0" = tail call fastcc  i64  @"type_list.length<0>"(i64  %"1$tmp$8##0")  
-  tail call ccc  void  @print_int(i64  %"1$tmp$7##0")  
+  %"1#tmp#8##0" = tail call fastcc  i64  @"type_list.,,<0>[410bae77d3]"(i64  %19, i64  %35)  
+  %"1#tmp#7##0" = tail call fastcc  i64  @"type_list.length<0>"(i64  %"1#tmp#8##0")  
+  tail call ccc  void  @print_int(i64  %"1#tmp#7##0")  
   ret void 
 }
 
 
 define external fastcc  i64 @"type_list.,,<0>"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$tmp$5##0" = icmp ne i64 %"x##0", 0 
-  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
+  %"1#tmp#5##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
   %41 = inttoptr i64 %"x##0" to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
@@ -184,7 +184,7 @@ if.then:
   %45 = inttoptr i64 %44 to i64* 
   %46 = getelementptr  i64, i64* %45, i64 0 
   %47 = load  i64, i64* %46 
-  %"2$tmp$2##0" = tail call fastcc  i64  @"type_list.,,<0>"(i64  %47, i64  %"y##0")  
+  %"2#tmp#2##0" = tail call fastcc  i64  @"type_list.,,<0>"(i64  %47, i64  %"y##0")  
   %48 = trunc i64 16 to i32  
   %49 = tail call ccc  i8*  @wybe_malloc(i32  %48)  
   %50 = ptrtoint i8* %49 to i64 
@@ -194,7 +194,7 @@ if.then:
   %53 = add   i64 %50, 8 
   %54 = inttoptr i64 %53 to i64* 
   %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %"2$tmp$2##0", i64* %55 
+  store  i64 %"2#tmp#2##0", i64* %55 
   ret i64 %50 
 if.else:
   ret i64 %"y##0" 
@@ -203,18 +203,18 @@ if.else:
 
 define external fastcc  i64 @"type_list.,,<0>[410bae77d3]"(i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1$tmp$5##0" = icmp ne i64 %"x##0", 0 
-  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
+  %"1#tmp#5##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
   %56 = add   i64 %"x##0", 8 
   %57 = inttoptr i64 %56 to i64* 
   %58 = getelementptr  i64, i64* %57, i64 0 
   %59 = load  i64, i64* %58 
-  %"2$tmp$2##0" = tail call fastcc  i64  @"type_list.,,<0>[410bae77d3]"(i64  %59, i64  %"y##0")  
+  %"2#tmp#2##0" = tail call fastcc  i64  @"type_list.,,<0>[410bae77d3]"(i64  %59, i64  %"y##0")  
   %60 = add   i64 %"x##0", 8 
   %61 = inttoptr i64 %60 to i64* 
   %62 = getelementptr  i64, i64* %61, i64 0 
-  store  i64 %"2$tmp$2##0", i64* %62 
+  store  i64 %"2#tmp#2##0", i64* %62 
   ret i64 %"x##0" 
 if.else:
   ret i64 %"y##0" 
@@ -223,16 +223,16 @@ if.else:
 
 define external fastcc  i64 @"type_list.length<0>"(i64  %"x##0")    {
 entry:
-  %"1$tmp$5##0" = icmp ne i64 %"x##0", 0 
-  br i1 %"1$tmp$5##0", label %if.then, label %if.else 
+  %"1#tmp#5##0" = icmp ne i64 %"x##0", 0 
+  br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
   %63 = add   i64 %"x##0", 8 
   %64 = inttoptr i64 %63 to i64* 
   %65 = getelementptr  i64, i64* %64, i64 0 
   %66 = load  i64, i64* %65 
-  %"2$tmp$2##0" = tail call fastcc  i64  @"type_list.length<0>"(i64  %66)  
-  %"2$$##0" = add   i64 %"2$tmp$2##0", 1 
-  ret i64 %"2$$##0" 
+  %"2#tmp#2##0" = tail call fastcc  i64  @"type_list.length<0>"(i64  %66)  
+  %"2####0" = add   i64 %"2#tmp#2##0", 1 
+  ret i64 %"2####0" 
 if.else:
   ret i64 0 
 }
@@ -257,32 +257,32 @@ if.else:
 
 = > public (2 calls)
 0: type_list.intlist.=<0>
-=($left##0:type_list.intlist, $right##0:type_list.intlist, ?$$##0:wybe.bool):
+=(#left##0:type_list.intlist, #right##0:type_list.intlist, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($left##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#left##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm icmp_eq(~$left##0:type_list.intlist, ~$right##0:type_list.intlist, ?$$##0:wybe.bool)
+        foreign llvm icmp_eq(~#left##0:type_list.intlist, ~#right##0:type_list.intlist, ?####0:wybe.bool)
 
     1:
-        foreign lpvm access($left##0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$head##0:wybe.int)
-        foreign lpvm access(~$left##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$left$tail##0:type_list.intlist)
-        foreign llvm icmp_ne($right##0:wybe.int, 0:wybe.int, ?tmp$9##0:wybe.bool)
-        case ~tmp$9##0:wybe.bool of
+        foreign lpvm access(#left##0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#head##0:wybe.int)
+        foreign lpvm access(~#left##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#left#tail##0:type_list.intlist)
+        foreign llvm icmp_ne(#right##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
+        case ~tmp#9##0:wybe.bool of
         0:
-            foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+            foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
         1:
-            foreign lpvm access($right##0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$head##0:wybe.int)
-            foreign lpvm access(~$right##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$right$tail##0:type_list.intlist)
-            foreign llvm icmp_eq(~$left$head##0:wybe.int, ~$right$head##0:wybe.int, ?tmp$4##0:wybe.bool) @int:nn:nn
-            case ~tmp$4##0:wybe.bool of
+            foreign lpvm access(#right##0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#head##0:wybe.int)
+            foreign lpvm access(~#right##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#right#tail##0:type_list.intlist)
+            foreign llvm icmp_eq(~#left#head##0:wybe.int, ~#right#head##0:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
+            case ~tmp#4##0:wybe.bool of
             0:
-                foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+                foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
 
             1:
-                type_list.intlist.=<0>(~$left$tail##0:type_list.intlist, ~$right$tail##0:type_list.intlist, ?$$##0:wybe.bool) #3
+                type_list.intlist.=<0>(~#left#tail##0:type_list.intlist, ~#right#tail##0:type_list.intlist, ?####0:wybe.bool) #3
 
 
 
@@ -290,110 +290,110 @@ if.else:
 
 cons > public {inline} (0 calls)
 0: type_list.intlist.cons<0>
-cons(head##0:wybe.int, tail##0:type_list.intlist, ?$##0:type_list.intlist):
+cons(head##0:wybe.int, tail##0:type_list.intlist, ?###0:type_list.intlist):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?$rec##0:type_list.intlist)
-    foreign lpvm mutate(~$rec##0:type_list.intlist, ?$rec##1:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
-    foreign lpvm mutate(~$rec##1:type_list.intlist, ?$##0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:type_list.intlist)
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:type_list.intlist)
+    foreign lpvm mutate(~#rec##0:type_list.intlist, ?#rec##1:type_list.intlist, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~head##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:type_list.intlist, ?###0:type_list.intlist, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tail##0:type_list.intlist)
 cons > public {inline} (12 calls)
 1: type_list.intlist.cons<1>
-cons(?head##0:wybe.int, ?tail##0:type_list.intlist, $##0:type_list.intlist, ?$$##0:wybe.bool):
+cons(?head##0:wybe.int, ?tail##0:type_list.intlist, ###0:type_list.intlist, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(###0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?head##0:wybe.int)
         foreign llvm move(undef:type_list.intlist, ?tail##0:type_list.intlist)
 
     1:
-        foreign lpvm access($##0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
-        foreign lpvm access(~$##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:type_list.intlist)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(###0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?head##0:wybe.int)
+        foreign lpvm access(~###0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tail##0:type_list.intlist)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 head > public {inline} (0 calls)
 0: type_list.intlist.head<0>
-head($rec##0:type_list.intlist, ?$##0:wybe.int, ?$$##0:wybe.bool):
+head(#rec##0:type_list.intlist, ?###0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:wybe.int, ?$##0:wybe.int)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:wybe.int, ?###0:wybe.int)
 
     1:
-        foreign lpvm access(~$rec##0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:type_list.intlist, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 head > public {inline} (0 calls)
 1: type_list.intlist.head<1>
-head($rec##0:type_list.intlist, ?$rec##1:type_list.intlist, $field##0:wybe.int, ?$$##0:wybe.bool):
+head(#rec##0:type_list.intlist, ?#rec##1:type_list.intlist, #field##0:wybe.int, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:type_list.intlist, ?$rec##1:type_list.intlist)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:type_list.intlist, ?#rec##1:type_list.intlist)
 
     1:
-        foreign lpvm mutate(~$rec##0:type_list.intlist, ?$rec##1:type_list.intlist, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:wybe.int)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm mutate(~#rec##0:type_list.intlist, ?#rec##1:type_list.intlist, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:wybe.int)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 nil > public {inline} (0 calls)
 0: type_list.intlist.nil<0>
-nil(?$##0:type_list.intlist):
+nil(?###0:type_list.intlist):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:type_list.intlist, ?$##0:type_list.intlist)
+    foreign llvm move(0:type_list.intlist, ?###0:type_list.intlist)
 
 
 tail > public {inline} (0 calls)
 0: type_list.intlist.tail<0>
-tail($rec##0:type_list.intlist, ?$##0:type_list.intlist, ?$$##0:wybe.bool):
+tail(#rec##0:type_list.intlist, ?###0:type_list.intlist, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(undef:type_list.intlist, ?$##0:type_list.intlist)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(undef:type_list.intlist, ?###0:type_list.intlist)
 
     1:
-        foreign lpvm access(~$rec##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?$##0:type_list.intlist)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm access(~#rec##0:type_list.intlist, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?###0:type_list.intlist)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 tail > public {inline} (0 calls)
 1: type_list.intlist.tail<1>
-tail($rec##0:type_list.intlist, ?$rec##1:type_list.intlist, $field##0:type_list.intlist, ?$$##0:wybe.bool):
+tail(#rec##0:type_list.intlist, ?#rec##1:type_list.intlist, #field##0:type_list.intlist, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne($rec##0:wybe.int, 0:wybe.int, ?tmp$0##0:wybe.bool)
-    case ~tmp$0##0:wybe.bool of
+    foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
+    case ~tmp#0##0:wybe.bool of
     0:
-        foreign llvm move(0:wybe.bool, ?$$##0:wybe.bool)
-        foreign llvm move(~$rec##0:type_list.intlist, ?$rec##1:type_list.intlist)
+        foreign llvm move(0:wybe.bool, ?####0:wybe.bool)
+        foreign llvm move(~#rec##0:type_list.intlist, ?#rec##1:type_list.intlist)
 
     1:
-        foreign lpvm {noalias} mutate(~$rec##0:type_list.intlist, ?$rec##1:type_list.intlist, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~$field##0:type_list.intlist)
-        foreign llvm move(1:wybe.bool, ?$$##0:wybe.bool)
+        foreign lpvm {noalias} mutate(~#rec##0:type_list.intlist, ?#rec##1:type_list.intlist, 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:type_list.intlist)
+        foreign llvm move(1:wybe.bool, ?####0:wybe.bool)
 
 
 
 ~= > public {inline} (0 calls)
 0: type_list.intlist.~=<0>
-~=($left##0:type_list.intlist, $right##0:type_list.intlist, ?$$##0:wybe.bool):
+~=(#left##0:type_list.intlist, #right##0:type_list.intlist, ?####0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    type_list.intlist.=<0>(~$left##0:type_list.intlist, ~$right##0:type_list.intlist, ?tmp$0##0:wybe.bool) #0
-    foreign llvm xor(~tmp$0##0:wybe.bool, 1:wybe.bool, ?$$##0:wybe.bool)
+    type_list.intlist.=<0>(~#left##0:type_list.intlist, ~#right##0:type_list.intlist, ?tmp#0##0:wybe.bool) #0
+    foreign llvm xor(~tmp#0##0:wybe.bool, 1:wybe.bool, ?####0:wybe.bool)
 
   LLVM code       :
 
@@ -409,38 +409,38 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i1 @"type_list.intlist.=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"type_list.intlist.=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$left##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#left##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %1 = inttoptr i64 %"$left##0" to i64* 
+  %1 = inttoptr i64 %"#left##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %4 = add   i64 %"$left##0", 8 
+  %4 = add   i64 %"#left##0", 8 
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %"2$tmp$9##0" = icmp ne i64 %"$right##0", 0 
-  br i1 %"2$tmp$9##0", label %if.then1, label %if.else1 
+  %"2#tmp#9##0" = icmp ne i64 %"#right##0", 0 
+  br i1 %"2#tmp#9##0", label %if.then1, label %if.else1 
 if.else:
-  %"3$$$##0" = icmp eq i64 %"$left##0", %"$right##0" 
-  ret i1 %"3$$$##0" 
+  %"3#####0" = icmp eq i64 %"#left##0", %"#right##0" 
+  ret i1 %"3#####0" 
 if.then1:
-  %8 = inttoptr i64 %"$right##0" to i64* 
+  %8 = inttoptr i64 %"#right##0" to i64* 
   %9 = getelementptr  i64, i64* %8, i64 0 
   %10 = load  i64, i64* %9 
-  %11 = add   i64 %"$right##0", 8 
+  %11 = add   i64 %"#right##0", 8 
   %12 = inttoptr i64 %11 to i64* 
   %13 = getelementptr  i64, i64* %12, i64 0 
   %14 = load  i64, i64* %13 
-  %"4$tmp$4##0" = icmp eq i64 %3, %10 
-  br i1 %"4$tmp$4##0", label %if.then2, label %if.else2 
+  %"4#tmp#4##0" = icmp eq i64 %3, %10 
+  br i1 %"4#tmp#4##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6$$$##0" = tail call fastcc  i1  @"type_list.intlist.=<0>"(i64  %7, i64  %14)  
-  ret i1 %"6$$$##0" 
+  %"6#####0" = tail call fastcc  i1  @"type_list.intlist.=<0>"(i64  %7, i64  %14)  
+  ret i1 %"6#####0" 
 if.else2:
   ret i1 0 
 }
@@ -462,15 +462,15 @@ entry:
 }
 
 
-define external fastcc  {i64, i64, i1} @"type_list.intlist.cons<1>"(i64  %"$##0")    {
+define external fastcc  {i64, i64, i1} @"type_list.intlist.cons<1>"(i64  %"###0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"###0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %23 = inttoptr i64 %"$##0" to i64* 
+  %23 = inttoptr i64 %"###0" to i64* 
   %24 = getelementptr  i64, i64* %23, i64 0 
   %25 = load  i64, i64* %24 
-  %26 = add   i64 %"$##0", 8 
+  %26 = add   i64 %"###0", 8 
   %27 = inttoptr i64 %26 to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
   %29 = load  i64, i64* %28 
@@ -486,12 +486,12 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"type_list.intlist.head<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"type_list.intlist.head<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %36 = inttoptr i64 %"$rec##0" to i64* 
+  %36 = inttoptr i64 %"#rec##0" to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
   %39 = insertvalue {i64, i1} undef, i64 %38, 0 
@@ -504,26 +504,26 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"type_list.intlist.head<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"type_list.intlist.head<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %43 = trunc i64 16 to i32  
   %44 = tail call ccc  i8*  @wybe_malloc(i32  %43)  
   %45 = ptrtoint i8* %44 to i64 
   %46 = inttoptr i64 %45 to i8* 
-  %47 = inttoptr i64 %"$rec##0" to i8* 
+  %47 = inttoptr i64 %"#rec##0" to i8* 
   %48 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %46, i8*  %47, i32  %48, i32  8, i1  0)  
   %49 = inttoptr i64 %45 to i64* 
   %50 = getelementptr  i64, i64* %49, i64 0 
-  store  i64 %"$field##0", i64* %50 
+  store  i64 %"#field##0", i64* %50 
   %51 = insertvalue {i64, i1} undef, i64 %45, 0 
   %52 = insertvalue {i64, i1} %51, i1 1, 1 
   ret {i64, i1} %52 
 if.else:
-  %53 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %53 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %54 = insertvalue {i64, i1} %53, i1 0, 1 
   ret {i64, i1} %54 
 }
@@ -535,12 +535,12 @@ entry:
 }
 
 
-define external fastcc  {i64, i1} @"type_list.intlist.tail<0>"(i64  %"$rec##0")    {
+define external fastcc  {i64, i1} @"type_list.intlist.tail<0>"(i64  %"#rec##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %55 = add   i64 %"$rec##0", 8 
+  %55 = add   i64 %"#rec##0", 8 
   %56 = inttoptr i64 %55 to i64* 
   %57 = getelementptr  i64, i64* %56, i64 0 
   %58 = load  i64, i64* %57 
@@ -554,35 +554,35 @@ if.else:
 }
 
 
-define external fastcc  {i64, i1} @"type_list.intlist.tail<1>"(i64  %"$rec##0", i64  %"$field##0")    {
+define external fastcc  {i64, i1} @"type_list.intlist.tail<1>"(i64  %"#rec##0", i64  %"#field##0")    {
 entry:
-  %"1$tmp$0##0" = icmp ne i64 %"$rec##0", 0 
-  br i1 %"1$tmp$0##0", label %if.then, label %if.else 
+  %"1#tmp#0##0" = icmp ne i64 %"#rec##0", 0 
+  br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   %63 = trunc i64 16 to i32  
   %64 = tail call ccc  i8*  @wybe_malloc(i32  %63)  
   %65 = ptrtoint i8* %64 to i64 
   %66 = inttoptr i64 %65 to i8* 
-  %67 = inttoptr i64 %"$rec##0" to i8* 
+  %67 = inttoptr i64 %"#rec##0" to i8* 
   %68 = trunc i64 16 to i32  
   tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %66, i8*  %67, i32  %68, i32  8, i1  0)  
   %69 = add   i64 %65, 8 
   %70 = inttoptr i64 %69 to i64* 
   %71 = getelementptr  i64, i64* %70, i64 0 
-  store  i64 %"$field##0", i64* %71 
+  store  i64 %"#field##0", i64* %71 
   %72 = insertvalue {i64, i1} undef, i64 %65, 0 
   %73 = insertvalue {i64, i1} %72, i1 1, 1 
   ret {i64, i1} %73 
 if.else:
-  %74 = insertvalue {i64, i1} undef, i64 %"$rec##0", 0 
+  %74 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
   %75 = insertvalue {i64, i1} %74, i1 0, 1 
   ret {i64, i1} %75 
 }
 
 
-define external fastcc  i1 @"type_list.intlist.~=<0>"(i64  %"$left##0", i64  %"$right##0")    {
+define external fastcc  i1 @"type_list.intlist.~=<0>"(i64  %"#left##0", i64  %"#right##0")    {
 entry:
-  %"1$tmp$0##0" = tail call fastcc  i1  @"type_list.intlist.=<0>"(i64  %"$left##0", i64  %"$right##0")  
-  %"1$$$##0" = xor i1 %"1$tmp$0##0", 1 
-  ret i1 %"1$$$##0" 
+  %"1#tmp#0##0" = tail call fastcc  i1  @"type_list.intlist.=<0>"(i64  %"#left##0", i64  %"#right##0")  
+  %"1#####0" = xor i1 %"1#tmp#0##0", 1 
+  ret i1 %"1#####0" 
 }

--- a/test-cases/final-dump/unneeded.exp
+++ b/test-cases/final-dump/unneeded.exp
@@ -11,10 +11,10 @@ AFTER EVERYTHING:
 
 unneeded > {inline} (0 calls)
 0: unneeded.unneeded<0>
-unneeded(x#0:wybe.int, [y#0:wybe.int], ?z#0:wybe.int, q#0:wybe.int, [?q#0:wybe.int]):
+unneeded(x##0:wybe.int, [y##0:wybe.int], ?z##0:wybe.int, q##0:wybe.int, [?q##0:wybe.int]):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~x#0:wybe.int, 1:wybe.int, ?z#0:wybe.int) @int:nn:nn
+    foreign llvm add(~x##0:wybe.int, 1:wybe.int, ?z##0:wybe.int) @int:nn:nn
 
   LLVM code       :
 
@@ -30,8 +30,8 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i64 @"unneeded.unneeded<0>"(i64  %"x#0", i64  %"q#0")    {
+define external fastcc  i64 @"unneeded.unneeded<0>"(i64  %"x##0", i64  %"q##0")    {
 entry:
-  %"1$z#0" = add   i64 %"x#0", 1 
-  ret i64 %"1$z#0" 
+  %"1$z##0" = add   i64 %"x##0", 1 
+  ret i64 %"1$z##0" 
 }

--- a/test-cases/final-dump/unneeded.exp
+++ b/test-cases/final-dump/unneeded.exp
@@ -32,6 +32,6 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  i64 @"unneeded.unneeded<0>"(i64  %"x##0", i64  %"q##0")    {
 entry:
-  %"1$z##0" = add   i64 %"x##0", 1 
-  ret i64 %"1$z##0" 
+  %"1#z##0" = add   i64 %"x##0", 1 
+  ret i64 %"1#z##0" 
 }

--- a/test-cases/final-dump/update.exp
+++ b/test-cases/final-dump/update.exp
@@ -12,18 +12,18 @@ AFTER EVERYTHING:
 
 inc2 > public {inline} (0 calls)
 0: update.inc2<0>
-inc2(x#0:wybe.int, ?$#0:wybe.int):
+inc2(x##0:wybe.int, ?$##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~x#0:wybe.int, 1:wybe.int, ?tmp$1#0:wybe.int) @int:nn:nn
-    foreign llvm add(~tmp$1#0:wybe.int, 1:wybe.int, ?$#0:wybe.int) @int:nn:nn
+    foreign llvm add(~x##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.int) @int:nn:nn
+    foreign llvm add(~tmp$1##0:wybe.int, 1:wybe.int, ?$##0:wybe.int) @int:nn:nn
 inc2 > public {inline} (0 calls)
 1: update.inc2<1>
-inc2(?x#0:wybe.int, y#0:wybe.int):
+inc2(?x##0:wybe.int, y##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm sub(~y#0:wybe.int, 1:wybe.int, ?tmp$0#0:wybe.int) @int:nn:nn
-    foreign llvm sub(~tmp$0#0:wybe.int, 1:wybe.int, ?x#0:wybe.int) @int:nn:nn
+    foreign llvm sub(~y##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
+    foreign llvm sub(~tmp$0##0:wybe.int, 1:wybe.int, ?x##0:wybe.int) @int:nn:nn
 
   LLVM code       :
 
@@ -39,17 +39,17 @@ declare external ccc  i8* @wybe_malloc(i32)
 declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
 
 
-define external fastcc  i64 @"update.inc2<0>"(i64  %"x#0")    {
+define external fastcc  i64 @"update.inc2<0>"(i64  %"x##0")    {
 entry:
-  %"1$tmp$1#0" = add   i64 %"x#0", 1 
-  %"1$$#0" = add   i64 %"1$tmp$1#0", 1 
-  ret i64 %"1$$#0" 
+  %"1$tmp$1##0" = add   i64 %"x##0", 1 
+  %"1$$##0" = add   i64 %"1$tmp$1##0", 1 
+  ret i64 %"1$$##0" 
 }
 
 
-define external fastcc  i64 @"update.inc2<1>"(i64  %"y#0")    {
+define external fastcc  i64 @"update.inc2<1>"(i64  %"y##0")    {
 entry:
-  %"1$tmp$0#0" = sub   i64 %"y#0", 1 
-  %"1$x#0" = sub   i64 %"1$tmp$0#0", 1 
-  ret i64 %"1$x#0" 
+  %"1$tmp$0##0" = sub   i64 %"y##0", 1 
+  %"1$x##0" = sub   i64 %"1$tmp$0##0", 1 
+  ret i64 %"1$x##0" 
 }

--- a/test-cases/final-dump/update.exp
+++ b/test-cases/final-dump/update.exp
@@ -12,11 +12,11 @@ AFTER EVERYTHING:
 
 inc2 > public {inline} (0 calls)
 0: update.inc2<0>
-inc2(x##0:wybe.int, ?###0:wybe.int):
+inc2(x##0:wybe.int, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm add(~x##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int) @int:nn:nn
-    foreign llvm add(~tmp#1##0:wybe.int, 1:wybe.int, ?###0:wybe.int) @int:nn:nn
+    foreign llvm add(~tmp#1##0:wybe.int, 1:wybe.int, ?#result##0:wybe.int) @int:nn:nn
 inc2 > public {inline} (0 calls)
 1: update.inc2<1>
 inc2(?x##0:wybe.int, y##0:wybe.int):
@@ -42,8 +42,8 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 define external fastcc  i64 @"update.inc2<0>"(i64  %"x##0")    {
 entry:
   %"1#tmp#1##0" = add   i64 %"x##0", 1 
-  %"1####0" = add   i64 %"1#tmp#1##0", 1 
-  ret i64 %"1####0" 
+  %"1##result##0" = add   i64 %"1#tmp#1##0", 1 
+  ret i64 %"1##result##0" 
 }
 
 

--- a/test-cases/final-dump/update.exp
+++ b/test-cases/final-dump/update.exp
@@ -12,18 +12,18 @@ AFTER EVERYTHING:
 
 inc2 > public {inline} (0 calls)
 0: update.inc2<0>
-inc2(x##0:wybe.int, ?$##0:wybe.int):
+inc2(x##0:wybe.int, ?###0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~x##0:wybe.int, 1:wybe.int, ?tmp$1##0:wybe.int) @int:nn:nn
-    foreign llvm add(~tmp$1##0:wybe.int, 1:wybe.int, ?$##0:wybe.int) @int:nn:nn
+    foreign llvm add(~x##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int) @int:nn:nn
+    foreign llvm add(~tmp#1##0:wybe.int, 1:wybe.int, ?###0:wybe.int) @int:nn:nn
 inc2 > public {inline} (0 calls)
 1: update.inc2<1>
 inc2(?x##0:wybe.int, y##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm sub(~y##0:wybe.int, 1:wybe.int, ?tmp$0##0:wybe.int) @int:nn:nn
-    foreign llvm sub(~tmp$0##0:wybe.int, 1:wybe.int, ?x##0:wybe.int) @int:nn:nn
+    foreign llvm sub(~y##0:wybe.int, 1:wybe.int, ?tmp#0##0:wybe.int) @int:nn:nn
+    foreign llvm sub(~tmp#0##0:wybe.int, 1:wybe.int, ?x##0:wybe.int) @int:nn:nn
 
   LLVM code       :
 
@@ -41,15 +41,15 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  i64 @"update.inc2<0>"(i64  %"x##0")    {
 entry:
-  %"1$tmp$1##0" = add   i64 %"x##0", 1 
-  %"1$$##0" = add   i64 %"1$tmp$1##0", 1 
-  ret i64 %"1$$##0" 
+  %"1#tmp#1##0" = add   i64 %"x##0", 1 
+  %"1####0" = add   i64 %"1#tmp#1##0", 1 
+  ret i64 %"1####0" 
 }
 
 
 define external fastcc  i64 @"update.inc2<1>"(i64  %"y##0")    {
 entry:
-  %"1$tmp$0##0" = sub   i64 %"y##0", 1 
-  %"1$x##0" = sub   i64 %"1$tmp$0##0", 1 
-  ret i64 %"1$x##0" 
+  %"1#tmp#0##0" = sub   i64 %"y##0", 1 
+  %"1#x##0" = sub   i64 %"1#tmp#0##0", 1 
+  ret i64 %"1#x##0" 
 }

--- a/test-cases/final-dump/use_resource.exp
+++ b/test-cases/final-dump/use_resource.exp
@@ -11,42 +11,42 @@ AFTER EVERYTHING:
 
 *main* > public (0 calls)
 0: use_resource.<0>
-(?count#2:wybe.int, io#0:wybe.phantom, ?io#1:wybe.phantom):
+(?count##2:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("Inner count (4): ":wybe.string, ~#io#0:wybe.phantom, ?tmp$6#0:wybe.phantom) @io:nn:nn
-    foreign c print_int(4:wybe.int, ~tmp$6#0:wybe.phantom, ?tmp$7#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$7#0:wybe.phantom, ?tmp$8#0:wybe.phantom) @io:nn:nn
-    foreign llvm move(1:wybe.int, ?#count#2:wybe.int)
-    foreign c print_string("Outer count (1): ":wybe.string, ~tmp$8#0:wybe.phantom, ?tmp$9#0:wybe.phantom) @io:nn:nn
-    foreign c print_int(1:wybe.int, ~tmp$9#0:wybe.phantom, ?tmp$10#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$10#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
+    foreign c print_string("Inner count (4): ":wybe.string, ~#io##0:wybe.phantom, ?tmp$6##0:wybe.phantom) @io:nn:nn
+    foreign c print_int(4:wybe.int, ~tmp$6##0:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?tmp$8##0:wybe.phantom) @io:nn:nn
+    foreign llvm move(1:wybe.int, ?#count##2:wybe.int)
+    foreign c print_string("Outer count (1): ":wybe.string, ~tmp$8##0:wybe.phantom, ?tmp$9##0:wybe.phantom) @io:nn:nn
+    foreign c print_int(1:wybe.int, ~tmp$9##0:wybe.phantom, ?tmp$10##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 inc_count > {inline} (4 calls)
 0: use_resource.inc_count<0>
-inc_count(count#0:wybe.int, ?count#1:wybe.int):
+inc_count(count##0:wybe.int, ?count##1:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~count#0:wybe.int, 1:wybe.int, ?count#1:wybe.int) @int:nn:nn
+    foreign llvm add(~count##0:wybe.int, 1:wybe.int, ?count##1:wybe.int) @int:nn:nn
 
 
 use_test > {inline} (1 calls)
 0: use_resource.use_test<0>
-use_test(count#0:wybe.int, ?count#5:wybe.int, io#0:wybe.phantom, ?io#4:wybe.phantom):
+use_test(count##0:wybe.int, ?count##5:wybe.int, io##0:wybe.phantom, ?io##4:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm add(~#count#0:wybe.int, 1:wybe.int, ?#count#1:wybe.int) @int:nn:nn
-    foreign llvm add(#count#1:wybe.int, 1:wybe.int, ?#count#2:wybe.int) @int:nn:nn
-    foreign llvm add(~#count#2:wybe.int, 1:wybe.int, ?#count#3:wybe.int) @int:nn:nn
-    foreign llvm add(~#count#3:wybe.int, 1:wybe.int, ?#count#4:wybe.int) @int:nn:nn
-    foreign c print_string("Inner count (4): ":wybe.string, ~#io#0:wybe.phantom, ?#io#1:wybe.phantom) @io:nn:nn
-    foreign c print_int(~count#4:wybe.int, ~#io#1:wybe.phantom, ?tmp$9#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$9#0:wybe.phantom, ?#io#2:wybe.phantom) @io:nn:nn
-    foreign llvm move(count#1:wybe.int, ?count#5:wybe.int)
-    foreign c print_string("Outer count (1): ":wybe.string, ~#io#2:wybe.phantom, ?#io#3:wybe.phantom) @io:nn:nn
-    foreign c print_int(~count#1:wybe.int, ~#io#3:wybe.phantom, ?tmp$14#0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14#0:wybe.phantom, ?#io#4:wybe.phantom) @io:nn:nn
+    foreign llvm add(~#count##0:wybe.int, 1:wybe.int, ?#count##1:wybe.int) @int:nn:nn
+    foreign llvm add(#count##1:wybe.int, 1:wybe.int, ?#count##2:wybe.int) @int:nn:nn
+    foreign llvm add(~#count##2:wybe.int, 1:wybe.int, ?#count##3:wybe.int) @int:nn:nn
+    foreign llvm add(~#count##3:wybe.int, 1:wybe.int, ?#count##4:wybe.int) @int:nn:nn
+    foreign c print_string("Inner count (4): ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_int(~count##4:wybe.int, ~#io##1:wybe.phantom, ?tmp$9##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$9##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign llvm move(count##1:wybe.int, ?count##5:wybe.int)
+    foreign c print_string("Outer count (1): ":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
+    foreign c print_int(~count##1:wybe.int, ~#io##3:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -97,26 +97,26 @@ entry:
 }
 
 
-define external fastcc  i64 @"use_resource.inc_count<0>"(i64  %"count#0")    {
+define external fastcc  i64 @"use_resource.inc_count<0>"(i64  %"count##0")    {
 entry:
-  %"1$count#1" = add   i64 %"count#0", 1 
-  ret i64 %"1$count#1" 
+  %"1$count##1" = add   i64 %"count##0", 1 
+  ret i64 %"1$count##1" 
 }
 
 
-define external fastcc  i64 @"use_resource.use_test<0>"(i64  %"count#0")    {
+define external fastcc  i64 @"use_resource.use_test<0>"(i64  %"count##0")    {
 entry:
-  %"1$count#1" = add   i64 %"count#0", 1 
-  %"1$count#2" = add   i64 %"1$count#1", 1 
-  %"1$count#3" = add   i64 %"1$count#2", 1 
-  %"1$count#4" = add   i64 %"1$count#3", 1 
+  %"1$count##1" = add   i64 %"count##0", 1 
+  %"1$count##2" = add   i64 %"1$count##1", 1 
+  %"1$count##3" = add   i64 %"1$count##2", 1 
+  %"1$count##4" = add   i64 %"1$count##3", 1 
   %6 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @use_resource.5, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %6)  
-  tail call ccc  void  @print_int(i64  %"1$count#4")  
+  tail call ccc  void  @print_int(i64  %"1$count##4")  
   tail call ccc  void  @putchar(i8  10)  
   %8 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @use_resource.7, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %8)  
-  tail call ccc  void  @print_int(i64  %"1$count#1")  
+  tail call ccc  void  @print_int(i64  %"1$count##1")  
   tail call ccc  void  @putchar(i8  10)  
-  ret i64 %"1$count#1" 
+  ret i64 %"1$count##1" 
 }

--- a/test-cases/final-dump/use_resource.exp
+++ b/test-cases/final-dump/use_resource.exp
@@ -14,13 +14,13 @@ AFTER EVERYTHING:
 (?count##2:wybe.int, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_string("Inner count (4): ":wybe.string, ~#io##0:wybe.phantom, ?tmp$6##0:wybe.phantom) @io:nn:nn
-    foreign c print_int(4:wybe.int, ~tmp$6##0:wybe.phantom, ?tmp$7##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$7##0:wybe.phantom, ?tmp$8##0:wybe.phantom) @io:nn:nn
+    foreign c print_string("Inner count (4): ":wybe.string, ~#io##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
+    foreign c print_int(4:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @io:nn:nn
     foreign llvm move(1:wybe.int, ?#count##2:wybe.int)
-    foreign c print_string("Outer count (1): ":wybe.string, ~tmp$8##0:wybe.phantom, ?tmp$9##0:wybe.phantom) @io:nn:nn
-    foreign c print_int(1:wybe.int, ~tmp$9##0:wybe.phantom, ?tmp$10##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+    foreign c print_string("Outer count (1): ":wybe.string, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @io:nn:nn
+    foreign c print_int(1:wybe.int, ~tmp#9##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 inc_count > {inline} (4 calls)
@@ -41,12 +41,12 @@ use_test(count##0:wybe.int, ?count##5:wybe.int, io##0:wybe.phantom, ?io##4:wybe.
     foreign llvm add(~#count##2:wybe.int, 1:wybe.int, ?#count##3:wybe.int) @int:nn:nn
     foreign llvm add(~#count##3:wybe.int, 1:wybe.int, ?#count##4:wybe.int) @int:nn:nn
     foreign c print_string("Inner count (4): ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign c print_int(~count##4:wybe.int, ~#io##1:wybe.phantom, ?tmp$9##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$9##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_int(~count##4:wybe.int, ~#io##1:wybe.phantom, ?tmp#9##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#9##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     foreign llvm move(count##1:wybe.int, ?count##5:wybe.int)
     foreign c print_string("Outer count (1): ":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    foreign c print_int(~count##1:wybe.int, ~#io##3:wybe.phantom, ?tmp$14##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp$14##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
+    foreign c print_int(~count##1:wybe.int, ~#io##3:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 
@@ -99,24 +99,24 @@ entry:
 
 define external fastcc  i64 @"use_resource.inc_count<0>"(i64  %"count##0")    {
 entry:
-  %"1$count##1" = add   i64 %"count##0", 1 
-  ret i64 %"1$count##1" 
+  %"1#count##1" = add   i64 %"count##0", 1 
+  ret i64 %"1#count##1" 
 }
 
 
 define external fastcc  i64 @"use_resource.use_test<0>"(i64  %"count##0")    {
 entry:
-  %"1$count##1" = add   i64 %"count##0", 1 
-  %"1$count##2" = add   i64 %"1$count##1", 1 
-  %"1$count##3" = add   i64 %"1$count##2", 1 
-  %"1$count##4" = add   i64 %"1$count##3", 1 
+  %"1#count##1" = add   i64 %"count##0", 1 
+  %"1#count##2" = add   i64 %"1#count##1", 1 
+  %"1#count##3" = add   i64 %"1#count##2", 1 
+  %"1#count##4" = add   i64 %"1#count##3", 1 
   %6 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @use_resource.5, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %6)  
-  tail call ccc  void  @print_int(i64  %"1$count##4")  
+  tail call ccc  void  @print_int(i64  %"1#count##4")  
   tail call ccc  void  @putchar(i8  10)  
   %8 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @use_resource.7, i32 0, i32 0) to i64 
   tail call ccc  void  @print_string(i64  %8)  
-  tail call ccc  void  @print_int(i64  %"1$count##1")  
+  tail call ccc  void  @print_int(i64  %"1#count##1")  
   tail call ccc  void  @putchar(i8  10)  
-  ret i64 %"1$count##1" 
+  ret i64 %"1#count##1" 
 }


### PR DESCRIPTION
Fix #157.  Disallow newlines, hash characters, and control characters in backquoted symbols, and disallow empty backqoted symbols.  Revise variable name generation to use # instead of $ to mark that it is generated.  Rename function result parameter to #result and test success indicator to from $$ to #success.  This makes pervasive, very boring changes in most expected output files.  Documented backquoted symbol restrictions and added new test cases for the restrictions.