### PR TITLE
Refactoring codegen of primargs and casts

### DIFF
--- a/src/Codegen.hs
+++ b/src/Codegen.hs
@@ -18,8 +18,9 @@ module Codegen (
   phi, br, cbr, getBlock, retNothing, fresh,
   -- * Symbol storage
   alloca, store, local, assign, load, getVar, localVar, preservingSymtab,
-  operandType, doAlloca, doLoad, bitcast, inttoptr, ptrtoint,
-  trunc, zext, sext,
+  operandType, doAlloca, doLoad, 
+  bitcast, cbitcast, inttoptr, cinttoptr, ptrtoint, cptrtoint,
+  trunc, ctrunc, zext, czext, sext, csext,
   -- * Types
   int_t, phantom_t, float_t, char_t, ptr_t, void_t, string_t, array_t,
   struct_t, address_t, byte_ptr_t,
@@ -609,11 +610,20 @@ load ptr = Load False ptr Nothing 0 []
 bitcast :: Operand -> LLVMAST.Type -> Codegen Operand
 bitcast op ty = instr ty $ BitCast op ty []
 
+cbitcast :: C.Constant -> LLVMAST.Type -> Codegen C.Constant
+cbitcast op ty = return $ C.BitCast op ty
+
 inttoptr :: Operand -> LLVMAST.Type -> Codegen Operand
 inttoptr op ty = instr ty $ IntToPtr op ty []
 
+cinttoptr :: C.Constant -> LLVMAST.Type -> Codegen C.Constant
+cinttoptr op ty = return $ C.IntToPtr op ty
+
 ptrtoint :: Operand -> LLVMAST.Type -> Codegen Operand
 ptrtoint op ty = instr ty $ PtrToInt op ty []
+
+cptrtoint :: C.Constant -> LLVMAST.Type -> Codegen C.Constant
+cptrtoint op ty = return $ C.PtrToInt op ty
 
 -- constBitcast :: Operand -> LLVMAST.Type -> Operand
 -- constBitcast (ConstantOperand c) ty =  cons $ C.BitCast c ty
@@ -627,13 +637,20 @@ constInttoptr c ty = cons $ C.IntToPtr c ty
 trunc :: Operand -> LLVMAST.Type -> Codegen Operand
 trunc op ty = instr ty $ Trunc op ty []
 
+ctrunc :: C.Constant -> LLVMAST.Type -> Codegen C.Constant
+ctrunc op ty = return $ C.Trunc op ty
+
 zext :: Operand -> LLVMAST.Type -> Codegen Operand
 zext op ty = instr ty $ ZExt op ty []
+
+czext :: C.Constant -> LLVMAST.Type -> Codegen C.Constant
+czext op ty = return $ C.ZExt op ty
 
 sext :: Operand -> LLVMAST.Type -> Codegen Operand
 sext op ty = instr ty $ SExt op ty []
 
-
+csext :: C.Constant -> LLVMAST.Type -> Codegen C.Constant
+csext op ty = return $ C.SExt op ty
 
 
 -- Helpers for allocating, storing, loading

--- a/test-cases/complex/exp/testcase_multi_specz-drone.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-drone.exp
@@ -121,7 +121,7 @@ declare external ccc  void @error_exit(i64, i64)
 declare external fastcc  {i64, i64, i1} @"wybe.array.[|]<0>"(i64)    
 
 
-@command_line.18 =    constant [?? x i8] c"Erroneous program argument vector\00"
+@command_line.17 =    constant [?? x i8] c"Erroneous program argument vector\00"
 
 
 @command_line.16 =    constant [?? x i8] c"command_line:17:6\00"
@@ -156,13 +156,11 @@ if.then:
   %15 = insertvalue {i64, i64, i64} %14, i64 0, 2 
   ret {i64, i64, i64} %15 
 if.else:
-  %17 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @command_line.16, i32 0, i32 0) to i64 
-  %19 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @command_line.18, i32 0, i32 0) to i64 
-  tail call ccc  void  @error_exit(i64  %17, i64  %19)  
-  %20 = insertvalue {i64, i64, i64} undef, i64 %11, 0 
-  %21 = insertvalue {i64, i64, i64} %20, i64 %10, 1 
-  %22 = insertvalue {i64, i64, i64} %21, i64 undef, 2 
-  ret {i64, i64, i64} %22 
+  tail call ccc  void  @error_exit(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @command_line.16, i32 0, i32 0) to i64), i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @command_line.17, i32 0, i32 0) to i64))  
+  %18 = insertvalue {i64, i64, i64} undef, i64 %11, 0 
+  %19 = insertvalue {i64, i64, i64} %18, i64 %10, 1 
+  %20 = insertvalue {i64, i64, i64} %19, i64 undef, 2 
+  ret {i64, i64, i64} %20 
 }
 
 
@@ -724,7 +722,7 @@ declare external ccc  void @error_exit(i64, i64)
 declare external fastcc  {i64, i64, i1} @"wybe.array.[|]<0>"(i64)    
 
 
-@command_line.18 =    constant [?? x i8] c"Erroneous program argument vector\00"
+@command_line.17 =    constant [?? x i8] c"Erroneous program argument vector\00"
 
 
 @command_line.16 =    constant [?? x i8] c"command_line:17:6\00"
@@ -759,13 +757,11 @@ if.then:
   %15 = insertvalue {i64, i64, i64} %14, i64 0, 2 
   ret {i64, i64, i64} %15 
 if.else:
-  %17 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @command_line.16, i32 0, i32 0) to i64 
-  %19 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @command_line.18, i32 0, i32 0) to i64 
-  tail call ccc  void  @error_exit(i64  %17, i64  %19)  
-  %20 = insertvalue {i64, i64, i64} undef, i64 %11, 0 
-  %21 = insertvalue {i64, i64, i64} %20, i64 %10, 1 
-  %22 = insertvalue {i64, i64, i64} %21, i64 undef, 2 
-  ret {i64, i64, i64} %22 
+  tail call ccc  void  @error_exit(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @command_line.16, i32 0, i32 0) to i64), i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @command_line.17, i32 0, i32 0) to i64))  
+  %18 = insertvalue {i64, i64, i64} undef, i64 %11, 0 
+  %19 = insertvalue {i64, i64, i64} %18, i64 %10, 1 
+  %20 = insertvalue {i64, i64, i64} %19, i64 undef, 2 
+  ret {i64, i64, i64} %20 
 }
 
 
@@ -1166,10 +1162,10 @@ declare external ccc  i64 @malloc_count()
 declare external ccc  i8 @read_char()    
 
 
-@drone.8 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @drone.7 to i64) }
+@drone.7 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @drone.6 to i64) }
 
 
-@drone.7 =    constant [?? x i8] c"** malloc count: \00"
+@drone.6 =    constant [?? x i8] c"** malloc count: \00"
 
 
 @drone.5 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @drone.4 to i64) }
@@ -1178,94 +1174,94 @@ declare external ccc  i8 @read_char()
 @drone.4 =    constant [?? x i8] c"** malloc count: \00"
 
 
-@drone.165 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @drone.164 to i64) }
+@drone.163 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @drone.162 to i64) }
 
 
-@drone.164 =    constant [?? x i8] c"** malloc count: \00"
+@drone.162 =    constant [?? x i8] c"** malloc count: \00"
 
 
-@drone.224 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @drone.223 to i64) }
+@drone.217 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @drone.216 to i64) }
 
 
-@drone.223 =    constant [?? x i8] c"invalid action!\00"
+@drone.216 =    constant [?? x i8] c"invalid action!\00"
 
 
-@drone.214 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @drone.213 to i64) }
+@drone.208 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @drone.207 to i64) }
 
 
-@drone.213 =    constant [?? x i8] c") #\00"
+@drone.207 =    constant [?? x i8] c") #\00"
 
 
-@drone.207 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @drone.206 to i64) }
+@drone.202 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @drone.201 to i64) }
 
 
-@drone.206 =    constant [?? x i8] c", \00"
+@drone.201 =    constant [?? x i8] c", \00"
 
 
-@drone.200 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @drone.199 to i64) }
+@drone.196 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @drone.195 to i64) }
 
 
-@drone.199 =    constant [?? x i8] c", \00"
+@drone.195 =    constant [?? x i8] c", \00"
 
 
-@drone.194 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @drone.193 to i64) }
+@drone.191 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @drone.190 to i64) }
 
 
-@drone.193 =    constant [?? x i8] c"(\00"
+@drone.190 =    constant [?? x i8] c"(\00"
 
 
-@drone.257 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @drone.256 to i64) }
+@drone.245 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @drone.244 to i64) }
 
 
-@drone.256 =    constant [?? x i8] c"invalid action!\00"
+@drone.244 =    constant [?? x i8] c"invalid action!\00"
 
 
-@drone.247 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @drone.246 to i64) }
+@drone.236 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @drone.235 to i64) }
 
 
-@drone.246 =    constant [?? x i8] c") #\00"
+@drone.235 =    constant [?? x i8] c") #\00"
 
 
-@drone.240 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @drone.239 to i64) }
+@drone.230 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @drone.229 to i64) }
 
 
-@drone.239 =    constant [?? x i8] c", \00"
+@drone.229 =    constant [?? x i8] c", \00"
 
 
-@drone.233 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @drone.232 to i64) }
+@drone.224 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @drone.223 to i64) }
 
 
-@drone.232 =    constant [?? x i8] c", \00"
+@drone.223 =    constant [?? x i8] c", \00"
 
 
-@drone.227 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @drone.226 to i64) }
+@drone.219 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @drone.218 to i64) }
 
 
-@drone.226 =    constant [?? x i8] c"(\00"
+@drone.218 =    constant [?? x i8] c"(\00"
 
 
-@drone.280 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @drone.279 to i64) }
+@drone.264 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @drone.263 to i64) }
 
 
-@drone.279 =    constant [?? x i8] c") #\00"
+@drone.263 =    constant [?? x i8] c") #\00"
 
 
-@drone.273 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @drone.272 to i64) }
+@drone.258 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @drone.257 to i64) }
 
 
-@drone.272 =    constant [?? x i8] c", \00"
+@drone.257 =    constant [?? x i8] c", \00"
 
 
-@drone.266 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @drone.265 to i64) }
+@drone.252 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @drone.251 to i64) }
 
 
-@drone.265 =    constant [?? x i8] c", \00"
+@drone.251 =    constant [?? x i8] c", \00"
 
 
-@drone.260 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @drone.259 to i64) }
+@drone.247 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @drone.246 to i64) }
 
 
-@drone.259 =    constant [?? x i8] c"(\00"
+@drone.246 =    constant [?? x i8] c"(\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -1287,15 +1283,13 @@ entry:
 if.then:
   tail call fastcc  void  @"drone.loop<0>[410bae77d3]"(i64  %"1#tmp#0##0", i8  %"1#ch##0")  
   %"2#tmp#10##0" = tail call ccc  i64  @malloc_count()  
-  %6 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.5, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %6)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %"2#tmp#10##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else:
   %"3#tmp#10##0" = tail call ccc  i64  @malloc_count()  
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.7, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %"3#tmp#10##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -1307,147 +1301,147 @@ entry:
   %"1#tmp#21##0" = icmp eq i8 %"action##0", 110 
   br i1 %"1#tmp#21##0", label %if.then, label %if.else 
 if.then:
-  %10 = add   i64 %"d##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %"2#tmp#1##0" = sub   i64 %13, 1 
-  %14 = trunc i64 32 to i32  
-  %15 = tail call ccc  i8*  @wybe_malloc(i32  %14)  
-  %16 = ptrtoint i8* %15 to i64 
-  %17 = inttoptr i64 %16 to i8* 
-  %18 = inttoptr i64 %"d##0" to i8* 
-  %19 = trunc i64 32 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %17, i8*  %18, i32  %19, i32  8, i1  0)  
-  %20 = add   i64 %16, 8 
-  %21 = inttoptr i64 %20 to i64* 
-  %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 %"2#tmp#1##0", i64* %22 
-  %"2#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %16, i1  1)  
-  %23 = insertvalue {i64, i1} undef, i64 %"2#d##2", 0 
-  %24 = insertvalue {i64, i1} %23, i1 1, 1 
-  ret {i64, i1} %24 
+  %8 = add   i64 %"d##0", 8 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = getelementptr  i64, i64* %9, i64 0 
+  %11 = load  i64, i64* %10 
+  %"2#tmp#1##0" = sub   i64 %11, 1 
+  %12 = trunc i64 32 to i32  
+  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
+  %14 = ptrtoint i8* %13 to i64 
+  %15 = inttoptr i64 %14 to i8* 
+  %16 = inttoptr i64 %"d##0" to i8* 
+  %17 = trunc i64 32 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %15, i8*  %16, i32  %17, i32  8, i1  0)  
+  %18 = add   i64 %14, 8 
+  %19 = inttoptr i64 %18 to i64* 
+  %20 = getelementptr  i64, i64* %19, i64 0 
+  store  i64 %"2#tmp#1##0", i64* %20 
+  %"2#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %14, i1  1)  
+  %21 = insertvalue {i64, i1} undef, i64 %"2#d##2", 0 
+  %22 = insertvalue {i64, i1} %21, i1 1, 1 
+  ret {i64, i1} %22 
 if.else:
   %"3#tmp#20##0" = icmp eq i8 %"action##0", 115 
   br i1 %"3#tmp#20##0", label %if.then1, label %if.else1 
 if.then1:
-  %25 = add   i64 %"d##0", 8 
-  %26 = inttoptr i64 %25 to i64* 
-  %27 = getelementptr  i64, i64* %26, i64 0 
-  %28 = load  i64, i64* %27 
-  %"4#tmp#3##0" = add   i64 %28, 1 
-  %29 = trunc i64 32 to i32  
-  %30 = tail call ccc  i8*  @wybe_malloc(i32  %29)  
-  %31 = ptrtoint i8* %30 to i64 
-  %32 = inttoptr i64 %31 to i8* 
-  %33 = inttoptr i64 %"d##0" to i8* 
-  %34 = trunc i64 32 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %32, i8*  %33, i32  %34, i32  8, i1  0)  
-  %35 = add   i64 %31, 8 
-  %36 = inttoptr i64 %35 to i64* 
-  %37 = getelementptr  i64, i64* %36, i64 0 
-  store  i64 %"4#tmp#3##0", i64* %37 
-  %"4#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %31, i1  1)  
-  %38 = insertvalue {i64, i1} undef, i64 %"4#d##2", 0 
-  %39 = insertvalue {i64, i1} %38, i1 1, 1 
-  ret {i64, i1} %39 
+  %23 = add   i64 %"d##0", 8 
+  %24 = inttoptr i64 %23 to i64* 
+  %25 = getelementptr  i64, i64* %24, i64 0 
+  %26 = load  i64, i64* %25 
+  %"4#tmp#3##0" = add   i64 %26, 1 
+  %27 = trunc i64 32 to i32  
+  %28 = tail call ccc  i8*  @wybe_malloc(i32  %27)  
+  %29 = ptrtoint i8* %28 to i64 
+  %30 = inttoptr i64 %29 to i8* 
+  %31 = inttoptr i64 %"d##0" to i8* 
+  %32 = trunc i64 32 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %30, i8*  %31, i32  %32, i32  8, i1  0)  
+  %33 = add   i64 %29, 8 
+  %34 = inttoptr i64 %33 to i64* 
+  %35 = getelementptr  i64, i64* %34, i64 0 
+  store  i64 %"4#tmp#3##0", i64* %35 
+  %"4#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %29, i1  1)  
+  %36 = insertvalue {i64, i1} undef, i64 %"4#d##2", 0 
+  %37 = insertvalue {i64, i1} %36, i1 1, 1 
+  ret {i64, i1} %37 
 if.else1:
   %"5#tmp#19##0" = icmp eq i8 %"action##0", 119 
   br i1 %"5#tmp#19##0", label %if.then2, label %if.else2 
 if.then2:
-  %40 = inttoptr i64 %"d##0" to i64* 
-  %41 = getelementptr  i64, i64* %40, i64 0 
-  %42 = load  i64, i64* %41 
-  %"6#tmp#5##0" = sub   i64 %42, 1 
-  %43 = trunc i64 32 to i32  
-  %44 = tail call ccc  i8*  @wybe_malloc(i32  %43)  
-  %45 = ptrtoint i8* %44 to i64 
-  %46 = inttoptr i64 %45 to i8* 
-  %47 = inttoptr i64 %"d##0" to i8* 
-  %48 = trunc i64 32 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %46, i8*  %47, i32  %48, i32  8, i1  0)  
-  %49 = inttoptr i64 %45 to i64* 
-  %50 = getelementptr  i64, i64* %49, i64 0 
-  store  i64 %"6#tmp#5##0", i64* %50 
-  %"6#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %45, i1  1)  
-  %51 = insertvalue {i64, i1} undef, i64 %"6#d##2", 0 
-  %52 = insertvalue {i64, i1} %51, i1 1, 1 
-  ret {i64, i1} %52 
+  %38 = inttoptr i64 %"d##0" to i64* 
+  %39 = getelementptr  i64, i64* %38, i64 0 
+  %40 = load  i64, i64* %39 
+  %"6#tmp#5##0" = sub   i64 %40, 1 
+  %41 = trunc i64 32 to i32  
+  %42 = tail call ccc  i8*  @wybe_malloc(i32  %41)  
+  %43 = ptrtoint i8* %42 to i64 
+  %44 = inttoptr i64 %43 to i8* 
+  %45 = inttoptr i64 %"d##0" to i8* 
+  %46 = trunc i64 32 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %44, i8*  %45, i32  %46, i32  8, i1  0)  
+  %47 = inttoptr i64 %43 to i64* 
+  %48 = getelementptr  i64, i64* %47, i64 0 
+  store  i64 %"6#tmp#5##0", i64* %48 
+  %"6#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %43, i1  1)  
+  %49 = insertvalue {i64, i1} undef, i64 %"6#d##2", 0 
+  %50 = insertvalue {i64, i1} %49, i1 1, 1 
+  ret {i64, i1} %50 
 if.else2:
   %"7#tmp#18##0" = icmp eq i8 %"action##0", 101 
   br i1 %"7#tmp#18##0", label %if.then3, label %if.else3 
 if.then3:
-  %53 = inttoptr i64 %"d##0" to i64* 
-  %54 = getelementptr  i64, i64* %53, i64 0 
-  %55 = load  i64, i64* %54 
-  %"8#tmp#7##0" = add   i64 %55, 1 
-  %56 = trunc i64 32 to i32  
-  %57 = tail call ccc  i8*  @wybe_malloc(i32  %56)  
-  %58 = ptrtoint i8* %57 to i64 
-  %59 = inttoptr i64 %58 to i8* 
-  %60 = inttoptr i64 %"d##0" to i8* 
-  %61 = trunc i64 32 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %59, i8*  %60, i32  %61, i32  8, i1  0)  
-  %62 = inttoptr i64 %58 to i64* 
-  %63 = getelementptr  i64, i64* %62, i64 0 
-  store  i64 %"8#tmp#7##0", i64* %63 
-  %"8#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %58, i1  1)  
-  %64 = insertvalue {i64, i1} undef, i64 %"8#d##2", 0 
-  %65 = insertvalue {i64, i1} %64, i1 1, 1 
-  ret {i64, i1} %65 
+  %51 = inttoptr i64 %"d##0" to i64* 
+  %52 = getelementptr  i64, i64* %51, i64 0 
+  %53 = load  i64, i64* %52 
+  %"8#tmp#7##0" = add   i64 %53, 1 
+  %54 = trunc i64 32 to i32  
+  %55 = tail call ccc  i8*  @wybe_malloc(i32  %54)  
+  %56 = ptrtoint i8* %55 to i64 
+  %57 = inttoptr i64 %56 to i8* 
+  %58 = inttoptr i64 %"d##0" to i8* 
+  %59 = trunc i64 32 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %57, i8*  %58, i32  %59, i32  8, i1  0)  
+  %60 = inttoptr i64 %56 to i64* 
+  %61 = getelementptr  i64, i64* %60, i64 0 
+  store  i64 %"8#tmp#7##0", i64* %61 
+  %"8#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %56, i1  1)  
+  %62 = insertvalue {i64, i1} undef, i64 %"8#d##2", 0 
+  %63 = insertvalue {i64, i1} %62, i1 1, 1 
+  ret {i64, i1} %63 
 if.else3:
   %"9#tmp#17##0" = icmp eq i8 %"action##0", 117 
   br i1 %"9#tmp#17##0", label %if.then4, label %if.else4 
 if.then4:
-  %66 = add   i64 %"d##0", 16 
-  %67 = inttoptr i64 %66 to i64* 
-  %68 = getelementptr  i64, i64* %67, i64 0 
-  %69 = load  i64, i64* %68 
-  %"10#tmp#9##0" = add   i64 %69, 1 
-  %70 = trunc i64 32 to i32  
-  %71 = tail call ccc  i8*  @wybe_malloc(i32  %70)  
-  %72 = ptrtoint i8* %71 to i64 
-  %73 = inttoptr i64 %72 to i8* 
-  %74 = inttoptr i64 %"d##0" to i8* 
-  %75 = trunc i64 32 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %73, i8*  %74, i32  %75, i32  8, i1  0)  
-  %76 = add   i64 %72, 16 
-  %77 = inttoptr i64 %76 to i64* 
-  %78 = getelementptr  i64, i64* %77, i64 0 
-  store  i64 %"10#tmp#9##0", i64* %78 
-  %"10#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %72, i1  1)  
-  %79 = insertvalue {i64, i1} undef, i64 %"10#d##2", 0 
-  %80 = insertvalue {i64, i1} %79, i1 1, 1 
-  ret {i64, i1} %80 
+  %64 = add   i64 %"d##0", 16 
+  %65 = inttoptr i64 %64 to i64* 
+  %66 = getelementptr  i64, i64* %65, i64 0 
+  %67 = load  i64, i64* %66 
+  %"10#tmp#9##0" = add   i64 %67, 1 
+  %68 = trunc i64 32 to i32  
+  %69 = tail call ccc  i8*  @wybe_malloc(i32  %68)  
+  %70 = ptrtoint i8* %69 to i64 
+  %71 = inttoptr i64 %70 to i8* 
+  %72 = inttoptr i64 %"d##0" to i8* 
+  %73 = trunc i64 32 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %71, i8*  %72, i32  %73, i32  8, i1  0)  
+  %74 = add   i64 %70, 16 
+  %75 = inttoptr i64 %74 to i64* 
+  %76 = getelementptr  i64, i64* %75, i64 0 
+  store  i64 %"10#tmp#9##0", i64* %76 
+  %"10#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %70, i1  1)  
+  %77 = insertvalue {i64, i1} undef, i64 %"10#d##2", 0 
+  %78 = insertvalue {i64, i1} %77, i1 1, 1 
+  ret {i64, i1} %78 
 if.else4:
   %"11#tmp#16##0" = icmp eq i8 %"action##0", 100 
   br i1 %"11#tmp#16##0", label %if.then5, label %if.else5 
 if.then5:
-  %81 = add   i64 %"d##0", 16 
-  %82 = inttoptr i64 %81 to i64* 
-  %83 = getelementptr  i64, i64* %82, i64 0 
-  %84 = load  i64, i64* %83 
-  %"12#tmp#11##0" = sub   i64 %84, 1 
-  %85 = trunc i64 32 to i32  
-  %86 = tail call ccc  i8*  @wybe_malloc(i32  %85)  
-  %87 = ptrtoint i8* %86 to i64 
-  %88 = inttoptr i64 %87 to i8* 
-  %89 = inttoptr i64 %"d##0" to i8* 
-  %90 = trunc i64 32 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %88, i8*  %89, i32  %90, i32  8, i1  0)  
-  %91 = add   i64 %87, 16 
-  %92 = inttoptr i64 %91 to i64* 
-  %93 = getelementptr  i64, i64* %92, i64 0 
-  store  i64 %"12#tmp#11##0", i64* %93 
-  %"12#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %87, i1  1)  
-  %94 = insertvalue {i64, i1} undef, i64 %"12#d##2", 0 
-  %95 = insertvalue {i64, i1} %94, i1 1, 1 
-  ret {i64, i1} %95 
+  %79 = add   i64 %"d##0", 16 
+  %80 = inttoptr i64 %79 to i64* 
+  %81 = getelementptr  i64, i64* %80, i64 0 
+  %82 = load  i64, i64* %81 
+  %"12#tmp#11##0" = sub   i64 %82, 1 
+  %83 = trunc i64 32 to i32  
+  %84 = tail call ccc  i8*  @wybe_malloc(i32  %83)  
+  %85 = ptrtoint i8* %84 to i64 
+  %86 = inttoptr i64 %85 to i8* 
+  %87 = inttoptr i64 %"d##0" to i8* 
+  %88 = trunc i64 32 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %86, i8*  %87, i32  %88, i32  8, i1  0)  
+  %89 = add   i64 %85, 16 
+  %90 = inttoptr i64 %89 to i64* 
+  %91 = getelementptr  i64, i64* %90, i64 0 
+  store  i64 %"12#tmp#11##0", i64* %91 
+  %"12#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %85, i1  1)  
+  %92 = insertvalue {i64, i1} undef, i64 %"12#d##2", 0 
+  %93 = insertvalue {i64, i1} %92, i1 1, 1 
+  ret {i64, i1} %93 
 if.else5:
   %"13#d##2" = tail call fastcc  i64  @"drone.gen#2<0>"(i64  %"d##0", i1  0)  
-  %96 = insertvalue {i64, i1} undef, i64 %"13#d##2", 0 
-  %97 = insertvalue {i64, i1} %96, i1 0, 1 
-  ret {i64, i1} %97 
+  %94 = insertvalue {i64, i1} undef, i64 %"13#d##2", 0 
+  %95 = insertvalue {i64, i1} %94, i1 0, 1 
+  ret {i64, i1} %95 
 }
 
 
@@ -1456,137 +1450,136 @@ entry:
   %"1#tmp#21##0" = icmp eq i8 %"action##0", 110 
   br i1 %"1#tmp#21##0", label %if.then, label %if.else 
 if.then:
-  %98 = add   i64 %"d##0", 8 
-  %99 = inttoptr i64 %98 to i64* 
-  %100 = getelementptr  i64, i64* %99, i64 0 
-  %101 = load  i64, i64* %100 
-  %"2#tmp#1##0" = sub   i64 %101, 1 
-  %102 = add   i64 %"d##0", 8 
-  %103 = inttoptr i64 %102 to i64* 
-  %104 = getelementptr  i64, i64* %103, i64 0 
-  store  i64 %"2#tmp#1##0", i64* %104 
+  %96 = add   i64 %"d##0", 8 
+  %97 = inttoptr i64 %96 to i64* 
+  %98 = getelementptr  i64, i64* %97, i64 0 
+  %99 = load  i64, i64* %98 
+  %"2#tmp#1##0" = sub   i64 %99, 1 
+  %100 = add   i64 %"d##0", 8 
+  %101 = inttoptr i64 %100 to i64* 
+  %102 = getelementptr  i64, i64* %101, i64 0 
+  store  i64 %"2#tmp#1##0", i64* %102 
   %"2#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
-  %105 = insertvalue {i64, i1} undef, i64 %"2#d##2", 0 
-  %106 = insertvalue {i64, i1} %105, i1 1, 1 
-  ret {i64, i1} %106 
+  %103 = insertvalue {i64, i1} undef, i64 %"2#d##2", 0 
+  %104 = insertvalue {i64, i1} %103, i1 1, 1 
+  ret {i64, i1} %104 
 if.else:
   %"3#tmp#20##0" = icmp eq i8 %"action##0", 115 
   br i1 %"3#tmp#20##0", label %if.then1, label %if.else1 
 if.then1:
-  %107 = add   i64 %"d##0", 8 
-  %108 = inttoptr i64 %107 to i64* 
-  %109 = getelementptr  i64, i64* %108, i64 0 
-  %110 = load  i64, i64* %109 
-  %"4#tmp#3##0" = add   i64 %110, 1 
-  %111 = add   i64 %"d##0", 8 
-  %112 = inttoptr i64 %111 to i64* 
-  %113 = getelementptr  i64, i64* %112, i64 0 
-  store  i64 %"4#tmp#3##0", i64* %113 
+  %105 = add   i64 %"d##0", 8 
+  %106 = inttoptr i64 %105 to i64* 
+  %107 = getelementptr  i64, i64* %106, i64 0 
+  %108 = load  i64, i64* %107 
+  %"4#tmp#3##0" = add   i64 %108, 1 
+  %109 = add   i64 %"d##0", 8 
+  %110 = inttoptr i64 %109 to i64* 
+  %111 = getelementptr  i64, i64* %110, i64 0 
+  store  i64 %"4#tmp#3##0", i64* %111 
   %"4#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
-  %114 = insertvalue {i64, i1} undef, i64 %"4#d##2", 0 
-  %115 = insertvalue {i64, i1} %114, i1 1, 1 
-  ret {i64, i1} %115 
+  %112 = insertvalue {i64, i1} undef, i64 %"4#d##2", 0 
+  %113 = insertvalue {i64, i1} %112, i1 1, 1 
+  ret {i64, i1} %113 
 if.else1:
   %"5#tmp#19##0" = icmp eq i8 %"action##0", 119 
   br i1 %"5#tmp#19##0", label %if.then2, label %if.else2 
 if.then2:
-  %116 = inttoptr i64 %"d##0" to i64* 
-  %117 = getelementptr  i64, i64* %116, i64 0 
-  %118 = load  i64, i64* %117 
-  %"6#tmp#5##0" = sub   i64 %118, 1 
-  %119 = inttoptr i64 %"d##0" to i64* 
-  %120 = getelementptr  i64, i64* %119, i64 0 
-  store  i64 %"6#tmp#5##0", i64* %120 
+  %114 = inttoptr i64 %"d##0" to i64* 
+  %115 = getelementptr  i64, i64* %114, i64 0 
+  %116 = load  i64, i64* %115 
+  %"6#tmp#5##0" = sub   i64 %116, 1 
+  %117 = inttoptr i64 %"d##0" to i64* 
+  %118 = getelementptr  i64, i64* %117, i64 0 
+  store  i64 %"6#tmp#5##0", i64* %118 
   %"6#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
-  %121 = insertvalue {i64, i1} undef, i64 %"6#d##2", 0 
-  %122 = insertvalue {i64, i1} %121, i1 1, 1 
-  ret {i64, i1} %122 
+  %119 = insertvalue {i64, i1} undef, i64 %"6#d##2", 0 
+  %120 = insertvalue {i64, i1} %119, i1 1, 1 
+  ret {i64, i1} %120 
 if.else2:
   %"7#tmp#18##0" = icmp eq i8 %"action##0", 101 
   br i1 %"7#tmp#18##0", label %if.then3, label %if.else3 
 if.then3:
-  %123 = inttoptr i64 %"d##0" to i64* 
-  %124 = getelementptr  i64, i64* %123, i64 0 
-  %125 = load  i64, i64* %124 
-  %"8#tmp#7##0" = add   i64 %125, 1 
-  %126 = inttoptr i64 %"d##0" to i64* 
-  %127 = getelementptr  i64, i64* %126, i64 0 
-  store  i64 %"8#tmp#7##0", i64* %127 
+  %121 = inttoptr i64 %"d##0" to i64* 
+  %122 = getelementptr  i64, i64* %121, i64 0 
+  %123 = load  i64, i64* %122 
+  %"8#tmp#7##0" = add   i64 %123, 1 
+  %124 = inttoptr i64 %"d##0" to i64* 
+  %125 = getelementptr  i64, i64* %124, i64 0 
+  store  i64 %"8#tmp#7##0", i64* %125 
   %"8#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
-  %128 = insertvalue {i64, i1} undef, i64 %"8#d##2", 0 
-  %129 = insertvalue {i64, i1} %128, i1 1, 1 
-  ret {i64, i1} %129 
+  %126 = insertvalue {i64, i1} undef, i64 %"8#d##2", 0 
+  %127 = insertvalue {i64, i1} %126, i1 1, 1 
+  ret {i64, i1} %127 
 if.else3:
   %"9#tmp#17##0" = icmp eq i8 %"action##0", 117 
   br i1 %"9#tmp#17##0", label %if.then4, label %if.else4 
 if.then4:
-  %130 = add   i64 %"d##0", 16 
-  %131 = inttoptr i64 %130 to i64* 
-  %132 = getelementptr  i64, i64* %131, i64 0 
-  %133 = load  i64, i64* %132 
-  %"10#tmp#9##0" = add   i64 %133, 1 
-  %134 = add   i64 %"d##0", 16 
-  %135 = inttoptr i64 %134 to i64* 
-  %136 = getelementptr  i64, i64* %135, i64 0 
-  store  i64 %"10#tmp#9##0", i64* %136 
+  %128 = add   i64 %"d##0", 16 
+  %129 = inttoptr i64 %128 to i64* 
+  %130 = getelementptr  i64, i64* %129, i64 0 
+  %131 = load  i64, i64* %130 
+  %"10#tmp#9##0" = add   i64 %131, 1 
+  %132 = add   i64 %"d##0", 16 
+  %133 = inttoptr i64 %132 to i64* 
+  %134 = getelementptr  i64, i64* %133, i64 0 
+  store  i64 %"10#tmp#9##0", i64* %134 
   %"10#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
-  %137 = insertvalue {i64, i1} undef, i64 %"10#d##2", 0 
-  %138 = insertvalue {i64, i1} %137, i1 1, 1 
-  ret {i64, i1} %138 
+  %135 = insertvalue {i64, i1} undef, i64 %"10#d##2", 0 
+  %136 = insertvalue {i64, i1} %135, i1 1, 1 
+  ret {i64, i1} %136 
 if.else4:
   %"11#tmp#16##0" = icmp eq i8 %"action##0", 100 
   br i1 %"11#tmp#16##0", label %if.then5, label %if.else5 
 if.then5:
-  %139 = add   i64 %"d##0", 16 
-  %140 = inttoptr i64 %139 to i64* 
-  %141 = getelementptr  i64, i64* %140, i64 0 
-  %142 = load  i64, i64* %141 
-  %"12#tmp#11##0" = sub   i64 %142, 1 
-  %143 = add   i64 %"d##0", 16 
-  %144 = inttoptr i64 %143 to i64* 
-  %145 = getelementptr  i64, i64* %144, i64 0 
-  store  i64 %"12#tmp#11##0", i64* %145 
+  %137 = add   i64 %"d##0", 16 
+  %138 = inttoptr i64 %137 to i64* 
+  %139 = getelementptr  i64, i64* %138, i64 0 
+  %140 = load  i64, i64* %139 
+  %"12#tmp#11##0" = sub   i64 %140, 1 
+  %141 = add   i64 %"d##0", 16 
+  %142 = inttoptr i64 %141 to i64* 
+  %143 = getelementptr  i64, i64* %142, i64 0 
+  store  i64 %"12#tmp#11##0", i64* %143 
   %"12#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  1)  
-  %146 = insertvalue {i64, i1} undef, i64 %"12#d##2", 0 
-  %147 = insertvalue {i64, i1} %146, i1 1, 1 
-  ret {i64, i1} %147 
+  %144 = insertvalue {i64, i1} undef, i64 %"12#d##2", 0 
+  %145 = insertvalue {i64, i1} %144, i1 1, 1 
+  ret {i64, i1} %145 
 if.else5:
   %"13#d##2" = tail call fastcc  i64  @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  0)  
-  %148 = insertvalue {i64, i1} undef, i64 %"13#d##2", 0 
-  %149 = insertvalue {i64, i1} %148, i1 0, 1 
-  ret {i64, i1} %149 
+  %146 = insertvalue {i64, i1} undef, i64 %"13#d##2", 0 
+  %147 = insertvalue {i64, i1} %146, i1 0, 1 
+  ret {i64, i1} %147 
 }
 
 
 define external fastcc  i64 @"drone.drone_init<0>"()    {
 entry:
-  %150 = trunc i64 32 to i32  
-  %151 = tail call ccc  i8*  @wybe_malloc(i32  %150)  
-  %152 = ptrtoint i8* %151 to i64 
-  %153 = inttoptr i64 %152 to i64* 
-  %154 = getelementptr  i64, i64* %153, i64 0 
-  store  i64 0, i64* %154 
-  %155 = add   i64 %152, 8 
-  %156 = inttoptr i64 %155 to i64* 
-  %157 = getelementptr  i64, i64* %156, i64 0 
-  store  i64 0, i64* %157 
-  %158 = add   i64 %152, 16 
-  %159 = inttoptr i64 %158 to i64* 
-  %160 = getelementptr  i64, i64* %159, i64 0 
-  store  i64 0, i64* %160 
-  %161 = add   i64 %152, 24 
-  %162 = inttoptr i64 %161 to i64* 
-  %163 = getelementptr  i64, i64* %162, i64 0 
-  store  i64 0, i64* %163 
-  ret i64 %152 
+  %148 = trunc i64 32 to i32  
+  %149 = tail call ccc  i8*  @wybe_malloc(i32  %148)  
+  %150 = ptrtoint i8* %149 to i64 
+  %151 = inttoptr i64 %150 to i64* 
+  %152 = getelementptr  i64, i64* %151, i64 0 
+  store  i64 0, i64* %152 
+  %153 = add   i64 %150, 8 
+  %154 = inttoptr i64 %153 to i64* 
+  %155 = getelementptr  i64, i64* %154, i64 0 
+  store  i64 0, i64* %155 
+  %156 = add   i64 %150, 16 
+  %157 = inttoptr i64 %156 to i64* 
+  %158 = getelementptr  i64, i64* %157, i64 0 
+  store  i64 0, i64* %158 
+  %159 = add   i64 %150, 24 
+  %160 = inttoptr i64 %159 to i64* 
+  %161 = getelementptr  i64, i64* %160, i64 0 
+  store  i64 0, i64* %161 
+  ret i64 %150 
 }
 
 
 define external fastcc  void @"drone.gen#1<0>"()    {
 entry:
   %"1#mc##0" = tail call ccc  i64  @malloc_count()  
-  %166 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.165, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %166)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.163, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %"1#mc##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -1597,23 +1590,23 @@ define external fastcc  i64 @"drone.gen#2<0>"(i64  %"d##0", i1  %"success##0")  
 entry:
   br i1 %"success##0", label %if.then, label %if.else 
 if.then:
-  %167 = add   i64 %"d##0", 24 
-  %168 = inttoptr i64 %167 to i64* 
-  %169 = getelementptr  i64, i64* %168, i64 0 
-  %170 = load  i64, i64* %169 
-  %"2#tmp#14##0" = add   i64 %170, 1 
-  %171 = trunc i64 32 to i32  
-  %172 = tail call ccc  i8*  @wybe_malloc(i32  %171)  
-  %173 = ptrtoint i8* %172 to i64 
-  %174 = inttoptr i64 %173 to i8* 
-  %175 = inttoptr i64 %"d##0" to i8* 
-  %176 = trunc i64 32 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %174, i8*  %175, i32  %176, i32  8, i1  0)  
-  %177 = add   i64 %173, 24 
-  %178 = inttoptr i64 %177 to i64* 
-  %179 = getelementptr  i64, i64* %178, i64 0 
-  store  i64 %"2#tmp#14##0", i64* %179 
-  ret i64 %173 
+  %164 = add   i64 %"d##0", 24 
+  %165 = inttoptr i64 %164 to i64* 
+  %166 = getelementptr  i64, i64* %165, i64 0 
+  %167 = load  i64, i64* %166 
+  %"2#tmp#14##0" = add   i64 %167, 1 
+  %168 = trunc i64 32 to i32  
+  %169 = tail call ccc  i8*  @wybe_malloc(i32  %168)  
+  %170 = ptrtoint i8* %169 to i64 
+  %171 = inttoptr i64 %170 to i8* 
+  %172 = inttoptr i64 %"d##0" to i8* 
+  %173 = trunc i64 32 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %171, i8*  %172, i32  %173, i32  8, i1  0)  
+  %174 = add   i64 %170, 24 
+  %175 = inttoptr i64 %174 to i64* 
+  %176 = getelementptr  i64, i64* %175, i64 0 
+  store  i64 %"2#tmp#14##0", i64* %176 
+  ret i64 %170 
 if.else:
   ret i64 %"d##0" 
 }
@@ -1623,15 +1616,15 @@ define external fastcc  i64 @"drone.gen#2<0>[6dacb8fd25]"(i64  %"d##0", i1  %"su
 entry:
   br i1 %"success##0", label %if.then, label %if.else 
 if.then:
-  %180 = add   i64 %"d##0", 24 
-  %181 = inttoptr i64 %180 to i64* 
-  %182 = getelementptr  i64, i64* %181, i64 0 
-  %183 = load  i64, i64* %182 
-  %"2#tmp#14##0" = add   i64 %183, 1 
-  %184 = add   i64 %"d##0", 24 
-  %185 = inttoptr i64 %184 to i64* 
-  %186 = getelementptr  i64, i64* %185, i64 0 
-  store  i64 %"2#tmp#14##0", i64* %186 
+  %177 = add   i64 %"d##0", 24 
+  %178 = inttoptr i64 %177 to i64* 
+  %179 = getelementptr  i64, i64* %178, i64 0 
+  %180 = load  i64, i64* %179 
+  %"2#tmp#14##0" = add   i64 %180, 1 
+  %181 = add   i64 %"d##0", 24 
+  %182 = inttoptr i64 %181 to i64* 
+  %183 = getelementptr  i64, i64* %182, i64 0 
+  store  i64 %"2#tmp#14##0", i64* %183 
   ret i64 %"d##0" 
 if.else:
   ret i64 %"d##0" 
@@ -1641,11 +1634,11 @@ if.else:
 define external fastcc  void @"drone.gen#3<0>"(i64  %"d##0")    {
 entry:
   %"1#ch##1" = tail call ccc  i8  @read_char()  
-  %187 = alloca i64 
-  store  i64 -1, i64* %187 
-  %188 = load  i64, i64* %187 
-  %189 = trunc i64 %188 to i8  
-  %"1#tmp#4##0" = icmp ne i8 %"1#ch##1", %189 
+  %184 = alloca i64 
+  store  i64 -1, i64* %184 
+  %185 = load  i64, i64* %184 
+  %186 = trunc i64 %185 to i8  
+  %"1#tmp#4##0" = icmp ne i8 %"1#ch##1", %186 
   br i1 %"1#tmp#4##0", label %if.then, label %if.else 
 if.then:
   tail call fastcc  void  @"drone.loop<0>"(i64  %"d##0", i8  %"1#ch##1")  
@@ -1658,11 +1651,11 @@ if.else:
 define external fastcc  void @"drone.gen#3<0>[6dacb8fd25]"(i64  %"d##0")    {
 entry:
   %"1#ch##1" = tail call ccc  i8  @read_char()  
-  %190 = alloca i64 
-  store  i64 -1, i64* %190 
-  %191 = load  i64, i64* %190 
-  %192 = trunc i64 %191 to i8  
-  %"1#tmp#4##0" = icmp ne i8 %"1#ch##1", %192 
+  %187 = alloca i64 
+  store  i64 -1, i64* %187 
+  %188 = load  i64, i64* %187 
+  %189 = trunc i64 %188 to i8  
+  %"1#tmp#4##0" = icmp ne i8 %"1#ch##1", %189 
   br i1 %"1#tmp#4##0", label %if.then, label %if.else 
 if.then:
   tail call fastcc  void  @"drone.loop<0>[410bae77d3]"(i64  %"d##0", i8  %"1#ch##1")  
@@ -1685,50 +1678,45 @@ if.else:
   tail call fastcc  void  @"drone.gen#3<0>"(i64  %"d##0")  
   ret void 
 if.then1:
-  %195 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.194, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %195)  
-  %196 = inttoptr i64 %"d##0" to i64* 
-  %197 = getelementptr  i64, i64* %196, i64 0 
-  %198 = load  i64, i64* %197 
-  tail call ccc  void  @print_int(i64  %198)  
-  %201 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.200, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %201)  
-  %202 = add   i64 %"d##0", 8 
-  %203 = inttoptr i64 %202 to i64* 
-  %204 = getelementptr  i64, i64* %203, i64 0 
-  %205 = load  i64, i64* %204 
-  tail call ccc  void  @print_int(i64  %205)  
-  %208 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.207, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %208)  
-  %209 = add   i64 %"d##0", 16 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.191, i32 0, i32 0) to i64))  
+  %192 = inttoptr i64 %"d##0" to i64* 
+  %193 = getelementptr  i64, i64* %192, i64 0 
+  %194 = load  i64, i64* %193 
+  tail call ccc  void  @print_int(i64  %194)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.196, i32 0, i32 0) to i64))  
+  %197 = add   i64 %"d##0", 8 
+  %198 = inttoptr i64 %197 to i64* 
+  %199 = getelementptr  i64, i64* %198, i64 0 
+  %200 = load  i64, i64* %199 
+  tail call ccc  void  @print_int(i64  %200)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.202, i32 0, i32 0) to i64))  
+  %203 = add   i64 %"d##0", 16 
+  %204 = inttoptr i64 %203 to i64* 
+  %205 = getelementptr  i64, i64* %204, i64 0 
+  %206 = load  i64, i64* %205 
+  tail call ccc  void  @print_int(i64  %206)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.208, i32 0, i32 0) to i64))  
+  %209 = add   i64 %"d##0", 24 
   %210 = inttoptr i64 %209 to i64* 
   %211 = getelementptr  i64, i64* %210, i64 0 
   %212 = load  i64, i64* %211 
   tail call ccc  void  @print_int(i64  %212)  
-  %215 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.214, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %215)  
-  %216 = add   i64 %"d##0", 24 
-  %217 = inttoptr i64 %216 to i64* 
-  %218 = getelementptr  i64, i64* %217, i64 0 
-  %219 = load  i64, i64* %218 
-  tail call ccc  void  @print_int(i64  %219)  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"drone.gen#3<0>"(i64  %"d##0")  
   ret void 
 if.else1:
-  %220 = tail call fastcc  {i64, i1}  @"drone.do_action<0>"(i64  %"d##0", i8  %"ch##0")  
-  %221 = extractvalue {i64, i1} %220, 0 
-  %222 = extractvalue {i64, i1} %220, 1 
-  %"5#tmp#5##0" = icmp eq i1 %222, 0 
+  %213 = tail call fastcc  {i64, i1}  @"drone.do_action<0>"(i64  %"d##0", i8  %"ch##0")  
+  %214 = extractvalue {i64, i1} %213, 0 
+  %215 = extractvalue {i64, i1} %213, 1 
+  %"5#tmp#5##0" = icmp eq i1 %215, 0 
   br i1 %"5#tmp#5##0", label %if.then2, label %if.else2 
 if.then2:
-  %225 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.224, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %225)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.217, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"drone.gen#3<0>"(i64  %221)  
+  tail call fastcc  void  @"drone.gen#3<0>"(i64  %214)  
   ret void 
 if.else2:
-  tail call fastcc  void  @"drone.gen#3<0>"(i64  %221)  
+  tail call fastcc  void  @"drone.gen#3<0>"(i64  %214)  
   ret void 
 }
 
@@ -1746,83 +1734,74 @@ if.else:
   tail call fastcc  void  @"drone.gen#3<0>[6dacb8fd25]"(i64  %"d##0")  
   ret void 
 if.then1:
-  %228 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.227, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %228)  
-  %229 = inttoptr i64 %"d##0" to i64* 
-  %230 = getelementptr  i64, i64* %229, i64 0 
-  %231 = load  i64, i64* %230 
-  tail call ccc  void  @print_int(i64  %231)  
-  %234 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.233, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %234)  
-  %235 = add   i64 %"d##0", 8 
-  %236 = inttoptr i64 %235 to i64* 
-  %237 = getelementptr  i64, i64* %236, i64 0 
-  %238 = load  i64, i64* %237 
-  tail call ccc  void  @print_int(i64  %238)  
-  %241 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.240, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %241)  
-  %242 = add   i64 %"d##0", 16 
-  %243 = inttoptr i64 %242 to i64* 
-  %244 = getelementptr  i64, i64* %243, i64 0 
-  %245 = load  i64, i64* %244 
-  tail call ccc  void  @print_int(i64  %245)  
-  %248 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.247, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %248)  
-  %249 = add   i64 %"d##0", 24 
-  %250 = inttoptr i64 %249 to i64* 
-  %251 = getelementptr  i64, i64* %250, i64 0 
-  %252 = load  i64, i64* %251 
-  tail call ccc  void  @print_int(i64  %252)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.219, i32 0, i32 0) to i64))  
+  %220 = inttoptr i64 %"d##0" to i64* 
+  %221 = getelementptr  i64, i64* %220, i64 0 
+  %222 = load  i64, i64* %221 
+  tail call ccc  void  @print_int(i64  %222)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.224, i32 0, i32 0) to i64))  
+  %225 = add   i64 %"d##0", 8 
+  %226 = inttoptr i64 %225 to i64* 
+  %227 = getelementptr  i64, i64* %226, i64 0 
+  %228 = load  i64, i64* %227 
+  tail call ccc  void  @print_int(i64  %228)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.230, i32 0, i32 0) to i64))  
+  %231 = add   i64 %"d##0", 16 
+  %232 = inttoptr i64 %231 to i64* 
+  %233 = getelementptr  i64, i64* %232, i64 0 
+  %234 = load  i64, i64* %233 
+  tail call ccc  void  @print_int(i64  %234)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.236, i32 0, i32 0) to i64))  
+  %237 = add   i64 %"d##0", 24 
+  %238 = inttoptr i64 %237 to i64* 
+  %239 = getelementptr  i64, i64* %238, i64 0 
+  %240 = load  i64, i64* %239 
+  tail call ccc  void  @print_int(i64  %240)  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"drone.gen#3<0>[6dacb8fd25]"(i64  %"d##0")  
   ret void 
 if.else1:
-  %253 = tail call fastcc  {i64, i1}  @"drone.do_action<0>[410bae77d3]"(i64  %"d##0", i8  %"ch##0")  
-  %254 = extractvalue {i64, i1} %253, 0 
-  %255 = extractvalue {i64, i1} %253, 1 
-  %"5#tmp#5##0" = icmp eq i1 %255, 0 
+  %241 = tail call fastcc  {i64, i1}  @"drone.do_action<0>[410bae77d3]"(i64  %"d##0", i8  %"ch##0")  
+  %242 = extractvalue {i64, i1} %241, 0 
+  %243 = extractvalue {i64, i1} %241, 1 
+  %"5#tmp#5##0" = icmp eq i1 %243, 0 
   br i1 %"5#tmp#5##0", label %if.then2, label %if.else2 
 if.then2:
-  %258 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.257, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %258)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.245, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"drone.gen#3<0>[6dacb8fd25]"(i64  %254)  
+  tail call fastcc  void  @"drone.gen#3<0>[6dacb8fd25]"(i64  %242)  
   ret void 
 if.else2:
-  tail call fastcc  void  @"drone.gen#3<0>[6dacb8fd25]"(i64  %254)  
+  tail call fastcc  void  @"drone.gen#3<0>[6dacb8fd25]"(i64  %242)  
   ret void 
 }
 
 
 define external fastcc  void @"drone.print_info<0>"(i64  %"d##0")    {
 entry:
-  %261 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.260, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %261)  
-  %262 = inttoptr i64 %"d##0" to i64* 
-  %263 = getelementptr  i64, i64* %262, i64 0 
-  %264 = load  i64, i64* %263 
-  tail call ccc  void  @print_int(i64  %264)  
-  %267 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.266, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %267)  
-  %268 = add   i64 %"d##0", 8 
-  %269 = inttoptr i64 %268 to i64* 
-  %270 = getelementptr  i64, i64* %269, i64 0 
-  %271 = load  i64, i64* %270 
-  tail call ccc  void  @print_int(i64  %271)  
-  %274 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.273, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %274)  
-  %275 = add   i64 %"d##0", 16 
-  %276 = inttoptr i64 %275 to i64* 
-  %277 = getelementptr  i64, i64* %276, i64 0 
-  %278 = load  i64, i64* %277 
-  tail call ccc  void  @print_int(i64  %278)  
-  %281 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.280, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %281)  
-  %282 = add   i64 %"d##0", 24 
-  %283 = inttoptr i64 %282 to i64* 
-  %284 = getelementptr  i64, i64* %283, i64 0 
-  %285 = load  i64, i64* %284 
-  tail call ccc  void  @print_int(i64  %285)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.247, i32 0, i32 0) to i64))  
+  %248 = inttoptr i64 %"d##0" to i64* 
+  %249 = getelementptr  i64, i64* %248, i64 0 
+  %250 = load  i64, i64* %249 
+  tail call ccc  void  @print_int(i64  %250)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.252, i32 0, i32 0) to i64))  
+  %253 = add   i64 %"d##0", 8 
+  %254 = inttoptr i64 %253 to i64* 
+  %255 = getelementptr  i64, i64* %254, i64 0 
+  %256 = load  i64, i64* %255 
+  tail call ccc  void  @print_int(i64  %256)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.258, i32 0, i32 0) to i64))  
+  %259 = add   i64 %"d##0", 16 
+  %260 = inttoptr i64 %259 to i64* 
+  %261 = getelementptr  i64, i64* %260, i64 0 
+  %262 = load  i64, i64* %261 
+  tail call ccc  void  @print_int(i64  %262)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @drone.264, i32 0, i32 0) to i64))  
+  %265 = add   i64 %"d##0", 24 
+  %266 = inttoptr i64 %265 to i64* 
+  %267 = getelementptr  i64, i64* %266, i64 0 
+  %268 = load  i64, i64* %267 
+  tail call ccc  void  @print_int(i64  %268)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/complex/exp/testcase_multi_specz-int_list.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-int_list.exp
@@ -190,7 +190,7 @@ declare external ccc  void @error_exit(i64, i64)
 declare external fastcc  {i64, i64, i1} @"wybe.array.[|]<0>"(i64)    
 
 
-@command_line.18 =    constant [?? x i8] c"Erroneous program argument vector\00"
+@command_line.17 =    constant [?? x i8] c"Erroneous program argument vector\00"
 
 
 @command_line.16 =    constant [?? x i8] c"command_line:17:6\00"
@@ -225,13 +225,11 @@ if.then:
   %15 = insertvalue {i64, i64, i64} %14, i64 0, 2 
   ret {i64, i64, i64} %15 
 if.else:
-  %17 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @command_line.16, i32 0, i32 0) to i64 
-  %19 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @command_line.18, i32 0, i32 0) to i64 
-  tail call ccc  void  @error_exit(i64  %17, i64  %19)  
-  %20 = insertvalue {i64, i64, i64} undef, i64 %11, 0 
-  %21 = insertvalue {i64, i64, i64} %20, i64 %10, 1 
-  %22 = insertvalue {i64, i64, i64} %21, i64 undef, 2 
-  ret {i64, i64, i64} %22 
+  tail call ccc  void  @error_exit(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @command_line.16, i32 0, i32 0) to i64), i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @command_line.17, i32 0, i32 0) to i64))  
+  %18 = insertvalue {i64, i64, i64} undef, i64 %11, 0 
+  %19 = insertvalue {i64, i64, i64} %18, i64 %10, 1 
+  %20 = insertvalue {i64, i64, i64} %19, i64 undef, 2 
+  ret {i64, i64, i64} %20 
 }
 
 
@@ -1044,7 +1042,7 @@ declare external ccc  void @error_exit(i64, i64)
 declare external fastcc  {i64, i64, i1} @"wybe.array.[|]<0>"(i64)    
 
 
-@command_line.18 =    constant [?? x i8] c"Erroneous program argument vector\00"
+@command_line.17 =    constant [?? x i8] c"Erroneous program argument vector\00"
 
 
 @command_line.16 =    constant [?? x i8] c"command_line:17:6\00"
@@ -1079,13 +1077,11 @@ if.then:
   %15 = insertvalue {i64, i64, i64} %14, i64 0, 2 
   ret {i64, i64, i64} %15 
 if.else:
-  %17 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @command_line.16, i32 0, i32 0) to i64 
-  %19 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @command_line.18, i32 0, i32 0) to i64 
-  tail call ccc  void  @error_exit(i64  %17, i64  %19)  
-  %20 = insertvalue {i64, i64, i64} undef, i64 %11, 0 
-  %21 = insertvalue {i64, i64, i64} %20, i64 %10, 1 
-  %22 = insertvalue {i64, i64, i64} %21, i64 undef, 2 
-  ret {i64, i64, i64} %22 
+  tail call ccc  void  @error_exit(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @command_line.16, i32 0, i32 0) to i64), i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @command_line.17, i32 0, i32 0) to i64))  
+  %18 = insertvalue {i64, i64, i64} undef, i64 %11, 0 
+  %19 = insertvalue {i64, i64, i64} %18, i64 %10, 1 
+  %20 = insertvalue {i64, i64, i64} %19, i64 undef, 2 
+  ret {i64, i64, i64} %20 
 }
 
 
@@ -2828,64 +2824,64 @@ declare external fastcc  void @"int_list.print<0>"(i64)
 declare external fastcc  i64 @"int_list.gen#2<0>[410bae77d3]"(i64, i64, i64, i64, i64)    
 
 
-@int_list_test.32 =    constant {i64, i64} { i64 39, i64 ptrtoint ([?? x i8]* @int_list_test.31 to i64) }
+@int_list_test.22 =    constant {i64, i64} { i64 39, i64 ptrtoint ([?? x i8]* @int_list_test.21 to i64) }
 
 
-@int_list_test.31 =    constant [?? x i8] c" ** malloc count of test(non-aliased): \00"
+@int_list_test.21 =    constant [?? x i8] c" ** malloc count of test(non-aliased): \00"
 
 
-@int_list_test.29 =    constant {i64, i64} { i64 35, i64 ptrtoint ([?? x i8]* @int_list_test.28 to i64) }
+@int_list_test.20 =    constant {i64, i64} { i64 35, i64 ptrtoint ([?? x i8]* @int_list_test.19 to i64) }
 
 
-@int_list_test.28 =    constant [?? x i8] c" ** malloc count of test(aliased): \00"
+@int_list_test.19 =    constant [?? x i8] c" ** malloc count of test(aliased): \00"
 
 
-@int_list_test.26 =    constant {i64, i64} { i64 36, i64 ptrtoint ([?? x i8]* @int_list_test.25 to i64) }
+@int_list_test.18 =    constant {i64, i64} { i64 36, i64 ptrtoint ([?? x i8]* @int_list_test.17 to i64) }
 
 
-@int_list_test.25 =    constant [?? x i8] c" ** malloc count of building lists: \00"
+@int_list_test.17 =    constant [?? x i8] c" ** malloc count of building lists: \00"
 
 
-@int_list_test.23 =    constant {i64, i64} { i64 20, i64 ptrtoint ([?? x i8]* @int_list_test.22 to i64) }
+@int_list_test.16 =    constant {i64, i64} { i64 20, i64 ptrtoint ([?? x i8]* @int_list_test.15 to i64) }
 
 
-@int_list_test.22 =    constant [?? x i8] c"--------------------\00"
+@int_list_test.15 =    constant [?? x i8] c"--------------------\00"
 
 
-@int_list_test.20 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @int_list_test.19 to i64) }
+@int_list_test.14 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @int_list_test.13 to i64) }
 
 
-@int_list_test.19 =    constant [?? x i8] c"tests without alias\00"
+@int_list_test.13 =    constant [?? x i8] c"tests without alias\00"
 
 
-@int_list_test.17 =    constant {i64, i64} { i64 20, i64 ptrtoint ([?? x i8]* @int_list_test.16 to i64) }
+@int_list_test.12 =    constant {i64, i64} { i64 20, i64 ptrtoint ([?? x i8]* @int_list_test.11 to i64) }
 
 
-@int_list_test.16 =    constant [?? x i8] c"--------------------\00"
+@int_list_test.11 =    constant [?? x i8] c"--------------------\00"
 
 
-@int_list_test.14 =    constant {i64, i64} { i64 20, i64 ptrtoint ([?? x i8]* @int_list_test.13 to i64) }
+@int_list_test.10 =    constant {i64, i64} { i64 20, i64 ptrtoint ([?? x i8]* @int_list_test.9 to i64) }
 
 
-@int_list_test.13 =    constant [?? x i8] c"--------------------\00"
+@int_list_test.9 =    constant [?? x i8] c"--------------------\00"
 
 
-@int_list_test.11 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @int_list_test.10 to i64) }
+@int_list_test.8 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @int_list_test.7 to i64) }
 
 
-@int_list_test.10 =    constant [?? x i8] c"original x y z:\00"
+@int_list_test.7 =    constant [?? x i8] c"original x y z:\00"
 
 
-@int_list_test.8 =    constant {i64, i64} { i64 16, i64 ptrtoint ([?? x i8]* @int_list_test.7 to i64) }
+@int_list_test.6 =    constant {i64, i64} { i64 16, i64 ptrtoint ([?? x i8]* @int_list_test.5 to i64) }
 
 
-@int_list_test.7 =    constant [?? x i8] c"tests with alias\00"
+@int_list_test.5 =    constant [?? x i8] c"tests with alias\00"
 
 
-@int_list_test.5 =    constant {i64, i64} { i64 20, i64 ptrtoint ([?? x i8]* @int_list_test.4 to i64) }
+@int_list_test.4 =    constant {i64, i64} { i64 20, i64 ptrtoint ([?? x i8]* @int_list_test.3 to i64) }
 
 
-@int_list_test.4 =    constant [?? x i8] c"--------------------\00"
+@int_list_test.3 =    constant [?? x i8] c"--------------------\00"
 
 
 @int_list_test.2 =    constant {i64, i64} { i64 6, i64 ptrtoint ([?? x i8]* @int_list_test.1 to i64) }
@@ -2915,28 +2911,28 @@ declare external fastcc  i64 @"int_list.append<0>"(i64, i64)
 declare external fastcc  i64 @"int_list.reverse_helper<0>"(i64, i64)    
 
 
-@int_list_test.44 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @int_list_test.43 to i64) }
+@int_list_test.30 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @int_list_test.29 to i64) }
 
 
-@int_list_test.43 =    constant [?? x i8] c"-\00"
+@int_list_test.29 =    constant [?? x i8] c"-\00"
 
 
-@int_list_test.41 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @int_list_test.40 to i64) }
+@int_list_test.28 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @int_list_test.27 to i64) }
 
 
-@int_list_test.40 =    constant [?? x i8] c"-\00"
+@int_list_test.27 =    constant [?? x i8] c"-\00"
 
 
-@int_list_test.38 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @int_list_test.37 to i64) }
+@int_list_test.26 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @int_list_test.25 to i64) }
 
 
-@int_list_test.37 =    constant [?? x i8] c"-\00"
+@int_list_test.25 =    constant [?? x i8] c"-\00"
 
 
-@int_list_test.35 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @int_list_test.34 to i64) }
+@int_list_test.24 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @int_list_test.23 to i64) }
 
 
-@int_list_test.34 =    constant [?? x i8] c"-\00"
+@int_list_test.23 =    constant [?? x i8] c"-\00"
 
 
 declare external fastcc  i64 @"int_list.append<0>[410bae77d3]"(i64, i64)    
@@ -2945,28 +2941,28 @@ declare external fastcc  i64 @"int_list.append<0>[410bae77d3]"(i64, i64)
 declare external fastcc  i64 @"int_list.reverse_helper<0>[410bae77d3]"(i64, i64)    
 
 
-@int_list_test.56 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @int_list_test.55 to i64) }
+@int_list_test.38 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @int_list_test.37 to i64) }
 
 
-@int_list_test.55 =    constant [?? x i8] c"-\00"
+@int_list_test.37 =    constant [?? x i8] c"-\00"
 
 
-@int_list_test.53 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @int_list_test.52 to i64) }
+@int_list_test.36 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @int_list_test.35 to i64) }
 
 
-@int_list_test.52 =    constant [?? x i8] c"-\00"
+@int_list_test.35 =    constant [?? x i8] c"-\00"
 
 
-@int_list_test.50 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @int_list_test.49 to i64) }
+@int_list_test.34 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @int_list_test.33 to i64) }
 
 
-@int_list_test.49 =    constant [?? x i8] c"-\00"
+@int_list_test.33 =    constant [?? x i8] c"-\00"
 
 
-@int_list_test.47 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @int_list_test.46 to i64) }
+@int_list_test.32 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @int_list_test.31 to i64) }
 
 
-@int_list_test.46 =    constant [?? x i8] c"-\00"
+@int_list_test.31 =    constant [?? x i8] c"-\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -2981,8 +2977,7 @@ entry:
   %"1#tmp#0##0" = tail call fastcc  i64  @"int_list.gen#2<0>[410bae77d3]"(i64  0, i64  1, i64  1, i64  10, i64  0)  
   %"1#tmp#1##0" = tail call fastcc  i64  @"int_list.gen#2<0>[410bae77d3]"(i64  0, i64  2, i64  2, i64  20, i64  0)  
   %"1#tmp#2##0" = tail call fastcc  i64  @"int_list.gen#2<0>[410bae77d3]"(i64  0, i64  3, i64  3, i64  30, i64  0)  
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"int_list.print<0>"(i64  %"1#tmp#0##0")  
   tail call ccc  void  @putchar(i8  10)  
@@ -2992,18 +2987,15 @@ entry:
   tail call ccc  void  @putchar(i8  10)  
   %"1#mc2##0" = tail call ccc  i64  @malloc_count()  
   %"1#tmp#3##0" = sub   i64 %"1#mc2##0", %"1#mc1##0" 
-  %6 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.5, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %6)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.4, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.6, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   %"1#mc1##1" = tail call ccc  i64  @malloc_count()  
   tail call fastcc  void  @"int_list_test.test_int_list<0>"(i64  %"1#tmp#0##0", i64  %"1#tmp#1##0", i64  %"1#tmp#2##0")  
   %"1#mc2##1" = tail call ccc  i64  @malloc_count()  
   %"1#tmp#4##0" = sub   i64 %"1#mc2##1", %"1#mc1##1" 
-  %12 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.11, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %12)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.8, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"int_list.print<0>"(i64  %"1#tmp#0##0")  
   tail call ccc  void  @putchar(i8  10)  
@@ -3011,32 +3003,25 @@ entry:
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"int_list.print<0>"(i64  %"1#tmp#2##0")  
   tail call ccc  void  @putchar(i8  10)  
-  %15 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.14, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %15)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.10, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %18 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.17, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %18)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.12, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %21 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.20, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %21)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.14, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   %"1#mc1##2" = tail call ccc  i64  @malloc_count()  
   tail call fastcc  void  @"int_list_test.test_int_list<0>[9e35cb823b]"(i64  %"1#tmp#0##0", i64  %"1#tmp#1##0", i64  %"1#tmp#2##0")  
   %"1#mc2##2" = tail call ccc  i64  @malloc_count()  
   %"1#tmp#5##0" = sub   i64 %"1#mc2##2", %"1#mc1##2" 
-  %24 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.23, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %24)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.16, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %27 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.26, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %27)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.18, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %"1#tmp#3##0")  
   tail call ccc  void  @putchar(i8  10)  
-  %30 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.29, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %30)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.20, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %"1#tmp#4##0")  
   tail call ccc  void  @putchar(i8  10)  
-  %33 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.32, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %33)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.22, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %"1#tmp#5##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -3048,8 +3033,7 @@ entry:
   %"1#x##1" = tail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %"x##0", i64  0)  
   %"1#z##1" = tail call fastcc  i64  @"int_list.reverse_helper<0>"(i64  %"z##0", i64  0)  
   %"1#tmp#0##0" = tail call fastcc  i64  @"int_list.append<0>"(i64  %"y##0", i64  99)  
-  %36 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.35, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %36)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.24, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"int_list.print<0>"(i64  %"1#x##1")  
   tail call ccc  void  @putchar(i8  10)  
@@ -3059,22 +3043,19 @@ entry:
   tail call ccc  void  @putchar(i8  10)  
   %"1#tmp#1##0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"1#x##1", i64  %"1#tmp#0##0")  
   %"1#tmp#2##0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"1#tmp#1##0", i64  %"1#z##1")  
-  %39 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.38, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %39)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.26, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"int_list.print<0>"(i64  %"1#tmp#2##0")  
   tail call ccc  void  @putchar(i8  10)  
   %"1#tmp#3##0" = tail call fastcc  i64  @"int_list.insert<0>[410bae77d3]"(i64  %"1#tmp#2##0", i64  4, i64  78)  
   %"1#tmp#4##0" = tail call fastcc  i64  @"int_list.pop<0>[410bae77d3]"(i64  %"1#tmp#3##0", i64  20)  
   %"1#tmp#5##0" = tail call fastcc  i64  @"int_list.remove<0>[410bae77d3]"(i64  %"1#tmp#4##0", i64  2)  
-  %42 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.41, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %42)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.28, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"int_list.print<0>"(i64  %"1#tmp#5##0")  
   tail call ccc  void  @putchar(i8  10)  
   %"1#l##5" = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %"1#tmp#5##0")  
-  %45 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.44, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %45)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.30, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"int_list.print<0>"(i64  %"1#l##5")  
   tail call ccc  void  @putchar(i8  10)  
@@ -3087,8 +3068,7 @@ entry:
   %"1#x##1" = tail call fastcc  i64  @"int_list.reverse_helper<0>[410bae77d3]"(i64  %"x##0", i64  0)  
   %"1#z##1" = tail call fastcc  i64  @"int_list.reverse_helper<0>[410bae77d3]"(i64  %"z##0", i64  0)  
   %"1#tmp#0##0" = tail call fastcc  i64  @"int_list.append<0>[410bae77d3]"(i64  %"y##0", i64  99)  
-  %48 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.47, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %48)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.32, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"int_list.print<0>"(i64  %"1#x##1")  
   tail call ccc  void  @putchar(i8  10)  
@@ -3098,22 +3078,19 @@ entry:
   tail call ccc  void  @putchar(i8  10)  
   %"1#tmp#1##0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"1#x##1", i64  %"1#tmp#0##0")  
   %"1#tmp#2##0" = tail call fastcc  i64  @"int_list.extend<0>[410bae77d3]"(i64  %"1#tmp#1##0", i64  %"1#z##1")  
-  %51 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.50, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %51)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.34, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"int_list.print<0>"(i64  %"1#tmp#2##0")  
   tail call ccc  void  @putchar(i8  10)  
   %"1#tmp#3##0" = tail call fastcc  i64  @"int_list.insert<0>[410bae77d3]"(i64  %"1#tmp#2##0", i64  4, i64  78)  
   %"1#tmp#4##0" = tail call fastcc  i64  @"int_list.pop<0>[410bae77d3]"(i64  %"1#tmp#3##0", i64  20)  
   %"1#tmp#5##0" = tail call fastcc  i64  @"int_list.remove<0>[410bae77d3]"(i64  %"1#tmp#4##0", i64  2)  
-  %54 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.53, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %54)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.36, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"int_list.print<0>"(i64  %"1#tmp#5##0")  
   tail call ccc  void  @putchar(i8  10)  
   %"1#l##5" = tail call fastcc  i64  @"int_list.sort<0>[410bae77d3]"(i64  %"1#tmp#5##0")  
-  %57 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.56, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %57)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @int_list_test.38, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"int_list.print<0>"(i64  %"1#l##5")  
   tail call ccc  void  @putchar(i8  10)  

--- a/test-cases/final-dump/aaa.exp
+++ b/test-cases/final-dump/aaa.exp
@@ -47,8 +47,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"aaa.<0>"()    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @aaa.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @aaa.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -99,8 +98,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"bbb.<0>"()    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @bbb.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @bbb.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -151,8 +149,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"ccc.<0>"()    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @ccc.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @ccc.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -202,8 +199,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"ddd.<0>"()    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @ddd.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @ddd.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/alias1.exp
+++ b/test-cases/final-dump/alias1.exp
@@ -138,16 +138,16 @@ declare external ccc  void @putchar(i8)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@alias1.8 =    constant {i64, i64} { i64 28, i64 ptrtoint ([?? x i8]* @alias1.7 to i64) }
+@alias1.6 =    constant {i64, i64} { i64 28, i64 ptrtoint ([?? x i8]* @alias1.5 to i64) }
 
 
-@alias1.7 =    constant [?? x i8] c"-------------- Calling baz: \00"
+@alias1.5 =    constant [?? x i8] c"-------------- Calling baz: \00"
 
 
-@alias1.5 =    constant {i64, i64} { i64 28, i64 ptrtoint ([?? x i8]* @alias1.4 to i64) }
+@alias1.4 =    constant {i64, i64} { i64 28, i64 ptrtoint ([?? x i8]* @alias1.3 to i64) }
 
 
-@alias1.4 =    constant [?? x i8] c"-------------- Calling bar: \00"
+@alias1.3 =    constant [?? x i8] c"-------------- Calling bar: \00"
 
 
 @alias1.2 =    constant {i64, i64} { i64 28, i64 ptrtoint ([?? x i8]* @alias1.1 to i64) }
@@ -159,133 +159,133 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external fastcc  void @"position.printPosition<0>"(i64)    
 
 
-@alias1.42 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.41 to i64) }
+@alias1.34 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.33 to i64) }
 
 
-@alias1.41 =    constant [?? x i8] c"expect p2(555,102):\00"
+@alias1.33 =    constant [?? x i8] c"expect p2(555,102):\00"
 
 
-@alias1.39 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.38 to i64) }
+@alias1.32 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.31 to i64) }
 
 
-@alias1.38 =    constant [?? x i8] c"expect p1(101,102):\00"
+@alias1.31 =    constant [?? x i8] c"expect p1(101,102):\00"
 
 
-@alias1.36 =    constant {i64, i64} { i64 43, i64 ptrtoint ([?? x i8]* @alias1.35 to i64) }
+@alias1.30 =    constant {i64, i64} { i64 43, i64 ptrtoint ([?? x i8]* @alias1.29 to i64) }
 
 
-@alias1.35 =    constant [?? x i8] c"--- Inside bar, after calling x(!p2, 555): \00"
+@alias1.29 =    constant [?? x i8] c"--- Inside bar, after calling x(!p2, 555): \00"
 
 
-@alias1.25 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.24 to i64) }
+@alias1.20 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.19 to i64) }
 
 
-@alias1.24 =    constant [?? x i8] c"expect p2(101,102):\00"
+@alias1.19 =    constant [?? x i8] c"expect p2(101,102):\00"
 
 
-@alias1.22 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.21 to i64) }
+@alias1.18 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.17 to i64) }
 
 
-@alias1.21 =    constant [?? x i8] c"expect p1(101,102):\00"
+@alias1.17 =    constant [?? x i8] c"expect p1(101,102):\00"
 
 
-@alias1.19 =    constant {i64, i64} { i64 16, i64 ptrtoint ([?? x i8]* @alias1.18 to i64) }
+@alias1.16 =    constant {i64, i64} { i64 16, i64 ptrtoint ([?? x i8]* @alias1.15 to i64) }
 
 
-@alias1.18 =    constant [?? x i8] c"--- Inside bar: \00"
+@alias1.15 =    constant [?? x i8] c"--- Inside bar: \00"
 
 
-@alias1.94 =    constant {i64, i64} { i64 24, i64 ptrtoint ([?? x i8]* @alias1.93 to i64) }
+@alias1.78 =    constant {i64, i64} { i64 24, i64 ptrtoint ([?? x i8]* @alias1.77 to i64) }
 
 
-@alias1.93 =    constant [?? x i8] c"expect p3(33333333,102):\00"
+@alias1.77 =    constant [?? x i8] c"expect p3(33333333,102):\00"
 
 
-@alias1.91 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.90 to i64) }
+@alias1.76 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.75 to i64) }
 
 
-@alias1.90 =    constant [?? x i8] c"expect p2(101,102):\00"
+@alias1.75 =    constant [?? x i8] c"expect p2(101,102):\00"
 
 
-@alias1.88 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.87 to i64) }
+@alias1.74 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.73 to i64) }
 
 
-@alias1.87 =    constant [?? x i8] c"expect p1(555,102):\00"
+@alias1.73 =    constant [?? x i8] c"expect p1(555,102):\00"
 
 
-@alias1.85 =    constant {i64, i64} { i64 43, i64 ptrtoint ([?? x i8]* @alias1.84 to i64) }
+@alias1.72 =    constant {i64, i64} { i64 43, i64 ptrtoint ([?? x i8]* @alias1.71 to i64) }
 
 
-@alias1.84 =    constant [?? x i8] c"--- Inside baz, after calling x(!p1, 555): \00"
+@alias1.71 =    constant [?? x i8] c"--- Inside baz, after calling x(!p1, 555): \00"
 
 
-@alias1.74 =    constant {i64, i64} { i64 24, i64 ptrtoint ([?? x i8]* @alias1.73 to i64) }
+@alias1.62 =    constant {i64, i64} { i64 24, i64 ptrtoint ([?? x i8]* @alias1.61 to i64) }
 
 
-@alias1.73 =    constant [?? x i8] c"expect p3(33333333,102):\00"
+@alias1.61 =    constant [?? x i8] c"expect p3(33333333,102):\00"
 
 
-@alias1.59 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.58 to i64) }
+@alias1.48 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.47 to i64) }
 
 
-@alias1.58 =    constant [?? x i8] c"expect p2(101,102):\00"
+@alias1.47 =    constant [?? x i8] c"expect p2(101,102):\00"
 
 
-@alias1.56 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.55 to i64) }
+@alias1.46 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.45 to i64) }
 
 
-@alias1.55 =    constant [?? x i8] c"expect p1(101,102):\00"
+@alias1.45 =    constant [?? x i8] c"expect p1(101,102):\00"
 
 
-@alias1.53 =    constant {i64, i64} { i64 16, i64 ptrtoint ([?? x i8]* @alias1.52 to i64) }
+@alias1.44 =    constant {i64, i64} { i64 16, i64 ptrtoint ([?? x i8]* @alias1.43 to i64) }
 
 
-@alias1.52 =    constant [?? x i8] c"--- Inside baz: \00"
+@alias1.43 =    constant [?? x i8] c"--- Inside baz: \00"
 
 
-@alias1.128 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.127 to i64) }
+@alias1.106 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.105 to i64) }
 
 
-@alias1.127 =    constant [?? x i8] c"expect p2(101,102):\00"
+@alias1.105 =    constant [?? x i8] c"expect p2(101,102):\00"
 
 
-@alias1.125 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.124 to i64) }
+@alias1.104 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.103 to i64) }
 
 
-@alias1.124 =    constant [?? x i8] c"expect p1(555,102):\00"
+@alias1.103 =    constant [?? x i8] c"expect p1(555,102):\00"
 
 
-@alias1.122 =    constant {i64, i64} { i64 43, i64 ptrtoint ([?? x i8]* @alias1.121 to i64) }
+@alias1.102 =    constant {i64, i64} { i64 43, i64 ptrtoint ([?? x i8]* @alias1.101 to i64) }
 
 
-@alias1.121 =    constant [?? x i8] c"--- Inside foo, after calling x(!p1, 555): \00"
+@alias1.101 =    constant [?? x i8] c"--- Inside foo, after calling x(!p1, 555): \00"
 
 
-@alias1.111 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.110 to i64) }
+@alias1.92 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.91 to i64) }
 
 
-@alias1.110 =    constant [?? x i8] c"expect p2(101,102):\00"
+@alias1.91 =    constant [?? x i8] c"expect p2(101,102):\00"
 
 
-@alias1.108 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.107 to i64) }
+@alias1.90 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias1.89 to i64) }
 
 
-@alias1.107 =    constant [?? x i8] c"expect p1(101,102):\00"
+@alias1.89 =    constant [?? x i8] c"expect p1(101,102):\00"
 
 
-@alias1.105 =    constant {i64, i64} { i64 16, i64 ptrtoint ([?? x i8]* @alias1.104 to i64) }
+@alias1.88 =    constant {i64, i64} { i64 16, i64 ptrtoint ([?? x i8]* @alias1.87 to i64) }
 
 
-@alias1.104 =    constant [?? x i8] c"--- Inside foo: \00"
+@alias1.87 =    constant [?? x i8] c"--- Inside foo: \00"
 
 
 declare external ccc  void @print_int(i64)    
 
 
-@alias1.139 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @alias1.138 to i64) }
+@alias1.116 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @alias1.115 to i64) }
 
 
-@alias1.138 =    constant [?? x i8] c"random print\00"
+@alias1.115 =    constant [?? x i8] c"random print\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -296,16 +296,13 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"alias1.<0>"()    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"alias1.foo<0>"()  
-  %6 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.5, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %6)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.4, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"alias1.bar<0>"()  
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.6, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"alias1.baz<0>"()  
   ret void 
@@ -314,154 +311,134 @@ entry:
 
 define external fastcc  void @"alias1.bar<0>"()    {
 entry:
-  %10 = trunc i64 16 to i32  
-  %11 = tail call ccc  i8*  @wybe_malloc(i32  %10)  
-  %12 = ptrtoint i8* %11 to i64 
+  %7 = trunc i64 16 to i32  
+  %8 = tail call ccc  i8*  @wybe_malloc(i32  %7)  
+  %9 = ptrtoint i8* %8 to i64 
+  %10 = inttoptr i64 %9 to i64* 
+  %11 = getelementptr  i64, i64* %10, i64 0 
+  store  i64 101, i64* %11 
+  %12 = add   i64 %9, 8 
   %13 = inttoptr i64 %12 to i64* 
   %14 = getelementptr  i64, i64* %13, i64 0 
-  store  i64 101, i64* %14 
-  %15 = add   i64 %12, 8 
-  %16 = inttoptr i64 %15 to i64* 
-  %17 = getelementptr  i64, i64* %16, i64 0 
-  store  i64 102, i64* %17 
-  %"1#p2##0" = tail call fastcc  i64  @"alias1.replicate<0>"(i64  %12)  
-  %20 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.19, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %20)  
+  store  i64 102, i64* %14 
+  %"1#p2##0" = tail call fastcc  i64  @"alias1.replicate<0>"(i64  %9)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.16, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %23 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.22, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %23)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %12)  
-  %26 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.25, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %26)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.18, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %9)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.20, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
-  %27 = trunc i64 16 to i32  
-  %28 = tail call ccc  i8*  @wybe_malloc(i32  %27)  
-  %29 = ptrtoint i8* %28 to i64 
-  %30 = inttoptr i64 %29 to i8* 
-  %31 = inttoptr i64 %"1#p2##0" to i8* 
-  %32 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %30, i8*  %31, i32  %32, i32  8, i1  0)  
-  %33 = inttoptr i64 %29 to i64* 
-  %34 = getelementptr  i64, i64* %33, i64 0 
-  store  i64 555, i64* %34 
-  %37 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.36, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %37)  
+  %21 = trunc i64 16 to i32  
+  %22 = tail call ccc  i8*  @wybe_malloc(i32  %21)  
+  %23 = ptrtoint i8* %22 to i64 
+  %24 = inttoptr i64 %23 to i8* 
+  %25 = inttoptr i64 %"1#p2##0" to i8* 
+  %26 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %24, i8*  %25, i32  %26, i32  8, i1  0)  
+  %27 = inttoptr i64 %23 to i64* 
+  %28 = getelementptr  i64, i64* %27, i64 0 
+  store  i64 555, i64* %28 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.30, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %40 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.39, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %40)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %12)  
-  %43 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.42, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %43)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %29)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.32, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %9)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.34, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %23)  
   ret void 
 }
 
 
 define external fastcc  void @"alias1.baz<0>"()    {
 entry:
-  %44 = trunc i64 16 to i32  
-  %45 = tail call ccc  i8*  @wybe_malloc(i32  %44)  
-  %46 = ptrtoint i8* %45 to i64 
-  %47 = inttoptr i64 %46 to i64* 
-  %48 = getelementptr  i64, i64* %47, i64 0 
-  store  i64 101, i64* %48 
-  %49 = add   i64 %46, 8 
+  %35 = trunc i64 16 to i32  
+  %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
+  %37 = ptrtoint i8* %36 to i64 
+  %38 = inttoptr i64 %37 to i64* 
+  %39 = getelementptr  i64, i64* %38, i64 0 
+  store  i64 101, i64* %39 
+  %40 = add   i64 %37, 8 
+  %41 = inttoptr i64 %40 to i64* 
+  %42 = getelementptr  i64, i64* %41, i64 0 
+  store  i64 102, i64* %42 
+  %"1#p2##0" = tail call fastcc  i64  @"alias1.replicate<0>"(i64  %37)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.44, i32 0, i32 0) to i64))  
+  tail call ccc  void  @putchar(i8  10)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.46, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %37)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.48, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
+  %49 = add   i64 %"1#p2##0", 8 
   %50 = inttoptr i64 %49 to i64* 
   %51 = getelementptr  i64, i64* %50, i64 0 
-  store  i64 102, i64* %51 
-  %"1#p2##0" = tail call fastcc  i64  @"alias1.replicate<0>"(i64  %46)  
-  %54 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.53, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %54)  
+  %52 = load  i64, i64* %51 
+  %53 = trunc i64 16 to i32  
+  %54 = tail call ccc  i8*  @wybe_malloc(i32  %53)  
+  %55 = ptrtoint i8* %54 to i64 
+  %56 = inttoptr i64 %55 to i64* 
+  %57 = getelementptr  i64, i64* %56, i64 0 
+  store  i64 33333333, i64* %57 
+  %58 = add   i64 %55, 8 
+  %59 = inttoptr i64 %58 to i64* 
+  %60 = getelementptr  i64, i64* %59, i64 0 
+  store  i64 %52, i64* %60 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.62, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %55)  
+  %63 = trunc i64 16 to i32  
+  %64 = tail call ccc  i8*  @wybe_malloc(i32  %63)  
+  %65 = ptrtoint i8* %64 to i64 
+  %66 = inttoptr i64 %65 to i8* 
+  %67 = inttoptr i64 %37 to i8* 
+  %68 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %66, i8*  %67, i32  %68, i32  8, i1  0)  
+  %69 = inttoptr i64 %65 to i64* 
+  %70 = getelementptr  i64, i64* %69, i64 0 
+  store  i64 555, i64* %70 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.72, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %57 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.56, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %57)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %46)  
-  %60 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.59, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %60)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.74, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %65)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.76, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
-  %61 = add   i64 %"1#p2##0", 8 
-  %62 = inttoptr i64 %61 to i64* 
-  %63 = getelementptr  i64, i64* %62, i64 0 
-  %64 = load  i64, i64* %63 
-  %65 = trunc i64 16 to i32  
-  %66 = tail call ccc  i8*  @wybe_malloc(i32  %65)  
-  %67 = ptrtoint i8* %66 to i64 
-  %68 = inttoptr i64 %67 to i64* 
-  %69 = getelementptr  i64, i64* %68, i64 0 
-  store  i64 33333333, i64* %69 
-  %70 = add   i64 %67, 8 
-  %71 = inttoptr i64 %70 to i64* 
-  %72 = getelementptr  i64, i64* %71, i64 0 
-  store  i64 %64, i64* %72 
-  %75 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.74, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %75)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %67)  
-  %76 = trunc i64 16 to i32  
-  %77 = tail call ccc  i8*  @wybe_malloc(i32  %76)  
-  %78 = ptrtoint i8* %77 to i64 
-  %79 = inttoptr i64 %78 to i8* 
-  %80 = inttoptr i64 %46 to i8* 
-  %81 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %79, i8*  %80, i32  %81, i32  8, i1  0)  
-  %82 = inttoptr i64 %78 to i64* 
-  %83 = getelementptr  i64, i64* %82, i64 0 
-  store  i64 555, i64* %83 
-  %86 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.85, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %86)  
-  tail call ccc  void  @putchar(i8  10)  
-  %89 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.88, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %89)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %78)  
-  %92 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.91, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %92)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
-  %95 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.94, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %95)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %67)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.78, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %55)  
   ret void 
 }
 
 
 define external fastcc  void @"alias1.foo<0>"()    {
 entry:
-  %96 = trunc i64 16 to i32  
-  %97 = tail call ccc  i8*  @wybe_malloc(i32  %96)  
-  %98 = ptrtoint i8* %97 to i64 
-  %99 = inttoptr i64 %98 to i64* 
-  %100 = getelementptr  i64, i64* %99, i64 0 
-  store  i64 101, i64* %100 
-  %101 = add   i64 %98, 8 
-  %102 = inttoptr i64 %101 to i64* 
-  %103 = getelementptr  i64, i64* %102, i64 0 
-  store  i64 102, i64* %103 
-  %"1#p2##0" = tail call fastcc  i64  @"alias1.replicate<0>"(i64  %98)  
-  %106 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.105, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %106)  
+  %79 = trunc i64 16 to i32  
+  %80 = tail call ccc  i8*  @wybe_malloc(i32  %79)  
+  %81 = ptrtoint i8* %80 to i64 
+  %82 = inttoptr i64 %81 to i64* 
+  %83 = getelementptr  i64, i64* %82, i64 0 
+  store  i64 101, i64* %83 
+  %84 = add   i64 %81, 8 
+  %85 = inttoptr i64 %84 to i64* 
+  %86 = getelementptr  i64, i64* %85, i64 0 
+  store  i64 102, i64* %86 
+  %"1#p2##0" = tail call fastcc  i64  @"alias1.replicate<0>"(i64  %81)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.88, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %109 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.108, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %109)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %98)  
-  %112 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.111, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %112)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.90, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %81)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.92, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
-  %113 = trunc i64 16 to i32  
-  %114 = tail call ccc  i8*  @wybe_malloc(i32  %113)  
-  %115 = ptrtoint i8* %114 to i64 
-  %116 = inttoptr i64 %115 to i8* 
-  %117 = inttoptr i64 %98 to i8* 
-  %118 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %116, i8*  %117, i32  %118, i32  8, i1  0)  
-  %119 = inttoptr i64 %115 to i64* 
-  %120 = getelementptr  i64, i64* %119, i64 0 
-  store  i64 555, i64* %120 
-  %123 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.122, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %123)  
+  %93 = trunc i64 16 to i32  
+  %94 = tail call ccc  i8*  @wybe_malloc(i32  %93)  
+  %95 = ptrtoint i8* %94 to i64 
+  %96 = inttoptr i64 %95 to i8* 
+  %97 = inttoptr i64 %81 to i8* 
+  %98 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %96, i8*  %97, i32  %98, i32  8, i1  0)  
+  %99 = inttoptr i64 %95 to i64* 
+  %100 = getelementptr  i64, i64* %99, i64 0 
+  store  i64 555, i64* %100 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.102, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %126 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.125, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %126)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %115)  
-  %129 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.128, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %129)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.104, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %95)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.106, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
   ret void 
 }
@@ -469,22 +446,21 @@ entry:
 
 define external fastcc  i64 @"alias1.replicate<0>"(i64  %"p1##0")    {
 entry:
-  %130 = trunc i64 16 to i32  
-  %131 = tail call ccc  i8*  @wybe_malloc(i32  %130)  
-  %132 = ptrtoint i8* %131 to i64 
-  %133 = inttoptr i64 %132 to i64* 
-  %134 = getelementptr  i64, i64* %133, i64 0 
-  store  i64 0, i64* %134 
-  %135 = add   i64 %132, 8 
-  %136 = inttoptr i64 %135 to i64* 
-  %137 = getelementptr  i64, i64* %136, i64 0 
-  store  i64 0, i64* %137 
-  %140 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.139, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %140)  
-  %141 = inttoptr i64 %132 to i64* 
-  %142 = getelementptr  i64, i64* %141, i64 0 
-  %143 = load  i64, i64* %142 
-  tail call ccc  void  @print_int(i64  %143)  
+  %107 = trunc i64 16 to i32  
+  %108 = tail call ccc  i8*  @wybe_malloc(i32  %107)  
+  %109 = ptrtoint i8* %108 to i64 
+  %110 = inttoptr i64 %109 to i64* 
+  %111 = getelementptr  i64, i64* %110, i64 0 
+  store  i64 0, i64* %111 
+  %112 = add   i64 %109, 8 
+  %113 = inttoptr i64 %112 to i64* 
+  %114 = getelementptr  i64, i64* %113, i64 0 
+  store  i64 0, i64* %114 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias1.116, i32 0, i32 0) to i64))  
+  %117 = inttoptr i64 %109 to i64* 
+  %118 = getelementptr  i64, i64* %117, i64 0 
+  %119 = load  i64, i64* %118 
+  tail call ccc  void  @print_int(i64  %119)  
   tail call ccc  void  @putchar(i8  10)  
   ret i64 %"p1##0" 
 }
@@ -539,16 +515,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@position.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.14 to i64) }
+@position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.14 =    constant [?? x i8] c")\00"
+@position.12 =    constant [?? x i8] c")\00"
 
 
-@position.8 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.7 to i64) }
+@position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
 
 
-@position.7 =    constant [?? x i8] c",\00"
+@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
@@ -565,21 +541,18 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
-  %4 = inttoptr i64 %"pos##0" to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
-  %10 = add   i64 %"pos##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  tail call ccc  void  @print_int(i64  %13)  
-  %16 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.15, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %16)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64))  
+  %3 = inttoptr i64 %"pos##0" to i64* 
+  %4 = getelementptr  i64, i64* %3, i64 0 
+  %5 = load  i64, i64* %4 
+  tail call ccc  void  @print_int(i64  %5)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.7, i32 0, i32 0) to i64))  
+  %8 = add   i64 %"pos##0", 8 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = getelementptr  i64, i64* %9, i64 0 
+  %11 = load  i64, i64* %10 
+  tail call ccc  void  @print_int(i64  %11)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/alias2.exp
+++ b/test-cases/final-dump/alias2.exp
@@ -77,16 +77,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @putchar(i8)    
 
 
-@alias2.16 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias2.15 to i64) }
+@alias2.14 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias2.13 to i64) }
 
 
-@alias2.15 =    constant [?? x i8] c"expect r(0,20):\00"
+@alias2.13 =    constant [?? x i8] c"expect r(0,20):\00"
 
 
-@alias2.13 =    constant {i64, i64} { i64 25, i64 ptrtoint ([?? x i8]* @alias2.12 to i64) }
+@alias2.12 =    constant {i64, i64} { i64 25, i64 ptrtoint ([?? x i8]* @alias2.11 to i64) }
 
 
-@alias2.12 =    constant [?? x i8] c"--- After calling pcopy: \00"
+@alias2.11 =    constant [?? x i8] c"--- After calling pcopy: \00"
 
 
 @alias2.2 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias2.1 to i64) }
@@ -95,16 +95,16 @@ declare external ccc  void @putchar(i8)
 @alias2.1 =    constant [?? x i8] c"copy a position\00"
 
 
-@alias2.62 =    constant {i64, i64} { i64 16, i64 ptrtoint ([?? x i8]* @alias2.61 to i64) }
+@alias2.58 =    constant {i64, i64} { i64 16, i64 ptrtoint ([?? x i8]* @alias2.57 to i64) }
 
 
-@alias2.61 =    constant [?? x i8] c"expect p2(0,20):\00"
+@alias2.57 =    constant [?? x i8] c"expect p2(0,20):\00"
 
 
-@alias2.59 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias2.58 to i64) }
+@alias2.56 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias2.55 to i64) }
 
 
-@alias2.58 =    constant [?? x i8] c"--- Inside pcopy: \00"
+@alias2.55 =    constant [?? x i8] c"--- Inside pcopy: \00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -115,25 +115,22 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"alias2.<0>"()    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias2.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias2.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %4 = trunc i64 16 to i32  
-  %5 = tail call ccc  i8*  @wybe_malloc(i32  %4)  
-  %6 = ptrtoint i8* %5 to i64 
-  %7 = inttoptr i64 %6 to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  store  i64 0, i64* %8 
-  %9 = add   i64 %6, 8 
-  %10 = inttoptr i64 %9 to i64* 
-  %11 = getelementptr  i64, i64* %10, i64 0 
-  store  i64 20, i64* %11 
-  %"1#r##0" = tail call fastcc  i64  @"alias2.pcopy<0>"(i64  %6)  
-  %14 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias2.13, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %14)  
+  %3 = trunc i64 16 to i32  
+  %4 = tail call ccc  i8*  @wybe_malloc(i32  %3)  
+  %5 = ptrtoint i8* %4 to i64 
+  %6 = inttoptr i64 %5 to i64* 
+  %7 = getelementptr  i64, i64* %6, i64 0 
+  store  i64 0, i64* %7 
+  %8 = add   i64 %5, 8 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = getelementptr  i64, i64* %9, i64 0 
+  store  i64 20, i64* %10 
+  %"1#r##0" = tail call fastcc  i64  @"alias2.pcopy<0>"(i64  %5)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias2.12, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %17 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias2.16, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %17)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias2.14, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#r##0")  
   ret void 
 }
@@ -141,67 +138,65 @@ entry:
 
 define external fastcc  i64 @"alias2.fcopy<0>"(i64  %"p1##0")    {
 entry:
-  %18 = trunc i64 16 to i32  
-  %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
-  %20 = ptrtoint i8* %19 to i64 
+  %15 = trunc i64 16 to i32  
+  %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
+  %17 = ptrtoint i8* %16 to i64 
+  %18 = inttoptr i64 %17 to i64* 
+  %19 = getelementptr  i64, i64* %18, i64 0 
+  store  i64 0, i64* %19 
+  %20 = add   i64 %17, 8 
   %21 = inttoptr i64 %20 to i64* 
   %22 = getelementptr  i64, i64* %21, i64 0 
   store  i64 0, i64* %22 
-  %23 = add   i64 %20, 8 
-  %24 = inttoptr i64 %23 to i64* 
-  %25 = getelementptr  i64, i64* %24, i64 0 
-  store  i64 0, i64* %25 
-  %26 = inttoptr i64 %"p1##0" to i64* 
+  %23 = inttoptr i64 %"p1##0" to i64* 
+  %24 = getelementptr  i64, i64* %23, i64 0 
+  %25 = load  i64, i64* %24 
+  %26 = inttoptr i64 %17 to i64* 
   %27 = getelementptr  i64, i64* %26, i64 0 
-  %28 = load  i64, i64* %27 
-  %29 = inttoptr i64 %20 to i64* 
+  store  i64 %25, i64* %27 
+  %28 = add   i64 %"p1##0", 8 
+  %29 = inttoptr i64 %28 to i64* 
   %30 = getelementptr  i64, i64* %29, i64 0 
-  store  i64 %28, i64* %30 
-  %31 = add   i64 %"p1##0", 8 
-  %32 = inttoptr i64 %31 to i64* 
-  %33 = getelementptr  i64, i64* %32, i64 0 
-  %34 = load  i64, i64* %33 
-  %35 = add   i64 %20, 8 
-  %36 = inttoptr i64 %35 to i64* 
-  %37 = getelementptr  i64, i64* %36, i64 0 
-  store  i64 %34, i64* %37 
-  ret i64 %20 
+  %31 = load  i64, i64* %30 
+  %32 = add   i64 %17, 8 
+  %33 = inttoptr i64 %32 to i64* 
+  %34 = getelementptr  i64, i64* %33, i64 0 
+  store  i64 %31, i64* %34 
+  ret i64 %17 
 }
 
 
 define external fastcc  i64 @"alias2.pcopy<0>"(i64  %"p1##0")    {
 entry:
-  %38 = trunc i64 16 to i32  
-  %39 = tail call ccc  i8*  @wybe_malloc(i32  %38)  
-  %40 = ptrtoint i8* %39 to i64 
+  %35 = trunc i64 16 to i32  
+  %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
+  %37 = ptrtoint i8* %36 to i64 
+  %38 = inttoptr i64 %37 to i64* 
+  %39 = getelementptr  i64, i64* %38, i64 0 
+  store  i64 0, i64* %39 
+  %40 = add   i64 %37, 8 
   %41 = inttoptr i64 %40 to i64* 
   %42 = getelementptr  i64, i64* %41, i64 0 
   store  i64 0, i64* %42 
-  %43 = add   i64 %40, 8 
-  %44 = inttoptr i64 %43 to i64* 
-  %45 = getelementptr  i64, i64* %44, i64 0 
-  store  i64 0, i64* %45 
-  %46 = inttoptr i64 %"p1##0" to i64* 
+  %43 = inttoptr i64 %"p1##0" to i64* 
+  %44 = getelementptr  i64, i64* %43, i64 0 
+  %45 = load  i64, i64* %44 
+  %46 = inttoptr i64 %37 to i64* 
   %47 = getelementptr  i64, i64* %46, i64 0 
-  %48 = load  i64, i64* %47 
-  %49 = inttoptr i64 %40 to i64* 
+  store  i64 %45, i64* %47 
+  %48 = add   i64 %"p1##0", 8 
+  %49 = inttoptr i64 %48 to i64* 
   %50 = getelementptr  i64, i64* %49, i64 0 
-  store  i64 %48, i64* %50 
-  %51 = add   i64 %"p1##0", 8 
-  %52 = inttoptr i64 %51 to i64* 
-  %53 = getelementptr  i64, i64* %52, i64 0 
-  %54 = load  i64, i64* %53 
-  %55 = add   i64 %40, 8 
-  %56 = inttoptr i64 %55 to i64* 
-  %57 = getelementptr  i64, i64* %56, i64 0 
-  store  i64 %54, i64* %57 
-  %60 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias2.59, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %60)  
+  %51 = load  i64, i64* %50 
+  %52 = add   i64 %37, 8 
+  %53 = inttoptr i64 %52 to i64* 
+  %54 = getelementptr  i64, i64* %53, i64 0 
+  store  i64 %51, i64* %54 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias2.56, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %63 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias2.62, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %63)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %40)  
-  ret i64 %40 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias2.58, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %37)  
+  ret i64 %37 
 }
 --------------------------------------------------
  Module position
@@ -254,16 +249,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@position.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.14 to i64) }
+@position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.14 =    constant [?? x i8] c")\00"
+@position.12 =    constant [?? x i8] c")\00"
 
 
-@position.8 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.7 to i64) }
+@position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
 
 
-@position.7 =    constant [?? x i8] c",\00"
+@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
@@ -280,21 +275,18 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
-  %4 = inttoptr i64 %"pos##0" to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
-  %10 = add   i64 %"pos##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  tail call ccc  void  @print_int(i64  %13)  
-  %16 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.15, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %16)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64))  
+  %3 = inttoptr i64 %"pos##0" to i64* 
+  %4 = getelementptr  i64, i64* %3, i64 0 
+  %5 = load  i64, i64* %4 
+  tail call ccc  void  @print_int(i64  %5)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.7, i32 0, i32 0) to i64))  
+  %8 = add   i64 %"pos##0", 8 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = getelementptr  i64, i64* %9, i64 0 
+  %11 = load  i64, i64* %10 
+  tail call ccc  void  @print_int(i64  %11)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/alias3.exp
+++ b/test-cases/final-dump/alias3.exp
@@ -77,34 +77,34 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @putchar(i8)    
 
 
-@alias3.27 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias3.26 to i64) }
+@alias3.22 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias3.21 to i64) }
 
 
-@alias3.26 =    constant [?? x i8] c"expect p2(2,2):\00"
+@alias3.21 =    constant [?? x i8] c"expect p2(2,2):\00"
 
 
-@alias3.24 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias3.23 to i64) }
+@alias3.20 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias3.19 to i64) }
 
 
-@alias3.23 =    constant [?? x i8] c"expect p1(555,1):\00"
+@alias3.19 =    constant [?? x i8] c"expect p1(555,1):\00"
 
 
-@alias3.21 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @alias3.20 to i64) }
+@alias3.18 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @alias3.17 to i64) }
 
 
-@alias3.20 =    constant [?? x i8] c"--- After calling x(!p1, 555): \00"
+@alias3.17 =    constant [?? x i8] c"--- After calling x(!p1, 555): \00"
 
 
-@alias3.16 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias3.15 to i64) }
+@alias3.14 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias3.13 to i64) }
 
 
-@alias3.15 =    constant [?? x i8] c"expect p2(2,2):\00"
+@alias3.13 =    constant [?? x i8] c"expect p2(2,2):\00"
 
 
-@alias3.13 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias3.12 to i64) }
+@alias3.12 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias3.11 to i64) }
 
 
-@alias3.12 =    constant [?? x i8] c"expect p1(1,1):\00"
+@alias3.11 =    constant [?? x i8] c"expect p1(1,1):\00"
 
 
 @alias3.10 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @alias3.9 to i64) }
@@ -113,28 +113,28 @@ declare external ccc  void @putchar(i8)
 @alias3.9 =    constant [?? x i8] c"--- After calling replicate1: \00"
 
 
-@alias3.50 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias3.49 to i64) }
+@alias3.41 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias3.40 to i64) }
 
 
-@alias3.49 =    constant [?? x i8] c"expect p2(2,2):\00"
+@alias3.40 =    constant [?? x i8] c"expect p2(2,2):\00"
 
 
-@alias3.47 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias3.46 to i64) }
+@alias3.39 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias3.38 to i64) }
 
 
-@alias3.46 =    constant [?? x i8] c"expect p1(1,1):\00"
+@alias3.38 =    constant [?? x i8] c"expect p1(1,1):\00"
 
 
-@alias3.33 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias3.32 to i64) }
+@alias3.26 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias3.25 to i64) }
 
 
-@alias3.32 =    constant [?? x i8] c"expect p1(1,1):\00"
+@alias3.25 =    constant [?? x i8] c"expect p1(1,1):\00"
 
 
-@alias3.30 =    constant {i64, i64} { i64 23, i64 ptrtoint ([?? x i8]* @alias3.29 to i64) }
+@alias3.24 =    constant {i64, i64} { i64 23, i64 ptrtoint ([?? x i8]* @alias3.23 to i64) }
 
 
-@alias3.29 =    constant [?? x i8] c"--- Inside replicate1: \00"
+@alias3.23 =    constant [?? x i8] c"--- Inside replicate1: \00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -163,26 +163,20 @@ entry:
   %8 = getelementptr  i64, i64* %7, i64 0 
   store  i64 1, i64* %8 
   %"1#p2##0" = tail call fastcc  i64  @"alias3.replicate1<0>"(i64  %3)  
-  %11 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.10, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %11)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.10, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %14 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.13, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %14)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.12, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %3)  
-  %17 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.16, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %17)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.14, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
-  %18 = inttoptr i64 %3 to i64* 
-  %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 555, i64* %19 
-  %22 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.21, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %22)  
+  %15 = inttoptr i64 %3 to i64* 
+  %16 = getelementptr  i64, i64* %15, i64 0 
+  store  i64 555, i64* %16 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.18, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %25 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.24, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %25)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.20, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %3)  
-  %28 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.27, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %28)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.22, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
   ret void 
 }
@@ -190,33 +184,29 @@ entry:
 
 define external fastcc  i64 @"alias3.replicate1<0>"(i64  %"p1##0")    {
 entry:
-  %31 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.30, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %31)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.24, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %34 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.33, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %34)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.26, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"p1##0")  
-  %35 = trunc i64 16 to i32  
-  %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
-  %37 = ptrtoint i8* %36 to i64 
-  %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"p1##0" to i8* 
-  %40 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
-  %41 = inttoptr i64 %37 to i64* 
-  %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 2, i64* %42 
-  %43 = add   i64 %37, 8 
-  %44 = inttoptr i64 %43 to i64* 
-  %45 = getelementptr  i64, i64* %44, i64 0 
-  store  i64 2, i64* %45 
-  %48 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.47, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %48)  
+  %27 = trunc i64 16 to i32  
+  %28 = tail call ccc  i8*  @wybe_malloc(i32  %27)  
+  %29 = ptrtoint i8* %28 to i64 
+  %30 = inttoptr i64 %29 to i8* 
+  %31 = inttoptr i64 %"p1##0" to i8* 
+  %32 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %30, i8*  %31, i32  %32, i32  8, i1  0)  
+  %33 = inttoptr i64 %29 to i64* 
+  %34 = getelementptr  i64, i64* %33, i64 0 
+  store  i64 2, i64* %34 
+  %35 = add   i64 %29, 8 
+  %36 = inttoptr i64 %35 to i64* 
+  %37 = getelementptr  i64, i64* %36, i64 0 
+  store  i64 2, i64* %37 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.39, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"p1##0")  
-  %51 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.50, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %51)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %37)  
-  ret i64 %37 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias3.41, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %29)  
+  ret i64 %29 
 }
 --------------------------------------------------
  Module position
@@ -269,16 +259,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@position.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.14 to i64) }
+@position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.14 =    constant [?? x i8] c")\00"
+@position.12 =    constant [?? x i8] c")\00"
 
 
-@position.8 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.7 to i64) }
+@position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
 
 
-@position.7 =    constant [?? x i8] c",\00"
+@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
@@ -295,21 +285,18 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
-  %4 = inttoptr i64 %"pos##0" to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
-  %10 = add   i64 %"pos##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  tail call ccc  void  @print_int(i64  %13)  
-  %16 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.15, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %16)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64))  
+  %3 = inttoptr i64 %"pos##0" to i64* 
+  %4 = getelementptr  i64, i64* %3, i64 0 
+  %5 = load  i64, i64* %4 
+  tail call ccc  void  @print_int(i64  %5)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.7, i32 0, i32 0) to i64))  
+  %8 = add   i64 %"pos##0", 8 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = getelementptr  i64, i64* %9, i64 0 
+  %11 = load  i64, i64* %10 
+  tail call ccc  void  @print_int(i64  %11)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/alias4.exp
+++ b/test-cases/final-dump/alias4.exp
@@ -78,34 +78,34 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @putchar(i8)    
 
 
-@alias4.27 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias4.26 to i64) }
+@alias4.22 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias4.21 to i64) }
 
 
-@alias4.26 =    constant [?? x i8] c"expect p2(100,200):\00"
+@alias4.21 =    constant [?? x i8] c"expect p2(100,200):\00"
 
 
-@alias4.24 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias4.23 to i64) }
+@alias4.20 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias4.19 to i64) }
 
 
-@alias4.23 =    constant [?? x i8] c"expect p1(555,100):\00"
+@alias4.19 =    constant [?? x i8] c"expect p1(555,100):\00"
 
 
-@alias4.21 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @alias4.20 to i64) }
+@alias4.18 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @alias4.17 to i64) }
 
 
-@alias4.20 =    constant [?? x i8] c"--- After calling x(!p1, 555): \00"
+@alias4.17 =    constant [?? x i8] c"--- After calling x(!p1, 555): \00"
 
 
-@alias4.16 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias4.15 to i64) }
+@alias4.14 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias4.13 to i64) }
 
 
-@alias4.15 =    constant [?? x i8] c"expect p2(100,200):\00"
+@alias4.13 =    constant [?? x i8] c"expect p2(100,200):\00"
 
 
-@alias4.13 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias4.12 to i64) }
+@alias4.12 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias4.11 to i64) }
 
 
-@alias4.12 =    constant [?? x i8] c"expect p1(100,100):\00"
+@alias4.11 =    constant [?? x i8] c"expect p1(100,100):\00"
 
 
 @alias4.10 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @alias4.9 to i64) }
@@ -117,10 +117,10 @@ declare external ccc  void @putchar(i8)
 declare external ccc  void @print_int(i64)    
 
 
-@alias4.38 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias4.37 to i64) }
+@alias4.32 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias4.31 to i64) }
 
 
-@alias4.37 =    constant [?? x i8] c"random replicate1\00"
+@alias4.31 =    constant [?? x i8] c"random replicate1\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -149,26 +149,20 @@ entry:
   %8 = getelementptr  i64, i64* %7, i64 0 
   store  i64 100, i64* %8 
   %"1#p2##0" = tail call fastcc  i64  @"alias4.replicate1<0>"(i64  %3)  
-  %11 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias4.10, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %11)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias4.10, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %14 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias4.13, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %14)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias4.12, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %3)  
-  %17 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias4.16, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %17)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias4.14, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
-  %18 = inttoptr i64 %3 to i64* 
-  %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 555, i64* %19 
-  %22 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias4.21, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %22)  
+  %15 = inttoptr i64 %3 to i64* 
+  %16 = getelementptr  i64, i64* %15, i64 0 
+  store  i64 555, i64* %16 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias4.18, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %25 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias4.24, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %25)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias4.20, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %3)  
-  %28 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias4.27, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %28)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias4.22, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
   ret void 
 }
@@ -176,35 +170,34 @@ entry:
 
 define external fastcc  i64 @"alias4.replicate1<0>"(i64  %"p1##0")    {
 entry:
-  %29 = trunc i64 16 to i32  
-  %30 = tail call ccc  i8*  @wybe_malloc(i32  %29)  
-  %31 = ptrtoint i8* %30 to i64 
-  %32 = inttoptr i64 %31 to i64* 
-  %33 = getelementptr  i64, i64* %32, i64 0 
-  store  i64 0, i64* %33 
-  %34 = add   i64 %31, 8 
-  %35 = inttoptr i64 %34 to i64* 
-  %36 = getelementptr  i64, i64* %35, i64 0 
-  store  i64 0, i64* %36 
-  %39 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias4.38, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %39)  
+  %23 = trunc i64 16 to i32  
+  %24 = tail call ccc  i8*  @wybe_malloc(i32  %23)  
+  %25 = ptrtoint i8* %24 to i64 
+  %26 = inttoptr i64 %25 to i64* 
+  %27 = getelementptr  i64, i64* %26, i64 0 
+  store  i64 0, i64* %27 
+  %28 = add   i64 %25, 8 
+  %29 = inttoptr i64 %28 to i64* 
+  %30 = getelementptr  i64, i64* %29, i64 0 
+  store  i64 0, i64* %30 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias4.32, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %40 = inttoptr i64 %31 to i64* 
-  %41 = getelementptr  i64, i64* %40, i64 0 
-  %42 = load  i64, i64* %41 
-  tail call ccc  void  @print_int(i64  %42)  
+  %33 = inttoptr i64 %25 to i64* 
+  %34 = getelementptr  i64, i64* %33, i64 0 
+  %35 = load  i64, i64* %34 
+  tail call ccc  void  @print_int(i64  %35)  
   tail call ccc  void  @putchar(i8  10)  
-  %43 = inttoptr i64 %"p1##0" to i64* 
-  %44 = getelementptr  i64, i64* %43, i64 0 
-  %45 = load  i64, i64* %44 
-  %46 = inttoptr i64 %31 to i64* 
-  %47 = getelementptr  i64, i64* %46, i64 0 
-  store  i64 %45, i64* %47 
-  %48 = add   i64 %31, 8 
-  %49 = inttoptr i64 %48 to i64* 
-  %50 = getelementptr  i64, i64* %49, i64 0 
-  store  i64 200, i64* %50 
-  ret i64 %31 
+  %36 = inttoptr i64 %"p1##0" to i64* 
+  %37 = getelementptr  i64, i64* %36, i64 0 
+  %38 = load  i64, i64* %37 
+  %39 = inttoptr i64 %25 to i64* 
+  %40 = getelementptr  i64, i64* %39, i64 0 
+  store  i64 %38, i64* %40 
+  %41 = add   i64 %25, 8 
+  %42 = inttoptr i64 %41 to i64* 
+  %43 = getelementptr  i64, i64* %42, i64 0 
+  store  i64 200, i64* %43 
+  ret i64 %25 
 }
 --------------------------------------------------
  Module position
@@ -257,16 +250,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@position.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.14 to i64) }
+@position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.14 =    constant [?? x i8] c")\00"
+@position.12 =    constant [?? x i8] c")\00"
 
 
-@position.8 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.7 to i64) }
+@position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
 
 
-@position.7 =    constant [?? x i8] c",\00"
+@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
@@ -283,21 +276,18 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
-  %4 = inttoptr i64 %"pos##0" to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
-  %10 = add   i64 %"pos##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  tail call ccc  void  @print_int(i64  %13)  
-  %16 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.15, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %16)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64))  
+  %3 = inttoptr i64 %"pos##0" to i64* 
+  %4 = getelementptr  i64, i64* %3, i64 0 
+  %5 = load  i64, i64* %4 
+  tail call ccc  void  @print_int(i64  %5)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.7, i32 0, i32 0) to i64))  
+  %8 = add   i64 %"pos##0", 8 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = getelementptr  i64, i64* %9, i64 0 
+  %11 = load  i64, i64* %10 
+  tail call ccc  void  @print_int(i64  %11)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/alias5.exp
+++ b/test-cases/final-dump/alias5.exp
@@ -70,22 +70,22 @@ declare external ccc  void @print_int(i64)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@alias5.17 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias5.16 to i64) }
+@alias5.14 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias5.13 to i64) }
 
 
-@alias5.16 =    constant [?? x i8] c"expect p4=45000: \00"
+@alias5.13 =    constant [?? x i8] c"expect p4=45000: \00"
 
 
-@alias5.14 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias5.13 to i64) }
+@alias5.12 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias5.11 to i64) }
 
 
-@alias5.13 =    constant [?? x i8] c"expect p3=100: \00"
+@alias5.11 =    constant [?? x i8] c"expect p3=100: \00"
 
 
-@alias5.11 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias5.10 to i64) }
+@alias5.10 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias5.9 to i64) }
 
 
-@alias5.10 =    constant [?? x i8] c"expect p2=100: \00"
+@alias5.9 =    constant [?? x i8] c"expect p2=100: \00"
 
 
 @alias5.8 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias5.7 to i64) }
@@ -94,10 +94,10 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @alias5.7 =    constant [?? x i8] c"expect p1=111: \00"
 
 
-@alias5.20 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias5.19 to i64) }
+@alias5.16 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias5.15 to i64) }
 
 
-@alias5.19 =    constant [?? x i8] c"random replicate1\00"
+@alias5.15 =    constant [?? x i8] c"random replicate1\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -121,20 +121,16 @@ entry:
   %4 = tail call fastcc  {i64, i64}  @"alias5.replicate1<0>"(i64  100, i64  800)  
   %5 = extractvalue {i64, i64} %4, 0 
   %6 = extractvalue {i64, i64} %4, 1 
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias5.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias5.8, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  111)  
   tail call ccc  void  @putchar(i8  10)  
-  %12 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias5.11, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %12)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias5.10, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %2)  
   tail call ccc  void  @putchar(i8  10)  
-  %15 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias5.14, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %15)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias5.12, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %5)  
   tail call ccc  void  @putchar(i8  10)  
-  %18 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias5.17, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %18)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias5.14, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %6)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -143,14 +139,13 @@ entry:
 
 define external fastcc  {i64, i64} @"alias5.replicate1<0>"(i64  %"v1##0", i64  %"v3##0")    {
 entry:
-  %21 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias5.20, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %21)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias5.16, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  2)  
   tail call ccc  void  @putchar(i8  10)  
   %"1#tmp#0##0" = add   i64 %"v3##0", 100 
   %"1#tmp#2##0" = mul   i64 %"1#tmp#0##0", 200 
   %"1#v4##1" = sdiv exact i64 %"1#tmp#2##0", 4 
-  %22 = insertvalue {i64, i64} undef, i64 %"v1##0", 0 
-  %23 = insertvalue {i64, i64} %22, i64 %"1#v4##1", 1 
-  ret {i64, i64} %23 
+  %17 = insertvalue {i64, i64} undef, i64 %"v1##0", 0 
+  %18 = insertvalue {i64, i64} %17, i64 %"1#v4##1", 1 
+  ret {i64, i64} %18 
 }

--- a/test-cases/final-dump/alias_cyclic.exp
+++ b/test-cases/final-dump/alias_cyclic.exp
@@ -115,10 +115,10 @@ declare external fastcc  void @"position.printPosition<0>"(i64)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@alias_cyclic.13 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @alias_cyclic.12 to i64) }
+@alias_cyclic.12 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @alias_cyclic.11 to i64) }
 
 
-@alias_cyclic.12 =    constant [?? x i8] c"p2(102,900):\00"
+@alias_cyclic.11 =    constant [?? x i8] c"p2(102,900):\00"
 
 
 @alias_cyclic.10 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @alias_cyclic.9 to i64) }
@@ -153,11 +153,9 @@ entry:
   %8 = getelementptr  i64, i64* %7, i64 0 
   store  i64 900, i64* %8 
   %"1#p2##0" = tail call fastcc  i64  @"alias_cyclic.updateX<0>"(i64  %3)  
-  %11 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_cyclic.10, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %11)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_cyclic.10, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %3)  
-  %14 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_cyclic.13, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %14)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_cyclic.12, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
   ret void 
 }
@@ -165,44 +163,44 @@ entry:
 
 define external fastcc  i64 @"alias_cyclic.updateX<0>"(i64  %"p1##0")    {
 entry:
-  %15 = inttoptr i64 %"p1##0" to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  %17 = load  i64, i64* %16 
-  %"1#tmp#3##0" = icmp sgt i64 %17, 101 
+  %13 = inttoptr i64 %"p1##0" to i64* 
+  %14 = getelementptr  i64, i64* %13, i64 0 
+  %15 = load  i64, i64* %14 
+  %"1#tmp#3##0" = icmp sgt i64 %15, 101 
   br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
   ret i64 %"p1##0" 
 if.else:
-  %"3#tmp#2##0" = add   i64 %17, 1 
-  %18 = trunc i64 16 to i32  
-  %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
-  %20 = ptrtoint i8* %19 to i64 
-  %21 = inttoptr i64 %20 to i8* 
-  %22 = inttoptr i64 %"p1##0" to i8* 
-  %23 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %21, i8*  %22, i32  %23, i32  8, i1  0)  
-  %24 = inttoptr i64 %20 to i64* 
-  %25 = getelementptr  i64, i64* %24, i64 0 
-  store  i64 %"3#tmp#2##0", i64* %25 
-  %"3#p2##0" = tail call fastcc  i64  @"alias_cyclic.updateY<0>[410bae77d3]"(i64  %20)  
+  %"3#tmp#2##0" = add   i64 %15, 1 
+  %16 = trunc i64 16 to i32  
+  %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
+  %18 = ptrtoint i8* %17 to i64 
+  %19 = inttoptr i64 %18 to i8* 
+  %20 = inttoptr i64 %"p1##0" to i8* 
+  %21 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %19, i8*  %20, i32  %21, i32  8, i1  0)  
+  %22 = inttoptr i64 %18 to i64* 
+  %23 = getelementptr  i64, i64* %22, i64 0 
+  store  i64 %"3#tmp#2##0", i64* %23 
+  %"3#p2##0" = tail call fastcc  i64  @"alias_cyclic.updateY<0>[410bae77d3]"(i64  %18)  
   ret i64 %"3#p2##0" 
 }
 
 
 define external fastcc  i64 @"alias_cyclic.updateX<0>[410bae77d3]"(i64  %"p1##0")    {
 entry:
-  %26 = inttoptr i64 %"p1##0" to i64* 
-  %27 = getelementptr  i64, i64* %26, i64 0 
-  %28 = load  i64, i64* %27 
-  %"1#tmp#3##0" = icmp sgt i64 %28, 101 
+  %24 = inttoptr i64 %"p1##0" to i64* 
+  %25 = getelementptr  i64, i64* %24, i64 0 
+  %26 = load  i64, i64* %25 
+  %"1#tmp#3##0" = icmp sgt i64 %26, 101 
   br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
   ret i64 %"p1##0" 
 if.else:
-  %"3#tmp#2##0" = add   i64 %28, 1 
-  %29 = inttoptr i64 %"p1##0" to i64* 
-  %30 = getelementptr  i64, i64* %29, i64 0 
-  store  i64 %"3#tmp#2##0", i64* %30 
+  %"3#tmp#2##0" = add   i64 %26, 1 
+  %27 = inttoptr i64 %"p1##0" to i64* 
+  %28 = getelementptr  i64, i64* %27, i64 0 
+  store  i64 %"3#tmp#2##0", i64* %28 
   %"3#p2##0" = tail call fastcc  i64  @"alias_cyclic.updateY<0>[410bae77d3]"(i64  %"p1##0")  
   ret i64 %"3#p2##0" 
 }
@@ -210,48 +208,48 @@ if.else:
 
 define external fastcc  i64 @"alias_cyclic.updateY<0>"(i64  %"p1##0")    {
 entry:
-  %31 = add   i64 %"p1##0", 8 
-  %32 = inttoptr i64 %31 to i64* 
-  %33 = getelementptr  i64, i64* %32, i64 0 
-  %34 = load  i64, i64* %33 
-  %"1#tmp#3##0" = icmp sgt i64 %34, 901 
+  %29 = add   i64 %"p1##0", 8 
+  %30 = inttoptr i64 %29 to i64* 
+  %31 = getelementptr  i64, i64* %30, i64 0 
+  %32 = load  i64, i64* %31 
+  %"1#tmp#3##0" = icmp sgt i64 %32, 901 
   br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
   ret i64 %"p1##0" 
 if.else:
-  %"3#tmp#2##0" = add   i64 %34, 1 
-  %35 = trunc i64 16 to i32  
-  %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
-  %37 = ptrtoint i8* %36 to i64 
-  %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"p1##0" to i8* 
-  %40 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
-  %41 = add   i64 %37, 8 
-  %42 = inttoptr i64 %41 to i64* 
-  %43 = getelementptr  i64, i64* %42, i64 0 
-  store  i64 %"3#tmp#2##0", i64* %43 
-  %"3#p2##0" = tail call fastcc  i64  @"alias_cyclic.updateX<0>[410bae77d3]"(i64  %37)  
+  %"3#tmp#2##0" = add   i64 %32, 1 
+  %33 = trunc i64 16 to i32  
+  %34 = tail call ccc  i8*  @wybe_malloc(i32  %33)  
+  %35 = ptrtoint i8* %34 to i64 
+  %36 = inttoptr i64 %35 to i8* 
+  %37 = inttoptr i64 %"p1##0" to i8* 
+  %38 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %36, i8*  %37, i32  %38, i32  8, i1  0)  
+  %39 = add   i64 %35, 8 
+  %40 = inttoptr i64 %39 to i64* 
+  %41 = getelementptr  i64, i64* %40, i64 0 
+  store  i64 %"3#tmp#2##0", i64* %41 
+  %"3#p2##0" = tail call fastcc  i64  @"alias_cyclic.updateX<0>[410bae77d3]"(i64  %35)  
   ret i64 %"3#p2##0" 
 }
 
 
 define external fastcc  i64 @"alias_cyclic.updateY<0>[410bae77d3]"(i64  %"p1##0")    {
 entry:
-  %44 = add   i64 %"p1##0", 8 
-  %45 = inttoptr i64 %44 to i64* 
-  %46 = getelementptr  i64, i64* %45, i64 0 
-  %47 = load  i64, i64* %46 
-  %"1#tmp#3##0" = icmp sgt i64 %47, 901 
+  %42 = add   i64 %"p1##0", 8 
+  %43 = inttoptr i64 %42 to i64* 
+  %44 = getelementptr  i64, i64* %43, i64 0 
+  %45 = load  i64, i64* %44 
+  %"1#tmp#3##0" = icmp sgt i64 %45, 901 
   br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
   ret i64 %"p1##0" 
 if.else:
-  %"3#tmp#2##0" = add   i64 %47, 1 
-  %48 = add   i64 %"p1##0", 8 
-  %49 = inttoptr i64 %48 to i64* 
-  %50 = getelementptr  i64, i64* %49, i64 0 
-  store  i64 %"3#tmp#2##0", i64* %50 
+  %"3#tmp#2##0" = add   i64 %45, 1 
+  %46 = add   i64 %"p1##0", 8 
+  %47 = inttoptr i64 %46 to i64* 
+  %48 = getelementptr  i64, i64* %47, i64 0 
+  store  i64 %"3#tmp#2##0", i64* %48 
   %"3#p2##0" = tail call fastcc  i64  @"alias_cyclic.updateX<0>[410bae77d3]"(i64  %"p1##0")  
   ret i64 %"3#p2##0" 
 }
@@ -306,16 +304,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@position.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.14 to i64) }
+@position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.14 =    constant [?? x i8] c")\00"
+@position.12 =    constant [?? x i8] c")\00"
 
 
-@position.8 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.7 to i64) }
+@position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
 
 
-@position.7 =    constant [?? x i8] c",\00"
+@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
@@ -332,21 +330,18 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
-  %4 = inttoptr i64 %"pos##0" to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
-  %10 = add   i64 %"pos##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  tail call ccc  void  @print_int(i64  %13)  
-  %16 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.15, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %16)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64))  
+  %3 = inttoptr i64 %"pos##0" to i64* 
+  %4 = getelementptr  i64, i64* %3, i64 0 
+  %5 = load  i64, i64* %4 
+  tail call ccc  void  @print_int(i64  %5)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.7, i32 0, i32 0) to i64))  
+  %8 = add   i64 %"pos##0", 8 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = getelementptr  i64, i64* %9, i64 0 
+  %11 = load  i64, i64* %10 
+  tail call ccc  void  @print_int(i64  %11)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/alias_data.exp
+++ b/test-cases/final-dump/alias_data.exp
@@ -63,16 +63,16 @@ declare external ccc  void @putchar(i8)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@alias_data.24 =    constant {i64, i64} { i64 8, i64 ptrtoint ([?? x i8]* @alias_data.23 to i64) }
+@alias_data.22 =    constant {i64, i64} { i64 8, i64 ptrtoint ([?? x i8]* @alias_data.21 to i64) }
 
 
-@alias_data.23 =    constant [?? x i8] c"student2\00"
+@alias_data.21 =    constant [?? x i8] c"student2\00"
 
 
-@alias_data.21 =    constant {i64, i64} { i64 8, i64 ptrtoint ([?? x i8]* @alias_data.20 to i64) }
+@alias_data.20 =    constant {i64, i64} { i64 8, i64 ptrtoint ([?? x i8]* @alias_data.19 to i64) }
 
 
-@alias_data.20 =    constant [?? x i8] c"student1\00"
+@alias_data.19 =    constant [?? x i8] c"student1\00"
 
 
 @alias_data.10 =    constant {i64, i64} { i64 11, i64 ptrtoint ([?? x i8]* @alias_data.9 to i64) }
@@ -111,26 +111,23 @@ entry:
   %6 = add   i64 %3, 8 
   %7 = inttoptr i64 %6 to i64* 
   %8 = getelementptr  i64, i64* %7, i64 0 
-  %11 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_data.10, i32 0, i32 0) to i64 
-  store  i64 %11, i64* %8 
-  %12 = trunc i64 16 to i32  
-  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
-  %14 = ptrtoint i8* %13 to i64 
-  %15 = inttoptr i64 %14 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  store  i64 9401, i64* %16 
-  %17 = add   i64 %14, 8 
-  %18 = inttoptr i64 %17 to i64* 
-  %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %3, i64* %19 
-  %22 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_data.21, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %22)  
+  store  i64 ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_data.10, i32 0, i32 0) to i64), i64* %8 
+  %11 = trunc i64 16 to i32  
+  %12 = tail call ccc  i8*  @wybe_malloc(i32  %11)  
+  %13 = ptrtoint i8* %12 to i64 
+  %14 = inttoptr i64 %13 to i64* 
+  %15 = getelementptr  i64, i64* %14, i64 0 
+  store  i64 9401, i64* %15 
+  %16 = add   i64 %13, 8 
+  %17 = inttoptr i64 %16 to i64* 
+  %18 = getelementptr  i64, i64* %17, i64 0 
+  store  i64 %3, i64* %18 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_data.20, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"student.printStudent<0>"(i64  %14)  
-  %25 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_data.24, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %25)  
+  tail call fastcc  void  @"student.printStudent<0>"(i64  %13)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_data.22, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"student.printStudent<0>"(i64  %14)  
+  tail call fastcc  void  @"student.printStudent<0>"(i64  %13)  
   ret void 
 }
 --------------------------------------------------
@@ -220,22 +217,22 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@student.37 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @student.36 to i64) }
+@student.34 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @student.33 to i64) }
 
 
-@student.36 =    constant [?? x i8] c"course name: \00"
+@student.33 =    constant [?? x i8] c"course name: \00"
 
 
-@student.31 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @student.30 to i64) }
+@student.29 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @student.28 to i64) }
 
 
-@student.30 =    constant [?? x i8] c"course code: \00"
+@student.28 =    constant [?? x i8] c"course code: \00"
 
 
-@student.21 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @student.20 to i64) }
+@student.20 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @student.19 to i64) }
 
 
-@student.20 =    constant [?? x i8] c"student id: \00"
+@student.19 =    constant [?? x i8] c"student id: \00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -255,50 +252,46 @@ entry:
   %6 = add   i64 %3, 8 
   %7 = inttoptr i64 %6 to i64* 
   %8 = getelementptr  i64, i64* %7, i64 0 
-  %11 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @student.10, i32 0, i32 0) to i64 
-  store  i64 %11, i64* %8 
-  %12 = trunc i64 16 to i32  
-  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
-  %14 = ptrtoint i8* %13 to i64 
-  %15 = inttoptr i64 %14 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  store  i64 12345, i64* %16 
-  %17 = add   i64 %14, 8 
-  %18 = inttoptr i64 %17 to i64* 
-  %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %3, i64* %19 
-  tail call fastcc  void  @"student.printStudent<0>"(i64  %14)  
+  store  i64 ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @student.10, i32 0, i32 0) to i64), i64* %8 
+  %11 = trunc i64 16 to i32  
+  %12 = tail call ccc  i8*  @wybe_malloc(i32  %11)  
+  %13 = ptrtoint i8* %12 to i64 
+  %14 = inttoptr i64 %13 to i64* 
+  %15 = getelementptr  i64, i64* %14, i64 0 
+  store  i64 12345, i64* %15 
+  %16 = add   i64 %13, 8 
+  %17 = inttoptr i64 %16 to i64* 
+  %18 = getelementptr  i64, i64* %17, i64 0 
+  store  i64 %3, i64* %18 
+  tail call fastcc  void  @"student.printStudent<0>"(i64  %13)  
   ret void 
 }
 
 
 define external fastcc  void @"student.printStudent<0>"(i64  %"stu##0")    {
 entry:
-  %22 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @student.21, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %22)  
-  %23 = inttoptr i64 %"stu##0" to i64* 
-  %24 = getelementptr  i64, i64* %23, i64 0 
-  %25 = load  i64, i64* %24 
-  tail call ccc  void  @print_int(i64  %25)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @student.20, i32 0, i32 0) to i64))  
+  %21 = inttoptr i64 %"stu##0" to i64* 
+  %22 = getelementptr  i64, i64* %21, i64 0 
+  %23 = load  i64, i64* %22 
+  tail call ccc  void  @print_int(i64  %23)  
   tail call ccc  void  @putchar(i8  10)  
-  %26 = add   i64 %"stu##0", 8 
-  %27 = inttoptr i64 %26 to i64* 
-  %28 = getelementptr  i64, i64* %27, i64 0 
-  %29 = load  i64, i64* %28 
-  %32 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @student.31, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %32)  
-  %33 = inttoptr i64 %29 to i64* 
-  %34 = getelementptr  i64, i64* %33, i64 0 
-  %35 = load  i64, i64* %34 
-  tail call ccc  void  @print_int(i64  %35)  
+  %24 = add   i64 %"stu##0", 8 
+  %25 = inttoptr i64 %24 to i64* 
+  %26 = getelementptr  i64, i64* %25, i64 0 
+  %27 = load  i64, i64* %26 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @student.29, i32 0, i32 0) to i64))  
+  %30 = inttoptr i64 %27 to i64* 
+  %31 = getelementptr  i64, i64* %30, i64 0 
+  %32 = load  i64, i64* %31 
+  tail call ccc  void  @print_int(i64  %32)  
   tail call ccc  void  @putchar(i8  10)  
-  %38 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @student.37, i32 0, i32 0) to i64 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @student.34, i32 0, i32 0) to i64))  
+  %35 = add   i64 %27, 8 
+  %36 = inttoptr i64 %35 to i64* 
+  %37 = getelementptr  i64, i64* %36, i64 0 
+  %38 = load  i64, i64* %37 
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %38)  
-  %39 = add   i64 %29, 8 
-  %40 = inttoptr i64 %39 to i64* 
-  %41 = getelementptr  i64, i64* %40, i64 0 
-  %42 = load  i64, i64* %41 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %42)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/alias_des.exp
+++ b/test-cases/final-dump/alias_des.exp
@@ -72,16 +72,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @alias_des.3 =    constant [?? x i8] c"--- after x(!p2, 20000) - expect p2(20000,103):\00"
 
 
-@alias_des.38 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_des.37 to i64) }
+@alias_des.36 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_des.35 to i64) }
 
 
-@alias_des.37 =    constant [?? x i8] c"expect p2(101,103):\00"
+@alias_des.35 =    constant [?? x i8] c"expect p2(101,103):\00"
 
 
-@alias_des.35 =    constant {i64, i64} { i64 21, i64 ptrtoint ([?? x i8]* @alias_des.34 to i64) }
+@alias_des.34 =    constant {i64, i64} { i64 21, i64 ptrtoint ([?? x i8]* @alias_des.33 to i64) }
 
 
-@alias_des.34 =    constant [?? x i8] c"expect p1(10000,102):\00"
+@alias_des.33 =    constant [?? x i8] c"expect p1(10000,102):\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -103,8 +103,7 @@ entry:
   %1 = inttoptr i64 %"1#p2##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   store  i64 20000, i64* %2 
-  %5 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_des.4, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %5)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_des.4, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
   ret void 
 }
@@ -112,48 +111,46 @@ entry:
 
 define external fastcc  i64 @"alias_des.replicate<0>"()    {
 entry:
-  %6 = trunc i64 16 to i32  
-  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
-  %8 = ptrtoint i8* %7 to i64 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 101, i64* %10 
-  %11 = add   i64 %8, 8 
-  %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 102, i64* %13 
-  %14 = inttoptr i64 %8 to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  %16 = load  i64, i64* %15 
-  %17 = trunc i64 16 to i32  
-  %18 = tail call ccc  i8*  @wybe_malloc(i32  %17)  
-  %19 = ptrtoint i8* %18 to i64 
-  %20 = inttoptr i64 %19 to i64* 
-  %21 = getelementptr  i64, i64* %20, i64 0 
-  store  i64 %16, i64* %21 
-  %22 = add   i64 %19, 8 
-  %23 = inttoptr i64 %22 to i64* 
-  %24 = getelementptr  i64, i64* %23, i64 0 
-  store  i64 102, i64* %24 
-  %25 = inttoptr i64 %8 to i64* 
-  %26 = getelementptr  i64, i64* %25, i64 0 
-  store  i64 10000, i64* %26 
-  %27 = add   i64 %8, 8 
-  %28 = inttoptr i64 %27 to i64* 
-  %29 = getelementptr  i64, i64* %28, i64 0 
-  %30 = load  i64, i64* %29 
-  %"1#tmp#4##0" = add   i64 %30, 1 
-  %31 = add   i64 %19, 8 
-  %32 = inttoptr i64 %31 to i64* 
-  %33 = getelementptr  i64, i64* %32, i64 0 
-  store  i64 %"1#tmp#4##0", i64* %33 
-  %36 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_des.35, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %36)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %8)  
-  %39 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_des.38, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %39)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %19)  
-  ret i64 %19 
+  %5 = trunc i64 16 to i32  
+  %6 = tail call ccc  i8*  @wybe_malloc(i32  %5)  
+  %7 = ptrtoint i8* %6 to i64 
+  %8 = inttoptr i64 %7 to i64* 
+  %9 = getelementptr  i64, i64* %8, i64 0 
+  store  i64 101, i64* %9 
+  %10 = add   i64 %7, 8 
+  %11 = inttoptr i64 %10 to i64* 
+  %12 = getelementptr  i64, i64* %11, i64 0 
+  store  i64 102, i64* %12 
+  %13 = inttoptr i64 %7 to i64* 
+  %14 = getelementptr  i64, i64* %13, i64 0 
+  %15 = load  i64, i64* %14 
+  %16 = trunc i64 16 to i32  
+  %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
+  %18 = ptrtoint i8* %17 to i64 
+  %19 = inttoptr i64 %18 to i64* 
+  %20 = getelementptr  i64, i64* %19, i64 0 
+  store  i64 %15, i64* %20 
+  %21 = add   i64 %18, 8 
+  %22 = inttoptr i64 %21 to i64* 
+  %23 = getelementptr  i64, i64* %22, i64 0 
+  store  i64 102, i64* %23 
+  %24 = inttoptr i64 %7 to i64* 
+  %25 = getelementptr  i64, i64* %24, i64 0 
+  store  i64 10000, i64* %25 
+  %26 = add   i64 %7, 8 
+  %27 = inttoptr i64 %26 to i64* 
+  %28 = getelementptr  i64, i64* %27, i64 0 
+  %29 = load  i64, i64* %28 
+  %"1#tmp#4##0" = add   i64 %29, 1 
+  %30 = add   i64 %18, 8 
+  %31 = inttoptr i64 %30 to i64* 
+  %32 = getelementptr  i64, i64* %31, i64 0 
+  store  i64 %"1#tmp#4##0", i64* %32 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_des.34, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %7)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_des.36, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %18)  
+  ret i64 %18 
 }
 --------------------------------------------------
  Module position
@@ -206,16 +203,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@position.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.14 to i64) }
+@position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.14 =    constant [?? x i8] c")\00"
+@position.12 =    constant [?? x i8] c")\00"
 
 
-@position.8 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.7 to i64) }
+@position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
 
 
-@position.7 =    constant [?? x i8] c",\00"
+@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
@@ -232,21 +229,18 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
-  %4 = inttoptr i64 %"pos##0" to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
-  %10 = add   i64 %"pos##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  tail call ccc  void  @print_int(i64  %13)  
-  %16 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.15, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %16)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64))  
+  %3 = inttoptr i64 %"pos##0" to i64* 
+  %4 = getelementptr  i64, i64* %3, i64 0 
+  %5 = load  i64, i64* %4 
+  tail call ccc  void  @print_int(i64  %5)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.7, i32 0, i32 0) to i64))  
+  %8 = add   i64 %"pos##0", 8 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = getelementptr  i64, i64* %9, i64 0 
+  %11 = load  i64, i64* %10 
+  tail call ccc  void  @print_int(i64  %11)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/alias_des2.exp
+++ b/test-cases/final-dump/alias_des2.exp
@@ -63,8 +63,7 @@ entry:
   %9 = inttoptr i64 %3 to i64* 
   %10 = getelementptr  i64, i64* %9, i64 0 
   store  i64 200, i64* %10 
-  %13 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_des2.12, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %13)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_des2.12, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %3)  
   ret void 
 }
@@ -119,16 +118,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@position.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.14 to i64) }
+@position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.14 =    constant [?? x i8] c")\00"
+@position.12 =    constant [?? x i8] c")\00"
 
 
-@position.8 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.7 to i64) }
+@position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
 
 
-@position.7 =    constant [?? x i8] c",\00"
+@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
@@ -145,21 +144,18 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
-  %4 = inttoptr i64 %"pos##0" to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
-  %10 = add   i64 %"pos##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  tail call ccc  void  @print_int(i64  %13)  
-  %16 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.15, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %16)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64))  
+  %3 = inttoptr i64 %"pos##0" to i64* 
+  %4 = getelementptr  i64, i64* %3, i64 0 
+  %5 = load  i64, i64* %4 
+  tail call ccc  void  @print_int(i64  %5)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.7, i32 0, i32 0) to i64))  
+  %8 = add   i64 %"pos##0", 8 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = getelementptr  i64, i64* %9, i64 0 
+  %11 = load  i64, i64* %10 
+  tail call ccc  void  @print_int(i64  %11)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/alias_fork1.exp
+++ b/test-cases/final-dump/alias_fork1.exp
@@ -99,10 +99,10 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external fastcc  i64 @"mytree.printTree1<0>"(i64, i64)    
 
 
-@alias_fork1.27 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork1.26 to i64) }
+@alias_fork1.26 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork1.25 to i64) }
 
 
-@alias_fork1.26 =    constant [?? x i8] c"}\00"
+@alias_fork1.25 =    constant [?? x i8] c"}\00"
 
 
 @alias_fork1.24 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork1.23 to i64) }
@@ -148,10 +148,8 @@ entry:
   %22 = getelementptr  i64, i64* %21, i64 0 
   store  i64 0, i64* %22 
   %"1#tmp#6##0" = tail call fastcc  i64  @"alias_fork1.simpleMerge<0>"(i64  %3, i64  %14)  
-  %25 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork1.24, i32 0, i32 0) to i64 
-  %"1#tmp#21##0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"1#tmp#6##0", i64  %25)  
-  %28 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork1.27, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %28)  
+  %"1#tmp#21##0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"1#tmp#6##0", i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork1.24, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork1.26, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -168,91 +166,91 @@ entry:
   %"1#tmp#15##0" = icmp ne i64 %"tl##0", 0 
   br i1 %"1#tmp#15##0", label %if.then, label %if.else 
 if.then:
-  %29 = add   i64 %"tl##0", 8 
-  %30 = inttoptr i64 %29 to i64* 
-  %31 = getelementptr  i64, i64* %30, i64 0 
-  %32 = load  i64, i64* %31 
-  %33 = add   i64 %"tl##0", 16 
-  %34 = inttoptr i64 %33 to i64* 
-  %35 = getelementptr  i64, i64* %34, i64 0 
-  %36 = load  i64, i64* %35 
+  %27 = add   i64 %"tl##0", 8 
+  %28 = inttoptr i64 %27 to i64* 
+  %29 = getelementptr  i64, i64* %28, i64 0 
+  %30 = load  i64, i64* %29 
+  %31 = add   i64 %"tl##0", 16 
+  %32 = inttoptr i64 %31 to i64* 
+  %33 = getelementptr  i64, i64* %32, i64 0 
+  %34 = load  i64, i64* %33 
   %"2#tmp#17##0" = icmp ne i64 %"tr##0", 0 
   br i1 %"2#tmp#17##0", label %if.then1, label %if.else1 
 if.else:
-  %78 = trunc i64 24 to i32  
-  %79 = tail call ccc  i8*  @wybe_malloc(i32  %78)  
-  %80 = ptrtoint i8* %79 to i64 
-  %81 = inttoptr i64 %80 to i64* 
-  %82 = getelementptr  i64, i64* %81, i64 0 
-  store  i64 0, i64* %82 
-  %83 = add   i64 %80, 8 
-  %84 = inttoptr i64 %83 to i64* 
-  %85 = getelementptr  i64, i64* %84, i64 0 
-  store  i64 0, i64* %85 
-  %86 = add   i64 %80, 16 
-  %87 = inttoptr i64 %86 to i64* 
-  %88 = getelementptr  i64, i64* %87, i64 0 
-  store  i64 0, i64* %88 
-  ret i64 %80 
+  %76 = trunc i64 24 to i32  
+  %77 = tail call ccc  i8*  @wybe_malloc(i32  %76)  
+  %78 = ptrtoint i8* %77 to i64 
+  %79 = inttoptr i64 %78 to i64* 
+  %80 = getelementptr  i64, i64* %79, i64 0 
+  store  i64 0, i64* %80 
+  %81 = add   i64 %78, 8 
+  %82 = inttoptr i64 %81 to i64* 
+  %83 = getelementptr  i64, i64* %82, i64 0 
+  store  i64 0, i64* %83 
+  %84 = add   i64 %78, 16 
+  %85 = inttoptr i64 %84 to i64* 
+  %86 = getelementptr  i64, i64* %85, i64 0 
+  store  i64 0, i64* %86 
+  ret i64 %78 
 if.then1:
-  %37 = add   i64 %"tr##0", 8 
-  %38 = inttoptr i64 %37 to i64* 
-  %39 = getelementptr  i64, i64* %38, i64 0 
-  %40 = load  i64, i64* %39 
-  %41 = add   i64 %"tr##0", 16 
-  %42 = inttoptr i64 %41 to i64* 
-  %43 = getelementptr  i64, i64* %42, i64 0 
-  %44 = load  i64, i64* %43 
-  %"4#tmp#11##0" = icmp slt i64 %32, %40 
+  %35 = add   i64 %"tr##0", 8 
+  %36 = inttoptr i64 %35 to i64* 
+  %37 = getelementptr  i64, i64* %36, i64 0 
+  %38 = load  i64, i64* %37 
+  %39 = add   i64 %"tr##0", 16 
+  %40 = inttoptr i64 %39 to i64* 
+  %41 = getelementptr  i64, i64* %40, i64 0 
+  %42 = load  i64, i64* %41 
+  %"4#tmp#11##0" = icmp slt i64 %30, %38 
   br i1 %"4#tmp#11##0", label %if.then2, label %if.else2 
 if.else1:
-  %67 = trunc i64 24 to i32  
-  %68 = tail call ccc  i8*  @wybe_malloc(i32  %67)  
-  %69 = ptrtoint i8* %68 to i64 
-  %70 = inttoptr i64 %69 to i64* 
-  %71 = getelementptr  i64, i64* %70, i64 0 
-  store  i64 0, i64* %71 
-  %72 = add   i64 %69, 8 
-  %73 = inttoptr i64 %72 to i64* 
-  %74 = getelementptr  i64, i64* %73, i64 0 
-  store  i64 0, i64* %74 
-  %75 = add   i64 %69, 16 
-  %76 = inttoptr i64 %75 to i64* 
-  %77 = getelementptr  i64, i64* %76, i64 0 
-  store  i64 0, i64* %77 
-  ret i64 %69 
+  %65 = trunc i64 24 to i32  
+  %66 = tail call ccc  i8*  @wybe_malloc(i32  %65)  
+  %67 = ptrtoint i8* %66 to i64 
+  %68 = inttoptr i64 %67 to i64* 
+  %69 = getelementptr  i64, i64* %68, i64 0 
+  store  i64 0, i64* %69 
+  %70 = add   i64 %67, 8 
+  %71 = inttoptr i64 %70 to i64* 
+  %72 = getelementptr  i64, i64* %71, i64 0 
+  store  i64 0, i64* %72 
+  %73 = add   i64 %67, 16 
+  %74 = inttoptr i64 %73 to i64* 
+  %75 = getelementptr  i64, i64* %74, i64 0 
+  store  i64 0, i64* %75 
+  ret i64 %67 
 if.then2:
-  %45 = trunc i64 24 to i32  
-  %46 = tail call ccc  i8*  @wybe_malloc(i32  %45)  
-  %47 = ptrtoint i8* %46 to i64 
-  %48 = inttoptr i64 %47 to i64* 
-  %49 = getelementptr  i64, i64* %48, i64 0 
-  store  i64 %"tl##0", i64* %49 
-  %50 = add   i64 %47, 8 
-  %51 = inttoptr i64 %50 to i64* 
-  %52 = getelementptr  i64, i64* %51, i64 0 
-  store  i64 %40, i64* %52 
-  %53 = add   i64 %47, 16 
-  %54 = inttoptr i64 %53 to i64* 
-  %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %44, i64* %55 
-  ret i64 %47 
+  %43 = trunc i64 24 to i32  
+  %44 = tail call ccc  i8*  @wybe_malloc(i32  %43)  
+  %45 = ptrtoint i8* %44 to i64 
+  %46 = inttoptr i64 %45 to i64* 
+  %47 = getelementptr  i64, i64* %46, i64 0 
+  store  i64 %"tl##0", i64* %47 
+  %48 = add   i64 %45, 8 
+  %49 = inttoptr i64 %48 to i64* 
+  %50 = getelementptr  i64, i64* %49, i64 0 
+  store  i64 %38, i64* %50 
+  %51 = add   i64 %45, 16 
+  %52 = inttoptr i64 %51 to i64* 
+  %53 = getelementptr  i64, i64* %52, i64 0 
+  store  i64 %42, i64* %53 
+  ret i64 %45 
 if.else2:
-  %56 = trunc i64 24 to i32  
-  %57 = tail call ccc  i8*  @wybe_malloc(i32  %56)  
-  %58 = ptrtoint i8* %57 to i64 
-  %59 = inttoptr i64 %58 to i64* 
-  %60 = getelementptr  i64, i64* %59, i64 0 
-  store  i64 %"tr##0", i64* %60 
-  %61 = add   i64 %58, 8 
-  %62 = inttoptr i64 %61 to i64* 
-  %63 = getelementptr  i64, i64* %62, i64 0 
-  store  i64 %32, i64* %63 
-  %64 = add   i64 %58, 16 
-  %65 = inttoptr i64 %64 to i64* 
-  %66 = getelementptr  i64, i64* %65, i64 0 
-  store  i64 %36, i64* %66 
-  ret i64 %58 
+  %54 = trunc i64 24 to i32  
+  %55 = tail call ccc  i8*  @wybe_malloc(i32  %54)  
+  %56 = ptrtoint i8* %55 to i64 
+  %57 = inttoptr i64 %56 to i64* 
+  %58 = getelementptr  i64, i64* %57, i64 0 
+  store  i64 %"tr##0", i64* %58 
+  %59 = add   i64 %56, 8 
+  %60 = inttoptr i64 %59 to i64* 
+  %61 = getelementptr  i64, i64* %60, i64 0 
+  store  i64 %30, i64* %61 
+  %62 = add   i64 %56, 16 
+  %63 = inttoptr i64 %62 to i64* 
+  %64 = getelementptr  i64, i64* %63, i64 0 
+  store  i64 %34, i64* %64 
+  ret i64 %56 
 }
 --------------------------------------------------
  Module mytree
@@ -319,10 +317,10 @@ printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string, io##
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@mytree.5 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @mytree.4 to i64) }
+@mytree.4 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @mytree.3 to i64) }
 
 
-@mytree.4 =    constant [?? x i8] c"}\00"
+@mytree.3 =    constant [?? x i8] c"}\00"
 
 
 @mytree.2 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @mytree.1 to i64) }
@@ -334,10 +332,10 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@mytree.19 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @mytree.18 to i64) }
+@mytree.17 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @mytree.16 to i64) }
 
 
-@mytree.18 =    constant [?? x i8] c", \00"
+@mytree.16 =    constant [?? x i8] c", \00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -348,10 +346,8 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"mytree.printTree<0>"(i64  %"t##0")    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.2, i32 0, i32 0) to i64 
-  %"1#prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t##0", i64  %3)  
-  %6 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.5, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %6)  
+  %"1#prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t##0", i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.2, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.4, i32 0, i32 0) to i64))  
   ret void 
 }
 
@@ -361,22 +357,21 @@ entry:
   %"1#tmp#2##0" = icmp ne i64 %"t##0", 0 
   br i1 %"1#tmp#2##0", label %if.then, label %if.else 
 if.then:
-  %7 = inttoptr i64 %"t##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  %9 = load  i64, i64* %8 
-  %10 = add   i64 %"t##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = add   i64 %"t##0", 16 
-  %15 = inttoptr i64 %14 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  %17 = load  i64, i64* %16 
-  %"2#prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %9, i64  %"prefix##0")  
+  %5 = inttoptr i64 %"t##0" to i64* 
+  %6 = getelementptr  i64, i64* %5, i64 0 
+  %7 = load  i64, i64* %6 
+  %8 = add   i64 %"t##0", 8 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = getelementptr  i64, i64* %9, i64 0 
+  %11 = load  i64, i64* %10 
+  %12 = add   i64 %"t##0", 16 
+  %13 = inttoptr i64 %12 to i64* 
+  %14 = getelementptr  i64, i64* %13, i64 0 
+  %15 = load  i64, i64* %14 
+  %"2#prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %7, i64  %"prefix##0")  
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %"2#prefix##1")  
-  tail call ccc  void  @print_int(i64  %13)  
-  %20 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.19, i32 0, i32 0) to i64 
-  %"2#prefix##3" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %17, i64  %20)  
+  tail call ccc  void  @print_int(i64  %11)  
+  %"2#prefix##3" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %15, i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.17, i32 0, i32 0) to i64))  
   ret i64 %"2#prefix##3" 
 if.else:
   ret i64 %"prefix##0" 

--- a/test-cases/final-dump/alias_fork2.exp
+++ b/test-cases/final-dump/alias_fork2.exp
@@ -88,22 +88,22 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external fastcc  i64 @"mytree.printTree1<0>"(i64, i64)    
 
 
-@alias_fork2.22 =    constant {i64, i64} { i64 0, i64 ptrtoint ([?? x i8]* @alias_fork2.21 to i64) }
+@alias_fork2.19 =    constant {i64, i64} { i64 0, i64 ptrtoint ([?? x i8]* @alias_fork2.18 to i64) }
 
 
-@alias_fork2.21 =    constant [?? x i8] c"\00"
+@alias_fork2.18 =    constant [?? x i8] c"\00"
 
 
-@alias_fork2.19 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork2.18 to i64) }
+@alias_fork2.17 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork2.16 to i64) }
 
 
-@alias_fork2.18 =    constant [?? x i8] c"}\00"
+@alias_fork2.16 =    constant [?? x i8] c"}\00"
 
 
-@alias_fork2.16 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork2.15 to i64) }
+@alias_fork2.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork2.14 to i64) }
 
 
-@alias_fork2.15 =    constant [?? x i8] c"{\00"
+@alias_fork2.14 =    constant [?? x i8] c"{\00"
 
 
 @alias_fork2.13 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias_fork2.12 to i64) }
@@ -112,52 +112,52 @@ declare external fastcc  i64 @"mytree.printTree1<0>"(i64, i64)
 @alias_fork2.12 =    constant [?? x i8] c"expect t -  1 200:\00"
 
 
-@alias_fork2.60 =    constant {i64, i64} { i64 0, i64 ptrtoint ([?? x i8]* @alias_fork2.59 to i64) }
+@alias_fork2.49 =    constant {i64, i64} { i64 0, i64 ptrtoint ([?? x i8]* @alias_fork2.48 to i64) }
 
 
-@alias_fork2.59 =    constant [?? x i8] c"\00"
+@alias_fork2.48 =    constant [?? x i8] c"\00"
 
 
-@alias_fork2.57 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork2.56 to i64) }
+@alias_fork2.47 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork2.46 to i64) }
 
 
-@alias_fork2.56 =    constant [?? x i8] c"}\00"
-
-
-@alias_fork2.54 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork2.53 to i64) }
-
-
-@alias_fork2.53 =    constant [?? x i8] c"{\00"
-
-
-@alias_fork2.51 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias_fork2.50 to i64) }
-
-
-@alias_fork2.50 =    constant [?? x i8] c"expect t1 - 1 200:\00"
-
-
-@alias_fork2.48 =    constant {i64, i64} { i64 0, i64 ptrtoint ([?? x i8]* @alias_fork2.47 to i64) }
-
-
-@alias_fork2.47 =    constant [?? x i8] c"\00"
+@alias_fork2.46 =    constant [?? x i8] c"}\00"
 
 
 @alias_fork2.45 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork2.44 to i64) }
 
 
-@alias_fork2.44 =    constant [?? x i8] c"}\00"
+@alias_fork2.44 =    constant [?? x i8] c"{\00"
 
 
-@alias_fork2.42 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork2.41 to i64) }
+@alias_fork2.43 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias_fork2.42 to i64) }
 
 
-@alias_fork2.41 =    constant [?? x i8] c"{\00"
+@alias_fork2.42 =    constant [?? x i8] c"expect t1 - 1 200:\00"
 
 
-@alias_fork2.39 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_fork2.38 to i64) }
+@alias_fork2.41 =    constant {i64, i64} { i64 0, i64 ptrtoint ([?? x i8]* @alias_fork2.40 to i64) }
 
 
-@alias_fork2.38 =    constant [?? x i8] c"expect t1 - 1000:\00"
+@alias_fork2.40 =    constant [?? x i8] c"\00"
+
+
+@alias_fork2.39 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork2.38 to i64) }
+
+
+@alias_fork2.38 =    constant [?? x i8] c"}\00"
+
+
+@alias_fork2.37 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork2.36 to i64) }
+
+
+@alias_fork2.36 =    constant [?? x i8] c"{\00"
+
+
+@alias_fork2.35 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_fork2.34 to i64) }
+
+
+@alias_fork2.34 =    constant [?? x i8] c"expect t1 - 1000:\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -183,37 +183,33 @@ entry:
   %11 = getelementptr  i64, i64* %10, i64 0 
   store  i64 0, i64* %11 
   %"1#tmp#3##0" = tail call fastcc  i64  @"alias_fork2.simpleMerge<0>"(i64  %3)  
-  %14 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.13, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %14)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %17 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.16, i32 0, i32 0) to i64 
-  %"1#tmp#17##0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"1#tmp#3##0", i64  %17)  
-  %20 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.19, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %20)  
-  %23 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.22, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %23)  
+  %"1#tmp#17##0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"1#tmp#3##0", i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.15, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.17, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.19, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   %"1#tmp#23##0" = icmp ne i64 %3, 0 
   br i1 %"1#tmp#23##0", label %if.then, label %if.else 
 if.then:
-  %24 = inttoptr i64 %3 to i64* 
-  %25 = getelementptr  i64, i64* %24, i64 0 
-  %26 = load  i64, i64* %25 
-  %27 = trunc i64 24 to i32  
-  %28 = tail call ccc  i8*  @wybe_malloc(i32  %27)  
-  %29 = ptrtoint i8* %28 to i64 
-  %30 = inttoptr i64 %29 to i64* 
-  %31 = getelementptr  i64, i64* %30, i64 0 
-  store  i64 %26, i64* %31 
-  %32 = add   i64 %29, 8 
-  %33 = inttoptr i64 %32 to i64* 
-  %34 = getelementptr  i64, i64* %33, i64 0 
-  store  i64 1000, i64* %34 
-  %35 = add   i64 %29, 16 
-  %36 = inttoptr i64 %35 to i64* 
-  %37 = getelementptr  i64, i64* %36, i64 0 
-  store  i64 0, i64* %37 
-  tail call fastcc  void  @"alias_fork2.gen#1<0>"(i64  %"1#tmp#3##0", i64  %29)  
+  %20 = inttoptr i64 %3 to i64* 
+  %21 = getelementptr  i64, i64* %20, i64 0 
+  %22 = load  i64, i64* %21 
+  %23 = trunc i64 24 to i32  
+  %24 = tail call ccc  i8*  @wybe_malloc(i32  %23)  
+  %25 = ptrtoint i8* %24 to i64 
+  %26 = inttoptr i64 %25 to i64* 
+  %27 = getelementptr  i64, i64* %26, i64 0 
+  store  i64 %22, i64* %27 
+  %28 = add   i64 %25, 8 
+  %29 = inttoptr i64 %28 to i64* 
+  %30 = getelementptr  i64, i64* %29, i64 0 
+  store  i64 1000, i64* %30 
+  %31 = add   i64 %25, 16 
+  %32 = inttoptr i64 %31 to i64* 
+  %33 = getelementptr  i64, i64* %32, i64 0 
+  store  i64 0, i64* %33 
+  tail call fastcc  void  @"alias_fork2.gen#1<0>"(i64  %"1#tmp#3##0", i64  %25)  
   ret void 
 if.else:
   tail call fastcc  void  @"alias_fork2.gen#1<0>"(i64  %"1#tmp#3##0", i64  %3)  
@@ -223,25 +219,17 @@ if.else:
 
 define external fastcc  void @"alias_fork2.gen#1<0>"(i64  %"t##0", i64  %"t1##0")    {
 entry:
-  %40 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.39, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %40)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.35, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %43 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.42, i32 0, i32 0) to i64 
-  %"1#tmp#10##0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t1##0", i64  %43)  
-  %46 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.45, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %46)  
-  %49 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.48, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %49)  
+  %"1#tmp#10##0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t1##0", i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.37, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.39, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.41, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %52 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.51, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %52)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.43, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %55 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.54, i32 0, i32 0) to i64 
-  %"1#tmp#20##0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t##0", i64  %55)  
-  %58 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.57, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %58)  
-  %61 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.60, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %61)  
+  %"1#tmp#20##0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t##0", i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.45, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.47, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork2.49, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -249,21 +237,21 @@ entry:
 
 define external fastcc  i64 @"alias_fork2.simpleMerge<0>"(i64  %"tl##0")    {
 entry:
-  %62 = trunc i64 24 to i32  
-  %63 = tail call ccc  i8*  @wybe_malloc(i32  %62)  
-  %64 = ptrtoint i8* %63 to i64 
-  %65 = inttoptr i64 %64 to i64* 
-  %66 = getelementptr  i64, i64* %65, i64 0 
-  store  i64 %"tl##0", i64* %66 
-  %67 = add   i64 %64, 8 
-  %68 = inttoptr i64 %67 to i64* 
-  %69 = getelementptr  i64, i64* %68, i64 0 
-  store  i64 200, i64* %69 
-  %70 = add   i64 %64, 16 
-  %71 = inttoptr i64 %70 to i64* 
-  %72 = getelementptr  i64, i64* %71, i64 0 
-  store  i64 0, i64* %72 
-  ret i64 %64 
+  %50 = trunc i64 24 to i32  
+  %51 = tail call ccc  i8*  @wybe_malloc(i32  %50)  
+  %52 = ptrtoint i8* %51 to i64 
+  %53 = inttoptr i64 %52 to i64* 
+  %54 = getelementptr  i64, i64* %53, i64 0 
+  store  i64 %"tl##0", i64* %54 
+  %55 = add   i64 %52, 8 
+  %56 = inttoptr i64 %55 to i64* 
+  %57 = getelementptr  i64, i64* %56, i64 0 
+  store  i64 200, i64* %57 
+  %58 = add   i64 %52, 16 
+  %59 = inttoptr i64 %58 to i64* 
+  %60 = getelementptr  i64, i64* %59, i64 0 
+  store  i64 0, i64* %60 
+  ret i64 %52 
 }
 --------------------------------------------------
  Module mytree
@@ -330,10 +318,10 @@ printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string, io##
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@mytree.5 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @mytree.4 to i64) }
+@mytree.4 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @mytree.3 to i64) }
 
 
-@mytree.4 =    constant [?? x i8] c"}\00"
+@mytree.3 =    constant [?? x i8] c"}\00"
 
 
 @mytree.2 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @mytree.1 to i64) }
@@ -345,10 +333,10 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@mytree.19 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @mytree.18 to i64) }
+@mytree.17 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @mytree.16 to i64) }
 
 
-@mytree.18 =    constant [?? x i8] c", \00"
+@mytree.16 =    constant [?? x i8] c", \00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -359,10 +347,8 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"mytree.printTree<0>"(i64  %"t##0")    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.2, i32 0, i32 0) to i64 
-  %"1#prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t##0", i64  %3)  
-  %6 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.5, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %6)  
+  %"1#prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t##0", i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.2, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.4, i32 0, i32 0) to i64))  
   ret void 
 }
 
@@ -372,22 +358,21 @@ entry:
   %"1#tmp#2##0" = icmp ne i64 %"t##0", 0 
   br i1 %"1#tmp#2##0", label %if.then, label %if.else 
 if.then:
-  %7 = inttoptr i64 %"t##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  %9 = load  i64, i64* %8 
-  %10 = add   i64 %"t##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = add   i64 %"t##0", 16 
-  %15 = inttoptr i64 %14 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  %17 = load  i64, i64* %16 
-  %"2#prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %9, i64  %"prefix##0")  
+  %5 = inttoptr i64 %"t##0" to i64* 
+  %6 = getelementptr  i64, i64* %5, i64 0 
+  %7 = load  i64, i64* %6 
+  %8 = add   i64 %"t##0", 8 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = getelementptr  i64, i64* %9, i64 0 
+  %11 = load  i64, i64* %10 
+  %12 = add   i64 %"t##0", 16 
+  %13 = inttoptr i64 %12 to i64* 
+  %14 = getelementptr  i64, i64* %13, i64 0 
+  %15 = load  i64, i64* %14 
+  %"2#prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %7, i64  %"prefix##0")  
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %"2#prefix##1")  
-  tail call ccc  void  @print_int(i64  %13)  
-  %20 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.19, i32 0, i32 0) to i64 
-  %"2#prefix##3" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %17, i64  %20)  
+  tail call ccc  void  @print_int(i64  %11)  
+  %"2#prefix##3" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %15, i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.17, i32 0, i32 0) to i64))  
   ret i64 %"2#prefix##3" 
 if.else:
   ret i64 %"prefix##0" 

--- a/test-cases/final-dump/alias_fork3.exp
+++ b/test-cases/final-dump/alias_fork3.exp
@@ -67,22 +67,22 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external fastcc  i64 @"mytree.printTree1<0>"(i64, i64)    
 
 
-@alias_fork3.33 =    constant {i64, i64} { i64 0, i64 ptrtoint ([?? x i8]* @alias_fork3.32 to i64) }
+@alias_fork3.30 =    constant {i64, i64} { i64 0, i64 ptrtoint ([?? x i8]* @alias_fork3.29 to i64) }
 
 
-@alias_fork3.32 =    constant [?? x i8] c"\00"
+@alias_fork3.29 =    constant [?? x i8] c"\00"
 
 
-@alias_fork3.30 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork3.29 to i64) }
+@alias_fork3.28 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork3.27 to i64) }
 
 
-@alias_fork3.29 =    constant [?? x i8] c"}\00"
+@alias_fork3.27 =    constant [?? x i8] c"}\00"
 
 
-@alias_fork3.27 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork3.26 to i64) }
+@alias_fork3.26 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @alias_fork3.25 to i64) }
 
 
-@alias_fork3.26 =    constant [?? x i8] c"{\00"
+@alias_fork3.25 =    constant [?? x i8] c"{\00"
 
 
 @alias_fork3.24 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias_fork3.23 to i64) }
@@ -128,15 +128,11 @@ entry:
   %22 = getelementptr  i64, i64* %21, i64 0 
   store  i64 0, i64* %22 
   %"1#tmp#5##0" = tail call fastcc  i64  @"alias_fork3.simpleSlice<0>"(i64  %14)  
-  %25 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork3.24, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %25)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork3.24, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %28 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork3.27, i32 0, i32 0) to i64 
-  %"1#tmp#23##0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"1#tmp#5##0", i64  %28)  
-  %31 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork3.30, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %31)  
-  %34 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork3.33, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %34)  
+  %"1#tmp#23##0" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"1#tmp#5##0", i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork3.26, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork3.28, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_fork3.30, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -147,26 +143,26 @@ entry:
   %"1#tmp#6##0" = icmp ne i64 %"tr##0", 0 
   br i1 %"1#tmp#6##0", label %if.then, label %if.else 
 if.then:
-  %35 = inttoptr i64 %"tr##0" to i64* 
-  %36 = getelementptr  i64, i64* %35, i64 0 
-  %37 = load  i64, i64* %36 
-  ret i64 %37 
+  %31 = inttoptr i64 %"tr##0" to i64* 
+  %32 = getelementptr  i64, i64* %31, i64 0 
+  %33 = load  i64, i64* %32 
+  ret i64 %33 
 if.else:
-  %38 = trunc i64 24 to i32  
-  %39 = tail call ccc  i8*  @wybe_malloc(i32  %38)  
-  %40 = ptrtoint i8* %39 to i64 
-  %41 = inttoptr i64 %40 to i64* 
-  %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 0, i64* %42 
-  %43 = add   i64 %40, 8 
-  %44 = inttoptr i64 %43 to i64* 
-  %45 = getelementptr  i64, i64* %44, i64 0 
-  store  i64 -1, i64* %45 
-  %46 = add   i64 %40, 16 
-  %47 = inttoptr i64 %46 to i64* 
-  %48 = getelementptr  i64, i64* %47, i64 0 
-  store  i64 0, i64* %48 
-  ret i64 %40 
+  %34 = trunc i64 24 to i32  
+  %35 = tail call ccc  i8*  @wybe_malloc(i32  %34)  
+  %36 = ptrtoint i8* %35 to i64 
+  %37 = inttoptr i64 %36 to i64* 
+  %38 = getelementptr  i64, i64* %37, i64 0 
+  store  i64 0, i64* %38 
+  %39 = add   i64 %36, 8 
+  %40 = inttoptr i64 %39 to i64* 
+  %41 = getelementptr  i64, i64* %40, i64 0 
+  store  i64 -1, i64* %41 
+  %42 = add   i64 %36, 16 
+  %43 = inttoptr i64 %42 to i64* 
+  %44 = getelementptr  i64, i64* %43, i64 0 
+  store  i64 0, i64* %44 
+  ret i64 %36 
 }
 --------------------------------------------------
  Module mytree
@@ -233,10 +229,10 @@ printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string, io##
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@mytree.5 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @mytree.4 to i64) }
+@mytree.4 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @mytree.3 to i64) }
 
 
-@mytree.4 =    constant [?? x i8] c"}\00"
+@mytree.3 =    constant [?? x i8] c"}\00"
 
 
 @mytree.2 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @mytree.1 to i64) }
@@ -248,10 +244,10 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@mytree.19 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @mytree.18 to i64) }
+@mytree.17 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @mytree.16 to i64) }
 
 
-@mytree.18 =    constant [?? x i8] c", \00"
+@mytree.16 =    constant [?? x i8] c", \00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -262,10 +258,8 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"mytree.printTree<0>"(i64  %"t##0")    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.2, i32 0, i32 0) to i64 
-  %"1#prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t##0", i64  %3)  
-  %6 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.5, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %6)  
+  %"1#prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t##0", i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.2, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.4, i32 0, i32 0) to i64))  
   ret void 
 }
 
@@ -275,22 +269,21 @@ entry:
   %"1#tmp#2##0" = icmp ne i64 %"t##0", 0 
   br i1 %"1#tmp#2##0", label %if.then, label %if.else 
 if.then:
-  %7 = inttoptr i64 %"t##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  %9 = load  i64, i64* %8 
-  %10 = add   i64 %"t##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = add   i64 %"t##0", 16 
-  %15 = inttoptr i64 %14 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  %17 = load  i64, i64* %16 
-  %"2#prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %9, i64  %"prefix##0")  
+  %5 = inttoptr i64 %"t##0" to i64* 
+  %6 = getelementptr  i64, i64* %5, i64 0 
+  %7 = load  i64, i64* %6 
+  %8 = add   i64 %"t##0", 8 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = getelementptr  i64, i64* %9, i64 0 
+  %11 = load  i64, i64* %10 
+  %12 = add   i64 %"t##0", 16 
+  %13 = inttoptr i64 %12 to i64* 
+  %14 = getelementptr  i64, i64* %13, i64 0 
+  %15 = load  i64, i64* %14 
+  %"2#prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %7, i64  %"prefix##0")  
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %"2#prefix##1")  
-  tail call ccc  void  @print_int(i64  %13)  
-  %20 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.19, i32 0, i32 0) to i64 
-  %"2#prefix##3" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %17, i64  %20)  
+  tail call ccc  void  @print_int(i64  %11)  
+  %"2#prefix##3" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %15, i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.17, i32 0, i32 0) to i64))  
   ret i64 %"2#prefix##3" 
 if.else:
   ret i64 %"prefix##0" 

--- a/test-cases/final-dump/alias_m.exp
+++ b/test-cases/final-dump/alias_m.exp
@@ -44,16 +44,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external fastcc  {i64, i64} @"alias_mfoo.foo<0>"(i64)    
 
 
-@alias_m.19 =    constant {i64, i64} { i64 14, i64 ptrtoint ([?? x i8]* @alias_m.18 to i64) }
+@alias_m.17 =    constant {i64, i64} { i64 14, i64 ptrtoint ([?? x i8]* @alias_m.16 to i64) }
 
 
-@alias_m.18 =    constant [?? x i8] c"expect p3(3,3)\00"
+@alias_m.16 =    constant [?? x i8] c"expect p3(3,3)\00"
 
 
-@alias_m.16 =    constant {i64, i64} { i64 14, i64 ptrtoint ([?? x i8]* @alias_m.15 to i64) }
+@alias_m.15 =    constant {i64, i64} { i64 14, i64 ptrtoint ([?? x i8]* @alias_m.14 to i64) }
 
 
-@alias_m.15 =    constant [?? x i8] c"expect p2(2,2)\00"
+@alias_m.14 =    constant [?? x i8] c"expect p2(2,2)\00"
 
 
 @alias_m.13 =    constant {i64, i64} { i64 14, i64 ptrtoint ([?? x i8]* @alias_m.12 to i64) }
@@ -83,14 +83,11 @@ entry:
   %9 = tail call fastcc  {i64, i64}  @"alias_mfoo.foo<0>"(i64  %3)  
   %10 = extractvalue {i64, i64} %9, 0 
   %11 = extractvalue {i64, i64} %9, 1 
-  %14 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_m.13, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %14)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_m.13, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %3)  
-  %17 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_m.16, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %17)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_m.15, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %10)  
-  %20 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_m.19, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %20)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_m.17, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %11)  
   ret void 
 }
@@ -289,10 +286,10 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @alias_mfoo.12 =    constant [?? x i8] c"p3:\00"
 
 
-@alias_mfoo.47 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @alias_mfoo.46 to i64) }
+@alias_mfoo.46 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @alias_mfoo.45 to i64) }
 
 
-@alias_mfoo.46 =    constant [?? x i8] c"p3:\00"
+@alias_mfoo.45 =    constant [?? x i8] c"p3:\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -319,84 +316,82 @@ if.then:
   %10 = inttoptr i64 %9 to i64* 
   %11 = getelementptr  i64, i64* %10, i64 0 
   store  i64 3, i64* %11 
-  %14 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_mfoo.13, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %14)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_mfoo.13, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %6)  
-  %15 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
-  %16 = insertvalue {i64, i64} %15, i64 %6, 1 
-  ret {i64, i64} %16 
+  %14 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
+  %15 = insertvalue {i64, i64} %14, i64 %6, 1 
+  ret {i64, i64} %15 
 if.else:
   %"3#tmp#3##0" = add   i64 %3, 1 
-  %17 = trunc i64 16 to i32  
-  %18 = tail call ccc  i8*  @wybe_malloc(i32  %17)  
-  %19 = ptrtoint i8* %18 to i64 
-  %20 = inttoptr i64 %19 to i8* 
-  %21 = inttoptr i64 %"p1##0" to i8* 
-  %22 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %20, i8*  %21, i32  %22, i32  8, i1  0)  
-  %23 = inttoptr i64 %19 to i64* 
-  %24 = getelementptr  i64, i64* %23, i64 0 
-  store  i64 %"3#tmp#3##0", i64* %24 
-  %"3#p3##0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %19)  
-  %25 = trunc i64 16 to i32  
-  %26 = tail call ccc  i8*  @wybe_malloc(i32  %25)  
-  %27 = ptrtoint i8* %26 to i64 
-  %28 = inttoptr i64 %27 to i64* 
-  %29 = getelementptr  i64, i64* %28, i64 0 
-  store  i64 2, i64* %29 
-  %30 = add   i64 %27, 8 
-  %31 = inttoptr i64 %30 to i64* 
-  %32 = getelementptr  i64, i64* %31, i64 0 
-  store  i64 2, i64* %32 
-  %33 = insertvalue {i64, i64} undef, i64 %27, 0 
-  %34 = insertvalue {i64, i64} %33, i64 %"3#p3##0", 1 
-  ret {i64, i64} %34 
+  %16 = trunc i64 16 to i32  
+  %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
+  %18 = ptrtoint i8* %17 to i64 
+  %19 = inttoptr i64 %18 to i8* 
+  %20 = inttoptr i64 %"p1##0" to i8* 
+  %21 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %19, i8*  %20, i32  %21, i32  8, i1  0)  
+  %22 = inttoptr i64 %18 to i64* 
+  %23 = getelementptr  i64, i64* %22, i64 0 
+  store  i64 %"3#tmp#3##0", i64* %23 
+  %"3#p3##0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %18)  
+  %24 = trunc i64 16 to i32  
+  %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
+  %26 = ptrtoint i8* %25 to i64 
+  %27 = inttoptr i64 %26 to i64* 
+  %28 = getelementptr  i64, i64* %27, i64 0 
+  store  i64 2, i64* %28 
+  %29 = add   i64 %26, 8 
+  %30 = inttoptr i64 %29 to i64* 
+  %31 = getelementptr  i64, i64* %30, i64 0 
+  store  i64 2, i64* %31 
+  %32 = insertvalue {i64, i64} undef, i64 %26, 0 
+  %33 = insertvalue {i64, i64} %32, i64 %"3#p3##0", 1 
+  ret {i64, i64} %33 
 }
 
 
 define external fastcc  {i64, i64} @"alias_mfoo.foo<0>[410bae77d3]"(i64  %"p1##0")    {
 entry:
-  %35 = inttoptr i64 %"p1##0" to i64* 
-  %36 = getelementptr  i64, i64* %35, i64 0 
-  %37 = load  i64, i64* %36 
-  %"1#tmp#5##0" = icmp sgt i64 %37, 1 
+  %34 = inttoptr i64 %"p1##0" to i64* 
+  %35 = getelementptr  i64, i64* %34, i64 0 
+  %36 = load  i64, i64* %35 
+  %"1#tmp#5##0" = icmp sgt i64 %36, 1 
   br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
-  %38 = trunc i64 16 to i32  
-  %39 = tail call ccc  i8*  @wybe_malloc(i32  %38)  
-  %40 = ptrtoint i8* %39 to i64 
-  %41 = inttoptr i64 %40 to i64* 
-  %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 3, i64* %42 
-  %43 = add   i64 %40, 8 
-  %44 = inttoptr i64 %43 to i64* 
-  %45 = getelementptr  i64, i64* %44, i64 0 
-  store  i64 3, i64* %45 
-  %48 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_mfoo.47, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %48)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %40)  
-  %49 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
-  %50 = insertvalue {i64, i64} %49, i64 %40, 1 
-  ret {i64, i64} %50 
+  %37 = trunc i64 16 to i32  
+  %38 = tail call ccc  i8*  @wybe_malloc(i32  %37)  
+  %39 = ptrtoint i8* %38 to i64 
+  %40 = inttoptr i64 %39 to i64* 
+  %41 = getelementptr  i64, i64* %40, i64 0 
+  store  i64 3, i64* %41 
+  %42 = add   i64 %39, 8 
+  %43 = inttoptr i64 %42 to i64* 
+  %44 = getelementptr  i64, i64* %43, i64 0 
+  store  i64 3, i64* %44 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_mfoo.46, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %39)  
+  %47 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
+  %48 = insertvalue {i64, i64} %47, i64 %39, 1 
+  ret {i64, i64} %48 
 if.else:
-  %"3#tmp#3##0" = add   i64 %37, 1 
-  %51 = inttoptr i64 %"p1##0" to i64* 
-  %52 = getelementptr  i64, i64* %51, i64 0 
-  store  i64 %"3#tmp#3##0", i64* %52 
+  %"3#tmp#3##0" = add   i64 %36, 1 
+  %49 = inttoptr i64 %"p1##0" to i64* 
+  %50 = getelementptr  i64, i64* %49, i64 0 
+  store  i64 %"3#tmp#3##0", i64* %50 
   %"3#p3##0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %"p1##0")  
-  %53 = trunc i64 16 to i32  
-  %54 = tail call ccc  i8*  @wybe_malloc(i32  %53)  
-  %55 = ptrtoint i8* %54 to i64 
-  %56 = inttoptr i64 %55 to i64* 
-  %57 = getelementptr  i64, i64* %56, i64 0 
-  store  i64 2, i64* %57 
-  %58 = add   i64 %55, 8 
-  %59 = inttoptr i64 %58 to i64* 
-  %60 = getelementptr  i64, i64* %59, i64 0 
-  store  i64 2, i64* %60 
-  %61 = insertvalue {i64, i64} undef, i64 %55, 0 
-  %62 = insertvalue {i64, i64} %61, i64 %"3#p3##0", 1 
-  ret {i64, i64} %62 
+  %51 = trunc i64 16 to i32  
+  %52 = tail call ccc  i8*  @wybe_malloc(i32  %51)  
+  %53 = ptrtoint i8* %52 to i64 
+  %54 = inttoptr i64 %53 to i64* 
+  %55 = getelementptr  i64, i64* %54, i64 0 
+  store  i64 2, i64* %55 
+  %56 = add   i64 %53, 8 
+  %57 = inttoptr i64 %56 to i64* 
+  %58 = getelementptr  i64, i64* %57, i64 0 
+  store  i64 2, i64* %58 
+  %59 = insertvalue {i64, i64} undef, i64 %53, 0 
+  %60 = insertvalue {i64, i64} %59, i64 %"3#p3##0", 1 
+  ret {i64, i64} %60 
 }
 --------------------------------------------------
  Module position
@@ -449,16 +444,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@position.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.14 to i64) }
+@position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.14 =    constant [?? x i8] c")\00"
+@position.12 =    constant [?? x i8] c")\00"
 
 
-@position.8 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.7 to i64) }
+@position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
 
 
-@position.7 =    constant [?? x i8] c",\00"
+@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
@@ -475,21 +470,18 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
-  %4 = inttoptr i64 %"pos##0" to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
-  %10 = add   i64 %"pos##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  tail call ccc  void  @print_int(i64  %13)  
-  %16 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.15, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %16)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64))  
+  %3 = inttoptr i64 %"pos##0" to i64* 
+  %4 = getelementptr  i64, i64* %3, i64 0 
+  %5 = load  i64, i64* %4 
+  tail call ccc  void  @print_int(i64  %5)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.7, i32 0, i32 0) to i64))  
+  %8 = add   i64 %"pos##0", 8 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = getelementptr  i64, i64* %9, i64 0 
+  %11 = load  i64, i64* %10 
+  tail call ccc  void  @print_int(i64  %11)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/alias_mbar.exp
+++ b/test-cases/final-dump/alias_mbar.exp
@@ -194,10 +194,10 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @alias_mfoo.12 =    constant [?? x i8] c"p3:\00"
 
 
-@alias_mfoo.47 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @alias_mfoo.46 to i64) }
+@alias_mfoo.46 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @alias_mfoo.45 to i64) }
 
 
-@alias_mfoo.46 =    constant [?? x i8] c"p3:\00"
+@alias_mfoo.45 =    constant [?? x i8] c"p3:\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -224,84 +224,82 @@ if.then:
   %10 = inttoptr i64 %9 to i64* 
   %11 = getelementptr  i64, i64* %10, i64 0 
   store  i64 3, i64* %11 
-  %14 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_mfoo.13, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %14)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_mfoo.13, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %6)  
-  %15 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
-  %16 = insertvalue {i64, i64} %15, i64 %6, 1 
-  ret {i64, i64} %16 
+  %14 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
+  %15 = insertvalue {i64, i64} %14, i64 %6, 1 
+  ret {i64, i64} %15 
 if.else:
   %"3#tmp#3##0" = add   i64 %3, 1 
-  %17 = trunc i64 16 to i32  
-  %18 = tail call ccc  i8*  @wybe_malloc(i32  %17)  
-  %19 = ptrtoint i8* %18 to i64 
-  %20 = inttoptr i64 %19 to i8* 
-  %21 = inttoptr i64 %"p1##0" to i8* 
-  %22 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %20, i8*  %21, i32  %22, i32  8, i1  0)  
-  %23 = inttoptr i64 %19 to i64* 
-  %24 = getelementptr  i64, i64* %23, i64 0 
-  store  i64 %"3#tmp#3##0", i64* %24 
-  %"3#p3##0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %19)  
-  %25 = trunc i64 16 to i32  
-  %26 = tail call ccc  i8*  @wybe_malloc(i32  %25)  
-  %27 = ptrtoint i8* %26 to i64 
-  %28 = inttoptr i64 %27 to i64* 
-  %29 = getelementptr  i64, i64* %28, i64 0 
-  store  i64 2, i64* %29 
-  %30 = add   i64 %27, 8 
-  %31 = inttoptr i64 %30 to i64* 
-  %32 = getelementptr  i64, i64* %31, i64 0 
-  store  i64 2, i64* %32 
-  %33 = insertvalue {i64, i64} undef, i64 %27, 0 
-  %34 = insertvalue {i64, i64} %33, i64 %"3#p3##0", 1 
-  ret {i64, i64} %34 
+  %16 = trunc i64 16 to i32  
+  %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
+  %18 = ptrtoint i8* %17 to i64 
+  %19 = inttoptr i64 %18 to i8* 
+  %20 = inttoptr i64 %"p1##0" to i8* 
+  %21 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %19, i8*  %20, i32  %21, i32  8, i1  0)  
+  %22 = inttoptr i64 %18 to i64* 
+  %23 = getelementptr  i64, i64* %22, i64 0 
+  store  i64 %"3#tmp#3##0", i64* %23 
+  %"3#p3##0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %18)  
+  %24 = trunc i64 16 to i32  
+  %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
+  %26 = ptrtoint i8* %25 to i64 
+  %27 = inttoptr i64 %26 to i64* 
+  %28 = getelementptr  i64, i64* %27, i64 0 
+  store  i64 2, i64* %28 
+  %29 = add   i64 %26, 8 
+  %30 = inttoptr i64 %29 to i64* 
+  %31 = getelementptr  i64, i64* %30, i64 0 
+  store  i64 2, i64* %31 
+  %32 = insertvalue {i64, i64} undef, i64 %26, 0 
+  %33 = insertvalue {i64, i64} %32, i64 %"3#p3##0", 1 
+  ret {i64, i64} %33 
 }
 
 
 define external fastcc  {i64, i64} @"alias_mfoo.foo<0>[410bae77d3]"(i64  %"p1##0")    {
 entry:
-  %35 = inttoptr i64 %"p1##0" to i64* 
-  %36 = getelementptr  i64, i64* %35, i64 0 
-  %37 = load  i64, i64* %36 
-  %"1#tmp#5##0" = icmp sgt i64 %37, 1 
+  %34 = inttoptr i64 %"p1##0" to i64* 
+  %35 = getelementptr  i64, i64* %34, i64 0 
+  %36 = load  i64, i64* %35 
+  %"1#tmp#5##0" = icmp sgt i64 %36, 1 
   br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
-  %38 = trunc i64 16 to i32  
-  %39 = tail call ccc  i8*  @wybe_malloc(i32  %38)  
-  %40 = ptrtoint i8* %39 to i64 
-  %41 = inttoptr i64 %40 to i64* 
-  %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 3, i64* %42 
-  %43 = add   i64 %40, 8 
-  %44 = inttoptr i64 %43 to i64* 
-  %45 = getelementptr  i64, i64* %44, i64 0 
-  store  i64 3, i64* %45 
-  %48 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_mfoo.47, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %48)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %40)  
-  %49 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
-  %50 = insertvalue {i64, i64} %49, i64 %40, 1 
-  ret {i64, i64} %50 
+  %37 = trunc i64 16 to i32  
+  %38 = tail call ccc  i8*  @wybe_malloc(i32  %37)  
+  %39 = ptrtoint i8* %38 to i64 
+  %40 = inttoptr i64 %39 to i64* 
+  %41 = getelementptr  i64, i64* %40, i64 0 
+  store  i64 3, i64* %41 
+  %42 = add   i64 %39, 8 
+  %43 = inttoptr i64 %42 to i64* 
+  %44 = getelementptr  i64, i64* %43, i64 0 
+  store  i64 3, i64* %44 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_mfoo.46, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %39)  
+  %47 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
+  %48 = insertvalue {i64, i64} %47, i64 %39, 1 
+  ret {i64, i64} %48 
 if.else:
-  %"3#tmp#3##0" = add   i64 %37, 1 
-  %51 = inttoptr i64 %"p1##0" to i64* 
-  %52 = getelementptr  i64, i64* %51, i64 0 
-  store  i64 %"3#tmp#3##0", i64* %52 
+  %"3#tmp#3##0" = add   i64 %36, 1 
+  %49 = inttoptr i64 %"p1##0" to i64* 
+  %50 = getelementptr  i64, i64* %49, i64 0 
+  store  i64 %"3#tmp#3##0", i64* %50 
   %"3#p3##0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %"p1##0")  
-  %53 = trunc i64 16 to i32  
-  %54 = tail call ccc  i8*  @wybe_malloc(i32  %53)  
-  %55 = ptrtoint i8* %54 to i64 
-  %56 = inttoptr i64 %55 to i64* 
-  %57 = getelementptr  i64, i64* %56, i64 0 
-  store  i64 2, i64* %57 
-  %58 = add   i64 %55, 8 
-  %59 = inttoptr i64 %58 to i64* 
-  %60 = getelementptr  i64, i64* %59, i64 0 
-  store  i64 2, i64* %60 
-  %61 = insertvalue {i64, i64} undef, i64 %55, 0 
-  %62 = insertvalue {i64, i64} %61, i64 %"3#p3##0", 1 
-  ret {i64, i64} %62 
+  %51 = trunc i64 16 to i32  
+  %52 = tail call ccc  i8*  @wybe_malloc(i32  %51)  
+  %53 = ptrtoint i8* %52 to i64 
+  %54 = inttoptr i64 %53 to i64* 
+  %55 = getelementptr  i64, i64* %54, i64 0 
+  store  i64 2, i64* %55 
+  %56 = add   i64 %53, 8 
+  %57 = inttoptr i64 %56 to i64* 
+  %58 = getelementptr  i64, i64* %57, i64 0 
+  store  i64 2, i64* %58 
+  %59 = insertvalue {i64, i64} undef, i64 %53, 0 
+  %60 = insertvalue {i64, i64} %59, i64 %"3#p3##0", 1 
+  ret {i64, i64} %60 
 }
 --------------------------------------------------
  Module position
@@ -354,16 +352,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@position.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.14 to i64) }
+@position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.14 =    constant [?? x i8] c")\00"
+@position.12 =    constant [?? x i8] c")\00"
 
 
-@position.8 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.7 to i64) }
+@position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
 
 
-@position.7 =    constant [?? x i8] c",\00"
+@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
@@ -380,21 +378,18 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
-  %4 = inttoptr i64 %"pos##0" to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
-  %10 = add   i64 %"pos##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  tail call ccc  void  @print_int(i64  %13)  
-  %16 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.15, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %16)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64))  
+  %3 = inttoptr i64 %"pos##0" to i64* 
+  %4 = getelementptr  i64, i64* %3, i64 0 
+  %5 = load  i64, i64* %4 
+  tail call ccc  void  @print_int(i64  %5)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.7, i32 0, i32 0) to i64))  
+  %8 = add   i64 %"pos##0", 8 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = getelementptr  i64, i64* %9, i64 0 
+  %11 = load  i64, i64* %10 
+  tail call ccc  void  @print_int(i64  %11)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/alias_mfoo.exp
+++ b/test-cases/final-dump/alias_mfoo.exp
@@ -194,10 +194,10 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @alias_mfoo.12 =    constant [?? x i8] c"p3:\00"
 
 
-@alias_mfoo.47 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @alias_mfoo.46 to i64) }
+@alias_mfoo.46 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @alias_mfoo.45 to i64) }
 
 
-@alias_mfoo.46 =    constant [?? x i8] c"p3:\00"
+@alias_mfoo.45 =    constant [?? x i8] c"p3:\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -224,84 +224,82 @@ if.then:
   %10 = inttoptr i64 %9 to i64* 
   %11 = getelementptr  i64, i64* %10, i64 0 
   store  i64 3, i64* %11 
-  %14 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_mfoo.13, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %14)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_mfoo.13, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %6)  
-  %15 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
-  %16 = insertvalue {i64, i64} %15, i64 %6, 1 
-  ret {i64, i64} %16 
+  %14 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
+  %15 = insertvalue {i64, i64} %14, i64 %6, 1 
+  ret {i64, i64} %15 
 if.else:
   %"3#tmp#3##0" = add   i64 %3, 1 
-  %17 = trunc i64 16 to i32  
-  %18 = tail call ccc  i8*  @wybe_malloc(i32  %17)  
-  %19 = ptrtoint i8* %18 to i64 
-  %20 = inttoptr i64 %19 to i8* 
-  %21 = inttoptr i64 %"p1##0" to i8* 
-  %22 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %20, i8*  %21, i32  %22, i32  8, i1  0)  
-  %23 = inttoptr i64 %19 to i64* 
-  %24 = getelementptr  i64, i64* %23, i64 0 
-  store  i64 %"3#tmp#3##0", i64* %24 
-  %"3#p3##0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %19)  
-  %25 = trunc i64 16 to i32  
-  %26 = tail call ccc  i8*  @wybe_malloc(i32  %25)  
-  %27 = ptrtoint i8* %26 to i64 
-  %28 = inttoptr i64 %27 to i64* 
-  %29 = getelementptr  i64, i64* %28, i64 0 
-  store  i64 2, i64* %29 
-  %30 = add   i64 %27, 8 
-  %31 = inttoptr i64 %30 to i64* 
-  %32 = getelementptr  i64, i64* %31, i64 0 
-  store  i64 2, i64* %32 
-  %33 = insertvalue {i64, i64} undef, i64 %27, 0 
-  %34 = insertvalue {i64, i64} %33, i64 %"3#p3##0", 1 
-  ret {i64, i64} %34 
+  %16 = trunc i64 16 to i32  
+  %17 = tail call ccc  i8*  @wybe_malloc(i32  %16)  
+  %18 = ptrtoint i8* %17 to i64 
+  %19 = inttoptr i64 %18 to i8* 
+  %20 = inttoptr i64 %"p1##0" to i8* 
+  %21 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %19, i8*  %20, i32  %21, i32  8, i1  0)  
+  %22 = inttoptr i64 %18 to i64* 
+  %23 = getelementptr  i64, i64* %22, i64 0 
+  store  i64 %"3#tmp#3##0", i64* %23 
+  %"3#p3##0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %18)  
+  %24 = trunc i64 16 to i32  
+  %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
+  %26 = ptrtoint i8* %25 to i64 
+  %27 = inttoptr i64 %26 to i64* 
+  %28 = getelementptr  i64, i64* %27, i64 0 
+  store  i64 2, i64* %28 
+  %29 = add   i64 %26, 8 
+  %30 = inttoptr i64 %29 to i64* 
+  %31 = getelementptr  i64, i64* %30, i64 0 
+  store  i64 2, i64* %31 
+  %32 = insertvalue {i64, i64} undef, i64 %26, 0 
+  %33 = insertvalue {i64, i64} %32, i64 %"3#p3##0", 1 
+  ret {i64, i64} %33 
 }
 
 
 define external fastcc  {i64, i64} @"alias_mfoo.foo<0>[410bae77d3]"(i64  %"p1##0")    {
 entry:
-  %35 = inttoptr i64 %"p1##0" to i64* 
-  %36 = getelementptr  i64, i64* %35, i64 0 
-  %37 = load  i64, i64* %36 
-  %"1#tmp#5##0" = icmp sgt i64 %37, 1 
+  %34 = inttoptr i64 %"p1##0" to i64* 
+  %35 = getelementptr  i64, i64* %34, i64 0 
+  %36 = load  i64, i64* %35 
+  %"1#tmp#5##0" = icmp sgt i64 %36, 1 
   br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
-  %38 = trunc i64 16 to i32  
-  %39 = tail call ccc  i8*  @wybe_malloc(i32  %38)  
-  %40 = ptrtoint i8* %39 to i64 
-  %41 = inttoptr i64 %40 to i64* 
-  %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 3, i64* %42 
-  %43 = add   i64 %40, 8 
-  %44 = inttoptr i64 %43 to i64* 
-  %45 = getelementptr  i64, i64* %44, i64 0 
-  store  i64 3, i64* %45 
-  %48 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_mfoo.47, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %48)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %40)  
-  %49 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
-  %50 = insertvalue {i64, i64} %49, i64 %40, 1 
-  ret {i64, i64} %50 
+  %37 = trunc i64 16 to i32  
+  %38 = tail call ccc  i8*  @wybe_malloc(i32  %37)  
+  %39 = ptrtoint i8* %38 to i64 
+  %40 = inttoptr i64 %39 to i64* 
+  %41 = getelementptr  i64, i64* %40, i64 0 
+  store  i64 3, i64* %41 
+  %42 = add   i64 %39, 8 
+  %43 = inttoptr i64 %42 to i64* 
+  %44 = getelementptr  i64, i64* %43, i64 0 
+  store  i64 3, i64* %44 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_mfoo.46, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %39)  
+  %47 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
+  %48 = insertvalue {i64, i64} %47, i64 %39, 1 
+  ret {i64, i64} %48 
 if.else:
-  %"3#tmp#3##0" = add   i64 %37, 1 
-  %51 = inttoptr i64 %"p1##0" to i64* 
-  %52 = getelementptr  i64, i64* %51, i64 0 
-  store  i64 %"3#tmp#3##0", i64* %52 
+  %"3#tmp#3##0" = add   i64 %36, 1 
+  %49 = inttoptr i64 %"p1##0" to i64* 
+  %50 = getelementptr  i64, i64* %49, i64 0 
+  store  i64 %"3#tmp#3##0", i64* %50 
   %"3#p3##0" = tail call fastcc  i64  @"alias_mbar.bar<0>[410bae77d3]"(i64  %"p1##0")  
-  %53 = trunc i64 16 to i32  
-  %54 = tail call ccc  i8*  @wybe_malloc(i32  %53)  
-  %55 = ptrtoint i8* %54 to i64 
-  %56 = inttoptr i64 %55 to i64* 
-  %57 = getelementptr  i64, i64* %56, i64 0 
-  store  i64 2, i64* %57 
-  %58 = add   i64 %55, 8 
-  %59 = inttoptr i64 %58 to i64* 
-  %60 = getelementptr  i64, i64* %59, i64 0 
-  store  i64 2, i64* %60 
-  %61 = insertvalue {i64, i64} undef, i64 %55, 0 
-  %62 = insertvalue {i64, i64} %61, i64 %"3#p3##0", 1 
-  ret {i64, i64} %62 
+  %51 = trunc i64 16 to i32  
+  %52 = tail call ccc  i8*  @wybe_malloc(i32  %51)  
+  %53 = ptrtoint i8* %52 to i64 
+  %54 = inttoptr i64 %53 to i64* 
+  %55 = getelementptr  i64, i64* %54, i64 0 
+  store  i64 2, i64* %55 
+  %56 = add   i64 %53, 8 
+  %57 = inttoptr i64 %56 to i64* 
+  %58 = getelementptr  i64, i64* %57, i64 0 
+  store  i64 2, i64* %58 
+  %59 = insertvalue {i64, i64} undef, i64 %53, 0 
+  %60 = insertvalue {i64, i64} %59, i64 %"3#p3##0", 1 
+  ret {i64, i64} %60 
 }
 --------------------------------------------------
  Module position
@@ -354,16 +352,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@position.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.14 to i64) }
+@position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.14 =    constant [?? x i8] c")\00"
+@position.12 =    constant [?? x i8] c")\00"
 
 
-@position.8 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.7 to i64) }
+@position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
 
 
-@position.7 =    constant [?? x i8] c",\00"
+@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
@@ -380,21 +378,18 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
-  %4 = inttoptr i64 %"pos##0" to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
-  %10 = add   i64 %"pos##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  tail call ccc  void  @print_int(i64  %13)  
-  %16 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.15, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %16)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64))  
+  %3 = inttoptr i64 %"pos##0" to i64* 
+  %4 = getelementptr  i64, i64* %3, i64 0 
+  %5 = load  i64, i64* %4 
+  tail call ccc  void  @print_int(i64  %5)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.7, i32 0, i32 0) to i64))  
+  %8 = add   i64 %"pos##0", 8 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = getelementptr  i64, i64* %9, i64 0 
+  %11 = load  i64, i64* %10 
+  tail call ccc  void  @print_int(i64  %11)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/alias_mod_param.exp
+++ b/test-cases/final-dump/alias_mod_param.exp
@@ -53,10 +53,10 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @alias_mod_param.9 =    constant [?? x i8] c"expect p1(10,10):\00"
 
 
-@alias_mod_param.21 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_mod_param.20 to i64) }
+@alias_mod_param.20 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_mod_param.19 to i64) }
 
 
-@alias_mod_param.20 =    constant [?? x i8] c"expect pa(1111,10):\00"
+@alias_mod_param.19 =    constant [?? x i8] c"expect pa(1111,10):\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -78,8 +78,7 @@ entry:
   %8 = getelementptr  i64, i64* %7, i64 0 
   store  i64 10, i64* %8 
   tail call fastcc  void  @"alias_mod_param.foo<0>"(i64  %3)  
-  %11 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_mod_param.10, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %11)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_mod_param.10, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %3)  
   ret void 
 }
@@ -87,19 +86,18 @@ entry:
 
 define external fastcc  void @"alias_mod_param.foo<0>"(i64  %"pa##0")    {
 entry:
-  %12 = trunc i64 16 to i32  
-  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
-  %14 = ptrtoint i8* %13 to i64 
-  %15 = inttoptr i64 %14 to i8* 
-  %16 = inttoptr i64 %"pa##0" to i8* 
-  %17 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %15, i8*  %16, i32  %17, i32  8, i1  0)  
-  %18 = inttoptr i64 %14 to i64* 
-  %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 1111, i64* %19 
-  %22 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_mod_param.21, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %22)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %14)  
+  %11 = trunc i64 16 to i32  
+  %12 = tail call ccc  i8*  @wybe_malloc(i32  %11)  
+  %13 = ptrtoint i8* %12 to i64 
+  %14 = inttoptr i64 %13 to i8* 
+  %15 = inttoptr i64 %"pa##0" to i8* 
+  %16 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %14, i8*  %15, i32  %16, i32  8, i1  0)  
+  %17 = inttoptr i64 %13 to i64* 
+  %18 = getelementptr  i64, i64* %17, i64 0 
+  store  i64 1111, i64* %18 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_mod_param.20, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %13)  
   ret void 
 }
 --------------------------------------------------
@@ -153,16 +151,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@position.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.14 to i64) }
+@position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.14 =    constant [?? x i8] c")\00"
+@position.12 =    constant [?? x i8] c")\00"
 
 
-@position.8 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.7 to i64) }
+@position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
 
 
-@position.7 =    constant [?? x i8] c",\00"
+@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
@@ -179,21 +177,18 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
-  %4 = inttoptr i64 %"pos##0" to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
-  %10 = add   i64 %"pos##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  tail call ccc  void  @print_int(i64  %13)  
-  %16 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.15, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %16)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64))  
+  %3 = inttoptr i64 %"pos##0" to i64* 
+  %4 = getelementptr  i64, i64* %3, i64 0 
+  %5 = load  i64, i64* %4 
+  tail call ccc  void  @print_int(i64  %5)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.7, i32 0, i32 0) to i64))  
+  %8 = add   i64 %"pos##0", 8 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = getelementptr  i64, i64* %9, i64 0 
+  %11 = load  i64, i64* %10 
+  tail call ccc  void  @print_int(i64  %11)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/alias_multifunc.exp
+++ b/test-cases/final-dump/alias_multifunc.exp
@@ -96,46 +96,46 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @putchar(i8)    
 
 
-@alias_multifunc.42 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_multifunc.41 to i64) }
+@alias_multifunc.35 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_multifunc.34 to i64) }
 
 
-@alias_multifunc.41 =    constant [?? x i8] c"expect p3(101,102):\00"
+@alias_multifunc.34 =    constant [?? x i8] c"expect p3(101,102):\00"
 
 
-@alias_multifunc.39 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_multifunc.38 to i64) }
+@alias_multifunc.33 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_multifunc.32 to i64) }
 
 
-@alias_multifunc.38 =    constant [?? x i8] c"expect p2(101,102):\00"
+@alias_multifunc.32 =    constant [?? x i8] c"expect p2(101,102):\00"
 
 
-@alias_multifunc.36 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_multifunc.35 to i64) }
+@alias_multifunc.31 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_multifunc.30 to i64) }
 
 
-@alias_multifunc.35 =    constant [?? x i8] c"expect p1(555,102):\00"
+@alias_multifunc.30 =    constant [?? x i8] c"expect p1(555,102):\00"
 
 
-@alias_multifunc.33 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @alias_multifunc.32 to i64) }
+@alias_multifunc.29 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @alias_multifunc.28 to i64) }
 
 
-@alias_multifunc.32 =    constant [?? x i8] c"--- After calling x(!p1, 555): \00"
-
-
-@alias_multifunc.22 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_multifunc.21 to i64) }
-
-
-@alias_multifunc.21 =    constant [?? x i8] c"expect p3(101,102):\00"
+@alias_multifunc.28 =    constant [?? x i8] c"--- After calling x(!p1, 555): \00"
 
 
 @alias_multifunc.19 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_multifunc.18 to i64) }
 
 
-@alias_multifunc.18 =    constant [?? x i8] c"expect p2(101,102):\00"
+@alias_multifunc.18 =    constant [?? x i8] c"expect p3(101,102):\00"
 
 
-@alias_multifunc.16 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_multifunc.15 to i64) }
+@alias_multifunc.17 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_multifunc.16 to i64) }
 
 
-@alias_multifunc.15 =    constant [?? x i8] c"expect p1(101,102):\00"
+@alias_multifunc.16 =    constant [?? x i8] c"expect p2(101,102):\00"
+
+
+@alias_multifunc.15 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_multifunc.14 to i64) }
+
+
+@alias_multifunc.14 =    constant [?? x i8] c"expect p1(101,102):\00"
 
 
 @alias_multifunc.13 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @alias_multifunc.12 to i64) }
@@ -147,16 +147,16 @@ declare external ccc  void @putchar(i8)
 declare external ccc  void @print_int(i64)    
 
 
-@alias_multifunc.53 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias_multifunc.52 to i64) }
+@alias_multifunc.45 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias_multifunc.44 to i64) }
 
 
-@alias_multifunc.52 =    constant [?? x i8] c"random replicate1 \00"
+@alias_multifunc.44 =    constant [?? x i8] c"random replicate1 \00"
 
 
-@alias_multifunc.69 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias_multifunc.68 to i64) }
+@alias_multifunc.60 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias_multifunc.59 to i64) }
 
 
-@alias_multifunc.68 =    constant [?? x i8] c"random replicate2 \00"
+@alias_multifunc.59 =    constant [?? x i8] c"random replicate2 \00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -187,39 +187,31 @@ entry:
   %9 = tail call fastcc  {i64, i64}  @"alias_multifunc.replicate1<0>"(i64  %3)  
   %10 = extractvalue {i64, i64} %9, 0 
   %11 = extractvalue {i64, i64} %9, 1 
-  %14 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.13, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %14)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %17 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.16, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %17)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.15, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %3)  
-  %20 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.19, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %20)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.17, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %10)  
-  %23 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.22, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %23)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.19, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %11)  
-  %24 = trunc i64 16 to i32  
-  %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
-  %26 = ptrtoint i8* %25 to i64 
-  %27 = inttoptr i64 %26 to i8* 
-  %28 = inttoptr i64 %3 to i8* 
-  %29 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %27, i8*  %28, i32  %29, i32  8, i1  0)  
-  %30 = inttoptr i64 %26 to i64* 
-  %31 = getelementptr  i64, i64* %30, i64 0 
-  store  i64 555, i64* %31 
-  %34 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.33, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %34)  
+  %20 = trunc i64 16 to i32  
+  %21 = tail call ccc  i8*  @wybe_malloc(i32  %20)  
+  %22 = ptrtoint i8* %21 to i64 
+  %23 = inttoptr i64 %22 to i8* 
+  %24 = inttoptr i64 %3 to i8* 
+  %25 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %23, i8*  %24, i32  %25, i32  8, i1  0)  
+  %26 = inttoptr i64 %22 to i64* 
+  %27 = getelementptr  i64, i64* %26, i64 0 
+  store  i64 555, i64* %27 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.29, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %37 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.36, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %37)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %26)  
-  %40 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.39, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %40)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.31, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %22)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.33, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %10)  
-  %43 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.42, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %43)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.35, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %11)  
   ret void 
 }
@@ -227,48 +219,46 @@ entry:
 
 define external fastcc  {i64, i64} @"alias_multifunc.replicate1<0>"(i64  %"p1##0")    {
 entry:
-  %44 = trunc i64 16 to i32  
-  %45 = tail call ccc  i8*  @wybe_malloc(i32  %44)  
-  %46 = ptrtoint i8* %45 to i64 
-  %47 = inttoptr i64 %46 to i64* 
-  %48 = getelementptr  i64, i64* %47, i64 0 
-  store  i64 0, i64* %48 
-  %49 = add   i64 %46, 8 
-  %50 = inttoptr i64 %49 to i64* 
-  %51 = getelementptr  i64, i64* %50, i64 0 
-  store  i64 0, i64* %51 
-  %54 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.53, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %54)  
-  %55 = inttoptr i64 %46 to i64* 
-  %56 = getelementptr  i64, i64* %55, i64 0 
-  %57 = load  i64, i64* %56 
-  tail call ccc  void  @print_int(i64  %57)  
+  %36 = trunc i64 16 to i32  
+  %37 = tail call ccc  i8*  @wybe_malloc(i32  %36)  
+  %38 = ptrtoint i8* %37 to i64 
+  %39 = inttoptr i64 %38 to i64* 
+  %40 = getelementptr  i64, i64* %39, i64 0 
+  store  i64 0, i64* %40 
+  %41 = add   i64 %38, 8 
+  %42 = inttoptr i64 %41 to i64* 
+  %43 = getelementptr  i64, i64* %42, i64 0 
+  store  i64 0, i64* %43 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.45, i32 0, i32 0) to i64))  
+  %46 = inttoptr i64 %38 to i64* 
+  %47 = getelementptr  i64, i64* %46, i64 0 
+  %48 = load  i64, i64* %47 
+  tail call ccc  void  @print_int(i64  %48)  
   tail call ccc  void  @putchar(i8  10)  
   %"1#p3##0" = tail call fastcc  i64  @"alias_multifunc.replicate2<0>"(i64  %"p1##0")  
-  %58 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
-  %59 = insertvalue {i64, i64} %58, i64 %"1#p3##0", 1 
-  ret {i64, i64} %59 
+  %49 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
+  %50 = insertvalue {i64, i64} %49, i64 %"1#p3##0", 1 
+  ret {i64, i64} %50 
 }
 
 
 define external fastcc  i64 @"alias_multifunc.replicate2<0>"(i64  %"p1##0")    {
 entry:
-  %60 = trunc i64 16 to i32  
-  %61 = tail call ccc  i8*  @wybe_malloc(i32  %60)  
-  %62 = ptrtoint i8* %61 to i64 
-  %63 = inttoptr i64 %62 to i64* 
-  %64 = getelementptr  i64, i64* %63, i64 0 
-  store  i64 0, i64* %64 
-  %65 = add   i64 %62, 8 
-  %66 = inttoptr i64 %65 to i64* 
-  %67 = getelementptr  i64, i64* %66, i64 0 
-  store  i64 0, i64* %67 
-  %70 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.69, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %70)  
-  %71 = inttoptr i64 %62 to i64* 
-  %72 = getelementptr  i64, i64* %71, i64 0 
-  %73 = load  i64, i64* %72 
-  tail call ccc  void  @print_int(i64  %73)  
+  %51 = trunc i64 16 to i32  
+  %52 = tail call ccc  i8*  @wybe_malloc(i32  %51)  
+  %53 = ptrtoint i8* %52 to i64 
+  %54 = inttoptr i64 %53 to i64* 
+  %55 = getelementptr  i64, i64* %54, i64 0 
+  store  i64 0, i64* %55 
+  %56 = add   i64 %53, 8 
+  %57 = inttoptr i64 %56 to i64* 
+  %58 = getelementptr  i64, i64* %57, i64 0 
+  store  i64 0, i64* %58 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc.60, i32 0, i32 0) to i64))  
+  %61 = inttoptr i64 %53 to i64* 
+  %62 = getelementptr  i64, i64* %61, i64 0 
+  %63 = load  i64, i64* %62 
+  tail call ccc  void  @print_int(i64  %63)  
   tail call ccc  void  @putchar(i8  10)  
   ret i64 %"p1##0" 
 }
@@ -323,16 +313,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@position.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.14 to i64) }
+@position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.14 =    constant [?? x i8] c")\00"
+@position.12 =    constant [?? x i8] c")\00"
 
 
-@position.8 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.7 to i64) }
+@position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
 
 
-@position.7 =    constant [?? x i8] c",\00"
+@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
@@ -349,21 +339,18 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
-  %4 = inttoptr i64 %"pos##0" to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
-  %10 = add   i64 %"pos##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  tail call ccc  void  @print_int(i64  %13)  
-  %16 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.15, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %16)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64))  
+  %3 = inttoptr i64 %"pos##0" to i64* 
+  %4 = getelementptr  i64, i64* %3, i64 0 
+  %5 = load  i64, i64* %4 
+  tail call ccc  void  @print_int(i64  %5)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.7, i32 0, i32 0) to i64))  
+  %8 = add   i64 %"pos##0", 8 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = getelementptr  i64, i64* %9, i64 0 
+  %11 = load  i64, i64* %10 
+  tail call ccc  void  @print_int(i64  %11)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/alias_multifunc1.exp
+++ b/test-cases/final-dump/alias_multifunc1.exp
@@ -84,52 +84,52 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @putchar(i8)    
 
 
-@alias_multifunc1.47 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc1.46 to i64) }
+@alias_multifunc1.39 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc1.38 to i64) }
 
 
-@alias_multifunc1.46 =    constant [?? x i8] c"expect p3(10,10):\00"
+@alias_multifunc1.38 =    constant [?? x i8] c"expect p3(10,10):\00"
 
 
-@alias_multifunc1.44 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc1.43 to i64) }
+@alias_multifunc1.37 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc1.36 to i64) }
 
 
-@alias_multifunc1.43 =    constant [?? x i8] c"expect p1(11,10):\00"
+@alias_multifunc1.36 =    constant [?? x i8] c"expect p1(11,10):\00"
 
 
-@alias_multifunc1.41 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @alias_multifunc1.40 to i64) }
+@alias_multifunc1.35 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @alias_multifunc1.34 to i64) }
 
 
-@alias_multifunc1.40 =    constant [?? x i8] c"--- After calling x(!p1, 11): \00"
+@alias_multifunc1.34 =    constant [?? x i8] c"--- After calling x(!p1, 11): \00"
 
 
-@alias_multifunc1.30 =    constant {i64, i64} { i64 22, i64 ptrtoint ([?? x i8]* @alias_multifunc1.29 to i64) }
+@alias_multifunc1.25 =    constant {i64, i64} { i64 22, i64 ptrtoint ([?? x i8]* @alias_multifunc1.24 to i64) }
 
 
-@alias_multifunc1.29 =    constant [?? x i8] c"expect p2(2222222,10):\00"
+@alias_multifunc1.24 =    constant [?? x i8] c"expect p2(2222222,10):\00"
 
 
-@alias_multifunc1.27 =    constant {i64, i64} { i64 35, i64 ptrtoint ([?? x i8]* @alias_multifunc1.26 to i64) }
+@alias_multifunc1.23 =    constant {i64, i64} { i64 35, i64 ptrtoint ([?? x i8]* @alias_multifunc1.22 to i64) }
 
 
-@alias_multifunc1.26 =    constant [?? x i8] c"--- After calling x(!p2, 2222222): \00"
-
-
-@alias_multifunc1.22 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc1.21 to i64) }
-
-
-@alias_multifunc1.21 =    constant [?? x i8] c"expect p3(10,10):\00"
+@alias_multifunc1.22 =    constant [?? x i8] c"--- After calling x(!p2, 2222222): \00"
 
 
 @alias_multifunc1.19 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc1.18 to i64) }
 
 
-@alias_multifunc1.18 =    constant [?? x i8] c"expect p2(22,10):\00"
+@alias_multifunc1.18 =    constant [?? x i8] c"expect p3(10,10):\00"
 
 
-@alias_multifunc1.16 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc1.15 to i64) }
+@alias_multifunc1.17 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc1.16 to i64) }
 
 
-@alias_multifunc1.15 =    constant [?? x i8] c"expect p1(10,10):\00"
+@alias_multifunc1.16 =    constant [?? x i8] c"expect p2(22,10):\00"
+
+
+@alias_multifunc1.15 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc1.14 to i64) }
+
+
+@alias_multifunc1.14 =    constant [?? x i8] c"expect p1(10,10):\00"
 
 
 @alias_multifunc1.13 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @alias_multifunc1.12 to i64) }
@@ -141,10 +141,10 @@ declare external ccc  void @putchar(i8)
 declare external ccc  void @print_int(i64)    
 
 
-@alias_multifunc1.68 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @alias_multifunc1.67 to i64) }
+@alias_multifunc1.59 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @alias_multifunc1.58 to i64) }
 
 
-@alias_multifunc1.67 =    constant [?? x i8] c"some noise...\00"
+@alias_multifunc1.58 =    constant [?? x i8] c"some noise...\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -168,45 +168,36 @@ entry:
   %9 = tail call fastcc  {i64, i64}  @"alias_multifunc1.replicate1<0>"(i64  %3)  
   %10 = extractvalue {i64, i64} %9, 0 
   %11 = extractvalue {i64, i64} %9, 1 
-  %14 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.13, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %14)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %17 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.16, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %17)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.15, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %3)  
-  %20 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.19, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %20)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.17, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %10)  
-  %23 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.22, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %23)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.19, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %11)  
-  %24 = inttoptr i64 %10 to i64* 
-  %25 = getelementptr  i64, i64* %24, i64 0 
-  store  i64 2222222, i64* %25 
-  %28 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.27, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %28)  
+  %20 = inttoptr i64 %10 to i64* 
+  %21 = getelementptr  i64, i64* %20, i64 0 
+  store  i64 2222222, i64* %21 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.23, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %31 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.30, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %31)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.25, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %10)  
-  %32 = trunc i64 16 to i32  
-  %33 = tail call ccc  i8*  @wybe_malloc(i32  %32)  
-  %34 = ptrtoint i8* %33 to i64 
-  %35 = inttoptr i64 %34 to i8* 
-  %36 = inttoptr i64 %3 to i8* 
-  %37 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %35, i8*  %36, i32  %37, i32  8, i1  0)  
-  %38 = inttoptr i64 %34 to i64* 
-  %39 = getelementptr  i64, i64* %38, i64 0 
-  store  i64 11, i64* %39 
-  %42 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.41, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %42)  
+  %26 = trunc i64 16 to i32  
+  %27 = tail call ccc  i8*  @wybe_malloc(i32  %26)  
+  %28 = ptrtoint i8* %27 to i64 
+  %29 = inttoptr i64 %28 to i8* 
+  %30 = inttoptr i64 %3 to i8* 
+  %31 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %29, i8*  %30, i32  %31, i32  8, i1  0)  
+  %32 = inttoptr i64 %28 to i64* 
+  %33 = getelementptr  i64, i64* %32, i64 0 
+  store  i64 11, i64* %33 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.35, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %45 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.44, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %45)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %34)  
-  %48 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.47, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %48)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.37, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %28)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.39, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %11)  
   ret void 
 }
@@ -216,40 +207,39 @@ define external fastcc  {i64, i64} @"alias_multifunc1.replicate1<0>"(i64  %"p1##
 entry:
   %"1#p2##0" = tail call fastcc  i64  @"alias_multifunc1.replicate2<0>"(i64  %"p1##0")  
   %"1#p3##0" = tail call fastcc  i64  @"alias_multifunc1.replicate2<0>"(i64  %"1#p2##0")  
-  %49 = trunc i64 16 to i32  
-  %50 = tail call ccc  i8*  @wybe_malloc(i32  %49)  
-  %51 = ptrtoint i8* %50 to i64 
-  %52 = inttoptr i64 %51 to i8* 
-  %53 = inttoptr i64 %"1#p2##0" to i8* 
-  %54 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %52, i8*  %53, i32  %54, i32  8, i1  0)  
-  %55 = inttoptr i64 %51 to i64* 
-  %56 = getelementptr  i64, i64* %55, i64 0 
-  store  i64 22, i64* %56 
-  %57 = insertvalue {i64, i64} undef, i64 %51, 0 
-  %58 = insertvalue {i64, i64} %57, i64 %"1#p3##0", 1 
-  ret {i64, i64} %58 
+  %40 = trunc i64 16 to i32  
+  %41 = tail call ccc  i8*  @wybe_malloc(i32  %40)  
+  %42 = ptrtoint i8* %41 to i64 
+  %43 = inttoptr i64 %42 to i8* 
+  %44 = inttoptr i64 %"1#p2##0" to i8* 
+  %45 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %43, i8*  %44, i32  %45, i32  8, i1  0)  
+  %46 = inttoptr i64 %42 to i64* 
+  %47 = getelementptr  i64, i64* %46, i64 0 
+  store  i64 22, i64* %47 
+  %48 = insertvalue {i64, i64} undef, i64 %42, 0 
+  %49 = insertvalue {i64, i64} %48, i64 %"1#p3##0", 1 
+  ret {i64, i64} %49 
 }
 
 
 define external fastcc  i64 @"alias_multifunc1.replicate2<0>"(i64  %"p1##0")    {
 entry:
-  %59 = trunc i64 16 to i32  
-  %60 = tail call ccc  i8*  @wybe_malloc(i32  %59)  
-  %61 = ptrtoint i8* %60 to i64 
-  %62 = inttoptr i64 %61 to i64* 
-  %63 = getelementptr  i64, i64* %62, i64 0 
-  store  i64 0, i64* %63 
-  %64 = add   i64 %61, 8 
-  %65 = inttoptr i64 %64 to i64* 
-  %66 = getelementptr  i64, i64* %65, i64 0 
-  store  i64 0, i64* %66 
-  %69 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.68, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %69)  
-  %70 = inttoptr i64 %61 to i64* 
-  %71 = getelementptr  i64, i64* %70, i64 0 
-  %72 = load  i64, i64* %71 
-  tail call ccc  void  @print_int(i64  %72)  
+  %50 = trunc i64 16 to i32  
+  %51 = tail call ccc  i8*  @wybe_malloc(i32  %50)  
+  %52 = ptrtoint i8* %51 to i64 
+  %53 = inttoptr i64 %52 to i64* 
+  %54 = getelementptr  i64, i64* %53, i64 0 
+  store  i64 0, i64* %54 
+  %55 = add   i64 %52, 8 
+  %56 = inttoptr i64 %55 to i64* 
+  %57 = getelementptr  i64, i64* %56, i64 0 
+  store  i64 0, i64* %57 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc1.59, i32 0, i32 0) to i64))  
+  %60 = inttoptr i64 %52 to i64* 
+  %61 = getelementptr  i64, i64* %60, i64 0 
+  %62 = load  i64, i64* %61 
+  tail call ccc  void  @print_int(i64  %62)  
   tail call ccc  void  @putchar(i8  10)  
   ret i64 %"p1##0" 
 }
@@ -304,16 +294,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@position.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.14 to i64) }
+@position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.14 =    constant [?? x i8] c")\00"
+@position.12 =    constant [?? x i8] c")\00"
 
 
-@position.8 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.7 to i64) }
+@position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
 
 
-@position.7 =    constant [?? x i8] c",\00"
+@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
@@ -330,21 +320,18 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
-  %4 = inttoptr i64 %"pos##0" to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
-  %10 = add   i64 %"pos##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  tail call ccc  void  @print_int(i64  %13)  
-  %16 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.15, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %16)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64))  
+  %3 = inttoptr i64 %"pos##0" to i64* 
+  %4 = getelementptr  i64, i64* %3, i64 0 
+  %5 = load  i64, i64* %4 
+  tail call ccc  void  @print_int(i64  %5)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.7, i32 0, i32 0) to i64))  
+  %8 = add   i64 %"pos##0", 8 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = getelementptr  i64, i64* %9, i64 0 
+  %11 = load  i64, i64* %10 
+  tail call ccc  void  @print_int(i64  %11)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/alias_multifunc2.exp
+++ b/test-cases/final-dump/alias_multifunc2.exp
@@ -81,46 +81,46 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @putchar(i8)    
 
 
-@alias_multifunc2.42 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc2.41 to i64) }
+@alias_multifunc2.35 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc2.34 to i64) }
 
 
-@alias_multifunc2.41 =    constant [?? x i8] c"expect p3(10,10):\00"
+@alias_multifunc2.34 =    constant [?? x i8] c"expect p3(10,10):\00"
 
 
-@alias_multifunc2.39 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc2.38 to i64) }
+@alias_multifunc2.33 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc2.32 to i64) }
 
 
-@alias_multifunc2.38 =    constant [?? x i8] c"expect p2(22,10):\00"
+@alias_multifunc2.32 =    constant [?? x i8] c"expect p2(22,10):\00"
 
 
-@alias_multifunc2.36 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc2.35 to i64) }
+@alias_multifunc2.31 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc2.30 to i64) }
 
 
-@alias_multifunc2.35 =    constant [?? x i8] c"expect p1(11,10):\00"
+@alias_multifunc2.30 =    constant [?? x i8] c"expect p1(11,10):\00"
 
 
-@alias_multifunc2.33 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @alias_multifunc2.32 to i64) }
+@alias_multifunc2.29 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @alias_multifunc2.28 to i64) }
 
 
-@alias_multifunc2.32 =    constant [?? x i8] c"--- After calling x(!p1, 11): \00"
-
-
-@alias_multifunc2.22 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc2.21 to i64) }
-
-
-@alias_multifunc2.21 =    constant [?? x i8] c"expect p3(10,10):\00"
+@alias_multifunc2.28 =    constant [?? x i8] c"--- After calling x(!p1, 11): \00"
 
 
 @alias_multifunc2.19 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc2.18 to i64) }
 
 
-@alias_multifunc2.18 =    constant [?? x i8] c"expect p2(22,10):\00"
+@alias_multifunc2.18 =    constant [?? x i8] c"expect p3(10,10):\00"
 
 
-@alias_multifunc2.16 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc2.15 to i64) }
+@alias_multifunc2.17 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc2.16 to i64) }
 
 
-@alias_multifunc2.15 =    constant [?? x i8] c"expect p1(10,10):\00"
+@alias_multifunc2.16 =    constant [?? x i8] c"expect p2(22,10):\00"
+
+
+@alias_multifunc2.15 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc2.14 to i64) }
+
+
+@alias_multifunc2.14 =    constant [?? x i8] c"expect p1(10,10):\00"
 
 
 @alias_multifunc2.13 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @alias_multifunc2.12 to i64) }
@@ -132,10 +132,10 @@ declare external ccc  void @putchar(i8)
 declare external ccc  void @print_int(i64)    
 
 
-@alias_multifunc2.63 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias_multifunc2.62 to i64) }
+@alias_multifunc2.55 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias_multifunc2.54 to i64) }
 
 
-@alias_multifunc2.62 =    constant [?? x i8] c"random replicate2 \00"
+@alias_multifunc2.54 =    constant [?? x i8] c"random replicate2 \00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -159,39 +159,31 @@ entry:
   %9 = tail call fastcc  {i64, i64}  @"alias_multifunc2.replicate1<0>"(i64  %3)  
   %10 = extractvalue {i64, i64} %9, 0 
   %11 = extractvalue {i64, i64} %9, 1 
-  %14 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc2.13, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %14)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc2.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %17 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc2.16, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %17)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc2.15, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %3)  
-  %20 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc2.19, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %20)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc2.17, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %10)  
-  %23 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc2.22, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %23)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc2.19, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %11)  
-  %24 = trunc i64 16 to i32  
-  %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
-  %26 = ptrtoint i8* %25 to i64 
-  %27 = inttoptr i64 %26 to i8* 
-  %28 = inttoptr i64 %3 to i8* 
-  %29 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %27, i8*  %28, i32  %29, i32  8, i1  0)  
-  %30 = inttoptr i64 %26 to i64* 
-  %31 = getelementptr  i64, i64* %30, i64 0 
-  store  i64 11, i64* %31 
-  %34 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc2.33, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %34)  
+  %20 = trunc i64 16 to i32  
+  %21 = tail call ccc  i8*  @wybe_malloc(i32  %20)  
+  %22 = ptrtoint i8* %21 to i64 
+  %23 = inttoptr i64 %22 to i8* 
+  %24 = inttoptr i64 %3 to i8* 
+  %25 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %23, i8*  %24, i32  %25, i32  8, i1  0)  
+  %26 = inttoptr i64 %22 to i64* 
+  %27 = getelementptr  i64, i64* %26, i64 0 
+  store  i64 11, i64* %27 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc2.29, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %37 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc2.36, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %37)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %26)  
-  %40 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc2.39, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %40)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc2.31, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %22)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc2.33, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %10)  
-  %43 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc2.42, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %43)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc2.35, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %11)  
   ret void 
 }
@@ -201,40 +193,39 @@ define external fastcc  {i64, i64} @"alias_multifunc2.replicate1<0>"(i64  %"p1##
 entry:
   %"1#p2##0" = tail call fastcc  i64  @"alias_multifunc2.replicate2<0>"(i64  %"p1##0")  
   %"1#p3##0" = tail call fastcc  i64  @"alias_multifunc2.replicate2<0>"(i64  %"1#p2##0")  
-  %44 = trunc i64 16 to i32  
-  %45 = tail call ccc  i8*  @wybe_malloc(i32  %44)  
-  %46 = ptrtoint i8* %45 to i64 
-  %47 = inttoptr i64 %46 to i8* 
-  %48 = inttoptr i64 %"1#p2##0" to i8* 
-  %49 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %47, i8*  %48, i32  %49, i32  8, i1  0)  
-  %50 = inttoptr i64 %46 to i64* 
-  %51 = getelementptr  i64, i64* %50, i64 0 
-  store  i64 22, i64* %51 
-  %52 = insertvalue {i64, i64} undef, i64 %46, 0 
-  %53 = insertvalue {i64, i64} %52, i64 %"1#p3##0", 1 
-  ret {i64, i64} %53 
+  %36 = trunc i64 16 to i32  
+  %37 = tail call ccc  i8*  @wybe_malloc(i32  %36)  
+  %38 = ptrtoint i8* %37 to i64 
+  %39 = inttoptr i64 %38 to i8* 
+  %40 = inttoptr i64 %"1#p2##0" to i8* 
+  %41 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %39, i8*  %40, i32  %41, i32  8, i1  0)  
+  %42 = inttoptr i64 %38 to i64* 
+  %43 = getelementptr  i64, i64* %42, i64 0 
+  store  i64 22, i64* %43 
+  %44 = insertvalue {i64, i64} undef, i64 %38, 0 
+  %45 = insertvalue {i64, i64} %44, i64 %"1#p3##0", 1 
+  ret {i64, i64} %45 
 }
 
 
 define external fastcc  i64 @"alias_multifunc2.replicate2<0>"(i64  %"p1##0")    {
 entry:
-  %54 = trunc i64 16 to i32  
-  %55 = tail call ccc  i8*  @wybe_malloc(i32  %54)  
-  %56 = ptrtoint i8* %55 to i64 
-  %57 = inttoptr i64 %56 to i64* 
-  %58 = getelementptr  i64, i64* %57, i64 0 
-  store  i64 0, i64* %58 
-  %59 = add   i64 %56, 8 
-  %60 = inttoptr i64 %59 to i64* 
-  %61 = getelementptr  i64, i64* %60, i64 0 
-  store  i64 0, i64* %61 
-  %64 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc2.63, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %64)  
-  %65 = inttoptr i64 %56 to i64* 
-  %66 = getelementptr  i64, i64* %65, i64 0 
-  %67 = load  i64, i64* %66 
-  tail call ccc  void  @print_int(i64  %67)  
+  %46 = trunc i64 16 to i32  
+  %47 = tail call ccc  i8*  @wybe_malloc(i32  %46)  
+  %48 = ptrtoint i8* %47 to i64 
+  %49 = inttoptr i64 %48 to i64* 
+  %50 = getelementptr  i64, i64* %49, i64 0 
+  store  i64 0, i64* %50 
+  %51 = add   i64 %48, 8 
+  %52 = inttoptr i64 %51 to i64* 
+  %53 = getelementptr  i64, i64* %52, i64 0 
+  store  i64 0, i64* %53 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc2.55, i32 0, i32 0) to i64))  
+  %56 = inttoptr i64 %48 to i64* 
+  %57 = getelementptr  i64, i64* %56, i64 0 
+  %58 = load  i64, i64* %57 
+  tail call ccc  void  @print_int(i64  %58)  
   tail call ccc  void  @putchar(i8  10)  
   ret i64 %"p1##0" 
 }
@@ -289,16 +280,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@position.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.14 to i64) }
+@position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.14 =    constant [?? x i8] c")\00"
+@position.12 =    constant [?? x i8] c")\00"
 
 
-@position.8 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.7 to i64) }
+@position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
 
 
-@position.7 =    constant [?? x i8] c",\00"
+@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
@@ -315,21 +306,18 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
-  %4 = inttoptr i64 %"pos##0" to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
-  %10 = add   i64 %"pos##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  tail call ccc  void  @print_int(i64  %13)  
-  %16 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.15, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %16)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64))  
+  %3 = inttoptr i64 %"pos##0" to i64* 
+  %4 = getelementptr  i64, i64* %3, i64 0 
+  %5 = load  i64, i64* %4 
+  tail call ccc  void  @print_int(i64  %5)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.7, i32 0, i32 0) to i64))  
+  %8 = add   i64 %"pos##0", 8 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = getelementptr  i64, i64* %9, i64 0 
+  %11 = load  i64, i64* %10 
+  tail call ccc  void  @print_int(i64  %11)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/alias_multifunc3.exp
+++ b/test-cases/final-dump/alias_multifunc3.exp
@@ -66,34 +66,34 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @putchar(i8)    
 
 
-@alias_multifunc3.33 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc3.32 to i64) }
+@alias_multifunc3.28 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc3.27 to i64) }
 
 
-@alias_multifunc3.32 =    constant [?? x i8] c"expect p2(10,10):\00"
+@alias_multifunc3.27 =    constant [?? x i8] c"expect p2(10,10):\00"
 
 
-@alias_multifunc3.30 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias_multifunc3.29 to i64) }
+@alias_multifunc3.26 =    constant {i64, i64} { i64 18, i64 ptrtoint ([?? x i8]* @alias_multifunc3.25 to i64) }
 
 
-@alias_multifunc3.29 =    constant [?? x i8] c"expect p1(999,10):\00"
+@alias_multifunc3.25 =    constant [?? x i8] c"expect p1(999,10):\00"
 
 
-@alias_multifunc3.27 =    constant {i64, i64} { i64 29, i64 ptrtoint ([?? x i8]* @alias_multifunc3.26 to i64) }
+@alias_multifunc3.24 =    constant {i64, i64} { i64 29, i64 ptrtoint ([?? x i8]* @alias_multifunc3.23 to i64) }
 
 
-@alias_multifunc3.26 =    constant [?? x i8] c"--- After called x(!p1, 999):\00"
+@alias_multifunc3.23 =    constant [?? x i8] c"--- After called x(!p1, 999):\00"
 
 
-@alias_multifunc3.16 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc3.15 to i64) }
+@alias_multifunc3.14 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc3.13 to i64) }
 
 
-@alias_multifunc3.15 =    constant [?? x i8] c"expect p2(10,10):\00"
+@alias_multifunc3.13 =    constant [?? x i8] c"expect p2(10,10):\00"
 
 
-@alias_multifunc3.13 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc3.12 to i64) }
+@alias_multifunc3.12 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc3.11 to i64) }
 
 
-@alias_multifunc3.12 =    constant [?? x i8] c"expect p1(10,10):\00"
+@alias_multifunc3.11 =    constant [?? x i8] c"expect p1(10,10):\00"
 
 
 @alias_multifunc3.10 =    constant {i64, i64} { i64 29, i64 ptrtoint ([?? x i8]* @alias_multifunc3.9 to i64) }
@@ -102,22 +102,22 @@ declare external ccc  void @putchar(i8)
 @alias_multifunc3.9 =    constant [?? x i8] c"--- After calling replicate1:\00"
 
 
-@alias_multifunc3.50 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc3.49 to i64) }
+@alias_multifunc3.42 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc3.41 to i64) }
 
 
-@alias_multifunc3.49 =    constant [?? x i8] c"expect pb(10,10):\00"
+@alias_multifunc3.41 =    constant [?? x i8] c"expect pb(10,10):\00"
 
 
-@alias_multifunc3.47 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_multifunc3.46 to i64) }
+@alias_multifunc3.40 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_multifunc3.39 to i64) }
 
 
-@alias_multifunc3.46 =    constant [?? x i8] c"expect pa(1111,10):\00"
+@alias_multifunc3.39 =    constant [?? x i8] c"expect pa(1111,10):\00"
 
 
-@alias_multifunc3.44 =    constant {i64, i64} { i64 22, i64 ptrtoint ([?? x i8]* @alias_multifunc3.43 to i64) }
+@alias_multifunc3.38 =    constant {i64, i64} { i64 22, i64 ptrtoint ([?? x i8]* @alias_multifunc3.37 to i64) }
 
 
-@alias_multifunc3.43 =    constant [?? x i8] c"--- Inside replicate1:\00"
+@alias_multifunc3.37 =    constant [?? x i8] c"--- Inside replicate1:\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -139,33 +139,27 @@ entry:
   %8 = getelementptr  i64, i64* %7, i64 0 
   store  i64 10, i64* %8 
   %"1#p2##0" = tail call fastcc  i64  @"alias_multifunc3.replicate1<0>"(i64  %3)  
-  %11 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc3.10, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %11)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc3.10, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %14 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc3.13, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %14)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc3.12, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %3)  
-  %17 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc3.16, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %17)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc3.14, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
-  %18 = trunc i64 16 to i32  
-  %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
-  %20 = ptrtoint i8* %19 to i64 
-  %21 = inttoptr i64 %20 to i8* 
-  %22 = inttoptr i64 %3 to i8* 
-  %23 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %21, i8*  %22, i32  %23, i32  8, i1  0)  
-  %24 = inttoptr i64 %20 to i64* 
-  %25 = getelementptr  i64, i64* %24, i64 0 
-  store  i64 999, i64* %25 
-  %28 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc3.27, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %28)  
+  %15 = trunc i64 16 to i32  
+  %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
+  %17 = ptrtoint i8* %16 to i64 
+  %18 = inttoptr i64 %17 to i8* 
+  %19 = inttoptr i64 %3 to i8* 
+  %20 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %18, i8*  %19, i32  %20, i32  8, i1  0)  
+  %21 = inttoptr i64 %17 to i64* 
+  %22 = getelementptr  i64, i64* %21, i64 0 
+  store  i64 999, i64* %22 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc3.24, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %31 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc3.30, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %31)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %20)  
-  %34 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc3.33, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %34)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc3.26, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %17)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc3.28, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p2##0")  
   ret void 
 }
@@ -173,24 +167,21 @@ entry:
 
 define external fastcc  i64 @"alias_multifunc3.replicate1<0>"(i64  %"pa##0")    {
 entry:
-  %35 = trunc i64 16 to i32  
-  %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
-  %37 = ptrtoint i8* %36 to i64 
-  %38 = inttoptr i64 %37 to i8* 
-  %39 = inttoptr i64 %"pa##0" to i8* 
-  %40 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
-  %41 = inttoptr i64 %37 to i64* 
-  %42 = getelementptr  i64, i64* %41, i64 0 
-  store  i64 1111, i64* %42 
-  %45 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc3.44, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %45)  
+  %29 = trunc i64 16 to i32  
+  %30 = tail call ccc  i8*  @wybe_malloc(i32  %29)  
+  %31 = ptrtoint i8* %30 to i64 
+  %32 = inttoptr i64 %31 to i8* 
+  %33 = inttoptr i64 %"pa##0" to i8* 
+  %34 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %32, i8*  %33, i32  %34, i32  8, i1  0)  
+  %35 = inttoptr i64 %31 to i64* 
+  %36 = getelementptr  i64, i64* %35, i64 0 
+  store  i64 1111, i64* %36 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc3.38, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %48 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc3.47, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %48)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %37)  
-  %51 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc3.50, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %51)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc3.40, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %31)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc3.42, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"pa##0")  
   ret i64 %"pa##0" 
 }
@@ -245,16 +236,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@position.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.14 to i64) }
+@position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.14 =    constant [?? x i8] c")\00"
+@position.12 =    constant [?? x i8] c")\00"
 
 
-@position.8 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.7 to i64) }
+@position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
 
 
-@position.7 =    constant [?? x i8] c",\00"
+@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
@@ -271,21 +262,18 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
-  %4 = inttoptr i64 %"pos##0" to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
-  %10 = add   i64 %"pos##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  tail call ccc  void  @print_int(i64  %13)  
-  %16 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.15, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %16)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64))  
+  %3 = inttoptr i64 %"pos##0" to i64* 
+  %4 = getelementptr  i64, i64* %3, i64 0 
+  %5 = load  i64, i64* %4 
+  tail call ccc  void  @print_int(i64  %5)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.7, i32 0, i32 0) to i64))  
+  %8 = add   i64 %"pos##0", 8 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = getelementptr  i64, i64* %9, i64 0 
+  %11 = load  i64, i64* %10 
+  tail call ccc  void  @print_int(i64  %11)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/alias_multifunc4.exp
+++ b/test-cases/final-dump/alias_multifunc4.exp
@@ -103,52 +103,52 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @putchar(i8)    
 
 
-@alias_multifunc4.40 =    constant {i64, i64} { i64 28, i64 ptrtoint ([?? x i8]* @alias_multifunc4.39 to i64) }
+@alias_multifunc4.32 =    constant {i64, i64} { i64 28, i64 ptrtoint ([?? x i8]* @alias_multifunc4.31 to i64) }
 
 
-@alias_multifunc4.39 =    constant [?? x i8] c"expect p7(1111111111,99999):\00"
+@alias_multifunc4.31 =    constant [?? x i8] c"expect p7(1111111111,99999):\00"
 
 
-@alias_multifunc4.37 =    constant {i64, i64} { i64 23, i64 ptrtoint ([?? x i8]* @alias_multifunc4.36 to i64) }
+@alias_multifunc4.30 =    constant {i64, i64} { i64 23, i64 ptrtoint ([?? x i8]* @alias_multifunc4.29 to i64) }
 
 
-@alias_multifunc4.36 =    constant [?? x i8] c"expect p6(99999,99999):\00"
+@alias_multifunc4.29 =    constant [?? x i8] c"expect p6(99999,99999):\00"
 
 
-@alias_multifunc4.34 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @alias_multifunc4.33 to i64) }
+@alias_multifunc4.28 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @alias_multifunc4.27 to i64) }
 
 
-@alias_multifunc4.33 =    constant [?? x i8] c"--- After calling replicate22:\00"
+@alias_multifunc4.27 =    constant [?? x i8] c"--- After calling replicate22:\00"
 
 
-@alias_multifunc4.28 =    constant {i64, i64} { i64 23, i64 ptrtoint ([?? x i8]* @alias_multifunc4.27 to i64) }
+@alias_multifunc4.23 =    constant {i64, i64} { i64 23, i64 ptrtoint ([?? x i8]* @alias_multifunc4.22 to i64) }
 
 
-@alias_multifunc4.27 =    constant [?? x i8] c"expect p4(99999,99999):\00"
+@alias_multifunc4.22 =    constant [?? x i8] c"expect p4(99999,99999):\00"
 
 
-@alias_multifunc4.25 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @alias_multifunc4.24 to i64) }
+@alias_multifunc4.21 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @alias_multifunc4.20 to i64) }
 
 
-@alias_multifunc4.24 =    constant [?? x i8] c"--- After calling replicate21:\00"
-
-
-@alias_multifunc4.22 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc4.21 to i64) }
-
-
-@alias_multifunc4.21 =    constant [?? x i8] c"expect p3(10,10):\00"
+@alias_multifunc4.20 =    constant [?? x i8] c"--- After calling replicate21:\00"
 
 
 @alias_multifunc4.19 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc4.18 to i64) }
 
 
-@alias_multifunc4.18 =    constant [?? x i8] c"expect p2(99,10):\00"
+@alias_multifunc4.18 =    constant [?? x i8] c"expect p3(10,10):\00"
 
 
-@alias_multifunc4.16 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc4.15 to i64) }
+@alias_multifunc4.17 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc4.16 to i64) }
 
 
-@alias_multifunc4.15 =    constant [?? x i8] c"expect p1(10,10):\00"
+@alias_multifunc4.16 =    constant [?? x i8] c"expect p2(99,10):\00"
+
+
+@alias_multifunc4.15 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_multifunc4.14 to i64) }
+
+
+@alias_multifunc4.14 =    constant [?? x i8] c"expect p1(10,10):\00"
 
 
 @alias_multifunc4.13 =    constant {i64, i64} { i64 29, i64 ptrtoint ([?? x i8]* @alias_multifunc4.12 to i64) }
@@ -157,22 +157,22 @@ declare external ccc  void @putchar(i8)
 @alias_multifunc4.12 =    constant [?? x i8] c"--- After calling replicate1:\00"
 
 
-@alias_multifunc4.80 =    constant {i64, i64} { i64 53, i64 ptrtoint ([?? x i8]* @alias_multifunc4.79 to i64) }
+@alias_multifunc4.71 =    constant {i64, i64} { i64 53, i64 ptrtoint ([?? x i8]* @alias_multifunc4.70 to i64) }
 
 
-@alias_multifunc4.79 =    constant [?? x i8] c"--- Inside replicate21, expect pc(1111111111,99999): \00"
+@alias_multifunc4.70 =    constant [?? x i8] c"--- Inside replicate21, expect pc(1111111111,99999): \00"
 
 
-@alias_multifunc4.102 =    constant {i64, i64} { i64 86, i64 ptrtoint ([?? x i8]* @alias_multifunc4.101 to i64) }
+@alias_multifunc4.91 =    constant {i64, i64} { i64 86, i64 ptrtoint ([?? x i8]* @alias_multifunc4.90 to i64) }
 
 
-@alias_multifunc4.101 =    constant [?? x i8] c"--- Inside replicate22, after calling x(!pc,1111111111), expect pc(1111111111,99999): \00"
+@alias_multifunc4.90 =    constant [?? x i8] c"--- Inside replicate22, after calling x(!pc,1111111111), expect pc(1111111111,99999): \00"
 
 
-@alias_multifunc4.91 =    constant {i64, i64} { i64 47, i64 ptrtoint ([?? x i8]* @alias_multifunc4.90 to i64) }
+@alias_multifunc4.81 =    constant {i64, i64} { i64 47, i64 ptrtoint ([?? x i8]* @alias_multifunc4.80 to i64) }
 
 
-@alias_multifunc4.90 =    constant [?? x i8] c"--- Inside replicate22, expect pc(99999,99999):\00"
+@alias_multifunc4.80 =    constant [?? x i8] c"--- Inside replicate22, expect pc(99999,99999):\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -196,132 +196,120 @@ entry:
   %9 = tail call fastcc  {i64, i64}  @"alias_multifunc4.replicate1<0>"(i64  %3)  
   %10 = extractvalue {i64, i64} %9, 0 
   %11 = extractvalue {i64, i64} %9, 1 
-  %14 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.13, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %14)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %17 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.16, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %17)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.15, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %3)  
-  %20 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.19, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %20)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.17, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %10)  
-  %23 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.22, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %23)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.19, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %11)  
   %"1#p4##0" = tail call fastcc  i64  @"alias_multifunc4.replicate21<0>"()  
-  %26 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.25, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %26)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.21, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %29 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.28, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %29)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.23, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#p4##0")  
-  %30 = tail call fastcc  {i64, i64}  @"alias_multifunc4.replicate22<0>"()  
-  %31 = extractvalue {i64, i64} %30, 0 
-  %32 = extractvalue {i64, i64} %30, 1 
-  %35 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.34, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %35)  
+  %24 = tail call fastcc  {i64, i64}  @"alias_multifunc4.replicate22<0>"()  
+  %25 = extractvalue {i64, i64} %24, 0 
+  %26 = extractvalue {i64, i64} %24, 1 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.28, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %38 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.37, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %38)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %31)  
-  %41 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.40, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %41)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %32)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.30, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %25)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.32, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %26)  
   ret void 
 }
 
 
 define external fastcc  {i64, i64} @"alias_multifunc4.replicate1<0>"(i64  %"pa##0")    {
 entry:
-  %42 = trunc i64 16 to i32  
-  %43 = tail call ccc  i8*  @wybe_malloc(i32  %42)  
-  %44 = ptrtoint i8* %43 to i64 
-  %45 = inttoptr i64 %44 to i64* 
-  %46 = getelementptr  i64, i64* %45, i64 0 
-  store  i64 99, i64* %46 
-  %47 = add   i64 %44, 8 
-  %48 = inttoptr i64 %47 to i64* 
-  %49 = getelementptr  i64, i64* %48, i64 0 
-  store  i64 99, i64* %49 
-  %50 = inttoptr i64 %44 to i64* 
+  %33 = trunc i64 16 to i32  
+  %34 = tail call ccc  i8*  @wybe_malloc(i32  %33)  
+  %35 = ptrtoint i8* %34 to i64 
+  %36 = inttoptr i64 %35 to i64* 
+  %37 = getelementptr  i64, i64* %36, i64 0 
+  store  i64 99, i64* %37 
+  %38 = add   i64 %35, 8 
+  %39 = inttoptr i64 %38 to i64* 
+  %40 = getelementptr  i64, i64* %39, i64 0 
+  store  i64 99, i64* %40 
+  %41 = inttoptr i64 %35 to i64* 
+  %42 = getelementptr  i64, i64* %41, i64 0 
+  %43 = load  i64, i64* %42 
+  %44 = trunc i64 16 to i32  
+  %45 = tail call ccc  i8*  @wybe_malloc(i32  %44)  
+  %46 = ptrtoint i8* %45 to i64 
+  %47 = inttoptr i64 %46 to i8* 
+  %48 = inttoptr i64 %"pa##0" to i8* 
+  %49 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %47, i8*  %48, i32  %49, i32  8, i1  0)  
+  %50 = inttoptr i64 %46 to i64* 
   %51 = getelementptr  i64, i64* %50, i64 0 
-  %52 = load  i64, i64* %51 
-  %53 = trunc i64 16 to i32  
-  %54 = tail call ccc  i8*  @wybe_malloc(i32  %53)  
-  %55 = ptrtoint i8* %54 to i64 
-  %56 = inttoptr i64 %55 to i8* 
-  %57 = inttoptr i64 %"pa##0" to i8* 
-  %58 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %56, i8*  %57, i32  %58, i32  8, i1  0)  
-  %59 = inttoptr i64 %55 to i64* 
-  %60 = getelementptr  i64, i64* %59, i64 0 
-  store  i64 %52, i64* %60 
-  %61 = insertvalue {i64, i64} undef, i64 %55, 0 
-  %62 = insertvalue {i64, i64} %61, i64 %"pa##0", 1 
-  ret {i64, i64} %62 
+  store  i64 %43, i64* %51 
+  %52 = insertvalue {i64, i64} undef, i64 %46, 0 
+  %53 = insertvalue {i64, i64} %52, i64 %"pa##0", 1 
+  ret {i64, i64} %53 
 }
 
 
 define external fastcc  i64 @"alias_multifunc4.replicate21<0>"()    {
 entry:
-  %63 = trunc i64 16 to i32  
-  %64 = tail call ccc  i8*  @wybe_malloc(i32  %63)  
-  %65 = ptrtoint i8* %64 to i64 
-  %66 = inttoptr i64 %65 to i64* 
-  %67 = getelementptr  i64, i64* %66, i64 0 
-  store  i64 99999, i64* %67 
-  %68 = add   i64 %65, 8 
-  %69 = inttoptr i64 %68 to i64* 
-  %70 = getelementptr  i64, i64* %69, i64 0 
-  store  i64 99999, i64* %70 
-  %71 = trunc i64 16 to i32  
-  %72 = tail call ccc  i8*  @wybe_malloc(i32  %71)  
-  %73 = ptrtoint i8* %72 to i64 
-  %74 = inttoptr i64 %73 to i8* 
-  %75 = inttoptr i64 %65 to i8* 
-  %76 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %74, i8*  %75, i32  %76, i32  8, i1  0)  
-  %77 = inttoptr i64 %73 to i64* 
-  %78 = getelementptr  i64, i64* %77, i64 0 
-  store  i64 1111111111, i64* %78 
-  %81 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.80, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %81)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %73)  
-  ret i64 %65 
+  %54 = trunc i64 16 to i32  
+  %55 = tail call ccc  i8*  @wybe_malloc(i32  %54)  
+  %56 = ptrtoint i8* %55 to i64 
+  %57 = inttoptr i64 %56 to i64* 
+  %58 = getelementptr  i64, i64* %57, i64 0 
+  store  i64 99999, i64* %58 
+  %59 = add   i64 %56, 8 
+  %60 = inttoptr i64 %59 to i64* 
+  %61 = getelementptr  i64, i64* %60, i64 0 
+  store  i64 99999, i64* %61 
+  %62 = trunc i64 16 to i32  
+  %63 = tail call ccc  i8*  @wybe_malloc(i32  %62)  
+  %64 = ptrtoint i8* %63 to i64 
+  %65 = inttoptr i64 %64 to i8* 
+  %66 = inttoptr i64 %56 to i8* 
+  %67 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %65, i8*  %66, i32  %67, i32  8, i1  0)  
+  %68 = inttoptr i64 %64 to i64* 
+  %69 = getelementptr  i64, i64* %68, i64 0 
+  store  i64 1111111111, i64* %69 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.71, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %64)  
+  ret i64 %56 
 }
 
 
 define external fastcc  {i64, i64} @"alias_multifunc4.replicate22<0>"()    {
 entry:
+  %72 = trunc i64 16 to i32  
+  %73 = tail call ccc  i8*  @wybe_malloc(i32  %72)  
+  %74 = ptrtoint i8* %73 to i64 
+  %75 = inttoptr i64 %74 to i64* 
+  %76 = getelementptr  i64, i64* %75, i64 0 
+  store  i64 99999, i64* %76 
+  %77 = add   i64 %74, 8 
+  %78 = inttoptr i64 %77 to i64* 
+  %79 = getelementptr  i64, i64* %78, i64 0 
+  store  i64 99999, i64* %79 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.81, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %74)  
   %82 = trunc i64 16 to i32  
   %83 = tail call ccc  i8*  @wybe_malloc(i32  %82)  
   %84 = ptrtoint i8* %83 to i64 
-  %85 = inttoptr i64 %84 to i64* 
-  %86 = getelementptr  i64, i64* %85, i64 0 
-  store  i64 99999, i64* %86 
-  %87 = add   i64 %84, 8 
-  %88 = inttoptr i64 %87 to i64* 
+  %85 = inttoptr i64 %84 to i8* 
+  %86 = inttoptr i64 %74 to i8* 
+  %87 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %85, i8*  %86, i32  %87, i32  8, i1  0)  
+  %88 = inttoptr i64 %84 to i64* 
   %89 = getelementptr  i64, i64* %88, i64 0 
-  store  i64 99999, i64* %89 
-  %92 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.91, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %92)  
+  store  i64 1111111111, i64* %89 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.91, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %84)  
-  %93 = trunc i64 16 to i32  
-  %94 = tail call ccc  i8*  @wybe_malloc(i32  %93)  
-  %95 = ptrtoint i8* %94 to i64 
-  %96 = inttoptr i64 %95 to i8* 
-  %97 = inttoptr i64 %84 to i8* 
-  %98 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %96, i8*  %97, i32  %98, i32  8, i1  0)  
-  %99 = inttoptr i64 %95 to i64* 
-  %100 = getelementptr  i64, i64* %99, i64 0 
-  store  i64 1111111111, i64* %100 
-  %103 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_multifunc4.102, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %103)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %95)  
-  %104 = insertvalue {i64, i64} undef, i64 %84, 0 
-  %105 = insertvalue {i64, i64} %104, i64 %95, 1 
-  ret {i64, i64} %105 
+  %92 = insertvalue {i64, i64} undef, i64 %74, 0 
+  %93 = insertvalue {i64, i64} %92, i64 %84, 1 
+  ret {i64, i64} %93 
 }
 --------------------------------------------------
  Module position
@@ -374,16 +362,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@position.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.14 to i64) }
+@position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.14 =    constant [?? x i8] c")\00"
+@position.12 =    constant [?? x i8] c")\00"
 
 
-@position.8 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.7 to i64) }
+@position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
 
 
-@position.7 =    constant [?? x i8] c",\00"
+@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
@@ -400,21 +388,18 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
-  %4 = inttoptr i64 %"pos##0" to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
-  %10 = add   i64 %"pos##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  tail call ccc  void  @print_int(i64  %13)  
-  %16 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.15, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %16)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64))  
+  %3 = inttoptr i64 %"pos##0" to i64* 
+  %4 = getelementptr  i64, i64* %3, i64 0 
+  %5 = load  i64, i64* %4 
+  tail call ccc  void  @print_int(i64  %5)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.7, i32 0, i32 0) to i64))  
+  %8 = add   i64 %"pos##0", 8 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = getelementptr  i64, i64* %9, i64 0 
+  %11 = load  i64, i64* %10 
+  tail call ccc  void  @print_int(i64  %11)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/alias_recursion1.exp
+++ b/test-cases/final-dump/alias_recursion1.exp
@@ -80,64 +80,64 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @putchar(i8)    
 
 
-@alias_recursion1.56 =    constant {i64, i64} { i64 27, i64 ptrtoint ([?? x i8]* @alias_recursion1.55 to i64) }
+@alias_recursion1.46 =    constant {i64, i64} { i64 27, i64 ptrtoint ([?? x i8]* @alias_recursion1.45 to i64) }
 
 
-@alias_recursion1.55 =    constant [?? x i8] c"expect r still (-200,-201):\00"
+@alias_recursion1.45 =    constant [?? x i8] c"expect r still (-200,-201):\00"
 
 
-@alias_recursion1.53 =    constant {i64, i64} { i64 21, i64 ptrtoint ([?? x i8]* @alias_recursion1.52 to i64) }
+@alias_recursion1.44 =    constant {i64, i64} { i64 21, i64 ptrtoint ([?? x i8]* @alias_recursion1.43 to i64) }
 
 
-@alias_recursion1.52 =    constant [?? x i8] c"expect pa(-1000,101):\00"
+@alias_recursion1.43 =    constant [?? x i8] c"expect pa(-1000,101):\00"
 
 
-@alias_recursion1.42 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_recursion1.41 to i64) }
+@alias_recursion1.34 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @alias_recursion1.33 to i64) }
 
 
-@alias_recursion1.41 =    constant [?? x i8] c"--- modify pa^x: \00"
+@alias_recursion1.33 =    constant [?? x i8] c"--- modify pa^x: \00"
 
 
-@alias_recursion1.39 =    constant {i64, i64} { i64 20, i64 ptrtoint ([?? x i8]* @alias_recursion1.38 to i64) }
+@alias_recursion1.32 =    constant {i64, i64} { i64 20, i64 ptrtoint ([?? x i8]* @alias_recursion1.31 to i64) }
 
 
-@alias_recursion1.38 =    constant [?? x i8] c"expect r(-200,-201):\00"
+@alias_recursion1.31 =    constant [?? x i8] c"expect r(-200,-201):\00"
 
 
-@alias_recursion1.36 =    constant {i64, i64} { i64 38, i64 ptrtoint ([?? x i8]* @alias_recursion1.35 to i64) }
+@alias_recursion1.30 =    constant {i64, i64} { i64 38, i64 ptrtoint ([?? x i8]* @alias_recursion1.29 to i64) }
 
 
-@alias_recursion1.35 =    constant [?? x i8] c"--- expected result to be same as pb: \00"
+@alias_recursion1.29 =    constant [?? x i8] c"--- expected result to be same as pb: \00"
 
 
-@alias_recursion1.33 =    constant {i64, i64} { i64 21, i64 ptrtoint ([?? x i8]* @alias_recursion1.32 to i64) }
+@alias_recursion1.28 =    constant {i64, i64} { i64 21, i64 ptrtoint ([?? x i8]* @alias_recursion1.27 to i64) }
 
 
-@alias_recursion1.32 =    constant [?? x i8] c"expect pb(-200,-201):\00"
+@alias_recursion1.27 =    constant [?? x i8] c"expect pb(-200,-201):\00"
 
 
-@alias_recursion1.30 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_recursion1.29 to i64) }
+@alias_recursion1.26 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_recursion1.25 to i64) }
 
 
-@alias_recursion1.29 =    constant [?? x i8] c"expect pa(100,101):\00"
+@alias_recursion1.25 =    constant [?? x i8] c"expect pa(100,101):\00"
 
 
-@alias_recursion1.27 =    constant {i64, i64} { i64 57, i64 ptrtoint ([?? x i8]* @alias_recursion1.26 to i64) }
+@alias_recursion1.24 =    constant {i64, i64} { i64 57, i64 ptrtoint ([?? x i8]* @alias_recursion1.23 to i64) }
 
 
-@alias_recursion1.26 =    constant [?? x i8] c"--- after calling if_test, pa and pb should be the same: \00"
+@alias_recursion1.23 =    constant [?? x i8] c"--- after calling if_test, pa and pb should be the same: \00"
 
 
-@alias_recursion1.24 =    constant {i64, i64} { i64 21, i64 ptrtoint ([?? x i8]* @alias_recursion1.23 to i64) }
+@alias_recursion1.22 =    constant {i64, i64} { i64 21, i64 ptrtoint ([?? x i8]* @alias_recursion1.21 to i64) }
 
 
-@alias_recursion1.23 =    constant [?? x i8] c"expect pb(-200,-201):\00"
+@alias_recursion1.21 =    constant [?? x i8] c"expect pb(-200,-201):\00"
 
 
-@alias_recursion1.21 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_recursion1.20 to i64) }
+@alias_recursion1.20 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @alias_recursion1.19 to i64) }
 
 
-@alias_recursion1.20 =    constant [?? x i8] c"expect pa(100,101):\00"
+@alias_recursion1.19 =    constant [?? x i8] c"expect pa(100,101):\00"
 
 
 @alias_recursion1.18 =    constant {i64, i64} { i64 22, i64 ptrtoint ([?? x i8]* @alias_recursion1.17 to i64) }
@@ -174,49 +174,38 @@ entry:
   %15 = inttoptr i64 %14 to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
   store  i64 -201, i64* %16 
-  %19 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.18, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %19)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.18, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %22 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.21, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %22)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.20, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %3)  
-  %25 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.24, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %25)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.22, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %11)  
   %"1#r##0" = tail call fastcc  i64  @"alias_recursion1.if_test<0>"(i64  %3, i64  %11)  
-  %28 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.27, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %28)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.24, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %31 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.30, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %31)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.26, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %3)  
-  %34 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.33, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %34)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.28, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %11)  
-  %37 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.36, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %37)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.30, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %40 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.39, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %40)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.32, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#r##0")  
-  %43 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.42, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %43)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.34, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %44 = trunc i64 16 to i32  
-  %45 = tail call ccc  i8*  @wybe_malloc(i32  %44)  
-  %46 = ptrtoint i8* %45 to i64 
-  %47 = inttoptr i64 %46 to i8* 
-  %48 = inttoptr i64 %3 to i8* 
-  %49 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %47, i8*  %48, i32  %49, i32  8, i1  0)  
-  %50 = inttoptr i64 %46 to i64* 
-  %51 = getelementptr  i64, i64* %50, i64 0 
-  store  i64 -1000, i64* %51 
-  %54 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.53, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %54)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %46)  
-  %57 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.56, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %57)  
+  %35 = trunc i64 16 to i32  
+  %36 = tail call ccc  i8*  @wybe_malloc(i32  %35)  
+  %37 = ptrtoint i8* %36 to i64 
+  %38 = inttoptr i64 %37 to i8* 
+  %39 = inttoptr i64 %3 to i8* 
+  %40 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %38, i8*  %39, i32  %40, i32  8, i1  0)  
+  %41 = inttoptr i64 %37 to i64* 
+  %42 = getelementptr  i64, i64* %41, i64 0 
+  store  i64 -1000, i64* %42 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.44, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %37)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_recursion1.46, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"1#r##0")  
   ret void 
 }
@@ -224,10 +213,10 @@ entry:
 
 define external fastcc  i64 @"alias_recursion1.if_test<0>"(i64  %"a##0", i64  %"b##0")    {
 entry:
-  %58 = inttoptr i64 %"a##0" to i64* 
-  %59 = getelementptr  i64, i64* %58, i64 0 
-  %60 = load  i64, i64* %59 
-  %"1#tmp#1##0" = icmp sgt i64 %60, 0 
+  %47 = inttoptr i64 %"a##0" to i64* 
+  %48 = getelementptr  i64, i64* %47, i64 0 
+  %49 = load  i64, i64* %48 
+  %"1#tmp#1##0" = icmp sgt i64 %49, 0 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
   %"2#r##0" = tail call fastcc  i64  @"alias_recursion1.if_test<0>"(i64  %"b##0", i64  %"a##0")  
@@ -286,16 +275,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@position.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.14 to i64) }
+@position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.14 =    constant [?? x i8] c")\00"
+@position.12 =    constant [?? x i8] c")\00"
 
 
-@position.8 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.7 to i64) }
+@position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
 
 
-@position.7 =    constant [?? x i8] c",\00"
+@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
@@ -312,21 +301,18 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
-  %4 = inttoptr i64 %"pos##0" to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
-  %10 = add   i64 %"pos##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  tail call ccc  void  @print_int(i64  %13)  
-  %16 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.15, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %16)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64))  
+  %3 = inttoptr i64 %"pos##0" to i64* 
+  %4 = getelementptr  i64, i64* %3, i64 0 
+  %5 = load  i64, i64* %4 
+  tail call ccc  void  @print_int(i64  %5)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.7, i32 0, i32 0) to i64))  
+  %8 = add   i64 %"pos##0", 8 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = getelementptr  i64, i64* %9, i64 0 
+  %11 = load  i64, i64* %10 
+  tail call ccc  void  @print_int(i64  %11)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/alias_scc_proc.exp
+++ b/test-cases/final-dump/alias_scc_proc.exp
@@ -129,22 +129,22 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @putchar(i8)    
 
 
-@alias_scc_proc.22 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias_scc_proc.21 to i64) }
-
-
-@alias_scc_proc.21 =    constant [?? x i8] c"expect p3(3,3):\00"
-
-
 @alias_scc_proc.19 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias_scc_proc.18 to i64) }
 
 
-@alias_scc_proc.18 =    constant [?? x i8] c"expect p2(2,2):\00"
+@alias_scc_proc.18 =    constant [?? x i8] c"expect p3(3,3):\00"
 
 
-@alias_scc_proc.16 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias_scc_proc.15 to i64) }
+@alias_scc_proc.17 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias_scc_proc.16 to i64) }
 
 
-@alias_scc_proc.15 =    constant [?? x i8] c"expect p1(2,2):\00"
+@alias_scc_proc.16 =    constant [?? x i8] c"expect p2(2,2):\00"
+
+
+@alias_scc_proc.15 =    constant {i64, i64} { i64 15, i64 ptrtoint ([?? x i8]* @alias_scc_proc.14 to i64) }
+
+
+@alias_scc_proc.14 =    constant [?? x i8] c"expect p1(2,2):\00"
 
 
 @alias_scc_proc.13 =    constant {i64, i64} { i64 23, i64 ptrtoint ([?? x i8]* @alias_scc_proc.12 to i64) }
@@ -153,16 +153,16 @@ declare external ccc  void @putchar(i8)
 @alias_scc_proc.12 =    constant [?? x i8] c"--- After calling foo: \00"
 
 
-@alias_scc_proc.62 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @alias_scc_proc.61 to i64) }
+@alias_scc_proc.58 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @alias_scc_proc.57 to i64) }
 
 
-@alias_scc_proc.61 =    constant [?? x i8] c"--- Inside foo: expect p3(3,3):\00"
+@alias_scc_proc.57 =    constant [?? x i8] c"--- Inside foo: expect p3(3,3):\00"
 
 
-@alias_scc_proc.96 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @alias_scc_proc.95 to i64) }
+@alias_scc_proc.91 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @alias_scc_proc.90 to i64) }
 
 
-@alias_scc_proc.95 =    constant [?? x i8] c"--- Inside foo: expect p3(3,3):\00"
+@alias_scc_proc.90 =    constant [?? x i8] c"--- Inside foo: expect p3(3,3):\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -186,17 +186,13 @@ entry:
   %9 = tail call fastcc  {i64, i64}  @"alias_scc_proc.foo<0>"(i64  %3)  
   %10 = extractvalue {i64, i64} %9, 0 
   %11 = extractvalue {i64, i64} %9, 1 
-  %14 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_scc_proc.13, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %14)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_scc_proc.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %17 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_scc_proc.16, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %17)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_scc_proc.15, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %3)  
-  %20 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_scc_proc.19, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %20)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_scc_proc.17, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %10)  
-  %23 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_scc_proc.22, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %23)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_scc_proc.19, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %11)  
   ret void 
 }
@@ -204,153 +200,151 @@ entry:
 
 define external fastcc  i64 @"alias_scc_proc.bar<0>"(i64  %"p1##0")    {
 entry:
-  %24 = add   i64 %"p1##0", 8 
-  %25 = inttoptr i64 %24 to i64* 
-  %26 = getelementptr  i64, i64* %25, i64 0 
-  %27 = load  i64, i64* %26 
-  %"1#tmp#3##0" = icmp sgt i64 %27, 1 
+  %20 = add   i64 %"p1##0", 8 
+  %21 = inttoptr i64 %20 to i64* 
+  %22 = getelementptr  i64, i64* %21, i64 0 
+  %23 = load  i64, i64* %22 
+  %"1#tmp#3##0" = icmp sgt i64 %23, 1 
   br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
   ret i64 %"p1##0" 
 if.else:
-  %"3#tmp#2##0" = add   i64 %27, 1 
-  %28 = trunc i64 16 to i32  
-  %29 = tail call ccc  i8*  @wybe_malloc(i32  %28)  
-  %30 = ptrtoint i8* %29 to i64 
-  %31 = inttoptr i64 %30 to i8* 
-  %32 = inttoptr i64 %"p1##0" to i8* 
-  %33 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %31, i8*  %32, i32  %33, i32  8, i1  0)  
-  %34 = add   i64 %30, 8 
-  %35 = inttoptr i64 %34 to i64* 
-  %36 = getelementptr  i64, i64* %35, i64 0 
-  store  i64 %"3#tmp#2##0", i64* %36 
-  %37 = tail call fastcc  {i64, i64}  @"alias_scc_proc.foo<0>[410bae77d3]"(i64  %30)  
-  %38 = extractvalue {i64, i64} %37, 0 
-  %39 = extractvalue {i64, i64} %37, 1 
-  ret i64 %39 
+  %"3#tmp#2##0" = add   i64 %23, 1 
+  %24 = trunc i64 16 to i32  
+  %25 = tail call ccc  i8*  @wybe_malloc(i32  %24)  
+  %26 = ptrtoint i8* %25 to i64 
+  %27 = inttoptr i64 %26 to i8* 
+  %28 = inttoptr i64 %"p1##0" to i8* 
+  %29 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %27, i8*  %28, i32  %29, i32  8, i1  0)  
+  %30 = add   i64 %26, 8 
+  %31 = inttoptr i64 %30 to i64* 
+  %32 = getelementptr  i64, i64* %31, i64 0 
+  store  i64 %"3#tmp#2##0", i64* %32 
+  %33 = tail call fastcc  {i64, i64}  @"alias_scc_proc.foo<0>[410bae77d3]"(i64  %26)  
+  %34 = extractvalue {i64, i64} %33, 0 
+  %35 = extractvalue {i64, i64} %33, 1 
+  ret i64 %35 
 }
 
 
 define external fastcc  i64 @"alias_scc_proc.bar<0>[410bae77d3]"(i64  %"p1##0")    {
 entry:
-  %40 = add   i64 %"p1##0", 8 
-  %41 = inttoptr i64 %40 to i64* 
-  %42 = getelementptr  i64, i64* %41, i64 0 
-  %43 = load  i64, i64* %42 
-  %"1#tmp#3##0" = icmp sgt i64 %43, 1 
+  %36 = add   i64 %"p1##0", 8 
+  %37 = inttoptr i64 %36 to i64* 
+  %38 = getelementptr  i64, i64* %37, i64 0 
+  %39 = load  i64, i64* %38 
+  %"1#tmp#3##0" = icmp sgt i64 %39, 1 
   br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
   ret i64 %"p1##0" 
 if.else:
-  %"3#tmp#2##0" = add   i64 %43, 1 
-  %44 = add   i64 %"p1##0", 8 
-  %45 = inttoptr i64 %44 to i64* 
-  %46 = getelementptr  i64, i64* %45, i64 0 
-  store  i64 %"3#tmp#2##0", i64* %46 
-  %47 = tail call fastcc  {i64, i64}  @"alias_scc_proc.foo<0>[410bae77d3]"(i64  %"p1##0")  
-  %48 = extractvalue {i64, i64} %47, 0 
-  %49 = extractvalue {i64, i64} %47, 1 
-  ret i64 %49 
+  %"3#tmp#2##0" = add   i64 %39, 1 
+  %40 = add   i64 %"p1##0", 8 
+  %41 = inttoptr i64 %40 to i64* 
+  %42 = getelementptr  i64, i64* %41, i64 0 
+  store  i64 %"3#tmp#2##0", i64* %42 
+  %43 = tail call fastcc  {i64, i64}  @"alias_scc_proc.foo<0>[410bae77d3]"(i64  %"p1##0")  
+  %44 = extractvalue {i64, i64} %43, 0 
+  %45 = extractvalue {i64, i64} %43, 1 
+  ret i64 %45 
 }
 
 
 define external fastcc  {i64, i64} @"alias_scc_proc.foo<0>"(i64  %"p1##0")    {
 entry:
-  %50 = inttoptr i64 %"p1##0" to i64* 
-  %51 = getelementptr  i64, i64* %50, i64 0 
-  %52 = load  i64, i64* %51 
-  %"1#tmp#5##0" = icmp sgt i64 %52, 1 
+  %46 = inttoptr i64 %"p1##0" to i64* 
+  %47 = getelementptr  i64, i64* %46, i64 0 
+  %48 = load  i64, i64* %47 
+  %"1#tmp#5##0" = icmp sgt i64 %48, 1 
   br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
-  %53 = trunc i64 16 to i32  
-  %54 = tail call ccc  i8*  @wybe_malloc(i32  %53)  
-  %55 = ptrtoint i8* %54 to i64 
-  %56 = inttoptr i64 %55 to i64* 
-  %57 = getelementptr  i64, i64* %56, i64 0 
-  store  i64 3, i64* %57 
-  %58 = add   i64 %55, 8 
-  %59 = inttoptr i64 %58 to i64* 
-  %60 = getelementptr  i64, i64* %59, i64 0 
-  store  i64 3, i64* %60 
-  %63 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_scc_proc.62, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %63)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %55)  
-  %64 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
-  %65 = insertvalue {i64, i64} %64, i64 %55, 1 
-  ret {i64, i64} %65 
+  %49 = trunc i64 16 to i32  
+  %50 = tail call ccc  i8*  @wybe_malloc(i32  %49)  
+  %51 = ptrtoint i8* %50 to i64 
+  %52 = inttoptr i64 %51 to i64* 
+  %53 = getelementptr  i64, i64* %52, i64 0 
+  store  i64 3, i64* %53 
+  %54 = add   i64 %51, 8 
+  %55 = inttoptr i64 %54 to i64* 
+  %56 = getelementptr  i64, i64* %55, i64 0 
+  store  i64 3, i64* %56 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_scc_proc.58, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %51)  
+  %59 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
+  %60 = insertvalue {i64, i64} %59, i64 %51, 1 
+  ret {i64, i64} %60 
 if.else:
-  %"3#tmp#3##0" = add   i64 %52, 1 
+  %"3#tmp#3##0" = add   i64 %48, 1 
+  %61 = trunc i64 16 to i32  
+  %62 = tail call ccc  i8*  @wybe_malloc(i32  %61)  
+  %63 = ptrtoint i8* %62 to i64 
+  %64 = inttoptr i64 %63 to i8* 
+  %65 = inttoptr i64 %"p1##0" to i8* 
   %66 = trunc i64 16 to i32  
-  %67 = tail call ccc  i8*  @wybe_malloc(i32  %66)  
-  %68 = ptrtoint i8* %67 to i64 
-  %69 = inttoptr i64 %68 to i8* 
-  %70 = inttoptr i64 %"p1##0" to i8* 
-  %71 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %69, i8*  %70, i32  %71, i32  8, i1  0)  
-  %72 = inttoptr i64 %68 to i64* 
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %64, i8*  %65, i32  %66, i32  8, i1  0)  
+  %67 = inttoptr i64 %63 to i64* 
+  %68 = getelementptr  i64, i64* %67, i64 0 
+  store  i64 %"3#tmp#3##0", i64* %68 
+  %"3#p3##0" = tail call fastcc  i64  @"alias_scc_proc.bar<0>[410bae77d3]"(i64  %63)  
+  %69 = trunc i64 16 to i32  
+  %70 = tail call ccc  i8*  @wybe_malloc(i32  %69)  
+  %71 = ptrtoint i8* %70 to i64 
+  %72 = inttoptr i64 %71 to i64* 
   %73 = getelementptr  i64, i64* %72, i64 0 
-  store  i64 %"3#tmp#3##0", i64* %73 
-  %"3#p3##0" = tail call fastcc  i64  @"alias_scc_proc.bar<0>[410bae77d3]"(i64  %68)  
-  %74 = trunc i64 16 to i32  
-  %75 = tail call ccc  i8*  @wybe_malloc(i32  %74)  
-  %76 = ptrtoint i8* %75 to i64 
-  %77 = inttoptr i64 %76 to i64* 
-  %78 = getelementptr  i64, i64* %77, i64 0 
-  store  i64 2, i64* %78 
-  %79 = add   i64 %76, 8 
-  %80 = inttoptr i64 %79 to i64* 
-  %81 = getelementptr  i64, i64* %80, i64 0 
-  store  i64 2, i64* %81 
-  %82 = insertvalue {i64, i64} undef, i64 %76, 0 
-  %83 = insertvalue {i64, i64} %82, i64 %"3#p3##0", 1 
-  ret {i64, i64} %83 
+  store  i64 2, i64* %73 
+  %74 = add   i64 %71, 8 
+  %75 = inttoptr i64 %74 to i64* 
+  %76 = getelementptr  i64, i64* %75, i64 0 
+  store  i64 2, i64* %76 
+  %77 = insertvalue {i64, i64} undef, i64 %71, 0 
+  %78 = insertvalue {i64, i64} %77, i64 %"3#p3##0", 1 
+  ret {i64, i64} %78 
 }
 
 
 define external fastcc  {i64, i64} @"alias_scc_proc.foo<0>[410bae77d3]"(i64  %"p1##0")    {
 entry:
-  %84 = inttoptr i64 %"p1##0" to i64* 
-  %85 = getelementptr  i64, i64* %84, i64 0 
-  %86 = load  i64, i64* %85 
-  %"1#tmp#5##0" = icmp sgt i64 %86, 1 
+  %79 = inttoptr i64 %"p1##0" to i64* 
+  %80 = getelementptr  i64, i64* %79, i64 0 
+  %81 = load  i64, i64* %80 
+  %"1#tmp#5##0" = icmp sgt i64 %81, 1 
   br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
-  %87 = trunc i64 16 to i32  
-  %88 = tail call ccc  i8*  @wybe_malloc(i32  %87)  
-  %89 = ptrtoint i8* %88 to i64 
-  %90 = inttoptr i64 %89 to i64* 
-  %91 = getelementptr  i64, i64* %90, i64 0 
-  store  i64 3, i64* %91 
-  %92 = add   i64 %89, 8 
-  %93 = inttoptr i64 %92 to i64* 
-  %94 = getelementptr  i64, i64* %93, i64 0 
-  store  i64 3, i64* %94 
-  %97 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_scc_proc.96, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %97)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %89)  
-  %98 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
-  %99 = insertvalue {i64, i64} %98, i64 %89, 1 
-  ret {i64, i64} %99 
+  %82 = trunc i64 16 to i32  
+  %83 = tail call ccc  i8*  @wybe_malloc(i32  %82)  
+  %84 = ptrtoint i8* %83 to i64 
+  %85 = inttoptr i64 %84 to i64* 
+  %86 = getelementptr  i64, i64* %85, i64 0 
+  store  i64 3, i64* %86 
+  %87 = add   i64 %84, 8 
+  %88 = inttoptr i64 %87 to i64* 
+  %89 = getelementptr  i64, i64* %88, i64 0 
+  store  i64 3, i64* %89 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @alias_scc_proc.91, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %84)  
+  %92 = insertvalue {i64, i64} undef, i64 %"p1##0", 0 
+  %93 = insertvalue {i64, i64} %92, i64 %84, 1 
+  ret {i64, i64} %93 
 if.else:
-  %"3#tmp#3##0" = add   i64 %86, 1 
-  %100 = inttoptr i64 %"p1##0" to i64* 
-  %101 = getelementptr  i64, i64* %100, i64 0 
-  store  i64 %"3#tmp#3##0", i64* %101 
+  %"3#tmp#3##0" = add   i64 %81, 1 
+  %94 = inttoptr i64 %"p1##0" to i64* 
+  %95 = getelementptr  i64, i64* %94, i64 0 
+  store  i64 %"3#tmp#3##0", i64* %95 
   %"3#p3##0" = tail call fastcc  i64  @"alias_scc_proc.bar<0>[410bae77d3]"(i64  %"p1##0")  
-  %102 = trunc i64 16 to i32  
-  %103 = tail call ccc  i8*  @wybe_malloc(i32  %102)  
-  %104 = ptrtoint i8* %103 to i64 
-  %105 = inttoptr i64 %104 to i64* 
-  %106 = getelementptr  i64, i64* %105, i64 0 
-  store  i64 2, i64* %106 
-  %107 = add   i64 %104, 8 
-  %108 = inttoptr i64 %107 to i64* 
-  %109 = getelementptr  i64, i64* %108, i64 0 
-  store  i64 2, i64* %109 
-  %110 = insertvalue {i64, i64} undef, i64 %104, 0 
-  %111 = insertvalue {i64, i64} %110, i64 %"3#p3##0", 1 
-  ret {i64, i64} %111 
+  %96 = trunc i64 16 to i32  
+  %97 = tail call ccc  i8*  @wybe_malloc(i32  %96)  
+  %98 = ptrtoint i8* %97 to i64 
+  %99 = inttoptr i64 %98 to i64* 
+  %100 = getelementptr  i64, i64* %99, i64 0 
+  store  i64 2, i64* %100 
+  %101 = add   i64 %98, 8 
+  %102 = inttoptr i64 %101 to i64* 
+  %103 = getelementptr  i64, i64* %102, i64 0 
+  store  i64 2, i64* %103 
+  %104 = insertvalue {i64, i64} undef, i64 %98, 0 
+  %105 = insertvalue {i64, i64} %104, i64 %"3#p3##0", 1 
+  ret {i64, i64} %105 
 }
 --------------------------------------------------
  Module position
@@ -403,16 +397,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@position.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.14 to i64) }
+@position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.14 =    constant [?? x i8] c")\00"
+@position.12 =    constant [?? x i8] c")\00"
 
 
-@position.8 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.7 to i64) }
+@position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
 
 
-@position.7 =    constant [?? x i8] c",\00"
+@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
@@ -429,21 +423,18 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
-  %4 = inttoptr i64 %"pos##0" to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
-  %10 = add   i64 %"pos##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  tail call ccc  void  @print_int(i64  %13)  
-  %16 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.15, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %16)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64))  
+  %3 = inttoptr i64 %"pos##0" to i64* 
+  %4 = getelementptr  i64, i64* %3, i64 0 
+  %5 = load  i64, i64* %4 
+  tail call ccc  void  @print_int(i64  %5)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.7, i32 0, i32 0) to i64))  
+  %8 = add   i64 %"pos##0", 8 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = getelementptr  i64, i64* %9, i64 0 
+  %11 = load  i64, i64* %10 
+  tail call ccc  void  @print_int(i64  %11)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/anon_field.exp
+++ b/test-cases/final-dump/anon_field.exp
@@ -373,22 +373,22 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @anon_field.17 =    constant [?? x i8] c"uh oh\00"
 
 
-@anon_field.149 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @anon_field.148 to i64) }
+@anon_field.148 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @anon_field.147 to i64) }
 
 
-@anon_field.148 =    constant [?? x i8] c"good\00"
+@anon_field.147 =    constant [?? x i8] c"good\00"
 
 
-@anon_field.174 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @anon_field.173 to i64) }
+@anon_field.172 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @anon_field.171 to i64) }
 
 
-@anon_field.173 =    constant [?? x i8] c"bad\00"
+@anon_field.171 =    constant [?? x i8] c"bad\00"
 
 
-@anon_field.186 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @anon_field.185 to i64) }
+@anon_field.183 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @anon_field.182 to i64) }
 
 
-@anon_field.185 =    constant [?? x i8] c"maybe\00"
+@anon_field.182 =    constant [?? x i8] c"maybe\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -423,8 +423,7 @@ entry:
   %"1#tmp#17##0" = tail call fastcc  i1  @"anon_field.=<0>"(i64  %3, i64  %"1#tmp#2##0")  
   br i1 %"1#tmp#17##0", label %if.then, label %if.else 
 if.then:
-  %19 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @anon_field.18, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %19)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @anon_field.18, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"anon_field.gen#1<0>"()  
   ret void 
@@ -440,17 +439,17 @@ entry:
   %"1#tmp#14##0" = icmp eq i64 %"1#tmp#13##0", 0 
   br i1 %"1#tmp#14##0", label %if.then, label %if.else 
 if.then:
-  %20 = inttoptr i64 %"#left##0" to i1* 
-  %21 = getelementptr  i1, i1* %20, i64 0 
-  %22 = load  i1, i1* %21 
-  %23 = add   i64 %"#left##0", 8 
-  %24 = inttoptr i64 %23 to i64* 
-  %25 = getelementptr  i64, i64* %24, i64 0 
-  %26 = load  i64, i64* %25 
-  %27 = add   i64 %"#left##0", 16 
-  %28 = inttoptr i64 %27 to i64* 
-  %29 = getelementptr  i64, i64* %28, i64 0 
-  %30 = load  i64, i64* %29 
+  %19 = inttoptr i64 %"#left##0" to i1* 
+  %20 = getelementptr  i1, i1* %19, i64 0 
+  %21 = load  i1, i1* %20 
+  %22 = add   i64 %"#left##0", 8 
+  %23 = inttoptr i64 %22 to i64* 
+  %24 = getelementptr  i64, i64* %23, i64 0 
+  %25 = load  i64, i64* %24 
+  %26 = add   i64 %"#left##0", 16 
+  %27 = inttoptr i64 %26 to i64* 
+  %28 = getelementptr  i64, i64* %27, i64 0 
+  %29 = load  i64, i64* %28 
   %"2#tmp#16##0" = and i64 %"#right##0", 3 
   %"2#tmp#17##0" = icmp eq i64 %"2#tmp#16##0", 0 
   br i1 %"2#tmp#17##0", label %if.then1, label %if.else1 
@@ -458,36 +457,36 @@ if.else:
   %"3#tmp#17##0" = icmp eq i64 %"1#tmp#13##0", 1 
   br i1 %"3#tmp#17##0", label %if.then4, label %if.else4 
 if.then1:
-  %31 = inttoptr i64 %"#right##0" to i1* 
-  %32 = getelementptr  i1, i1* %31, i64 0 
-  %33 = load  i1, i1* %32 
-  %34 = add   i64 %"#right##0", 8 
-  %35 = inttoptr i64 %34 to i64* 
-  %36 = getelementptr  i64, i64* %35, i64 0 
-  %37 = load  i64, i64* %36 
-  %38 = add   i64 %"#right##0", 16 
-  %39 = inttoptr i64 %38 to i64* 
-  %40 = getelementptr  i64, i64* %39, i64 0 
-  %41 = load  i64, i64* %40 
-  %"4#tmp#2##0" = icmp eq i64 %26, %37 
+  %30 = inttoptr i64 %"#right##0" to i1* 
+  %31 = getelementptr  i1, i1* %30, i64 0 
+  %32 = load  i1, i1* %31 
+  %33 = add   i64 %"#right##0", 8 
+  %34 = inttoptr i64 %33 to i64* 
+  %35 = getelementptr  i64, i64* %34, i64 0 
+  %36 = load  i64, i64* %35 
+  %37 = add   i64 %"#right##0", 16 
+  %38 = inttoptr i64 %37 to i64* 
+  %39 = getelementptr  i64, i64* %38, i64 0 
+  %40 = load  i64, i64* %39 
+  %"4#tmp#2##0" = icmp eq i64 %25, %36 
   br i1 %"4#tmp#2##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
-  %"6#tmp#3##0" = icmp eq i1 %22, %33 
+  %"6#tmp#3##0" = icmp eq i1 %21, %32 
   br i1 %"6#tmp#3##0", label %if.then3, label %if.else3 
 if.else2:
   ret i1 0 
 if.then3:
-  %"8##success##0" = icmp eq i64 %30, %41 
+  %"8##success##0" = icmp eq i64 %29, %40 
   ret i1 %"8##success##0" 
 if.else3:
   ret i1 0 
 if.then4:
-  %42 = add   i64 %"#left##0", -1 
-  %43 = inttoptr i64 %42 to i64* 
-  %44 = getelementptr  i64, i64* %43, i64 0 
-  %45 = load  i64, i64* %44 
+  %41 = add   i64 %"#left##0", -1 
+  %42 = inttoptr i64 %41 to i64* 
+  %43 = getelementptr  i64, i64* %42, i64 0 
+  %44 = load  i64, i64* %43 
   %"10#tmp#19##0" = and i64 %"#right##0", 3 
   %"10#tmp#20##0" = icmp eq i64 %"10#tmp#19##0", 1 
   br i1 %"10#tmp#20##0", label %if.then5, label %if.else5 
@@ -495,30 +494,30 @@ if.else4:
   %"11#tmp#20##0" = icmp eq i64 %"1#tmp#13##0", 2 
   br i1 %"11#tmp#20##0", label %if.then6, label %if.else6 
 if.then5:
-  %46 = add   i64 %"#right##0", -1 
-  %47 = inttoptr i64 %46 to i64* 
-  %48 = getelementptr  i64, i64* %47, i64 0 
-  %49 = load  i64, i64* %48 
-  %"12##success##0" = icmp eq i64 %45, %49 
+  %45 = add   i64 %"#right##0", -1 
+  %46 = inttoptr i64 %45 to i64* 
+  %47 = getelementptr  i64, i64* %46, i64 0 
+  %48 = load  i64, i64* %47 
+  %"12##success##0" = icmp eq i64 %44, %48 
   ret i1 %"12##success##0" 
 if.else5:
   ret i1 0 
 if.then6:
-  %50 = add   i64 %"#left##0", -2 
-  %51 = inttoptr i64 %50 to i64* 
-  %52 = getelementptr  i64, i64* %51, i64 0 
-  %53 = load  i64, i64* %52 
+  %49 = add   i64 %"#left##0", -2 
+  %50 = inttoptr i64 %49 to i64* 
+  %51 = getelementptr  i64, i64* %50, i64 0 
+  %52 = load  i64, i64* %51 
   %"14#tmp#22##0" = and i64 %"#right##0", 3 
   %"14#tmp#23##0" = icmp eq i64 %"14#tmp#22##0", 2 
   br i1 %"14#tmp#23##0", label %if.then7, label %if.else7 
 if.else6:
   ret i1 0 
 if.then7:
-  %54 = add   i64 %"#right##0", -2 
-  %55 = inttoptr i64 %54 to i64* 
-  %56 = getelementptr  i64, i64* %55, i64 0 
-  %57 = load  i64, i64* %56 
-  %"16##success##0" = icmp eq i64 %53, %57 
+  %53 = add   i64 %"#right##0", -2 
+  %54 = inttoptr i64 %53 to i64* 
+  %55 = getelementptr  i64, i64* %54, i64 0 
+  %56 = load  i64, i64* %55 
+  %"16##success##0" = icmp eq i64 %52, %56 
   ret i1 %"16##success##0" 
 if.else7:
   ret i1 0 
@@ -527,13 +526,13 @@ if.else7:
 
 define external fastcc  i64 @"anon_field.bar<0>"(i64  %"bar#1##0")    {
 entry:
-  %58 = trunc i64 8 to i32  
-  %59 = tail call ccc  i8*  @wybe_malloc(i32  %58)  
-  %60 = ptrtoint i8* %59 to i64 
-  %61 = inttoptr i64 %60 to i64* 
-  %62 = getelementptr  i64, i64* %61, i64 0 
-  store  i64 %"bar#1##0", i64* %62 
-  %"1##result##0" = or i64 %60, 1 
+  %57 = trunc i64 8 to i32  
+  %58 = tail call ccc  i8*  @wybe_malloc(i32  %57)  
+  %59 = ptrtoint i8* %58 to i64 
+  %60 = inttoptr i64 %59 to i64* 
+  %61 = getelementptr  i64, i64* %60, i64 0 
+  store  i64 %"bar#1##0", i64* %61 
+  %"1##result##0" = or i64 %59, 1 
   ret i64 %"1##result##0" 
 }
 
@@ -544,29 +543,29 @@ entry:
   %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 1 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %63 = add   i64 %"#result##0", -1 
-  %64 = inttoptr i64 %63 to i64* 
-  %65 = getelementptr  i64, i64* %64, i64 0 
-  %66 = load  i64, i64* %65 
-  %67 = insertvalue {i64, i1} undef, i64 %66, 0 
-  %68 = insertvalue {i64, i1} %67, i1 1, 1 
-  ret {i64, i1} %68 
+  %62 = add   i64 %"#result##0", -1 
+  %63 = inttoptr i64 %62 to i64* 
+  %64 = getelementptr  i64, i64* %63, i64 0 
+  %65 = load  i64, i64* %64 
+  %66 = insertvalue {i64, i1} undef, i64 %65, 0 
+  %67 = insertvalue {i64, i1} %66, i1 1, 1 
+  ret {i64, i1} %67 
 if.else:
-  %69 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %70 = insertvalue {i64, i1} %69, i1 0, 1 
-  ret {i64, i1} %70 
+  %68 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %69 = insertvalue {i64, i1} %68, i1 0, 1 
+  ret {i64, i1} %69 
 }
 
 
 define external fastcc  i64 @"anon_field.baz<0>"(i64  %"field##0")    {
 entry:
-  %71 = trunc i64 8 to i32  
-  %72 = tail call ccc  i8*  @wybe_malloc(i32  %71)  
-  %73 = ptrtoint i8* %72 to i64 
-  %74 = inttoptr i64 %73 to i64* 
-  %75 = getelementptr  i64, i64* %74, i64 0 
-  store  i64 %"field##0", i64* %75 
-  %"1##result##0" = or i64 %73, 2 
+  %70 = trunc i64 8 to i32  
+  %71 = tail call ccc  i8*  @wybe_malloc(i32  %70)  
+  %72 = ptrtoint i8* %71 to i64 
+  %73 = inttoptr i64 %72 to i64* 
+  %74 = getelementptr  i64, i64* %73, i64 0 
+  store  i64 %"field##0", i64* %74 
+  %"1##result##0" = or i64 %72, 2 
   ret i64 %"1##result##0" 
 }
 
@@ -577,17 +576,17 @@ entry:
   %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 2 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %76 = add   i64 %"#result##0", -2 
-  %77 = inttoptr i64 %76 to i64* 
-  %78 = getelementptr  i64, i64* %77, i64 0 
-  %79 = load  i64, i64* %78 
-  %80 = insertvalue {i64, i1} undef, i64 %79, 0 
-  %81 = insertvalue {i64, i1} %80, i1 1, 1 
-  ret {i64, i1} %81 
+  %75 = add   i64 %"#result##0", -2 
+  %76 = inttoptr i64 %75 to i64* 
+  %77 = getelementptr  i64, i64* %76, i64 0 
+  %78 = load  i64, i64* %77 
+  %79 = insertvalue {i64, i1} undef, i64 %78, 0 
+  %80 = insertvalue {i64, i1} %79, i1 1, 1 
+  ret {i64, i1} %80 
 if.else:
-  %82 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %83 = insertvalue {i64, i1} %82, i1 0, 1 
-  ret {i64, i1} %83 
+  %81 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %82 = insertvalue {i64, i1} %81, i1 0, 1 
+  ret {i64, i1} %82 
 }
 
 
@@ -597,17 +596,17 @@ entry:
   %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 2 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %84 = add   i64 %"#rec##0", -2 
-  %85 = inttoptr i64 %84 to i64* 
-  %86 = getelementptr  i64, i64* %85, i64 0 
-  %87 = load  i64, i64* %86 
-  %88 = insertvalue {i64, i1} undef, i64 %87, 0 
-  %89 = insertvalue {i64, i1} %88, i1 1, 1 
-  ret {i64, i1} %89 
+  %83 = add   i64 %"#rec##0", -2 
+  %84 = inttoptr i64 %83 to i64* 
+  %85 = getelementptr  i64, i64* %84, i64 0 
+  %86 = load  i64, i64* %85 
+  %87 = insertvalue {i64, i1} undef, i64 %86, 0 
+  %88 = insertvalue {i64, i1} %87, i1 1, 1 
+  ret {i64, i1} %88 
 if.else:
-  %90 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %91 = insertvalue {i64, i1} %90, i1 0, 1 
-  ret {i64, i1} %91 
+  %89 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %90 = insertvalue {i64, i1} %89, i1 0, 1 
+  ret {i64, i1} %90 
 }
 
 
@@ -617,46 +616,46 @@ entry:
   %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 2 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %92 = trunc i64 8 to i32  
-  %93 = tail call ccc  i8*  @wybe_malloc(i32  %92)  
-  %94 = ptrtoint i8* %93 to i64 
-  %95 = add   i64 %94, 2 
-  %96 = sub   i64 %"#rec##0", 2 
-  %97 = inttoptr i64 %94 to i8* 
-  %98 = inttoptr i64 %96 to i8* 
-  %99 = trunc i64 8 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %97, i8*  %98, i32  %99, i32  8, i1  0)  
-  %100 = add   i64 %95, -2 
-  %101 = inttoptr i64 %100 to i64* 
-  %102 = getelementptr  i64, i64* %101, i64 0 
-  store  i64 %"#field##0", i64* %102 
-  %103 = insertvalue {i64, i1} undef, i64 %95, 0 
-  %104 = insertvalue {i64, i1} %103, i1 1, 1 
-  ret {i64, i1} %104 
+  %91 = trunc i64 8 to i32  
+  %92 = tail call ccc  i8*  @wybe_malloc(i32  %91)  
+  %93 = ptrtoint i8* %92 to i64 
+  %94 = add   i64 %93, 2 
+  %95 = sub   i64 %"#rec##0", 2 
+  %96 = inttoptr i64 %93 to i8* 
+  %97 = inttoptr i64 %95 to i8* 
+  %98 = trunc i64 8 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %96, i8*  %97, i32  %98, i32  8, i1  0)  
+  %99 = add   i64 %94, -2 
+  %100 = inttoptr i64 %99 to i64* 
+  %101 = getelementptr  i64, i64* %100, i64 0 
+  store  i64 %"#field##0", i64* %101 
+  %102 = insertvalue {i64, i1} undef, i64 %94, 0 
+  %103 = insertvalue {i64, i1} %102, i1 1, 1 
+  ret {i64, i1} %103 
 if.else:
-  %105 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %106 = insertvalue {i64, i1} %105, i1 0, 1 
-  ret {i64, i1} %106 
+  %104 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %105 = insertvalue {i64, i1} %104, i1 0, 1 
+  ret {i64, i1} %105 
 }
 
 
 define external fastcc  i64 @"anon_field.foo<0>"(i64  %"foo#1##0", i1  %"foo#2##0", i64  %"i##0")    {
 entry:
-  %107 = trunc i64 24 to i32  
-  %108 = tail call ccc  i8*  @wybe_malloc(i32  %107)  
-  %109 = ptrtoint i8* %108 to i64 
-  %110 = inttoptr i64 %109 to i1* 
-  %111 = getelementptr  i1, i1* %110, i64 0 
-  store  i1 %"foo#2##0", i1* %111 
-  %112 = add   i64 %109, 8 
-  %113 = inttoptr i64 %112 to i64* 
-  %114 = getelementptr  i64, i64* %113, i64 0 
-  store  i64 %"foo#1##0", i64* %114 
-  %115 = add   i64 %109, 16 
-  %116 = inttoptr i64 %115 to i64* 
-  %117 = getelementptr  i64, i64* %116, i64 0 
-  store  i64 %"i##0", i64* %117 
-  ret i64 %109 
+  %106 = trunc i64 24 to i32  
+  %107 = tail call ccc  i8*  @wybe_malloc(i32  %106)  
+  %108 = ptrtoint i8* %107 to i64 
+  %109 = inttoptr i64 %108 to i1* 
+  %110 = getelementptr  i1, i1* %109, i64 0 
+  store  i1 %"foo#2##0", i1* %110 
+  %111 = add   i64 %108, 8 
+  %112 = inttoptr i64 %111 to i64* 
+  %113 = getelementptr  i64, i64* %112, i64 0 
+  store  i64 %"foo#1##0", i64* %113 
+  %114 = add   i64 %108, 16 
+  %115 = inttoptr i64 %114 to i64* 
+  %116 = getelementptr  i64, i64* %115, i64 0 
+  store  i64 %"i##0", i64* %116 
+  ret i64 %108 
 }
 
 
@@ -666,53 +665,52 @@ entry:
   %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %118 = inttoptr i64 %"#result##0" to i1* 
-  %119 = getelementptr  i1, i1* %118, i64 0 
-  %120 = load  i1, i1* %119 
-  %121 = add   i64 %"#result##0", 8 
-  %122 = inttoptr i64 %121 to i64* 
-  %123 = getelementptr  i64, i64* %122, i64 0 
-  %124 = load  i64, i64* %123 
-  %125 = add   i64 %"#result##0", 16 
-  %126 = inttoptr i64 %125 to i64* 
-  %127 = getelementptr  i64, i64* %126, i64 0 
-  %128 = load  i64, i64* %127 
-  %129 = insertvalue {i64, i1, i64, i1} undef, i64 %124, 0 
-  %130 = insertvalue {i64, i1, i64, i1} %129, i1 %120, 1 
-  %131 = insertvalue {i64, i1, i64, i1} %130, i64 %128, 2 
-  %132 = insertvalue {i64, i1, i64, i1} %131, i1 1, 3 
-  ret {i64, i1, i64, i1} %132 
+  %117 = inttoptr i64 %"#result##0" to i1* 
+  %118 = getelementptr  i1, i1* %117, i64 0 
+  %119 = load  i1, i1* %118 
+  %120 = add   i64 %"#result##0", 8 
+  %121 = inttoptr i64 %120 to i64* 
+  %122 = getelementptr  i64, i64* %121, i64 0 
+  %123 = load  i64, i64* %122 
+  %124 = add   i64 %"#result##0", 16 
+  %125 = inttoptr i64 %124 to i64* 
+  %126 = getelementptr  i64, i64* %125, i64 0 
+  %127 = load  i64, i64* %126 
+  %128 = insertvalue {i64, i1, i64, i1} undef, i64 %123, 0 
+  %129 = insertvalue {i64, i1, i64, i1} %128, i1 %119, 1 
+  %130 = insertvalue {i64, i1, i64, i1} %129, i64 %127, 2 
+  %131 = insertvalue {i64, i1, i64, i1} %130, i1 1, 3 
+  ret {i64, i1, i64, i1} %131 
 if.else:
-  %133 = insertvalue {i64, i1, i64, i1} undef, i64 undef, 0 
-  %134 = insertvalue {i64, i1, i64, i1} %133, i1 undef, 1 
-  %135 = insertvalue {i64, i1, i64, i1} %134, i64 undef, 2 
-  %136 = insertvalue {i64, i1, i64, i1} %135, i1 0, 3 
-  ret {i64, i1, i64, i1} %136 
+  %132 = insertvalue {i64, i1, i64, i1} undef, i64 undef, 0 
+  %133 = insertvalue {i64, i1, i64, i1} %132, i1 undef, 1 
+  %134 = insertvalue {i64, i1, i64, i1} %133, i64 undef, 2 
+  %135 = insertvalue {i64, i1, i64, i1} %134, i1 0, 3 
+  ret {i64, i1, i64, i1} %135 
 }
 
 
 define external fastcc  void @"anon_field.gen#1<0>"()    {
 entry:
-  %137 = trunc i64 24 to i32  
-  %138 = tail call ccc  i8*  @wybe_malloc(i32  %137)  
-  %139 = ptrtoint i8* %138 to i64 
-  %140 = inttoptr i64 %139 to i1* 
-  %141 = getelementptr  i1, i1* %140, i64 0 
-  store  i1 0, i1* %141 
-  %142 = add   i64 %139, 8 
-  %143 = inttoptr i64 %142 to i64* 
-  %144 = getelementptr  i64, i64* %143, i64 0 
-  store  i64 1, i64* %144 
-  %145 = add   i64 %139, 16 
-  %146 = inttoptr i64 %145 to i64* 
-  %147 = getelementptr  i64, i64* %146, i64 0 
-  store  i64 1, i64* %147 
-  %"1#tmp#24##0" = and i64 %139, 3 
+  %136 = trunc i64 24 to i32  
+  %137 = tail call ccc  i8*  @wybe_malloc(i32  %136)  
+  %138 = ptrtoint i8* %137 to i64 
+  %139 = inttoptr i64 %138 to i1* 
+  %140 = getelementptr  i1, i1* %139, i64 0 
+  store  i1 0, i1* %140 
+  %141 = add   i64 %138, 8 
+  %142 = inttoptr i64 %141 to i64* 
+  %143 = getelementptr  i64, i64* %142, i64 0 
+  store  i64 1, i64* %143 
+  %144 = add   i64 %138, 16 
+  %145 = inttoptr i64 %144 to i64* 
+  %146 = getelementptr  i64, i64* %145, i64 0 
+  store  i64 1, i64* %146 
+  %"1#tmp#24##0" = and i64 %138, 3 
   %"1#tmp#25##0" = icmp eq i64 %"1#tmp#24##0", 0 
   br i1 %"1#tmp#25##0", label %if.then, label %if.else 
 if.then:
-  %150 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @anon_field.149, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %150)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @anon_field.148, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"anon_field.gen#2<0>"()  
   ret void 
@@ -724,39 +722,38 @@ if.else:
 
 define external fastcc  void @"anon_field.gen#2<0>"()    {
 entry:
-  %151 = trunc i64 24 to i32  
-  %152 = tail call ccc  i8*  @wybe_malloc(i32  %151)  
-  %153 = ptrtoint i8* %152 to i64 
-  %154 = inttoptr i64 %153 to i1* 
-  %155 = getelementptr  i1, i1* %154, i64 0 
-  store  i1 0, i1* %155 
-  %156 = add   i64 %153, 8 
-  %157 = inttoptr i64 %156 to i64* 
-  %158 = getelementptr  i64, i64* %157, i64 0 
-  store  i64 1, i64* %158 
-  %159 = add   i64 %153, 16 
-  %160 = inttoptr i64 %159 to i64* 
-  %161 = getelementptr  i64, i64* %160, i64 0 
-  store  i64 1, i64* %161 
-  %162 = trunc i64 24 to i32  
-  %163 = tail call ccc  i8*  @wybe_malloc(i32  %162)  
-  %164 = ptrtoint i8* %163 to i64 
-  %165 = inttoptr i64 %164 to i1* 
-  %166 = getelementptr  i1, i1* %165, i64 0 
-  store  i1 0, i1* %166 
-  %167 = add   i64 %164, 8 
-  %168 = inttoptr i64 %167 to i64* 
-  %169 = getelementptr  i64, i64* %168, i64 0 
-  store  i64 2, i64* %169 
-  %170 = add   i64 %164, 16 
-  %171 = inttoptr i64 %170 to i64* 
-  %172 = getelementptr  i64, i64* %171, i64 0 
-  store  i64 1, i64* %172 
-  %"1#tmp#14##0" = tail call fastcc  i1  @"anon_field.=<0>"(i64  %153, i64  %164)  
+  %149 = trunc i64 24 to i32  
+  %150 = tail call ccc  i8*  @wybe_malloc(i32  %149)  
+  %151 = ptrtoint i8* %150 to i64 
+  %152 = inttoptr i64 %151 to i1* 
+  %153 = getelementptr  i1, i1* %152, i64 0 
+  store  i1 0, i1* %153 
+  %154 = add   i64 %151, 8 
+  %155 = inttoptr i64 %154 to i64* 
+  %156 = getelementptr  i64, i64* %155, i64 0 
+  store  i64 1, i64* %156 
+  %157 = add   i64 %151, 16 
+  %158 = inttoptr i64 %157 to i64* 
+  %159 = getelementptr  i64, i64* %158, i64 0 
+  store  i64 1, i64* %159 
+  %160 = trunc i64 24 to i32  
+  %161 = tail call ccc  i8*  @wybe_malloc(i32  %160)  
+  %162 = ptrtoint i8* %161 to i64 
+  %163 = inttoptr i64 %162 to i1* 
+  %164 = getelementptr  i1, i1* %163, i64 0 
+  store  i1 0, i1* %164 
+  %165 = add   i64 %162, 8 
+  %166 = inttoptr i64 %165 to i64* 
+  %167 = getelementptr  i64, i64* %166, i64 0 
+  store  i64 2, i64* %167 
+  %168 = add   i64 %162, 16 
+  %169 = inttoptr i64 %168 to i64* 
+  %170 = getelementptr  i64, i64* %169, i64 0 
+  store  i64 1, i64* %170 
+  %"1#tmp#14##0" = tail call fastcc  i1  @"anon_field.=<0>"(i64  %151, i64  %162)  
   br i1 %"1#tmp#14##0", label %if.then, label %if.else 
 if.then:
-  %175 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @anon_field.174, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %175)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @anon_field.172, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"anon_field.gen#3<0>"()  
   ret void 
@@ -768,28 +765,27 @@ if.else:
 
 define external fastcc  void @"anon_field.gen#3<0>"()    {
 entry:
-  %176 = trunc i64 8 to i32  
-  %177 = tail call ccc  i8*  @wybe_malloc(i32  %176)  
-  %178 = ptrtoint i8* %177 to i64 
-  %179 = inttoptr i64 %178 to i64* 
-  %180 = getelementptr  i64, i64* %179, i64 0 
-  store  i64 1, i64* %180 
-  %"1#tmp#11##0" = or i64 %178, 2 
+  %173 = trunc i64 8 to i32  
+  %174 = tail call ccc  i8*  @wybe_malloc(i32  %173)  
+  %175 = ptrtoint i8* %174 to i64 
+  %176 = inttoptr i64 %175 to i64* 
+  %177 = getelementptr  i64, i64* %176, i64 0 
+  store  i64 1, i64* %177 
+  %"1#tmp#11##0" = or i64 %175, 2 
   %"1#tmp#18##0" = and i64 %"1#tmp#11##0", 3 
   %"1#tmp#19##0" = icmp eq i64 %"1#tmp#18##0", 2 
   br i1 %"1#tmp#19##0", label %if.then, label %if.else 
 if.then:
-  %181 = add   i64 %"1#tmp#11##0", -2 
-  %182 = inttoptr i64 %181 to i64* 
-  %183 = getelementptr  i64, i64* %182, i64 0 
-  %184 = load  i64, i64* %183 
-  %"2#tmp#13##0" = icmp ne i64 %184, 2 
+  %178 = add   i64 %"1#tmp#11##0", -2 
+  %179 = inttoptr i64 %178 to i64* 
+  %180 = getelementptr  i64, i64* %179, i64 0 
+  %181 = load  i64, i64* %180 
+  %"2#tmp#13##0" = icmp ne i64 %181, 2 
   br i1 %"2#tmp#13##0", label %if.then1, label %if.else1 
 if.else:
   ret void 
 if.then1:
-  %187 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @anon_field.186, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %187)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @anon_field.183, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else1:
@@ -803,17 +799,17 @@ entry:
   %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %188 = add   i64 %"#rec##0", 16 
-  %189 = inttoptr i64 %188 to i64* 
-  %190 = getelementptr  i64, i64* %189, i64 0 
-  %191 = load  i64, i64* %190 
-  %192 = insertvalue {i64, i1} undef, i64 %191, 0 
-  %193 = insertvalue {i64, i1} %192, i1 1, 1 
-  ret {i64, i1} %193 
+  %184 = add   i64 %"#rec##0", 16 
+  %185 = inttoptr i64 %184 to i64* 
+  %186 = getelementptr  i64, i64* %185, i64 0 
+  %187 = load  i64, i64* %186 
+  %188 = insertvalue {i64, i1} undef, i64 %187, 0 
+  %189 = insertvalue {i64, i1} %188, i1 1, 1 
+  ret {i64, i1} %189 
 if.else:
-  %194 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %195 = insertvalue {i64, i1} %194, i1 0, 1 
-  ret {i64, i1} %195 
+  %190 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %191 = insertvalue {i64, i1} %190, i1 0, 1 
+  ret {i64, i1} %191 
 }
 
 
@@ -823,24 +819,24 @@ entry:
   %"1#tmp#0##0" = icmp eq i64 %"1#tmp#1##0", 0 
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
-  %196 = trunc i64 24 to i32  
-  %197 = tail call ccc  i8*  @wybe_malloc(i32  %196)  
-  %198 = ptrtoint i8* %197 to i64 
-  %199 = inttoptr i64 %198 to i8* 
-  %200 = inttoptr i64 %"#rec##0" to i8* 
-  %201 = trunc i64 24 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %199, i8*  %200, i32  %201, i32  8, i1  0)  
-  %202 = add   i64 %198, 16 
-  %203 = inttoptr i64 %202 to i64* 
-  %204 = getelementptr  i64, i64* %203, i64 0 
-  store  i64 %"#field##0", i64* %204 
-  %205 = insertvalue {i64, i1} undef, i64 %198, 0 
-  %206 = insertvalue {i64, i1} %205, i1 1, 1 
-  ret {i64, i1} %206 
+  %192 = trunc i64 24 to i32  
+  %193 = tail call ccc  i8*  @wybe_malloc(i32  %192)  
+  %194 = ptrtoint i8* %193 to i64 
+  %195 = inttoptr i64 %194 to i8* 
+  %196 = inttoptr i64 %"#rec##0" to i8* 
+  %197 = trunc i64 24 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %195, i8*  %196, i32  %197, i32  8, i1  0)  
+  %198 = add   i64 %194, 16 
+  %199 = inttoptr i64 %198 to i64* 
+  %200 = getelementptr  i64, i64* %199, i64 0 
+  store  i64 %"#field##0", i64* %200 
+  %201 = insertvalue {i64, i1} undef, i64 %194, 0 
+  %202 = insertvalue {i64, i1} %201, i1 1, 1 
+  ret {i64, i1} %202 
 if.else:
-  %207 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
-  %208 = insertvalue {i64, i1} %207, i1 0, 1 
-  ret {i64, i1} %208 
+  %203 = insertvalue {i64, i1} undef, i64 %"#rec##0", 0 
+  %204 = insertvalue {i64, i1} %203, i1 0, 1 
+  ret {i64, i1} %204 
 }
 
 

--- a/test-cases/final-dump/assert_error.exp
+++ b/test-cases/final-dump/assert_error.exp
@@ -31,10 +31,10 @@ declare external ccc  void @error_exit(i64, i64)
 declare external fastcc  void @"wybe.control.assert<0>"(i1, i64)    
 
 
-@assert_error.5 =    constant [?? x i8] c"we should never get here\00"
+@assert_error.3 =    constant [?? x i8] c"we should never get here\00"
 
 
-@assert_error.3 =    constant [?? x i8] c"assert_error:5:2\00"
+@assert_error.2 =    constant [?? x i8] c"assert_error:5:2\00"
 
 
 @assert_error.1 =    constant [?? x i8] c"assert_error:3:2\00"
@@ -48,10 +48,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"assert_error.<0>"()    {
 entry:
-  %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @assert_error.1, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.control.assert<0>"(i1  0, i64  %2)  
-  %4 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @assert_error.3, i32 0, i32 0) to i64 
-  %6 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @assert_error.5, i32 0, i32 0) to i64 
-  tail call ccc  void  @error_exit(i64  %4, i64  %6)  
+  tail call fastcc  void  @"wybe.control.assert<0>"(i1  0, i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @assert_error.1, i32 0, i32 0) to i64))  
+  tail call ccc  void  @error_exit(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @assert_error.2, i32 0, i32 0) to i64), i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @assert_error.3, i32 0, i32 0) to i64))  
   ret void 
 }

--- a/test-cases/final-dump/bar.exp
+++ b/test-cases/final-dump/bar.exp
@@ -130,8 +130,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"numbers.<0>"()    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @numbers.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @numbers.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/bbb.exp
+++ b/test-cases/final-dump/bbb.exp
@@ -46,8 +46,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"bbb.<0>"()    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @bbb.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @bbb.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -97,8 +96,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"ddd.<0>"()    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @ddd.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @ddd.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/block_comment.exp
+++ b/test-cases/final-dump/block_comment.exp
@@ -42,16 +42,16 @@ declare external ccc  void @putchar(i8)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@block_comment.8 =    constant {i64, i64} { i64 45, i64 ptrtoint ([?? x i8]* @block_comment.7 to i64) }
+@block_comment.6 =    constant {i64, i64} { i64 45, i64 ptrtoint ([?? x i8]* @block_comment.5 to i64) }
 
 
-@block_comment.7 =    constant [?? x i8] c"println(x:string) generates an extra newline?\00"
+@block_comment.5 =    constant [?? x i8] c"println(x:string) generates an extra newline?\00"
 
 
-@block_comment.5 =    constant {i64, i64} { i64 45, i64 ptrtoint ([?? x i8]* @block_comment.4 to i64) }
+@block_comment.4 =    constant {i64, i64} { i64 45, i64 ptrtoint ([?? x i8]* @block_comment.3 to i64) }
 
 
-@block_comment.4 =    constant [?? x i8] c"println(x:string) generates an extra newline?\00"
+@block_comment.3 =    constant [?? x i8] c"println(x:string) generates an extra newline?\00"
 
 
 @block_comment.2 =    constant {i64, i64} { i64 41, i64 ptrtoint ([?? x i8]* @block_comment.1 to i64) }
@@ -68,13 +68,10 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"block_comment.<0>"()    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @block_comment.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
-  %6 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @block_comment.5, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %6)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @block_comment.2, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @block_comment.4, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @block_comment.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @block_comment.6, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call ccc  void  @putchar(i8  99)  
   tail call ccc  void  @putchar(i8  10)  

--- a/test-cases/final-dump/call_site_id.exp
+++ b/test-cases/final-dump/call_site_id.exp
@@ -92,28 +92,22 @@ declare external ccc  void @print_int(i64)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@call_site_id.20 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @call_site_id.19 to i64) }
-
-
-@call_site_id.19 =    constant [?? x i8] c" \00"
-
-
-@call_site_id.17 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @call_site_id.16 to i64) }
-
-
-@call_site_id.16 =    constant [?? x i8] c" \00"
-
-
 @call_site_id.14 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @call_site_id.13 to i64) }
 
 
 @call_site_id.13 =    constant [?? x i8] c" \00"
 
 
-@call_site_id.11 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @call_site_id.10 to i64) }
+@call_site_id.12 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @call_site_id.11 to i64) }
 
 
-@call_site_id.10 =    constant [?? x i8] c" \00"
+@call_site_id.11 =    constant [?? x i8] c" \00"
+
+
+@call_site_id.10 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @call_site_id.9 to i64) }
+
+
+@call_site_id.9 =    constant [?? x i8] c" \00"
 
 
 @call_site_id.8 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @call_site_id.7 to i64) }
@@ -122,10 +116,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @call_site_id.7 =    constant [?? x i8] c" \00"
 
 
-@call_site_id.5 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @call_site_id.4 to i64) }
+@call_site_id.6 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @call_site_id.5 to i64) }
 
 
-@call_site_id.4 =    constant [?? x i8] c" \00"
+@call_site_id.5 =    constant [?? x i8] c" \00"
+
+
+@call_site_id.4 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @call_site_id.3 to i64) }
+
+
+@call_site_id.3 =    constant [?? x i8] c" \00"
 
 
 @call_site_id.2 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @call_site_id.1 to i64) }
@@ -181,20 +181,13 @@ entry:
 
 define external fastcc  void @"call_site_id.foo<0>"(i64  %"x##0")    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @call_site_id.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
-  %6 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @call_site_id.5, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %6)  
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @call_site_id.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
-  %12 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @call_site_id.11, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %12)  
-  %15 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @call_site_id.14, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %15)  
-  %18 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @call_site_id.17, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %18)  
-  %21 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @call_site_id.20, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %21)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @call_site_id.2, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @call_site_id.4, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @call_site_id.6, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @call_site_id.8, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @call_site_id.10, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @call_site_id.12, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @call_site_id.14, i32 0, i32 0) to i64))  
   %"1#tmp#1##0" = mul   i64 %"x##0", 5 
   %"1#tmp#0##0" = add   i64 %"1#tmp#1##0", 10 
   tail call ccc  void  @print_int(i64  %"1#tmp#0##0")  

--- a/test-cases/final-dump/caret.exp
+++ b/test-cases/final-dump/caret.exp
@@ -114,16 +114,16 @@ declare external fastcc  i64 @"wybe.int.max<0>"(i64, i64)
 declare external fastcc  i64 @"wybe.int.min<0>"(i64, i64)    
 
 
-@caret.146 =    constant {i64, i64} { i64 10, i64 ptrtoint ([?? x i8]* @caret.145 to i64) }
+@caret.145 =    constant {i64, i64} { i64 10, i64 ptrtoint ([?? x i8]* @caret.144 to i64) }
 
 
-@caret.145 =    constant [?? x i8] c"now ten = \00"
+@caret.144 =    constant [?? x i8] c"now ten = \00"
 
 
-@caret.161 =    constant {i64, i64} { i64 10, i64 ptrtoint ([?? x i8]* @caret.160 to i64) }
+@caret.159 =    constant {i64, i64} { i64 10, i64 ptrtoint ([?? x i8]* @caret.158 to i64) }
 
 
-@caret.160 =    constant [?? x i8] c"now ten = \00"
+@caret.158 =    constant [?? x i8] c"now ten = \00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -167,8 +167,7 @@ entry:
   %25 = inttoptr i64 %11 to i64* 
   %26 = getelementptr  i64, i64* %25, i64 0 
   %27 = load  i64, i64* %26 
-  %30 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @caret.29, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %30)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @caret.29, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %27)  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"caret.gen#1<0>[6dacb8fd25]"(i64  %19)  
@@ -178,152 +177,151 @@ entry:
 
 define external fastcc  i64 @"caret.expand_region<0>"(i64  %"reg##0", i64  %"point##0")    {
 entry:
-  %31 = inttoptr i64 %"reg##0" to i64* 
-  %32 = getelementptr  i64, i64* %31, i64 0 
-  %33 = load  i64, i64* %32 
-  %34 = inttoptr i64 %33 to i64* 
-  %35 = getelementptr  i64, i64* %34, i64 0 
-  %36 = load  i64, i64* %35 
-  %37 = inttoptr i64 %"point##0" to i64* 
-  %38 = getelementptr  i64, i64* %37, i64 0 
-  %39 = load  i64, i64* %38 
-  %"1#tmp#1##0" = tail call fastcc  i64  @"wybe.int.min<0>"(i64  %36, i64  %39)  
-  %40 = trunc i64 16 to i32  
-  %41 = tail call ccc  i8*  @wybe_malloc(i32  %40)  
-  %42 = ptrtoint i8* %41 to i64 
-  %43 = inttoptr i64 %42 to i8* 
-  %44 = inttoptr i64 %33 to i8* 
-  %45 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %43, i8*  %44, i32  %45, i32  8, i1  0)  
-  %46 = inttoptr i64 %42 to i64* 
-  %47 = getelementptr  i64, i64* %46, i64 0 
-  store  i64 %"1#tmp#1##0", i64* %47 
-  %48 = trunc i64 16 to i32  
-  %49 = tail call ccc  i8*  @wybe_malloc(i32  %48)  
-  %50 = ptrtoint i8* %49 to i64 
-  %51 = inttoptr i64 %50 to i8* 
-  %52 = inttoptr i64 %"reg##0" to i8* 
-  %53 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %51, i8*  %52, i32  %53, i32  8, i1  0)  
-  %54 = inttoptr i64 %50 to i64* 
-  %55 = getelementptr  i64, i64* %54, i64 0 
-  store  i64 %42, i64* %55 
-  %56 = add   i64 %42, 8 
-  %57 = inttoptr i64 %56 to i64* 
-  %58 = getelementptr  i64, i64* %57, i64 0 
-  %59 = load  i64, i64* %58 
-  %60 = add   i64 %"point##0", 8 
-  %61 = inttoptr i64 %60 to i64* 
-  %62 = getelementptr  i64, i64* %61, i64 0 
-  %63 = load  i64, i64* %62 
-  %"1#tmp#6##0" = tail call fastcc  i64  @"wybe.int.min<0>"(i64  %59, i64  %63)  
-  %64 = trunc i64 16 to i32  
-  %65 = tail call ccc  i8*  @wybe_malloc(i32  %64)  
-  %66 = ptrtoint i8* %65 to i64 
-  %67 = inttoptr i64 %66 to i8* 
-  %68 = inttoptr i64 %42 to i8* 
-  %69 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %67, i8*  %68, i32  %69, i32  8, i1  0)  
-  %70 = add   i64 %66, 8 
-  %71 = inttoptr i64 %70 to i64* 
-  %72 = getelementptr  i64, i64* %71, i64 0 
-  store  i64 %"1#tmp#6##0", i64* %72 
-  %73 = trunc i64 16 to i32  
-  %74 = tail call ccc  i8*  @wybe_malloc(i32  %73)  
-  %75 = ptrtoint i8* %74 to i64 
-  %76 = inttoptr i64 %75 to i8* 
-  %77 = inttoptr i64 %50 to i8* 
-  %78 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %76, i8*  %77, i32  %78, i32  8, i1  0)  
-  %79 = inttoptr i64 %75 to i64* 
-  %80 = getelementptr  i64, i64* %79, i64 0 
-  store  i64 %66, i64* %80 
-  %81 = add   i64 %75, 8 
-  %82 = inttoptr i64 %81 to i64* 
-  %83 = getelementptr  i64, i64* %82, i64 0 
-  %84 = load  i64, i64* %83 
-  %85 = inttoptr i64 %84 to i64* 
-  %86 = getelementptr  i64, i64* %85, i64 0 
-  %87 = load  i64, i64* %86 
-  %"1#tmp#11##0" = tail call fastcc  i64  @"wybe.int.max<0>"(i64  %87, i64  %39)  
-  %88 = trunc i64 16 to i32  
-  %89 = tail call ccc  i8*  @wybe_malloc(i32  %88)  
-  %90 = ptrtoint i8* %89 to i64 
-  %91 = inttoptr i64 %90 to i8* 
-  %92 = inttoptr i64 %84 to i8* 
-  %93 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %91, i8*  %92, i32  %93, i32  8, i1  0)  
-  %94 = inttoptr i64 %90 to i64* 
-  %95 = getelementptr  i64, i64* %94, i64 0 
-  store  i64 %"1#tmp#11##0", i64* %95 
-  %96 = trunc i64 16 to i32  
-  %97 = tail call ccc  i8*  @wybe_malloc(i32  %96)  
-  %98 = ptrtoint i8* %97 to i64 
-  %99 = inttoptr i64 %98 to i8* 
-  %100 = inttoptr i64 %75 to i8* 
-  %101 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %99, i8*  %100, i32  %101, i32  8, i1  0)  
-  %102 = add   i64 %98, 8 
-  %103 = inttoptr i64 %102 to i64* 
-  %104 = getelementptr  i64, i64* %103, i64 0 
-  store  i64 %90, i64* %104 
-  %105 = add   i64 %90, 8 
-  %106 = inttoptr i64 %105 to i64* 
-  %107 = getelementptr  i64, i64* %106, i64 0 
-  %108 = load  i64, i64* %107 
-  %"1#tmp#16##0" = tail call fastcc  i64  @"wybe.int.max<0>"(i64  %108, i64  %63)  
-  %109 = trunc i64 16 to i32  
-  %110 = tail call ccc  i8*  @wybe_malloc(i32  %109)  
-  %111 = ptrtoint i8* %110 to i64 
-  %112 = inttoptr i64 %111 to i8* 
-  %113 = inttoptr i64 %90 to i8* 
-  %114 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %112, i8*  %113, i32  %114, i32  8, i1  0)  
-  %115 = add   i64 %111, 8 
-  %116 = inttoptr i64 %115 to i64* 
-  %117 = getelementptr  i64, i64* %116, i64 0 
-  store  i64 %"1#tmp#16##0", i64* %117 
-  %118 = trunc i64 16 to i32  
-  %119 = tail call ccc  i8*  @wybe_malloc(i32  %118)  
-  %120 = ptrtoint i8* %119 to i64 
-  %121 = inttoptr i64 %120 to i8* 
-  %122 = inttoptr i64 %98 to i8* 
-  %123 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %121, i8*  %122, i32  %123, i32  8, i1  0)  
-  %124 = add   i64 %120, 8 
-  %125 = inttoptr i64 %124 to i64* 
-  %126 = getelementptr  i64, i64* %125, i64 0 
-  store  i64 %111, i64* %126 
-  ret i64 %120 
+  %30 = inttoptr i64 %"reg##0" to i64* 
+  %31 = getelementptr  i64, i64* %30, i64 0 
+  %32 = load  i64, i64* %31 
+  %33 = inttoptr i64 %32 to i64* 
+  %34 = getelementptr  i64, i64* %33, i64 0 
+  %35 = load  i64, i64* %34 
+  %36 = inttoptr i64 %"point##0" to i64* 
+  %37 = getelementptr  i64, i64* %36, i64 0 
+  %38 = load  i64, i64* %37 
+  %"1#tmp#1##0" = tail call fastcc  i64  @"wybe.int.min<0>"(i64  %35, i64  %38)  
+  %39 = trunc i64 16 to i32  
+  %40 = tail call ccc  i8*  @wybe_malloc(i32  %39)  
+  %41 = ptrtoint i8* %40 to i64 
+  %42 = inttoptr i64 %41 to i8* 
+  %43 = inttoptr i64 %32 to i8* 
+  %44 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %42, i8*  %43, i32  %44, i32  8, i1  0)  
+  %45 = inttoptr i64 %41 to i64* 
+  %46 = getelementptr  i64, i64* %45, i64 0 
+  store  i64 %"1#tmp#1##0", i64* %46 
+  %47 = trunc i64 16 to i32  
+  %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
+  %49 = ptrtoint i8* %48 to i64 
+  %50 = inttoptr i64 %49 to i8* 
+  %51 = inttoptr i64 %"reg##0" to i8* 
+  %52 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %50, i8*  %51, i32  %52, i32  8, i1  0)  
+  %53 = inttoptr i64 %49 to i64* 
+  %54 = getelementptr  i64, i64* %53, i64 0 
+  store  i64 %41, i64* %54 
+  %55 = add   i64 %41, 8 
+  %56 = inttoptr i64 %55 to i64* 
+  %57 = getelementptr  i64, i64* %56, i64 0 
+  %58 = load  i64, i64* %57 
+  %59 = add   i64 %"point##0", 8 
+  %60 = inttoptr i64 %59 to i64* 
+  %61 = getelementptr  i64, i64* %60, i64 0 
+  %62 = load  i64, i64* %61 
+  %"1#tmp#6##0" = tail call fastcc  i64  @"wybe.int.min<0>"(i64  %58, i64  %62)  
+  %63 = trunc i64 16 to i32  
+  %64 = tail call ccc  i8*  @wybe_malloc(i32  %63)  
+  %65 = ptrtoint i8* %64 to i64 
+  %66 = inttoptr i64 %65 to i8* 
+  %67 = inttoptr i64 %41 to i8* 
+  %68 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %66, i8*  %67, i32  %68, i32  8, i1  0)  
+  %69 = add   i64 %65, 8 
+  %70 = inttoptr i64 %69 to i64* 
+  %71 = getelementptr  i64, i64* %70, i64 0 
+  store  i64 %"1#tmp#6##0", i64* %71 
+  %72 = trunc i64 16 to i32  
+  %73 = tail call ccc  i8*  @wybe_malloc(i32  %72)  
+  %74 = ptrtoint i8* %73 to i64 
+  %75 = inttoptr i64 %74 to i8* 
+  %76 = inttoptr i64 %49 to i8* 
+  %77 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %75, i8*  %76, i32  %77, i32  8, i1  0)  
+  %78 = inttoptr i64 %74 to i64* 
+  %79 = getelementptr  i64, i64* %78, i64 0 
+  store  i64 %65, i64* %79 
+  %80 = add   i64 %74, 8 
+  %81 = inttoptr i64 %80 to i64* 
+  %82 = getelementptr  i64, i64* %81, i64 0 
+  %83 = load  i64, i64* %82 
+  %84 = inttoptr i64 %83 to i64* 
+  %85 = getelementptr  i64, i64* %84, i64 0 
+  %86 = load  i64, i64* %85 
+  %"1#tmp#11##0" = tail call fastcc  i64  @"wybe.int.max<0>"(i64  %86, i64  %38)  
+  %87 = trunc i64 16 to i32  
+  %88 = tail call ccc  i8*  @wybe_malloc(i32  %87)  
+  %89 = ptrtoint i8* %88 to i64 
+  %90 = inttoptr i64 %89 to i8* 
+  %91 = inttoptr i64 %83 to i8* 
+  %92 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %90, i8*  %91, i32  %92, i32  8, i1  0)  
+  %93 = inttoptr i64 %89 to i64* 
+  %94 = getelementptr  i64, i64* %93, i64 0 
+  store  i64 %"1#tmp#11##0", i64* %94 
+  %95 = trunc i64 16 to i32  
+  %96 = tail call ccc  i8*  @wybe_malloc(i32  %95)  
+  %97 = ptrtoint i8* %96 to i64 
+  %98 = inttoptr i64 %97 to i8* 
+  %99 = inttoptr i64 %74 to i8* 
+  %100 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %98, i8*  %99, i32  %100, i32  8, i1  0)  
+  %101 = add   i64 %97, 8 
+  %102 = inttoptr i64 %101 to i64* 
+  %103 = getelementptr  i64, i64* %102, i64 0 
+  store  i64 %89, i64* %103 
+  %104 = add   i64 %89, 8 
+  %105 = inttoptr i64 %104 to i64* 
+  %106 = getelementptr  i64, i64* %105, i64 0 
+  %107 = load  i64, i64* %106 
+  %"1#tmp#16##0" = tail call fastcc  i64  @"wybe.int.max<0>"(i64  %107, i64  %62)  
+  %108 = trunc i64 16 to i32  
+  %109 = tail call ccc  i8*  @wybe_malloc(i32  %108)  
+  %110 = ptrtoint i8* %109 to i64 
+  %111 = inttoptr i64 %110 to i8* 
+  %112 = inttoptr i64 %89 to i8* 
+  %113 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %111, i8*  %112, i32  %113, i32  8, i1  0)  
+  %114 = add   i64 %110, 8 
+  %115 = inttoptr i64 %114 to i64* 
+  %116 = getelementptr  i64, i64* %115, i64 0 
+  store  i64 %"1#tmp#16##0", i64* %116 
+  %117 = trunc i64 16 to i32  
+  %118 = tail call ccc  i8*  @wybe_malloc(i32  %117)  
+  %119 = ptrtoint i8* %118 to i64 
+  %120 = inttoptr i64 %119 to i8* 
+  %121 = inttoptr i64 %97 to i8* 
+  %122 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %120, i8*  %121, i32  %122, i32  8, i1  0)  
+  %123 = add   i64 %119, 8 
+  %124 = inttoptr i64 %123 to i64* 
+  %125 = getelementptr  i64, i64* %124, i64 0 
+  store  i64 %110, i64* %125 
+  ret i64 %119 
 }
 
 
 define external fastcc  void @"caret.gen#1<0>"(i64  %"reg##0")    {
 entry:
-  %127 = add   i64 %"reg##0", 8 
-  %128 = inttoptr i64 %127 to i64* 
-  %129 = getelementptr  i64, i64* %128, i64 0 
-  %130 = load  i64, i64* %129 
-  %131 = inttoptr i64 %130 to i64* 
-  %132 = getelementptr  i64, i64* %131, i64 0 
-  %133 = load  i64, i64* %132 
-  %"1#tmp#5##1" = add   i64 %133, 1 
-  %134 = trunc i64 16 to i32  
-  %135 = tail call ccc  i8*  @wybe_malloc(i32  %134)  
-  %136 = ptrtoint i8* %135 to i64 
-  %137 = inttoptr i64 %136 to i8* 
-  %138 = inttoptr i64 %130 to i8* 
-  %139 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %137, i8*  %138, i32  %139, i32  8, i1  0)  
-  %140 = inttoptr i64 %136 to i64* 
-  %141 = getelementptr  i64, i64* %140, i64 0 
-  store  i64 %"1#tmp#5##1", i64* %141 
-  %142 = inttoptr i64 %136 to i64* 
-  %143 = getelementptr  i64, i64* %142, i64 0 
-  %144 = load  i64, i64* %143 
-  %147 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @caret.146, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %147)  
-  tail call ccc  void  @print_int(i64  %144)  
+  %126 = add   i64 %"reg##0", 8 
+  %127 = inttoptr i64 %126 to i64* 
+  %128 = getelementptr  i64, i64* %127, i64 0 
+  %129 = load  i64, i64* %128 
+  %130 = inttoptr i64 %129 to i64* 
+  %131 = getelementptr  i64, i64* %130, i64 0 
+  %132 = load  i64, i64* %131 
+  %"1#tmp#5##1" = add   i64 %132, 1 
+  %133 = trunc i64 16 to i32  
+  %134 = tail call ccc  i8*  @wybe_malloc(i32  %133)  
+  %135 = ptrtoint i8* %134 to i64 
+  %136 = inttoptr i64 %135 to i8* 
+  %137 = inttoptr i64 %129 to i8* 
+  %138 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %136, i8*  %137, i32  %138, i32  8, i1  0)  
+  %139 = inttoptr i64 %135 to i64* 
+  %140 = getelementptr  i64, i64* %139, i64 0 
+  store  i64 %"1#tmp#5##1", i64* %140 
+  %141 = inttoptr i64 %135 to i64* 
+  %142 = getelementptr  i64, i64* %141, i64 0 
+  %143 = load  i64, i64* %142 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @caret.145, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %143)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -331,23 +329,22 @@ entry:
 
 define external fastcc  void @"caret.gen#1<0>[6dacb8fd25]"(i64  %"reg##0")    {
 entry:
-  %148 = add   i64 %"reg##0", 8 
-  %149 = inttoptr i64 %148 to i64* 
-  %150 = getelementptr  i64, i64* %149, i64 0 
-  %151 = load  i64, i64* %150 
-  %152 = inttoptr i64 %151 to i64* 
-  %153 = getelementptr  i64, i64* %152, i64 0 
-  %154 = load  i64, i64* %153 
-  %"1#tmp#5##1" = add   i64 %154, 1 
-  %155 = inttoptr i64 %151 to i64* 
+  %146 = add   i64 %"reg##0", 8 
+  %147 = inttoptr i64 %146 to i64* 
+  %148 = getelementptr  i64, i64* %147, i64 0 
+  %149 = load  i64, i64* %148 
+  %150 = inttoptr i64 %149 to i64* 
+  %151 = getelementptr  i64, i64* %150, i64 0 
+  %152 = load  i64, i64* %151 
+  %"1#tmp#5##1" = add   i64 %152, 1 
+  %153 = inttoptr i64 %149 to i64* 
+  %154 = getelementptr  i64, i64* %153, i64 0 
+  store  i64 %"1#tmp#5##1", i64* %154 
+  %155 = inttoptr i64 %149 to i64* 
   %156 = getelementptr  i64, i64* %155, i64 0 
-  store  i64 %"1#tmp#5##1", i64* %156 
-  %157 = inttoptr i64 %151 to i64* 
-  %158 = getelementptr  i64, i64* %157, i64 0 
-  %159 = load  i64, i64* %158 
-  %162 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @caret.161, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %162)  
-  tail call ccc  void  @print_int(i64  %159)  
+  %157 = load  i64, i64* %156 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @caret.159, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %157)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -777,16 +774,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@position.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.14 to i64) }
+@position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.14 =    constant [?? x i8] c")\00"
+@position.12 =    constant [?? x i8] c")\00"
 
 
-@position.8 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.7 to i64) }
+@position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
 
 
-@position.7 =    constant [?? x i8] c",\00"
+@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
@@ -803,21 +800,18 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
-  %4 = inttoptr i64 %"pos##0" to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
-  %10 = add   i64 %"pos##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  tail call ccc  void  @print_int(i64  %13)  
-  %16 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.15, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %16)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64))  
+  %3 = inttoptr i64 %"pos##0" to i64* 
+  %4 = getelementptr  i64, i64* %3, i64 0 
+  %5 = load  i64, i64* %4 
+  tail call ccc  void  @print_int(i64  %5)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.7, i32 0, i32 0) to i64))  
+  %8 = add   i64 %"pos##0", 8 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = getelementptr  i64, i64* %9, i64 0 
+  %11 = load  i64, i64* %10 
+  tail call ccc  void  @print_int(i64  %11)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/ccc.exp
+++ b/test-cases/final-dump/ccc.exp
@@ -46,8 +46,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"ccc.<0>"()    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @ccc.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @ccc.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -97,8 +96,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"ddd.<0>"()    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @ddd.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @ddd.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/compute.exp
+++ b/test-cases/final-dump/compute.exp
@@ -187,8 +187,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"math.utils.<0>"()    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @math.utils.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @math.utils.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/coordinate.exp
+++ b/test-cases/final-dump/coordinate.exp
@@ -65,10 +65,10 @@ declare external ccc  void @print_int(i64)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@coordinate.23 =    constant {i64, i64} { i64 20, i64 ptrtoint ([?? x i8]* @coordinate.22 to i64) }
+@coordinate.22 =    constant {i64, i64} { i64 20, i64 ptrtoint ([?? x i8]* @coordinate.21 to i64) }
 
 
-@coordinate.22 =    constant [?? x i8] c"expect crd2^z=1000: \00"
+@coordinate.21 =    constant [?? x i8] c"expect crd2^z=1000: \00"
 
 
 @coordinate.16 =    constant {i64, i64} { i64 20, i64 ptrtoint ([?? x i8]* @coordinate.15 to i64) }
@@ -103,16 +103,14 @@ entry:
   %13 = inttoptr i64 %12 to i64* 
   %14 = getelementptr  i64, i64* %13, i64 0 
   store  i64 8000, i64* %14 
-  %17 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @coordinate.16, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %17)  
-  %18 = add   i64 %3, 16 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  %21 = load  i64, i64* %20 
-  tail call ccc  void  @print_int(i64  %21)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @coordinate.16, i32 0, i32 0) to i64))  
+  %17 = add   i64 %3, 16 
+  %18 = inttoptr i64 %17 to i64* 
+  %19 = getelementptr  i64, i64* %18, i64 0 
+  %20 = load  i64, i64* %19 
+  tail call ccc  void  @print_int(i64  %20)  
   tail call ccc  void  @putchar(i8  10)  
-  %24 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @coordinate.23, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %24)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @coordinate.22, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  1000)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 

--- a/test-cases/final-dump/ddd.exp
+++ b/test-cases/final-dump/ddd.exp
@@ -45,8 +45,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"ddd.<0>"()    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @ddd.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @ddd.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/dead_cell_size.exp
+++ b/test-cases/final-dump/dead_cell_size.exp
@@ -287,52 +287,52 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@dead_cell_size.110 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @dead_cell_size.109 to i64) }
+@dead_cell_size.102 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @dead_cell_size.101 to i64) }
 
 
-@dead_cell_size.109 =    constant [?? x i8] c")\00"
+@dead_cell_size.101 =    constant [?? x i8] c")\00"
 
 
-@dead_cell_size.107 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @dead_cell_size.106 to i64) }
+@dead_cell_size.100 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @dead_cell_size.99 to i64) }
 
 
-@dead_cell_size.106 =    constant [?? x i8] c"td(\00"
-
-
-@dead_cell_size.100 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @dead_cell_size.99 to i64) }
-
-
-@dead_cell_size.99 =    constant [?? x i8] c")\00"
-
-
-@dead_cell_size.97 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @dead_cell_size.96 to i64) }
-
-
-@dead_cell_size.96 =    constant [?? x i8] c",\00"
+@dead_cell_size.99 =    constant [?? x i8] c"td(\00"
 
 
 @dead_cell_size.94 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @dead_cell_size.93 to i64) }
 
 
-@dead_cell_size.93 =    constant [?? x i8] c",\00"
+@dead_cell_size.93 =    constant [?? x i8] c")\00"
 
 
-@dead_cell_size.91 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @dead_cell_size.90 to i64) }
+@dead_cell_size.92 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @dead_cell_size.91 to i64) }
 
 
-@dead_cell_size.90 =    constant [?? x i8] c"tc(\00"
+@dead_cell_size.91 =    constant [?? x i8] c",\00"
 
 
-@dead_cell_size.76 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @dead_cell_size.75 to i64) }
+@dead_cell_size.90 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @dead_cell_size.89 to i64) }
 
 
-@dead_cell_size.75 =    constant [?? x i8] c")\00"
+@dead_cell_size.89 =    constant [?? x i8] c",\00"
 
 
-@dead_cell_size.73 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @dead_cell_size.72 to i64) }
+@dead_cell_size.88 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @dead_cell_size.87 to i64) }
 
 
-@dead_cell_size.72 =    constant [?? x i8] c"tb(\00"
+@dead_cell_size.87 =    constant [?? x i8] c"tc(\00"
+
+
+@dead_cell_size.74 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @dead_cell_size.73 to i64) }
+
+
+@dead_cell_size.73 =    constant [?? x i8] c")\00"
+
+
+@dead_cell_size.72 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @dead_cell_size.71 to i64) }
+
+
+@dead_cell_size.71 =    constant [?? x i8] c"tb(\00"
 
 
 @dead_cell_size.67 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @dead_cell_size.66 to i64) }
@@ -341,22 +341,22 @@ declare external ccc  void @print_int(i64)
 @dead_cell_size.66 =    constant [?? x i8] c"ta\00"
 
 
-@dead_cell_size.122 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @dead_cell_size.121 to i64) }
+@dead_cell_size.111 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @dead_cell_size.110 to i64) }
 
 
-@dead_cell_size.121 =    constant [?? x i8] c")\00"
+@dead_cell_size.110 =    constant [?? x i8] c")\00"
 
 
-@dead_cell_size.119 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @dead_cell_size.118 to i64) }
+@dead_cell_size.109 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @dead_cell_size.108 to i64) }
 
 
-@dead_cell_size.118 =    constant [?? x i8] c"t2b(\00"
+@dead_cell_size.108 =    constant [?? x i8] c"t2b(\00"
 
 
-@dead_cell_size.113 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @dead_cell_size.112 to i64) }
+@dead_cell_size.104 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @dead_cell_size.103 to i64) }
 
 
-@dead_cell_size.112 =    constant [?? x i8] c"t2a\00"
+@dead_cell_size.103 =    constant [?? x i8] c"t2a\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -547,8 +547,7 @@ entry:
   %"1#tmp#4##0" = tail call fastcc  i1  @"dead_cell_size.t.=<0>"(i64  0, i64  %"x##0")  
   br i1 %"1#tmp#4##0", label %if.then, label %if.else 
 if.then:
-  %68 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.67, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %68)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.67, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else:
@@ -562,58 +561,50 @@ if.else1:
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.then2:
-  %69 = inttoptr i64 %"x##0" to i64* 
-  %70 = getelementptr  i64, i64* %69, i64 0 
-  %71 = load  i64, i64* %70 
-  %74 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.73, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %74)  
-  tail call ccc  void  @print_int(i64  %71)  
-  %77 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.76, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %77)  
+  %68 = inttoptr i64 %"x##0" to i64* 
+  %69 = getelementptr  i64, i64* %68, i64 0 
+  %70 = load  i64, i64* %69 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.72, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %70)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.74, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else2:
   %"7#tmp#12##0" = icmp eq i64 %"4#tmp#7##0", 1 
   br i1 %"7#tmp#12##0", label %if.then3, label %if.else3 
 if.then3:
-  %78 = add   i64 %"x##0", -1 
-  %79 = inttoptr i64 %78 to i64* 
-  %80 = getelementptr  i64, i64* %79, i64 0 
-  %81 = load  i64, i64* %80 
-  %82 = add   i64 %"x##0", 7 
-  %83 = inttoptr i64 %82 to i64* 
-  %84 = getelementptr  i64, i64* %83, i64 0 
-  %85 = load  i64, i64* %84 
-  %86 = add   i64 %"x##0", 15 
-  %87 = inttoptr i64 %86 to i64* 
-  %88 = getelementptr  i64, i64* %87, i64 0 
-  %89 = load  i64, i64* %88 
-  %92 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.91, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %92)  
-  tail call ccc  void  @print_int(i64  %81)  
-  %95 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.94, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %95)  
-  tail call ccc  void  @print_int(i64  %85)  
-  %98 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.97, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %98)  
-  tail call ccc  void  @print_int(i64  %89)  
-  %101 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.100, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %101)  
+  %75 = add   i64 %"x##0", -1 
+  %76 = inttoptr i64 %75 to i64* 
+  %77 = getelementptr  i64, i64* %76, i64 0 
+  %78 = load  i64, i64* %77 
+  %79 = add   i64 %"x##0", 7 
+  %80 = inttoptr i64 %79 to i64* 
+  %81 = getelementptr  i64, i64* %80, i64 0 
+  %82 = load  i64, i64* %81 
+  %83 = add   i64 %"x##0", 15 
+  %84 = inttoptr i64 %83 to i64* 
+  %85 = getelementptr  i64, i64* %84, i64 0 
+  %86 = load  i64, i64* %85 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.88, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %78)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.90, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %82)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.92, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %86)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.94, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else3:
   %"9#tmp#16##0" = icmp eq i64 %"4#tmp#7##0", 2 
   br i1 %"9#tmp#16##0", label %if.then4, label %if.else4 
 if.then4:
-  %102 = add   i64 %"x##0", -2 
-  %103 = inttoptr i64 %102 to i64* 
-  %104 = getelementptr  i64, i64* %103, i64 0 
-  %105 = load  i64, i64* %104 
-  %108 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.107, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %108)  
-  tail call ccc  void  @print_int(i64  %105)  
-  %111 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.110, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %111)  
+  %95 = add   i64 %"x##0", -2 
+  %96 = inttoptr i64 %95 to i64* 
+  %97 = getelementptr  i64, i64* %96, i64 0 
+  %98 = load  i64, i64* %97 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.100, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %98)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.102, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else4:
@@ -627,22 +618,19 @@ entry:
   %"1#tmp#2##0" = tail call fastcc  i1  @"dead_cell_size.t2.=<0>"(i64  0, i64  %"x##0")  
   br i1 %"1#tmp#2##0", label %if.then, label %if.else 
 if.then:
-  %114 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.113, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %114)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.104, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else:
   %"3#tmp#4##0" = icmp ne i64 %"x##0", 0 
   br i1 %"3#tmp#4##0", label %if.then1, label %if.else1 
 if.then1:
-  %115 = inttoptr i64 %"x##0" to i64* 
-  %116 = getelementptr  i64, i64* %115, i64 0 
-  %117 = load  i64, i64* %116 
-  %120 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.119, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %120)  
-  tail call ccc  void  @print_int(i64  %117)  
-  %123 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.122, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %123)  
+  %105 = inttoptr i64 %"x##0" to i64* 
+  %106 = getelementptr  i64, i64* %105, i64 0 
+  %107 = load  i64, i64* %106 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.109, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %107)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @dead_cell_size.111, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else1:

--- a/test-cases/final-dump/early_error.exp
+++ b/test-cases/final-dump/early_error.exp
@@ -48,10 +48,10 @@ declare external ccc  void @putchar(i8)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@early_error.5 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @early_error.4 to i64) }
+@early_error.4 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @early_error.3 to i64) }
 
 
-@early_error.4 =    constant [?? x i8] c"should print this error message\00"
+@early_error.3 =    constant [?? x i8] c"should print this error message\00"
 
 
 @early_error.2 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @early_error.1 to i64) }
@@ -68,11 +68,9 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"early_error.<0>"()    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @early_error.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @early_error.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %6 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @early_error.5, i32 0, i32 0) to i64 
-  tail call ccc  void  @puts(i64  %6)  
+  tail call ccc  void  @puts(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @early_error.4, i32 0, i32 0) to i64))  
   tail call ccc  void  @exit(i64  1)  
   ret void 
 }

--- a/test-cases/final-dump/early_exit.exp
+++ b/test-cases/final-dump/early_exit.exp
@@ -49,8 +49,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"early_exit.<0>"()    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @early_exit.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @early_exit.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call ccc  void  @exit(i64  1)  
   ret void 

--- a/test-cases/final-dump/early_exit2.exp
+++ b/test-cases/final-dump/early_exit2.exp
@@ -57,8 +57,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"early_exit2.<0>"()    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @early_exit2.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @early_exit2.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call ccc  void  @exit(i64  1)  
   ret void 

--- a/test-cases/final-dump/eof_comment.exp
+++ b/test-cases/final-dump/eof_comment.exp
@@ -45,8 +45,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"eof_comment.<0>"()    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @eof_comment.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @eof_comment.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/exp_if.exp
+++ b/test-cases/final-dump/exp_if.exp
@@ -51,16 +51,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @exp_if.1 =    constant [?? x i8] c"expect larger: \00"
 
 
-@exp_if.8 =    constant {i64, i64} { i64 7, i64 ptrtoint ([?? x i8]* @exp_if.7 to i64) }
+@exp_if.6 =    constant {i64, i64} { i64 7, i64 ptrtoint ([?? x i8]* @exp_if.5 to i64) }
 
 
-@exp_if.7 =    constant [?? x i8] c"smaller\00"
+@exp_if.5 =    constant [?? x i8] c"smaller\00"
 
 
-@exp_if.5 =    constant {i64, i64} { i64 6, i64 ptrtoint ([?? x i8]* @exp_if.4 to i64) }
+@exp_if.4 =    constant {i64, i64} { i64 6, i64 ptrtoint ([?? x i8]* @exp_if.3 to i64) }
 
 
-@exp_if.4 =    constant [?? x i8] c"larger\00"
+@exp_if.3 =    constant [?? x i8] c"larger\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -71,8 +71,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"exp_if.<0>"()    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @exp_if.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @exp_if.2, i32 0, i32 0) to i64))  
   %"1#tmp#0##0" = tail call fastcc  i64  @"exp_if.if_test<0>"(i64  3)  
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %"1#tmp#0##0")  
   ret void 
@@ -84,9 +83,7 @@ entry:
   %"1#tmp#1##0" = icmp sgt i64 %"x##0", 0 
   br i1 %"1#tmp#1##0", label %if.then, label %if.else 
 if.then:
-  %6 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @exp_if.5, i32 0, i32 0) to i64 
-  ret i64 %6 
+  ret i64 ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @exp_if.4, i32 0, i32 0) to i64) 
 if.else:
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @exp_if.8, i32 0, i32 0) to i64 
-  ret i64 %9 
+  ret i64 ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @exp_if.6, i32 0, i32 0) to i64) 
 }

--- a/test-cases/final-dump/exp_print.exp
+++ b/test-cases/final-dump/exp_print.exp
@@ -42,16 +42,16 @@ declare external ccc  void @putchar(i8)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@exp_print.8 =    constant {i64, i64} { i64 45, i64 ptrtoint ([?? x i8]* @exp_print.7 to i64) }
+@exp_print.6 =    constant {i64, i64} { i64 45, i64 ptrtoint ([?? x i8]* @exp_print.5 to i64) }
 
 
-@exp_print.7 =    constant [?? x i8] c"println(x:string) generates an extra newline?\00"
+@exp_print.5 =    constant [?? x i8] c"println(x:string) generates an extra newline?\00"
 
 
-@exp_print.5 =    constant {i64, i64} { i64 45, i64 ptrtoint ([?? x i8]* @exp_print.4 to i64) }
+@exp_print.4 =    constant {i64, i64} { i64 45, i64 ptrtoint ([?? x i8]* @exp_print.3 to i64) }
 
 
-@exp_print.4 =    constant [?? x i8] c"println(x:string) generates an extra newline?\00"
+@exp_print.3 =    constant [?? x i8] c"println(x:string) generates an extra newline?\00"
 
 
 @exp_print.2 =    constant {i64, i64} { i64 41, i64 ptrtoint ([?? x i8]* @exp_print.1 to i64) }
@@ -68,13 +68,10 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"exp_print.<0>"()    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @exp_print.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
-  %6 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @exp_print.5, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %6)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @exp_print.2, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @exp_print.4, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @exp_print.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @exp_print.6, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call ccc  void  @putchar(i8  99)  
   tail call ccc  void  @putchar(i8  10)  

--- a/test-cases/final-dump/exp_simple.exp
+++ b/test-cases/final-dump/exp_simple.exp
@@ -75,8 +75,7 @@ entry:
   tail call ccc  void  @putchar(i8  10)  
   tail call ccc  void  @putchar(i8  104)  
   tail call ccc  void  @putchar(i8  10)  
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @exp_simple.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @exp_simple.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  3)  
   tail call ccc  void  @putchar(i8  10)  
   tail call ccc  void  @print_int(i64  1001)  

--- a/test-cases/final-dump/generic_use.exp
+++ b/test-cases/final-dump/generic_use.exp
@@ -810,8 +810,7 @@ if.then:
   %64 = inttoptr i64 %63 to i64* 
   %65 = getelementptr  i64, i64* %64, i64 0 
   %66 = load  i64, i64* %65 
-  %69 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @generic_use.68, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %69)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @generic_use.68, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %62)  
   tail call fastcc  void  @"generic_use.print_tail<0>"(i64  %66)  
   ret void 
@@ -840,24 +839,24 @@ entry:
   %"1#tmp#5##0" = icmp ne i64 %"lst##0", 0 
   br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
-  %70 = inttoptr i64 %"lst##0" to i64* 
-  %71 = getelementptr  i64, i64* %70, i64 0 
-  %72 = load  i64, i64* %71 
-  %73 = add   i64 %"lst##0", 8 
-  %74 = inttoptr i64 %73 to i64* 
-  %75 = getelementptr  i64, i64* %74, i64 0 
-  %76 = load  i64, i64* %75 
-  %77 = trunc i64 16 to i32  
-  %78 = tail call ccc  i8*  @wybe_malloc(i32  %77)  
-  %79 = ptrtoint i8* %78 to i64 
-  %80 = inttoptr i64 %79 to i64* 
-  %81 = getelementptr  i64, i64* %80, i64 0 
-  store  i64 %72, i64* %81 
-  %82 = add   i64 %79, 8 
-  %83 = inttoptr i64 %82 to i64* 
-  %84 = getelementptr  i64, i64* %83, i64 0 
-  store  i64 %"suffix##0", i64* %84 
-  %"2##result##0" = tail call fastcc  i64  @"generic_use.reverse1<0>"(i64  %76, i64  %79)  
+  %69 = inttoptr i64 %"lst##0" to i64* 
+  %70 = getelementptr  i64, i64* %69, i64 0 
+  %71 = load  i64, i64* %70 
+  %72 = add   i64 %"lst##0", 8 
+  %73 = inttoptr i64 %72 to i64* 
+  %74 = getelementptr  i64, i64* %73, i64 0 
+  %75 = load  i64, i64* %74 
+  %76 = trunc i64 16 to i32  
+  %77 = tail call ccc  i8*  @wybe_malloc(i32  %76)  
+  %78 = ptrtoint i8* %77 to i64 
+  %79 = inttoptr i64 %78 to i64* 
+  %80 = getelementptr  i64, i64* %79, i64 0 
+  store  i64 %71, i64* %80 
+  %81 = add   i64 %78, 8 
+  %82 = inttoptr i64 %81 to i64* 
+  %83 = getelementptr  i64, i64* %82, i64 0 
+  store  i64 %"suffix##0", i64* %83 
+  %"2##result##0" = tail call fastcc  i64  @"generic_use.reverse1<0>"(i64  %75, i64  %78)  
   ret i64 %"2##result##0" 
 if.else:
   ret i64 %"suffix##0" 
@@ -869,15 +868,15 @@ entry:
   %"1#tmp#5##0" = icmp ne i64 %"lst##0", 0 
   br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
-  %85 = add   i64 %"lst##0", 8 
-  %86 = inttoptr i64 %85 to i64* 
-  %87 = getelementptr  i64, i64* %86, i64 0 
-  %88 = load  i64, i64* %87 
-  %89 = add   i64 %"lst##0", 8 
-  %90 = inttoptr i64 %89 to i64* 
-  %91 = getelementptr  i64, i64* %90, i64 0 
-  store  i64 %"suffix##0", i64* %91 
-  %"2##result##0" = tail call fastcc  i64  @"generic_use.reverse1<0>[410bae77d3]"(i64  %88, i64  %"lst##0")  
+  %84 = add   i64 %"lst##0", 8 
+  %85 = inttoptr i64 %84 to i64* 
+  %86 = getelementptr  i64, i64* %85, i64 0 
+  %87 = load  i64, i64* %86 
+  %88 = add   i64 %"lst##0", 8 
+  %89 = inttoptr i64 %88 to i64* 
+  %90 = getelementptr  i64, i64* %89, i64 0 
+  store  i64 %"suffix##0", i64* %90 
+  %"2##result##0" = tail call fastcc  i64  @"generic_use.reverse1<0>[410bae77d3]"(i64  %87, i64  %"lst##0")  
   ret i64 %"2##result##0" 
 if.else:
   ret i64 %"suffix##0" 

--- a/test-cases/final-dump/import.exp
+++ b/test-cases/final-dump/import.exp
@@ -173,16 +173,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@position.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.14 to i64) }
+@position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.14 =    constant [?? x i8] c")\00"
+@position.12 =    constant [?? x i8] c")\00"
 
 
-@position.8 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.7 to i64) }
+@position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
 
 
-@position.7 =    constant [?? x i8] c",\00"
+@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
@@ -199,21 +199,18 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
-  %4 = inttoptr i64 %"pos##0" to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
-  %10 = add   i64 %"pos##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  tail call ccc  void  @print_int(i64  %13)  
-  %16 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.15, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %16)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64))  
+  %3 = inttoptr i64 %"pos##0" to i64* 
+  %4 = getelementptr  i64, i64* %3, i64 0 
+  %5 = load  i64, i64* %4 
+  tail call ccc  void  @print_int(i64  %5)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.7, i32 0, i32 0) to i64))  
+  %8 = add   i64 %"pos##0", 8 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = getelementptr  i64, i64* %9, i64 0 
+  %11 = load  i64, i64* %10 
+  tail call ccc  void  @print_int(i64  %11)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/list_loop.exp
+++ b/test-cases/final-dump/list_loop.exp
@@ -117,10 +117,10 @@ declare external ccc  void @print_int(i64)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@list_loop.43 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @list_loop.42 to i64) }
+@list_loop.42 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @list_loop.41 to i64) }
 
 
-@list_loop.42 =    constant [?? x i8] c" \00"
+@list_loop.41 =    constant [?? x i8] c" \00"
 
 
 @list_loop.40 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @list_loop.39 to i64) }
@@ -129,16 +129,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @list_loop.39 =    constant [?? x i8] c"    \00"
 
 
-@list_loop.49 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @list_loop.48 to i64) }
+@list_loop.46 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @list_loop.45 to i64) }
 
 
-@list_loop.48 =    constant [?? x i8] c" \00"
+@list_loop.45 =    constant [?? x i8] c" \00"
 
 
-@list_loop.46 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @list_loop.45 to i64) }
+@list_loop.44 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @list_loop.43 to i64) }
 
 
-@list_loop.45 =    constant [?? x i8] c"    \00"
+@list_loop.43 =    constant [?? x i8] c"    \00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -226,11 +226,9 @@ if.then:
   %36 = inttoptr i64 %35 to i64* 
   %37 = getelementptr  i64, i64* %36, i64 0 
   %38 = load  i64, i64* %37 
-  %41 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @list_loop.40, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %41)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @list_loop.40, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %"h##0")  
-  %44 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @list_loop.43, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %44)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @list_loop.42, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %34)  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"list_loop.gen#3<0>"(i64  %"h##0", i64  %"l##0", i64  %38, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"x##0")  
@@ -243,11 +241,9 @@ if.else:
 
 define external fastcc  void @"list_loop.gen#4<0>"(i64  %"h##0", i64  %"h2##0", i64  %"l##0", i64  %"l2##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"x##0")    {
 entry:
-  %47 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @list_loop.46, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %47)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @list_loop.44, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %"h##0")  
-  %50 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @list_loop.49, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %50)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @list_loop.46, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %"h2##0")  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"list_loop.gen#3<0>"(i64  %"h##0", i64  %"l##0", i64  %"l2##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"x##0")  

--- a/test-cases/final-dump/loop_bug.exp
+++ b/test-cases/final-dump/loop_bug.exp
@@ -90,10 +90,10 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @loop_bug.8 =    constant [?? x i8] c", \00"
 
 
-@loop_bug.12 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @loop_bug.11 to i64) }
+@loop_bug.11 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @loop_bug.10 to i64) }
 
 
-@loop_bug.11 =    constant [?? x i8] c", \00"
+@loop_bug.10 =    constant [?? x i8] c", \00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -114,8 +114,7 @@ if.then:
   %5 = inttoptr i64 %4 to i64* 
   %6 = getelementptr  i64, i64* %5, i64 0 
   %7 = load  i64, i64* %6 
-  %10 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @loop_bug.9, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %10)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @loop_bug.9, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %3)  
   tail call fastcc  void  @"loop_bug.gen#1<0>"(i64  %"lst##0", i64  %7)  
   ret void 
@@ -127,8 +126,7 @@ if.else:
 
 define external fastcc  void @"loop_bug.gen#2<0>"(i64  %"h##0", i64  %"lst##0", i64  %"t##0")    {
 entry:
-  %13 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @loop_bug.12, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %13)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @loop_bug.11, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %"h##0")  
   tail call fastcc  void  @"loop_bug.gen#1<0>"(i64  %"lst##0", i64  %"t##0")  
   ret void 
@@ -141,15 +139,15 @@ entry:
   %"1#tmp#5##0" = icmp ne i64 %"lst##0", 0 
   br i1 %"1#tmp#5##0", label %if.then, label %if.else 
 if.then:
-  %14 = inttoptr i64 %"lst##0" to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  %16 = load  i64, i64* %15 
-  %17 = add   i64 %"lst##0", 8 
-  %18 = inttoptr i64 %17 to i64* 
-  %19 = getelementptr  i64, i64* %18, i64 0 
-  %20 = load  i64, i64* %19 
-  tail call ccc  void  @print_int(i64  %16)  
-  tail call fastcc  void  @"loop_bug.gen#1<0>"(i64  %"lst##0", i64  %20)  
+  %12 = inttoptr i64 %"lst##0" to i64* 
+  %13 = getelementptr  i64, i64* %12, i64 0 
+  %14 = load  i64, i64* %13 
+  %15 = add   i64 %"lst##0", 8 
+  %16 = inttoptr i64 %15 to i64* 
+  %17 = getelementptr  i64, i64* %16, i64 0 
+  %18 = load  i64, i64* %17 
+  tail call ccc  void  @print_int(i64  %14)  
+  tail call fastcc  void  @"loop_bug.gen#1<0>"(i64  %"lst##0", i64  %18)  
   ret void 
 if.else:
   tail call ccc  void  @putchar(i8  93)  

--- a/test-cases/final-dump/main_hello.exp
+++ b/test-cases/final-dump/main_hello.exp
@@ -58,7 +58,7 @@ declare external ccc  void @error_exit(i64, i64)
 declare external fastcc  {i64, i64, i1} @"wybe.array.[|]<0>"(i64)    
 
 
-@command_line.18 =    constant [?? x i8] c"Erroneous program argument vector\00"
+@command_line.17 =    constant [?? x i8] c"Erroneous program argument vector\00"
 
 
 @command_line.16 =    constant [?? x i8] c"command_line:17:6\00"
@@ -93,13 +93,11 @@ if.then:
   %15 = insertvalue {i64, i64, i64} %14, i64 0, 2 
   ret {i64, i64, i64} %15 
 if.else:
-  %17 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @command_line.16, i32 0, i32 0) to i64 
-  %19 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @command_line.18, i32 0, i32 0) to i64 
-  tail call ccc  void  @error_exit(i64  %17, i64  %19)  
-  %20 = insertvalue {i64, i64, i64} undef, i64 %11, 0 
-  %21 = insertvalue {i64, i64, i64} %20, i64 %10, 1 
-  %22 = insertvalue {i64, i64, i64} %21, i64 undef, 2 
-  ret {i64, i64, i64} %22 
+  tail call ccc  void  @error_exit(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @command_line.16, i32 0, i32 0) to i64), i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @command_line.17, i32 0, i32 0) to i64))  
+  %18 = insertvalue {i64, i64, i64} undef, i64 %11, 0 
+  %19 = insertvalue {i64, i64, i64} %18, i64 %10, 1 
+  %20 = insertvalue {i64, i64, i64} %19, i64 undef, 2 
+  ret {i64, i64, i64} %20 
 }
 
 
@@ -148,10 +146,10 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@main_hello.8 =    constant {i64, i64} { i64 25, i64 ptrtoint ([?? x i8]* @main_hello.7 to i64) }
+@main_hello.7 =    constant {i64, i64} { i64 25, i64 ptrtoint ([?? x i8]* @main_hello.6 to i64) }
 
 
-@main_hello.7 =    constant [?? x i8] c" command line argument(s)\00"
+@main_hello.6 =    constant [?? x i8] c" command line argument(s)\00"
 
 
 @main_hello.2 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @main_hello.1 to i64) }
@@ -168,15 +166,13 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  i64 @"main_hello.<0>"(i64  %"arguments##0", i64  %"command##0")    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @main_hello.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @main_hello.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %4 = inttoptr i64 %"arguments##0" to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @main_hello.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
+  %3 = inttoptr i64 %"arguments##0" to i64* 
+  %4 = getelementptr  i64, i64* %3, i64 0 
+  %5 = load  i64, i64* %4 
+  tail call ccc  void  @print_int(i64  %5)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @main_hello.7, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret i64 42 
 }

--- a/test-cases/final-dump/main_hello2.exp
+++ b/test-cases/final-dump/main_hello2.exp
@@ -32,10 +32,10 @@ declare external ccc  void @putchar(i8)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@main_hello2.5 =    constant {i64, i64} { i64 6, i64 ptrtoint ([?? x i8]* @main_hello2.4 to i64) }
+@main_hello2.4 =    constant {i64, i64} { i64 6, i64 ptrtoint ([?? x i8]* @main_hello2.3 to i64) }
 
 
-@main_hello2.4 =    constant [?? x i8] c"world!\00"
+@main_hello2.3 =    constant [?? x i8] c"world!\00"
 
 
 @main_hello2.2 =    constant {i64, i64} { i64 7, i64 ptrtoint ([?? x i8]* @main_hello2.1 to i64) }
@@ -52,10 +52,8 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"main_hello2.<0>"()    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @main_hello2.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
-  %6 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @main_hello2.5, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %6)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @main_hello2.2, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @main_hello2.4, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/multi_specz.exp
+++ b/test-cases/final-dump/multi_specz.exp
@@ -127,16 +127,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external fastcc  void @"position.printPosition<0>"(i64)    
 
 
-@multi_specz.40 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @multi_specz.39 to i64) }
+@multi_specz.38 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @multi_specz.37 to i64) }
 
 
-@multi_specz.39 =    constant [?? x i8] c"=============\00"
+@multi_specz.37 =    constant [?? x i8] c"=============\00"
 
 
-@multi_specz.37 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @multi_specz.36 to i64) }
+@multi_specz.36 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @multi_specz.35 to i64) }
 
 
-@multi_specz.36 =    constant [?? x i8] c"-------------\00"
+@multi_specz.35 =    constant [?? x i8] c"-------------\00"
 
 
 @multi_specz.34 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @multi_specz.33 to i64) }
@@ -145,22 +145,22 @@ declare external fastcc  void @"position.printPosition<0>"(i64)
 @multi_specz.33 =    constant [?? x i8] c"=============\00"
 
 
-@multi_specz.81 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @multi_specz.80 to i64) }
+@multi_specz.76 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @multi_specz.75 to i64) }
 
 
-@multi_specz.80 =    constant [?? x i8] c"=============\00"
+@multi_specz.75 =    constant [?? x i8] c"=============\00"
 
 
-@multi_specz.78 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @multi_specz.77 to i64) }
+@multi_specz.74 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @multi_specz.73 to i64) }
 
 
-@multi_specz.77 =    constant [?? x i8] c"-------------\00"
+@multi_specz.73 =    constant [?? x i8] c"-------------\00"
 
 
-@multi_specz.75 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @multi_specz.74 to i64) }
+@multi_specz.72 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @multi_specz.71 to i64) }
 
 
-@multi_specz.74 =    constant [?? x i8] c"=============\00"
+@multi_specz.71 =    constant [?? x i8] c"=============\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -219,17 +219,14 @@ entry:
   %31 = inttoptr i64 %30 to i64* 
   %32 = getelementptr  i64, i64* %31, i64 0 
   store  i64 4, i64* %32 
-  %35 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz.34, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %35)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz.34, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"multi_specz.foo<0>[7477e50a09]"(i64  %3, i64  %11, i64  %19, i64  %27)  
-  %38 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz.37, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %38)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz.36, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %19)  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %27)  
-  %41 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz.40, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %41)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz.38, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -237,59 +234,56 @@ entry:
 
 define external fastcc  void @"multi_specz.bar2<0>"()    {
 entry:
-  %42 = trunc i64 16 to i32  
-  %43 = tail call ccc  i8*  @wybe_malloc(i32  %42)  
-  %44 = ptrtoint i8* %43 to i64 
+  %39 = trunc i64 16 to i32  
+  %40 = tail call ccc  i8*  @wybe_malloc(i32  %39)  
+  %41 = ptrtoint i8* %40 to i64 
+  %42 = inttoptr i64 %41 to i64* 
+  %43 = getelementptr  i64, i64* %42, i64 0 
+  store  i64 0, i64* %43 
+  %44 = add   i64 %41, 8 
   %45 = inttoptr i64 %44 to i64* 
   %46 = getelementptr  i64, i64* %45, i64 0 
-  store  i64 0, i64* %46 
-  %47 = add   i64 %44, 8 
-  %48 = inttoptr i64 %47 to i64* 
-  %49 = getelementptr  i64, i64* %48, i64 0 
-  store  i64 1, i64* %49 
-  %50 = trunc i64 16 to i32  
-  %51 = tail call ccc  i8*  @wybe_malloc(i32  %50)  
-  %52 = ptrtoint i8* %51 to i64 
+  store  i64 1, i64* %46 
+  %47 = trunc i64 16 to i32  
+  %48 = tail call ccc  i8*  @wybe_malloc(i32  %47)  
+  %49 = ptrtoint i8* %48 to i64 
+  %50 = inttoptr i64 %49 to i64* 
+  %51 = getelementptr  i64, i64* %50, i64 0 
+  store  i64 0, i64* %51 
+  %52 = add   i64 %49, 8 
   %53 = inttoptr i64 %52 to i64* 
   %54 = getelementptr  i64, i64* %53, i64 0 
-  store  i64 0, i64* %54 
-  %55 = add   i64 %52, 8 
-  %56 = inttoptr i64 %55 to i64* 
-  %57 = getelementptr  i64, i64* %56, i64 0 
-  store  i64 2, i64* %57 
-  %58 = trunc i64 16 to i32  
-  %59 = tail call ccc  i8*  @wybe_malloc(i32  %58)  
-  %60 = ptrtoint i8* %59 to i64 
+  store  i64 2, i64* %54 
+  %55 = trunc i64 16 to i32  
+  %56 = tail call ccc  i8*  @wybe_malloc(i32  %55)  
+  %57 = ptrtoint i8* %56 to i64 
+  %58 = inttoptr i64 %57 to i64* 
+  %59 = getelementptr  i64, i64* %58, i64 0 
+  store  i64 0, i64* %59 
+  %60 = add   i64 %57, 8 
   %61 = inttoptr i64 %60 to i64* 
   %62 = getelementptr  i64, i64* %61, i64 0 
-  store  i64 0, i64* %62 
-  %63 = add   i64 %60, 8 
-  %64 = inttoptr i64 %63 to i64* 
-  %65 = getelementptr  i64, i64* %64, i64 0 
-  store  i64 3, i64* %65 
-  %66 = trunc i64 16 to i32  
-  %67 = tail call ccc  i8*  @wybe_malloc(i32  %66)  
-  %68 = ptrtoint i8* %67 to i64 
+  store  i64 3, i64* %62 
+  %63 = trunc i64 16 to i32  
+  %64 = tail call ccc  i8*  @wybe_malloc(i32  %63)  
+  %65 = ptrtoint i8* %64 to i64 
+  %66 = inttoptr i64 %65 to i64* 
+  %67 = getelementptr  i64, i64* %66, i64 0 
+  store  i64 0, i64* %67 
+  %68 = add   i64 %65, 8 
   %69 = inttoptr i64 %68 to i64* 
   %70 = getelementptr  i64, i64* %69, i64 0 
-  store  i64 0, i64* %70 
-  %71 = add   i64 %68, 8 
-  %72 = inttoptr i64 %71 to i64* 
-  %73 = getelementptr  i64, i64* %72, i64 0 
-  store  i64 4, i64* %73 
-  %76 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz.75, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %76)  
+  store  i64 4, i64* %70 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz.72, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"multi_specz.foo<0>"(i64  %44, i64  %52, i64  %60, i64  %68)  
-  %79 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz.78, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %79)  
+  tail call fastcc  void  @"multi_specz.foo<0>"(i64  %41, i64  %49, i64  %57, i64  %65)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz.74, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %44)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %52)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %60)  
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %68)  
-  %82 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz.81, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %82)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %41)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %49)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %57)  
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %65)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz.76, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -317,26 +311,26 @@ entry:
 
 define external fastcc  void @"multi_specz.modifyAndPrint<0>"(i64  %"pos##0", i64  %"v##0")    {
 entry:
-  %83 = trunc i64 16 to i32  
-  %84 = tail call ccc  i8*  @wybe_malloc(i32  %83)  
-  %85 = ptrtoint i8* %84 to i64 
-  %86 = inttoptr i64 %85 to i8* 
-  %87 = inttoptr i64 %"pos##0" to i8* 
-  %88 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %86, i8*  %87, i32  %88, i32  8, i1  0)  
-  %89 = inttoptr i64 %85 to i64* 
-  %90 = getelementptr  i64, i64* %89, i64 0 
-  store  i64 %"v##0", i64* %90 
-  tail call fastcc  void  @"position.printPosition<0>"(i64  %85)  
+  %77 = trunc i64 16 to i32  
+  %78 = tail call ccc  i8*  @wybe_malloc(i32  %77)  
+  %79 = ptrtoint i8* %78 to i64 
+  %80 = inttoptr i64 %79 to i8* 
+  %81 = inttoptr i64 %"pos##0" to i8* 
+  %82 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %80, i8*  %81, i32  %82, i32  8, i1  0)  
+  %83 = inttoptr i64 %79 to i64* 
+  %84 = getelementptr  i64, i64* %83, i64 0 
+  store  i64 %"v##0", i64* %84 
+  tail call fastcc  void  @"position.printPosition<0>"(i64  %79)  
   ret void 
 }
 
 
 define external fastcc  void @"multi_specz.modifyAndPrint<0>[410bae77d3]"(i64  %"pos##0", i64  %"v##0")    {
 entry:
-  %91 = inttoptr i64 %"pos##0" to i64* 
-  %92 = getelementptr  i64, i64* %91, i64 0 
-  store  i64 %"v##0", i64* %92 
+  %85 = inttoptr i64 %"pos##0" to i64* 
+  %86 = getelementptr  i64, i64* %85, i64 0 
+  store  i64 %"v##0", i64* %86 
   tail call fastcc  void  @"position.printPosition<0>"(i64  %"pos##0")  
   ret void 
 }
@@ -391,16 +385,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@position.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.14 to i64) }
+@position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.14 =    constant [?? x i8] c")\00"
+@position.12 =    constant [?? x i8] c")\00"
 
 
-@position.8 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.7 to i64) }
+@position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
 
 
-@position.7 =    constant [?? x i8] c",\00"
+@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
@@ -417,21 +411,18 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
-  %4 = inttoptr i64 %"pos##0" to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
-  %10 = add   i64 %"pos##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  tail call ccc  void  @print_int(i64  %13)  
-  %16 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.15, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %16)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64))  
+  %3 = inttoptr i64 %"pos##0" to i64* 
+  %4 = getelementptr  i64, i64* %3, i64 0 
+  %5 = load  i64, i64* %4 
+  tail call ccc  void  @print_int(i64  %5)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.7, i32 0, i32 0) to i64))  
+  %8 = add   i64 %"pos##0", 8 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = getelementptr  i64, i64* %9, i64 0 
+  %11 = load  i64, i64* %10 
+  tail call ccc  void  @print_int(i64  %11)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/multi_specz_cyclic_exe.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_exe.exp
@@ -67,16 +67,16 @@ declare external fastcc  void @"multi_specz_cyclic_lib.printPosition<0>"(i64)
 declare external fastcc  void @"multi_specz_cyclic_lib.foo1<0>[7477e50a09]"(i64, i64, i64, i64, i64)    
 
 
-@multi_specz_cyclic_exe.40 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_exe.39 to i64) }
+@multi_specz_cyclic_exe.38 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_exe.37 to i64) }
 
 
-@multi_specz_cyclic_exe.39 =    constant [?? x i8] c"=============\00"
+@multi_specz_cyclic_exe.37 =    constant [?? x i8] c"=============\00"
 
 
-@multi_specz_cyclic_exe.37 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_exe.36 to i64) }
+@multi_specz_cyclic_exe.36 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_exe.35 to i64) }
 
 
-@multi_specz_cyclic_exe.36 =    constant [?? x i8] c"-------------\00"
+@multi_specz_cyclic_exe.35 =    constant [?? x i8] c"-------------\00"
 
 
 @multi_specz_cyclic_exe.34 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_exe.33 to i64) }
@@ -140,17 +140,14 @@ entry:
   %31 = inttoptr i64 %30 to i64* 
   %32 = getelementptr  i64, i64* %31, i64 0 
   store  i64 4, i64* %32 
-  %35 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_exe.34, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %35)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_exe.34, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"multi_specz_cyclic_lib.foo1<0>[7477e50a09]"(i64  %3, i64  %11, i64  %19, i64  %27, i64  3)  
-  %38 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_exe.37, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %38)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_exe.36, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"multi_specz_cyclic_lib.printPosition<0>"(i64  %19)  
   tail call fastcc  void  @"multi_specz_cyclic_lib.printPosition<0>"(i64  %27)  
-  %41 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_exe.40, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %41)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_exe.38, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -276,16 +273,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@multi_specz_cyclic_lib.25 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_lib.24 to i64) }
+@multi_specz_cyclic_lib.23 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_lib.22 to i64) }
 
 
-@multi_specz_cyclic_lib.24 =    constant [?? x i8] c")\00"
+@multi_specz_cyclic_lib.22 =    constant [?? x i8] c")\00"
 
 
-@multi_specz_cyclic_lib.18 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_lib.17 to i64) }
+@multi_specz_cyclic_lib.17 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_lib.16 to i64) }
 
 
-@multi_specz_cyclic_lib.17 =    constant [?? x i8] c",\00"
+@multi_specz_cyclic_lib.16 =    constant [?? x i8] c",\00"
 
 
 @multi_specz_cyclic_lib.12 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_lib.11 to i64) }
@@ -380,21 +377,18 @@ entry:
 
 define external fastcc  void @"multi_specz_cyclic_lib.printPosition<0>"(i64  %"pos##0")    {
 entry:
-  %13 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_lib.12, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %13)  
-  %14 = inttoptr i64 %"pos##0" to i64* 
-  %15 = getelementptr  i64, i64* %14, i64 0 
-  %16 = load  i64, i64* %15 
-  tail call ccc  void  @print_int(i64  %16)  
-  %19 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_lib.18, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %19)  
-  %20 = add   i64 %"pos##0", 8 
-  %21 = inttoptr i64 %20 to i64* 
-  %22 = getelementptr  i64, i64* %21, i64 0 
-  %23 = load  i64, i64* %22 
-  tail call ccc  void  @print_int(i64  %23)  
-  %26 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_lib.25, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %26)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_lib.12, i32 0, i32 0) to i64))  
+  %13 = inttoptr i64 %"pos##0" to i64* 
+  %14 = getelementptr  i64, i64* %13, i64 0 
+  %15 = load  i64, i64* %14 
+  tail call ccc  void  @print_int(i64  %15)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_lib.17, i32 0, i32 0) to i64))  
+  %18 = add   i64 %"pos##0", 8 
+  %19 = inttoptr i64 %18 to i64* 
+  %20 = getelementptr  i64, i64* %19, i64 0 
+  %21 = load  i64, i64* %20 
+  tail call ccc  void  @print_int(i64  %21)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_lib.23, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/multi_specz_cyclic_lib.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_lib.exp
@@ -85,16 +85,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@multi_specz_cyclic_lib.23 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_lib.22 to i64) }
+@multi_specz_cyclic_lib.21 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_lib.20 to i64) }
 
 
-@multi_specz_cyclic_lib.22 =    constant [?? x i8] c")\00"
+@multi_specz_cyclic_lib.20 =    constant [?? x i8] c")\00"
 
 
-@multi_specz_cyclic_lib.16 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_lib.15 to i64) }
+@multi_specz_cyclic_lib.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_lib.14 to i64) }
 
 
-@multi_specz_cyclic_lib.15 =    constant [?? x i8] c",\00"
+@multi_specz_cyclic_lib.14 =    constant [?? x i8] c",\00"
 
 
 @multi_specz_cyclic_lib.10 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_lib.9 to i64) }
@@ -145,21 +145,18 @@ entry:
 
 define external fastcc  void @"multi_specz_cyclic_lib.printPosition<0>"(i64  %"pos##0")    {
 entry:
-  %11 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_lib.10, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %11)  
-  %12 = inttoptr i64 %"pos##0" to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  %14 = load  i64, i64* %13 
-  tail call ccc  void  @print_int(i64  %14)  
-  %17 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_lib.16, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %17)  
-  %18 = add   i64 %"pos##0", 8 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  %21 = load  i64, i64* %20 
-  tail call ccc  void  @print_int(i64  %21)  
-  %24 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_lib.23, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %24)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_lib.10, i32 0, i32 0) to i64))  
+  %11 = inttoptr i64 %"pos##0" to i64* 
+  %12 = getelementptr  i64, i64* %11, i64 0 
+  %13 = load  i64, i64* %12 
+  tail call ccc  void  @print_int(i64  %13)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_lib.15, i32 0, i32 0) to i64))  
+  %16 = add   i64 %"pos##0", 8 
+  %17 = inttoptr i64 %16 to i64* 
+  %18 = getelementptr  i64, i64* %17, i64 0 
+  %19 = load  i64, i64* %18 
+  tail call ccc  void  @print_int(i64  %19)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_lib.21, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/multi_specz_cyclic_lib2.exp
+++ b/test-cases/final-dump/multi_specz_cyclic_lib2.exp
@@ -85,16 +85,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@multi_specz_cyclic_lib.23 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_lib.22 to i64) }
+@multi_specz_cyclic_lib.21 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_lib.20 to i64) }
 
 
-@multi_specz_cyclic_lib.22 =    constant [?? x i8] c")\00"
+@multi_specz_cyclic_lib.20 =    constant [?? x i8] c")\00"
 
 
-@multi_specz_cyclic_lib.16 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_lib.15 to i64) }
+@multi_specz_cyclic_lib.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_lib.14 to i64) }
 
 
-@multi_specz_cyclic_lib.15 =    constant [?? x i8] c",\00"
+@multi_specz_cyclic_lib.14 =    constant [?? x i8] c",\00"
 
 
 @multi_specz_cyclic_lib.10 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @multi_specz_cyclic_lib.9 to i64) }
@@ -145,21 +145,18 @@ entry:
 
 define external fastcc  void @"multi_specz_cyclic_lib.printPosition<0>"(i64  %"pos##0")    {
 entry:
-  %11 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_lib.10, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %11)  
-  %12 = inttoptr i64 %"pos##0" to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  %14 = load  i64, i64* %13 
-  tail call ccc  void  @print_int(i64  %14)  
-  %17 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_lib.16, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %17)  
-  %18 = add   i64 %"pos##0", 8 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  %21 = load  i64, i64* %20 
-  tail call ccc  void  @print_int(i64  %21)  
-  %24 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_lib.23, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %24)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_lib.10, i32 0, i32 0) to i64))  
+  %11 = inttoptr i64 %"pos##0" to i64* 
+  %12 = getelementptr  i64, i64* %11, i64 0 
+  %13 = load  i64, i64* %12 
+  tail call ccc  void  @print_int(i64  %13)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_lib.15, i32 0, i32 0) to i64))  
+  %16 = add   i64 %"pos##0", 8 
+  %17 = inttoptr i64 %16 to i64* 
+  %18 = getelementptr  i64, i64* %17, i64 0 
+  %19 = load  i64, i64* %18 
+  tail call ccc  void  @print_int(i64  %19)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multi_specz_cyclic_lib.21, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/multictr2.exp
+++ b/test-cases/final-dump/multictr2.exp
@@ -171,106 +171,106 @@ declare external ccc  void @print_float(double)
 declare external ccc  void @print_int(i64)    
 
 
-@multictr2.92 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multictr2.91 to i64) }
+@multictr2.75 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multictr2.74 to i64) }
 
 
-@multictr2.91 =    constant [?? x i8] c")\00"
+@multictr2.74 =    constant [?? x i8] c")\00"
 
 
-@multictr2.89 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @multictr2.88 to i64) }
+@multictr2.73 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @multictr2.72 to i64) }
 
 
-@multictr2.88 =    constant [?? x i8] c", \00"
+@multictr2.72 =    constant [?? x i8] c", \00"
 
 
-@multictr2.86 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @multictr2.85 to i64) }
+@multictr2.71 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @multictr2.70 to i64) }
 
 
-@multictr2.85 =    constant [?? x i8] c", \00"
+@multictr2.70 =    constant [?? x i8] c", \00"
 
 
-@multictr2.83 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @multictr2.82 to i64) }
+@multictr2.69 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @multictr2.68 to i64) }
 
 
-@multictr2.82 =    constant [?? x i8] c"c08(\00"
+@multictr2.68 =    constant [?? x i8] c"c08(\00"
 
 
-@multictr2.68 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multictr2.67 to i64) }
+@multictr2.55 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multictr2.54 to i64) }
 
 
-@multictr2.67 =    constant [?? x i8] c")\00"
+@multictr2.54 =    constant [?? x i8] c")\00"
 
 
-@multictr2.65 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @multictr2.64 to i64) }
+@multictr2.53 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @multictr2.52 to i64) }
 
 
-@multictr2.64 =    constant [?? x i8] c"c07(\00"
+@multictr2.52 =    constant [?? x i8] c"c07(\00"
 
 
-@multictr2.58 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multictr2.57 to i64) }
+@multictr2.47 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multictr2.46 to i64) }
 
 
-@multictr2.57 =    constant [?? x i8] c")\00"
-
-
-@multictr2.55 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @multictr2.54 to i64) }
-
-
-@multictr2.54 =    constant [?? x i8] c"c06(\00"
-
-
-@multictr2.48 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multictr2.47 to i64) }
-
-
-@multictr2.47 =    constant [?? x i8] c")\00"
+@multictr2.46 =    constant [?? x i8] c")\00"
 
 
 @multictr2.45 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @multictr2.44 to i64) }
 
 
-@multictr2.44 =    constant [?? x i8] c"c05(\00"
+@multictr2.44 =    constant [?? x i8] c"c06(\00"
 
 
-@multictr2.38 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multictr2.37 to i64) }
+@multictr2.39 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multictr2.38 to i64) }
 
 
-@multictr2.37 =    constant [?? x i8] c")\00"
+@multictr2.38 =    constant [?? x i8] c")\00"
 
 
-@multictr2.35 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @multictr2.34 to i64) }
+@multictr2.37 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @multictr2.36 to i64) }
 
 
-@multictr2.34 =    constant [?? x i8] c"c04(\00"
+@multictr2.36 =    constant [?? x i8] c"c05(\00"
 
 
-@multictr2.28 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multictr2.27 to i64) }
+@multictr2.31 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multictr2.30 to i64) }
 
 
-@multictr2.27 =    constant [?? x i8] c")\00"
+@multictr2.30 =    constant [?? x i8] c")\00"
 
 
-@multictr2.25 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @multictr2.24 to i64) }
+@multictr2.29 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @multictr2.28 to i64) }
 
 
-@multictr2.24 =    constant [?? x i8] c"c03(\00"
+@multictr2.28 =    constant [?? x i8] c"c04(\00"
 
 
-@multictr2.18 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multictr2.17 to i64) }
+@multictr2.23 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multictr2.22 to i64) }
 
 
-@multictr2.17 =    constant [?? x i8] c")\00"
+@multictr2.22 =    constant [?? x i8] c")\00"
 
 
-@multictr2.15 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @multictr2.14 to i64) }
+@multictr2.21 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @multictr2.20 to i64) }
 
 
-@multictr2.14 =    constant [?? x i8] c"c03(\00"
+@multictr2.20 =    constant [?? x i8] c"c03(\00"
 
 
-@multictr2.8 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multictr2.7 to i64) }
+@multictr2.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multictr2.14 to i64) }
 
 
-@multictr2.7 =    constant [?? x i8] c")\00"
+@multictr2.14 =    constant [?? x i8] c")\00"
+
+
+@multictr2.13 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @multictr2.12 to i64) }
+
+
+@multictr2.12 =    constant [?? x i8] c"c03(\00"
+
+
+@multictr2.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @multictr2.6 to i64) }
+
+
+@multictr2.6 =    constant [?? x i8] c")\00"
 
 
 @multictr2.5 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @multictr2.4 to i64) }
@@ -294,130 +294,112 @@ if.then:
   %1 = inttoptr i64 %"x##0" to i64* 
   %2 = getelementptr  i64, i64* %1, i64 0 
   %3 = load  i64, i64* %2 
-  %6 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.5, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %6)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %3)  
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.7, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else:
   %"3#tmp#13##0" = icmp eq i64 %"1#tmp#9##0", 1 
   br i1 %"3#tmp#13##0", label %if.then1, label %if.else1 
 if.then1:
-  %10 = add   i64 %"x##0", -1 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %16 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.15, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %16)  
-  tail call ccc  void  @print_int(i64  %13)  
-  %19 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.18, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %19)  
+  %8 = add   i64 %"x##0", -1 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = getelementptr  i64, i64* %9, i64 0 
+  %11 = load  i64, i64* %10 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.13, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %11)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.15, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else1:
   %"5#tmp#16##0" = icmp eq i64 %"1#tmp#9##0", 2 
   br i1 %"5#tmp#16##0", label %if.then2, label %if.else2 
 if.then2:
-  %20 = add   i64 %"x##0", -2 
-  %21 = inttoptr i64 %20 to i64* 
-  %22 = getelementptr  i64, i64* %21, i64 0 
-  %23 = load  i64, i64* %22 
-  %26 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.25, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %26)  
-  tail call ccc  void  @print_int(i64  %23)  
-  %29 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.28, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %29)  
+  %16 = add   i64 %"x##0", -2 
+  %17 = inttoptr i64 %16 to i64* 
+  %18 = getelementptr  i64, i64* %17, i64 0 
+  %19 = load  i64, i64* %18 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.21, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %19)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.23, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else2:
   %"7#tmp#19##0" = icmp eq i64 %"1#tmp#9##0", 3 
   br i1 %"7#tmp#19##0", label %if.then3, label %if.else3 
 if.then3:
-  %30 = add   i64 %"x##0", -3 
-  %31 = inttoptr i64 %30 to i64* 
-  %32 = getelementptr  i64, i64* %31, i64 0 
-  %33 = load  i64, i64* %32 
-  %36 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.35, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %36)  
-  tail call ccc  void  @print_int(i64  %33)  
-  %39 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.38, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %39)  
+  %24 = add   i64 %"x##0", -3 
+  %25 = inttoptr i64 %24 to i64* 
+  %26 = getelementptr  i64, i64* %25, i64 0 
+  %27 = load  i64, i64* %26 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.29, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %27)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.31, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else3:
   %"9#tmp#22##0" = icmp eq i64 %"1#tmp#9##0", 4 
   br i1 %"9#tmp#22##0", label %if.then4, label %if.else4 
 if.then4:
-  %40 = add   i64 %"x##0", -4 
-  %41 = inttoptr i64 %40 to i64* 
-  %42 = getelementptr  i64, i64* %41, i64 0 
-  %43 = load  i64, i64* %42 
-  %46 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.45, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %46)  
-  tail call ccc  void  @print_int(i64  %43)  
-  %49 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.48, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %49)  
+  %32 = add   i64 %"x##0", -4 
+  %33 = inttoptr i64 %32 to i64* 
+  %34 = getelementptr  i64, i64* %33, i64 0 
+  %35 = load  i64, i64* %34 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.37, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %35)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.39, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else4:
   %"11#tmp#25##0" = icmp eq i64 %"1#tmp#9##0", 5 
   br i1 %"11#tmp#25##0", label %if.then5, label %if.else5 
 if.then5:
-  %50 = add   i64 %"x##0", -5 
-  %51 = inttoptr i64 %50 to i64* 
-  %52 = getelementptr  i64, i64* %51, i64 0 
-  %53 = load  i64, i64* %52 
-  %56 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.55, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %56)  
-  tail call ccc  void  @print_int(i64  %53)  
-  %59 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.58, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %59)  
+  %40 = add   i64 %"x##0", -5 
+  %41 = inttoptr i64 %40 to i64* 
+  %42 = getelementptr  i64, i64* %41, i64 0 
+  %43 = load  i64, i64* %42 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.45, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %43)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.47, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else5:
   %"13#tmp#28##0" = icmp eq i64 %"1#tmp#9##0", 6 
   br i1 %"13#tmp#28##0", label %if.then6, label %if.else6 
 if.then6:
-  %60 = add   i64 %"x##0", -6 
-  %61 = inttoptr i64 %60 to i64* 
-  %62 = getelementptr  i64, i64* %61, i64 0 
-  %63 = load  i64, i64* %62 
-  %66 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.65, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %66)  
-  tail call ccc  void  @print_int(i64  %63)  
-  %69 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.68, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %69)  
+  %48 = add   i64 %"x##0", -6 
+  %49 = inttoptr i64 %48 to i64* 
+  %50 = getelementptr  i64, i64* %49, i64 0 
+  %51 = load  i64, i64* %50 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.53, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %51)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.55, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else6:
   %"15#tmp#31##0" = icmp eq i64 %"1#tmp#9##0", 7 
   br i1 %"15#tmp#31##0", label %if.then7, label %if.else7 
 if.then7:
-  %70 = add   i64 %"x##0", -7 
-  %71 = inttoptr i64 %70 to i64* 
-  %72 = getelementptr  i64, i64* %71, i64 0 
-  %73 = load  i64, i64* %72 
-  %74 = add   i64 %"x##0", 1 
-  %75 = inttoptr i64 %74 to i64* 
-  %76 = getelementptr  i64, i64* %75, i64 0 
-  %77 = load  i64, i64* %76 
-  %78 = add   i64 %"x##0", 9 
-  %79 = inttoptr i64 %78 to double* 
-  %80 = getelementptr  double, double* %79, i64 0 
-  %81 = load  double, double* %80 
-  %84 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.83, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %84)  
-  tail call ccc  void  @print_int(i64  %73)  
-  %87 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.86, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %87)  
-  tail call ccc  void  @print_int(i64  %77)  
-  %90 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.89, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %90)  
-  tail call ccc  void  @print_float(double  %81)  
-  %93 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.92, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %93)  
+  %56 = add   i64 %"x##0", -7 
+  %57 = inttoptr i64 %56 to i64* 
+  %58 = getelementptr  i64, i64* %57, i64 0 
+  %59 = load  i64, i64* %58 
+  %60 = add   i64 %"x##0", 1 
+  %61 = inttoptr i64 %60 to i64* 
+  %62 = getelementptr  i64, i64* %61, i64 0 
+  %63 = load  i64, i64* %62 
+  %64 = add   i64 %"x##0", 9 
+  %65 = inttoptr i64 %64 to double* 
+  %66 = getelementptr  double, double* %65, i64 0 
+  %67 = load  double, double* %66 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.69, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %59)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.71, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_int(i64  %63)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.73, i32 0, i32 0) to i64))  
+  tail call ccc  void  @print_float(double  %67)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @multictr2.75, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else7:

--- a/test-cases/final-dump/mytree.exp
+++ b/test-cases/final-dump/mytree.exp
@@ -64,10 +64,10 @@ printTree1(t##0:mytree.tree, prefix##0:wybe.string, ?prefix##3:wybe.string, io##
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@mytree.5 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @mytree.4 to i64) }
+@mytree.4 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @mytree.3 to i64) }
 
 
-@mytree.4 =    constant [?? x i8] c"}\00"
+@mytree.3 =    constant [?? x i8] c"}\00"
 
 
 @mytree.2 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @mytree.1 to i64) }
@@ -79,10 +79,10 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@mytree.19 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @mytree.18 to i64) }
+@mytree.17 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @mytree.16 to i64) }
 
 
-@mytree.18 =    constant [?? x i8] c", \00"
+@mytree.16 =    constant [?? x i8] c", \00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -93,10 +93,8 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"mytree.printTree<0>"(i64  %"t##0")    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.2, i32 0, i32 0) to i64 
-  %"1#prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t##0", i64  %3)  
-  %6 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.5, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %6)  
+  %"1#prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %"t##0", i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.2, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.4, i32 0, i32 0) to i64))  
   ret void 
 }
 
@@ -106,22 +104,21 @@ entry:
   %"1#tmp#2##0" = icmp ne i64 %"t##0", 0 
   br i1 %"1#tmp#2##0", label %if.then, label %if.else 
 if.then:
-  %7 = inttoptr i64 %"t##0" to i64* 
-  %8 = getelementptr  i64, i64* %7, i64 0 
-  %9 = load  i64, i64* %8 
-  %10 = add   i64 %"t##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  %14 = add   i64 %"t##0", 16 
-  %15 = inttoptr i64 %14 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  %17 = load  i64, i64* %16 
-  %"2#prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %9, i64  %"prefix##0")  
+  %5 = inttoptr i64 %"t##0" to i64* 
+  %6 = getelementptr  i64, i64* %5, i64 0 
+  %7 = load  i64, i64* %6 
+  %8 = add   i64 %"t##0", 8 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = getelementptr  i64, i64* %9, i64 0 
+  %11 = load  i64, i64* %10 
+  %12 = add   i64 %"t##0", 16 
+  %13 = inttoptr i64 %12 to i64* 
+  %14 = getelementptr  i64, i64* %13, i64 0 
+  %15 = load  i64, i64* %14 
+  %"2#prefix##1" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %7, i64  %"prefix##0")  
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %"2#prefix##1")  
-  tail call ccc  void  @print_int(i64  %13)  
-  %20 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.19, i32 0, i32 0) to i64 
-  %"2#prefix##3" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %17, i64  %20)  
+  tail call ccc  void  @print_int(i64  %11)  
+  %"2#prefix##3" = tail call fastcc  i64  @"mytree.printTree1<0>"(i64  %15, i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @mytree.17, i32 0, i32 0) to i64))  
   ret i64 %"2#prefix##3" 
 if.else:
   ret i64 %"prefix##0" 

--- a/test-cases/final-dump/nested_if.exp
+++ b/test-cases/final-dump/nested_if.exp
@@ -55,22 +55,22 @@ declare external ccc  void @putchar(i8)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@nested_if.11 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @nested_if.10 to i64) }
+@nested_if.8 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @nested_if.7 to i64) }
 
 
-@nested_if.10 =    constant [?? x i8] c"other\00"
+@nested_if.7 =    constant [?? x i8] c"other\00"
 
 
-@nested_if.8 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @nested_if.7 to i64) }
+@nested_if.6 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @nested_if.5 to i64) }
 
 
-@nested_if.7 =    constant [?? x i8] c"two\00"
+@nested_if.5 =    constant [?? x i8] c"two\00"
 
 
-@nested_if.5 =    constant {i64, i64} { i64 20, i64 ptrtoint ([?? x i8]* @nested_if.4 to i64) }
+@nested_if.4 =    constant {i64, i64} { i64 20, i64 ptrtoint ([?? x i8]* @nested_if.3 to i64) }
 
 
-@nested_if.4 =    constant [?? x i8] c"one thousand and one\00"
+@nested_if.3 =    constant [?? x i8] c"one thousand and one\00"
 
 
 @nested_if.2 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @nested_if.1 to i64) }
@@ -90,29 +90,25 @@ entry:
   %"1#tmp#3##0" = icmp eq i64 %"i##0", 0 
   br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @nested_if.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @nested_if.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else:
   %"3#tmp#2##0" = icmp eq i64 %"i##0", 1001 
   br i1 %"3#tmp#2##0", label %if.then1, label %if.else1 
 if.then1:
-  %6 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @nested_if.5, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %6)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @nested_if.4, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else1:
   %"5#tmp#1##0" = icmp eq i64 %"i##0", 2 
   br i1 %"5#tmp#1##0", label %if.then2, label %if.else2 
 if.then2:
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @nested_if.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @nested_if.6, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else2:
-  %12 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @nested_if.11, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %12)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @nested_if.8, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/nested_loop.exp
+++ b/test-cases/final-dump/nested_loop.exp
@@ -56,10 +56,10 @@ declare external ccc  void @putchar(i8)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@nested_loop.5 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @nested_loop.4 to i64) }
+@nested_loop.4 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @nested_loop.3 to i64) }
 
 
-@nested_loop.4 =    constant [?? x i8] c"Inner\00"
+@nested_loop.3 =    constant [?? x i8] c"Inner\00"
 
 
 @nested_loop.2 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @nested_loop.1 to i64) }
@@ -68,22 +68,22 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @nested_loop.1 =    constant [?? x i8] c"Outer\00"
 
 
-@nested_loop.11 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @nested_loop.10 to i64) }
-
-
-@nested_loop.10 =    constant [?? x i8] c"Inner\00"
-
-
 @nested_loop.8 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @nested_loop.7 to i64) }
 
 
-@nested_loop.7 =    constant [?? x i8] c"Outer\00"
+@nested_loop.7 =    constant [?? x i8] c"Inner\00"
 
 
-@nested_loop.14 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @nested_loop.13 to i64) }
+@nested_loop.6 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @nested_loop.5 to i64) }
 
 
-@nested_loop.13 =    constant [?? x i8] c"Inner\00"
+@nested_loop.5 =    constant [?? x i8] c"Outer\00"
+
+
+@nested_loop.10 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @nested_loop.9 to i64) }
+
+
+@nested_loop.9 =    constant [?? x i8] c"Inner\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -94,11 +94,9 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"nested_loop.<0>"()    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @nested_loop.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @nested_loop.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %6 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @nested_loop.5, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %6)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @nested_loop.4, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"nested_loop.gen#2<0>"()  
   ret void 
@@ -107,11 +105,9 @@ entry:
 
 define external fastcc  void @"nested_loop.gen#1<0>"()    {
 entry:
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @nested_loop.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @nested_loop.6, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %12 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @nested_loop.11, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %12)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @nested_loop.8, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"nested_loop.gen#2<0>"()  
   ret void 
@@ -120,8 +116,7 @@ entry:
 
 define external fastcc  void @"nested_loop.gen#2<0>"()    {
 entry:
-  %15 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @nested_loop.14, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %15)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @nested_loop.10, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"nested_loop.gen#2<0>"()  
   ret void 

--- a/test-cases/final-dump/numbers.exp
+++ b/test-cases/final-dump/numbers.exp
@@ -73,8 +73,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"numbers.<0>"()    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @numbers.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @numbers.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/person1.exp
+++ b/test-cases/final-dump/person1.exp
@@ -51,8 +51,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"person1.<0>"()    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person1.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person1.2, i32 0, i32 0) to i64))  
   ret void 
 }
 --------------------------------------------------

--- a/test-cases/final-dump/person2.exp
+++ b/test-cases/final-dump/person2.exp
@@ -38,10 +38,10 @@ AFTER EVERYTHING:
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@person2.5 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @person2.4 to i64) }
+@person2.4 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @person2.3 to i64) }
 
 
-@person2.4 =    constant [?? x i8] c"Smith\00"
+@person2.3 =    constant [?? x i8] c"Smith\00"
 
 
 @person2.2 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @person2.1 to i64) }
@@ -58,10 +58,8 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"person2.<0>"()    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person2.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
-  %6 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person2.5, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %6)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person2.2, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person2.4, i32 0, i32 0) to i64))  
   ret void 
 }
 --------------------------------------------------

--- a/test-cases/final-dump/person3.exp
+++ b/test-cases/final-dump/person3.exp
@@ -38,10 +38,10 @@ AFTER EVERYTHING:
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@person3.5 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @person3.4 to i64) }
+@person3.4 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @person3.3 to i64) }
 
 
-@person3.4 =    constant [?? x i8] c"Wang\00"
+@person3.3 =    constant [?? x i8] c"Wang\00"
 
 
 @person3.2 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @person3.1 to i64) }
@@ -58,10 +58,8 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"person3.<0>"()    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person3.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
-  %6 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person3.5, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %6)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person3.2, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person3.4, i32 0, i32 0) to i64))  
   ret void 
 }
 --------------------------------------------------

--- a/test-cases/final-dump/person4.exp
+++ b/test-cases/final-dump/person4.exp
@@ -38,10 +38,10 @@ AFTER EVERYTHING:
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@person4.5 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @person4.4 to i64) }
+@person4.4 =    constant {i64, i64} { i64 5, i64 ptrtoint ([?? x i8]* @person4.3 to i64) }
 
 
-@person4.4 =    constant [?? x i8] c"Smith\00"
+@person4.3 =    constant [?? x i8] c"Smith\00"
 
 
 @person4.2 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @person4.1 to i64) }
@@ -58,10 +58,8 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"person4.<0>"()    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person4.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
-  %6 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person4.5, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %6)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person4.2, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person4.4, i32 0, i32 0) to i64))  
   ret void 
 }
 --------------------------------------------------

--- a/test-cases/final-dump/person5.exp
+++ b/test-cases/final-dump/person5.exp
@@ -47,10 +47,10 @@ update_both(p1##0:person5.person, ?p1##1:person5.person, p2##0:person5.person, ?
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@person5.5 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @person5.4 to i64) }
+@person5.4 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @person5.3 to i64) }
 
 
-@person5.4 =    constant [?? x i8] c"Bob\00"
+@person5.3 =    constant [?? x i8] c"Bob\00"
 
 
 @person5.2 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @person5.1 to i64) }
@@ -59,16 +59,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @person5.1 =    constant [?? x i8] c"Amy\00"
 
 
-@person5.27 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @person5.26 to i64) }
+@person5.24 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @person5.23 to i64) }
 
 
-@person5.26 =    constant [?? x i8] c"Bob\00"
+@person5.23 =    constant [?? x i8] c"Bob\00"
 
 
-@person5.16 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @person5.15 to i64) }
+@person5.14 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @person5.13 to i64) }
 
 
-@person5.15 =    constant [?? x i8] c"Amy\00"
+@person5.13 =    constant [?? x i8] c"Amy\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -79,41 +79,37 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"person5.<0>"()    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person5.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
-  %6 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person5.5, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %6)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person5.2, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person5.4, i32 0, i32 0) to i64))  
   ret void 
 }
 
 
 define external fastcc  {i64, i64} @"person5.update_both<0>"(i64  %"p1##0", i64  %"p2##0")    {
 entry:
-  %7 = trunc i64 16 to i32  
-  %8 = tail call ccc  i8*  @wybe_malloc(i32  %7)  
-  %9 = ptrtoint i8* %8 to i64 
-  %10 = inttoptr i64 %9 to i8* 
-  %11 = inttoptr i64 %"p1##0" to i8* 
-  %12 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %10, i8*  %11, i32  %12, i32  8, i1  0)  
-  %13 = inttoptr i64 %9 to i64* 
-  %14 = getelementptr  i64, i64* %13, i64 0 
-  %17 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person5.16, i32 0, i32 0) to i64 
-  store  i64 %17, i64* %14 
-  %18 = trunc i64 16 to i32  
-  %19 = tail call ccc  i8*  @wybe_malloc(i32  %18)  
-  %20 = ptrtoint i8* %19 to i64 
-  %21 = inttoptr i64 %20 to i8* 
-  %22 = inttoptr i64 %"p2##0" to i8* 
-  %23 = trunc i64 16 to i32  
-  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %21, i8*  %22, i32  %23, i32  8, i1  0)  
-  %24 = inttoptr i64 %20 to i64* 
-  %25 = getelementptr  i64, i64* %24, i64 0 
-  %28 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person5.27, i32 0, i32 0) to i64 
-  store  i64 %28, i64* %25 
-  %29 = insertvalue {i64, i64} undef, i64 %9, 0 
-  %30 = insertvalue {i64, i64} %29, i64 %20, 1 
-  ret {i64, i64} %30 
+  %5 = trunc i64 16 to i32  
+  %6 = tail call ccc  i8*  @wybe_malloc(i32  %5)  
+  %7 = ptrtoint i8* %6 to i64 
+  %8 = inttoptr i64 %7 to i8* 
+  %9 = inttoptr i64 %"p1##0" to i8* 
+  %10 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %8, i8*  %9, i32  %10, i32  8, i1  0)  
+  %11 = inttoptr i64 %7 to i64* 
+  %12 = getelementptr  i64, i64* %11, i64 0 
+  store  i64 ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person5.14, i32 0, i32 0) to i64), i64* %12 
+  %15 = trunc i64 16 to i32  
+  %16 = tail call ccc  i8*  @wybe_malloc(i32  %15)  
+  %17 = ptrtoint i8* %16 to i64 
+  %18 = inttoptr i64 %17 to i8* 
+  %19 = inttoptr i64 %"p2##0" to i8* 
+  %20 = trunc i64 16 to i32  
+  tail call ccc  void  @llvm.memcpy.p0i8.p0i8.i32(i8*  %18, i8*  %19, i32  %20, i32  8, i1  0)  
+  %21 = inttoptr i64 %17 to i64* 
+  %22 = getelementptr  i64, i64* %21, i64 0 
+  store  i64 ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @person5.24, i32 0, i32 0) to i64), i64* %22 
+  %25 = insertvalue {i64, i64} undef, i64 %7, 0 
+  %26 = insertvalue {i64, i64} %25, i64 %17, 1 
+  ret {i64, i64} %26 
 }
 --------------------------------------------------
  Module person5.person

--- a/test-cases/final-dump/position.exp
+++ b/test-cases/final-dump/position.exp
@@ -50,16 +50,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@position.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.14 to i64) }
+@position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.14 =    constant [?? x i8] c")\00"
+@position.12 =    constant [?? x i8] c")\00"
 
 
-@position.8 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.7 to i64) }
+@position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
 
 
-@position.7 =    constant [?? x i8] c",\00"
+@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
@@ -76,21 +76,18 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
-  %4 = inttoptr i64 %"pos##0" to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
-  %10 = add   i64 %"pos##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  tail call ccc  void  @print_int(i64  %13)  
-  %16 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.15, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %16)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64))  
+  %3 = inttoptr i64 %"pos##0" to i64* 
+  %4 = getelementptr  i64, i64* %3, i64 0 
+  %5 = load  i64, i64* %4 
+  tail call ccc  void  @print_int(i64  %5)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.7, i32 0, i32 0) to i64))  
+  %8 = add   i64 %"pos##0", 8 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = getelementptr  i64, i64* %9, i64 0 
+  %11 = load  i64, i64* %10 
+  tail call ccc  void  @print_int(i64  %11)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/position1.exp
+++ b/test-cases/final-dump/position1.exp
@@ -50,16 +50,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@position.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.14 to i64) }
+@position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.14 =    constant [?? x i8] c")\00"
+@position.12 =    constant [?? x i8] c")\00"
 
 
-@position.8 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.7 to i64) }
+@position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
 
 
-@position.7 =    constant [?? x i8] c",\00"
+@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
@@ -76,21 +76,18 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
-  %4 = inttoptr i64 %"pos##0" to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
-  %10 = add   i64 %"pos##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  tail call ccc  void  @print_int(i64  %13)  
-  %16 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.15, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %16)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64))  
+  %3 = inttoptr i64 %"pos##0" to i64* 
+  %4 = getelementptr  i64, i64* %3, i64 0 
+  %5 = load  i64, i64* %4 
+  tail call ccc  void  @print_int(i64  %5)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.7, i32 0, i32 0) to i64))  
+  %8 = add   i64 %"pos##0", 8 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = getelementptr  i64, i64* %9, i64 0 
+  %11 = load  i64, i64* %10 
+  tail call ccc  void  @print_int(i64  %11)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -410,8 +407,7 @@ entry:
   %10 = inttoptr i64 %9 to i64* 
   %11 = getelementptr  i64, i64* %10, i64 0 
   store  i64 112, i64* %11 
-  %14 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position1.13, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %14)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position1.13, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %3)  
   ret void 
 }

--- a/test-cases/final-dump/position2.exp
+++ b/test-cases/final-dump/position2.exp
@@ -50,16 +50,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@position.15 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.14 to i64) }
+@position.13 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.12 to i64) }
 
 
-@position.14 =    constant [?? x i8] c")\00"
+@position.12 =    constant [?? x i8] c")\00"
 
 
-@position.8 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.7 to i64) }
+@position.7 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @position.6 to i64) }
 
 
-@position.7 =    constant [?? x i8] c",\00"
+@position.6 =    constant [?? x i8] c",\00"
 
 
 @position.2 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @position.1 to i64) }
@@ -76,21 +76,18 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"position.printPosition<0>"(i64  %"pos##0")    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
-  %4 = inttoptr i64 %"pos##0" to i64* 
-  %5 = getelementptr  i64, i64* %4, i64 0 
-  %6 = load  i64, i64* %5 
-  tail call ccc  void  @print_int(i64  %6)  
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
-  %10 = add   i64 %"pos##0", 8 
-  %11 = inttoptr i64 %10 to i64* 
-  %12 = getelementptr  i64, i64* %11, i64 0 
-  %13 = load  i64, i64* %12 
-  tail call ccc  void  @print_int(i64  %13)  
-  %16 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.15, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %16)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.2, i32 0, i32 0) to i64))  
+  %3 = inttoptr i64 %"pos##0" to i64* 
+  %4 = getelementptr  i64, i64* %3, i64 0 
+  %5 = load  i64, i64* %4 
+  tail call ccc  void  @print_int(i64  %5)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.7, i32 0, i32 0) to i64))  
+  %8 = add   i64 %"pos##0", 8 
+  %9 = inttoptr i64 %8 to i64* 
+  %10 = getelementptr  i64, i64* %9, i64 0 
+  %11 = load  i64, i64* %10 
+  tail call ccc  void  @print_int(i64  %11)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -389,16 +386,16 @@ declare external fastcc  void @"position.printPosition<0>"(i64)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@position2.27 =    constant {i64, i64} { i64 21, i64 ptrtoint ([?? x i8]* @position2.26 to i64) }
+@position2.25 =    constant {i64, i64} { i64 21, i64 ptrtoint ([?? x i8]* @position2.24 to i64) }
 
 
-@position2.26 =    constant [?? x i8] c"expect posB(333,222):\00"
+@position2.24 =    constant [?? x i8] c"expect posB(333,222):\00"
 
 
-@position2.24 =    constant {i64, i64} { i64 23, i64 ptrtoint ([?? x i8]* @position2.23 to i64) }
+@position2.23 =    constant {i64, i64} { i64 23, i64 ptrtoint ([?? x i8]* @position2.22 to i64) }
 
 
-@position2.23 =    constant [?? x i8] c"expect posA(111,20000):\00"
+@position2.22 =    constant [?? x i8] c"expect posA(111,20000):\00"
 
 
 @position2.18 =    constant {i64, i64} { i64 21, i64 ptrtoint ([?? x i8]* @position2.17 to i64) }
@@ -435,18 +432,15 @@ entry:
   %15 = inttoptr i64 %14 to i64* 
   %16 = getelementptr  i64, i64* %15, i64 0 
   store  i64 222, i64* %16 
-  %19 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position2.18, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %19)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position2.18, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %3)  
-  %20 = add   i64 %3, 8 
-  %21 = inttoptr i64 %20 to i64* 
-  %22 = getelementptr  i64, i64* %21, i64 0 
-  store  i64 20000, i64* %22 
-  %25 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position2.24, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %25)  
+  %19 = add   i64 %3, 8 
+  %20 = inttoptr i64 %19 to i64* 
+  %21 = getelementptr  i64, i64* %20, i64 0 
+  store  i64 20000, i64* %21 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position2.23, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %3)  
-  %28 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position2.27, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %28)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @position2.25, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"position.printPosition<0>"(i64  %11)  
   ret void 
 }

--- a/test-cases/final-dump/proc_beer.exp
+++ b/test-cases/final-dump/proc_beer.exp
@@ -79,10 +79,10 @@ declare external ccc  void @print_int(i64)
 @proc_beer.1 =    constant [?? x i8] c" bottles of beer on the wall\00"
 
 
-@proc_beer.5 =    constant {i64, i64} { i64 28, i64 ptrtoint ([?? x i8]* @proc_beer.4 to i64) }
+@proc_beer.4 =    constant {i64, i64} { i64 28, i64 ptrtoint ([?? x i8]* @proc_beer.3 to i64) }
 
 
-@proc_beer.4 =    constant [?? x i8] c" bottles of beer on the wall\00"
+@proc_beer.3 =    constant [?? x i8] c" bottles of beer on the wall\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -111,8 +111,7 @@ entry:
   br i1 %"1#tmp#0##0", label %if.then, label %if.else 
 if.then:
   tail call ccc  void  @print_int(i64  %"count##0")  
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @proc_beer.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @proc_beer.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   %"2#tmp#8##0" = sub   i64 %"count##0", 1 
   tail call fastcc  void  @"proc_beer.gen#1<0>"(i64  %"2#tmp#8##0")  
@@ -125,8 +124,7 @@ if.else:
 define external fastcc  void @"proc_beer.gen#2<0>"(i64  %"count##0")    {
 entry:
   tail call ccc  void  @print_int(i64  %"count##0")  
-  %6 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @proc_beer.5, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %6)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @proc_beer.4, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   %"1#count##1" = sub   i64 %"count##0", 1 
   tail call fastcc  void  @"proc_beer.gen#1<0>"(i64  %"1#count##1")  

--- a/test-cases/final-dump/proc_hello.exp
+++ b/test-cases/final-dump/proc_hello.exp
@@ -45,8 +45,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"proc_hello.print2<0>"()    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @proc_hello.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @proc_hello.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/proc_yorn.exp
+++ b/test-cases/final-dump/proc_yorn.exp
@@ -104,16 +104,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  i8 @read_char()    
 
 
-@proc_yorn.8 =    constant {i64, i64} { i64 28, i64 ptrtoint ([?? x i8]* @proc_yorn.7 to i64) }
+@proc_yorn.6 =    constant {i64, i64} { i64 28, i64 ptrtoint ([?? x i8]* @proc_yorn.5 to i64) }
 
 
-@proc_yorn.7 =    constant [?? x i8] c"Please answer 'yes' or 'no'.\00"
+@proc_yorn.5 =    constant [?? x i8] c"Please answer 'yes' or 'no'.\00"
 
 
-@proc_yorn.5 =    constant {i64, i64} { i64 7, i64 ptrtoint ([?? x i8]* @proc_yorn.4 to i64) }
+@proc_yorn.4 =    constant {i64, i64} { i64 7, i64 ptrtoint ([?? x i8]* @proc_yorn.3 to i64) }
 
 
-@proc_yorn.4 =    constant [?? x i8] c" (y/n) \00"
+@proc_yorn.3 =    constant [?? x i8] c" (y/n) \00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -124,8 +124,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"proc_yorn.<0>"()    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @proc_yorn.2, i32 0, i32 0) to i64 
-  %"1#r##0" = tail call fastcc  i1  @"proc_yorn.gen#1<0>"(i64  %3)  
+  %"1#r##0" = tail call fastcc  i1  @"proc_yorn.gen#1<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @proc_yorn.2, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"wybe.io.print<5>"(i1  %"1#r##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -135,8 +134,7 @@ entry:
 define external fastcc  i1 @"proc_yorn.gen#1<0>"(i64  %"prompt##0")    {
 entry:
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %"prompt##0")  
-  %6 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @proc_yorn.5, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %6)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @proc_yorn.4, i32 0, i32 0) to i64))  
   %"1#response##0" = tail call ccc  i8  @read_char()  
   %"1#tmp#8##0" = icmp ne i8 %"1#response##0", 121 
   %"1#tmp#9##0" = icmp ne i8 %"1#response##0", 89 
@@ -147,8 +145,7 @@ entry:
 if.then:
   ret i1 %"1#tmp#0##0" 
 if.else:
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @proc_yorn.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @proc_yorn.6, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   %"3#result##1" = tail call fastcc  i1  @"proc_yorn.gen#1<0>"(i64  %"prompt##0")  
   ret i1 %"3#result##1" 

--- a/test-cases/final-dump/proc_yorn2.exp
+++ b/test-cases/final-dump/proc_yorn2.exp
@@ -56,10 +56,10 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  i8 @read_char()    
 
 
-@proc_yorn2.5 =    constant {i64, i64} { i64 28, i64 ptrtoint ([?? x i8]* @proc_yorn2.4 to i64) }
+@proc_yorn2.4 =    constant {i64, i64} { i64 28, i64 ptrtoint ([?? x i8]* @proc_yorn2.3 to i64) }
 
 
-@proc_yorn2.4 =    constant [?? x i8] c"Please answer 'yes' or 'no'.\00"
+@proc_yorn2.3 =    constant [?? x i8] c"Please answer 'yes' or 'no'.\00"
 
 
 @proc_yorn2.2 =    constant {i64, i64} { i64 7, i64 ptrtoint ([?? x i8]* @proc_yorn2.1 to i64) }
@@ -77,8 +77,7 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 define external fastcc  i1 @"proc_yorn2.gen#1<0>"(i64  %"prompt##0")    {
 entry:
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %"prompt##0")  
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @proc_yorn2.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @proc_yorn2.2, i32 0, i32 0) to i64))  
   %"1#response##0" = tail call ccc  i8  @read_char()  
   %"1#tmp#0##0" = icmp eq i8 %"1#response##0", 89 
   %"1#tmp#1##0" = icmp eq i8 %"1#response##0", 78 
@@ -87,8 +86,7 @@ entry:
 if.then:
   ret i1 %"1#tmp#0##0" 
 if.else:
-  %6 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @proc_yorn2.5, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %6)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @proc_yorn2.4, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   %"3#result##1" = tail call fastcc  i1  @"proc_yorn2.gen#1<0>"(i64  %"prompt##0")  
   ret i1 %"3#result##1" 

--- a/test-cases/final-dump/specials_one_module.exp
+++ b/test-cases/final-dump/specials_one_module.exp
@@ -96,28 +96,28 @@ declare external ccc  void @print_string(i64)
 declare external ccc  void @print_int(i64)    
 
 
+@specials_one_module.4 =    constant {i64, i64} { i64 20, i64 ptrtoint ([?? x i8]* @specials_one_module.3 to i64) }
+
+
+@specials_one_module.3 =    constant [?? x i8] c" (should be line 28)\00"
+
+
+@specials_one_module.2 =    constant [?? x i8] c"specials_one_module:29:2\00"
+
+
+@specials_one_module.1 =    constant [?? x i8] c"specials_one_module\00"
+
+
 @specials_one_module.6 =    constant {i64, i64} { i64 20, i64 ptrtoint ([?? x i8]* @specials_one_module.5 to i64) }
 
 
 @specials_one_module.5 =    constant [?? x i8] c" (should be line 28)\00"
 
 
-@specials_one_module.3 =    constant [?? x i8] c"specials_one_module:29:2\00"
+@specials_one_module.8 =    constant {i64, i64} { i64 20, i64 ptrtoint ([?? x i8]* @specials_one_module.7 to i64) }
 
 
-@specials_one_module.1 =    constant [?? x i8] c"specials_one_module\00"
-
-
-@specials_one_module.9 =    constant {i64, i64} { i64 20, i64 ptrtoint ([?? x i8]* @specials_one_module.8 to i64) }
-
-
-@specials_one_module.8 =    constant [?? x i8] c" (should be line 28)\00"
-
-
-@specials_one_module.12 =    constant {i64, i64} { i64 20, i64 ptrtoint ([?? x i8]* @specials_one_module.11 to i64) }
-
-
-@specials_one_module.11 =    constant [?? x i8] c" (should be line 28)\00"
+@specials_one_module.7 =    constant [?? x i8] c" (should be line 28)\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -128,17 +128,14 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"specials_one_module.<0>"()    {
 entry:
-  %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @specials_one_module.1, i32 0, i32 0) to i64 
-  tail call ccc  void  @print_string(i64  %2)  
+  tail call ccc  void  @print_string(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @specials_one_module.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call ccc  void  @print_int(i64  27)  
   tail call ccc  void  @putchar(i8  10)  
   tail call ccc  void  @print_int(i64  2)  
   tail call ccc  void  @putchar(i8  10)  
-  %4 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @specials_one_module.3, i32 0, i32 0) to i64 
-  tail call ccc  void  @print_string(i64  %4)  
-  %7 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @specials_one_module.6, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %7)  
+  tail call ccc  void  @print_string(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @specials_one_module.2, i32 0, i32 0) to i64))  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @specials_one_module.4, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -147,8 +144,7 @@ entry:
 define external fastcc  void @"specials_one_module.indirect_call_location<0>"(i64  %"call_source_location##0")    {
 entry:
   tail call ccc  void  @print_string(i64  %"call_source_location##0")  
-  %10 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @specials_one_module.9, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %10)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @specials_one_module.6, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -181,8 +177,7 @@ entry:
 define external fastcc  void @"specials_one_module.show_location<0>"(i64  %"call_source_location##0")    {
 entry:
   tail call ccc  void  @print_string(i64  %"call_source_location##0")  
-  %13 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @specials_one_module.12, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %13)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @specials_one_module.8, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/specials_use.exp
+++ b/test-cases/final-dump/specials_use.exp
@@ -182,13 +182,13 @@ declare external ccc  void @print_string(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@specials_use.7 =    constant [?? x i8] c"!ROOT!/final-dump/specials_use.wybe:8:2\00"
+@specials_use.4 =    constant [?? x i8] c"!ROOT!/final-dump/specials_use.wybe:8:2\00"
 
 
-@specials_use.5 =    constant [?? x i8] c"specials_use:7:2\00"
+@specials_use.3 =    constant [?? x i8] c"specials_use:7:2\00"
 
 
-@specials_use.3 =    constant [?? x i8] c"!ROOT!/final-dump/specials_use.wybe\00"
+@specials_use.2 =    constant [?? x i8] c"!ROOT!/final-dump/specials_use.wybe\00"
 
 
 @specials_use.1 =    constant [?? x i8] c"specials_use\00"
@@ -202,21 +202,17 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"specials_use.<0>"()    {
 entry:
-  %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @specials_use.1, i32 0, i32 0) to i64 
-  tail call ccc  void  @print_string(i64  %2)  
+  tail call ccc  void  @print_string(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @specials_use.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %4 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @specials_use.3, i32 0, i32 0) to i64 
-  tail call ccc  void  @print_string(i64  %4)  
+  tail call ccc  void  @print_string(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @specials_use.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call ccc  void  @print_int(i64  5)  
   tail call ccc  void  @putchar(i8  10)  
   tail call ccc  void  @print_int(i64  2)  
   tail call ccc  void  @putchar(i8  10)  
-  %6 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @specials_use.5, i32 0, i32 0) to i64 
-  tail call ccc  void  @print_string(i64  %6)  
+  tail call ccc  void  @print_string(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @specials_use.3, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %8 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @specials_use.7, i32 0, i32 0) to i64 
-  tail call ccc  void  @print_string(i64  %8)  
+  tail call ccc  void  @print_string(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @specials_use.4, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/stmt_for.exp
+++ b/test-cases/final-dump/stmt_for.exp
@@ -790,76 +790,76 @@ declare external ccc  void @putchar(i8)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@stmt_for.38 =    constant {i64, i64} { i64 21, i64 ptrtoint ([?? x i8]* @stmt_for.37 to i64) }
+@stmt_for.26 =    constant {i64, i64} { i64 21, i64 ptrtoint ([?? x i8]* @stmt_for.25 to i64) }
 
 
-@stmt_for.37 =    constant [?? x i8] c"\0ausing_irange_reverse\00"
+@stmt_for.25 =    constant [?? x i8] c"\0ausing_irange_reverse\00"
 
 
-@stmt_for.35 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @stmt_for.34 to i64) }
+@stmt_for.24 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @stmt_for.23 to i64) }
 
 
-@stmt_for.34 =    constant [?? x i8] c"\0ausing_irange\00"
+@stmt_for.23 =    constant [?? x i8] c"\0ausing_irange\00"
 
 
-@stmt_for.32 =    constant {i64, i64} { i64 21, i64 ptrtoint ([?? x i8]* @stmt_for.31 to i64) }
+@stmt_for.22 =    constant {i64, i64} { i64 21, i64 ptrtoint ([?? x i8]* @stmt_for.21 to i64) }
 
 
-@stmt_for.31 =    constant [?? x i8] c"\0ausing_xrange_reverse\00"
+@stmt_for.21 =    constant [?? x i8] c"\0ausing_xrange_reverse\00"
 
 
-@stmt_for.29 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @stmt_for.28 to i64) }
+@stmt_for.20 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @stmt_for.19 to i64) }
 
 
-@stmt_for.28 =    constant [?? x i8] c"\0ausing_xrange\00"
+@stmt_for.19 =    constant [?? x i8] c"\0ausing_xrange\00"
 
 
-@stmt_for.26 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @stmt_for.25 to i64) }
+@stmt_for.18 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @stmt_for.17 to i64) }
 
 
-@stmt_for.25 =    constant [?? x i8] c"\0ausing_unless\00"
+@stmt_for.17 =    constant [?? x i8] c"\0ausing_unless\00"
 
 
-@stmt_for.23 =    constant {i64, i64} { i64 11, i64 ptrtoint ([?? x i8]* @stmt_for.22 to i64) }
+@stmt_for.16 =    constant {i64, i64} { i64 11, i64 ptrtoint ([?? x i8]* @stmt_for.15 to i64) }
 
 
-@stmt_for.22 =    constant [?? x i8] c"\0ausing_when\00"
+@stmt_for.15 =    constant [?? x i8] c"\0ausing_when\00"
 
 
-@stmt_for.20 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @stmt_for.19 to i64) }
+@stmt_for.14 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @stmt_for.13 to i64) }
 
 
-@stmt_for.19 =    constant [?? x i8] c"\0ausing_until\00"
+@stmt_for.13 =    constant [?? x i8] c"\0ausing_until\00"
 
 
-@stmt_for.17 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @stmt_for.16 to i64) }
+@stmt_for.12 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @stmt_for.11 to i64) }
 
 
-@stmt_for.16 =    constant [?? x i8] c"\0ausing_while\00"
+@stmt_for.11 =    constant [?? x i8] c"\0ausing_while\00"
 
 
-@stmt_for.14 =    constant {i64, i64} { i64 11, i64 ptrtoint ([?? x i8]* @stmt_for.13 to i64) }
+@stmt_for.10 =    constant {i64, i64} { i64 11, i64 ptrtoint ([?? x i8]* @stmt_for.9 to i64) }
 
 
-@stmt_for.13 =    constant [?? x i8] c"\0ausing_next\00"
+@stmt_for.9 =    constant [?? x i8] c"\0ausing_next\00"
 
 
-@stmt_for.11 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @stmt_for.10 to i64) }
+@stmt_for.8 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @stmt_for.7 to i64) }
 
 
-@stmt_for.10 =    constant [?? x i8] c"\0ausing_break\00"
+@stmt_for.7 =    constant [?? x i8] c"\0ausing_break\00"
 
 
-@stmt_for.8 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @stmt_for.7 to i64) }
+@stmt_for.6 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @stmt_for.5 to i64) }
 
 
-@stmt_for.7 =    constant [?? x i8] c"\0ashortest_generator_termination\00"
+@stmt_for.5 =    constant [?? x i8] c"\0ashortest_generator_termination\00"
 
 
-@stmt_for.5 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @stmt_for.4 to i64) }
+@stmt_for.4 =    constant {i64, i64} { i64 19, i64 ptrtoint ([?? x i8]* @stmt_for.3 to i64) }
 
 
-@stmt_for.4 =    constant [?? x i8] c"\0amultiple_generator\00"
+@stmt_for.3 =    constant [?? x i8] c"\0amultiple_generator\00"
 
 
 @stmt_for.2 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @stmt_for.1 to i64) }
@@ -879,56 +879,43 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"stmt_for.<0>"()    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_for.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_for.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"stmt_for.single_generator<0>"()  
-  %6 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_for.5, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %6)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_for.4, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"stmt_for.multiple_generator<0>"()  
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_for.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_for.6, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"stmt_for.shortest_generator_termination<0>"()  
-  %12 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_for.11, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %12)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_for.8, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"stmt_for.using_break<0>"()  
-  %15 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_for.14, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %15)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_for.10, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"stmt_for.using_next<0>"()  
-  %18 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_for.17, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %18)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_for.12, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"stmt_for.using_while<0>"()  
-  %21 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_for.20, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %21)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_for.14, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"stmt_for.using_until<0>"()  
-  %24 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_for.23, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %24)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_for.16, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"stmt_for.using_when<0>"()  
-  %27 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_for.26, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %27)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_for.18, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"stmt_for.using_unless<0>"()  
-  %30 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_for.29, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %30)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_for.20, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"stmt_for.using_xrange<0>"()  
-  %33 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_for.32, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %33)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_for.22, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"stmt_for.using_xrange_reverse<0>"()  
-  %36 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_for.35, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %36)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_for.24, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"stmt_for.using_irange<0>"()  
-  %39 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_for.38, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %39)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_for.26, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"stmt_for.using_irange_reverse<0>"()  
   ret void 
@@ -940,14 +927,14 @@ entry:
   %"1#tmp#14##0" = icmp ne i64 %"tmp#8##0", 0 
   br i1 %"1#tmp#14##0", label %if.then, label %if.else 
 if.then:
-  %40 = inttoptr i64 %"tmp#8##0" to i64* 
-  %41 = getelementptr  i64, i64* %40, i64 0 
-  %42 = load  i64, i64* %41 
-  %43 = add   i64 %"tmp#8##0", 8 
-  %44 = inttoptr i64 %43 to i64* 
-  %45 = getelementptr  i64, i64* %44, i64 0 
-  %46 = load  i64, i64* %45 
-  tail call fastcc  void  @"stmt_for.gen#2<0>"(i64  %42, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %46, i64  %"tmp#9##0", i64  %"x##0", i64  %"y##0")  
+  %27 = inttoptr i64 %"tmp#8##0" to i64* 
+  %28 = getelementptr  i64, i64* %27, i64 0 
+  %29 = load  i64, i64* %28 
+  %30 = add   i64 %"tmp#8##0", 8 
+  %31 = inttoptr i64 %30 to i64* 
+  %32 = getelementptr  i64, i64* %31, i64 0 
+  %33 = load  i64, i64* %32 
+  tail call fastcc  void  @"stmt_for.gen#2<0>"(i64  %29, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %33, i64  %"tmp#9##0", i64  %"x##0", i64  %"y##0")  
   ret void 
 if.else:
   ret void 
@@ -959,14 +946,14 @@ entry:
   %"1#tmp#10##0" = icmp ne i64 %"tmp#5##0", 0 
   br i1 %"1#tmp#10##0", label %if.then, label %if.else 
 if.then:
-  %47 = inttoptr i64 %"tmp#5##0" to i64* 
-  %48 = getelementptr  i64, i64* %47, i64 0 
-  %49 = load  i64, i64* %48 
-  %50 = add   i64 %"tmp#5##0", 8 
-  %51 = inttoptr i64 %50 to i64* 
-  %52 = getelementptr  i64, i64* %51, i64 0 
-  %53 = load  i64, i64* %52 
-  tail call fastcc  void  @"stmt_for.gen#11<0>"(i64  %49, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %53, i64  %"x##0")  
+  %34 = inttoptr i64 %"tmp#5##0" to i64* 
+  %35 = getelementptr  i64, i64* %34, i64 0 
+  %36 = load  i64, i64* %35 
+  %37 = add   i64 %"tmp#5##0", 8 
+  %38 = inttoptr i64 %37 to i64* 
+  %39 = getelementptr  i64, i64* %38, i64 0 
+  %40 = load  i64, i64* %39 
+  tail call fastcc  void  @"stmt_for.gen#11<0>"(i64  %36, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %40, i64  %"x##0")  
   ret void 
 if.else:
   ret void 
@@ -989,15 +976,15 @@ if.else:
 
 define external fastcc  void @"stmt_for.gen#12<0>"(i64  %"tmp#0##0", i64  %"tmp#3##0")    {
 entry:
-  %54 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
-  %55 = extractvalue {i64, i64, i1} %54, 0 
-  %56 = extractvalue {i64, i64, i1} %54, 1 
-  %57 = extractvalue {i64, i64, i1} %54, 2 
-  br i1 %57, label %if.then, label %if.else 
+  %41 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
+  %42 = extractvalue {i64, i64, i1} %41, 0 
+  %43 = extractvalue {i64, i64, i1} %41, 1 
+  %44 = extractvalue {i64, i64, i1} %41, 2 
+  br i1 %44, label %if.then, label %if.else 
 if.then:
-  tail call ccc  void  @print_int(i64  %55)  
+  tail call ccc  void  @print_int(i64  %42)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen#12<0>"(i64  %56, i64  %"tmp#3##0")  
+  tail call fastcc  void  @"stmt_for.gen#12<0>"(i64  %43, i64  %"tmp#3##0")  
   ret void 
 if.else:
   ret void 
@@ -1006,15 +993,15 @@ if.else:
 
 define external fastcc  void @"stmt_for.gen#13<0>"(i64  %"tmp#0##0", i64  %"tmp#3##0")    {
 entry:
-  %58 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
-  %59 = extractvalue {i64, i64, i1} %58, 0 
-  %60 = extractvalue {i64, i64, i1} %58, 1 
-  %61 = extractvalue {i64, i64, i1} %58, 2 
-  br i1 %61, label %if.then, label %if.else 
+  %45 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
+  %46 = extractvalue {i64, i64, i1} %45, 0 
+  %47 = extractvalue {i64, i64, i1} %45, 1 
+  %48 = extractvalue {i64, i64, i1} %45, 2 
+  br i1 %48, label %if.then, label %if.else 
 if.then:
-  tail call ccc  void  @print_int(i64  %59)  
+  tail call ccc  void  @print_int(i64  %46)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen#13<0>"(i64  %60, i64  %"tmp#3##0")  
+  tail call fastcc  void  @"stmt_for.gen#13<0>"(i64  %47, i64  %"tmp#3##0")  
   ret void 
 if.else:
   ret void 
@@ -1026,14 +1013,14 @@ entry:
   %"1#tmp#10##0" = icmp ne i64 %"tmp#5##0", 0 
   br i1 %"1#tmp#10##0", label %if.then, label %if.else 
 if.then:
-  %62 = inttoptr i64 %"tmp#5##0" to i64* 
-  %63 = getelementptr  i64, i64* %62, i64 0 
-  %64 = load  i64, i64* %63 
-  %65 = add   i64 %"tmp#5##0", 8 
-  %66 = inttoptr i64 %65 to i64* 
-  %67 = getelementptr  i64, i64* %66, i64 0 
-  %68 = load  i64, i64* %67 
-  tail call fastcc  void  @"stmt_for.gen#15<0>"(i64  %64, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %68, i64  %"x##0")  
+  %49 = inttoptr i64 %"tmp#5##0" to i64* 
+  %50 = getelementptr  i64, i64* %49, i64 0 
+  %51 = load  i64, i64* %50 
+  %52 = add   i64 %"tmp#5##0", 8 
+  %53 = inttoptr i64 %52 to i64* 
+  %54 = getelementptr  i64, i64* %53, i64 0 
+  %55 = load  i64, i64* %54 
+  tail call fastcc  void  @"stmt_for.gen#15<0>"(i64  %51, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %55, i64  %"x##0")  
   ret void 
 if.else:
   ret void 
@@ -1060,14 +1047,14 @@ entry:
   %"1#tmp#10##0" = icmp ne i64 %"tmp#5##0", 0 
   br i1 %"1#tmp#10##0", label %if.then, label %if.else 
 if.then:
-  %69 = inttoptr i64 %"tmp#5##0" to i64* 
-  %70 = getelementptr  i64, i64* %69, i64 0 
-  %71 = load  i64, i64* %70 
-  %72 = add   i64 %"tmp#5##0", 8 
-  %73 = inttoptr i64 %72 to i64* 
-  %74 = getelementptr  i64, i64* %73, i64 0 
-  %75 = load  i64, i64* %74 
-  tail call fastcc  void  @"stmt_for.gen#17<0>"(i64  %71, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %75, i64  %"x##0")  
+  %56 = inttoptr i64 %"tmp#5##0" to i64* 
+  %57 = getelementptr  i64, i64* %56, i64 0 
+  %58 = load  i64, i64* %57 
+  %59 = add   i64 %"tmp#5##0", 8 
+  %60 = inttoptr i64 %59 to i64* 
+  %61 = getelementptr  i64, i64* %60, i64 0 
+  %62 = load  i64, i64* %61 
+  tail call fastcc  void  @"stmt_for.gen#17<0>"(i64  %58, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %62, i64  %"x##0")  
   ret void 
 if.else:
   ret void 
@@ -1094,14 +1081,14 @@ entry:
   %"1#tmp#10##0" = icmp ne i64 %"tmp#5##0", 0 
   br i1 %"1#tmp#10##0", label %if.then, label %if.else 
 if.then:
-  %76 = inttoptr i64 %"tmp#5##0" to i64* 
-  %77 = getelementptr  i64, i64* %76, i64 0 
-  %78 = load  i64, i64* %77 
-  %79 = add   i64 %"tmp#5##0", 8 
-  %80 = inttoptr i64 %79 to i64* 
-  %81 = getelementptr  i64, i64* %80, i64 0 
-  %82 = load  i64, i64* %81 
-  tail call fastcc  void  @"stmt_for.gen#19<0>"(i64  %78, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %82, i64  %"x##0")  
+  %63 = inttoptr i64 %"tmp#5##0" to i64* 
+  %64 = getelementptr  i64, i64* %63, i64 0 
+  %65 = load  i64, i64* %64 
+  %66 = add   i64 %"tmp#5##0", 8 
+  %67 = inttoptr i64 %66 to i64* 
+  %68 = getelementptr  i64, i64* %67, i64 0 
+  %69 = load  i64, i64* %68 
+  tail call fastcc  void  @"stmt_for.gen#19<0>"(i64  %65, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %69, i64  %"x##0")  
   ret void 
 if.else:
   ret void 
@@ -1127,18 +1114,18 @@ entry:
   %"1#tmp#14##0" = icmp ne i64 %"tmp#9##0", 0 
   br i1 %"1#tmp#14##0", label %if.then, label %if.else 
 if.then:
-  %83 = inttoptr i64 %"tmp#9##0" to i64* 
-  %84 = getelementptr  i64, i64* %83, i64 0 
-  %85 = load  i64, i64* %84 
-  %86 = add   i64 %"tmp#9##0", 8 
-  %87 = inttoptr i64 %86 to i64* 
-  %88 = getelementptr  i64, i64* %87, i64 0 
-  %89 = load  i64, i64* %88 
+  %70 = inttoptr i64 %"tmp#9##0" to i64* 
+  %71 = getelementptr  i64, i64* %70, i64 0 
+  %72 = load  i64, i64* %71 
+  %73 = add   i64 %"tmp#9##0", 8 
+  %74 = inttoptr i64 %73 to i64* 
+  %75 = getelementptr  i64, i64* %74, i64 0 
+  %76 = load  i64, i64* %75 
   tail call ccc  void  @print_int(i64  %"i##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call ccc  void  @print_int(i64  %85)  
+  tail call ccc  void  @print_int(i64  %72)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen#1<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %"tmp#8##0", i64  %89, i64  %"x##0", i64  %"y##0")  
+  tail call fastcc  void  @"stmt_for.gen#1<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %"tmp#8##0", i64  %76, i64  %"x##0", i64  %"y##0")  
   ret void 
 if.else:
   ret void 
@@ -1150,14 +1137,14 @@ entry:
   %"1#tmp#10##0" = icmp ne i64 %"tmp#5##0", 0 
   br i1 %"1#tmp#10##0", label %if.then, label %if.else 
 if.then:
-  %90 = inttoptr i64 %"tmp#5##0" to i64* 
-  %91 = getelementptr  i64, i64* %90, i64 0 
-  %92 = load  i64, i64* %91 
-  %93 = add   i64 %"tmp#5##0", 8 
-  %94 = inttoptr i64 %93 to i64* 
-  %95 = getelementptr  i64, i64* %94, i64 0 
-  %96 = load  i64, i64* %95 
-  tail call fastcc  void  @"stmt_for.gen#21<0>"(i64  %92, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %96, i64  %"x##0")  
+  %77 = inttoptr i64 %"tmp#5##0" to i64* 
+  %78 = getelementptr  i64, i64* %77, i64 0 
+  %79 = load  i64, i64* %78 
+  %80 = add   i64 %"tmp#5##0", 8 
+  %81 = inttoptr i64 %80 to i64* 
+  %82 = getelementptr  i64, i64* %81, i64 0 
+  %83 = load  i64, i64* %82 
+  tail call fastcc  void  @"stmt_for.gen#21<0>"(i64  %79, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %83, i64  %"x##0")  
   ret void 
 if.else:
   ret void 
@@ -1184,14 +1171,14 @@ entry:
   %"1#tmp#10##0" = icmp ne i64 %"tmp#5##0", 0 
   br i1 %"1#tmp#10##0", label %if.then, label %if.else 
 if.then:
-  %97 = inttoptr i64 %"tmp#5##0" to i64* 
-  %98 = getelementptr  i64, i64* %97, i64 0 
-  %99 = load  i64, i64* %98 
-  %100 = add   i64 %"tmp#5##0", 8 
-  %101 = inttoptr i64 %100 to i64* 
-  %102 = getelementptr  i64, i64* %101, i64 0 
-  %103 = load  i64, i64* %102 
-  tail call fastcc  void  @"stmt_for.gen#23<0>"(i64  %99, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %103, i64  %"x##0")  
+  %84 = inttoptr i64 %"tmp#5##0" to i64* 
+  %85 = getelementptr  i64, i64* %84, i64 0 
+  %86 = load  i64, i64* %85 
+  %87 = add   i64 %"tmp#5##0", 8 
+  %88 = inttoptr i64 %87 to i64* 
+  %89 = getelementptr  i64, i64* %88, i64 0 
+  %90 = load  i64, i64* %89 
+  tail call fastcc  void  @"stmt_for.gen#23<0>"(i64  %86, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %90, i64  %"x##0")  
   ret void 
 if.else:
   ret void 
@@ -1214,15 +1201,15 @@ if.else:
 
 define external fastcc  void @"stmt_for.gen#24<0>"(i64  %"tmp#0##0", i64  %"tmp#3##0")    {
 entry:
-  %104 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
-  %105 = extractvalue {i64, i64, i1} %104, 0 
-  %106 = extractvalue {i64, i64, i1} %104, 1 
-  %107 = extractvalue {i64, i64, i1} %104, 2 
-  br i1 %107, label %if.then, label %if.else 
+  %91 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
+  %92 = extractvalue {i64, i64, i1} %91, 0 
+  %93 = extractvalue {i64, i64, i1} %91, 1 
+  %94 = extractvalue {i64, i64, i1} %91, 2 
+  br i1 %94, label %if.then, label %if.else 
 if.then:
-  tail call ccc  void  @print_int(i64  %105)  
+  tail call ccc  void  @print_int(i64  %92)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen#24<0>"(i64  %106, i64  %"tmp#3##0")  
+  tail call fastcc  void  @"stmt_for.gen#24<0>"(i64  %93, i64  %"tmp#3##0")  
   ret void 
 if.else:
   ret void 
@@ -1231,15 +1218,15 @@ if.else:
 
 define external fastcc  void @"stmt_for.gen#25<0>"(i64  %"tmp#0##0", i64  %"tmp#3##0")    {
 entry:
-  %108 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
-  %109 = extractvalue {i64, i64, i1} %108, 0 
-  %110 = extractvalue {i64, i64, i1} %108, 1 
-  %111 = extractvalue {i64, i64, i1} %108, 2 
-  br i1 %111, label %if.then, label %if.else 
+  %95 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
+  %96 = extractvalue {i64, i64, i1} %95, 0 
+  %97 = extractvalue {i64, i64, i1} %95, 1 
+  %98 = extractvalue {i64, i64, i1} %95, 2 
+  br i1 %98, label %if.then, label %if.else 
 if.then:
-  tail call ccc  void  @print_int(i64  %109)  
+  tail call ccc  void  @print_int(i64  %96)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen#25<0>"(i64  %110, i64  %"tmp#3##0")  
+  tail call fastcc  void  @"stmt_for.gen#25<0>"(i64  %97, i64  %"tmp#3##0")  
   ret void 
 if.else:
   ret void 
@@ -1259,13 +1246,13 @@ entry:
 
 define external fastcc  i1 @"stmt_for.gen#4<0>"(i64  %"tmp#0##0", i64  %"tmp#3##0")    {
 entry:
-  %112 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
-  %113 = extractvalue {i64, i64, i1} %112, 0 
-  %114 = extractvalue {i64, i64, i1} %112, 1 
-  %115 = extractvalue {i64, i64, i1} %112, 2 
-  br i1 %115, label %if.then, label %if.else 
+  %99 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
+  %100 = extractvalue {i64, i64, i1} %99, 0 
+  %101 = extractvalue {i64, i64, i1} %99, 1 
+  %102 = extractvalue {i64, i64, i1} %99, 2 
+  br i1 %102, label %if.then, label %if.else 
 if.then:
-  %"2##success##0" = tail call fastcc  i1  @"stmt_for.gen#5<0>"(i64  %113, i64  %114, i64  %"tmp#3##0")  
+  %"2##success##0" = tail call fastcc  i1  @"stmt_for.gen#5<0>"(i64  %100, i64  %101, i64  %"tmp#3##0")  
   ret i1 %"2##success##0" 
 if.else:
   ret i1 1 
@@ -1291,14 +1278,14 @@ entry:
   %"1#tmp#14##0" = icmp ne i64 %"tmp#8##0", 0 
   br i1 %"1#tmp#14##0", label %if.then, label %if.else 
 if.then:
-  %116 = inttoptr i64 %"tmp#8##0" to i64* 
-  %117 = getelementptr  i64, i64* %116, i64 0 
-  %118 = load  i64, i64* %117 
-  %119 = add   i64 %"tmp#8##0", 8 
-  %120 = inttoptr i64 %119 to i64* 
-  %121 = getelementptr  i64, i64* %120, i64 0 
-  %122 = load  i64, i64* %121 
-  tail call fastcc  void  @"stmt_for.gen#7<0>"(i64  %118, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %122, i64  %"tmp#9##0", i64  %"x##0", i64  %"y##0")  
+  %103 = inttoptr i64 %"tmp#8##0" to i64* 
+  %104 = getelementptr  i64, i64* %103, i64 0 
+  %105 = load  i64, i64* %104 
+  %106 = add   i64 %"tmp#8##0", 8 
+  %107 = inttoptr i64 %106 to i64* 
+  %108 = getelementptr  i64, i64* %107, i64 0 
+  %109 = load  i64, i64* %108 
+  tail call fastcc  void  @"stmt_for.gen#7<0>"(i64  %105, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %109, i64  %"tmp#9##0", i64  %"x##0", i64  %"y##0")  
   ret void 
 if.else:
   ret void 
@@ -1310,18 +1297,18 @@ entry:
   %"1#tmp#14##0" = icmp ne i64 %"tmp#9##0", 0 
   br i1 %"1#tmp#14##0", label %if.then, label %if.else 
 if.then:
-  %123 = inttoptr i64 %"tmp#9##0" to i64* 
-  %124 = getelementptr  i64, i64* %123, i64 0 
-  %125 = load  i64, i64* %124 
-  %126 = add   i64 %"tmp#9##0", 8 
-  %127 = inttoptr i64 %126 to i64* 
-  %128 = getelementptr  i64, i64* %127, i64 0 
-  %129 = load  i64, i64* %128 
+  %110 = inttoptr i64 %"tmp#9##0" to i64* 
+  %111 = getelementptr  i64, i64* %110, i64 0 
+  %112 = load  i64, i64* %111 
+  %113 = add   i64 %"tmp#9##0", 8 
+  %114 = inttoptr i64 %113 to i64* 
+  %115 = getelementptr  i64, i64* %114, i64 0 
+  %116 = load  i64, i64* %115 
   tail call ccc  void  @print_int(i64  %"i##0")  
   tail call ccc  void  @putchar(i8  10)  
-  tail call ccc  void  @print_int(i64  %125)  
+  tail call ccc  void  @print_int(i64  %112)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen#6<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %"tmp#8##0", i64  %129, i64  %"x##0", i64  %"y##0")  
+  tail call fastcc  void  @"stmt_for.gen#6<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %"tmp#8##0", i64  %116, i64  %"x##0", i64  %"y##0")  
   ret void 
 if.else:
   ret void 
@@ -1344,16 +1331,16 @@ entry:
   %"1#tmp#8##0" = icmp ne i64 %"tmp#4##0", 0 
   br i1 %"1#tmp#8##0", label %if.then, label %if.else 
 if.then:
-  %130 = inttoptr i64 %"tmp#4##0" to i64* 
-  %131 = getelementptr  i64, i64* %130, i64 0 
-  %132 = load  i64, i64* %131 
-  %133 = add   i64 %"tmp#4##0", 8 
-  %134 = inttoptr i64 %133 to i64* 
-  %135 = getelementptr  i64, i64* %134, i64 0 
-  %136 = load  i64, i64* %135 
-  tail call ccc  void  @print_int(i64  %132)  
+  %117 = inttoptr i64 %"tmp#4##0" to i64* 
+  %118 = getelementptr  i64, i64* %117, i64 0 
+  %119 = load  i64, i64* %118 
+  %120 = add   i64 %"tmp#4##0", 8 
+  %121 = inttoptr i64 %120 to i64* 
+  %122 = getelementptr  i64, i64* %121, i64 0 
+  %123 = load  i64, i64* %122 
+  tail call ccc  void  @print_int(i64  %119)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen#9<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %136, i64  %"x##0")  
+  tail call fastcc  void  @"stmt_for.gen#9<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %123, i64  %"x##0")  
   ret void 
 if.else:
   ret void 
@@ -1366,104 +1353,104 @@ entry:
   br i1 %"1#tmp#4##0", label %if.then, label %if.else 
 if.then:
   %"2#tmp#2##0" = sub   i64 %"end##0", 1 
-  %137 = trunc i64 24 to i32  
-  %138 = tail call ccc  i8*  @wybe_malloc(i32  %137)  
-  %139 = ptrtoint i8* %138 to i64 
-  %140 = inttoptr i64 %139 to i64* 
-  %141 = getelementptr  i64, i64* %140, i64 0 
-  store  i64 %"start##0", i64* %141 
-  %142 = add   i64 %139, 8 
-  %143 = inttoptr i64 %142 to i64* 
-  %144 = getelementptr  i64, i64* %143, i64 0 
-  store  i64 %"stride##0", i64* %144 
-  %145 = add   i64 %139, 16 
-  %146 = inttoptr i64 %145 to i64* 
-  %147 = getelementptr  i64, i64* %146, i64 0 
-  store  i64 %"2#tmp#2##0", i64* %147 
-  ret i64 %139 
+  %124 = trunc i64 24 to i32  
+  %125 = tail call ccc  i8*  @wybe_malloc(i32  %124)  
+  %126 = ptrtoint i8* %125 to i64 
+  %127 = inttoptr i64 %126 to i64* 
+  %128 = getelementptr  i64, i64* %127, i64 0 
+  store  i64 %"start##0", i64* %128 
+  %129 = add   i64 %126, 8 
+  %130 = inttoptr i64 %129 to i64* 
+  %131 = getelementptr  i64, i64* %130, i64 0 
+  store  i64 %"stride##0", i64* %131 
+  %132 = add   i64 %126, 16 
+  %133 = inttoptr i64 %132 to i64* 
+  %134 = getelementptr  i64, i64* %133, i64 0 
+  store  i64 %"2#tmp#2##0", i64* %134 
+  ret i64 %126 
 if.else:
   %"3#tmp#3##0" = add   i64 %"end##0", 1 
-  %148 = trunc i64 24 to i32  
-  %149 = tail call ccc  i8*  @wybe_malloc(i32  %148)  
-  %150 = ptrtoint i8* %149 to i64 
-  %151 = inttoptr i64 %150 to i64* 
-  %152 = getelementptr  i64, i64* %151, i64 0 
-  store  i64 %"start##0", i64* %152 
-  %153 = add   i64 %150, 8 
-  %154 = inttoptr i64 %153 to i64* 
-  %155 = getelementptr  i64, i64* %154, i64 0 
-  store  i64 %"stride##0", i64* %155 
-  %156 = add   i64 %150, 16 
-  %157 = inttoptr i64 %156 to i64* 
-  %158 = getelementptr  i64, i64* %157, i64 0 
-  store  i64 %"3#tmp#3##0", i64* %158 
-  ret i64 %150 
+  %135 = trunc i64 24 to i32  
+  %136 = tail call ccc  i8*  @wybe_malloc(i32  %135)  
+  %137 = ptrtoint i8* %136 to i64 
+  %138 = inttoptr i64 %137 to i64* 
+  %139 = getelementptr  i64, i64* %138, i64 0 
+  store  i64 %"start##0", i64* %139 
+  %140 = add   i64 %137, 8 
+  %141 = inttoptr i64 %140 to i64* 
+  %142 = getelementptr  i64, i64* %141, i64 0 
+  store  i64 %"stride##0", i64* %142 
+  %143 = add   i64 %137, 16 
+  %144 = inttoptr i64 %143 to i64* 
+  %145 = getelementptr  i64, i64* %144, i64 0 
+  store  i64 %"3#tmp#3##0", i64* %145 
+  ret i64 %137 
 }
 
 
 define external fastcc  void @"stmt_for.multiple_generator<0>"()    {
 entry:
-  %159 = trunc i64 16 to i32  
-  %160 = tail call ccc  i8*  @wybe_malloc(i32  %159)  
-  %161 = ptrtoint i8* %160 to i64 
-  %162 = inttoptr i64 %161 to i64* 
-  %163 = getelementptr  i64, i64* %162, i64 0 
-  store  i64 3, i64* %163 
-  %164 = add   i64 %161, 8 
+  %146 = trunc i64 16 to i32  
+  %147 = tail call ccc  i8*  @wybe_malloc(i32  %146)  
+  %148 = ptrtoint i8* %147 to i64 
+  %149 = inttoptr i64 %148 to i64* 
+  %150 = getelementptr  i64, i64* %149, i64 0 
+  store  i64 3, i64* %150 
+  %151 = add   i64 %148, 8 
+  %152 = inttoptr i64 %151 to i64* 
+  %153 = getelementptr  i64, i64* %152, i64 0 
+  store  i64 0, i64* %153 
+  %154 = trunc i64 16 to i32  
+  %155 = tail call ccc  i8*  @wybe_malloc(i32  %154)  
+  %156 = ptrtoint i8* %155 to i64 
+  %157 = inttoptr i64 %156 to i64* 
+  %158 = getelementptr  i64, i64* %157, i64 0 
+  store  i64 2, i64* %158 
+  %159 = add   i64 %156, 8 
+  %160 = inttoptr i64 %159 to i64* 
+  %161 = getelementptr  i64, i64* %160, i64 0 
+  store  i64 %148, i64* %161 
+  %162 = trunc i64 16 to i32  
+  %163 = tail call ccc  i8*  @wybe_malloc(i32  %162)  
+  %164 = ptrtoint i8* %163 to i64 
   %165 = inttoptr i64 %164 to i64* 
   %166 = getelementptr  i64, i64* %165, i64 0 
-  store  i64 0, i64* %166 
-  %167 = trunc i64 16 to i32  
-  %168 = tail call ccc  i8*  @wybe_malloc(i32  %167)  
-  %169 = ptrtoint i8* %168 to i64 
-  %170 = inttoptr i64 %169 to i64* 
-  %171 = getelementptr  i64, i64* %170, i64 0 
-  store  i64 2, i64* %171 
-  %172 = add   i64 %169, 8 
+  store  i64 1, i64* %166 
+  %167 = add   i64 %164, 8 
+  %168 = inttoptr i64 %167 to i64* 
+  %169 = getelementptr  i64, i64* %168, i64 0 
+  store  i64 %156, i64* %169 
+  %170 = trunc i64 16 to i32  
+  %171 = tail call ccc  i8*  @wybe_malloc(i32  %170)  
+  %172 = ptrtoint i8* %171 to i64 
   %173 = inttoptr i64 %172 to i64* 
   %174 = getelementptr  i64, i64* %173, i64 0 
-  store  i64 %161, i64* %174 
-  %175 = trunc i64 16 to i32  
-  %176 = tail call ccc  i8*  @wybe_malloc(i32  %175)  
-  %177 = ptrtoint i8* %176 to i64 
-  %178 = inttoptr i64 %177 to i64* 
-  %179 = getelementptr  i64, i64* %178, i64 0 
-  store  i64 1, i64* %179 
-  %180 = add   i64 %177, 8 
+  store  i64 6, i64* %174 
+  %175 = add   i64 %172, 8 
+  %176 = inttoptr i64 %175 to i64* 
+  %177 = getelementptr  i64, i64* %176, i64 0 
+  store  i64 0, i64* %177 
+  %178 = trunc i64 16 to i32  
+  %179 = tail call ccc  i8*  @wybe_malloc(i32  %178)  
+  %180 = ptrtoint i8* %179 to i64 
   %181 = inttoptr i64 %180 to i64* 
   %182 = getelementptr  i64, i64* %181, i64 0 
-  store  i64 %169, i64* %182 
-  %183 = trunc i64 16 to i32  
-  %184 = tail call ccc  i8*  @wybe_malloc(i32  %183)  
-  %185 = ptrtoint i8* %184 to i64 
-  %186 = inttoptr i64 %185 to i64* 
-  %187 = getelementptr  i64, i64* %186, i64 0 
-  store  i64 6, i64* %187 
-  %188 = add   i64 %185, 8 
+  store  i64 5, i64* %182 
+  %183 = add   i64 %180, 8 
+  %184 = inttoptr i64 %183 to i64* 
+  %185 = getelementptr  i64, i64* %184, i64 0 
+  store  i64 %172, i64* %185 
+  %186 = trunc i64 16 to i32  
+  %187 = tail call ccc  i8*  @wybe_malloc(i32  %186)  
+  %188 = ptrtoint i8* %187 to i64 
   %189 = inttoptr i64 %188 to i64* 
   %190 = getelementptr  i64, i64* %189, i64 0 
-  store  i64 0, i64* %190 
-  %191 = trunc i64 16 to i32  
-  %192 = tail call ccc  i8*  @wybe_malloc(i32  %191)  
-  %193 = ptrtoint i8* %192 to i64 
-  %194 = inttoptr i64 %193 to i64* 
-  %195 = getelementptr  i64, i64* %194, i64 0 
-  store  i64 5, i64* %195 
-  %196 = add   i64 %193, 8 
-  %197 = inttoptr i64 %196 to i64* 
-  %198 = getelementptr  i64, i64* %197, i64 0 
-  store  i64 %185, i64* %198 
-  %199 = trunc i64 16 to i32  
-  %200 = tail call ccc  i8*  @wybe_malloc(i32  %199)  
-  %201 = ptrtoint i8* %200 to i64 
-  %202 = inttoptr i64 %201 to i64* 
-  %203 = getelementptr  i64, i64* %202, i64 0 
-  store  i64 4, i64* %203 
-  %204 = add   i64 %201, 8 
-  %205 = inttoptr i64 %204 to i64* 
-  %206 = getelementptr  i64, i64* %205, i64 0 
-  store  i64 %193, i64* %206 
-  tail call fastcc  void  @"stmt_for.gen#1<0>"(i64  %177, i64  %169, i64  %161, i64  0, i64  %201, i64  %193, i64  %185, i64  0, i64  %177, i64  %201, i64  %177, i64  %201)  
+  store  i64 4, i64* %190 
+  %191 = add   i64 %188, 8 
+  %192 = inttoptr i64 %191 to i64* 
+  %193 = getelementptr  i64, i64* %192, i64 0 
+  store  i64 %180, i64* %193 
+  tail call fastcc  void  @"stmt_for.gen#1<0>"(i64  %164, i64  %156, i64  %148, i64  0, i64  %188, i64  %180, i64  %172, i64  0, i64  %164, i64  %188, i64  %164, i64  %188)  
   ret void 
 }
 
@@ -1478,151 +1465,151 @@ entry:
 
 define external fastcc  void @"stmt_for.shortest_generator_termination<0>"()    {
 entry:
-  %207 = trunc i64 16 to i32  
-  %208 = tail call ccc  i8*  @wybe_malloc(i32  %207)  
-  %209 = ptrtoint i8* %208 to i64 
-  %210 = inttoptr i64 %209 to i64* 
-  %211 = getelementptr  i64, i64* %210, i64 0 
-  store  i64 4, i64* %211 
-  %212 = add   i64 %209, 8 
+  %194 = trunc i64 16 to i32  
+  %195 = tail call ccc  i8*  @wybe_malloc(i32  %194)  
+  %196 = ptrtoint i8* %195 to i64 
+  %197 = inttoptr i64 %196 to i64* 
+  %198 = getelementptr  i64, i64* %197, i64 0 
+  store  i64 4, i64* %198 
+  %199 = add   i64 %196, 8 
+  %200 = inttoptr i64 %199 to i64* 
+  %201 = getelementptr  i64, i64* %200, i64 0 
+  store  i64 0, i64* %201 
+  %202 = trunc i64 16 to i32  
+  %203 = tail call ccc  i8*  @wybe_malloc(i32  %202)  
+  %204 = ptrtoint i8* %203 to i64 
+  %205 = inttoptr i64 %204 to i64* 
+  %206 = getelementptr  i64, i64* %205, i64 0 
+  store  i64 3, i64* %206 
+  %207 = add   i64 %204, 8 
+  %208 = inttoptr i64 %207 to i64* 
+  %209 = getelementptr  i64, i64* %208, i64 0 
+  store  i64 %196, i64* %209 
+  %210 = trunc i64 16 to i32  
+  %211 = tail call ccc  i8*  @wybe_malloc(i32  %210)  
+  %212 = ptrtoint i8* %211 to i64 
   %213 = inttoptr i64 %212 to i64* 
   %214 = getelementptr  i64, i64* %213, i64 0 
-  store  i64 0, i64* %214 
-  %215 = trunc i64 16 to i32  
-  %216 = tail call ccc  i8*  @wybe_malloc(i32  %215)  
-  %217 = ptrtoint i8* %216 to i64 
-  %218 = inttoptr i64 %217 to i64* 
-  %219 = getelementptr  i64, i64* %218, i64 0 
-  store  i64 3, i64* %219 
-  %220 = add   i64 %217, 8 
+  store  i64 2, i64* %214 
+  %215 = add   i64 %212, 8 
+  %216 = inttoptr i64 %215 to i64* 
+  %217 = getelementptr  i64, i64* %216, i64 0 
+  store  i64 %204, i64* %217 
+  %218 = trunc i64 16 to i32  
+  %219 = tail call ccc  i8*  @wybe_malloc(i32  %218)  
+  %220 = ptrtoint i8* %219 to i64 
   %221 = inttoptr i64 %220 to i64* 
   %222 = getelementptr  i64, i64* %221, i64 0 
-  store  i64 %209, i64* %222 
-  %223 = trunc i64 16 to i32  
-  %224 = tail call ccc  i8*  @wybe_malloc(i32  %223)  
-  %225 = ptrtoint i8* %224 to i64 
-  %226 = inttoptr i64 %225 to i64* 
-  %227 = getelementptr  i64, i64* %226, i64 0 
-  store  i64 2, i64* %227 
-  %228 = add   i64 %225, 8 
+  store  i64 1, i64* %222 
+  %223 = add   i64 %220, 8 
+  %224 = inttoptr i64 %223 to i64* 
+  %225 = getelementptr  i64, i64* %224, i64 0 
+  store  i64 %212, i64* %225 
+  %226 = trunc i64 16 to i32  
+  %227 = tail call ccc  i8*  @wybe_malloc(i32  %226)  
+  %228 = ptrtoint i8* %227 to i64 
   %229 = inttoptr i64 %228 to i64* 
   %230 = getelementptr  i64, i64* %229, i64 0 
-  store  i64 %217, i64* %230 
-  %231 = trunc i64 16 to i32  
-  %232 = tail call ccc  i8*  @wybe_malloc(i32  %231)  
-  %233 = ptrtoint i8* %232 to i64 
-  %234 = inttoptr i64 %233 to i64* 
-  %235 = getelementptr  i64, i64* %234, i64 0 
-  store  i64 1, i64* %235 
-  %236 = add   i64 %233, 8 
+  store  i64 5, i64* %230 
+  %231 = add   i64 %228, 8 
+  %232 = inttoptr i64 %231 to i64* 
+  %233 = getelementptr  i64, i64* %232, i64 0 
+  store  i64 0, i64* %233 
+  %234 = trunc i64 16 to i32  
+  %235 = tail call ccc  i8*  @wybe_malloc(i32  %234)  
+  %236 = ptrtoint i8* %235 to i64 
   %237 = inttoptr i64 %236 to i64* 
   %238 = getelementptr  i64, i64* %237, i64 0 
-  store  i64 %225, i64* %238 
-  %239 = trunc i64 16 to i32  
-  %240 = tail call ccc  i8*  @wybe_malloc(i32  %239)  
-  %241 = ptrtoint i8* %240 to i64 
-  %242 = inttoptr i64 %241 to i64* 
-  %243 = getelementptr  i64, i64* %242, i64 0 
-  store  i64 5, i64* %243 
-  %244 = add   i64 %241, 8 
-  %245 = inttoptr i64 %244 to i64* 
-  %246 = getelementptr  i64, i64* %245, i64 0 
-  store  i64 0, i64* %246 
-  %247 = trunc i64 16 to i32  
-  %248 = tail call ccc  i8*  @wybe_malloc(i32  %247)  
-  %249 = ptrtoint i8* %248 to i64 
-  %250 = inttoptr i64 %249 to i64* 
-  %251 = getelementptr  i64, i64* %250, i64 0 
-  store  i64 4, i64* %251 
-  %252 = add   i64 %249, 8 
-  %253 = inttoptr i64 %252 to i64* 
-  %254 = getelementptr  i64, i64* %253, i64 0 
-  store  i64 %241, i64* %254 
-  tail call fastcc  void  @"stmt_for.gen#6<0>"(i64  %233, i64  %225, i64  %217, i64  %209, i64  0, i64  %249, i64  %241, i64  0, i64  %233, i64  %249, i64  %233, i64  %249)  
+  store  i64 4, i64* %238 
+  %239 = add   i64 %236, 8 
+  %240 = inttoptr i64 %239 to i64* 
+  %241 = getelementptr  i64, i64* %240, i64 0 
+  store  i64 %228, i64* %241 
+  tail call fastcc  void  @"stmt_for.gen#6<0>"(i64  %220, i64  %212, i64  %204, i64  %196, i64  0, i64  %236, i64  %228, i64  0, i64  %220, i64  %236, i64  %220, i64  %236)  
   ret void 
 }
 
 
 define external fastcc  void @"stmt_for.single_generator<0>"()    {
 entry:
-  %255 = trunc i64 16 to i32  
-  %256 = tail call ccc  i8*  @wybe_malloc(i32  %255)  
-  %257 = ptrtoint i8* %256 to i64 
-  %258 = inttoptr i64 %257 to i64* 
-  %259 = getelementptr  i64, i64* %258, i64 0 
-  store  i64 3, i64* %259 
-  %260 = add   i64 %257, 8 
+  %242 = trunc i64 16 to i32  
+  %243 = tail call ccc  i8*  @wybe_malloc(i32  %242)  
+  %244 = ptrtoint i8* %243 to i64 
+  %245 = inttoptr i64 %244 to i64* 
+  %246 = getelementptr  i64, i64* %245, i64 0 
+  store  i64 3, i64* %246 
+  %247 = add   i64 %244, 8 
+  %248 = inttoptr i64 %247 to i64* 
+  %249 = getelementptr  i64, i64* %248, i64 0 
+  store  i64 0, i64* %249 
+  %250 = trunc i64 16 to i32  
+  %251 = tail call ccc  i8*  @wybe_malloc(i32  %250)  
+  %252 = ptrtoint i8* %251 to i64 
+  %253 = inttoptr i64 %252 to i64* 
+  %254 = getelementptr  i64, i64* %253, i64 0 
+  store  i64 2, i64* %254 
+  %255 = add   i64 %252, 8 
+  %256 = inttoptr i64 %255 to i64* 
+  %257 = getelementptr  i64, i64* %256, i64 0 
+  store  i64 %244, i64* %257 
+  %258 = trunc i64 16 to i32  
+  %259 = tail call ccc  i8*  @wybe_malloc(i32  %258)  
+  %260 = ptrtoint i8* %259 to i64 
   %261 = inttoptr i64 %260 to i64* 
   %262 = getelementptr  i64, i64* %261, i64 0 
-  store  i64 0, i64* %262 
-  %263 = trunc i64 16 to i32  
-  %264 = tail call ccc  i8*  @wybe_malloc(i32  %263)  
-  %265 = ptrtoint i8* %264 to i64 
-  %266 = inttoptr i64 %265 to i64* 
-  %267 = getelementptr  i64, i64* %266, i64 0 
-  store  i64 2, i64* %267 
-  %268 = add   i64 %265, 8 
-  %269 = inttoptr i64 %268 to i64* 
-  %270 = getelementptr  i64, i64* %269, i64 0 
-  store  i64 %257, i64* %270 
-  %271 = trunc i64 16 to i32  
-  %272 = tail call ccc  i8*  @wybe_malloc(i32  %271)  
-  %273 = ptrtoint i8* %272 to i64 
-  %274 = inttoptr i64 %273 to i64* 
-  %275 = getelementptr  i64, i64* %274, i64 0 
-  store  i64 1, i64* %275 
-  %276 = add   i64 %273, 8 
-  %277 = inttoptr i64 %276 to i64* 
-  %278 = getelementptr  i64, i64* %277, i64 0 
-  store  i64 %265, i64* %278 
-  tail call fastcc  void  @"stmt_for.gen#9<0>"(i64  %273, i64  %265, i64  %257, i64  0, i64  %273, i64  %273)  
+  store  i64 1, i64* %262 
+  %263 = add   i64 %260, 8 
+  %264 = inttoptr i64 %263 to i64* 
+  %265 = getelementptr  i64, i64* %264, i64 0 
+  store  i64 %252, i64* %265 
+  tail call fastcc  void  @"stmt_for.gen#9<0>"(i64  %260, i64  %252, i64  %244, i64  0, i64  %260, i64  %260)  
   ret void 
 }
 
 
 define external fastcc  void @"stmt_for.using_break<0>"()    {
 entry:
-  %279 = trunc i64 16 to i32  
-  %280 = tail call ccc  i8*  @wybe_malloc(i32  %279)  
-  %281 = ptrtoint i8* %280 to i64 
-  %282 = inttoptr i64 %281 to i64* 
-  %283 = getelementptr  i64, i64* %282, i64 0 
-  store  i64 4, i64* %283 
-  %284 = add   i64 %281, 8 
+  %266 = trunc i64 16 to i32  
+  %267 = tail call ccc  i8*  @wybe_malloc(i32  %266)  
+  %268 = ptrtoint i8* %267 to i64 
+  %269 = inttoptr i64 %268 to i64* 
+  %270 = getelementptr  i64, i64* %269, i64 0 
+  store  i64 4, i64* %270 
+  %271 = add   i64 %268, 8 
+  %272 = inttoptr i64 %271 to i64* 
+  %273 = getelementptr  i64, i64* %272, i64 0 
+  store  i64 0, i64* %273 
+  %274 = trunc i64 16 to i32  
+  %275 = tail call ccc  i8*  @wybe_malloc(i32  %274)  
+  %276 = ptrtoint i8* %275 to i64 
+  %277 = inttoptr i64 %276 to i64* 
+  %278 = getelementptr  i64, i64* %277, i64 0 
+  store  i64 3, i64* %278 
+  %279 = add   i64 %276, 8 
+  %280 = inttoptr i64 %279 to i64* 
+  %281 = getelementptr  i64, i64* %280, i64 0 
+  store  i64 %268, i64* %281 
+  %282 = trunc i64 16 to i32  
+  %283 = tail call ccc  i8*  @wybe_malloc(i32  %282)  
+  %284 = ptrtoint i8* %283 to i64 
   %285 = inttoptr i64 %284 to i64* 
   %286 = getelementptr  i64, i64* %285, i64 0 
-  store  i64 0, i64* %286 
-  %287 = trunc i64 16 to i32  
-  %288 = tail call ccc  i8*  @wybe_malloc(i32  %287)  
-  %289 = ptrtoint i8* %288 to i64 
-  %290 = inttoptr i64 %289 to i64* 
-  %291 = getelementptr  i64, i64* %290, i64 0 
-  store  i64 3, i64* %291 
-  %292 = add   i64 %289, 8 
+  store  i64 2, i64* %286 
+  %287 = add   i64 %284, 8 
+  %288 = inttoptr i64 %287 to i64* 
+  %289 = getelementptr  i64, i64* %288, i64 0 
+  store  i64 %276, i64* %289 
+  %290 = trunc i64 16 to i32  
+  %291 = tail call ccc  i8*  @wybe_malloc(i32  %290)  
+  %292 = ptrtoint i8* %291 to i64 
   %293 = inttoptr i64 %292 to i64* 
   %294 = getelementptr  i64, i64* %293, i64 0 
-  store  i64 %281, i64* %294 
-  %295 = trunc i64 16 to i32  
-  %296 = tail call ccc  i8*  @wybe_malloc(i32  %295)  
-  %297 = ptrtoint i8* %296 to i64 
-  %298 = inttoptr i64 %297 to i64* 
-  %299 = getelementptr  i64, i64* %298, i64 0 
-  store  i64 2, i64* %299 
-  %300 = add   i64 %297, 8 
-  %301 = inttoptr i64 %300 to i64* 
-  %302 = getelementptr  i64, i64* %301, i64 0 
-  store  i64 %289, i64* %302 
-  %303 = trunc i64 16 to i32  
-  %304 = tail call ccc  i8*  @wybe_malloc(i32  %303)  
-  %305 = ptrtoint i8* %304 to i64 
-  %306 = inttoptr i64 %305 to i64* 
-  %307 = getelementptr  i64, i64* %306, i64 0 
-  store  i64 1, i64* %307 
-  %308 = add   i64 %305, 8 
-  %309 = inttoptr i64 %308 to i64* 
-  %310 = getelementptr  i64, i64* %309, i64 0 
-  store  i64 %297, i64* %310 
-  tail call fastcc  void  @"stmt_for.gen#10<0>"(i64  %305, i64  %297, i64  %289, i64  %281, i64  0, i64  %305, i64  %305)  
+  store  i64 1, i64* %294 
+  %295 = add   i64 %292, 8 
+  %296 = inttoptr i64 %295 to i64* 
+  %297 = getelementptr  i64, i64* %296, i64 0 
+  store  i64 %284, i64* %297 
+  tail call fastcc  void  @"stmt_for.gen#10<0>"(i64  %292, i64  %284, i64  %276, i64  %268, i64  0, i64  %292, i64  %292)  
   ret void 
 }
 
@@ -1645,235 +1632,235 @@ entry:
 
 define external fastcc  void @"stmt_for.using_next<0>"()    {
 entry:
-  %311 = trunc i64 16 to i32  
-  %312 = tail call ccc  i8*  @wybe_malloc(i32  %311)  
-  %313 = ptrtoint i8* %312 to i64 
-  %314 = inttoptr i64 %313 to i64* 
-  %315 = getelementptr  i64, i64* %314, i64 0 
-  store  i64 4, i64* %315 
-  %316 = add   i64 %313, 8 
+  %298 = trunc i64 16 to i32  
+  %299 = tail call ccc  i8*  @wybe_malloc(i32  %298)  
+  %300 = ptrtoint i8* %299 to i64 
+  %301 = inttoptr i64 %300 to i64* 
+  %302 = getelementptr  i64, i64* %301, i64 0 
+  store  i64 4, i64* %302 
+  %303 = add   i64 %300, 8 
+  %304 = inttoptr i64 %303 to i64* 
+  %305 = getelementptr  i64, i64* %304, i64 0 
+  store  i64 0, i64* %305 
+  %306 = trunc i64 16 to i32  
+  %307 = tail call ccc  i8*  @wybe_malloc(i32  %306)  
+  %308 = ptrtoint i8* %307 to i64 
+  %309 = inttoptr i64 %308 to i64* 
+  %310 = getelementptr  i64, i64* %309, i64 0 
+  store  i64 3, i64* %310 
+  %311 = add   i64 %308, 8 
+  %312 = inttoptr i64 %311 to i64* 
+  %313 = getelementptr  i64, i64* %312, i64 0 
+  store  i64 %300, i64* %313 
+  %314 = trunc i64 16 to i32  
+  %315 = tail call ccc  i8*  @wybe_malloc(i32  %314)  
+  %316 = ptrtoint i8* %315 to i64 
   %317 = inttoptr i64 %316 to i64* 
   %318 = getelementptr  i64, i64* %317, i64 0 
-  store  i64 0, i64* %318 
-  %319 = trunc i64 16 to i32  
-  %320 = tail call ccc  i8*  @wybe_malloc(i32  %319)  
-  %321 = ptrtoint i8* %320 to i64 
-  %322 = inttoptr i64 %321 to i64* 
-  %323 = getelementptr  i64, i64* %322, i64 0 
-  store  i64 3, i64* %323 
-  %324 = add   i64 %321, 8 
+  store  i64 2, i64* %318 
+  %319 = add   i64 %316, 8 
+  %320 = inttoptr i64 %319 to i64* 
+  %321 = getelementptr  i64, i64* %320, i64 0 
+  store  i64 %308, i64* %321 
+  %322 = trunc i64 16 to i32  
+  %323 = tail call ccc  i8*  @wybe_malloc(i32  %322)  
+  %324 = ptrtoint i8* %323 to i64 
   %325 = inttoptr i64 %324 to i64* 
   %326 = getelementptr  i64, i64* %325, i64 0 
-  store  i64 %313, i64* %326 
-  %327 = trunc i64 16 to i32  
-  %328 = tail call ccc  i8*  @wybe_malloc(i32  %327)  
-  %329 = ptrtoint i8* %328 to i64 
-  %330 = inttoptr i64 %329 to i64* 
-  %331 = getelementptr  i64, i64* %330, i64 0 
-  store  i64 2, i64* %331 
-  %332 = add   i64 %329, 8 
-  %333 = inttoptr i64 %332 to i64* 
-  %334 = getelementptr  i64, i64* %333, i64 0 
-  store  i64 %321, i64* %334 
-  %335 = trunc i64 16 to i32  
-  %336 = tail call ccc  i8*  @wybe_malloc(i32  %335)  
-  %337 = ptrtoint i8* %336 to i64 
-  %338 = inttoptr i64 %337 to i64* 
-  %339 = getelementptr  i64, i64* %338, i64 0 
-  store  i64 1, i64* %339 
-  %340 = add   i64 %337, 8 
-  %341 = inttoptr i64 %340 to i64* 
-  %342 = getelementptr  i64, i64* %341, i64 0 
-  store  i64 %329, i64* %342 
-  tail call fastcc  void  @"stmt_for.gen#14<0>"(i64  %337, i64  %329, i64  %321, i64  %313, i64  0, i64  %337, i64  %337)  
+  store  i64 1, i64* %326 
+  %327 = add   i64 %324, 8 
+  %328 = inttoptr i64 %327 to i64* 
+  %329 = getelementptr  i64, i64* %328, i64 0 
+  store  i64 %316, i64* %329 
+  tail call fastcc  void  @"stmt_for.gen#14<0>"(i64  %324, i64  %316, i64  %308, i64  %300, i64  0, i64  %324, i64  %324)  
   ret void 
 }
 
 
 define external fastcc  void @"stmt_for.using_unless<0>"()    {
 entry:
-  %343 = trunc i64 16 to i32  
-  %344 = tail call ccc  i8*  @wybe_malloc(i32  %343)  
-  %345 = ptrtoint i8* %344 to i64 
-  %346 = inttoptr i64 %345 to i64* 
-  %347 = getelementptr  i64, i64* %346, i64 0 
-  store  i64 4, i64* %347 
-  %348 = add   i64 %345, 8 
+  %330 = trunc i64 16 to i32  
+  %331 = tail call ccc  i8*  @wybe_malloc(i32  %330)  
+  %332 = ptrtoint i8* %331 to i64 
+  %333 = inttoptr i64 %332 to i64* 
+  %334 = getelementptr  i64, i64* %333, i64 0 
+  store  i64 4, i64* %334 
+  %335 = add   i64 %332, 8 
+  %336 = inttoptr i64 %335 to i64* 
+  %337 = getelementptr  i64, i64* %336, i64 0 
+  store  i64 0, i64* %337 
+  %338 = trunc i64 16 to i32  
+  %339 = tail call ccc  i8*  @wybe_malloc(i32  %338)  
+  %340 = ptrtoint i8* %339 to i64 
+  %341 = inttoptr i64 %340 to i64* 
+  %342 = getelementptr  i64, i64* %341, i64 0 
+  store  i64 3, i64* %342 
+  %343 = add   i64 %340, 8 
+  %344 = inttoptr i64 %343 to i64* 
+  %345 = getelementptr  i64, i64* %344, i64 0 
+  store  i64 %332, i64* %345 
+  %346 = trunc i64 16 to i32  
+  %347 = tail call ccc  i8*  @wybe_malloc(i32  %346)  
+  %348 = ptrtoint i8* %347 to i64 
   %349 = inttoptr i64 %348 to i64* 
   %350 = getelementptr  i64, i64* %349, i64 0 
-  store  i64 0, i64* %350 
-  %351 = trunc i64 16 to i32  
-  %352 = tail call ccc  i8*  @wybe_malloc(i32  %351)  
-  %353 = ptrtoint i8* %352 to i64 
-  %354 = inttoptr i64 %353 to i64* 
-  %355 = getelementptr  i64, i64* %354, i64 0 
-  store  i64 3, i64* %355 
-  %356 = add   i64 %353, 8 
+  store  i64 2, i64* %350 
+  %351 = add   i64 %348, 8 
+  %352 = inttoptr i64 %351 to i64* 
+  %353 = getelementptr  i64, i64* %352, i64 0 
+  store  i64 %340, i64* %353 
+  %354 = trunc i64 16 to i32  
+  %355 = tail call ccc  i8*  @wybe_malloc(i32  %354)  
+  %356 = ptrtoint i8* %355 to i64 
   %357 = inttoptr i64 %356 to i64* 
   %358 = getelementptr  i64, i64* %357, i64 0 
-  store  i64 %345, i64* %358 
-  %359 = trunc i64 16 to i32  
-  %360 = tail call ccc  i8*  @wybe_malloc(i32  %359)  
-  %361 = ptrtoint i8* %360 to i64 
-  %362 = inttoptr i64 %361 to i64* 
-  %363 = getelementptr  i64, i64* %362, i64 0 
-  store  i64 2, i64* %363 
-  %364 = add   i64 %361, 8 
-  %365 = inttoptr i64 %364 to i64* 
-  %366 = getelementptr  i64, i64* %365, i64 0 
-  store  i64 %353, i64* %366 
-  %367 = trunc i64 16 to i32  
-  %368 = tail call ccc  i8*  @wybe_malloc(i32  %367)  
-  %369 = ptrtoint i8* %368 to i64 
-  %370 = inttoptr i64 %369 to i64* 
-  %371 = getelementptr  i64, i64* %370, i64 0 
-  store  i64 1, i64* %371 
-  %372 = add   i64 %369, 8 
-  %373 = inttoptr i64 %372 to i64* 
-  %374 = getelementptr  i64, i64* %373, i64 0 
-  store  i64 %361, i64* %374 
-  tail call fastcc  void  @"stmt_for.gen#16<0>"(i64  %369, i64  %361, i64  %353, i64  %345, i64  0, i64  %369, i64  %369)  
+  store  i64 1, i64* %358 
+  %359 = add   i64 %356, 8 
+  %360 = inttoptr i64 %359 to i64* 
+  %361 = getelementptr  i64, i64* %360, i64 0 
+  store  i64 %348, i64* %361 
+  tail call fastcc  void  @"stmt_for.gen#16<0>"(i64  %356, i64  %348, i64  %340, i64  %332, i64  0, i64  %356, i64  %356)  
   ret void 
 }
 
 
 define external fastcc  void @"stmt_for.using_until<0>"()    {
 entry:
-  %375 = trunc i64 16 to i32  
-  %376 = tail call ccc  i8*  @wybe_malloc(i32  %375)  
-  %377 = ptrtoint i8* %376 to i64 
-  %378 = inttoptr i64 %377 to i64* 
-  %379 = getelementptr  i64, i64* %378, i64 0 
-  store  i64 4, i64* %379 
-  %380 = add   i64 %377, 8 
+  %362 = trunc i64 16 to i32  
+  %363 = tail call ccc  i8*  @wybe_malloc(i32  %362)  
+  %364 = ptrtoint i8* %363 to i64 
+  %365 = inttoptr i64 %364 to i64* 
+  %366 = getelementptr  i64, i64* %365, i64 0 
+  store  i64 4, i64* %366 
+  %367 = add   i64 %364, 8 
+  %368 = inttoptr i64 %367 to i64* 
+  %369 = getelementptr  i64, i64* %368, i64 0 
+  store  i64 0, i64* %369 
+  %370 = trunc i64 16 to i32  
+  %371 = tail call ccc  i8*  @wybe_malloc(i32  %370)  
+  %372 = ptrtoint i8* %371 to i64 
+  %373 = inttoptr i64 %372 to i64* 
+  %374 = getelementptr  i64, i64* %373, i64 0 
+  store  i64 3, i64* %374 
+  %375 = add   i64 %372, 8 
+  %376 = inttoptr i64 %375 to i64* 
+  %377 = getelementptr  i64, i64* %376, i64 0 
+  store  i64 %364, i64* %377 
+  %378 = trunc i64 16 to i32  
+  %379 = tail call ccc  i8*  @wybe_malloc(i32  %378)  
+  %380 = ptrtoint i8* %379 to i64 
   %381 = inttoptr i64 %380 to i64* 
   %382 = getelementptr  i64, i64* %381, i64 0 
-  store  i64 0, i64* %382 
-  %383 = trunc i64 16 to i32  
-  %384 = tail call ccc  i8*  @wybe_malloc(i32  %383)  
-  %385 = ptrtoint i8* %384 to i64 
-  %386 = inttoptr i64 %385 to i64* 
-  %387 = getelementptr  i64, i64* %386, i64 0 
-  store  i64 3, i64* %387 
-  %388 = add   i64 %385, 8 
+  store  i64 2, i64* %382 
+  %383 = add   i64 %380, 8 
+  %384 = inttoptr i64 %383 to i64* 
+  %385 = getelementptr  i64, i64* %384, i64 0 
+  store  i64 %372, i64* %385 
+  %386 = trunc i64 16 to i32  
+  %387 = tail call ccc  i8*  @wybe_malloc(i32  %386)  
+  %388 = ptrtoint i8* %387 to i64 
   %389 = inttoptr i64 %388 to i64* 
   %390 = getelementptr  i64, i64* %389, i64 0 
-  store  i64 %377, i64* %390 
-  %391 = trunc i64 16 to i32  
-  %392 = tail call ccc  i8*  @wybe_malloc(i32  %391)  
-  %393 = ptrtoint i8* %392 to i64 
-  %394 = inttoptr i64 %393 to i64* 
-  %395 = getelementptr  i64, i64* %394, i64 0 
-  store  i64 2, i64* %395 
-  %396 = add   i64 %393, 8 
-  %397 = inttoptr i64 %396 to i64* 
-  %398 = getelementptr  i64, i64* %397, i64 0 
-  store  i64 %385, i64* %398 
-  %399 = trunc i64 16 to i32  
-  %400 = tail call ccc  i8*  @wybe_malloc(i32  %399)  
-  %401 = ptrtoint i8* %400 to i64 
-  %402 = inttoptr i64 %401 to i64* 
-  %403 = getelementptr  i64, i64* %402, i64 0 
-  store  i64 1, i64* %403 
-  %404 = add   i64 %401, 8 
-  %405 = inttoptr i64 %404 to i64* 
-  %406 = getelementptr  i64, i64* %405, i64 0 
-  store  i64 %393, i64* %406 
-  tail call fastcc  void  @"stmt_for.gen#18<0>"(i64  %401, i64  %393, i64  %385, i64  %377, i64  0, i64  %401, i64  %401)  
+  store  i64 1, i64* %390 
+  %391 = add   i64 %388, 8 
+  %392 = inttoptr i64 %391 to i64* 
+  %393 = getelementptr  i64, i64* %392, i64 0 
+  store  i64 %380, i64* %393 
+  tail call fastcc  void  @"stmt_for.gen#18<0>"(i64  %388, i64  %380, i64  %372, i64  %364, i64  0, i64  %388, i64  %388)  
   ret void 
 }
 
 
 define external fastcc  void @"stmt_for.using_when<0>"()    {
 entry:
-  %407 = trunc i64 16 to i32  
-  %408 = tail call ccc  i8*  @wybe_malloc(i32  %407)  
-  %409 = ptrtoint i8* %408 to i64 
-  %410 = inttoptr i64 %409 to i64* 
-  %411 = getelementptr  i64, i64* %410, i64 0 
-  store  i64 4, i64* %411 
-  %412 = add   i64 %409, 8 
+  %394 = trunc i64 16 to i32  
+  %395 = tail call ccc  i8*  @wybe_malloc(i32  %394)  
+  %396 = ptrtoint i8* %395 to i64 
+  %397 = inttoptr i64 %396 to i64* 
+  %398 = getelementptr  i64, i64* %397, i64 0 
+  store  i64 4, i64* %398 
+  %399 = add   i64 %396, 8 
+  %400 = inttoptr i64 %399 to i64* 
+  %401 = getelementptr  i64, i64* %400, i64 0 
+  store  i64 0, i64* %401 
+  %402 = trunc i64 16 to i32  
+  %403 = tail call ccc  i8*  @wybe_malloc(i32  %402)  
+  %404 = ptrtoint i8* %403 to i64 
+  %405 = inttoptr i64 %404 to i64* 
+  %406 = getelementptr  i64, i64* %405, i64 0 
+  store  i64 3, i64* %406 
+  %407 = add   i64 %404, 8 
+  %408 = inttoptr i64 %407 to i64* 
+  %409 = getelementptr  i64, i64* %408, i64 0 
+  store  i64 %396, i64* %409 
+  %410 = trunc i64 16 to i32  
+  %411 = tail call ccc  i8*  @wybe_malloc(i32  %410)  
+  %412 = ptrtoint i8* %411 to i64 
   %413 = inttoptr i64 %412 to i64* 
   %414 = getelementptr  i64, i64* %413, i64 0 
-  store  i64 0, i64* %414 
-  %415 = trunc i64 16 to i32  
-  %416 = tail call ccc  i8*  @wybe_malloc(i32  %415)  
-  %417 = ptrtoint i8* %416 to i64 
-  %418 = inttoptr i64 %417 to i64* 
-  %419 = getelementptr  i64, i64* %418, i64 0 
-  store  i64 3, i64* %419 
-  %420 = add   i64 %417, 8 
+  store  i64 2, i64* %414 
+  %415 = add   i64 %412, 8 
+  %416 = inttoptr i64 %415 to i64* 
+  %417 = getelementptr  i64, i64* %416, i64 0 
+  store  i64 %404, i64* %417 
+  %418 = trunc i64 16 to i32  
+  %419 = tail call ccc  i8*  @wybe_malloc(i32  %418)  
+  %420 = ptrtoint i8* %419 to i64 
   %421 = inttoptr i64 %420 to i64* 
   %422 = getelementptr  i64, i64* %421, i64 0 
-  store  i64 %409, i64* %422 
-  %423 = trunc i64 16 to i32  
-  %424 = tail call ccc  i8*  @wybe_malloc(i32  %423)  
-  %425 = ptrtoint i8* %424 to i64 
-  %426 = inttoptr i64 %425 to i64* 
-  %427 = getelementptr  i64, i64* %426, i64 0 
-  store  i64 2, i64* %427 
-  %428 = add   i64 %425, 8 
-  %429 = inttoptr i64 %428 to i64* 
-  %430 = getelementptr  i64, i64* %429, i64 0 
-  store  i64 %417, i64* %430 
-  %431 = trunc i64 16 to i32  
-  %432 = tail call ccc  i8*  @wybe_malloc(i32  %431)  
-  %433 = ptrtoint i8* %432 to i64 
-  %434 = inttoptr i64 %433 to i64* 
-  %435 = getelementptr  i64, i64* %434, i64 0 
-  store  i64 1, i64* %435 
-  %436 = add   i64 %433, 8 
-  %437 = inttoptr i64 %436 to i64* 
-  %438 = getelementptr  i64, i64* %437, i64 0 
-  store  i64 %425, i64* %438 
-  tail call fastcc  void  @"stmt_for.gen#20<0>"(i64  %433, i64  %425, i64  %417, i64  %409, i64  0, i64  %433, i64  %433)  
+  store  i64 1, i64* %422 
+  %423 = add   i64 %420, 8 
+  %424 = inttoptr i64 %423 to i64* 
+  %425 = getelementptr  i64, i64* %424, i64 0 
+  store  i64 %412, i64* %425 
+  tail call fastcc  void  @"stmt_for.gen#20<0>"(i64  %420, i64  %412, i64  %404, i64  %396, i64  0, i64  %420, i64  %420)  
   ret void 
 }
 
 
 define external fastcc  void @"stmt_for.using_while<0>"()    {
 entry:
-  %439 = trunc i64 16 to i32  
-  %440 = tail call ccc  i8*  @wybe_malloc(i32  %439)  
-  %441 = ptrtoint i8* %440 to i64 
-  %442 = inttoptr i64 %441 to i64* 
-  %443 = getelementptr  i64, i64* %442, i64 0 
-  store  i64 4, i64* %443 
-  %444 = add   i64 %441, 8 
+  %426 = trunc i64 16 to i32  
+  %427 = tail call ccc  i8*  @wybe_malloc(i32  %426)  
+  %428 = ptrtoint i8* %427 to i64 
+  %429 = inttoptr i64 %428 to i64* 
+  %430 = getelementptr  i64, i64* %429, i64 0 
+  store  i64 4, i64* %430 
+  %431 = add   i64 %428, 8 
+  %432 = inttoptr i64 %431 to i64* 
+  %433 = getelementptr  i64, i64* %432, i64 0 
+  store  i64 0, i64* %433 
+  %434 = trunc i64 16 to i32  
+  %435 = tail call ccc  i8*  @wybe_malloc(i32  %434)  
+  %436 = ptrtoint i8* %435 to i64 
+  %437 = inttoptr i64 %436 to i64* 
+  %438 = getelementptr  i64, i64* %437, i64 0 
+  store  i64 3, i64* %438 
+  %439 = add   i64 %436, 8 
+  %440 = inttoptr i64 %439 to i64* 
+  %441 = getelementptr  i64, i64* %440, i64 0 
+  store  i64 %428, i64* %441 
+  %442 = trunc i64 16 to i32  
+  %443 = tail call ccc  i8*  @wybe_malloc(i32  %442)  
+  %444 = ptrtoint i8* %443 to i64 
   %445 = inttoptr i64 %444 to i64* 
   %446 = getelementptr  i64, i64* %445, i64 0 
-  store  i64 0, i64* %446 
-  %447 = trunc i64 16 to i32  
-  %448 = tail call ccc  i8*  @wybe_malloc(i32  %447)  
-  %449 = ptrtoint i8* %448 to i64 
-  %450 = inttoptr i64 %449 to i64* 
-  %451 = getelementptr  i64, i64* %450, i64 0 
-  store  i64 3, i64* %451 
-  %452 = add   i64 %449, 8 
+  store  i64 2, i64* %446 
+  %447 = add   i64 %444, 8 
+  %448 = inttoptr i64 %447 to i64* 
+  %449 = getelementptr  i64, i64* %448, i64 0 
+  store  i64 %436, i64* %449 
+  %450 = trunc i64 16 to i32  
+  %451 = tail call ccc  i8*  @wybe_malloc(i32  %450)  
+  %452 = ptrtoint i8* %451 to i64 
   %453 = inttoptr i64 %452 to i64* 
   %454 = getelementptr  i64, i64* %453, i64 0 
-  store  i64 %441, i64* %454 
-  %455 = trunc i64 16 to i32  
-  %456 = tail call ccc  i8*  @wybe_malloc(i32  %455)  
-  %457 = ptrtoint i8* %456 to i64 
-  %458 = inttoptr i64 %457 to i64* 
-  %459 = getelementptr  i64, i64* %458, i64 0 
-  store  i64 2, i64* %459 
-  %460 = add   i64 %457, 8 
-  %461 = inttoptr i64 %460 to i64* 
-  %462 = getelementptr  i64, i64* %461, i64 0 
-  store  i64 %449, i64* %462 
-  %463 = trunc i64 16 to i32  
-  %464 = tail call ccc  i8*  @wybe_malloc(i32  %463)  
-  %465 = ptrtoint i8* %464 to i64 
-  %466 = inttoptr i64 %465 to i64* 
-  %467 = getelementptr  i64, i64* %466, i64 0 
-  store  i64 1, i64* %467 
-  %468 = add   i64 %465, 8 
-  %469 = inttoptr i64 %468 to i64* 
-  %470 = getelementptr  i64, i64* %469, i64 0 
-  store  i64 %457, i64* %470 
-  tail call fastcc  void  @"stmt_for.gen#22<0>"(i64  %465, i64  %457, i64  %449, i64  %441, i64  0, i64  %465, i64  %465)  
+  store  i64 1, i64* %454 
+  %455 = add   i64 %452, 8 
+  %456 = inttoptr i64 %455 to i64* 
+  %457 = getelementptr  i64, i64* %456, i64 0 
+  store  i64 %444, i64* %457 
+  tail call fastcc  void  @"stmt_for.gen#22<0>"(i64  %452, i64  %444, i64  %436, i64  %428, i64  0, i64  %452, i64  %452)  
   ret void 
 }
 
@@ -1896,21 +1883,21 @@ entry:
 
 define external fastcc  i64 @"stmt_for.xrange<0>"(i64  %"start##0", i64  %"stride##0", i64  %"end##0")    {
 entry:
-  %471 = trunc i64 24 to i32  
-  %472 = tail call ccc  i8*  @wybe_malloc(i32  %471)  
-  %473 = ptrtoint i8* %472 to i64 
-  %474 = inttoptr i64 %473 to i64* 
-  %475 = getelementptr  i64, i64* %474, i64 0 
-  store  i64 %"start##0", i64* %475 
-  %476 = add   i64 %473, 8 
-  %477 = inttoptr i64 %476 to i64* 
-  %478 = getelementptr  i64, i64* %477, i64 0 
-  store  i64 %"stride##0", i64* %478 
-  %479 = add   i64 %473, 16 
-  %480 = inttoptr i64 %479 to i64* 
-  %481 = getelementptr  i64, i64* %480, i64 0 
-  store  i64 %"end##0", i64* %481 
-  ret i64 %473 
+  %458 = trunc i64 24 to i32  
+  %459 = tail call ccc  i8*  @wybe_malloc(i32  %458)  
+  %460 = ptrtoint i8* %459 to i64 
+  %461 = inttoptr i64 %460 to i64* 
+  %462 = getelementptr  i64, i64* %461, i64 0 
+  store  i64 %"start##0", i64* %462 
+  %463 = add   i64 %460, 8 
+  %464 = inttoptr i64 %463 to i64* 
+  %465 = getelementptr  i64, i64* %464, i64 0 
+  store  i64 %"stride##0", i64* %465 
+  %466 = add   i64 %460, 16 
+  %467 = inttoptr i64 %466 to i64* 
+  %468 = getelementptr  i64, i64* %467, i64 0 
+  store  i64 %"end##0", i64* %468 
+  ret i64 %460 
 }
 --------------------------------------------------
  Module stmt_for.int_sequence

--- a/test-cases/final-dump/stmt_if.exp
+++ b/test-cases/final-dump/stmt_if.exp
@@ -107,10 +107,10 @@ declare external ccc  void @putchar(i8)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@stmt_if.16 =    constant {i64, i64} { i64 35, i64 ptrtoint ([?? x i8]* @stmt_if.15 to i64) }
+@stmt_if.15 =    constant {i64, i64} { i64 35, i64 ptrtoint ([?? x i8]* @stmt_if.14 to i64) }
 
 
-@stmt_if.15 =    constant [?? x i8] c"lookup fails when it should succeed\00"
+@stmt_if.14 =    constant [?? x i8] c"lookup fails when it should succeed\00"
 
 
 @stmt_if.13 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @stmt_if.12 to i64) }
@@ -119,16 +119,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @stmt_if.12 =    constant [?? x i8] c"lookup succeeds when it should\00"
 
 
-@stmt_if.22 =    constant {i64, i64} { i64 35, i64 ptrtoint ([?? x i8]* @stmt_if.21 to i64) }
+@stmt_if.19 =    constant {i64, i64} { i64 35, i64 ptrtoint ([?? x i8]* @stmt_if.18 to i64) }
 
 
-@stmt_if.21 =    constant [?? x i8] c"lookup succeeds when it should fail\00"
+@stmt_if.18 =    constant [?? x i8] c"lookup succeeds when it should fail\00"
 
 
-@stmt_if.19 =    constant {i64, i64} { i64 27, i64 ptrtoint ([?? x i8]* @stmt_if.18 to i64) }
+@stmt_if.17 =    constant {i64, i64} { i64 27, i64 ptrtoint ([?? x i8]* @stmt_if.16 to i64) }
 
 
-@stmt_if.18 =    constant [?? x i8] c"lookup fails when it should\00"
+@stmt_if.16 =    constant [?? x i8] c"lookup fails when it should\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -156,14 +156,12 @@ entry:
   %"1#tmp#4##0" = tail call fastcc  i1  @"stmt_if.lookup<0>"(i64  1, i64  %3)  
   br i1 %"1#tmp#4##0", label %if.then, label %if.else 
 if.then:
-  %14 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_if.13, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %14)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_if.13, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"stmt_if.gen#1<0>"(i64  %3)  
   ret void 
 if.else:
-  %17 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_if.16, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %17)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_if.15, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"stmt_if.gen#1<0>"(i64  %3)  
   ret void 
@@ -175,13 +173,11 @@ entry:
   %"1#tmp#3##0" = tail call fastcc  i1  @"stmt_if.lookup<0>"(i64  3, i64  %"tr##0")  
   br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
-  %20 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_if.19, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %20)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_if.17, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else:
-  %23 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_if.22, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %23)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_if.19, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }
@@ -192,31 +188,31 @@ entry:
   %"1#tmp#6##0" = icmp ne i64 %"tree##0", 0 
   br i1 %"1#tmp#6##0", label %if.then, label %if.else 
 if.then:
-  %24 = inttoptr i64 %"tree##0" to i64* 
+  %20 = inttoptr i64 %"tree##0" to i64* 
+  %21 = getelementptr  i64, i64* %20, i64 0 
+  %22 = load  i64, i64* %21 
+  %23 = add   i64 %"tree##0", 8 
+  %24 = inttoptr i64 %23 to i64* 
   %25 = getelementptr  i64, i64* %24, i64 0 
   %26 = load  i64, i64* %25 
-  %27 = add   i64 %"tree##0", 8 
+  %27 = add   i64 %"tree##0", 16 
   %28 = inttoptr i64 %27 to i64* 
   %29 = getelementptr  i64, i64* %28, i64 0 
   %30 = load  i64, i64* %29 
-  %31 = add   i64 %"tree##0", 16 
-  %32 = inttoptr i64 %31 to i64* 
-  %33 = getelementptr  i64, i64* %32, i64 0 
-  %34 = load  i64, i64* %33 
-  %"2#tmp#3##0" = icmp eq i64 %"key##0", %30 
+  %"2#tmp#3##0" = icmp eq i64 %"key##0", %26 
   br i1 %"2#tmp#3##0", label %if.then1, label %if.else1 
 if.else:
   ret i1 0 
 if.then1:
   ret i1 1 
 if.else1:
-  %"5#tmp#2##0" = icmp slt i64 %"key##0", %30 
+  %"5#tmp#2##0" = icmp slt i64 %"key##0", %26 
   br i1 %"5#tmp#2##0", label %if.then2, label %if.else2 
 if.then2:
-  %"6#result##0" = tail call fastcc  i1  @"stmt_if.lookup<0>"(i64  %"key##0", i64  %26)  
+  %"6#result##0" = tail call fastcc  i1  @"stmt_if.lookup<0>"(i64  %"key##0", i64  %22)  
   ret i1 %"6#result##0" 
 if.else2:
-  %"7#result##0" = tail call fastcc  i1  @"stmt_if.lookup<0>"(i64  %"key##0", i64  %34)  
+  %"7#result##0" = tail call fastcc  i1  @"stmt_if.lookup<0>"(i64  %"key##0", i64  %30)  
   ret i1 %"7#result##0" 
 }
 --------------------------------------------------

--- a/test-cases/final-dump/stmt_if2.exp
+++ b/test-cases/final-dump/stmt_if2.exp
@@ -130,8 +130,7 @@ entry:
   %"1#tmp#3##0" = tail call fastcc  i1  @"stmt_if2.lookup<0>"(i64  1, i64  %3)  
   br i1 %"1#tmp#3##0", label %if.then, label %if.else 
 if.then:
-  %14 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_if2.13, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %14)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @stmt_if2.13, i32 0, i32 0) to i64))  
   ret void 
 if.else:
   ret void 
@@ -154,31 +153,31 @@ if.else:
   %"3#tmp#15##0" = icmp ne i64 %"tree##0", 0 
   br i1 %"3#tmp#15##0", label %if.then1, label %if.else1 
 if.then1:
-  %15 = inttoptr i64 %"tree##0" to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  %17 = load  i64, i64* %16 
-  %18 = add   i64 %"tree##0", 8 
-  %19 = inttoptr i64 %18 to i64* 
-  %20 = getelementptr  i64, i64* %19, i64 0 
-  %21 = load  i64, i64* %20 
-  %22 = add   i64 %"tree##0", 16 
-  %23 = inttoptr i64 %22 to i64* 
-  %24 = getelementptr  i64, i64* %23, i64 0 
-  %25 = load  i64, i64* %24 
-  %"4#tmp#11##0" = icmp eq i64 %21, %"key##0" 
+  %14 = inttoptr i64 %"tree##0" to i64* 
+  %15 = getelementptr  i64, i64* %14, i64 0 
+  %16 = load  i64, i64* %15 
+  %17 = add   i64 %"tree##0", 8 
+  %18 = inttoptr i64 %17 to i64* 
+  %19 = getelementptr  i64, i64* %18, i64 0 
+  %20 = load  i64, i64* %19 
+  %21 = add   i64 %"tree##0", 16 
+  %22 = inttoptr i64 %21 to i64* 
+  %23 = getelementptr  i64, i64* %22, i64 0 
+  %24 = load  i64, i64* %23 
+  %"4#tmp#11##0" = icmp eq i64 %20, %"key##0" 
   br i1 %"4#tmp#11##0", label %if.then2, label %if.else2 
 if.else1:
   ret i1 0 
 if.then2:
   ret i1 1 
 if.else2:
-  %"7#tmp#10##0" = icmp sgt i64 %21, %"key##0" 
+  %"7#tmp#10##0" = icmp sgt i64 %20, %"key##0" 
   br i1 %"7#tmp#10##0", label %if.then3, label %if.else3 
 if.then3:
-  %"8##result##0" = tail call fastcc  i1  @"stmt_if2.lookup<0>"(i64  %"key##0", i64  %17)  
+  %"8##result##0" = tail call fastcc  i1  @"stmt_if2.lookup<0>"(i64  %"key##0", i64  %16)  
   ret i1 %"8##result##0" 
 if.else3:
-  %"9##result##0" = tail call fastcc  i1  @"stmt_if2.lookup<0>"(i64  %"key##0", i64  %25)  
+  %"9##result##0" = tail call fastcc  i1  @"stmt_if2.lookup<0>"(i64  %"key##0", i64  %24)  
   ret i1 %"9##result##0" 
 }
 --------------------------------------------------

--- a/test-cases/final-dump/string.exp
+++ b/test-cases/final-dump/string.exp
@@ -180,64 +180,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external fastcc  i64 @"wybe.string.c_string<0>"(i64)    
 
 
-@string.76 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.75 to i64) }
+@string.50 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.49 to i64) }
 
 
-@string.75 =    constant [?? x i8] c"abc\00"
+@string.49 =    constant [?? x i8] c"abc\00"
 
 
-@string.73 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.72 to i64) }
+@string.48 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.47 to i64) }
 
 
-@string.72 =    constant [?? x i8] c"abc\00"
-
-
-@string.70 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.69 to i64) }
-
-
-@string.69 =    constant [?? x i8] c"abc\00"
-
-
-@string.67 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.66 to i64) }
-
-
-@string.66 =    constant [?? x i8] c"abc\00"
-
-
-@string.64 =    constant {i64, i64} { i64 8, i64 ptrtoint ([?? x i8]* @string.63 to i64) }
-
-
-@string.63 =    constant [?? x i8] c"abcdefgh\00"
-
-
-@string.61 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @string.60 to i64) }
-
-
-@string.60 =    constant [?? x i8] c"cd\00"
-
-
-@string.58 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @string.57 to i64) }
-
-
-@string.57 =    constant [?? x i8] c"ab\00"
-
-
-@string.55 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @string.54 to i64) }
-
-
-@string.54 =    constant [?? x i8] c"cd\00"
-
-
-@string.52 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @string.51 to i64) }
-
-
-@string.51 =    constant [?? x i8] c"ab\00"
-
-
-@string.49 =    constant {i64, i64} { i64 26, i64 ptrtoint ([?? x i8]* @string.48 to i64) }
-
-
-@string.48 =    constant [?? x i8] c"abcdefghijklmnopqrstuvwxyz\00"
+@string.47 =    constant [?? x i8] c"abc\00"
 
 
 @string.46 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.45 to i64) }
@@ -246,73 +198,115 @@ declare external fastcc  i64 @"wybe.string.c_string<0>"(i64)
 @string.45 =    constant [?? x i8] c"abc\00"
 
 
-@string.43 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.42 to i64) }
+@string.44 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.43 to i64) }
 
 
-@string.42 =    constant [?? x i8] c"abc\00"
+@string.43 =    constant [?? x i8] c"abc\00"
 
 
-@string.40 =    constant [?? x i8] c"\0aTESTING INDEXING\00"
+@string.42 =    constant {i64, i64} { i64 8, i64 ptrtoint ([?? x i8]* @string.41 to i64) }
 
 
-@string.38 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @string.37 to i64) }
+@string.41 =    constant [?? x i8] c"abcdefgh\00"
 
 
-@string.37 =    constant [?? x i8] c"abcdefghijkl\00"
+@string.40 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @string.39 to i64) }
 
 
-@string.35 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.34 to i64) }
+@string.39 =    constant [?? x i8] c"cd\00"
 
 
-@string.34 =    constant [?? x i8] c"abc\00"
+@string.38 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @string.37 to i64) }
 
 
-@string.32 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.31 to i64) }
+@string.37 =    constant [?? x i8] c"ab\00"
 
 
-@string.31 =    constant [?? x i8] c"abc\00"
+@string.36 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @string.35 to i64) }
 
 
-@string.29 =    constant [?? x i8] c"\0aTESTING LOOPS\00"
+@string.35 =    constant [?? x i8] c"cd\00"
 
 
-@string.27 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.26 to i64) }
+@string.34 =    constant {i64, i64} { i64 2, i64 ptrtoint ([?? x i8]* @string.33 to i64) }
 
 
-@string.26 =    constant [?? x i8] c"abc\00"
+@string.33 =    constant [?? x i8] c"ab\00"
 
 
-@string.24 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.23 to i64) }
+@string.32 =    constant {i64, i64} { i64 26, i64 ptrtoint ([?? x i8]* @string.31 to i64) }
 
 
-@string.23 =    constant [?? x i8] c"efg\00"
+@string.31 =    constant [?? x i8] c"abcdefghijklmnopqrstuvwxyz\00"
 
 
-@string.21 =    constant [?? x i8] c"\0aTESTING CONVERSION TO c_string\00"
+@string.30 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.29 to i64) }
 
 
-@string.19 =    constant {i64, i64} { i64 9, i64 ptrtoint ([?? x i8]* @string.18 to i64) }
+@string.29 =    constant [?? x i8] c"abc\00"
 
 
-@string.18 =    constant [?? x i8] c"abcdefghi\00"
+@string.28 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.27 to i64) }
 
 
-@string.16 =    constant {i64, i64} { i64 9, i64 ptrtoint ([?? x i8]* @string.15 to i64) }
+@string.27 =    constant [?? x i8] c"abc\00"
 
 
-@string.15 =    constant [?? x i8] c"abcdefghi\00"
+@string.26 =    constant [?? x i8] c"\0aTESTING INDEXING\00"
 
 
-@string.13 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.12 to i64) }
+@string.25 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @string.24 to i64) }
 
 
-@string.12 =    constant [?? x i8] c"abc\00"
+@string.24 =    constant [?? x i8] c"abcdefghijkl\00"
 
 
-@string.10 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.9 to i64) }
+@string.23 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.22 to i64) }
 
 
-@string.9 =    constant [?? x i8] c"abc\00"
+@string.22 =    constant [?? x i8] c"abc\00"
+
+
+@string.21 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.20 to i64) }
+
+
+@string.20 =    constant [?? x i8] c"abc\00"
+
+
+@string.19 =    constant [?? x i8] c"\0aTESTING LOOPS\00"
+
+
+@string.18 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.17 to i64) }
+
+
+@string.17 =    constant [?? x i8] c"abc\00"
+
+
+@string.16 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.15 to i64) }
+
+
+@string.15 =    constant [?? x i8] c"efg\00"
+
+
+@string.14 =    constant [?? x i8] c"\0aTESTING CONVERSION TO c_string\00"
+
+
+@string.13 =    constant {i64, i64} { i64 9, i64 ptrtoint ([?? x i8]* @string.12 to i64) }
+
+
+@string.12 =    constant [?? x i8] c"abcdefghi\00"
+
+
+@string.11 =    constant {i64, i64} { i64 9, i64 ptrtoint ([?? x i8]* @string.10 to i64) }
+
+
+@string.10 =    constant [?? x i8] c"abcdefghi\00"
+
+
+@string.9 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.8 to i64) }
+
+
+@string.8 =    constant [?? x i8] c"abc\00"
 
 
 @string.7 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.6 to i64) }
@@ -321,10 +315,16 @@ declare external fastcc  i64 @"wybe.string.c_string<0>"(i64)
 @string.6 =    constant [?? x i8] c"abc\00"
 
 
-@string.4 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @string.3 to i64) }
+@string.5 =    constant {i64, i64} { i64 3, i64 ptrtoint ([?? x i8]* @string.4 to i64) }
 
 
-@string.3 =    constant [?? x i8] c"a\00"
+@string.4 =    constant [?? x i8] c"abc\00"
+
+
+@string.3 =    constant {i64, i64} { i64 1, i64 ptrtoint ([?? x i8]* @string.2 to i64) }
+
+
+@string.2 =    constant [?? x i8] c"a\00"
 
 
 @string.1 =    constant [?? x i8] c"TESTING CONSTRUCTION\00"
@@ -339,7 +339,7 @@ declare external fastcc  {i8, i64, i1} @"wybe.string.[|]<0>[785a827a1b]"(i64)
 declare external fastcc  {i8, i1} @"wybe.string.[]<0>"(i64, i64)    
 
 
-@string.89 =    constant [?? x i8] c"OUT OF RANGE\00"
+@string.62 =    constant [?? x i8] c"OUT OF RANGE\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -350,20 +350,15 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"string.<0>"()    {
 entry:
-  %2 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @string.1, i32 0, i32 0) to i64 
-  tail call ccc  void  @print_string(i64  %2)  
+  tail call ccc  void  @print_string(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @string.1, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  0)  
   tail call ccc  void  @putchar(i8  10)  
-  %5 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.4, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %5)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.3, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %8 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.7, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %8)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.5, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %11 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.10, i32 0, i32 0) to i64 
-  %14 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.13, i32 0, i32 0) to i64 
-  %"1#tmp#1##0" = tail call fastcc  i64  @"wybe.string.,,<0>"(i64  %11, i64  %14)  
+  %"1#tmp#1##0" = tail call fastcc  i64  @"wybe.string.,,<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.7, i32 0, i32 0) to i64), i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.9, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %"1#tmp#1##0")  
   tail call ccc  void  @putchar(i8  10)  
   %"1#tmp#105##0" = shl   i64 97, 2 
@@ -372,77 +367,55 @@ entry:
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %"1#tmp#2##0")  
   tail call ccc  void  @putchar(i8  10)  
   %"1#tmp#4##0" = tail call fastcc  i64  @"wybe.range.construct<0>"(i64  1, i64  3, i64  100)  
-  %17 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.16, i32 0, i32 0) to i64 
-  %"1#tmp#3##0" = tail call fastcc  i64  @"wybe.string.[]<1>"(i64  %17, i64  %"1#tmp#4##0")  
+  %"1#tmp#3##0" = tail call fastcc  i64  @"wybe.string.[]<1>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.11, i32 0, i32 0) to i64), i64  %"1#tmp#4##0")  
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %"1#tmp#3##0")  
   tail call ccc  void  @putchar(i8  10)  
   %"1#tmp#7##0" = tail call fastcc  i64  @"wybe.range.construct<0>"(i64  1, i64  3, i64  100)  
-  %20 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.19, i32 0, i32 0) to i64 
-  %"1#tmp#6##0" = tail call fastcc  i64  @"wybe.string.[]<1>"(i64  %20, i64  %"1#tmp#7##0")  
+  %"1#tmp#6##0" = tail call fastcc  i64  @"wybe.string.[]<1>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.13, i32 0, i32 0) to i64), i64  %"1#tmp#7##0")  
   %"1#tmp#8##0" = tail call fastcc  i64  @"wybe.range...<0>"(i64  1, i64  3)  
   %"1#tmp#5##0" = tail call fastcc  i64  @"wybe.string.[]<1>"(i64  %"1#tmp#6##0", i64  %"1#tmp#8##0")  
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %"1#tmp#5##0")  
   tail call ccc  void  @putchar(i8  10)  
-  %22 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @string.21, i32 0, i32 0) to i64 
-  tail call ccc  void  @print_string(i64  %22)  
+  tail call ccc  void  @print_string(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @string.14, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   %"1#tmp#70##0" = shl   i64 100, 2 
   %"1#tmp#71##0" = or i64 %"1#tmp#70##0", 1024 
   %"1#tmp#11##0" = or i64 %"1#tmp#71##0", 3 
   %"1#tmp#13##0" = tail call fastcc  i64  @"wybe.range...<0>"(i64  1, i64  2)  
-  %25 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.24, i32 0, i32 0) to i64 
-  %"1#tmp#12##0" = tail call fastcc  i64  @"wybe.string.[]<1>"(i64  %25, i64  %"1#tmp#13##0")  
+  %"1#tmp#12##0" = tail call fastcc  i64  @"wybe.string.[]<1>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.16, i32 0, i32 0) to i64), i64  %"1#tmp#13##0")  
   %"1#tmp#10##0" = tail call fastcc  i64  @"wybe.string.,,<0>"(i64  %"1#tmp#11##0", i64  %"1#tmp#12##0")  
-  %28 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.27, i32 0, i32 0) to i64 
-  %"1#tmp#9##0" = tail call fastcc  i64  @"wybe.string.,,<0>"(i64  %28, i64  %"1#tmp#10##0")  
+  %"1#tmp#9##0" = tail call fastcc  i64  @"wybe.string.,,<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.18, i32 0, i32 0) to i64), i64  %"1#tmp#10##0")  
   %"1#r##0" = tail call fastcc  i64  @"wybe.string.c_string<0>"(i64  %"1#tmp#9##0")  
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %"1#tmp#9##0")  
   tail call ccc  void  @putchar(i8  32)  
   tail call ccc  void  @print_string(i64  %"1#r##0")  
   tail call ccc  void  @putchar(i8  10)  
-  %30 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @string.29, i32 0, i32 0) to i64 
-  tail call ccc  void  @print_string(i64  %30)  
+  tail call ccc  void  @print_string(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @string.19, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %33 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.32, i32 0, i32 0) to i64 
-  %36 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.35, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"string.gen#1<0>"(i64  %33, i64  %36)  
+  tail call fastcc  void  @"string.gen#1<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.21, i32 0, i32 0) to i64), i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.23, i32 0, i32 0) to i64))  
   %"1#tmp#15##0" = tail call fastcc  i64  @"wybe.range.irange<0>"(i64  10, i64  -1, i64  1)  
-  %39 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.38, i32 0, i32 0) to i64 
-  %"1#tmp#14##0" = tail call fastcc  i64  @"wybe.string.[]<1>"(i64  %39, i64  %"1#tmp#15##0")  
+  %"1#tmp#14##0" = tail call fastcc  i64  @"wybe.string.[]<1>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.25, i32 0, i32 0) to i64), i64  %"1#tmp#15##0")  
   tail call fastcc  void  @"string.gen#1<0>"(i64  %"1#tmp#14##0", i64  %"1#tmp#14##0")  
-  %41 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @string.40, i32 0, i32 0) to i64 
-  tail call ccc  void  @print_string(i64  %41)  
+  tail call ccc  void  @print_string(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @string.26, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
-  %44 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.43, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"string.test_index<0>"(i64  %44, i64  0)  
-  %47 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.46, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"string.test_index<0>"(i64  %47, i64  1)  
-  %50 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.49, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"string.test_index<0>"(i64  %50, i64  25)  
-  %53 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.52, i32 0, i32 0) to i64 
-  %56 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.55, i32 0, i32 0) to i64 
-  %"1#tmp#16##0" = tail call fastcc  i64  @"wybe.string.,,<0>"(i64  %53, i64  %56)  
+  tail call fastcc  void  @"string.test_index<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.28, i32 0, i32 0) to i64), i64  0)  
+  tail call fastcc  void  @"string.test_index<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.30, i32 0, i32 0) to i64), i64  1)  
+  tail call fastcc  void  @"string.test_index<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.32, i32 0, i32 0) to i64), i64  25)  
+  %"1#tmp#16##0" = tail call fastcc  i64  @"wybe.string.,,<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.34, i32 0, i32 0) to i64), i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.36, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"string.test_index<0>"(i64  %"1#tmp#16##0", i64  1)  
-  %59 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.58, i32 0, i32 0) to i64 
-  %62 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.61, i32 0, i32 0) to i64 
-  %"1#tmp#17##0" = tail call fastcc  i64  @"wybe.string.,,<0>"(i64  %59, i64  %62)  
+  %"1#tmp#17##0" = tail call fastcc  i64  @"wybe.string.,,<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.38, i32 0, i32 0) to i64), i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.40, i32 0, i32 0) to i64))  
   tail call fastcc  void  @"string.test_index<0>"(i64  %"1#tmp#17##0", i64  2)  
   tail call fastcc  void  @"string.test_index<0>"(i64  %"1#tmp#2##0", i64  0)  
   %"1#tmp#20##0" = tail call fastcc  i64  @"wybe.range.construct<0>"(i64  0, i64  2, i64  10)  
-  %65 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.64, i32 0, i32 0) to i64 
-  %"1#tmp#19##0" = tail call fastcc  i64  @"wybe.string.[]<1>"(i64  %65, i64  %"1#tmp#20##0")  
+  %"1#tmp#19##0" = tail call fastcc  i64  @"wybe.string.[]<1>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.42, i32 0, i32 0) to i64), i64  %"1#tmp#20##0")  
   tail call fastcc  void  @"string.test_index<0>"(i64  %"1#tmp#19##0", i64  0)  
-  %68 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.67, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"string.test_index<0>"(i64  %68, i64  3)  
+  tail call fastcc  void  @"string.test_index<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.44, i32 0, i32 0) to i64), i64  3)  
   tail call fastcc  void  @"string.test_index<0>"(i64  %"1#tmp#2##0", i64  3)  
-  %71 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.70, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"string.test_index<0>"(i64  %71, i64  -3)  
+  tail call fastcc  void  @"string.test_index<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.46, i32 0, i32 0) to i64), i64  -3)  
   %"1#tmp#23##0" = tail call fastcc  i64  @"wybe.range.construct<0>"(i64  0, i64  2, i64  10)  
-  %74 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.73, i32 0, i32 0) to i64 
-  %"1#tmp#22##0" = tail call fastcc  i64  @"wybe.string.[]<1>"(i64  %74, i64  %"1#tmp#23##0")  
+  %"1#tmp#22##0" = tail call fastcc  i64  @"wybe.string.[]<1>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.48, i32 0, i32 0) to i64), i64  %"1#tmp#23##0")  
   tail call fastcc  void  @"string.test_index<0>"(i64  %"1#tmp#22##0", i64  2)  
-  %77 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.76, i32 0, i32 0) to i64 
-  %"1#tmp#24##0" = tail call fastcc  i64  @"wybe.string.,,<0>"(i64  %77, i64  %"1#tmp#2##0")  
+  %"1#tmp#24##0" = tail call fastcc  i64  @"wybe.string.,,<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @string.50, i32 0, i32 0) to i64), i64  %"1#tmp#2##0")  
   tail call fastcc  void  @"string.test_index<0>"(i64  %"1#tmp#24##0", i64  2)  
   %"1#tmp#108##0" = shl   i64 98, 2 
   %"1#tmp#109##0" = or i64 %"1#tmp#108##0", 1024 
@@ -461,14 +434,14 @@ entry:
 
 define external fastcc  void @"string.gen#1<0>"(i64  %"s##0", i64  %"tmp#0##0")    {
 entry:
-  %78 = tail call fastcc  {i8, i64, i1}  @"wybe.string.[|]<0>"(i64  %"tmp#0##0")  
-  %79 = extractvalue {i8, i64, i1} %78, 0 
-  %80 = extractvalue {i8, i64, i1} %78, 1 
-  %81 = extractvalue {i8, i64, i1} %78, 2 
-  br i1 %81, label %if.then, label %if.else 
+  %51 = tail call fastcc  {i8, i64, i1}  @"wybe.string.[|]<0>"(i64  %"tmp#0##0")  
+  %52 = extractvalue {i8, i64, i1} %51, 0 
+  %53 = extractvalue {i8, i64, i1} %51, 1 
+  %54 = extractvalue {i8, i64, i1} %51, 2 
+  br i1 %54, label %if.then, label %if.else 
 if.then:
-  tail call ccc  void  @putchar(i8  %79)  
-  tail call fastcc  void  @"string.gen#1<0>[785a827a1b]"(i64  %"s##0", i64  %80)  
+  tail call ccc  void  @putchar(i8  %52)  
+  tail call fastcc  void  @"string.gen#1<0>[785a827a1b]"(i64  %"s##0", i64  %53)  
   ret void 
 if.else:
   tail call ccc  void  @putchar(i8  10)  
@@ -478,14 +451,14 @@ if.else:
 
 define external fastcc  void @"string.gen#1<0>[785a827a1b]"(i64  %"s##0", i64  %"tmp#0##0")    {
 entry:
-  %82 = tail call fastcc  {i8, i64, i1}  @"wybe.string.[|]<0>[785a827a1b]"(i64  %"tmp#0##0")  
-  %83 = extractvalue {i8, i64, i1} %82, 0 
-  %84 = extractvalue {i8, i64, i1} %82, 1 
-  %85 = extractvalue {i8, i64, i1} %82, 2 
-  br i1 %85, label %if.then, label %if.else 
+  %55 = tail call fastcc  {i8, i64, i1}  @"wybe.string.[|]<0>[785a827a1b]"(i64  %"tmp#0##0")  
+  %56 = extractvalue {i8, i64, i1} %55, 0 
+  %57 = extractvalue {i8, i64, i1} %55, 1 
+  %58 = extractvalue {i8, i64, i1} %55, 2 
+  br i1 %58, label %if.then, label %if.else 
 if.then:
-  tail call ccc  void  @putchar(i8  %83)  
-  tail call fastcc  void  @"string.gen#1<0>[785a827a1b]"(i64  %"s##0", i64  %84)  
+  tail call ccc  void  @putchar(i8  %56)  
+  tail call fastcc  void  @"string.gen#1<0>[785a827a1b]"(i64  %"s##0", i64  %57)  
   ret void 
 if.else:
   tail call ccc  void  @putchar(i8  10)  
@@ -502,17 +475,16 @@ entry:
 
 define external fastcc  void @"string.test_index<0>"(i64  %"s##0", i64  %"i##0")    {
 entry:
-  %86 = tail call fastcc  {i8, i1}  @"wybe.string.[]<0>"(i64  %"s##0", i64  %"i##0")  
-  %87 = extractvalue {i8, i1} %86, 0 
-  %88 = extractvalue {i8, i1} %86, 1 
-  br i1 %88, label %if.then, label %if.else 
+  %59 = tail call fastcc  {i8, i1}  @"wybe.string.[]<0>"(i64  %"s##0", i64  %"i##0")  
+  %60 = extractvalue {i8, i1} %59, 0 
+  %61 = extractvalue {i8, i1} %59, 1 
+  br i1 %61, label %if.then, label %if.else 
 if.then:
-  tail call ccc  void  @putchar(i8  %87)  
+  tail call ccc  void  @putchar(i8  %60)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else:
-  %90 = ptrtoint i8* getelementptr inbounds ([?? x i8], [?? x i8]* @string.89, i32 0, i32 0) to i64 
-  tail call ccc  void  @print_string(i64  %90)  
+  tail call ccc  void  @print_string(i64  ptrtoint (i8* getelementptr inbounds ([?? x i8], [?? x i8]* @string.62, i32 0, i32 0) to i64))  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/student.exp
+++ b/test-cases/final-dump/student.exp
@@ -86,22 +86,22 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 declare external ccc  void @print_int(i64)    
 
 
-@student.37 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @student.36 to i64) }
+@student.34 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @student.33 to i64) }
 
 
-@student.36 =    constant [?? x i8] c"course name: \00"
+@student.33 =    constant [?? x i8] c"course name: \00"
 
 
-@student.31 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @student.30 to i64) }
+@student.29 =    constant {i64, i64} { i64 13, i64 ptrtoint ([?? x i8]* @student.28 to i64) }
 
 
-@student.30 =    constant [?? x i8] c"course code: \00"
+@student.28 =    constant [?? x i8] c"course code: \00"
 
 
-@student.21 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @student.20 to i64) }
+@student.20 =    constant {i64, i64} { i64 12, i64 ptrtoint ([?? x i8]* @student.19 to i64) }
 
 
-@student.20 =    constant [?? x i8] c"student id: \00"
+@student.19 =    constant [?? x i8] c"student id: \00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -121,50 +121,46 @@ entry:
   %6 = add   i64 %3, 8 
   %7 = inttoptr i64 %6 to i64* 
   %8 = getelementptr  i64, i64* %7, i64 0 
-  %11 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @student.10, i32 0, i32 0) to i64 
-  store  i64 %11, i64* %8 
-  %12 = trunc i64 16 to i32  
-  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
-  %14 = ptrtoint i8* %13 to i64 
-  %15 = inttoptr i64 %14 to i64* 
-  %16 = getelementptr  i64, i64* %15, i64 0 
-  store  i64 12345, i64* %16 
-  %17 = add   i64 %14, 8 
-  %18 = inttoptr i64 %17 to i64* 
-  %19 = getelementptr  i64, i64* %18, i64 0 
-  store  i64 %3, i64* %19 
-  tail call fastcc  void  @"student.printStudent<0>"(i64  %14)  
+  store  i64 ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @student.10, i32 0, i32 0) to i64), i64* %8 
+  %11 = trunc i64 16 to i32  
+  %12 = tail call ccc  i8*  @wybe_malloc(i32  %11)  
+  %13 = ptrtoint i8* %12 to i64 
+  %14 = inttoptr i64 %13 to i64* 
+  %15 = getelementptr  i64, i64* %14, i64 0 
+  store  i64 12345, i64* %15 
+  %16 = add   i64 %13, 8 
+  %17 = inttoptr i64 %16 to i64* 
+  %18 = getelementptr  i64, i64* %17, i64 0 
+  store  i64 %3, i64* %18 
+  tail call fastcc  void  @"student.printStudent<0>"(i64  %13)  
   ret void 
 }
 
 
 define external fastcc  void @"student.printStudent<0>"(i64  %"stu##0")    {
 entry:
-  %22 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @student.21, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %22)  
-  %23 = inttoptr i64 %"stu##0" to i64* 
-  %24 = getelementptr  i64, i64* %23, i64 0 
-  %25 = load  i64, i64* %24 
-  tail call ccc  void  @print_int(i64  %25)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @student.20, i32 0, i32 0) to i64))  
+  %21 = inttoptr i64 %"stu##0" to i64* 
+  %22 = getelementptr  i64, i64* %21, i64 0 
+  %23 = load  i64, i64* %22 
+  tail call ccc  void  @print_int(i64  %23)  
   tail call ccc  void  @putchar(i8  10)  
-  %26 = add   i64 %"stu##0", 8 
-  %27 = inttoptr i64 %26 to i64* 
-  %28 = getelementptr  i64, i64* %27, i64 0 
-  %29 = load  i64, i64* %28 
-  %32 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @student.31, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %32)  
-  %33 = inttoptr i64 %29 to i64* 
-  %34 = getelementptr  i64, i64* %33, i64 0 
-  %35 = load  i64, i64* %34 
-  tail call ccc  void  @print_int(i64  %35)  
+  %24 = add   i64 %"stu##0", 8 
+  %25 = inttoptr i64 %24 to i64* 
+  %26 = getelementptr  i64, i64* %25, i64 0 
+  %27 = load  i64, i64* %26 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @student.29, i32 0, i32 0) to i64))  
+  %30 = inttoptr i64 %27 to i64* 
+  %31 = getelementptr  i64, i64* %30, i64 0 
+  %32 = load  i64, i64* %31 
+  tail call ccc  void  @print_int(i64  %32)  
   tail call ccc  void  @putchar(i8  10)  
-  %38 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @student.37, i32 0, i32 0) to i64 
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @student.34, i32 0, i32 0) to i64))  
+  %35 = add   i64 %27, 8 
+  %36 = inttoptr i64 %35 to i64* 
+  %37 = getelementptr  i64, i64* %36, i64 0 
+  %38 = load  i64, i64* %37 
   tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %38)  
-  %39 = add   i64 %29, 8 
-  %40 = inttoptr i64 %39 to i64* 
-  %41 = getelementptr  i64, i64* %40, i64 0 
-  %42 = load  i64, i64* %41 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %42)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 }

--- a/test-cases/final-dump/submodule.exp
+++ b/test-cases/final-dump/submodule.exp
@@ -68,10 +68,10 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @submodule.privatetest.1 =    constant [?? x i8] c"private proc in a private module\00"
 
 
-@submodule.privatetest.5 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @submodule.privatetest.4 to i64) }
+@submodule.privatetest.4 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @submodule.privatetest.3 to i64) }
 
 
-@submodule.privatetest.4 =    constant [?? x i8] c"public proc in a private module\00"
+@submodule.privatetest.3 =    constant [?? x i8] c"public proc in a private module\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -82,16 +82,14 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"submodule.privatetest.hidden<0>"()    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @submodule.privatetest.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @submodule.privatetest.2, i32 0, i32 0) to i64))  
   ret void 
 }
 
 
 define external fastcc  void @"submodule.privatetest.semi_hidden<0>"()    {
 entry:
-  %6 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @submodule.privatetest.5, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %6)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @submodule.privatetest.4, i32 0, i32 0) to i64))  
   ret void 
 }
 --------------------------------------------------
@@ -137,10 +135,10 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @submodule.publictest.1 =    constant [?? x i8] c"private proc in a public module\00"
 
 
-@submodule.publictest.5 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @submodule.publictest.4 to i64) }
+@submodule.publictest.4 =    constant {i64, i64} { i64 30, i64 ptrtoint ([?? x i8]* @submodule.publictest.3 to i64) }
 
 
-@submodule.publictest.4 =    constant [?? x i8] c"public proc in a public module\00"
+@submodule.publictest.3 =    constant [?? x i8] c"public proc in a public module\00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -151,15 +149,13 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  void @"submodule.publictest.semi_visible<0>"()    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @submodule.publictest.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @submodule.publictest.2, i32 0, i32 0) to i64))  
   ret void 
 }
 
 
 define external fastcc  void @"submodule.publictest.visible<0>"()    {
 entry:
-  %6 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @submodule.publictest.5, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %6)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @submodule.publictest.4, i32 0, i32 0) to i64))  
   ret void 
 }

--- a/test-cases/final-dump/test_loop.exp
+++ b/test-cases/final-dump/test_loop.exp
@@ -126,16 +126,16 @@ declare external ccc  void @print_int(i64)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@test_loop.27 =    constant {i64, i64} { i64 39, i64 ptrtoint ([?? x i8]* @test_loop.26 to i64) }
+@test_loop.25 =    constant {i64, i64} { i64 39, i64 ptrtoint ([?? x i8]* @test_loop.24 to i64) }
 
 
-@test_loop.26 =    constant [?? x i8] c"Couldn't find even number divisible by \00"
+@test_loop.24 =    constant [?? x i8] c"Couldn't find even number divisible by \00"
 
 
-@test_loop.24 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @test_loop.23 to i64) }
+@test_loop.23 =    constant {i64, i64} { i64 4, i64 ptrtoint ([?? x i8]* @test_loop.22 to i64) }
 
 
-@test_loop.23 =    constant [?? x i8] c" is \00"
+@test_loop.22 =    constant [?? x i8] c" is \00"
 
 
 @test_loop.21 =    constant {i64, i64} { i64 31, i64 ptrtoint ([?? x i8]* @test_loop.20 to i64) }
@@ -190,17 +190,14 @@ entry:
   %19 = extractvalue {i64, i1} %17, 1 
   br i1 %19, label %if.then, label %if.else 
 if.then:
-  %22 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @test_loop.21, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %22)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @test_loop.21, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %"modulus##0")  
-  %25 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @test_loop.24, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %25)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @test_loop.23, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %18)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else:
-  %28 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @test_loop.27, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %28)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @test_loop.25, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %"modulus##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -209,59 +206,59 @@ if.else:
 
 define external fastcc  {i64, i1} @"test_loop.gen#1<0>"(i64  %"modulus##0", i64  %"seq##0")    {
 entry:
-  %29 = tail call fastcc  {i64, i64, i1}  @"test_loop.int_seq.seq_next<0>"(i64  %"seq##0")  
-  %30 = extractvalue {i64, i64, i1} %29, 0 
-  %31 = extractvalue {i64, i64, i1} %29, 1 
-  %32 = extractvalue {i64, i64, i1} %29, 2 
-  br i1 %32, label %if.then, label %if.else 
+  %26 = tail call fastcc  {i64, i64, i1}  @"test_loop.int_seq.seq_next<0>"(i64  %"seq##0")  
+  %27 = extractvalue {i64, i64, i1} %26, 0 
+  %28 = extractvalue {i64, i64, i1} %26, 1 
+  %29 = extractvalue {i64, i64, i1} %26, 2 
+  br i1 %29, label %if.then, label %if.else 
 if.then:
-  %"2#tmp#0##0" = srem i64 %31, %"modulus##0" 
+  %"2#tmp#0##0" = srem i64 %28, %"modulus##0" 
   %"2#tmp#2##0" = icmp eq i64 %"2#tmp#0##0", 0 
   br i1 %"2#tmp#2##0", label %if.then1, label %if.else1 
 if.else:
-  %40 = insertvalue {i64, i1} undef, i64 %31, 0 
-  %41 = insertvalue {i64, i1} %40, i1 0, 1 
-  ret {i64, i1} %41 
+  %37 = insertvalue {i64, i1} undef, i64 %28, 0 
+  %38 = insertvalue {i64, i1} %37, i1 0, 1 
+  ret {i64, i1} %38 
 if.then1:
-  %33 = insertvalue {i64, i1} undef, i64 %31, 0 
-  %34 = insertvalue {i64, i1} %33, i1 1, 1 
-  ret {i64, i1} %34 
+  %30 = insertvalue {i64, i1} undef, i64 %28, 0 
+  %31 = insertvalue {i64, i1} %30, i1 1, 1 
+  ret {i64, i1} %31 
 if.else1:
-  %35 = tail call fastcc  {i64, i1}  @"test_loop.gen#1<0>"(i64  %"modulus##0", i64  %30)  
-  %36 = extractvalue {i64, i1} %35, 0 
-  %37 = extractvalue {i64, i1} %35, 1 
-  %38 = insertvalue {i64, i1} undef, i64 %36, 0 
-  %39 = insertvalue {i64, i1} %38, i1 %37, 1 
-  ret {i64, i1} %39 
+  %32 = tail call fastcc  {i64, i1}  @"test_loop.gen#1<0>"(i64  %"modulus##0", i64  %27)  
+  %33 = extractvalue {i64, i1} %32, 0 
+  %34 = extractvalue {i64, i1} %32, 1 
+  %35 = insertvalue {i64, i1} undef, i64 %33, 0 
+  %36 = insertvalue {i64, i1} %35, i1 %34, 1 
+  ret {i64, i1} %36 
 }
 
 
 define external fastcc  {i64, i1} @"test_loop.gen#1<0>[6dacb8fd25]"(i64  %"modulus##0", i64  %"seq##0")    {
 entry:
-  %42 = tail call fastcc  {i64, i64, i1}  @"test_loop.int_seq.seq_next<0>[410bae77d3]"(i64  %"seq##0")  
-  %43 = extractvalue {i64, i64, i1} %42, 0 
-  %44 = extractvalue {i64, i64, i1} %42, 1 
-  %45 = extractvalue {i64, i64, i1} %42, 2 
-  br i1 %45, label %if.then, label %if.else 
+  %39 = tail call fastcc  {i64, i64, i1}  @"test_loop.int_seq.seq_next<0>[410bae77d3]"(i64  %"seq##0")  
+  %40 = extractvalue {i64, i64, i1} %39, 0 
+  %41 = extractvalue {i64, i64, i1} %39, 1 
+  %42 = extractvalue {i64, i64, i1} %39, 2 
+  br i1 %42, label %if.then, label %if.else 
 if.then:
-  %"2#tmp#0##0" = srem i64 %44, %"modulus##0" 
+  %"2#tmp#0##0" = srem i64 %41, %"modulus##0" 
   %"2#tmp#2##0" = icmp eq i64 %"2#tmp#0##0", 0 
   br i1 %"2#tmp#2##0", label %if.then1, label %if.else1 
 if.else:
-  %53 = insertvalue {i64, i1} undef, i64 %44, 0 
-  %54 = insertvalue {i64, i1} %53, i1 0, 1 
-  ret {i64, i1} %54 
+  %50 = insertvalue {i64, i1} undef, i64 %41, 0 
+  %51 = insertvalue {i64, i1} %50, i1 0, 1 
+  ret {i64, i1} %51 
 if.then1:
-  %46 = insertvalue {i64, i1} undef, i64 %44, 0 
-  %47 = insertvalue {i64, i1} %46, i1 1, 1 
-  ret {i64, i1} %47 
+  %43 = insertvalue {i64, i1} undef, i64 %41, 0 
+  %44 = insertvalue {i64, i1} %43, i1 1, 1 
+  ret {i64, i1} %44 
 if.else1:
-  %48 = tail call fastcc  {i64, i1}  @"test_loop.gen#1<0>[6dacb8fd25]"(i64  %"modulus##0", i64  %43)  
-  %49 = extractvalue {i64, i1} %48, 0 
-  %50 = extractvalue {i64, i1} %48, 1 
-  %51 = insertvalue {i64, i1} undef, i64 %49, 0 
-  %52 = insertvalue {i64, i1} %51, i1 %50, 1 
-  ret {i64, i1} %52 
+  %45 = tail call fastcc  {i64, i1}  @"test_loop.gen#1<0>[6dacb8fd25]"(i64  %"modulus##0", i64  %40)  
+  %46 = extractvalue {i64, i1} %45, 0 
+  %47 = extractvalue {i64, i1} %45, 1 
+  %48 = insertvalue {i64, i1} undef, i64 %46, 0 
+  %49 = insertvalue {i64, i1} %48, i1 %47, 1 
+  ret {i64, i1} %49 
 }
 --------------------------------------------------
  Module test_loop.int_seq

--- a/test-cases/final-dump/type_generics.exp
+++ b/test-cases/final-dump/type_generics.exp
@@ -179,16 +179,14 @@ define external fastcc  void @"type_generics.<0>"()    {
 entry:
   tail call fastcc  void  @"type_generics.foo<0>"(i64  1)  
   tail call fastcc  void  @"type_generics.foo<0>"(i64  1)  
-  %1 = bitcast double 1.000000e0 to i64 
-  tail call fastcc  void  @"type_generics.foo<0>"(i64  %1)  
-  %2 = bitcast double 1.000000e0 to i64 
-  tail call fastcc  void  @"type_generics.foo<0>"(i64  %2)  
-  %3 = tail call fastcc  {i64, i1}  @"type_generics.foo2<0>"(i64  1)  
-  %4 = extractvalue {i64, i1} %3, 0 
-  %5 = extractvalue {i64, i1} %3, 1 
-  br i1 %5, label %if.then, label %if.else 
+  tail call fastcc  void  @"type_generics.foo<0>"(i64  bitcast (double 1.000000e0 to i64))  
+  tail call fastcc  void  @"type_generics.foo<0>"(i64  bitcast (double 1.000000e0 to i64))  
+  %1 = tail call fastcc  {i64, i1}  @"type_generics.foo2<0>"(i64  1)  
+  %2 = extractvalue {i64, i1} %1, 0 
+  %3 = extractvalue {i64, i1} %1, 1 
+  br i1 %3, label %if.then, label %if.else 
 if.then:
-  tail call ccc  void  @print_int(i64  %4)  
+  tail call ccc  void  @print_int(i64  %2)  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"type_generics.gen#1<0>"()  
   ret void 
@@ -200,17 +198,17 @@ if.else:
 
 define external fastcc  void @"type_generics.foo<0>"(i64  %"x##0")    {
 entry:
-  %6 = trunc i64 16 to i32  
-  %7 = tail call ccc  i8*  @wybe_malloc(i32  %6)  
-  %8 = ptrtoint i8* %7 to i64 
-  %9 = inttoptr i64 %8 to i64* 
-  %10 = getelementptr  i64, i64* %9, i64 0 
-  store  i64 %"x##0", i64* %10 
-  %11 = add   i64 %8, 8 
-  %12 = inttoptr i64 %11 to i64* 
-  %13 = getelementptr  i64, i64* %12, i64 0 
-  store  i64 0, i64* %13 
-  %"1#tmp#2##0" = tail call fastcc  i64  @"wybe.list.length1<0>"(i64  %8, i64  0)  
+  %4 = trunc i64 16 to i32  
+  %5 = tail call ccc  i8*  @wybe_malloc(i32  %4)  
+  %6 = ptrtoint i8* %5 to i64 
+  %7 = inttoptr i64 %6 to i64* 
+  %8 = getelementptr  i64, i64* %7, i64 0 
+  store  i64 %"x##0", i64* %8 
+  %9 = add   i64 %6, 8 
+  %10 = inttoptr i64 %9 to i64* 
+  %11 = getelementptr  i64, i64* %10, i64 0 
+  store  i64 0, i64* %11 
+  %"1#tmp#2##0" = tail call fastcc  i64  @"wybe.list.length1<0>"(i64  %6, i64  0)  
   tail call ccc  void  @print_int(i64  %"1#tmp#2##0")  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
@@ -219,40 +217,40 @@ entry:
 
 define external fastcc  {i64, i1} @"type_generics.foo2<0>"(i64  %"x##0")    {
 entry:
-  %14 = trunc i64 16 to i32  
-  %15 = tail call ccc  i8*  @wybe_malloc(i32  %14)  
-  %16 = ptrtoint i8* %15 to i64 
-  %17 = inttoptr i64 %16 to i64* 
-  %18 = getelementptr  i64, i64* %17, i64 0 
-  store  i64 %"x##0", i64* %18 
-  %19 = add   i64 %16, 8 
-  %20 = inttoptr i64 %19 to i64* 
-  %21 = getelementptr  i64, i64* %20, i64 0 
-  store  i64 0, i64* %21 
-  %"1#tmp#9##0" = icmp ne i64 %16, 0 
+  %12 = trunc i64 16 to i32  
+  %13 = tail call ccc  i8*  @wybe_malloc(i32  %12)  
+  %14 = ptrtoint i8* %13 to i64 
+  %15 = inttoptr i64 %14 to i64* 
+  %16 = getelementptr  i64, i64* %15, i64 0 
+  store  i64 %"x##0", i64* %16 
+  %17 = add   i64 %14, 8 
+  %18 = inttoptr i64 %17 to i64* 
+  %19 = getelementptr  i64, i64* %18, i64 0 
+  store  i64 0, i64* %19 
+  %"1#tmp#9##0" = icmp ne i64 %14, 0 
   br i1 %"1#tmp#9##0", label %if.then, label %if.else 
 if.then:
-  %22 = inttoptr i64 %16 to i64* 
-  %23 = getelementptr  i64, i64* %22, i64 0 
-  %24 = load  i64, i64* %23 
-  %25 = insertvalue {i64, i1} undef, i64 %24, 0 
-  %26 = insertvalue {i64, i1} %25, i1 1, 1 
-  ret {i64, i1} %26 
+  %20 = inttoptr i64 %14 to i64* 
+  %21 = getelementptr  i64, i64* %20, i64 0 
+  %22 = load  i64, i64* %21 
+  %23 = insertvalue {i64, i1} undef, i64 %22, 0 
+  %24 = insertvalue {i64, i1} %23, i1 1, 1 
+  ret {i64, i1} %24 
 if.else:
-  %27 = insertvalue {i64, i1} undef, i64 undef, 0 
-  %28 = insertvalue {i64, i1} %27, i1 0, 1 
-  ret {i64, i1} %28 
+  %25 = insertvalue {i64, i1} undef, i64 undef, 0 
+  %26 = insertvalue {i64, i1} %25, i1 0, 1 
+  ret {i64, i1} %26 
 }
 
 
 define external fastcc  void @"type_generics.gen#1<0>"()    {
 entry:
-  %29 = tail call fastcc  {i64, i1}  @"type_generics.foo2<0>"(i64  1)  
-  %30 = extractvalue {i64, i1} %29, 0 
-  %31 = extractvalue {i64, i1} %29, 1 
-  br i1 %31, label %if.then, label %if.else 
+  %27 = tail call fastcc  {i64, i1}  @"type_generics.foo2<0>"(i64  1)  
+  %28 = extractvalue {i64, i1} %27, 0 
+  %29 = extractvalue {i64, i1} %27, 1 
+  br i1 %29, label %if.then, label %if.else 
 if.then:
-  tail call ccc  void  @print_int(i64  %30)  
+  tail call ccc  void  @print_int(i64  %28)  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"type_generics.gen#2<0>"()  
   ret void 
@@ -264,14 +262,13 @@ if.else:
 
 define external fastcc  void @"type_generics.gen#2<0>"()    {
 entry:
-  %32 = bitcast double 1.000000e0 to i64 
-  %33 = tail call fastcc  {i64, i1}  @"type_generics.foo2<0>"(i64  %32)  
-  %34 = extractvalue {i64, i1} %33, 0 
-  %35 = extractvalue {i64, i1} %33, 1 
-  br i1 %35, label %if.then, label %if.else 
+  %30 = tail call fastcc  {i64, i1}  @"type_generics.foo2<0>"(i64  bitcast (double 1.000000e0 to i64))  
+  %31 = extractvalue {i64, i1} %30, 0 
+  %32 = extractvalue {i64, i1} %30, 1 
+  br i1 %32, label %if.then, label %if.else 
 if.then:
-  %36 = bitcast i64 %34 to double 
-  tail call ccc  void  @print_float(double  %36)  
+  %33 = bitcast i64 %31 to double 
+  tail call ccc  void  @print_float(double  %33)  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"type_generics.gen#3<0>"()  
   ret void 
@@ -283,14 +280,13 @@ if.else:
 
 define external fastcc  void @"type_generics.gen#3<0>"()    {
 entry:
-  %37 = bitcast double 1.000000e0 to i64 
-  %38 = tail call fastcc  {i64, i1}  @"type_generics.foo2<0>"(i64  %37)  
-  %39 = extractvalue {i64, i1} %38, 0 
-  %40 = extractvalue {i64, i1} %38, 1 
-  br i1 %40, label %if.then, label %if.else 
+  %34 = tail call fastcc  {i64, i1}  @"type_generics.foo2<0>"(i64  bitcast (double 1.000000e0 to i64))  
+  %35 = extractvalue {i64, i1} %34, 0 
+  %36 = extractvalue {i64, i1} %34, 1 
+  br i1 %36, label %if.then, label %if.else 
 if.then:
-  %41 = bitcast i64 %39 to double 
-  tail call ccc  void  @print_float(double  %41)  
+  %37 = bitcast i64 %35 to double 
+  tail call ccc  void  @print_float(double  %37)  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"type_generics.gen#4<0>"()  
   ret void 
@@ -302,13 +298,13 @@ if.else:
 
 define external fastcc  void @"type_generics.gen#4<0>"()    {
 entry:
-  %42 = tail call fastcc  {i64, i1}  @"type_generics.foo2<0>"(i64  97)  
-  %43 = extractvalue {i64, i1} %42, 0 
-  %44 = extractvalue {i64, i1} %42, 1 
-  br i1 %44, label %if.then, label %if.else 
+  %38 = tail call fastcc  {i64, i1}  @"type_generics.foo2<0>"(i64  97)  
+  %39 = extractvalue {i64, i1} %38, 0 
+  %40 = extractvalue {i64, i1} %38, 1 
+  br i1 %40, label %if.then, label %if.else 
 if.then:
-  %45 = trunc i64 %43 to i8  
-  tail call ccc  void  @putchar(i8  %45)  
+  %41 = trunc i64 %39 to i8  
+  tail call ccc  void  @putchar(i8  %41)  
   tail call ccc  void  @putchar(i8  10)  
   tail call fastcc  void  @"type_generics.gen#5<0>"()  
   ret void 
@@ -320,13 +316,13 @@ if.else:
 
 define external fastcc  void @"type_generics.gen#5<0>"()    {
 entry:
-  %46 = tail call fastcc  {i64, i1}  @"type_generics.foo2<0>"(i64  0)  
-  %47 = extractvalue {i64, i1} %46, 0 
-  %48 = extractvalue {i64, i1} %46, 1 
-  br i1 %48, label %if.then, label %if.else 
+  %42 = tail call fastcc  {i64, i1}  @"type_generics.foo2<0>"(i64  0)  
+  %43 = extractvalue {i64, i1} %42, 0 
+  %44 = extractvalue {i64, i1} %42, 1 
+  br i1 %44, label %if.then, label %if.else 
 if.then:
-  %49 = trunc i64 %47 to i1  
-  tail call fastcc  void  @"wybe.io.print<5>"(i1  %49)  
+  %45 = trunc i64 %43 to i1  
+  tail call fastcc  void  @"wybe.io.print<5>"(i1  %45)  
   tail call ccc  void  @putchar(i8  10)  
   ret void 
 if.else:

--- a/test-cases/final-dump/use_resource.exp
+++ b/test-cases/final-dump/use_resource.exp
@@ -65,10 +65,10 @@ declare external ccc  void @print_int(i64)
 declare external fastcc  void @"wybe.string.print_string<0>"(i64)    
 
 
-@use_resource.5 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @use_resource.4 to i64) }
+@use_resource.4 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @use_resource.3 to i64) }
 
 
-@use_resource.4 =    constant [?? x i8] c"Outer count (1): \00"
+@use_resource.3 =    constant [?? x i8] c"Outer count (1): \00"
 
 
 @use_resource.2 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @use_resource.1 to i64) }
@@ -77,16 +77,16 @@ declare external fastcc  void @"wybe.string.print_string<0>"(i64)
 @use_resource.1 =    constant [?? x i8] c"Inner count (4): \00"
 
 
-@use_resource.11 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @use_resource.10 to i64) }
-
-
-@use_resource.10 =    constant [?? x i8] c"Outer count (1): \00"
-
-
 @use_resource.8 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @use_resource.7 to i64) }
 
 
-@use_resource.7 =    constant [?? x i8] c"Inner count (4): \00"
+@use_resource.7 =    constant [?? x i8] c"Outer count (1): \00"
+
+
+@use_resource.6 =    constant {i64, i64} { i64 17, i64 ptrtoint ([?? x i8]* @use_resource.5 to i64) }
+
+
+@use_resource.5 =    constant [?? x i8] c"Inner count (4): \00"
 
 
 declare external ccc  i8* @wybe_malloc(i32)    
@@ -97,12 +97,10 @@ declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)
 
 define external fastcc  i64 @"use_resource.<0>"()    {
 entry:
-  %3 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @use_resource.2, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %3)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @use_resource.2, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  4)  
   tail call ccc  void  @putchar(i8  10)  
-  %6 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @use_resource.5, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %6)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @use_resource.4, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  1)  
   tail call ccc  void  @putchar(i8  10)  
   ret i64 1 
@@ -122,12 +120,10 @@ entry:
   %"1#count##2" = add   i64 %"1#count##1", 1 
   %"1#count##3" = add   i64 %"1#count##2", 1 
   %"1#count##4" = add   i64 %"1#count##3", 1 
-  %9 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @use_resource.8, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %9)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @use_resource.6, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %"1#count##4")  
   tail call ccc  void  @putchar(i8  10)  
-  %12 = ptrtoint i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @use_resource.11, i32 0, i32 0) to i64 
-  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  %12)  
+  tail call fastcc  void  @"wybe.string.print_string<0>"(i64  ptrtoint (i64* getelementptr inbounds ({i64, i64}, {i64, i64}* @use_resource.8, i32 0, i32 0) to i64))  
   tail call ccc  void  @print_int(i64  %"1#count##1")  
   tail call ccc  void  @putchar(i8  10)  
   ret i64 %"1#count##1" 


### PR DESCRIPTION
This PR refactors how code generation works, especially in the case of constant prim arguments. 

When an argument is constant, casts and such no longer generate a name (`%n`) for LPVM operands, and instead are performed via LPVM constants.

This does not change does not have large effects now, however I foresee it being useful for myself to generate different code for constant or variable closures in the future.