### PR TITLE
Changed the notation for type variables

### DIFF
--- a/WYBE.md
+++ b/WYBE.md
@@ -1039,10 +1039,10 @@ be placed in a Wybe source file to define a linked list type with whatever name
 is deemed suitable.
 
 ```
-constructors(?T) null | cons(head:?T, tail:_(?T))
+constructors(T) null | cons(head:T, tail:_(T))
 
 
-def concat(a:_(?T), b:_(?T)):_(?T) =
+def concat(a:_(T), b:_(T)):_(T) =
     if cons(?h, ?t) = a then cons(h, concat(t,b)) else b
 ```
 
@@ -1083,11 +1083,10 @@ element type, without the need to separately define different kinds of lists, or
 the operations on them.
 
 The basis of generic types is the *type variable*, which stands for a type we
-don't know yet, and thus is a variable in the type system.  A type variable
-follows the same naming convention as normal program variables, except they are
-always preceded with a question mark.  Since we rarely have more than one or two
-type variables in any given context, we conventionally use a single upper case
-letter for a type variable.
+don't know yet, and thus is a variable in the type system.  A type variable is
+denoted by an uppercase letter followed by zero or more numbers.  Since we 
+rarely have more than one or two type variables in any given context, we 
+conventionally use a single upper case letter for a type variable.
 
 Generic types are defined in the same way as described above, except that:
 
@@ -1099,13 +1098,13 @@ Generic types are defined in the same way as described above, except that:
 For example, a generic list type can be defined as:
 
 ```
-constructors(?T) null | cons(head:?T, tail:_(?T))
+constructors(T) null | cons(head:T, tail:_(T))
 ```
 
 If specified with a `type` declaration, this would be written:
 
 ```
-type list(?T) {null | cons(head:?T, tail:_(?T)) ... }
+type list(T) {null | cons(head:T, tail:_(T)) ... }
 ```
 
 All type variables appearing in the definition of any constructor must appear in
@@ -1116,7 +1115,7 @@ variables.  Each occurrence of the same type variable must signify the same
 type.  For example, you can define list concatenation:
 
 ```
-def concat(a:list(?T), b:list(?T)):list(?T) =
+def concat(a:list(T), b:list(T)):list(T) =
     if { cons(?h, ?t) = a:: cons(h, concat(t,b)) | else:: b }
 ```
 

--- a/src/AST.hs
+++ b/src/AST.hs
@@ -3122,7 +3122,7 @@ showProcDef thisID
 instance Show TypeSpec where
   show AnyType              = "any"
   show InvalidType          = "XXX"
-  show (TypeVariable name)  = "?" ++ show name
+  show (TypeVariable name)  = show name
   show (Representation rep) = show rep
   show (TypeSpec optmod ident args) =
       maybeModPrefix optmod ++ ident ++ showArguments args

--- a/src/Snippets.hs
+++ b/src/Snippets.hs
@@ -7,7 +7,7 @@
 
 module Snippets (castFromTo, castTo, withType, intType, intCast,
                  tagType, tagCast, phantomType, stringType, cStringType,
-                 varSet, varGet, varGetSet,
+                 isTypeVar, varSet, varGet, varGetSet,
                  boolType, boolCast, boolTrue, boolFalse, boolBool,
                  boolVarSet, boolVarGet, intVarSet, intVarGet,
                  lpvmCast, lpvmCastExp, lpvmCastToVar, iVal, move, primMove,
@@ -15,6 +15,7 @@ module Snippets (castFromTo, castTo, withType, intType, intCast,
 
 import AST
 import Data.String (String)
+import Data.Char (isUpper, isDigit)
 
 -- |An expression to cast a value to the specified type
 castFromTo :: TypeSpec -> TypeSpec -> Exp -> Exp
@@ -75,6 +76,11 @@ stringType = TypeSpec ["wybe"] "string" []
 -- | The c_string type, a C string
 cStringType :: TypeSpec
 cStringType = TypeSpec ["wybe"] "c_string" []
+
+-- | Is the given string a type variable name
+isTypeVar :: String -> Bool
+isTypeVar (alpha:digits) | isUpper alpha && all isDigit digits = True
+isTypeVar _                                                    = False
 
 -- |An output variable reference (lvalue)
 varSet :: Ident -> Exp

--- a/test-cases/complex/exp/testcase_multi_specz-drone.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-drone.exp
@@ -86,10 +86,10 @@ LLVM code       : None
 (argc##0:wybe.int, [?argc##0:wybe.int], ?arguments##1:wybe.array(wybe.c_string), argv##0:wybe.array.raw_array(wybe.c_string), [?argv##0:wybe.array.raw_array(wybe.c_string)], ?command##1:wybe.c_string, ?exit_code##0:wybe.int, io##0:wybe.phantom, [?io##0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:wybe.array(?T))
-    foreign lpvm mutate(~tmp#4##0:wybe.array(?T), ?tmp#5##0:wybe.array(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
-    foreign lpvm mutate(~tmp#5##0:wybe.array(?T), ?tmp#0##0:wybe.array(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(?T))
-    wybe.array.[|]<0>(?command##1:?T, ?arguments##1:wybe.array(?T), ~tmp#0##0:wybe.array(?T), ?tmp#1##0:wybe.bool) #1 @command_line:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:wybe.array(T))
+    foreign lpvm mutate(~tmp#4##0:wybe.array(T), ?tmp#5##0:wybe.array(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
+    foreign lpvm mutate(~tmp#5##0:wybe.array(T), ?tmp#0##0:wybe.array(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(T))
+    wybe.array.[|]<0>(?command##1:T, ?arguments##1:wybe.array(T), ~tmp#0##0:wybe.array(T), ?tmp#1##0:wybe.bool) #1 @command_line:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
         foreign c {terminal,semipure} error_exit(c"command_line:17:6":wybe.c_string, c"Erroneous program argument vector":wybe.c_string) @control:nn:nn
@@ -687,10 +687,10 @@ entry:
 (argc##0:wybe.int, [?argc##0:wybe.int], ?arguments##1:wybe.array(wybe.c_string), argv##0:wybe.array.raw_array(wybe.c_string), [?argv##0:wybe.array.raw_array(wybe.c_string)], ?command##1:wybe.c_string, ?exit_code##0:wybe.int, io##0:wybe.phantom, [?io##0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:wybe.array(?T))
-    foreign lpvm mutate(~tmp#4##0:wybe.array(?T), ?tmp#5##0:wybe.array(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
-    foreign lpvm mutate(~tmp#5##0:wybe.array(?T), ?tmp#0##0:wybe.array(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(?T))
-    wybe.array.[|]<0>(?command##1:?T, ?arguments##1:wybe.array(?T), ~tmp#0##0:wybe.array(?T), ?tmp#1##0:wybe.bool) #1 @command_line:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:wybe.array(T))
+    foreign lpvm mutate(~tmp#4##0:wybe.array(T), ?tmp#5##0:wybe.array(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
+    foreign lpvm mutate(~tmp#5##0:wybe.array(T), ?tmp#0##0:wybe.array(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(T))
+    wybe.array.[|]<0>(?command##1:T, ?arguments##1:wybe.array(T), ~tmp#0##0:wybe.array(T), ?tmp#1##0:wybe.bool) #1 @command_line:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
         foreign c {terminal,semipure} error_exit(c"command_line:17:6":wybe.c_string, c"Erroneous program argument vector":wybe.c_string) @control:nn:nn

--- a/test-cases/complex/exp/testcase_multi_specz-int_list.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-int_list.exp
@@ -155,10 +155,10 @@ LLVM code       : None
 (argc##0:wybe.int, [?argc##0:wybe.int], ?arguments##1:wybe.array(wybe.c_string), argv##0:wybe.array.raw_array(wybe.c_string), [?argv##0:wybe.array.raw_array(wybe.c_string)], ?command##1:wybe.c_string, ?exit_code##0:wybe.int, io##0:wybe.phantom, [?io##0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:wybe.array(?T))
-    foreign lpvm mutate(~tmp#4##0:wybe.array(?T), ?tmp#5##0:wybe.array(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
-    foreign lpvm mutate(~tmp#5##0:wybe.array(?T), ?tmp#0##0:wybe.array(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(?T))
-    wybe.array.[|]<0>(?command##1:?T, ?arguments##1:wybe.array(?T), ~tmp#0##0:wybe.array(?T), ?tmp#1##0:wybe.bool) #1 @command_line:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:wybe.array(T))
+    foreign lpvm mutate(~tmp#4##0:wybe.array(T), ?tmp#5##0:wybe.array(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
+    foreign lpvm mutate(~tmp#5##0:wybe.array(T), ?tmp#0##0:wybe.array(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(T))
+    wybe.array.[|]<0>(?command##1:T, ?arguments##1:wybe.array(T), ~tmp#0##0:wybe.array(T), ?tmp#1##0:wybe.bool) #1 @command_line:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
         foreign c {terminal,semipure} error_exit(c"command_line:17:6":wybe.c_string, c"Erroneous program argument vector":wybe.c_string) @control:nn:nn
@@ -1007,10 +1007,10 @@ entry:
 (argc##0:wybe.int, [?argc##0:wybe.int], ?arguments##1:wybe.array(wybe.c_string), argv##0:wybe.array.raw_array(wybe.c_string), [?argv##0:wybe.array.raw_array(wybe.c_string)], ?command##1:wybe.c_string, ?exit_code##0:wybe.int, io##0:wybe.phantom, [?io##0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:wybe.array(?T))
-    foreign lpvm mutate(~tmp#4##0:wybe.array(?T), ?tmp#5##0:wybe.array(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
-    foreign lpvm mutate(~tmp#5##0:wybe.array(?T), ?tmp#0##0:wybe.array(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(?T))
-    wybe.array.[|]<0>(?command##1:?T, ?arguments##1:wybe.array(?T), ~tmp#0##0:wybe.array(?T), ?tmp#1##0:wybe.bool) #1 @command_line:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:wybe.array(T))
+    foreign lpvm mutate(~tmp#4##0:wybe.array(T), ?tmp#5##0:wybe.array(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
+    foreign lpvm mutate(~tmp#5##0:wybe.array(T), ?tmp#0##0:wybe.array(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(T))
+    wybe.array.[|]<0>(?command##1:T, ?arguments##1:wybe.array(T), ~tmp#0##0:wybe.array(T), ?tmp#1##0:wybe.bool) #1 @command_line:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
         foreign c {terminal,semipure} error_exit(c"command_line:17:6":wybe.c_string, c"Erroneous program argument vector":wybe.c_string) @control:nn:nn

--- a/test-cases/execution/type_generics.wybe
+++ b/test-cases/execution/type_generics.wybe
@@ -1,4 +1,4 @@
-def foo(x:?t) use !io {
+def foo(x:T) use !io {
     ?l = [x]
     !println(length(l))
 }
@@ -8,7 +8,7 @@ def foo(x:?t) use !io {
 !foo(1.0)
 ?x = 1.0; !foo(x) 
 
-def {test} foo2(x:?T, ?y:?T) {
+def {test} foo2(x:T0, ?y:T0) {
     ?l = [x]
     [?y|_] = l
 }

--- a/test-cases/final-dump/anon_field_variable.exp
+++ b/test-cases/final-dump/anon_field_variable.exp
@@ -18,8 +18,8 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?tmp#4##0:anon_field_variable(?T))
-    foreign lpvm mutate(~tmp#4##0:anon_field_variable(?T), ?tmp#0##0:anon_field_variable(?T), 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 0:?T)
+    foreign lpvm alloc(8:wybe.int, ?tmp#4##0:anon_field_variable(T))
+    foreign lpvm mutate(~tmp#4##0:anon_field_variable(T), ?tmp#0##0:anon_field_variable(T), 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 0:T)
     foreign llvm and(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#6##0:wybe.int)
     foreign llvm icmp_eq(~tmp#6##0:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.bool)
     case ~tmp#7##0:wybe.bool of
@@ -34,17 +34,17 @@ AFTER EVERYTHING:
 
 bar > public {inline} (0 calls)
 0: anon_field_variable.bar<0>
-bar(bar#1##0:wybe.int, field##0:?T, bar#3##0:?T, ?#result##0:anon_field_variable(?T)):
+bar(bar#1##0:wybe.int, field##0:T, bar#3##0:T, ?#result##0:anon_field_variable(T)):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(24:wybe.int, ?#rec##0:anon_field_variable(?T))
-    foreign lpvm mutate(~#rec##0:anon_field_variable(?T), ?#rec##1:anon_field_variable(?T), 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~bar#1##0:wybe.int)
-    foreign lpvm mutate(~#rec##1:anon_field_variable(?T), ?#rec##2:anon_field_variable(?T), 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~field##0:?T)
-    foreign lpvm mutate(~#rec##2:anon_field_variable(?T), ?#rec##3:anon_field_variable(?T), 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~bar#3##0:?T)
-    foreign llvm or(~#rec##3:anon_field_variable(?T), 1:wybe.int, ?#result##0:anon_field_variable(?T))
+    foreign lpvm alloc(24:wybe.int, ?#rec##0:anon_field_variable(T))
+    foreign lpvm mutate(~#rec##0:anon_field_variable(T), ?#rec##1:anon_field_variable(T), 0:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~bar#1##0:wybe.int)
+    foreign lpvm mutate(~#rec##1:anon_field_variable(T), ?#rec##2:anon_field_variable(T), 8:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~field##0:T)
+    foreign lpvm mutate(~#rec##2:anon_field_variable(T), ?#rec##3:anon_field_variable(T), 16:wybe.int, 1:wybe.int, 24:wybe.int, 0:wybe.int, ~bar#3##0:T)
+    foreign llvm or(~#rec##3:anon_field_variable(T), 1:wybe.int, ?#result##0:anon_field_variable(T))
 bar > public {inline} (0 calls)
 1: anon_field_variable.bar<1>
-bar(?bar#1##0:wybe.int, ?field##0:?T, ?bar#3##0:?T, #result##0:anon_field_variable(?T), ?#success##0:wybe.bool):
+bar(?bar#1##0:wybe.int, ?field##0:T, ?bar#3##0:T, #result##0:anon_field_variable(T), ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#result##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int)
@@ -53,20 +53,20 @@ bar(?bar#1##0:wybe.int, ?field##0:?T, ?bar#3##0:?T, #result##0:anon_field_variab
     0:
         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(undef:wybe.int, ?bar#1##0:wybe.int)
-        foreign llvm move(undef:?T, ?field##0:?T)
-        foreign llvm move(undef:?T, ?bar#3##0:?T)
+        foreign llvm move(undef:T, ?field##0:T)
+        foreign llvm move(undef:T, ?bar#3##0:T)
 
     1:
-        foreign lpvm access(#result##0:anon_field_variable(?T), -1:wybe.int, 24:wybe.int, 1:wybe.int, ?bar#1##0:wybe.int)
-        foreign lpvm access(#result##0:anon_field_variable(?T), 7:wybe.int, 24:wybe.int, 1:wybe.int, ?field##0:?T)
-        foreign lpvm access(~#result##0:anon_field_variable(?T), 15:wybe.int, 24:wybe.int, 1:wybe.int, ?bar#3##0:?T)
+        foreign lpvm access(#result##0:anon_field_variable(T), -1:wybe.int, 24:wybe.int, 1:wybe.int, ?bar#1##0:wybe.int)
+        foreign lpvm access(#result##0:anon_field_variable(T), 7:wybe.int, 24:wybe.int, 1:wybe.int, ?field##0:T)
+        foreign lpvm access(~#result##0:anon_field_variable(T), 15:wybe.int, 24:wybe.int, 1:wybe.int, ?bar#3##0:T)
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 field > {inline} (0 calls)
 0: anon_field_variable.field<0>
-field(#rec##0:anon_field_variable(?T), ?#result##0:?T, ?#success##0:wybe.bool):
+field(#rec##0:anon_field_variable(T), ?#result##0:T, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int)
@@ -74,15 +74,15 @@ field(#rec##0:anon_field_variable(?T), ?#result##0:?T, ?#success##0:wybe.bool):
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
-        foreign llvm move(undef:?T, ?#result##0:?T)
+        foreign llvm move(undef:T, ?#result##0:T)
 
     1:
-        foreign lpvm access(~#rec##0:anon_field_variable(?T), 7:wybe.int, 24:wybe.int, 1:wybe.int, ?#result##0:?T)
+        foreign lpvm access(~#rec##0:anon_field_variable(T), 7:wybe.int, 24:wybe.int, 1:wybe.int, ?#result##0:T)
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 field > {inline} (0 calls)
 1: anon_field_variable.field<1>
-field(#rec##0:anon_field_variable(?T), ?#rec##1:anon_field_variable(?T), #field##0:?T, ?#success##0:wybe.bool):
+field(#rec##0:anon_field_variable(T), ?#rec##1:anon_field_variable(T), #field##0:T, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#rec##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int)
@@ -90,24 +90,24 @@ field(#rec##0:anon_field_variable(?T), ?#rec##1:anon_field_variable(?T), #field#
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
-        foreign llvm move(~#rec##0:anon_field_variable(?T), ?#rec##1:anon_field_variable(?T))
+        foreign llvm move(~#rec##0:anon_field_variable(T), ?#rec##1:anon_field_variable(T))
 
     1:
-        foreign lpvm {noalias} mutate(~#rec##0:anon_field_variable(?T), ?#rec##1:anon_field_variable(?T), 7:wybe.int, 0:wybe.int, 24:wybe.int, 1:wybe.int, ~#field##0:?T)
+        foreign lpvm {noalias} mutate(~#rec##0:anon_field_variable(T), ?#rec##1:anon_field_variable(T), 7:wybe.int, 0:wybe.int, 24:wybe.int, 1:wybe.int, ~#field##0:T)
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 foo > public {inline} (3 calls)
 0: anon_field_variable.foo<0>
-foo(foo#1##0:?T, ?#result##0:anon_field_variable(?T)):
+foo(foo#1##0:T, ?#result##0:anon_field_variable(T)):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(8:wybe.int, ?#rec##0:anon_field_variable(?T))
-    foreign lpvm mutate(~#rec##0:anon_field_variable(?T), ?#result##0:anon_field_variable(?T), 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~foo#1##0:?T)
+    foreign lpvm alloc(8:wybe.int, ?#rec##0:anon_field_variable(T))
+    foreign lpvm mutate(~#rec##0:anon_field_variable(T), ?#result##0:anon_field_variable(T), 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, ~foo#1##0:T)
 foo > public {inline} (3 calls)
 1: anon_field_variable.foo<1>
-foo(?foo#1##0:?T, #result##0:anon_field_variable(?T), ?#success##0:wybe.bool):
+foo(?foo#1##0:T, #result##0:anon_field_variable(T), ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm and(#result##0:wybe.int, 1:wybe.int, ?tmp#1##0:wybe.int)
@@ -115,10 +115,10 @@ foo(?foo#1##0:?T, #result##0:anon_field_variable(?T), ?#success##0:wybe.bool):
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
-        foreign llvm move(undef:?T, ?foo#1##0:?T)
+        foreign llvm move(undef:T, ?foo#1##0:T)
 
     1:
-        foreign lpvm access(~#result##0:anon_field_variable(?T), 0:wybe.int, 8:wybe.int, 0:wybe.int, ?foo#1##0:?T)
+        foreign lpvm access(~#result##0:anon_field_variable(T), 0:wybe.int, 8:wybe.int, 0:wybe.int, ?foo#1##0:T)
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 

--- a/test-cases/final-dump/anon_field_variable.wybe
+++ b/test-cases/final-dump/anon_field_variable.wybe
@@ -1,5 +1,5 @@
 
-constructors (?T) foo(?T) | bar(int, field:?T, ?T) 
+constructors (T) foo(T) | bar(int, field:T, T) 
 
 ?t = foo(false)
 if { t = foo(?_) :: !println("foo") }

--- a/test-cases/final-dump/bad_module_name.exp
+++ b/test-cases/final-dump/bad_module_name.exp
@@ -1,0 +1,3 @@
+Error detected during loading module: bad_module_name
+[91mfinal-dump/bad_module_name.wybe:3:8: Syntax error: unexpected identifier T0
+[0m

--- a/test-cases/final-dump/bad_module_name.wybe
+++ b/test-cases/final-dump/bad_module_name.wybe
@@ -1,0 +1,3 @@
+# this tests bad module names, that is, module names that look like type variables
+
+module T0 { }

--- a/test-cases/final-dump/generic_list.exp
+++ b/test-cases/final-dump/generic_list.exp
@@ -19,127 +19,127 @@ AFTER EVERYTHING:
 
 append > public (1 calls)
 0: generic_list.append<0>
-append(x##0:generic_list(?T), y##0:generic_list(?T), ?#result##0:generic_list(?T)):
+append(x##0:generic_list(T), y##0:generic_list(T), ?#result##0:generic_list(T)):
  AliasPairs: [(#result##0,y##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(generic_list.append<0>,fromList [NonAliasedParamCond 0 [0]]))]
     foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
     case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~y##0:generic_list(?T), ?#result##0:generic_list(?T)) @generic_list:nn:nn
+        foreign llvm move(~y##0:generic_list(T), ?#result##0:generic_list(T)) @generic_list:nn:nn
 
     1:
-        foreign lpvm access(x##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:?T)
-        foreign lpvm access(~x##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
-        generic_list.append<0>(~t##0:generic_list(?T), ~y##0:generic_list(?T), ?tmp#2##0:generic_list(?T)) #1 @generic_list:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:generic_list(?T))
-        foreign lpvm mutate(~tmp#8##0:generic_list(?T), ?tmp#9##0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:?T)
-        foreign lpvm mutate(~tmp#9##0:generic_list(?T), ?#result##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:generic_list(?T))
+        foreign lpvm access(x##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:T)
+        foreign lpvm access(~x##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T))
+        generic_list.append<0>(~t##0:generic_list(T), ~y##0:generic_list(T), ?tmp#2##0:generic_list(T)) #1 @generic_list:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:generic_list(T))
+        foreign lpvm mutate(~tmp#8##0:generic_list(T), ?tmp#9##0:generic_list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:T)
+        foreign lpvm mutate(~tmp#9##0:generic_list(T), ?#result##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:generic_list(T))
 
 
 
 car > public {inline} (0 calls)
 0: generic_list.car<0>
-car(#rec##0:generic_list(?T), ?#result##0:?T, ?#success##0:wybe.bool):
+car(#rec##0:generic_list(T), ?#result##0:T, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
-        foreign llvm move(undef:?T, ?#result##0:?T)
+        foreign llvm move(undef:T, ?#result##0:T)
 
     1:
-        foreign lpvm access(~#rec##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:?T)
+        foreign lpvm access(~#rec##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:T)
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 car > public {inline} (0 calls)
 1: generic_list.car<1>
-car(#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), #field##0:?T, ?#success##0:wybe.bool):
+car(#rec##0:generic_list(T), ?#rec##1:generic_list(T), #field##0:T, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
-        foreign llvm move(~#rec##0:generic_list(?T), ?#rec##1:generic_list(?T))
+        foreign llvm move(~#rec##0:generic_list(T), ?#rec##1:generic_list(T))
 
     1:
-        foreign lpvm mutate(~#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:?T)
+        foreign lpvm mutate(~#rec##0:generic_list(T), ?#rec##1:generic_list(T), 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:T)
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 cdr > public {inline} (0 calls)
 0: generic_list.cdr<0>
-cdr(#rec##0:generic_list(?T), ?#result##0:generic_list(?T), ?#success##0:wybe.bool):
+cdr(#rec##0:generic_list(T), ?#result##0:generic_list(T), ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
-        foreign llvm move(undef:generic_list(?T), ?#result##0:generic_list(?T))
+        foreign llvm move(undef:generic_list(T), ?#result##0:generic_list(T))
 
     1:
-        foreign lpvm access(~#rec##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:generic_list(?T))
+        foreign lpvm access(~#rec##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:generic_list(T))
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 cdr > public {inline} (0 calls)
 1: generic_list.cdr<1>
-cdr(#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), #field##0:generic_list(?T), ?#success##0:wybe.bool):
+cdr(#rec##0:generic_list(T), ?#rec##1:generic_list(T), #field##0:generic_list(T), ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
-        foreign llvm move(~#rec##0:generic_list(?T), ?#rec##1:generic_list(?T))
+        foreign llvm move(~#rec##0:generic_list(T), ?#rec##1:generic_list(T))
 
     1:
-        foreign lpvm {noalias} mutate(~#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:generic_list(?T))
+        foreign lpvm {noalias} mutate(~#rec##0:generic_list(T), ?#rec##1:generic_list(T), 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:generic_list(T))
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 cons > public {inline} (1 calls)
 0: generic_list.cons<0>
-cons(car##0:?T, cdr##0:generic_list(?T), ?#result##0:generic_list(?T)):
+cons(car##0:T, cdr##0:generic_list(T), ?#result##0:generic_list(T)):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:generic_list(?T))
-    foreign lpvm mutate(~#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~car##0:?T)
-    foreign lpvm mutate(~#rec##1:generic_list(?T), ?#result##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr##0:generic_list(?T))
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:generic_list(T))
+    foreign lpvm mutate(~#rec##0:generic_list(T), ?#rec##1:generic_list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~car##0:T)
+    foreign lpvm mutate(~#rec##1:generic_list(T), ?#result##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr##0:generic_list(T))
 cons > public {inline} (6 calls)
 1: generic_list.cons<1>
-cons(?car##0:?T, ?cdr##0:generic_list(?T), #result##0:generic_list(?T), ?#success##0:wybe.bool):
+cons(?car##0:T, ?cdr##0:generic_list(T), #result##0:generic_list(T), ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
-        foreign llvm move(undef:?T, ?car##0:?T)
-        foreign llvm move(undef:generic_list(?T), ?cdr##0:generic_list(?T))
+        foreign llvm move(undef:T, ?car##0:T)
+        foreign llvm move(undef:generic_list(T), ?cdr##0:generic_list(T))
 
     1:
-        foreign lpvm access(#result##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?car##0:?T)
-        foreign lpvm access(~#result##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?cdr##0:generic_list(?T))
+        foreign lpvm access(#result##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?car##0:T)
+        foreign lpvm access(~#result##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?cdr##0:generic_list(T))
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 length > public {inline} (0 calls)
 0: generic_list.length<0>
-length(x##0:generic_list(?T), ?#result##0:wybe.int):
+length(x##0:generic_list(T), ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    generic_list.length1<0>(~x##0:generic_list(?T), 0:wybe.int, ?#result##0:wybe.int) #0 @generic_list:nn:nn
+    generic_list.length1<0>(~x##0:generic_list(T), 0:wybe.int, ?#result##0:wybe.int) #0 @generic_list:nn:nn
 
 
 length1 > (2 calls)
 0: generic_list.length1<0>
-length1(x##0:generic_list(?T), acc##0:wybe.int, ?#result##0:wybe.int):
+length1(x##0:generic_list(T), acc##0:wybe.int, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
@@ -148,18 +148,18 @@ length1(x##0:generic_list(?T), acc##0:wybe.int, ?#result##0:wybe.int):
         foreign llvm move(~acc##0:wybe.int, ?#result##0:wybe.int) @generic_list:nn:nn
 
     1:
-        foreign lpvm access(~x##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
+        foreign lpvm access(~x##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T))
         foreign llvm add(~acc##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
-        generic_list.length1<0>(~t##0:generic_list(?T), ~tmp#2##0:wybe.int, ?#result##0:wybe.int) #2 @generic_list:nn:nn
+        generic_list.length1<0>(~t##0:generic_list(T), ~tmp#2##0:wybe.int, ?#result##0:wybe.int) #2 @generic_list:nn:nn
 
 
 
 nil > public {inline} (0 calls)
 0: generic_list.nil<0>
-nil(?#result##0:generic_list(?T)):
+nil(?#result##0:generic_list(T)):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:generic_list(?T), ?#result##0:generic_list(?T))
+    foreign llvm move(0:generic_list(T), ?#result##0:generic_list(T))
 
   LLVM code       :
 

--- a/test-cases/final-dump/generic_list.wybe
+++ b/test-cases/final-dump/generic_list.wybe
@@ -1,11 +1,11 @@
-pub constructors(?T) nil | cons(car: ?T, cdr:generic_list(?T))
+pub constructors(T) nil | cons(car: T, cdr:generic_list(T))
 
-pub def append(x:generic_list(?T), y:generic_list(?T)):generic_list(?T) =
+pub def append(x:generic_list(T), y:generic_list(T)):generic_list(T) =
     if {x = cons(?h, ?t):: cons(h, append(t,y))
        | else:: y
     }
 
-pub def length(x:generic_list(?T)) : int = length1(x, 0)
+pub def length(x:generic_list(T)) : int = length1(x, 0)
 
-def length1(x:generic_list(?T), acc:int) : int =
+def length1(x:generic_list(T), acc:int) : int =
     if {x = cons(?h, ?t):: length1(t, acc+1) | else:: acc}

--- a/test-cases/final-dump/generic_missing_param.exp
+++ b/test-cases/final-dump/generic_missing_param.exp
@@ -1,3 +1,3 @@
 Error detected during preliminary processing of module generic_missing_param
-[91mfinal-dump/generic_missing_param.wybe:1:28: Constructors for type generic_missing_param use unbound type variable(s) ?U
+[91mfinal-dump/generic_missing_param.wybe:1:27: Constructors for type generic_missing_param use unbound type variable(s) ?U
 [0m

--- a/test-cases/final-dump/generic_missing_param.wybe
+++ b/test-cases/final-dump/generic_missing_param.wybe
@@ -1,1 +1,1 @@
-pub constructors(?T) nil | cons(car: ?U, cdr:generic_missing_param(?T))
+pub constructors(T) nil | cons(car:U, cdr:generic_missing_param(T))

--- a/test-cases/final-dump/generic_resource.exp
+++ b/test-cases/final-dump/generic_resource.exp
@@ -1,3 +1,3 @@
 Error detected during preliminary processing of module generic_resource
-[91mfinal-dump/generic_resource.wybe:1:1: Resource type cannot contain type variables: list(?foo)
+[91mfinal-dump/generic_resource.wybe:1:1: Resource type cannot contain type variables: list(F00)
 [0m

--- a/test-cases/final-dump/generic_resource.wybe
+++ b/test-cases/final-dump/generic_resource.wybe
@@ -1,1 +1,1 @@
-resource foo:list(?foo)
+resource foo:list(F00)

--- a/test-cases/final-dump/generic_use.exp
+++ b/test-cases/final-dump/generic_use.exp
@@ -19,127 +19,127 @@ AFTER EVERYTHING:
 
 append > public (1 calls)
 0: generic_list.append<0>
-append(x##0:generic_list(?T), y##0:generic_list(?T), ?#result##0:generic_list(?T)):
+append(x##0:generic_list(T), y##0:generic_list(T), ?#result##0:generic_list(T)):
  AliasPairs: [(#result##0,y##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(generic_list.append<0>,fromList [NonAliasedParamCond 0 [0]]))]
     foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
     case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~y##0:generic_list(?T), ?#result##0:generic_list(?T)) @generic_list:nn:nn
+        foreign llvm move(~y##0:generic_list(T), ?#result##0:generic_list(T)) @generic_list:nn:nn
 
     1:
-        foreign lpvm access(x##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:?T)
-        foreign lpvm access(~x##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
-        generic_list.append<0>(~t##0:generic_list(?T), ~y##0:generic_list(?T), ?tmp#2##0:generic_list(?T)) #1 @generic_list:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:generic_list(?T))
-        foreign lpvm mutate(~tmp#8##0:generic_list(?T), ?tmp#9##0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:?T)
-        foreign lpvm mutate(~tmp#9##0:generic_list(?T), ?#result##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:generic_list(?T))
+        foreign lpvm access(x##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:T)
+        foreign lpvm access(~x##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T))
+        generic_list.append<0>(~t##0:generic_list(T), ~y##0:generic_list(T), ?tmp#2##0:generic_list(T)) #1 @generic_list:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:generic_list(T))
+        foreign lpvm mutate(~tmp#8##0:generic_list(T), ?tmp#9##0:generic_list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:T)
+        foreign lpvm mutate(~tmp#9##0:generic_list(T), ?#result##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:generic_list(T))
 
 
 
 car > public {inline} (0 calls)
 0: generic_list.car<0>
-car(#rec##0:generic_list(?T), ?#result##0:?T, ?#success##0:wybe.bool):
+car(#rec##0:generic_list(T), ?#result##0:T, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
-        foreign llvm move(undef:?T, ?#result##0:?T)
+        foreign llvm move(undef:T, ?#result##0:T)
 
     1:
-        foreign lpvm access(~#rec##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:?T)
+        foreign lpvm access(~#rec##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:T)
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 car > public {inline} (0 calls)
 1: generic_list.car<1>
-car(#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), #field##0:?T, ?#success##0:wybe.bool):
+car(#rec##0:generic_list(T), ?#rec##1:generic_list(T), #field##0:T, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
-        foreign llvm move(~#rec##0:generic_list(?T), ?#rec##1:generic_list(?T))
+        foreign llvm move(~#rec##0:generic_list(T), ?#rec##1:generic_list(T))
 
     1:
-        foreign lpvm mutate(~#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:?T)
+        foreign lpvm mutate(~#rec##0:generic_list(T), ?#rec##1:generic_list(T), 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:T)
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 cdr > public {inline} (0 calls)
 0: generic_list.cdr<0>
-cdr(#rec##0:generic_list(?T), ?#result##0:generic_list(?T), ?#success##0:wybe.bool):
+cdr(#rec##0:generic_list(T), ?#result##0:generic_list(T), ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
-        foreign llvm move(undef:generic_list(?T), ?#result##0:generic_list(?T))
+        foreign llvm move(undef:generic_list(T), ?#result##0:generic_list(T))
 
     1:
-        foreign lpvm access(~#rec##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:generic_list(?T))
+        foreign lpvm access(~#rec##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:generic_list(T))
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 cdr > public {inline} (0 calls)
 1: generic_list.cdr<1>
-cdr(#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), #field##0:generic_list(?T), ?#success##0:wybe.bool):
+cdr(#rec##0:generic_list(T), ?#rec##1:generic_list(T), #field##0:generic_list(T), ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
-        foreign llvm move(~#rec##0:generic_list(?T), ?#rec##1:generic_list(?T))
+        foreign llvm move(~#rec##0:generic_list(T), ?#rec##1:generic_list(T))
 
     1:
-        foreign lpvm {noalias} mutate(~#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:generic_list(?T))
+        foreign lpvm {noalias} mutate(~#rec##0:generic_list(T), ?#rec##1:generic_list(T), 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:generic_list(T))
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 cons > public {inline} (1 calls)
 0: generic_list.cons<0>
-cons(car##0:?T, cdr##0:generic_list(?T), ?#result##0:generic_list(?T)):
+cons(car##0:T, cdr##0:generic_list(T), ?#result##0:generic_list(T)):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:generic_list(?T))
-    foreign lpvm mutate(~#rec##0:generic_list(?T), ?#rec##1:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~car##0:?T)
-    foreign lpvm mutate(~#rec##1:generic_list(?T), ?#result##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr##0:generic_list(?T))
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:generic_list(T))
+    foreign lpvm mutate(~#rec##0:generic_list(T), ?#rec##1:generic_list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~car##0:T)
+    foreign lpvm mutate(~#rec##1:generic_list(T), ?#result##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr##0:generic_list(T))
 cons > public {inline} (6 calls)
 1: generic_list.cons<1>
-cons(?car##0:?T, ?cdr##0:generic_list(?T), #result##0:generic_list(?T), ?#success##0:wybe.bool):
+cons(?car##0:T, ?cdr##0:generic_list(T), #result##0:generic_list(T), ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
-        foreign llvm move(undef:?T, ?car##0:?T)
-        foreign llvm move(undef:generic_list(?T), ?cdr##0:generic_list(?T))
+        foreign llvm move(undef:T, ?car##0:T)
+        foreign llvm move(undef:generic_list(T), ?cdr##0:generic_list(T))
 
     1:
-        foreign lpvm access(#result##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?car##0:?T)
-        foreign lpvm access(~#result##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?cdr##0:generic_list(?T))
+        foreign lpvm access(#result##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?car##0:T)
+        foreign lpvm access(~#result##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?cdr##0:generic_list(T))
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 length > public {inline} (0 calls)
 0: generic_list.length<0>
-length(x##0:generic_list(?T), ?#result##0:wybe.int):
+length(x##0:generic_list(T), ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    generic_list.length1<0>(~x##0:generic_list(?T), 0:wybe.int, ?#result##0:wybe.int) #0 @generic_list:nn:nn
+    generic_list.length1<0>(~x##0:generic_list(T), 0:wybe.int, ?#result##0:wybe.int) #0 @generic_list:nn:nn
 
 
 length1 > (2 calls)
 0: generic_list.length1<0>
-length1(x##0:generic_list(?T), acc##0:wybe.int, ?#result##0:wybe.int):
+length1(x##0:generic_list(T), acc##0:wybe.int, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
@@ -148,18 +148,18 @@ length1(x##0:generic_list(?T), acc##0:wybe.int, ?#result##0:wybe.int):
         foreign llvm move(~acc##0:wybe.int, ?#result##0:wybe.int) @generic_list:nn:nn
 
     1:
-        foreign lpvm access(~x##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
+        foreign lpvm access(~x##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T))
         foreign llvm add(~acc##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
-        generic_list.length1<0>(~t##0:generic_list(?T), ~tmp#2##0:wybe.int, ?#result##0:wybe.int) #2 @generic_list:nn:nn
+        generic_list.length1<0>(~t##0:generic_list(T), ~tmp#2##0:wybe.int, ?#result##0:wybe.int) #2 @generic_list:nn:nn
 
 
 
 nil > public {inline} (0 calls)
 0: generic_list.nil<0>
-nil(?#result##0:generic_list(?T)):
+nil(?#result##0:generic_list(T)):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:generic_list(?T), ?#result##0:generic_list(?T))
+    foreign llvm move(0:generic_list(T), ?#result##0:generic_list(T))
 
   LLVM code       :
 
@@ -389,46 +389,46 @@ entry:
     foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     generic_use.print<0>(tmp#1##0:generic_list(wybe.int), ~#io##1:wybe.phantom, ?tmp#13##0:wybe.phantom) #13 @generic_use:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    generic_use.concat<0>(tmp#0##0:generic_list(?t), tmp#1##0:generic_list(?t), ?tmp#2##0:generic_list(?t)) #4 @generic_use:nn:nn
+    generic_use.concat<0>(tmp#0##0:generic_list(T), tmp#1##0:generic_list(T), ?tmp#2##0:generic_list(T)) #4 @generic_use:nn:nn
     generic_use.print<0>(~tmp#2##0:generic_list(wybe.int), ~#io##2:wybe.phantom, ?tmp#16##0:wybe.phantom) #14 @generic_use:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    generic_use.reverse1<0>[410bae77d3](~tmp#0##0:generic_list(?t), 0:generic_list(?t), ?tmp#3##0:generic_list(?t)) #15 @generic_use:nn:nn
+    generic_use.reverse1<0>[410bae77d3](~tmp#0##0:generic_list(T), 0:generic_list(T), ?tmp#3##0:generic_list(T)) #15 @generic_use:nn:nn
     generic_use.print<0>(~tmp#3##0:generic_list(wybe.int), ~#io##3:wybe.phantom, ?tmp#20##0:wybe.phantom) #16 @generic_use:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#20##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    generic_use.nrev<0>[410bae77d3](~tmp#1##0:generic_list(?t), ?tmp#4##0:generic_list(?t)) #8 @generic_use:nn:nn
+    generic_use.nrev<0>[410bae77d3](~tmp#1##0:generic_list(T), ?tmp#4##0:generic_list(T)) #8 @generic_use:nn:nn
     generic_use.print<0>(~tmp#4##0:generic_list(wybe.int), ~#io##4:wybe.phantom, ?tmp#23##0:wybe.phantom) #17 @generic_use:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#23##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
 
 concat > public (3 calls)
 0: generic_use.concat<0>[410bae77d3]
-concat(l1##0:generic_list(?t), l2##0:generic_list(?t), ?#result##0:generic_list(?t)):
+concat(l1##0:generic_list(T), l2##0:generic_list(T), ?#result##0:generic_list(T)):
  AliasPairs: [(#result##0,l2##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(generic_use.concat<0>,fromList [NonAliasedParamCond 0 [0]]))]
     foreign llvm icmp_ne(l1##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
     case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~l2##0:generic_list(?t), ?#result##0:generic_list(?t)) @generic_use:nn:nn
+        foreign llvm move(~l2##0:generic_list(T), ?#result##0:generic_list(T)) @generic_use:nn:nn
 
     1:
-        foreign lpvm access(l1##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:?T)
-        foreign lpvm access(~l1##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
-        generic_use.concat<0>(~t##0:generic_list(?t), ~l2##0:generic_list(?t), ?tmp#2##0:generic_list(?t)) #1 @generic_use:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:generic_list(?T))
-        foreign lpvm mutate(~tmp#8##0:generic_list(?T), ?tmp#9##0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:?T)
-        foreign lpvm mutate(~tmp#9##0:generic_list(?T), ?#result##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:generic_list(?T))
+        foreign lpvm access(l1##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:T)
+        foreign lpvm access(~l1##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T))
+        generic_use.concat<0>(~t##0:generic_list(T), ~l2##0:generic_list(T), ?tmp#2##0:generic_list(T)) #1 @generic_use:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:generic_list(T))
+        foreign lpvm mutate(~tmp#8##0:generic_list(T), ?tmp#9##0:generic_list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:T)
+        foreign lpvm mutate(~tmp#9##0:generic_list(T), ?#result##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:generic_list(T))
 
  [410bae77d3] [NonAliasedParam 0] :
     foreign llvm icmp_ne(l1##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
     case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~l2##0:generic_list(?t), ?#result##0:generic_list(?t)) @generic_use:nn:nn
+        foreign llvm move(~l2##0:generic_list(T), ?#result##0:generic_list(T)) @generic_use:nn:nn
 
     1:
-        foreign lpvm access(l1##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
-        generic_use.concat<0>[410bae77d3](~t##0:generic_list(?t), ~l2##0:generic_list(?t), ?tmp#2##0:generic_list(?t)) #1 @generic_use:nn:nn
-        foreign lpvm mutate(~l1##0:generic_list(?T), ?#result##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:generic_list(?T))
+        foreign lpvm access(l1##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T))
+        generic_use.concat<0>[410bae77d3](~t##0:generic_list(T), ~l2##0:generic_list(T), ?tmp#2##0:generic_list(T)) #1 @generic_use:nn:nn
+        foreign lpvm mutate(~l1##0:generic_list(T), ?#result##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:generic_list(T))
 
 
 
@@ -452,9 +452,9 @@ fromto1(lo##0:wybe.int, hi##0:wybe.int, sofar##0:generic_list(wybe.int), ?#resul
 
     1:
         foreign llvm sub(hi##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:generic_list(?T))
-        foreign lpvm mutate(~tmp#11##0:generic_list(?T), ?tmp#12##0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~hi##0:?T)
-        foreign lpvm mutate(~tmp#12##0:generic_list(?T), ?tmp#3##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~sofar##0:generic_list(?T))
+        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:generic_list(T))
+        foreign lpvm mutate(~tmp#11##0:generic_list(T), ?tmp#12##0:generic_list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~hi##0:T)
+        foreign lpvm mutate(~tmp#12##0:generic_list(T), ?tmp#3##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~sofar##0:generic_list(T))
         generic_use.fromto1<0>(~lo##0:wybe.int, ~tmp#2##0:wybe.int, ~tmp#3##0:generic_list(wybe.int), ?#result##0:generic_list(wybe.int)) #3 @generic_use:nn:nn
 
 
@@ -469,35 +469,35 @@ iota(n##0:wybe.int, ?#result##0:generic_list(wybe.int)):
 
 nrev > public (2 calls)
 0: generic_use.nrev<0>[410bae77d3]
-nrev(lst##0:generic_list(?t), ?#result##0:generic_list(?t)):
+nrev(lst##0:generic_list(T), ?#result##0:generic_list(T)):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(generic_use.nrev<0>,fromList [NonAliasedParamCond 0 [0]])),(4,(generic_use.concat<0>,fromList [NonAliasedParamCond 0 []]))]
     foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool)
     case ~tmp#8##0:wybe.bool of
     0:
-        foreign llvm move(0:generic_list(?t), ?#result##0:generic_list(?t)) @generic_use:nn:nn
+        foreign llvm move(0:generic_list(T), ?#result##0:generic_list(T)) @generic_use:nn:nn
 
     1:
-        foreign lpvm access(lst##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:?T)
-        foreign lpvm access(~lst##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
-        generic_use.nrev<0>(~t##0:generic_list(?t), ?tmp#2##0:generic_list(?t)) #1 @generic_use:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:generic_list(?T))
-        foreign lpvm mutate(~tmp#11##0:generic_list(?T), ?tmp#12##0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:?T)
-        foreign lpvm mutate(~tmp#12##0:generic_list(?T), ?tmp#3##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:generic_list(?T))
-        generic_use.concat<0>[410bae77d3](~tmp#2##0:generic_list(?t), ~tmp#3##0:generic_list(?t), ?#result##0:generic_list(?t)) #4 @generic_use:nn:nn
+        foreign lpvm access(lst##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:T)
+        foreign lpvm access(~lst##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T))
+        generic_use.nrev<0>(~t##0:generic_list(T), ?tmp#2##0:generic_list(T)) #1 @generic_use:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#11##0:generic_list(T))
+        foreign lpvm mutate(~tmp#11##0:generic_list(T), ?tmp#12##0:generic_list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:T)
+        foreign lpvm mutate(~tmp#12##0:generic_list(T), ?tmp#3##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:generic_list(T))
+        generic_use.concat<0>[410bae77d3](~tmp#2##0:generic_list(T), ~tmp#3##0:generic_list(T), ?#result##0:generic_list(T)) #4 @generic_use:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
     foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool)
     case ~tmp#8##0:wybe.bool of
     0:
-        foreign llvm move(0:generic_list(?t), ?#result##0:generic_list(?t)) @generic_use:nn:nn
+        foreign llvm move(0:generic_list(T), ?#result##0:generic_list(T)) @generic_use:nn:nn
 
     1:
-        foreign lpvm access(lst##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
-        generic_use.nrev<0>[410bae77d3](~t##0:generic_list(?t), ?tmp#2##0:generic_list(?t)) #1 @generic_use:nn:nn
-        foreign lpvm mutate(~lst##0:generic_list(?T), ?tmp#3##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:generic_list(?T))
-        generic_use.concat<0>[410bae77d3](~tmp#2##0:generic_list(?t), ~tmp#3##0:generic_list(?t), ?#result##0:generic_list(?t)) #4 @generic_use:nn:nn
+        foreign lpvm access(lst##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T))
+        generic_use.nrev<0>[410bae77d3](~t##0:generic_list(T), ?tmp#2##0:generic_list(T)) #1 @generic_use:nn:nn
+        foreign lpvm mutate(~lst##0:generic_list(T), ?tmp#3##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:generic_list(T))
+        generic_use.concat<0>[410bae77d3](~tmp#2##0:generic_list(T), ~tmp#3##0:generic_list(T), ?#result##0:generic_list(T)) #4 @generic_use:nn:nn
 
 
 
@@ -513,8 +513,8 @@ print(lst##0:generic_list(wybe.int), io##0:wybe.phantom, ?io##4:wybe.phantom):
         foreign c putchar(']':wybe.char, ~#io##1:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
 
     1:
-        foreign lpvm access(lst##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:?T)
-        foreign lpvm access(~lst##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
+        foreign lpvm access(lst##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:T)
+        foreign lpvm access(~lst##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T))
         foreign c print_int(~h##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
         generic_use.print_tail<0>(~t##0:generic_list(wybe.int), ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @generic_use:nn:nn
         foreign c putchar(']':wybe.char, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
@@ -532,8 +532,8 @@ print_tail(lst##0:generic_list(wybe.int), io##0:wybe.phantom, ?io##3:wybe.phanto
         foreign llvm move(~io##0:wybe.phantom, ?io##3:wybe.phantom)
 
     1:
-        foreign lpvm access(lst##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:?T)
-        foreign lpvm access(~lst##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
+        foreign lpvm access(lst##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:T)
+        foreign lpvm access(~lst##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T))
         wybe.string.print_string<0>(", ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #4 @io:nn:nn
         foreign c print_int(~h##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
         generic_use.print_tail<0>(~t##0:generic_list(wybe.int), ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @generic_use:nn:nn
@@ -551,41 +551,41 @@ println(lst##0:generic_list(wybe.int), io##0:wybe.phantom, ?io##2:wybe.phantom):
 
 reverse > public {inline} (1 calls)
 0: generic_use.reverse<0>
-reverse(lst##0:generic_list(?t), ?#result##0:generic_list(?t)):
+reverse(lst##0:generic_list(T), ?#result##0:generic_list(T)):
  AliasPairs: []
  InterestingCallProperties: []
-    generic_use.reverse1<0>(~lst##0:generic_list(?t), 0:generic_list(?t), ?#result##0:generic_list(?t)) #1 @generic_use:nn:nn
+    generic_use.reverse1<0>(~lst##0:generic_list(T), 0:generic_list(T), ?#result##0:generic_list(T)) #1 @generic_use:nn:nn
 
 
 reverse1 > public (2 calls)
 0: generic_use.reverse1<0>[410bae77d3]
-reverse1(lst##0:generic_list(?t), suffix##0:generic_list(?t), ?#result##0:generic_list(?t)):
+reverse1(lst##0:generic_list(T), suffix##0:generic_list(T), ?#result##0:generic_list(T)):
  AliasPairs: [(#result##0,suffix##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(2,(generic_use.reverse1<0>,fromList [NonAliasedParamCond 0 [0]]))]
     foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
     case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~suffix##0:generic_list(?t), ?#result##0:generic_list(?t)) @generic_use:nn:nn
+        foreign llvm move(~suffix##0:generic_list(T), ?#result##0:generic_list(T)) @generic_use:nn:nn
 
     1:
-        foreign lpvm access(lst##0:generic_list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:?T)
-        foreign lpvm access(~lst##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
-        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:generic_list(?T))
-        foreign lpvm mutate(~tmp#8##0:generic_list(?T), ?tmp#9##0:generic_list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:?T)
-        foreign lpvm mutate(~tmp#9##0:generic_list(?T), ?tmp#2##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~suffix##0:generic_list(?T))
-        generic_use.reverse1<0>(~t##0:generic_list(?t), ~tmp#2##0:generic_list(?t), ?#result##0:generic_list(?t)) #2 @generic_use:nn:nn
+        foreign lpvm access(lst##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:T)
+        foreign lpvm access(~lst##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T))
+        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:generic_list(T))
+        foreign lpvm mutate(~tmp#8##0:generic_list(T), ?tmp#9##0:generic_list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:T)
+        foreign lpvm mutate(~tmp#9##0:generic_list(T), ?tmp#2##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~suffix##0:generic_list(T))
+        generic_use.reverse1<0>(~t##0:generic_list(T), ~tmp#2##0:generic_list(T), ?#result##0:generic_list(T)) #2 @generic_use:nn:nn
 
  [410bae77d3] [NonAliasedParam 0] :
     foreign llvm icmp_ne(lst##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
     case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~suffix##0:generic_list(?t), ?#result##0:generic_list(?t)) @generic_use:nn:nn
+        foreign llvm move(~suffix##0:generic_list(T), ?#result##0:generic_list(T)) @generic_use:nn:nn
 
     1:
-        foreign lpvm access(lst##0:generic_list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(?T))
-        foreign lpvm mutate(~lst##0:generic_list(?T), ?tmp#2##0:generic_list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~suffix##0:generic_list(?T))
-        generic_use.reverse1<0>[410bae77d3](~t##0:generic_list(?t), ~tmp#2##0:generic_list(?t), ?#result##0:generic_list(?t)) #2 @generic_use:nn:nn
+        foreign lpvm access(lst##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T))
+        foreign lpvm mutate(~lst##0:generic_list(T), ?tmp#2##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~suffix##0:generic_list(T))
+        generic_use.reverse1<0>[410bae77d3](~t##0:generic_list(T), ~tmp#2##0:generic_list(T), ?#result##0:generic_list(T)) #2 @generic_use:nn:nn
 
 
   LLVM code       :

--- a/test-cases/final-dump/generic_use.wybe
+++ b/test-cases/final-dump/generic_use.wybe
@@ -5,15 +5,15 @@ pub def fromto(lo:int, hi:int) : generic_list(int) = fromto1(lo, hi, nil)
 def fromto1(lo:int, hi:int, sofar:generic_list(int)) : generic_list(int) =
     if {lo <= hi:: fromto1(lo, hi-1, cons(hi,sofar)) |else:: sofar}
 
-pub def concat(l1:generic_list(?t), l2:generic_list(?t)):generic_list(?t) =
+pub def concat(l1:generic_list(T), l2:generic_list(T)):generic_list(T) =
     if {l1 = cons(?h , ?t):: cons(h,concat(t,l2)) |else:: l2}
 
-pub def nrev(lst:generic_list(?t)) : generic_list(?t) =
+pub def nrev(lst:generic_list(T)) : generic_list(T) =
     if {lst = cons(?h , ?t):: concat(nrev(t), cons(h,nil)) |else:: nil}
 
-pub def reverse(lst:generic_list(?t)) : generic_list(?t) = reverse1(lst, nil)
-pub def reverse1(lst:generic_list(?t), suffix:generic_list(?t))
-        : generic_list(?t) =
+pub def reverse(lst:generic_list(T)) : generic_list(T) = reverse1(lst, nil)
+pub def reverse1(lst:generic_list(T), suffix:generic_list(T))
+        : generic_list(T) =
     if {lst = cons(?h , ?t):: reverse1(t,cons(h,suffix)) |else:: suffix}
 
 

--- a/test-cases/final-dump/incompatible_generics.exp
+++ b/test-cases/final-dump/incompatible_generics.exp
@@ -1,3 +1,3 @@
 Error detected during type checking of module(s) incompatible_generics
-[91mfinal-dump/incompatible_generics.wybe:1:25: Type of ?j incompatible with i
+[91mfinal-dump/incompatible_generics.wybe:1:23: Type of ?j incompatible with i
 [0m

--- a/test-cases/final-dump/incompatible_generics.wybe
+++ b/test-cases/final-dump/incompatible_generics.wybe
@@ -1,1 +1,1 @@
-def foo(i:?I, ?j:?J) { ?j = i }
+def foo(i:I, ?j:J) { ?j = i }

--- a/test-cases/final-dump/incompatible_generics_2.exp
+++ b/test-cases/final-dump/incompatible_generics_2.exp
@@ -1,5 +1,5 @@
 Error detected during type checking of module(s) incompatible_generics_2
-[91mfinal-dump/incompatible_generics_2.wybe:1:29: Type error in call to +, argument 1
-[0m[91mfinal-dump/incompatible_generics_2.wybe:1:29: Type error in call to +, argument 2
-[0m[91mfinal-dump/incompatible_generics_2.wybe:1:29: Type error in call to +, argument 3
+[91mfinal-dump/incompatible_generics_2.wybe:1:27: Type error in call to +, argument 1
+[0m[91mfinal-dump/incompatible_generics_2.wybe:1:27: Type error in call to +, argument 2
+[0m[91mfinal-dump/incompatible_generics_2.wybe:1:27: Type error in call to +, argument 3
 [0m

--- a/test-cases/final-dump/incompatible_generics_2.wybe
+++ b/test-cases/final-dump/incompatible_generics_2.wybe
@@ -1,1 +1,1 @@
-def foo(i:?I, ?j:?I) { ?j = i + 1 }
+def foo(i:I, ?j:I) { ?j = i + 1 }

--- a/test-cases/final-dump/list_this.exp
+++ b/test-cases/final-dump/list_this.exp
@@ -19,127 +19,127 @@ AFTER EVERYTHING:
 
 append > public (1 calls)
 0: list_this.append<0>
-append(x##0:list_this(?T), y##0:list_this(?T), ?#result##0:list_this(?T)):
+append(x##0:list_this(T), y##0:list_this(T), ?#result##0:list_this(T)):
  AliasPairs: [(#result##0,y##0)]
  InterestingCallProperties: [InterestingUnaliased 0]
  MultiSpeczDepInfo: [(1,(list_this.append<0>,fromList [NonAliasedParamCond 0 [0]]))]
     foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
     case ~tmp#5##0:wybe.bool of
     0:
-        foreign llvm move(~y##0:list_this(?T), ?#result##0:list_this(?T)) @list_this:nn:nn
+        foreign llvm move(~y##0:list_this(T), ?#result##0:list_this(T)) @list_this:nn:nn
 
     1:
-        foreign lpvm access(x##0:list_this(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:?T)
-        foreign lpvm access(~x##0:list_this(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:list_this(?T))
-        list_this.append<0>(~t##0:list_this(?T), ~y##0:list_this(?T), ?tmp#2##0:list_this(?T)) #1 @list_this:nn:nn
-        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:list_this(?T))
-        foreign lpvm mutate(~tmp#8##0:list_this(?T), ?tmp#9##0:list_this(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:?T)
-        foreign lpvm mutate(~tmp#9##0:list_this(?T), ?#result##0:list_this(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:list_this(?T))
+        foreign lpvm access(x##0:list_this(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:T)
+        foreign lpvm access(~x##0:list_this(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:list_this(T))
+        list_this.append<0>(~t##0:list_this(T), ~y##0:list_this(T), ?tmp#2##0:list_this(T)) #1 @list_this:nn:nn
+        foreign lpvm alloc(16:wybe.int, ?tmp#8##0:list_this(T))
+        foreign lpvm mutate(~tmp#8##0:list_this(T), ?tmp#9##0:list_this(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~h##0:T)
+        foreign lpvm mutate(~tmp#9##0:list_this(T), ?#result##0:list_this(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#2##0:list_this(T))
 
 
 
 car > public {inline} (0 calls)
 0: list_this.car<0>
-car(#rec##0:list_this(?T), ?#result##0:?T, ?#success##0:wybe.bool):
+car(#rec##0:list_this(T), ?#result##0:T, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
-        foreign llvm move(undef:?T, ?#result##0:?T)
+        foreign llvm move(undef:T, ?#result##0:T)
 
     1:
-        foreign lpvm access(~#rec##0:list_this(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:?T)
+        foreign lpvm access(~#rec##0:list_this(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:T)
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 car > public {inline} (0 calls)
 1: list_this.car<1>
-car(#rec##0:list_this(?T), ?#rec##1:list_this(?T), #field##0:?T, ?#success##0:wybe.bool):
+car(#rec##0:list_this(T), ?#rec##1:list_this(T), #field##0:T, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
-        foreign llvm move(~#rec##0:list_this(?T), ?#rec##1:list_this(?T))
+        foreign llvm move(~#rec##0:list_this(T), ?#rec##1:list_this(T))
 
     1:
-        foreign lpvm mutate(~#rec##0:list_this(?T), ?#rec##1:list_this(?T), 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:?T)
+        foreign lpvm mutate(~#rec##0:list_this(T), ?#rec##1:list_this(T), 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:T)
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 cdr > public {inline} (0 calls)
 0: list_this.cdr<0>
-cdr(#rec##0:list_this(?T), ?#result##0:list_this(?T), ?#success##0:wybe.bool):
+cdr(#rec##0:list_this(T), ?#result##0:list_this(T), ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
-        foreign llvm move(undef:list_this(?T), ?#result##0:list_this(?T))
+        foreign llvm move(undef:list_this(T), ?#result##0:list_this(T))
 
     1:
-        foreign lpvm access(~#rec##0:list_this(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:list_this(?T))
+        foreign lpvm access(~#rec##0:list_this(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?#result##0:list_this(T))
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 cdr > public {inline} (0 calls)
 1: list_this.cdr<1>
-cdr(#rec##0:list_this(?T), ?#rec##1:list_this(?T), #field##0:list_this(?T), ?#success##0:wybe.bool):
+cdr(#rec##0:list_this(T), ?#rec##1:list_this(T), #field##0:list_this(T), ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#rec##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
-        foreign llvm move(~#rec##0:list_this(?T), ?#rec##1:list_this(?T))
+        foreign llvm move(~#rec##0:list_this(T), ?#rec##1:list_this(T))
 
     1:
-        foreign lpvm {noalias} mutate(~#rec##0:list_this(?T), ?#rec##1:list_this(?T), 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:list_this(?T))
+        foreign lpvm {noalias} mutate(~#rec##0:list_this(T), ?#rec##1:list_this(T), 8:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~#field##0:list_this(T))
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 cons > public {inline} (1 calls)
 0: list_this.cons<0>
-cons(car##0:?T, cdr##0:list_this(?T), ?#result##0:list_this(?T)):
+cons(car##0:T, cdr##0:list_this(T), ?#result##0:list_this(T)):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?#rec##0:list_this(?T))
-    foreign lpvm mutate(~#rec##0:list_this(?T), ?#rec##1:list_this(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~car##0:?T)
-    foreign lpvm mutate(~#rec##1:list_this(?T), ?#result##0:list_this(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr##0:list_this(?T))
+    foreign lpvm alloc(16:wybe.int, ?#rec##0:list_this(T))
+    foreign lpvm mutate(~#rec##0:list_this(T), ?#rec##1:list_this(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~car##0:T)
+    foreign lpvm mutate(~#rec##1:list_this(T), ?#result##0:list_this(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~cdr##0:list_this(T))
 cons > public {inline} (6 calls)
 1: list_this.cons<1>
-cons(?car##0:?T, ?cdr##0:list_this(?T), #result##0:list_this(?T), ?#success##0:wybe.bool):
+cons(?car##0:T, ?cdr##0:list_this(T), #result##0:list_this(T), ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(#result##0:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.bool)
     case ~tmp#0##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
-        foreign llvm move(undef:?T, ?car##0:?T)
-        foreign llvm move(undef:list_this(?T), ?cdr##0:list_this(?T))
+        foreign llvm move(undef:T, ?car##0:T)
+        foreign llvm move(undef:list_this(T), ?cdr##0:list_this(T))
 
     1:
-        foreign lpvm access(#result##0:list_this(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?car##0:?T)
-        foreign lpvm access(~#result##0:list_this(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?cdr##0:list_this(?T))
+        foreign lpvm access(#result##0:list_this(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?car##0:T)
+        foreign lpvm access(~#result##0:list_this(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?cdr##0:list_this(T))
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
 
 length > public {inline} (0 calls)
 0: list_this.length<0>
-length(x##0:list_this(?T), ?#result##0:wybe.int):
+length(x##0:list_this(T), ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
-    list_this.length1<0>(~x##0:list_this(?T), 0:wybe.int, ?#result##0:wybe.int) #0 @list_this:nn:nn
+    list_this.length1<0>(~x##0:list_this(T), 0:wybe.int, ?#result##0:wybe.int) #0 @list_this:nn:nn
 
 
 length1 > (2 calls)
 0: list_this.length1<0>
-length1(x##0:list_this(?T), acc##0:wybe.int, ?#result##0:wybe.int):
+length1(x##0:list_this(T), acc##0:wybe.int, ?#result##0:wybe.int):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(x##0:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.bool)
@@ -148,18 +148,18 @@ length1(x##0:list_this(?T), acc##0:wybe.int, ?#result##0:wybe.int):
         foreign llvm move(~acc##0:wybe.int, ?#result##0:wybe.int) @list_this:nn:nn
 
     1:
-        foreign lpvm access(~x##0:list_this(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:list_this(?T))
+        foreign lpvm access(~x##0:list_this(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:list_this(T))
         foreign llvm add(~acc##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
-        list_this.length1<0>(~t##0:list_this(?T), ~tmp#2##0:wybe.int, ?#result##0:wybe.int) #2 @list_this:nn:nn
+        list_this.length1<0>(~t##0:list_this(T), ~tmp#2##0:wybe.int, ?#result##0:wybe.int) #2 @list_this:nn:nn
 
 
 
 nil > public {inline} (0 calls)
 0: list_this.nil<0>
-nil(?#result##0:list_this(?T)):
+nil(?#result##0:list_this(T)):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm move(0:list_this(?T), ?#result##0:list_this(?T))
+    foreign llvm move(0:list_this(T), ?#result##0:list_this(T))
 
   LLVM code       :
 

--- a/test-cases/final-dump/list_this.wybe
+++ b/test-cases/final-dump/list_this.wybe
@@ -1,11 +1,11 @@
-pub constructors(?T) nil | cons(car: ?T, cdr:_(?T))
+pub constructors(T) nil | cons(car: T, cdr:_(T))
 
-pub def append(x:_(?T), y:_(?T)):_(?T) =
+pub def append(x:_(T), y:_(T)):_(T) =
     if {x = cons(?h, ?t) :: cons(h, append(t,y))
        |else:: y
     }
 
-pub def length(x:_(?T)) : int = length1(x, 0)
+pub def length(x:_(T)) : int = length1(x, 0)
 
-def length1(x:_(?T), acc:int) : int =
+def length1(x:_(T), acc:int) : int =
     if {x = cons(?h, ?t):: length1(t, acc+1) |else:: acc }

--- a/test-cases/final-dump/main_hello.exp
+++ b/test-cases/final-dump/main_hello.exp
@@ -23,10 +23,10 @@ AFTER EVERYTHING:
 (argc##0:wybe.int, [?argc##0:wybe.int], ?arguments##1:wybe.array(wybe.c_string), argv##0:wybe.array.raw_array(wybe.c_string), [?argv##0:wybe.array.raw_array(wybe.c_string)], ?command##1:wybe.c_string, ?exit_code##0:wybe.int, io##0:wybe.phantom, [?io##0:wybe.phantom]):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:wybe.array(?T))
-    foreign lpvm mutate(~tmp#4##0:wybe.array(?T), ?tmp#5##0:wybe.array(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
-    foreign lpvm mutate(~tmp#5##0:wybe.array(?T), ?tmp#0##0:wybe.array(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(?T))
-    wybe.array.[|]<0>(?command##1:?T, ?arguments##1:wybe.array(?T), ~tmp#0##0:wybe.array(?T), ?tmp#1##0:wybe.bool) #1 @command_line:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#4##0:wybe.array(T))
+    foreign lpvm mutate(~tmp#4##0:wybe.array(T), ?tmp#5##0:wybe.array(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
+    foreign lpvm mutate(~tmp#5##0:wybe.array(T), ?tmp#0##0:wybe.array(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(T))
+    wybe.array.[|]<0>(?command##1:T, ?arguments##1:wybe.array(T), ~tmp#0##0:wybe.array(T), ?tmp#1##0:wybe.bool) #1 @command_line:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
         foreign c {terminal,semipure} error_exit(c"command_line:17:6":wybe.c_string, c"Erroneous program argument vector":wybe.c_string) @control:nn:nn
@@ -124,7 +124,7 @@ entry:
     foreign llvm move(42:wybe.int, ?#exit_code##1:wybe.int) @command_line:nn:nn
     wybe.string.print_string<0>("hello, world!":wybe.string, ~#io##0:wybe.phantom, ?tmp#5##0:wybe.phantom) #5 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign lpvm access(arguments##0:wybe.array(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
+    foreign lpvm access(arguments##0:wybe.array(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##0:wybe.int)
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
     wybe.string.print_string<0>(" command line argument(s)":wybe.string, ~#io##2:wybe.phantom, ?tmp#11##0:wybe.phantom) #6 @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn

--- a/test-cases/final-dump/stmt_for.exp
+++ b/test-cases/final-dump/stmt_for.exp
@@ -86,7 +86,7 @@ AFTER EVERYTHING:
 
 gen#1 > (2 calls)
 0: stmt_for.gen#1<0>
-gen#1(io##0:wybe.phantom, tmp#0##0:wybe.list(?T), tmp#1##0:wybe.list(?T), tmp#2##0:wybe.list(?T), tmp#3##0:wybe.list(?T), tmp#4##0:wybe.list(?T), tmp#5##0:wybe.list(?T), tmp#6##0:wybe.list(?T), tmp#7##0:wybe.list(?T), tmp#8##0:wybe.list(wybe.int), tmp#9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
+gen#1(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(T), tmp#5##0:wybe.list(T), tmp#6##0:wybe.list(T), tmp#7##0:wybe.list(T), tmp#8##0:wybe.list(wybe.int), tmp#9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(tmp#8##0:wybe.int, 0:wybe.int, ?tmp#14##0:wybe.bool)
@@ -95,15 +95,15 @@ gen#1(io##0:wybe.phantom, tmp#0##0:wybe.list(?T), tmp#1##0:wybe.list(?T), tmp#2#
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp#8##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
-        foreign lpvm access(~tmp#8##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.list(?T))
+        foreign lpvm access(tmp#8##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:T)
+        foreign lpvm access(~tmp#8##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.list(T))
         stmt_for.gen#2<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int), ~tmp#6##0:wybe.list(wybe.int), ~tmp#7##0:wybe.list(wybe.int), ~tmp#10##0:wybe.list(wybe.int), ~tmp#9##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
 
 
 
 gen#10 > (2 calls)
 0: stmt_for.gen#10<0>
-gen#10(io##0:wybe.phantom, tmp#0##0:wybe.list(?T), tmp#1##0:wybe.list(?T), tmp#2##0:wybe.list(?T), tmp#3##0:wybe.list(?T), tmp#4##0:wybe.list(?T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
+gen#10(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
@@ -112,8 +112,8 @@ gen#10(io##0:wybe.phantom, tmp#0##0:wybe.list(?T), tmp#1##0:wybe.list(?T), tmp#2
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp#5##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
-        foreign lpvm access(~tmp#5##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.list(?T))
+        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:T)
+        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.list(T))
         stmt_for.gen#11<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#6##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
 
 
@@ -128,7 +128,7 @@ gen#11(i##0:wybe.int, io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0
     0:
         foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
         foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_for.gen#10<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), ~tmp#4##0:wybe.list(?T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
+        stmt_for.gen#10<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
 
     1:
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
@@ -171,7 +171,7 @@ gen#13(io##0:wybe.phantom, tmp#0##0:stmt_for.int_sequence, tmp#3##0:stmt_for.int
 
 gen#14 > (3 calls)
 0: stmt_for.gen#14<0>
-gen#14(io##0:wybe.phantom, tmp#0##0:wybe.list(?T), tmp#1##0:wybe.list(?T), tmp#2##0:wybe.list(?T), tmp#3##0:wybe.list(?T), tmp#4##0:wybe.list(?T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
+gen#14(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
@@ -180,8 +180,8 @@ gen#14(io##0:wybe.phantom, tmp#0##0:wybe.list(?T), tmp#1##0:wybe.list(?T), tmp#2
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp#5##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
-        foreign lpvm access(~tmp#5##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.list(?T))
+        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:T)
+        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.list(T))
         stmt_for.gen#15<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#6##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
 
 
@@ -196,16 +196,16 @@ gen#15(i##0:wybe.int, io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0
     0:
         foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
         foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_for.gen#14<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), ~tmp#4##0:wybe.list(?T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #3 @stmt_for:nn:nn
+        stmt_for.gen#14<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #3 @stmt_for:nn:nn
 
     1:
-        stmt_for.gen#14<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), ~tmp#4##0:wybe.list(?T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #1 @stmt_for:nn:nn
+        stmt_for.gen#14<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #1 @stmt_for:nn:nn
 
 
 
 gen#16 > (3 calls)
 0: stmt_for.gen#16<0>
-gen#16(io##0:wybe.phantom, tmp#0##0:wybe.list(?T), tmp#1##0:wybe.list(?T), tmp#2##0:wybe.list(?T), tmp#3##0:wybe.list(?T), tmp#4##0:wybe.list(?T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
+gen#16(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
@@ -214,8 +214,8 @@ gen#16(io##0:wybe.phantom, tmp#0##0:wybe.list(?T), tmp#1##0:wybe.list(?T), tmp#2
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp#5##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
-        foreign lpvm access(~tmp#5##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.list(?T))
+        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:T)
+        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.list(T))
         stmt_for.gen#17<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#6##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
 
 
@@ -230,16 +230,16 @@ gen#17(i##0:wybe.int, io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0
     0:
         foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
         foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_for.gen#16<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), ~tmp#4##0:wybe.list(?T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #3 @stmt_for:nn:nn
+        stmt_for.gen#16<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #3 @stmt_for:nn:nn
 
     1:
-        stmt_for.gen#16<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), ~tmp#4##0:wybe.list(?T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #1 @stmt_for:nn:nn
+        stmt_for.gen#16<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #1 @stmt_for:nn:nn
 
 
 
 gen#18 > (2 calls)
 0: stmt_for.gen#18<0>
-gen#18(io##0:wybe.phantom, tmp#0##0:wybe.list(?T), tmp#1##0:wybe.list(?T), tmp#2##0:wybe.list(?T), tmp#3##0:wybe.list(?T), tmp#4##0:wybe.list(?T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
+gen#18(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
@@ -248,8 +248,8 @@ gen#18(io##0:wybe.phantom, tmp#0##0:wybe.list(?T), tmp#1##0:wybe.list(?T), tmp#2
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp#5##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
-        foreign lpvm access(~tmp#5##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.list(?T))
+        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:T)
+        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.list(T))
         stmt_for.gen#19<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#6##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
 
 
@@ -264,7 +264,7 @@ gen#19(i##0:wybe.int, io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0
     0:
         foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
         foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_for.gen#18<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), ~tmp#4##0:wybe.list(?T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
+        stmt_for.gen#18<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
 
     1:
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
@@ -282,19 +282,19 @@ gen#2(i##0:wybe.int, io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp#9##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?j##0:?T)
-        foreign lpvm access(~tmp#9##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#11##0:wybe.list(?T))
+        foreign lpvm access(tmp#9##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?j##0:T)
+        foreign lpvm access(~tmp#9##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#11##0:wybe.list(T))
         foreign c print_int(~i##0:wybe.int, ~io##0:wybe.phantom, ?tmp#33##0:wybe.phantom) @io:nn:nn
         foreign c putchar('\n':wybe.char, ~tmp#33##0:wybe.phantom, ?tmp#34##0:wybe.phantom) @io:nn:nn
         foreign c print_int(~j##0:wybe.int, ~tmp#34##0:wybe.phantom, ?tmp#35##0:wybe.phantom) @io:nn:nn
         foreign c putchar('\n':wybe.char, ~tmp#35##0:wybe.phantom, ?tmp#36##0:wybe.phantom) @io:nn:nn
-        stmt_for.gen#1<0>(~tmp#36##0:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), ~tmp#4##0:wybe.list(?T), ~tmp#5##0:wybe.list(?T), ~tmp#6##0:wybe.list(?T), ~tmp#7##0:wybe.list(?T), ~tmp#8##0:wybe.list(wybe.int), ~tmp#11##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #2 @stmt_for:nn:nn
+        stmt_for.gen#1<0>(~tmp#36##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##0:wybe.list(T), ~tmp#6##0:wybe.list(T), ~tmp#7##0:wybe.list(T), ~tmp#8##0:wybe.list(wybe.int), ~tmp#11##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #2 @stmt_for:nn:nn
 
 
 
 gen#20 > (3 calls)
 0: stmt_for.gen#20<0>
-gen#20(io##0:wybe.phantom, tmp#0##0:wybe.list(?T), tmp#1##0:wybe.list(?T), tmp#2##0:wybe.list(?T), tmp#3##0:wybe.list(?T), tmp#4##0:wybe.list(?T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
+gen#20(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
@@ -303,8 +303,8 @@ gen#20(io##0:wybe.phantom, tmp#0##0:wybe.list(?T), tmp#1##0:wybe.list(?T), tmp#2
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp#5##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
-        foreign lpvm access(~tmp#5##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.list(?T))
+        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:T)
+        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.list(T))
         stmt_for.gen#21<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#6##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
 
 
@@ -317,18 +317,18 @@ gen#21(i##0:wybe.int, io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0
     foreign llvm icmp_slt(i##0:wybe.int, 3:wybe.int, ?tmp#8##0:wybe.bool) @int:nn:nn
     case ~tmp#8##0:wybe.bool of
     0:
-        stmt_for.gen#20<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), ~tmp#4##0:wybe.list(?T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #3 @stmt_for:nn:nn
+        stmt_for.gen#20<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #3 @stmt_for:nn:nn
 
     1:
         foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
         foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_for.gen#20<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), ~tmp#4##0:wybe.list(?T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
+        stmt_for.gen#20<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
 
 
 
 gen#22 > (2 calls)
 0: stmt_for.gen#22<0>
-gen#22(io##0:wybe.phantom, tmp#0##0:wybe.list(?T), tmp#1##0:wybe.list(?T), tmp#2##0:wybe.list(?T), tmp#3##0:wybe.list(?T), tmp#4##0:wybe.list(?T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
+gen#22(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
@@ -337,8 +337,8 @@ gen#22(io##0:wybe.phantom, tmp#0##0:wybe.list(?T), tmp#1##0:wybe.list(?T), tmp#2
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp#5##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
-        foreign lpvm access(~tmp#5##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.list(?T))
+        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:T)
+        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.list(T))
         stmt_for.gen#23<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#6##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
 
 
@@ -356,7 +356,7 @@ gen#23(i##0:wybe.int, io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0
     1:
         foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
         foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_for.gen#22<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), ~tmp#4##0:wybe.list(?T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
+        stmt_for.gen#22<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
 
 
 
@@ -403,7 +403,7 @@ gen#3(i##0:wybe.int, io##0:wybe.phantom, j##0:wybe.int, tmp#0##0:wybe.list(wybe.
     foreign c putchar('\n':wybe.char, ~tmp#15##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     foreign c print_int(~j##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#18##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#18##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    stmt_for.gen#1<0>(~io##2:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), ~tmp#4##0:wybe.list(?T), ~tmp#5##0:wybe.list(?T), ~tmp#6##0:wybe.list(?T), ~tmp#7##0:wybe.list(?T), ~tmp#8##0:wybe.list(wybe.int), ~tmp#9##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##3:wybe.phantom) #2 @stmt_for:nn:nn
+    stmt_for.gen#1<0>(~io##2:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##0:wybe.list(T), ~tmp#6##0:wybe.list(T), ~tmp#7##0:wybe.list(T), ~tmp#8##0:wybe.list(wybe.int), ~tmp#9##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##3:wybe.phantom) #2 @stmt_for:nn:nn
 
 
 gen#4 > (2 calls)
@@ -442,7 +442,7 @@ gen#5(i##0:wybe.int, io##0:wybe.phantom, tmp#0##0:stmt_for.int_sequence, [tmp#1#
 
 gen#6 > (2 calls)
 0: stmt_for.gen#6<0>
-gen#6(io##0:wybe.phantom, tmp#0##0:wybe.list(?T), tmp#1##0:wybe.list(?T), tmp#2##0:wybe.list(?T), tmp#3##0:wybe.list(?T), tmp#4##0:wybe.list(?T), tmp#5##0:wybe.list(?T), tmp#6##0:wybe.list(?T), tmp#7##0:wybe.list(?T), tmp#8##0:wybe.list(wybe.int), tmp#9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
+gen#6(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(T), tmp#5##0:wybe.list(T), tmp#6##0:wybe.list(T), tmp#7##0:wybe.list(T), tmp#8##0:wybe.list(wybe.int), tmp#9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(tmp#8##0:wybe.int, 0:wybe.int, ?tmp#14##0:wybe.bool)
@@ -451,8 +451,8 @@ gen#6(io##0:wybe.phantom, tmp#0##0:wybe.list(?T), tmp#1##0:wybe.list(?T), tmp#2#
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp#8##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
-        foreign lpvm access(~tmp#8##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.list(?T))
+        foreign lpvm access(tmp#8##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:T)
+        foreign lpvm access(~tmp#8##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.list(T))
         stmt_for.gen#7<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int), ~tmp#6##0:wybe.list(wybe.int), ~tmp#7##0:wybe.list(wybe.int), ~tmp#10##0:wybe.list(wybe.int), ~tmp#9##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
 
 
@@ -468,13 +468,13 @@ gen#7(i##0:wybe.int, io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp#9##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?j##0:?T)
-        foreign lpvm access(~tmp#9##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#11##0:wybe.list(?T))
+        foreign lpvm access(tmp#9##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?j##0:T)
+        foreign lpvm access(~tmp#9##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#11##0:wybe.list(T))
         foreign c print_int(~i##0:wybe.int, ~io##0:wybe.phantom, ?tmp#33##0:wybe.phantom) @io:nn:nn
         foreign c putchar('\n':wybe.char, ~tmp#33##0:wybe.phantom, ?tmp#34##0:wybe.phantom) @io:nn:nn
         foreign c print_int(~j##0:wybe.int, ~tmp#34##0:wybe.phantom, ?tmp#35##0:wybe.phantom) @io:nn:nn
         foreign c putchar('\n':wybe.char, ~tmp#35##0:wybe.phantom, ?tmp#36##0:wybe.phantom) @io:nn:nn
-        stmt_for.gen#6<0>(~tmp#36##0:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), ~tmp#4##0:wybe.list(?T), ~tmp#5##0:wybe.list(?T), ~tmp#6##0:wybe.list(?T), ~tmp#7##0:wybe.list(?T), ~tmp#8##0:wybe.list(wybe.int), ~tmp#11##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #2 @stmt_for:nn:nn
+        stmt_for.gen#6<0>(~tmp#36##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##0:wybe.list(T), ~tmp#6##0:wybe.list(T), ~tmp#7##0:wybe.list(T), ~tmp#8##0:wybe.list(wybe.int), ~tmp#11##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #2 @stmt_for:nn:nn
 
 
 
@@ -487,12 +487,12 @@ gen#8(i##0:wybe.int, io##0:wybe.phantom, j##0:wybe.int, tmp#0##0:wybe.list(wybe.
     foreign c putchar('\n':wybe.char, ~tmp#15##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     foreign c print_int(~j##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#18##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#18##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    stmt_for.gen#6<0>(~io##2:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), ~tmp#4##0:wybe.list(?T), ~tmp#5##0:wybe.list(?T), ~tmp#6##0:wybe.list(?T), ~tmp#7##0:wybe.list(?T), ~tmp#8##0:wybe.list(wybe.int), ~tmp#9##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##3:wybe.phantom) #2 @stmt_for:nn:nn
+    stmt_for.gen#6<0>(~io##2:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##0:wybe.list(T), ~tmp#6##0:wybe.list(T), ~tmp#7##0:wybe.list(T), ~tmp#8##0:wybe.list(wybe.int), ~tmp#9##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##3:wybe.phantom) #2 @stmt_for:nn:nn
 
 
 gen#9 > (2 calls)
 0: stmt_for.gen#9<0>
-gen#9(io##0:wybe.phantom, tmp#0##0:wybe.list(?T), tmp#1##0:wybe.list(?T), tmp#2##0:wybe.list(?T), tmp#3##0:wybe.list(?T), tmp#4##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
+gen#9(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(tmp#4##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool)
@@ -501,11 +501,11 @@ gen#9(io##0:wybe.phantom, tmp#0##0:wybe.list(?T), tmp#1##0:wybe.list(?T), tmp#2#
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp#4##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:?T)
-        foreign lpvm access(~tmp#4##0:wybe.list(?T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.list(?T))
+        foreign lpvm access(tmp#4##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:T)
+        foreign lpvm access(~tmp#4##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.list(T))
         foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
         foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_for.gen#9<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
+        stmt_for.gen#9<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
 
 
 
@@ -537,25 +537,25 @@ multiple_generator > public (1 calls)
 multiple_generator(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#15##0:wybe.list(?T), ?tmp#16##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
-    foreign lpvm mutate(~tmp#16##0:wybe.list(?T), ?tmp#2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#19##0:wybe.list(?T), ?tmp#20##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
-    foreign lpvm mutate(~tmp#20##0:wybe.list(?T), ?tmp#1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#23##0:wybe.list(?T), ?tmp#24##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
-    foreign lpvm mutate(~tmp#24##0:wybe.list(?T), ?tmp#0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#27##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#27##0:wybe.list(?T), ?tmp#28##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 6:?T)
-    foreign lpvm mutate(~tmp#28##0:wybe.list(?T), ?tmp#6##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#31##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#31##0:wybe.list(?T), ?tmp#32##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 5:?T)
-    foreign lpvm mutate(~tmp#32##0:wybe.list(?T), ?tmp#5##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#6##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#35##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#35##0:wybe.list(?T), ?tmp#36##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
-    foreign lpvm mutate(~tmp#36##0:wybe.list(?T), ?tmp#4##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#5##0:wybe.list(?T))
-    stmt_for.gen#1<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), 0:wybe.list(?T), ~tmp#4##0:wybe.list(?T), ~tmp#5##0:wybe.list(?T), ~tmp#6##0:wybe.list(?T), 0:wybe.list(?T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #8 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#16##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
+    foreign lpvm mutate(~tmp#16##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#20##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
+    foreign lpvm mutate(~tmp#20##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#24##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
+    foreign lpvm mutate(~tmp#24##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#27##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#27##0:wybe.list(T), ?tmp#28##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 6:T)
+    foreign lpvm mutate(~tmp#28##0:wybe.list(T), ?tmp#6##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#31##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#31##0:wybe.list(T), ?tmp#32##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 5:T)
+    foreign lpvm mutate(~tmp#32##0:wybe.list(T), ?tmp#5##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#6##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#35##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#35##0:wybe.list(T), ?tmp#36##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
+    foreign lpvm mutate(~tmp#36##0:wybe.list(T), ?tmp#4##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#5##0:wybe.list(T))
+    stmt_for.gen#1<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), 0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##0:wybe.list(T), ~tmp#6##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #8 @stmt_for:nn:nn
 
 
 semi_det_for_loop > public (0 calls)
@@ -572,25 +572,25 @@ shortest_generator_termination > public (1 calls)
 shortest_generator_termination(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#15##0:wybe.list(?T), ?tmp#16##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
-    foreign lpvm mutate(~tmp#16##0:wybe.list(?T), ?tmp#3##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#19##0:wybe.list(?T), ?tmp#20##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
-    foreign lpvm mutate(~tmp#20##0:wybe.list(?T), ?tmp#2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#23##0:wybe.list(?T), ?tmp#24##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
-    foreign lpvm mutate(~tmp#24##0:wybe.list(?T), ?tmp#1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#27##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#27##0:wybe.list(?T), ?tmp#28##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
-    foreign lpvm mutate(~tmp#28##0:wybe.list(?T), ?tmp#0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#31##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#31##0:wybe.list(?T), ?tmp#32##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 5:?T)
-    foreign lpvm mutate(~tmp#32##0:wybe.list(?T), ?tmp#6##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#35##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#35##0:wybe.list(?T), ?tmp#36##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
-    foreign lpvm mutate(~tmp#36##0:wybe.list(?T), ?tmp#5##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#6##0:wybe.list(?T))
-    stmt_for.gen#6<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), 0:wybe.list(?T), ~tmp#5##0:wybe.list(?T), ~tmp#6##0:wybe.list(?T), 0:wybe.list(?T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #8 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#16##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
+    foreign lpvm mutate(~tmp#16##0:wybe.list(T), ?tmp#3##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#20##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
+    foreign lpvm mutate(~tmp#20##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#24##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
+    foreign lpvm mutate(~tmp#24##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#27##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#27##0:wybe.list(T), ?tmp#28##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
+    foreign lpvm mutate(~tmp#28##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#31##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#31##0:wybe.list(T), ?tmp#32##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 5:T)
+    foreign lpvm mutate(~tmp#32##0:wybe.list(T), ?tmp#6##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#35##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#35##0:wybe.list(T), ?tmp#36##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
+    foreign lpvm mutate(~tmp#36##0:wybe.list(T), ?tmp#5##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#6##0:wybe.list(T))
+    stmt_for.gen#6<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), 0:wybe.list(T), ~tmp#5##0:wybe.list(T), ~tmp#6##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #8 @stmt_for:nn:nn
 
 
 single_generator > public (1 calls)
@@ -598,16 +598,16 @@ single_generator > public (1 calls)
 single_generator(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#9##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#9##0:wybe.list(?T), ?tmp#10##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
-    foreign lpvm mutate(~tmp#10##0:wybe.list(?T), ?tmp#2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#13##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#13##0:wybe.list(?T), ?tmp#14##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
-    foreign lpvm mutate(~tmp#14##0:wybe.list(?T), ?tmp#1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#17##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#17##0:wybe.list(?T), ?tmp#18##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
-    foreign lpvm mutate(~tmp#18##0:wybe.list(?T), ?tmp#0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(?T))
-    stmt_for.gen#9<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), 0:wybe.list(?T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #4 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#9##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#9##0:wybe.list(T), ?tmp#10##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
+    foreign lpvm mutate(~tmp#10##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#13##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#13##0:wybe.list(T), ?tmp#14##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
+    foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#17##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#17##0:wybe.list(T), ?tmp#18##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
+    foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
+    stmt_for.gen#9<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #4 @stmt_for:nn:nn
 
 
 using_break > public (1 calls)
@@ -615,19 +615,19 @@ using_break > public (1 calls)
 using_break(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#11##0:wybe.list(?T), ?tmp#12##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
-    foreign lpvm mutate(~tmp#12##0:wybe.list(?T), ?tmp#3##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#15##0:wybe.list(?T), ?tmp#16##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
-    foreign lpvm mutate(~tmp#16##0:wybe.list(?T), ?tmp#2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#19##0:wybe.list(?T), ?tmp#20##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
-    foreign lpvm mutate(~tmp#20##0:wybe.list(?T), ?tmp#1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#23##0:wybe.list(?T), ?tmp#24##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
-    foreign lpvm mutate(~tmp#24##0:wybe.list(?T), ?tmp#0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(?T))
-    stmt_for.gen#10<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), 0:wybe.list(?T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#12##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
+    foreign lpvm mutate(~tmp#12##0:wybe.list(T), ?tmp#3##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#16##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
+    foreign lpvm mutate(~tmp#16##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#20##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
+    foreign lpvm mutate(~tmp#20##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#24##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
+    foreign lpvm mutate(~tmp#24##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
+    stmt_for.gen#10<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
 using_irange > public (1 calls)
@@ -653,19 +653,19 @@ using_next > public (1 calls)
 using_next(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#11##0:wybe.list(?T), ?tmp#12##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
-    foreign lpvm mutate(~tmp#12##0:wybe.list(?T), ?tmp#3##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#15##0:wybe.list(?T), ?tmp#16##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
-    foreign lpvm mutate(~tmp#16##0:wybe.list(?T), ?tmp#2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#19##0:wybe.list(?T), ?tmp#20##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
-    foreign lpvm mutate(~tmp#20##0:wybe.list(?T), ?tmp#1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#23##0:wybe.list(?T), ?tmp#24##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
-    foreign lpvm mutate(~tmp#24##0:wybe.list(?T), ?tmp#0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(?T))
-    stmt_for.gen#14<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), 0:wybe.list(?T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#12##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
+    foreign lpvm mutate(~tmp#12##0:wybe.list(T), ?tmp#3##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#16##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
+    foreign lpvm mutate(~tmp#16##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#20##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
+    foreign lpvm mutate(~tmp#20##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#24##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
+    foreign lpvm mutate(~tmp#24##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
+    stmt_for.gen#14<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
 using_unless > public (1 calls)
@@ -673,19 +673,19 @@ using_unless > public (1 calls)
 using_unless(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#11##0:wybe.list(?T), ?tmp#12##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
-    foreign lpvm mutate(~tmp#12##0:wybe.list(?T), ?tmp#3##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#15##0:wybe.list(?T), ?tmp#16##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
-    foreign lpvm mutate(~tmp#16##0:wybe.list(?T), ?tmp#2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#19##0:wybe.list(?T), ?tmp#20##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
-    foreign lpvm mutate(~tmp#20##0:wybe.list(?T), ?tmp#1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#23##0:wybe.list(?T), ?tmp#24##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
-    foreign lpvm mutate(~tmp#24##0:wybe.list(?T), ?tmp#0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(?T))
-    stmt_for.gen#16<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), 0:wybe.list(?T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#12##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
+    foreign lpvm mutate(~tmp#12##0:wybe.list(T), ?tmp#3##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#16##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
+    foreign lpvm mutate(~tmp#16##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#20##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
+    foreign lpvm mutate(~tmp#20##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#24##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
+    foreign lpvm mutate(~tmp#24##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
+    stmt_for.gen#16<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
 using_until > public (1 calls)
@@ -693,19 +693,19 @@ using_until > public (1 calls)
 using_until(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#11##0:wybe.list(?T), ?tmp#12##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
-    foreign lpvm mutate(~tmp#12##0:wybe.list(?T), ?tmp#3##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#15##0:wybe.list(?T), ?tmp#16##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
-    foreign lpvm mutate(~tmp#16##0:wybe.list(?T), ?tmp#2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#19##0:wybe.list(?T), ?tmp#20##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
-    foreign lpvm mutate(~tmp#20##0:wybe.list(?T), ?tmp#1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#23##0:wybe.list(?T), ?tmp#24##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
-    foreign lpvm mutate(~tmp#24##0:wybe.list(?T), ?tmp#0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(?T))
-    stmt_for.gen#18<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), 0:wybe.list(?T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#12##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
+    foreign lpvm mutate(~tmp#12##0:wybe.list(T), ?tmp#3##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#16##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
+    foreign lpvm mutate(~tmp#16##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#20##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
+    foreign lpvm mutate(~tmp#20##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#24##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
+    foreign lpvm mutate(~tmp#24##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
+    stmt_for.gen#18<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
 using_when > public (1 calls)
@@ -713,19 +713,19 @@ using_when > public (1 calls)
 using_when(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#11##0:wybe.list(?T), ?tmp#12##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
-    foreign lpvm mutate(~tmp#12##0:wybe.list(?T), ?tmp#3##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#15##0:wybe.list(?T), ?tmp#16##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
-    foreign lpvm mutate(~tmp#16##0:wybe.list(?T), ?tmp#2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#19##0:wybe.list(?T), ?tmp#20##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
-    foreign lpvm mutate(~tmp#20##0:wybe.list(?T), ?tmp#1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#23##0:wybe.list(?T), ?tmp#24##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
-    foreign lpvm mutate(~tmp#24##0:wybe.list(?T), ?tmp#0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(?T))
-    stmt_for.gen#20<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), 0:wybe.list(?T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#12##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
+    foreign lpvm mutate(~tmp#12##0:wybe.list(T), ?tmp#3##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#16##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
+    foreign lpvm mutate(~tmp#16##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#20##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
+    foreign lpvm mutate(~tmp#20##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#24##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
+    foreign lpvm mutate(~tmp#24##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
+    stmt_for.gen#20<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
 using_while > public (1 calls)
@@ -733,19 +733,19 @@ using_while > public (1 calls)
 using_while(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#11##0:wybe.list(?T), ?tmp#12##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:?T)
-    foreign lpvm mutate(~tmp#12##0:wybe.list(?T), ?tmp#3##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#15##0:wybe.list(?T), ?tmp#16##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:?T)
-    foreign lpvm mutate(~tmp#16##0:wybe.list(?T), ?tmp#2##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#19##0:wybe.list(?T), ?tmp#20##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:?T)
-    foreign lpvm mutate(~tmp#20##0:wybe.list(?T), ?tmp#1##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(?T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#23##0:wybe.list(?T), ?tmp#24##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:?T)
-    foreign lpvm mutate(~tmp#24##0:wybe.list(?T), ?tmp#0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(?T))
-    stmt_for.gen#22<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(?T), ~tmp#1##0:wybe.list(?T), ~tmp#2##0:wybe.list(?T), ~tmp#3##0:wybe.list(?T), 0:wybe.list(?T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#12##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
+    foreign lpvm mutate(~tmp#12##0:wybe.list(T), ?tmp#3##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#16##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
+    foreign lpvm mutate(~tmp#16##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#20##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
+    foreign lpvm mutate(~tmp#20##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#24##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
+    foreign lpvm mutate(~tmp#24##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
+    stmt_for.gen#22<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
 using_xrange > public (1 calls)

--- a/test-cases/final-dump/type_generics.exp
+++ b/test-cases/final-dump/type_generics.exp
@@ -14,11 +14,11 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    type_generics.foo<0>(1:?t, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @type_generics:nn:nn
-    type_generics.foo<0>(1:?t, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #2 @type_generics:nn:nn
-    type_generics.foo<0>(1.0:?t, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @type_generics:nn:nn
-    type_generics.foo<0>(1.0:?t, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @type_generics:nn:nn
-    type_generics.foo2<0>(1:?T, ?y##0:?T, ?tmp#7##0:wybe.bool) #5 @type_generics:nn:nn
+    type_generics.foo<0>(1:T, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @type_generics:nn:nn
+    type_generics.foo<0>(1:T, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #2 @type_generics:nn:nn
+    type_generics.foo<0>(1.0:T, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @type_generics:nn:nn
+    type_generics.foo<0>(1.0:T, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @type_generics:nn:nn
+    type_generics.foo2<0>(1:T0, ?y##0:T0, ?tmp#7##0:wybe.bool) #5 @type_generics:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:
         type_generics.gen#1<0>(~io##4:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##6:wybe.phantom) #8
@@ -32,33 +32,33 @@ AFTER EVERYTHING:
 
 foo > (12 calls)
 0: type_generics.foo<0>
-foo(x##0:?t, io##0:wybe.phantom, ?io##1:wybe.phantom):
+foo(x##0:T, io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#5##0:wybe.list(?T), ?tmp#6##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:?T)
-    foreign lpvm mutate(~tmp#6##0:wybe.list(?T), ?tmp#0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
-    wybe.list.length1<0>(~tmp#0##0:wybe.list(?T), 0:wybe.int, ?tmp#2##0:wybe.int) #4 @list:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#5##0:wybe.list(T), ?tmp#6##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:T)
+    foreign lpvm mutate(~tmp#6##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    wybe.list.length1<0>(~tmp#0##0:wybe.list(T), 0:wybe.int, ?tmp#2##0:wybe.int) #4 @list:nn:nn
     foreign c print_int(~tmp#2##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
 
 
 foo2 > (18 calls)
 0: type_generics.foo2<0>
-foo2(x##0:?T, ?y##0:?T, ?#success##0:wybe.bool):
+foo2(x##0:T0, ?y##0:T0, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#6##0:wybe.list(?T))
-    foreign lpvm mutate(~tmp#6##0:wybe.list(?T), ?tmp#7##0:wybe.list(?T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:?T)
-    foreign lpvm mutate(~tmp#7##0:wybe.list(?T), ?tmp#0##0:wybe.list(?T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(?T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#6##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#6##0:wybe.list(T), ?tmp#7##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:T)
+    foreign lpvm mutate(~tmp#7##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
     foreign llvm icmp_ne(tmp#0##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
     case ~tmp#9##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
-        foreign llvm move(undef:?T, ?y##0:?T)
+        foreign llvm move(undef:T, ?y##0:T)
 
     1:
-        foreign lpvm access(~tmp#0##0:wybe.list(?T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:?T)
+        foreign lpvm access(~tmp#0##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:T)
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -68,7 +68,7 @@ gen#1 > (2 calls)
 gen#1(io##0:wybe.phantom, [tmp#0##0:wybe.bool], [x##0:wybe.float], ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    type_generics.foo2<0>(1:?T, ?y##0:?T, ?tmp#6##0:wybe.bool) #0 @type_generics:nn:nn
+    type_generics.foo2<0>(1:T0, ?y##0:T0, ?tmp#6##0:wybe.bool) #0 @type_generics:nn:nn
     case ~tmp#6##0:wybe.bool of
     0:
         type_generics.gen#2<0>(_:wybe.int, ~io##0:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##2:wybe.phantom) #3
@@ -85,7 +85,7 @@ gen#2 > (2 calls)
 gen#2([i##0:wybe.int], io##0:wybe.phantom, [tmp#0##0:wybe.bool], [x##0:wybe.float], ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    type_generics.foo2<0>(1.0:?T, ?fx##0:?T, ?tmp#5##0:wybe.bool) #0 @type_generics:nn:nn
+    type_generics.foo2<0>(1.0:T0, ?fx##0:T0, ?tmp#5##0:wybe.bool) #0 @type_generics:nn:nn
     case ~tmp#5##0:wybe.bool of
     0:
         type_generics.gen#3<0>(_:wybe.float, _:wybe.int, ~io##0:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##2:wybe.phantom) #3
@@ -102,7 +102,7 @@ gen#3 > (2 calls)
 gen#3([f##0:wybe.float], [i##0:wybe.int], io##0:wybe.phantom, [tmp#0##0:wybe.bool], [x##0:wybe.float], ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    type_generics.foo2<0>(1.0:?T, ?x##1:?T, ?tmp#4##0:wybe.bool) #0 @type_generics:nn:nn
+    type_generics.foo2<0>(1.0:T0, ?x##1:T0, ?tmp#4##0:wybe.bool) #0 @type_generics:nn:nn
     case ~tmp#4##0:wybe.bool of
     0:
         type_generics.gen#4<0>(_:wybe.float, _:wybe.int, ~io##0:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##2:wybe.phantom) #3
@@ -119,7 +119,7 @@ gen#4 > (2 calls)
 gen#4([f##0:wybe.float], [i##0:wybe.int], io##0:wybe.phantom, [tmp#0##0:wybe.bool], [x##0:wybe.float], ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    type_generics.foo2<0>('a':?T, ?z##0:?T, ?tmp#3##0:wybe.bool) #0 @type_generics:nn:nn
+    type_generics.foo2<0>('a':T0, ?z##0:T0, ?tmp#3##0:wybe.bool) #0 @type_generics:nn:nn
     case ~tmp#3##0:wybe.bool of
     0:
         type_generics.gen#5<0>(_:wybe.float, _:wybe.int, ~io##0:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##2:wybe.phantom) #3
@@ -136,7 +136,7 @@ gen#5 > (2 calls)
 gen#5([f##0:wybe.float], [i##0:wybe.int], io##0:wybe.phantom, [tmp#0##0:wybe.bool], [x##0:wybe.float], ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    type_generics.foo2<0>(0:?T, ?b##0:?T, ?tmp#2##0:wybe.bool) #1 @type_generics:nn:nn
+    type_generics.foo2<0>(0:T0, ?b##0:T0, ?tmp#2##0:wybe.bool) #1 @type_generics:nn:nn
     case ~tmp#2##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)

--- a/test-cases/final-dump/type_generics.wybe
+++ b/test-cases/final-dump/type_generics.wybe
@@ -1,4 +1,4 @@
-def foo(x:?t) use !io {
+def foo(x:T) use !io {
     ?l = [x]
     !println(length(l))
 }
@@ -8,7 +8,7 @@ def foo(x:?t) use !io {
 !foo(1.0)
 ?x = 1.0; !foo(x) 
 
-def {test} foo2(x:?T, ?y:?T) {
+def {test} foo2(x:T0, ?y:T0) {
     ?l = [x]
     [?y|_] = l
 }

--- a/wybelibs/wybe/array.wybe
+++ b/wybelibs/wybe/array.wybe
@@ -2,11 +2,11 @@ pragma no_standard_library  # Standard library can't depend on itself!
 
 use wybe.bool, wybe.int
 
-pub constructor(?T) array(length:int,raw_data:raw_array(?T))
+pub constructor (T) array(length:int,raw_data:raw_array(T))
 
-pub type raw_array(?T) is address {}
+pub type raw_array(T) is address {}
 
-pub def {test} `[|]`(?head:?T, ?tail:array(?T), a:array(?T)) {
+pub def {test} `[|]`(?head:T, ?tail:array(T), a:array(T)) {
     (array(?length,?data) = a)
     (length > 0)
     foreign lpvm access(data,0,0,0,?head)

--- a/wybelibs/wybe/list.wybe
+++ b/wybelibs/wybe/list.wybe
@@ -2,17 +2,17 @@ pragma no_standard_library  # Standard library can't depend on itself!
 
 use wybe.bool, wybe.int
 
-pub constructors(?T) [] | [head:?T | tail:_(?T)]
+pub constructors (T) [] | [head:T | tail:_(T)]
 
-pub def (x:_(?T) ,, y:_(?T)):_(?T) =
+pub def (x:_(T) ,, y:_(T)):_(T) =
     if { x = [?h|?t] :: [h|t,,y] | else :: y }
 
-pub def length(x:_(?T)) : int = length1(x, 0)
+pub def length(x:_(T)) : int = length1(x, 0)
 
-def length1(x:_(?T), acc:int) : int =
+def length1(x:_(T), acc:int) : int =
     if { x = [?h|?t]:: length1(t, acc+1) | else:: acc }
 
-pub def reverse(x:_(?T)):_(?T) = reverse1(x, [])
+pub def reverse(x:_(T)):_(T) = reverse1(x, [])
 
-def reverse1(x:_(?T), tail:_(?T)):_(?T) =
+def reverse1(x:_(T), tail:_(T)):_(T) =
     if { x = [?h|?t]:: reverse1(t, [h|tail]) | else:: tail }


### PR DESCRIPTION
This PR concerns issue #166 

Type variables are now of the form `[A-Z][0-9]*`, and types/modules cannot be declared with these names.