### PR TITLE
fixed unbranching issues; refactored flattening of for-loops

### DIFF
--- a/src/Codegen.hs
+++ b/src/Codegen.hs
@@ -432,6 +432,7 @@ operandType (ConstantOperand cons) =
         C.GlobalReference ty _ -> ty
         C.GetElementPtr _ (C.GlobalReference ty _) _ -> ty
         C.IntToPtr _ ty -> ty
+        C.PtrToInt _ ty -> ty
         C.Undef ty -> ty
         _ -> shouldnt $ "Not a recognised constant operand: " ++ show cons
 operandType _ = void_t

--- a/src/Flatten.hs
+++ b/src/Flatten.hs
@@ -330,83 +330,38 @@ flattenStmt' for@(For generators body) pos detism = do
     --          <stmts>
     --      }
     -- will be transformed into
-    -- ?tempGen1 = x
-    -- ?tempGen2 = y
+    -- ?temp1 = x
+    -- ?temp2 = y
     -- do {
-    --     `[|]`(?i, ?tempGen3, tempGen1, ?tempHasNextGen)
-    --      if {
-    --          tempHasNextGen :: ?tempGen1 = tempGen3
-    --          otherwise      :: break
-    --      }
-    --      `[|]`(?j, ?tempGen4, tempGen2, ?tempHasNextGen)
-    --      if {
-    --          tempHasNextGen :: ?tempGen2 = tempGen4
-    --          otherwise      :: break
-    --      }
-    --      
-    --      <stmts>
+    --     if { `[|]`(?i, ?temp1, temp1) :: 
+    --          if { `[|]`(?2, ?temp2, temp2) ::
+    --              <stmts>
+    --          | otherwise :: break
+    --          }
+    --     | otherwise :: break
+    --     }
     -- }
-    -- OR
-    -- ?tempGen1 = x
-    -- ?tempGen2
-    tempGens <- mapM (const tempVar) generators
-    tempNextGens <- mapM (const tempVar) generators
-    tempHasNextGen <- tempVar
     logFlatten $ "Generating for " ++ showStmt 4 for
-    -- XXX Should check for input only
-    generators' <- mapM (flattenPExp . genExp) generators
-    let instrs =
-            zipWith
-            ( \g' g ->
-                ForeignCall
-                    "llvm"
-                    "move"
-                    []
-                    [g', Unplaced $ varSet g]
-            )
-            generators'
-            tempGens
+    temps <- mapM (const tempVar) generators
+    -- XXX Should check for input only    
+    origs <- mapM (flattenPExp . genExp) generators
+    let instrs = zipWith (\orig temp ->
+                            ForeignCall "llvm" "move" [] 
+                                [orig, Unplaced $ varSet temp])
+                    origs temps
     mapM_ (emit pos) instrs
-    modify (\s -> s {defdVars = Set.union (Set.fromList tempGens) $ defdVars s})
-    modify (\s -> s {defdVars = Set.union (Set.fromList tempNextGens) $ defdVars s})
-    modify (\s -> s {defdVars = Set.insert tempHasNextGen $ defdVars s})
-    let nextVals =
-            concat $
-            zipWith3
-                ( \generator tempNextGen tempGen ->
-                    [ Unplaced $
-                        ProcCall
-                        []
-                        "[|]"
-                        Nothing
-                        Det
-                        False
-                        [ loopVar generator,
-                          Unplaced $ Var tempNextGen ParamOut Ordinary,
-                          Unplaced $ Var tempGen ParamIn Ordinary,
-                          Unplaced $ Var tempHasNextGen ParamOut Ordinary
-                        ]
-                    , Unplaced $
-                            Cond
-                            (Unplaced $ TestBool $ varGet tempHasNextGen)
-                            [ Unplaced $
-                                ForeignCall
-                                    "llvm"
-                                    "move"
-                                    []
-                                    [Unplaced $ varGet tempNextGen, Unplaced $ varSet tempGen]
-                            ]
-                            [Unplaced Break]
-                            Nothing -- TODO: Check if we need to replace Nothing with actual
-                            Nothing
-                    ]
-                )
-                generators
-                tempNextGens
-                tempGens
-    let generated = Loop (nextVals ++ body) Nothing -- TODO: Replace Nothing
+    modify (\s -> s {defdVars = Set.union (Set.fromList temps) $ defdVars s})
+    let loop = List.foldr 
+                (\(var, gen) loop -> 
+                    [Unplaced $ Cond (Unplaced $ ProcCall [] "[|]" Nothing SemiDet False 
+                                        [var,
+                                         Unplaced $ Var gen ParamOut Ordinary,
+                                         Unplaced $ Var gen ParamIn Ordinary]) 
+                                loop [Unplaced Break]
+                      Nothing Nothing]
+                    ) body $ zip (loopVar <$> generators) temps
+    let generated = Loop loop Nothing
     logFlatten $ "Generated for: " ++ showStmt 4 generated
-    -- emit pos generated
     flattenStmt' generated pos detism
 flattenStmt' (UseResources res old body) pos detism = do
     oldVars <- gets defdVars

--- a/test-cases/final-dump/alias_recursion3.exp
+++ b/test-cases/final-dump/alias_recursion3.exp
@@ -1,5 +1,6 @@
 Error detected during type checking of module(s) alias_recursion3, alias_recursion3.mynode
-[91mfinal-dump/alias_recursion3.wybe:15:17: Calling test proc alias_recursion3.mynode.next<0> in a normal (total) context
+[91mfinal-dump/alias_recursion3.wybe:12:5: Output parameter resutl1 not defined by proc "foo"
+[0m[91mfinal-dump/alias_recursion3.wybe:15:17: Calling test proc alias_recursion3.mynode.next<0> in a normal (total) context
 [0m[91mfinal-dump/alias_recursion3.wybe:16:13: Calling test proc alias_recursion3.mynode.next<1> in a normal (total) context
 [0m[91mfinal-dump/alias_recursion3.wybe:16:28: Calling test proc alias_recursion3.mynode.next<0> in a normal (total) context
 [0m

--- a/test-cases/final-dump/caret.exp
+++ b/test-cases/final-dump/caret.exp
@@ -19,20 +19,20 @@ AFTER EVERYTHING:
  AliasPairs: []
  InterestingCallProperties: []
  MultiSpeczDepInfo: [(8,(caret.gen#1<0>,fromList [NonAliasedParamCond 1 []]))]
-    foreign lpvm alloc(16:wybe.int, ?tmp#13##0:position.position)
-    foreign lpvm mutate(~tmp#13##0:position.position, ?tmp#14##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
-    foreign lpvm mutate(~tmp#14##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp#17##0:position.position)
-    foreign lpvm mutate(~tmp#17##0:position.position, ?tmp#18##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    foreign lpvm mutate(~tmp#18##0:position.position, ?tmp#2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 12:wybe.int)
-    foreign lpvm alloc(16:wybe.int, ?tmp#21##0:caret.region)
-    foreign lpvm mutate(~tmp#21##0:caret.region, ?tmp#22##0:caret.region, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:position.position)
-    foreign lpvm mutate(~tmp#22##0:caret.region, ?tmp#23##0:caret.region, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:position.position)
+    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:position.position)
+    foreign lpvm mutate(~tmp#14##0:position.position, ?tmp#15##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.int)
+    foreign lpvm mutate(~tmp#15##0:position.position, ?tmp#1##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:position.position)
+    foreign lpvm mutate(~tmp#18##0:position.position, ?tmp#19##0:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    foreign lpvm mutate(~tmp#19##0:position.position, ?tmp#2##0:position.position, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 12:wybe.int)
+    foreign lpvm alloc(16:wybe.int, ?tmp#22##0:caret.region)
+    foreign lpvm mutate(~tmp#22##0:caret.region, ?tmp#23##0:caret.region, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#1##0:position.position)
+    foreign lpvm mutate(~tmp#23##0:caret.region, ?tmp#24##0:caret.region, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:position.position)
     foreign lpvm access(~tmp#2##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ten##0:wybe.int)
     wybe.string.print_string<0>("ten = ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #11 @io:nn:nn
-    foreign c print_int(~ten##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#32##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#32##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    caret.gen#1<0>[6dacb8fd25](~io##2:wybe.phantom, ~tmp#23##0:caret.region, _:caret.region, _:position.position, _:position.position, ?io##3:wybe.phantom) #8
+    foreign c print_int(~ten##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#33##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#33##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    caret.gen#1<0>[6dacb8fd25](~io##2:wybe.phantom, ~tmp#24##0:caret.region, _:caret.region, _:position.position, _:position.position, ?io##3:wybe.phantom) #8
 
 
 expand_region > public (0 calls)
@@ -73,8 +73,8 @@ gen#1(io##0:wybe.phantom, reg##0:caret.region, [tmp#0##0:caret.region], [tmp#1##
     foreign lpvm {noalias} mutate(~%tmp#6##0:position.position, ?%tmp#6##1:position.position, 0:wybe.int, 0:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##1:wybe.int)
     foreign lpvm access(~tmp#6##1:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ten##0:wybe.int)
     wybe.string.print_string<0>("now ten = ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #9 @io:nn:nn
-    foreign c print_int(~ten##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#23##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#23##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_int(~ten##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#24##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#24##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
  [6dacb8fd25] [NonAliasedParam 1] :
     foreign lpvm access(~reg##0:caret.region, 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:position.position)
     foreign lpvm access(tmp#6##0:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.int)
@@ -82,8 +82,8 @@ gen#1(io##0:wybe.phantom, reg##0:caret.region, [tmp#0##0:caret.region], [tmp#1##
     foreign lpvm {noalias} mutate(~%tmp#6##0:position.position, ?%tmp#6##1:position.position, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~tmp#5##1:wybe.int)
     foreign lpvm access(~tmp#6##1:position.position, 0:wybe.int, 16:wybe.int, 0:wybe.int, ?ten##0:wybe.int)
     wybe.string.print_string<0>("now ten = ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #9 @io:nn:nn
-    foreign c print_int(~ten##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#23##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#23##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+    foreign c print_int(~ten##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#24##0:wybe.phantom) @io:nn:nn
+    foreign c putchar('\n':wybe.char, ~tmp#24##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/for_unbound_after.exp
+++ b/test-cases/final-dump/for_unbound_after.exp
@@ -1,0 +1,3 @@
+Error detected during type checking of module(s) for_unbound_after
+[91mfinal-dump/for_unbound_after.wybe:2:2: Uninitialised argument in call to print, argument 1
+[0m

--- a/test-cases/final-dump/for_unbound_after.wybe
+++ b/test-cases/final-dump/for_unbound_after.wybe
@@ -1,0 +1,2 @@
+for ?i in [1] { pass }
+!print i

--- a/test-cases/final-dump/int_sequence.exp
+++ b/test-cases/final-dump/int_sequence.exp
@@ -23,10 +23,10 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#6##0:int_sequence)
-    foreign lpvm mutate(~tmp#6##0:int_sequence, ?tmp#7##0:int_sequence, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
-    foreign lpvm mutate(~tmp#7##0:int_sequence, ?tmp#3##0:int_sequence, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
-    int_sequence.gen#1<0>(~io##0:wybe.phantom, ~tmp#3##0:int_sequence, ~tmp#3##0:int_sequence, ?io##1:wybe.phantom) #1 @int_sequence:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#5##0:int_sequence)
+    foreign lpvm mutate(~tmp#5##0:int_sequence, ?tmp#6##0:int_sequence, 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:wybe.int)
+    foreign lpvm mutate(~tmp#6##0:int_sequence, ?tmp#1##0:int_sequence, 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 10:wybe.int)
+    int_sequence.gen#1<0>(~io##0:wybe.phantom, ~tmp#1##0:int_sequence, ~tmp#1##0:int_sequence, ?io##1:wybe.phantom) #1 @int_sequence:nn:nn
 
 
 .. > public {inline} (2 calls)
@@ -108,30 +108,30 @@ AFTER EVERYTHING:
 
 gen#1 > (2 calls)
 0: int_sequence.gen#1<0>[6dacb8fd25]
-gen#1(io##0:wybe.phantom, tmp#0##0:int_sequence, tmp#3##0:int_sequence, ?io##2:wybe.phantom):
+gen#1(io##0:wybe.phantom, tmp#0##0:int_sequence, tmp#1##0:int_sequence, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 1]
  MultiSpeczDepInfo: [(0,(int_sequence.[|]<0>,fromList [NonAliasedParamCond 2 [1]])),(2,(int_sequence.gen#1<0>,fromList [NonAliasedParamCond 1 []]))]
-    int_sequence.[|]<0>(?i##0:wybe.int, ?tmp#1##0:int_sequence, ~tmp#0##0:int_sequence, ?tmp#2##0:wybe.bool) #0
+    int_sequence.[|]<0>(?i##0:wybe.int, ?tmp#0##1:int_sequence, ~tmp#0##0:int_sequence, ?tmp#2##0:wybe.bool) #0
     case ~tmp#2##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        int_sequence.gen#1<0>[6dacb8fd25](~io##1:wybe.phantom, ~tmp#1##0:int_sequence, ~tmp#3##0:int_sequence, ?io##2:wybe.phantom) #2 @int_sequence:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        int_sequence.gen#1<0>[6dacb8fd25](~io##1:wybe.phantom, ~tmp#0##1:int_sequence, ~tmp#1##0:int_sequence, ?io##2:wybe.phantom) #2 @int_sequence:nn:nn
 
  [6dacb8fd25] [NonAliasedParam 1] :
-    int_sequence.[|]<0>[785a827a1b](?i##0:wybe.int, ?tmp#1##0:int_sequence, ~tmp#0##0:int_sequence, ?tmp#2##0:wybe.bool) #0
+    int_sequence.[|]<0>[785a827a1b](?i##0:wybe.int, ?tmp#0##1:int_sequence, ~tmp#0##0:int_sequence, ?tmp#2##0:wybe.bool) #0
     case ~tmp#2##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        int_sequence.gen#1<0>[6dacb8fd25](~io##1:wybe.phantom, ~tmp#1##0:int_sequence, ~tmp#3##0:int_sequence, ?io##2:wybe.phantom) #2 @int_sequence:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        int_sequence.gen#1<0>[6dacb8fd25](~io##1:wybe.phantom, ~tmp#0##1:int_sequence, ~tmp#1##0:int_sequence, ?io##2:wybe.phantom) #2 @int_sequence:nn:nn
 
 
 
@@ -344,7 +344,7 @@ if.else:
 }
 
 
-define external fastcc  void @"int_sequence.gen#1<0>"(i64  %"tmp#0##0", i64  %"tmp#3##0")    {
+define external fastcc  void @"int_sequence.gen#1<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0")    {
 entry:
   %79 = tail call fastcc  {i64, i64, i1}  @"int_sequence.[|]<0>"(i64  %"tmp#0##0")  
   %80 = extractvalue {i64, i64, i1} %79, 0 
@@ -354,14 +354,14 @@ entry:
 if.then:
   tail call ccc  void  @print_int(i64  %80)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_sequence.gen#1<0>[6dacb8fd25]"(i64  %81, i64  %"tmp#3##0")  
+  tail call fastcc  void  @"int_sequence.gen#1<0>[6dacb8fd25]"(i64  %81, i64  %"tmp#1##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"int_sequence.gen#1<0>[6dacb8fd25]"(i64  %"tmp#0##0", i64  %"tmp#3##0")    {
+define external fastcc  void @"int_sequence.gen#1<0>[6dacb8fd25]"(i64  %"tmp#0##0", i64  %"tmp#1##0")    {
 entry:
   %83 = tail call fastcc  {i64, i64, i1}  @"int_sequence.[|]<0>[785a827a1b]"(i64  %"tmp#0##0")  
   %84 = extractvalue {i64, i64, i1} %83, 0 
@@ -371,7 +371,7 @@ entry:
 if.then:
   tail call ccc  void  @print_int(i64  %84)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"int_sequence.gen#1<0>[6dacb8fd25]"(i64  %85, i64  %"tmp#3##0")  
+  tail call fastcc  void  @"int_sequence.gen#1<0>[6dacb8fd25]"(i64  %85, i64  %"tmp#1##0")  
   ret void 
 if.else:
   ret void 

--- a/test-cases/final-dump/loop_if_if_unbranching.exp
+++ b/test-cases/final-dump/loop_if_if_unbranching.exp
@@ -1,0 +1,96 @@
+======================================================================
+AFTER EVERYTHING:
+ Module loop_if_if_unbranching
+  representation  : (not a type)
+  public submods  : 
+  public resources: 
+  public procs    : loop_if_if_unbranching.<0>
+  imports         : use wybe
+  resources       : 
+  procs           : 
+
+*main* > public {inline,impure} (0 calls)
+0: loop_if_if_unbranching.<0>
+(io##0:wybe.phantom, ?io##1:wybe.phantom):
+ AliasPairs: []
+ InterestingCallProperties: []
+    loop_if_if_unbranching.gen#3<0>(~io##0:wybe.phantom, 0:wybe.list(4), 0:wybe.list(T), ?io##1:wybe.phantom) #1 @loop_if_if_unbranching:nn:nn
+
+
+gen#1 > {inline} (1 calls)
+0: loop_if_if_unbranching.gen#1<0>
+gen#1(io##0:wybe.phantom, [tmp#0##0:wybe.list(4)], [tmp#1##0:wybe.list(4)], ?io##1:wybe.phantom):
+ AliasPairs: []
+ InterestingCallProperties: []
+    foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
+
+
+gen#2 > {inline} (1 calls)
+0: loop_if_if_unbranching.gen#2<0>
+gen#2(io##0:wybe.phantom, [tmp#0##0:wybe.list(4)], [tmp#1##0:wybe.list(4)], [?io##0:wybe.phantom]):
+ AliasPairs: []
+ InterestingCallProperties: []
+
+
+gen#3 > (2 calls)
+0: loop_if_if_unbranching.gen#3<0>
+gen#3(io##0:wybe.phantom, tmp#0##0:wybe.list(4), tmp#1##0:wybe.list(T), ?io##1:wybe.phantom):
+ AliasPairs: []
+ InterestingCallProperties: []
+    foreign llvm icmp_ne(tmp#0##0:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.bool)
+    case ~tmp#6##0:wybe.bool of
+    0:
+        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
+
+    1:
+        foreign lpvm access(~tmp#0##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##1:wybe.list(T))
+        loop_if_if_unbranching.gen#3<0>(~io##0:wybe.phantom, ~tmp#0##1:wybe.list(4), ~tmp#1##0:wybe.list(T), ?io##1:wybe.phantom) #1 @loop_if_if_unbranching:nn:nn
+
+
+  LLVM code       :
+
+; ModuleID = 'loop_if_if_unbranching'
+
+
+ 
+
+
+declare external ccc  i8* @wybe_malloc(i32)    
+
+
+declare external ccc  void @llvm.memcpy.p0i8.p0i8.i32(i8*, i8*, i32, i32, i1)    
+
+
+define external fastcc  void @"loop_if_if_unbranching.<0>"()    {
+entry:
+  tail call fastcc  void  @"loop_if_if_unbranching.gen#3<0>"(i64  0, i64  0)  
+  ret void 
+}
+
+
+define external fastcc  void @"loop_if_if_unbranching.gen#1<0>"()    {
+entry:
+  ret void 
+}
+
+
+define external fastcc  void @"loop_if_if_unbranching.gen#2<0>"()    {
+entry:
+  ret void 
+}
+
+
+define external fastcc  void @"loop_if_if_unbranching.gen#3<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0")    {
+entry:
+  %"1#tmp#6##0" = icmp ne i64 %"tmp#0##0", 0 
+  br i1 %"1#tmp#6##0", label %if.then, label %if.else 
+if.then:
+  %1 = add   i64 %"tmp#0##0", 8 
+  %2 = inttoptr i64 %1 to i64* 
+  %3 = getelementptr  i64, i64* %2, i64 0 
+  %4 = load  i64, i64* %3 
+  tail call fastcc  void  @"loop_if_if_unbranching.gen#3<0>"(i64  %4, i64  %"tmp#1##0")  
+  ret void 
+if.else:
+  ret void 
+}

--- a/test-cases/final-dump/loop_if_if_unbranching.wybe
+++ b/test-cases/final-dump/loop_if_if_unbranching.wybe
@@ -1,0 +1,3 @@
+for ?i in [] { pass }
+if { true :: pass }
+if { true :: pass }

--- a/test-cases/final-dump/stmt_for.exp
+++ b/test-cases/final-dump/stmt_for.exp
@@ -86,426 +86,330 @@ AFTER EVERYTHING:
 
 gen#1 > (2 calls)
 0: stmt_for.gen#1<0>
-gen#1(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(T), tmp#5##0:wybe.list(T), tmp#6##0:wybe.list(T), tmp#7##0:wybe.list(T), tmp#8##0:wybe.list(wybe.int), tmp#9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
+gen#1(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(T), tmp#5##0:wybe.list(T), tmp#6##0:wybe.list(T), tmp#7##0:wybe.list(T), tmp#8##0:wybe.list(wybe.int), tmp#9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int), ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp#8##0:wybe.int, 0:wybe.int, ?tmp#14##0:wybe.bool)
-    case ~tmp#14##0:wybe.bool of
+    foreign llvm icmp_ne(tmp#8##0:wybe.int, 0:wybe.int, ?tmp#13##0:wybe.bool)
+    case ~tmp#13##0:wybe.bool of
     0:
-        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##3:wybe.phantom)
 
     1:
         foreign lpvm access(tmp#8##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:T)
-        foreign lpvm access(~tmp#8##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.list(T))
-        stmt_for.gen#2<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int), ~tmp#6##0:wybe.list(wybe.int), ~tmp#7##0:wybe.list(wybe.int), ~tmp#10##0:wybe.list(wybe.int), ~tmp#9##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
+        foreign lpvm access(~tmp#8##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##1:wybe.list(T))
+        foreign llvm icmp_ne(tmp#9##0:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.bool)
+        case ~tmp#15##0:wybe.bool of
+        0:
+            foreign llvm move(~io##0:wybe.phantom, ?io##3:wybe.phantom)
+
+        1:
+            foreign lpvm access(tmp#9##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?j##0:T)
+            foreign lpvm access(~tmp#9##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##1:wybe.list(T))
+            foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @io:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#18##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+            foreign c print_int(~j##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#21##0:wybe.phantom) @io:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+            stmt_for.gen#1<0>(~io##2:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##0:wybe.list(T), ~tmp#6##0:wybe.list(T), ~tmp#7##0:wybe.list(T), ~tmp#8##1:wybe.list(wybe.int), ~tmp#9##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##3:wybe.phantom) #4 @stmt_for:nn:nn
+
 
 
 
 gen#10 > (2 calls)
 0: stmt_for.gen#10<0>
-gen#10(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
+gen#10(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
-    case ~tmp#10##0:wybe.bool of
+    foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
+    case ~tmp#9##0:wybe.bool of
     0:
-        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
+        foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
         foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:T)
-        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.list(T))
-        stmt_for.gen#11<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#6##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
+        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(T))
+        foreign llvm icmp_eq(i##0:wybe.int, 3:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
+        case ~tmp#6##0:wybe.bool of
+        0:
+            foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+            stmt_for.gen#10<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #3 @stmt_for:nn:nn
+
+        1:
+            foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
 
 
-gen#11 > (1 calls)
+
+gen#11 > (3 calls)
 0: stmt_for.gen#11<0>
-gen#11(i##0:wybe.int, io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), [tmp#6##0:wybe.list(wybe.int)], [tmp#7##0:wybe.bool], x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
+gen#11(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_eq(i##0:wybe.int, 3:wybe.int, ?tmp#8##0:wybe.bool) @int:nn:nn
-    case ~tmp#8##0:wybe.bool of
+    foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
+    case ~tmp#9##0:wybe.bool of
     0:
-        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_for.gen#10<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
+        foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
+        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:T)
+        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(T))
+        foreign llvm icmp_slt(i##0:wybe.int, 3:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
+        case ~tmp#6##0:wybe.bool of
+        0:
+            stmt_for.gen#11<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #4 @stmt_for:nn:nn
+
+        1:
+            foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+            stmt_for.gen#11<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #3 @stmt_for:nn:nn
+
 
 
 
 gen#12 > (2 calls)
 0: stmt_for.gen#12<0>
-gen#12(io##0:wybe.phantom, tmp#0##0:stmt_for.int_sequence, tmp#3##0:stmt_for.int_sequence, ?io##2:wybe.phantom):
+gen#12(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp#1##0:stmt_for.int_sequence, ~tmp#0##0:stmt_for.int_sequence, ?tmp#2##0:wybe.bool) #0
-    case ~tmp#2##0:wybe.bool of
+    foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
+    case ~tmp#9##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_for.gen#12<0>(~io##1:wybe.phantom, ~tmp#1##0:stmt_for.int_sequence, ~tmp#3##0:stmt_for.int_sequence, ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
+        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:T)
+        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(T))
+        foreign llvm icmp_slt(i##0:wybe.int, 3:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
+        case ~tmp#6##0:wybe.bool of
+        0:
+            foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
+
+        1:
+            foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+            stmt_for.gen#12<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #3 @stmt_for:nn:nn
+
 
 
 
 gen#13 > (2 calls)
 0: stmt_for.gen#13<0>
-gen#13(io##0:wybe.phantom, tmp#0##0:stmt_for.int_sequence, tmp#3##0:stmt_for.int_sequence, ?io##2:wybe.phantom):
+gen#13(io##0:wybe.phantom, tmp#0##0:stmt_for.int_sequence, tmp#1##0:stmt_for.int_sequence, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp#1##0:stmt_for.int_sequence, ~tmp#0##0:stmt_for.int_sequence, ?tmp#2##0:wybe.bool) #0
+    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp#0##1:stmt_for.int_sequence, ~tmp#0##0:stmt_for.int_sequence, ?tmp#2##0:wybe.bool) #0
     case ~tmp#2##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_for.gen#13<0>(~io##1:wybe.phantom, ~tmp#1##0:stmt_for.int_sequence, ~tmp#3##0:stmt_for.int_sequence, ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_for.gen#13<0>(~io##1:wybe.phantom, ~tmp#0##1:stmt_for.int_sequence, ~tmp#1##0:stmt_for.int_sequence, ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
 
 
 
-gen#14 > (3 calls)
+gen#14 > (2 calls)
 0: stmt_for.gen#14<0>
-gen#14(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
+gen#14(io##0:wybe.phantom, tmp#0##0:stmt_for.int_sequence, tmp#1##0:stmt_for.int_sequence, ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
-    case ~tmp#10##0:wybe.bool of
+    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp#0##1:stmt_for.int_sequence, ~tmp#0##0:stmt_for.int_sequence, ?tmp#2##0:wybe.bool) #0
+    case ~tmp#2##0:wybe.bool of
     0:
-        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
-
-    1:
-        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:T)
-        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.list(T))
-        stmt_for.gen#15<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#6##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
-
-
-
-gen#15 > (1 calls)
-0: stmt_for.gen#15<0>
-gen#15(i##0:wybe.int, io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), [tmp#6##0:wybe.list(wybe.int)], [tmp#7##0:wybe.bool], x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
- AliasPairs: []
- InterestingCallProperties: []
-    foreign llvm icmp_eq(i##0:wybe.int, 3:wybe.int, ?tmp#8##0:wybe.bool) @int:nn:nn
-    case ~tmp#8##0:wybe.bool of
-    0:
-        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_for.gen#14<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #3 @stmt_for:nn:nn
-
-    1:
-        stmt_for.gen#14<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #1 @stmt_for:nn:nn
-
-
-
-gen#16 > (3 calls)
-0: stmt_for.gen#16<0>
-gen#16(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
- AliasPairs: []
- InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
-    case ~tmp#10##0:wybe.bool of
-    0:
-        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
-
-    1:
-        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:T)
-        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.list(T))
-        stmt_for.gen#17<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#6##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
-
-
-
-gen#17 > (1 calls)
-0: stmt_for.gen#17<0>
-gen#17(i##0:wybe.int, io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), [tmp#6##0:wybe.list(wybe.int)], [tmp#7##0:wybe.bool], x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
- AliasPairs: []
- InterestingCallProperties: []
-    foreign llvm icmp_slt(i##0:wybe.int, 3:wybe.int, ?tmp#8##0:wybe.bool) @int:nn:nn
-    case ~tmp#8##0:wybe.bool of
-    0:
-        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_for.gen#16<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #3 @stmt_for:nn:nn
-
-    1:
-        stmt_for.gen#16<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #1 @stmt_for:nn:nn
-
-
-
-gen#18 > (2 calls)
-0: stmt_for.gen#18<0>
-gen#18(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
- AliasPairs: []
- InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
-    case ~tmp#10##0:wybe.bool of
-    0:
-        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
-
-    1:
-        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:T)
-        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.list(T))
-        stmt_for.gen#19<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#6##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
-
-
-
-gen#19 > (1 calls)
-0: stmt_for.gen#19<0>
-gen#19(i##0:wybe.int, io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), [tmp#6##0:wybe.list(wybe.int)], [tmp#7##0:wybe.bool], x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
- AliasPairs: []
- InterestingCallProperties: []
-    foreign llvm icmp_eq(i##0:wybe.int, 3:wybe.int, ?tmp#8##0:wybe.bool) @int:nn:nn
-    case ~tmp#8##0:wybe.bool of
-    0:
-        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_for.gen#18<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
-
-    1:
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
+    1:
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_for.gen#14<0>(~io##1:wybe.phantom, ~tmp#0##1:stmt_for.int_sequence, ~tmp#1##0:stmt_for.int_sequence, ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
 
 
-gen#2 > (1 calls)
+
+gen#2 > (2 calls)
 0: stmt_for.gen#2<0>
-gen#2(i##0:wybe.int, io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), [tmp#10##0:wybe.list(wybe.int)], [tmp#12##0:wybe.bool], tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), tmp#6##0:wybe.list(wybe.int), tmp#7##0:wybe.list(wybe.int), tmp#8##0:wybe.list(wybe.int), tmp#9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
+gen#2(io##0:wybe.phantom, tmp#0##0:stmt_for.int_sequence, tmp#1##0:stmt_for.int_sequence, ?io##2:wybe.phantom, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp#9##0:wybe.int, 0:wybe.int, ?tmp#14##0:wybe.bool)
-    case ~tmp#14##0:wybe.bool of
+    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp#0##1:stmt_for.int_sequence, ~tmp#0##0:stmt_for.int_sequence, ?tmp#3##0:wybe.bool) #0
+    case ~tmp#3##0:wybe.bool of
     0:
-        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
-
-    1:
-        foreign lpvm access(tmp#9##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?j##0:T)
-        foreign lpvm access(~tmp#9##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#11##0:wybe.list(T))
-        foreign c print_int(~i##0:wybe.int, ~io##0:wybe.phantom, ?tmp#33##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#33##0:wybe.phantom, ?tmp#34##0:wybe.phantom) @io:nn:nn
-        foreign c print_int(~j##0:wybe.int, ~tmp#34##0:wybe.phantom, ?tmp#35##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#35##0:wybe.phantom, ?tmp#36##0:wybe.phantom) @io:nn:nn
-        stmt_for.gen#1<0>(~tmp#36##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##0:wybe.list(T), ~tmp#6##0:wybe.list(T), ~tmp#7##0:wybe.list(T), ~tmp#8##0:wybe.list(wybe.int), ~tmp#11##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #2 @stmt_for:nn:nn
-
-
-
-gen#20 > (3 calls)
-0: stmt_for.gen#20<0>
-gen#20(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
- AliasPairs: []
- InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
-    case ~tmp#10##0:wybe.bool of
-    0:
-        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
-
-    1:
-        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:T)
-        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.list(T))
-        stmt_for.gen#21<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#6##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
-
-
-
-gen#21 > (1 calls)
-0: stmt_for.gen#21<0>
-gen#21(i##0:wybe.int, io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), [tmp#6##0:wybe.list(wybe.int)], [tmp#7##0:wybe.bool], x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
- AliasPairs: []
- InterestingCallProperties: []
-    foreign llvm icmp_slt(i##0:wybe.int, 3:wybe.int, ?tmp#8##0:wybe.bool) @int:nn:nn
-    case ~tmp#8##0:wybe.bool of
-    0:
-        stmt_for.gen#20<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #3 @stmt_for:nn:nn
-
-    1:
-        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_for.gen#20<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
-
-
-
-gen#22 > (2 calls)
-0: stmt_for.gen#22<0>
-gen#22(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
- AliasPairs: []
- InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.bool)
-    case ~tmp#10##0:wybe.bool of
-    0:
-        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
-
-    1:
-        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:T)
-        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.list(T))
-        stmt_for.gen#23<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#6##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~x##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
-
-
-
-gen#23 > (1 calls)
-0: stmt_for.gen#23<0>
-gen#23(i##0:wybe.int, io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), [tmp#6##0:wybe.list(wybe.int)], [tmp#7##0:wybe.bool], x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
- AliasPairs: []
- InterestingCallProperties: []
-    foreign llvm icmp_slt(i##0:wybe.int, 3:wybe.int, ?tmp#8##0:wybe.bool) @int:nn:nn
-    case ~tmp#8##0:wybe.bool of
-    0:
+        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#13##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_for.gen#22<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
+        foreign llvm icmp_slt(i##0:wybe.int, 5:wybe.int, ?tmp#2##0:wybe.bool) @int:nn:nn
+        case ~tmp#2##0:wybe.bool of
+        0:
+            foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
+            foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
+
+        1:
+            foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @io:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#8##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+            stmt_for.gen#2<0>(~io##1:wybe.phantom, ~tmp#0##1:stmt_for.int_sequence, ~tmp#1##0:stmt_for.int_sequence, ?io##2:wybe.phantom, ?#success##0:wybe.bool) #3 @stmt_for:nn:nn
 
 
 
-gen#24 > (2 calls)
-0: stmt_for.gen#24<0>
-gen#24(io##0:wybe.phantom, tmp#0##0:stmt_for.int_sequence, tmp#3##0:stmt_for.int_sequence, ?io##2:wybe.phantom):
- AliasPairs: []
- InterestingCallProperties: []
-    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp#1##0:stmt_for.int_sequence, ~tmp#0##0:stmt_for.int_sequence, ?tmp#2##0:wybe.bool) #0
-    case ~tmp#2##0:wybe.bool of
-    0:
-        foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
-    1:
-        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_for.gen#24<0>(~io##1:wybe.phantom, ~tmp#1##0:stmt_for.int_sequence, ~tmp#3##0:stmt_for.int_sequence, ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
-
-
-
-gen#25 > (2 calls)
-0: stmt_for.gen#25<0>
-gen#25(io##0:wybe.phantom, tmp#0##0:stmt_for.int_sequence, tmp#3##0:stmt_for.int_sequence, ?io##2:wybe.phantom):
- AliasPairs: []
- InterestingCallProperties: []
-    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp#1##0:stmt_for.int_sequence, ~tmp#0##0:stmt_for.int_sequence, ?tmp#2##0:wybe.bool) #0
-    case ~tmp#2##0:wybe.bool of
-    0:
-        foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
-
-    1:
-        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_for.gen#25<0>(~io##1:wybe.phantom, ~tmp#1##0:stmt_for.int_sequence, ~tmp#3##0:stmt_for.int_sequence, ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
-
-
-
-gen#3 > {inline} (1 calls)
+gen#3 > (2 calls)
 0: stmt_for.gen#3<0>
-gen#3(i##0:wybe.int, io##0:wybe.phantom, j##0:wybe.int, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), [tmp#10##0:wybe.list(wybe.int)], [tmp#11##0:wybe.list(wybe.int)], [tmp#12##0:wybe.bool], tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), tmp#6##0:wybe.list(wybe.int), tmp#7##0:wybe.list(wybe.int), tmp#8##0:wybe.list(wybe.int), tmp#9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int), ?io##3:wybe.phantom):
+gen#3(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(T), tmp#5##0:wybe.list(T), tmp#6##0:wybe.list(T), tmp#7##0:wybe.list(T), tmp#8##0:wybe.list(wybe.int), tmp#9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int), ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#15##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign c print_int(~j##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#18##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#18##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    stmt_for.gen#1<0>(~io##2:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##0:wybe.list(T), ~tmp#6##0:wybe.list(T), ~tmp#7##0:wybe.list(T), ~tmp#8##0:wybe.list(wybe.int), ~tmp#9##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##3:wybe.phantom) #2 @stmt_for:nn:nn
+    foreign llvm icmp_ne(tmp#8##0:wybe.int, 0:wybe.int, ?tmp#13##0:wybe.bool)
+    case ~tmp#13##0:wybe.bool of
+    0:
+        foreign llvm move(~io##0:wybe.phantom, ?io##3:wybe.phantom)
+
+    1:
+        foreign lpvm access(tmp#8##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:T)
+        foreign lpvm access(~tmp#8##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##1:wybe.list(T))
+        foreign llvm icmp_ne(tmp#9##0:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.bool)
+        case ~tmp#15##0:wybe.bool of
+        0:
+            foreign llvm move(~io##0:wybe.phantom, ?io##3:wybe.phantom)
+
+        1:
+            foreign lpvm access(tmp#9##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?j##0:T)
+            foreign lpvm access(~tmp#9##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##1:wybe.list(T))
+            foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @io:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#18##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+            foreign c print_int(~j##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#21##0:wybe.phantom) @io:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
+            stmt_for.gen#3<0>(~io##2:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##0:wybe.list(T), ~tmp#6##0:wybe.list(T), ~tmp#7##0:wybe.list(T), ~tmp#8##1:wybe.list(wybe.int), ~tmp#9##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##3:wybe.phantom) #4 @stmt_for:nn:nn
+
+
 
 
 gen#4 > (2 calls)
 0: stmt_for.gen#4<0>
-gen#4(io##0:wybe.phantom, tmp#0##0:stmt_for.int_sequence, tmp#3##0:stmt_for.int_sequence, ?io##1:wybe.phantom, ?#success##0:wybe.bool):
+gen#4(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp#1##0:stmt_for.int_sequence, ~tmp#0##0:stmt_for.int_sequence, ?tmp#2##0:wybe.bool) #0
-    case ~tmp#2##0:wybe.bool of
-    0:
-        foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
-        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
-
-    1:
-        stmt_for.gen#5<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp#1##0:stmt_for.int_sequence, _:stmt_for.int_sequence, _:wybe.bool, ~tmp#3##0:stmt_for.int_sequence, ?io##1:wybe.phantom, ?#success##0:wybe.bool) #1
-
-
-
-gen#5 > (1 calls)
-0: stmt_for.gen#5<0>
-gen#5(i##0:wybe.int, io##0:wybe.phantom, tmp#0##0:stmt_for.int_sequence, [tmp#1##0:stmt_for.int_sequence], [tmp#2##0:wybe.bool], tmp#3##0:stmt_for.int_sequence, ?io##2:wybe.phantom, ?#success##0:wybe.bool):
- AliasPairs: []
- InterestingCallProperties: []
-    foreign llvm icmp_slt(i##0:wybe.int, 5:wybe.int, ?tmp#4##0:wybe.bool) @int:nn:nn
-    case ~tmp#4##0:wybe.bool of
-    0:
-        foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
-        foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
-
-    1:
-        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#9##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#9##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_for.gen#4<0>(~io##1:wybe.phantom, ~tmp#0##0:stmt_for.int_sequence, ~tmp#3##0:stmt_for.int_sequence, ?io##2:wybe.phantom, ?#success##0:wybe.bool) #2 @stmt_for:nn:nn
-
-
-
-gen#6 > (2 calls)
-0: stmt_for.gen#6<0>
-gen#6(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(T), tmp#5##0:wybe.list(T), tmp#6##0:wybe.list(T), tmp#7##0:wybe.list(T), tmp#8##0:wybe.list(wybe.int), tmp#9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
- AliasPairs: []
- InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp#8##0:wybe.int, 0:wybe.int, ?tmp#14##0:wybe.bool)
-    case ~tmp#14##0:wybe.bool of
-    0:
-        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
-
-    1:
-        foreign lpvm access(tmp#8##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:T)
-        foreign lpvm access(~tmp#8##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#10##0:wybe.list(T))
-        stmt_for.gen#7<0>(~i##0:wybe.int, ~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), _:wybe.list(wybe.int), _:wybe.bool, ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int), ~tmp#6##0:wybe.list(wybe.int), ~tmp#7##0:wybe.list(wybe.int), ~tmp#10##0:wybe.list(wybe.int), ~tmp#9##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #1
-
-
-
-gen#7 > (1 calls)
-0: stmt_for.gen#7<0>
-gen#7(i##0:wybe.int, io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), [tmp#10##0:wybe.list(wybe.int)], [tmp#12##0:wybe.bool], tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), tmp#6##0:wybe.list(wybe.int), tmp#7##0:wybe.list(wybe.int), tmp#8##0:wybe.list(wybe.int), tmp#9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int), ?io##1:wybe.phantom):
- AliasPairs: []
- InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp#9##0:wybe.int, 0:wybe.int, ?tmp#14##0:wybe.bool)
-    case ~tmp#14##0:wybe.bool of
-    0:
-        foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
-
-    1:
-        foreign lpvm access(tmp#9##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?j##0:T)
-        foreign lpvm access(~tmp#9##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#11##0:wybe.list(T))
-        foreign c print_int(~i##0:wybe.int, ~io##0:wybe.phantom, ?tmp#33##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#33##0:wybe.phantom, ?tmp#34##0:wybe.phantom) @io:nn:nn
-        foreign c print_int(~j##0:wybe.int, ~tmp#34##0:wybe.phantom, ?tmp#35##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#35##0:wybe.phantom, ?tmp#36##0:wybe.phantom) @io:nn:nn
-        stmt_for.gen#6<0>(~tmp#36##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##0:wybe.list(T), ~tmp#6##0:wybe.list(T), ~tmp#7##0:wybe.list(T), ~tmp#8##0:wybe.list(wybe.int), ~tmp#11##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #2 @stmt_for:nn:nn
-
-
-
-gen#8 > {inline} (1 calls)
-0: stmt_for.gen#8<0>
-gen#8(i##0:wybe.int, io##0:wybe.phantom, j##0:wybe.int, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), [tmp#10##0:wybe.list(wybe.int)], [tmp#11##0:wybe.list(wybe.int)], [tmp#12##0:wybe.bool], tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), tmp#6##0:wybe.list(wybe.int), tmp#7##0:wybe.list(wybe.int), tmp#8##0:wybe.list(wybe.int), tmp#9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int), ?io##3:wybe.phantom):
- AliasPairs: []
- InterestingCallProperties: []
-    foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#15##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#15##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign c print_int(~j##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#18##0:wybe.phantom) @io:nn:nn
-    foreign c putchar('\n':wybe.char, ~tmp#18##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    stmt_for.gen#6<0>(~io##2:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##0:wybe.list(T), ~tmp#6##0:wybe.list(T), ~tmp#7##0:wybe.list(T), ~tmp#8##0:wybe.list(wybe.int), ~tmp#9##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##3:wybe.phantom) #2 @stmt_for:nn:nn
-
-
-gen#9 > (2 calls)
-0: stmt_for.gen#9<0>
-gen#9(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
- AliasPairs: []
- InterestingCallProperties: []
-    foreign llvm icmp_ne(tmp#4##0:wybe.int, 0:wybe.int, ?tmp#8##0:wybe.bool)
-    case ~tmp#8##0:wybe.bool of
+    foreign llvm icmp_ne(tmp#4##0:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.bool)
+    case ~tmp#7##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
         foreign lpvm access(tmp#4##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:T)
-        foreign lpvm access(~tmp#4##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##0:wybe.list(T))
-        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#11##0:wybe.phantom) @io:nn:nn
-        foreign c putchar('\n':wybe.char, ~tmp#11##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_for.gen#9<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#5##0:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
+        foreign lpvm access(~tmp#4##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##1:wybe.list(T))
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_for.gen#4<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
+
+
+
+gen#5 > (2 calls)
+0: stmt_for.gen#5<0>
+gen#5(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
+ AliasPairs: []
+ InterestingCallProperties: []
+    foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
+    case ~tmp#9##0:wybe.bool of
+    0:
+        foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
+
+    1:
+        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:T)
+        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(T))
+        foreign llvm icmp_eq(i##0:wybe.int, 3:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
+        case ~tmp#6##0:wybe.bool of
+        0:
+            foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+            stmt_for.gen#5<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #3 @stmt_for:nn:nn
+
+        1:
+            foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
+
+
+
+
+gen#6 > (2 calls)
+0: stmt_for.gen#6<0>
+gen#6(io##0:wybe.phantom, tmp#0##0:stmt_for.int_sequence, tmp#1##0:stmt_for.int_sequence, ?io##2:wybe.phantom):
+ AliasPairs: []
+ InterestingCallProperties: []
+    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp#0##1:stmt_for.int_sequence, ~tmp#0##0:stmt_for.int_sequence, ?tmp#2##0:wybe.bool) #0
+    case ~tmp#2##0:wybe.bool of
+    0:
+        foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
+
+    1:
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_for.gen#6<0>(~io##1:wybe.phantom, ~tmp#0##1:stmt_for.int_sequence, ~tmp#1##0:stmt_for.int_sequence, ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
+
+
+
+gen#7 > (2 calls)
+0: stmt_for.gen#7<0>
+gen#7(io##0:wybe.phantom, tmp#0##0:stmt_for.int_sequence, tmp#1##0:stmt_for.int_sequence, ?io##2:wybe.phantom):
+ AliasPairs: []
+ InterestingCallProperties: []
+    stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp#0##1:stmt_for.int_sequence, ~tmp#0##0:stmt_for.int_sequence, ?tmp#2##0:wybe.bool) #0
+    case ~tmp#2##0:wybe.bool of
+    0:
+        foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
+
+    1:
+        foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
+        foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+        stmt_for.gen#7<0>(~io##1:wybe.phantom, ~tmp#0##1:stmt_for.int_sequence, ~tmp#1##0:stmt_for.int_sequence, ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
+
+
+
+gen#8 > (3 calls)
+0: stmt_for.gen#8<0>
+gen#8(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
+ AliasPairs: []
+ InterestingCallProperties: []
+    foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
+    case ~tmp#9##0:wybe.bool of
+    0:
+        foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
+
+    1:
+        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:T)
+        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(T))
+        foreign llvm icmp_eq(i##0:wybe.int, 3:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
+        case ~tmp#6##0:wybe.bool of
+        0:
+            foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+            stmt_for.gen#8<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #4 @stmt_for:nn:nn
+
+        1:
+            stmt_for.gen#8<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
+
+
+
+
+gen#9 > (3 calls)
+0: stmt_for.gen#9<0>
+gen#9(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
+ AliasPairs: []
+ InterestingCallProperties: []
+    foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
+    case ~tmp#9##0:wybe.bool of
+    0:
+        foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
+
+    1:
+        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:T)
+        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(T))
+        foreign llvm icmp_slt(i##0:wybe.int, 3:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
+        case ~tmp#6##0:wybe.bool of
+        0:
+            foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
+            foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
+            stmt_for.gen#9<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #4 @stmt_for:nn:nn
+
+        1:
+            stmt_for.gen#9<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
+
 
 
 
@@ -537,24 +441,24 @@ multiple_generator > public (1 calls)
 multiple_generator(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#16##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
-    foreign lpvm mutate(~tmp#16##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#20##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
-    foreign lpvm mutate(~tmp#20##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#24##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
-    foreign lpvm mutate(~tmp#24##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#27##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#27##0:wybe.list(T), ?tmp#28##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 6:T)
-    foreign lpvm mutate(~tmp#28##0:wybe.list(T), ?tmp#6##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#31##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#31##0:wybe.list(T), ?tmp#32##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 5:T)
-    foreign lpvm mutate(~tmp#32##0:wybe.list(T), ?tmp#5##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#6##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#35##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#35##0:wybe.list(T), ?tmp#36##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
-    foreign lpvm mutate(~tmp#36##0:wybe.list(T), ?tmp#4##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#5##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#26##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#26##0:wybe.list(T), ?tmp#27##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 6:T)
+    foreign lpvm mutate(~tmp#27##0:wybe.list(T), ?tmp#6##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#30##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#30##0:wybe.list(T), ?tmp#31##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 5:T)
+    foreign lpvm mutate(~tmp#31##0:wybe.list(T), ?tmp#5##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#6##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#34##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#34##0:wybe.list(T), ?tmp#35##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
+    foreign lpvm mutate(~tmp#35##0:wybe.list(T), ?tmp#4##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#5##0:wybe.list(T))
     stmt_for.gen#1<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), 0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##0:wybe.list(T), ~tmp#6##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #8 @stmt_for:nn:nn
 
 
@@ -563,8 +467,8 @@ semi_det_for_loop > public (0 calls)
 semi_det_for_loop(io##0:wybe.phantom, ?io##1:wybe.phantom, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_for.xrange<0>(0:wybe.int, 1:wybe.int, 10:wybe.int, ?tmp#3##0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
-    stmt_for.gen#4<0>(~io##0:wybe.phantom, ~tmp#3##0:stmt_for.int_sequence, ~tmp#3##0:stmt_for.int_sequence, ?io##1:wybe.phantom, ?#success##0:wybe.bool) #1 @stmt_for:nn:nn
+    stmt_for.xrange<0>(0:wybe.int, 1:wybe.int, 10:wybe.int, ?tmp#1##0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
+    stmt_for.gen#2<0>(~io##0:wybe.phantom, ~tmp#1##0:stmt_for.int_sequence, ~tmp#1##0:stmt_for.int_sequence, ?io##1:wybe.phantom, ?#success##0:wybe.bool) #1 @stmt_for:nn:nn
 
 
 shortest_generator_termination > public (1 calls)
@@ -572,25 +476,25 @@ shortest_generator_termination > public (1 calls)
 shortest_generator_termination(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#16##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
-    foreign lpvm mutate(~tmp#16##0:wybe.list(T), ?tmp#3##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#20##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
-    foreign lpvm mutate(~tmp#20##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#24##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
-    foreign lpvm mutate(~tmp#24##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#27##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#27##0:wybe.list(T), ?tmp#28##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
-    foreign lpvm mutate(~tmp#28##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#31##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#31##0:wybe.list(T), ?tmp#32##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 5:T)
-    foreign lpvm mutate(~tmp#32##0:wybe.list(T), ?tmp#6##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#35##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#35##0:wybe.list(T), ?tmp#36##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
-    foreign lpvm mutate(~tmp#36##0:wybe.list(T), ?tmp#5##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#6##0:wybe.list(T))
-    stmt_for.gen#6<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), 0:wybe.list(T), ~tmp#5##0:wybe.list(T), ~tmp#6##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #8 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#3##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#26##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#26##0:wybe.list(T), ?tmp#27##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
+    foreign lpvm mutate(~tmp#27##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#30##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#30##0:wybe.list(T), ?tmp#31##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 5:T)
+    foreign lpvm mutate(~tmp#31##0:wybe.list(T), ?tmp#6##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#34##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#34##0:wybe.list(T), ?tmp#35##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
+    foreign lpvm mutate(~tmp#35##0:wybe.list(T), ?tmp#5##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#6##0:wybe.list(T))
+    stmt_for.gen#3<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), 0:wybe.list(T), ~tmp#5##0:wybe.list(T), ~tmp#6##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #8 @stmt_for:nn:nn
 
 
 single_generator > public (1 calls)
@@ -598,16 +502,16 @@ single_generator > public (1 calls)
 single_generator(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#9##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#9##0:wybe.list(T), ?tmp#10##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
-    foreign lpvm mutate(~tmp#10##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#13##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#13##0:wybe.list(T), ?tmp#14##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
-    foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#17##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#17##0:wybe.list(T), ?tmp#18##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
-    foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
-    stmt_for.gen#9<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #4 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#8##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#8##0:wybe.list(T), ?tmp#9##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
+    foreign lpvm mutate(~tmp#9##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#12##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#12##0:wybe.list(T), ?tmp#13##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
+    foreign lpvm mutate(~tmp#13##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#16##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#16##0:wybe.list(T), ?tmp#17##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
+    foreign lpvm mutate(~tmp#17##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
+    stmt_for.gen#4<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #4 @stmt_for:nn:nn
 
 
 using_break > public (1 calls)
@@ -615,19 +519,19 @@ using_break > public (1 calls)
 using_break(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#12##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
-    foreign lpvm mutate(~tmp#12##0:wybe.list(T), ?tmp#3##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#16##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
-    foreign lpvm mutate(~tmp#16##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#20##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
-    foreign lpvm mutate(~tmp#20##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#24##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
-    foreign lpvm mutate(~tmp#24##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
-    stmt_for.gen#10<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#10##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#10##0:wybe.list(T), ?tmp#11##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
+    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
+    stmt_for.gen#5<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
 using_irange > public (1 calls)
@@ -635,8 +539,8 @@ using_irange > public (1 calls)
 using_irange(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_for.irange<0>(1:wybe.int, 1:wybe.int, 10:wybe.int, ?tmp#3##0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
-    stmt_for.gen#12<0>(~io##0:wybe.phantom, ~tmp#3##0:stmt_for.int_sequence, ~tmp#3##0:stmt_for.int_sequence, ?io##1:wybe.phantom) #1 @stmt_for:nn:nn
+    stmt_for.irange<0>(1:wybe.int, 1:wybe.int, 10:wybe.int, ?tmp#1##0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
+    stmt_for.gen#6<0>(~io##0:wybe.phantom, ~tmp#1##0:stmt_for.int_sequence, ~tmp#1##0:stmt_for.int_sequence, ?io##1:wybe.phantom) #1 @stmt_for:nn:nn
 
 
 using_irange_reverse > public (1 calls)
@@ -644,8 +548,8 @@ using_irange_reverse > public (1 calls)
 using_irange_reverse(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_for.irange<0>(10:wybe.int, -1:wybe.int, 1:wybe.int, ?tmp#3##0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
-    stmt_for.gen#13<0>(~io##0:wybe.phantom, ~tmp#3##0:stmt_for.int_sequence, ~tmp#3##0:stmt_for.int_sequence, ?io##1:wybe.phantom) #1 @stmt_for:nn:nn
+    stmt_for.irange<0>(10:wybe.int, -1:wybe.int, 1:wybe.int, ?tmp#1##0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
+    stmt_for.gen#7<0>(~io##0:wybe.phantom, ~tmp#1##0:stmt_for.int_sequence, ~tmp#1##0:stmt_for.int_sequence, ?io##1:wybe.phantom) #1 @stmt_for:nn:nn
 
 
 using_next > public (1 calls)
@@ -653,19 +557,19 @@ using_next > public (1 calls)
 using_next(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#12##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
-    foreign lpvm mutate(~tmp#12##0:wybe.list(T), ?tmp#3##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#16##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
-    foreign lpvm mutate(~tmp#16##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#20##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
-    foreign lpvm mutate(~tmp#20##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#24##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
-    foreign lpvm mutate(~tmp#24##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
-    stmt_for.gen#14<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#10##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#10##0:wybe.list(T), ?tmp#11##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
+    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
+    stmt_for.gen#8<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
 using_unless > public (1 calls)
@@ -673,19 +577,19 @@ using_unless > public (1 calls)
 using_unless(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#12##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
-    foreign lpvm mutate(~tmp#12##0:wybe.list(T), ?tmp#3##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#16##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
-    foreign lpvm mutate(~tmp#16##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#20##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
-    foreign lpvm mutate(~tmp#20##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#24##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
-    foreign lpvm mutate(~tmp#24##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
-    stmt_for.gen#16<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#10##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#10##0:wybe.list(T), ?tmp#11##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
+    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
+    stmt_for.gen#9<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
 using_until > public (1 calls)
@@ -693,19 +597,19 @@ using_until > public (1 calls)
 using_until(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#12##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
-    foreign lpvm mutate(~tmp#12##0:wybe.list(T), ?tmp#3##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#16##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
-    foreign lpvm mutate(~tmp#16##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#20##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
-    foreign lpvm mutate(~tmp#20##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#24##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
-    foreign lpvm mutate(~tmp#24##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
-    stmt_for.gen#18<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#10##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#10##0:wybe.list(T), ?tmp#11##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
+    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
+    stmt_for.gen#10<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
 using_when > public (1 calls)
@@ -713,19 +617,19 @@ using_when > public (1 calls)
 using_when(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#12##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
-    foreign lpvm mutate(~tmp#12##0:wybe.list(T), ?tmp#3##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#16##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
-    foreign lpvm mutate(~tmp#16##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#20##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
-    foreign lpvm mutate(~tmp#20##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#24##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
-    foreign lpvm mutate(~tmp#24##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
-    stmt_for.gen#20<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#10##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#10##0:wybe.list(T), ?tmp#11##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
+    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
+    stmt_for.gen#11<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
 using_while > public (1 calls)
@@ -733,19 +637,19 @@ using_while > public (1 calls)
 using_while(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    foreign lpvm alloc(16:wybe.int, ?tmp#11##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#12##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
-    foreign lpvm mutate(~tmp#12##0:wybe.list(T), ?tmp#3##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#15##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#16##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
-    foreign lpvm mutate(~tmp#16##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#19##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#20##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
-    foreign lpvm mutate(~tmp#20##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
-    foreign lpvm alloc(16:wybe.int, ?tmp#23##0:wybe.list(T))
-    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#24##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
-    foreign lpvm mutate(~tmp#24##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
-    stmt_for.gen#22<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
+    foreign lpvm alloc(16:wybe.int, ?tmp#10##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#10##0:wybe.list(T), ?tmp#11##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
+    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
+    foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
+    stmt_for.gen#12<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
 using_xrange > public (1 calls)
@@ -753,8 +657,8 @@ using_xrange > public (1 calls)
 using_xrange(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_for.xrange<0>(1:wybe.int, 1:wybe.int, 10:wybe.int, ?tmp#3##0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
-    stmt_for.gen#24<0>(~io##0:wybe.phantom, ~tmp#3##0:stmt_for.int_sequence, ~tmp#3##0:stmt_for.int_sequence, ?io##1:wybe.phantom) #1 @stmt_for:nn:nn
+    stmt_for.xrange<0>(1:wybe.int, 1:wybe.int, 10:wybe.int, ?tmp#1##0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
+    stmt_for.gen#13<0>(~io##0:wybe.phantom, ~tmp#1##0:stmt_for.int_sequence, ~tmp#1##0:stmt_for.int_sequence, ?io##1:wybe.phantom) #1 @stmt_for:nn:nn
 
 
 using_xrange_reverse > public (1 calls)
@@ -762,8 +666,8 @@ using_xrange_reverse > public (1 calls)
 using_xrange_reverse(io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    stmt_for.xrange<0>(10:wybe.int, -1:wybe.int, 1:wybe.int, ?tmp#3##0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
-    stmt_for.gen#25<0>(~io##0:wybe.phantom, ~tmp#3##0:stmt_for.int_sequence, ~tmp#3##0:stmt_for.int_sequence, ?io##1:wybe.phantom) #1 @stmt_for:nn:nn
+    stmt_for.xrange<0>(10:wybe.int, -1:wybe.int, 1:wybe.int, ?tmp#1##0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
+    stmt_for.gen#14<0>(~io##0:wybe.phantom, ~tmp#1##0:stmt_for.int_sequence, ~tmp#1##0:stmt_for.int_sequence, ?io##1:wybe.phantom) #1 @stmt_for:nn:nn
 
 
 xrange > public (3 calls)
@@ -924,8 +828,8 @@ entry:
 
 define external fastcc  void @"stmt_for.gen#1<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %"tmp#8##0", i64  %"tmp#9##0", i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1#tmp#14##0" = icmp ne i64 %"tmp#8##0", 0 
-  br i1 %"1#tmp#14##0", label %if.then, label %if.else 
+  %"1#tmp#13##0" = icmp ne i64 %"tmp#8##0", 0 
+  br i1 %"1#tmp#13##0", label %if.then, label %if.else 
 if.then:
   %27 = inttoptr i64 %"tmp#8##0" to i64* 
   %28 = getelementptr  i64, i64* %27, i64 0 
@@ -934,415 +838,330 @@ if.then:
   %31 = inttoptr i64 %30 to i64* 
   %32 = getelementptr  i64, i64* %31, i64 0 
   %33 = load  i64, i64* %32 
-  tail call fastcc  void  @"stmt_for.gen#2<0>"(i64  %29, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %33, i64  %"tmp#9##0", i64  %"x##0", i64  %"y##0")  
-  ret void 
+  %"2#tmp#15##0" = icmp ne i64 %"tmp#9##0", 0 
+  br i1 %"2#tmp#15##0", label %if.then1, label %if.else1 
 if.else:
+  ret void 
+if.then1:
+  %34 = inttoptr i64 %"tmp#9##0" to i64* 
+  %35 = getelementptr  i64, i64* %34, i64 0 
+  %36 = load  i64, i64* %35 
+  %37 = add   i64 %"tmp#9##0", 8 
+  %38 = inttoptr i64 %37 to i64* 
+  %39 = getelementptr  i64, i64* %38, i64 0 
+  %40 = load  i64, i64* %39 
+  tail call ccc  void  @print_int(i64  %29)  
+  tail call ccc  void  @putchar(i8  10)  
+  tail call ccc  void  @print_int(i64  %36)  
+  tail call ccc  void  @putchar(i8  10)  
+  tail call fastcc  void  @"stmt_for.gen#1<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %33, i64  %40, i64  %"x##0", i64  %"y##0")  
+  ret void 
+if.else1:
   ret void 
 }
 
 
 define external fastcc  void @"stmt_for.gen#10<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
 entry:
-  %"1#tmp#10##0" = icmp ne i64 %"tmp#5##0", 0 
-  br i1 %"1#tmp#10##0", label %if.then, label %if.else 
+  %"1#tmp#9##0" = icmp ne i64 %"tmp#5##0", 0 
+  br i1 %"1#tmp#9##0", label %if.then, label %if.else 
 if.then:
-  %34 = inttoptr i64 %"tmp#5##0" to i64* 
-  %35 = getelementptr  i64, i64* %34, i64 0 
-  %36 = load  i64, i64* %35 
-  %37 = add   i64 %"tmp#5##0", 8 
-  %38 = inttoptr i64 %37 to i64* 
-  %39 = getelementptr  i64, i64* %38, i64 0 
-  %40 = load  i64, i64* %39 
-  tail call fastcc  void  @"stmt_for.gen#11<0>"(i64  %36, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %40, i64  %"x##0")  
-  ret void 
+  %41 = inttoptr i64 %"tmp#5##0" to i64* 
+  %42 = getelementptr  i64, i64* %41, i64 0 
+  %43 = load  i64, i64* %42 
+  %44 = add   i64 %"tmp#5##0", 8 
+  %45 = inttoptr i64 %44 to i64* 
+  %46 = getelementptr  i64, i64* %45, i64 0 
+  %47 = load  i64, i64* %46 
+  %"2#tmp#6##0" = icmp eq i64 %43, 3 
+  br i1 %"2#tmp#6##0", label %if.then1, label %if.else1 
 if.else:
   ret void 
-}
-
-
-define external fastcc  void @"stmt_for.gen#11<0>"(i64  %"i##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
-entry:
-  %"1#tmp#8##0" = icmp eq i64 %"i##0", 3 
-  br i1 %"1#tmp#8##0", label %if.then, label %if.else 
-if.then:
+if.then1:
   ret void 
-if.else:
-  tail call ccc  void  @print_int(i64  %"i##0")  
+if.else1:
+  tail call ccc  void  @print_int(i64  %43)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen#10<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")  
+  tail call fastcc  void  @"stmt_for.gen#10<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %47, i64  %"x##0")  
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen#12<0>"(i64  %"tmp#0##0", i64  %"tmp#3##0")    {
+define external fastcc  void @"stmt_for.gen#11<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
 entry:
-  %41 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
-  %42 = extractvalue {i64, i64, i1} %41, 0 
-  %43 = extractvalue {i64, i64, i1} %41, 1 
-  %44 = extractvalue {i64, i64, i1} %41, 2 
-  br i1 %44, label %if.then, label %if.else 
+  %"1#tmp#9##0" = icmp ne i64 %"tmp#5##0", 0 
+  br i1 %"1#tmp#9##0", label %if.then, label %if.else 
 if.then:
-  tail call ccc  void  @print_int(i64  %42)  
+  %48 = inttoptr i64 %"tmp#5##0" to i64* 
+  %49 = getelementptr  i64, i64* %48, i64 0 
+  %50 = load  i64, i64* %49 
+  %51 = add   i64 %"tmp#5##0", 8 
+  %52 = inttoptr i64 %51 to i64* 
+  %53 = getelementptr  i64, i64* %52, i64 0 
+  %54 = load  i64, i64* %53 
+  %"2#tmp#6##0" = icmp slt i64 %50, 3 
+  br i1 %"2#tmp#6##0", label %if.then1, label %if.else1 
+if.else:
+  ret void 
+if.then1:
+  tail call ccc  void  @print_int(i64  %50)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen#12<0>"(i64  %43, i64  %"tmp#3##0")  
+  tail call fastcc  void  @"stmt_for.gen#11<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %54, i64  %"x##0")  
   ret void 
-if.else:
+if.else1:
+  tail call fastcc  void  @"stmt_for.gen#11<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %54, i64  %"x##0")  
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen#13<0>"(i64  %"tmp#0##0", i64  %"tmp#3##0")    {
+define external fastcc  void @"stmt_for.gen#12<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
 entry:
-  %45 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
-  %46 = extractvalue {i64, i64, i1} %45, 0 
-  %47 = extractvalue {i64, i64, i1} %45, 1 
-  %48 = extractvalue {i64, i64, i1} %45, 2 
-  br i1 %48, label %if.then, label %if.else 
+  %"1#tmp#9##0" = icmp ne i64 %"tmp#5##0", 0 
+  br i1 %"1#tmp#9##0", label %if.then, label %if.else 
 if.then:
-  tail call ccc  void  @print_int(i64  %46)  
+  %55 = inttoptr i64 %"tmp#5##0" to i64* 
+  %56 = getelementptr  i64, i64* %55, i64 0 
+  %57 = load  i64, i64* %56 
+  %58 = add   i64 %"tmp#5##0", 8 
+  %59 = inttoptr i64 %58 to i64* 
+  %60 = getelementptr  i64, i64* %59, i64 0 
+  %61 = load  i64, i64* %60 
+  %"2#tmp#6##0" = icmp slt i64 %57, 3 
+  br i1 %"2#tmp#6##0", label %if.then1, label %if.else1 
+if.else:
+  ret void 
+if.then1:
+  tail call ccc  void  @print_int(i64  %57)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen#13<0>"(i64  %47, i64  %"tmp#3##0")  
+  tail call fastcc  void  @"stmt_for.gen#12<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %61, i64  %"x##0")  
   ret void 
-if.else:
-  ret void 
-}
-
-
-define external fastcc  void @"stmt_for.gen#14<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
-entry:
-  %"1#tmp#10##0" = icmp ne i64 %"tmp#5##0", 0 
-  br i1 %"1#tmp#10##0", label %if.then, label %if.else 
-if.then:
-  %49 = inttoptr i64 %"tmp#5##0" to i64* 
-  %50 = getelementptr  i64, i64* %49, i64 0 
-  %51 = load  i64, i64* %50 
-  %52 = add   i64 %"tmp#5##0", 8 
-  %53 = inttoptr i64 %52 to i64* 
-  %54 = getelementptr  i64, i64* %53, i64 0 
-  %55 = load  i64, i64* %54 
-  tail call fastcc  void  @"stmt_for.gen#15<0>"(i64  %51, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %55, i64  %"x##0")  
-  ret void 
-if.else:
+if.else1:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen#15<0>"(i64  %"i##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
+define external fastcc  void @"stmt_for.gen#13<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0")    {
 entry:
-  %"1#tmp#8##0" = icmp eq i64 %"i##0", 3 
-  br i1 %"1#tmp#8##0", label %if.then, label %if.else 
+  %62 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
+  %63 = extractvalue {i64, i64, i1} %62, 0 
+  %64 = extractvalue {i64, i64, i1} %62, 1 
+  %65 = extractvalue {i64, i64, i1} %62, 2 
+  br i1 %65, label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"stmt_for.gen#14<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")  
-  ret void 
-if.else:
-  tail call ccc  void  @print_int(i64  %"i##0")  
+  tail call ccc  void  @print_int(i64  %63)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen#14<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")  
-  ret void 
-}
-
-
-define external fastcc  void @"stmt_for.gen#16<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
-entry:
-  %"1#tmp#10##0" = icmp ne i64 %"tmp#5##0", 0 
-  br i1 %"1#tmp#10##0", label %if.then, label %if.else 
-if.then:
-  %56 = inttoptr i64 %"tmp#5##0" to i64* 
-  %57 = getelementptr  i64, i64* %56, i64 0 
-  %58 = load  i64, i64* %57 
-  %59 = add   i64 %"tmp#5##0", 8 
-  %60 = inttoptr i64 %59 to i64* 
-  %61 = getelementptr  i64, i64* %60, i64 0 
-  %62 = load  i64, i64* %61 
-  tail call fastcc  void  @"stmt_for.gen#17<0>"(i64  %58, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %62, i64  %"x##0")  
+  tail call fastcc  void  @"stmt_for.gen#13<0>"(i64  %64, i64  %"tmp#1##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen#17<0>"(i64  %"i##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
+define external fastcc  void @"stmt_for.gen#14<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0")    {
 entry:
-  %"1#tmp#8##0" = icmp slt i64 %"i##0", 3 
-  br i1 %"1#tmp#8##0", label %if.then, label %if.else 
+  %66 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
+  %67 = extractvalue {i64, i64, i1} %66, 0 
+  %68 = extractvalue {i64, i64, i1} %66, 1 
+  %69 = extractvalue {i64, i64, i1} %66, 2 
+  br i1 %69, label %if.then, label %if.else 
 if.then:
-  tail call fastcc  void  @"stmt_for.gen#16<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")  
-  ret void 
-if.else:
-  tail call ccc  void  @print_int(i64  %"i##0")  
+  tail call ccc  void  @print_int(i64  %67)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen#16<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")  
-  ret void 
-}
-
-
-define external fastcc  void @"stmt_for.gen#18<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
-entry:
-  %"1#tmp#10##0" = icmp ne i64 %"tmp#5##0", 0 
-  br i1 %"1#tmp#10##0", label %if.then, label %if.else 
-if.then:
-  %63 = inttoptr i64 %"tmp#5##0" to i64* 
-  %64 = getelementptr  i64, i64* %63, i64 0 
-  %65 = load  i64, i64* %64 
-  %66 = add   i64 %"tmp#5##0", 8 
-  %67 = inttoptr i64 %66 to i64* 
-  %68 = getelementptr  i64, i64* %67, i64 0 
-  %69 = load  i64, i64* %68 
-  tail call fastcc  void  @"stmt_for.gen#19<0>"(i64  %65, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %69, i64  %"x##0")  
+  tail call fastcc  void  @"stmt_for.gen#14<0>"(i64  %68, i64  %"tmp#1##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen#19<0>"(i64  %"i##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
+define external fastcc  i1 @"stmt_for.gen#2<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0")    {
 entry:
-  %"1#tmp#8##0" = icmp eq i64 %"i##0", 3 
-  br i1 %"1#tmp#8##0", label %if.then, label %if.else 
+  %70 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
+  %71 = extractvalue {i64, i64, i1} %70, 0 
+  %72 = extractvalue {i64, i64, i1} %70, 1 
+  %73 = extractvalue {i64, i64, i1} %70, 2 
+  br i1 %73, label %if.then, label %if.else 
 if.then:
-  ret void 
-if.else:
-  tail call ccc  void  @print_int(i64  %"i##0")  
-  tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen#18<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")  
-  ret void 
-}
-
-
-define external fastcc  void @"stmt_for.gen#2<0>"(i64  %"i##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %"tmp#8##0", i64  %"tmp#9##0", i64  %"x##0", i64  %"y##0")    {
-entry:
-  %"1#tmp#14##0" = icmp ne i64 %"tmp#9##0", 0 
-  br i1 %"1#tmp#14##0", label %if.then, label %if.else 
-if.then:
-  %70 = inttoptr i64 %"tmp#9##0" to i64* 
-  %71 = getelementptr  i64, i64* %70, i64 0 
-  %72 = load  i64, i64* %71 
-  %73 = add   i64 %"tmp#9##0", 8 
-  %74 = inttoptr i64 %73 to i64* 
-  %75 = getelementptr  i64, i64* %74, i64 0 
-  %76 = load  i64, i64* %75 
-  tail call ccc  void  @print_int(i64  %"i##0")  
-  tail call ccc  void  @putchar(i8  10)  
-  tail call ccc  void  @print_int(i64  %72)  
-  tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen#1<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %"tmp#8##0", i64  %76, i64  %"x##0", i64  %"y##0")  
-  ret void 
-if.else:
-  ret void 
-}
-
-
-define external fastcc  void @"stmt_for.gen#20<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
-entry:
-  %"1#tmp#10##0" = icmp ne i64 %"tmp#5##0", 0 
-  br i1 %"1#tmp#10##0", label %if.then, label %if.else 
-if.then:
-  %77 = inttoptr i64 %"tmp#5##0" to i64* 
-  %78 = getelementptr  i64, i64* %77, i64 0 
-  %79 = load  i64, i64* %78 
-  %80 = add   i64 %"tmp#5##0", 8 
-  %81 = inttoptr i64 %80 to i64* 
-  %82 = getelementptr  i64, i64* %81, i64 0 
-  %83 = load  i64, i64* %82 
-  tail call fastcc  void  @"stmt_for.gen#21<0>"(i64  %79, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %83, i64  %"x##0")  
-  ret void 
-if.else:
-  ret void 
-}
-
-
-define external fastcc  void @"stmt_for.gen#21<0>"(i64  %"i##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
-entry:
-  %"1#tmp#8##0" = icmp slt i64 %"i##0", 3 
-  br i1 %"1#tmp#8##0", label %if.then, label %if.else 
-if.then:
-  tail call ccc  void  @print_int(i64  %"i##0")  
-  tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen#20<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")  
-  ret void 
-if.else:
-  tail call fastcc  void  @"stmt_for.gen#20<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")  
-  ret void 
-}
-
-
-define external fastcc  void @"stmt_for.gen#22<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
-entry:
-  %"1#tmp#10##0" = icmp ne i64 %"tmp#5##0", 0 
-  br i1 %"1#tmp#10##0", label %if.then, label %if.else 
-if.then:
-  %84 = inttoptr i64 %"tmp#5##0" to i64* 
-  %85 = getelementptr  i64, i64* %84, i64 0 
-  %86 = load  i64, i64* %85 
-  %87 = add   i64 %"tmp#5##0", 8 
-  %88 = inttoptr i64 %87 to i64* 
-  %89 = getelementptr  i64, i64* %88, i64 0 
-  %90 = load  i64, i64* %89 
-  tail call fastcc  void  @"stmt_for.gen#23<0>"(i64  %86, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %90, i64  %"x##0")  
-  ret void 
-if.else:
-  ret void 
-}
-
-
-define external fastcc  void @"stmt_for.gen#23<0>"(i64  %"i##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
-entry:
-  %"1#tmp#8##0" = icmp slt i64 %"i##0", 3 
-  br i1 %"1#tmp#8##0", label %if.then, label %if.else 
-if.then:
-  tail call ccc  void  @print_int(i64  %"i##0")  
-  tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen#22<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")  
-  ret void 
-if.else:
-  ret void 
-}
-
-
-define external fastcc  void @"stmt_for.gen#24<0>"(i64  %"tmp#0##0", i64  %"tmp#3##0")    {
-entry:
-  %91 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
-  %92 = extractvalue {i64, i64, i1} %91, 0 
-  %93 = extractvalue {i64, i64, i1} %91, 1 
-  %94 = extractvalue {i64, i64, i1} %91, 2 
-  br i1 %94, label %if.then, label %if.else 
-if.then:
-  tail call ccc  void  @print_int(i64  %92)  
-  tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen#24<0>"(i64  %93, i64  %"tmp#3##0")  
-  ret void 
-if.else:
-  ret void 
-}
-
-
-define external fastcc  void @"stmt_for.gen#25<0>"(i64  %"tmp#0##0", i64  %"tmp#3##0")    {
-entry:
-  %95 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
-  %96 = extractvalue {i64, i64, i1} %95, 0 
-  %97 = extractvalue {i64, i64, i1} %95, 1 
-  %98 = extractvalue {i64, i64, i1} %95, 2 
-  br i1 %98, label %if.then, label %if.else 
-if.then:
-  tail call ccc  void  @print_int(i64  %96)  
-  tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen#25<0>"(i64  %97, i64  %"tmp#3##0")  
-  ret void 
-if.else:
-  ret void 
-}
-
-
-define external fastcc  void @"stmt_for.gen#3<0>"(i64  %"i##0", i64  %"j##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %"tmp#8##0", i64  %"tmp#9##0", i64  %"x##0", i64  %"y##0")    {
-entry:
-  tail call ccc  void  @print_int(i64  %"i##0")  
-  tail call ccc  void  @putchar(i8  10)  
-  tail call ccc  void  @print_int(i64  %"j##0")  
-  tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen#1<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %"tmp#8##0", i64  %"tmp#9##0", i64  %"x##0", i64  %"y##0")  
-  ret void 
-}
-
-
-define external fastcc  i1 @"stmt_for.gen#4<0>"(i64  %"tmp#0##0", i64  %"tmp#3##0")    {
-entry:
-  %99 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
-  %100 = extractvalue {i64, i64, i1} %99, 0 
-  %101 = extractvalue {i64, i64, i1} %99, 1 
-  %102 = extractvalue {i64, i64, i1} %99, 2 
-  br i1 %102, label %if.then, label %if.else 
-if.then:
-  %"2##success##0" = tail call fastcc  i1  @"stmt_for.gen#5<0>"(i64  %100, i64  %101, i64  %"tmp#3##0")  
-  ret i1 %"2##success##0" 
+  %"2#tmp#2##0" = icmp slt i64 %71, 5 
+  br i1 %"2#tmp#2##0", label %if.then1, label %if.else1 
 if.else:
   ret i1 1 
-}
-
-
-define external fastcc  i1 @"stmt_for.gen#5<0>"(i64  %"i##0", i64  %"tmp#0##0", i64  %"tmp#3##0")    {
-entry:
-  %"1#tmp#4##0" = icmp slt i64 %"i##0", 5 
-  br i1 %"1#tmp#4##0", label %if.then, label %if.else 
-if.then:
-  tail call ccc  void  @print_int(i64  %"i##0")  
+if.then1:
+  tail call ccc  void  @print_int(i64  %71)  
   tail call ccc  void  @putchar(i8  10)  
-  %"2##success##0" = tail call fastcc  i1  @"stmt_for.gen#4<0>"(i64  %"tmp#0##0", i64  %"tmp#3##0")  
-  ret i1 %"2##success##0" 
-if.else:
+  %"4##success##0" = tail call fastcc  i1  @"stmt_for.gen#2<0>"(i64  %72, i64  %"tmp#1##0")  
+  ret i1 %"4##success##0" 
+if.else1:
   ret i1 0 
 }
 
 
-define external fastcc  void @"stmt_for.gen#6<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %"tmp#8##0", i64  %"tmp#9##0", i64  %"x##0", i64  %"y##0")    {
+define external fastcc  void @"stmt_for.gen#3<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %"tmp#8##0", i64  %"tmp#9##0", i64  %"x##0", i64  %"y##0")    {
 entry:
-  %"1#tmp#14##0" = icmp ne i64 %"tmp#8##0", 0 
-  br i1 %"1#tmp#14##0", label %if.then, label %if.else 
+  %"1#tmp#13##0" = icmp ne i64 %"tmp#8##0", 0 
+  br i1 %"1#tmp#13##0", label %if.then, label %if.else 
 if.then:
-  %103 = inttoptr i64 %"tmp#8##0" to i64* 
-  %104 = getelementptr  i64, i64* %103, i64 0 
-  %105 = load  i64, i64* %104 
-  %106 = add   i64 %"tmp#8##0", 8 
-  %107 = inttoptr i64 %106 to i64* 
-  %108 = getelementptr  i64, i64* %107, i64 0 
-  %109 = load  i64, i64* %108 
-  tail call fastcc  void  @"stmt_for.gen#7<0>"(i64  %105, i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %109, i64  %"tmp#9##0", i64  %"x##0", i64  %"y##0")  
+  %74 = inttoptr i64 %"tmp#8##0" to i64* 
+  %75 = getelementptr  i64, i64* %74, i64 0 
+  %76 = load  i64, i64* %75 
+  %77 = add   i64 %"tmp#8##0", 8 
+  %78 = inttoptr i64 %77 to i64* 
+  %79 = getelementptr  i64, i64* %78, i64 0 
+  %80 = load  i64, i64* %79 
+  %"2#tmp#15##0" = icmp ne i64 %"tmp#9##0", 0 
+  br i1 %"2#tmp#15##0", label %if.then1, label %if.else1 
+if.else:
+  ret void 
+if.then1:
+  %81 = inttoptr i64 %"tmp#9##0" to i64* 
+  %82 = getelementptr  i64, i64* %81, i64 0 
+  %83 = load  i64, i64* %82 
+  %84 = add   i64 %"tmp#9##0", 8 
+  %85 = inttoptr i64 %84 to i64* 
+  %86 = getelementptr  i64, i64* %85, i64 0 
+  %87 = load  i64, i64* %86 
+  tail call ccc  void  @print_int(i64  %76)  
+  tail call ccc  void  @putchar(i8  10)  
+  tail call ccc  void  @print_int(i64  %83)  
+  tail call ccc  void  @putchar(i8  10)  
+  tail call fastcc  void  @"stmt_for.gen#3<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %80, i64  %87, i64  %"x##0", i64  %"y##0")  
+  ret void 
+if.else1:
+  ret void 
+}
+
+
+define external fastcc  void @"stmt_for.gen#4<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"x##0")    {
+entry:
+  %"1#tmp#7##0" = icmp ne i64 %"tmp#4##0", 0 
+  br i1 %"1#tmp#7##0", label %if.then, label %if.else 
+if.then:
+  %88 = inttoptr i64 %"tmp#4##0" to i64* 
+  %89 = getelementptr  i64, i64* %88, i64 0 
+  %90 = load  i64, i64* %89 
+  %91 = add   i64 %"tmp#4##0", 8 
+  %92 = inttoptr i64 %91 to i64* 
+  %93 = getelementptr  i64, i64* %92, i64 0 
+  %94 = load  i64, i64* %93 
+  tail call ccc  void  @print_int(i64  %90)  
+  tail call ccc  void  @putchar(i8  10)  
+  tail call fastcc  void  @"stmt_for.gen#4<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %94, i64  %"x##0")  
   ret void 
 if.else:
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen#7<0>"(i64  %"i##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %"tmp#8##0", i64  %"tmp#9##0", i64  %"x##0", i64  %"y##0")    {
+define external fastcc  void @"stmt_for.gen#5<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
 entry:
-  %"1#tmp#14##0" = icmp ne i64 %"tmp#9##0", 0 
-  br i1 %"1#tmp#14##0", label %if.then, label %if.else 
+  %"1#tmp#9##0" = icmp ne i64 %"tmp#5##0", 0 
+  br i1 %"1#tmp#9##0", label %if.then, label %if.else 
 if.then:
-  %110 = inttoptr i64 %"tmp#9##0" to i64* 
+  %95 = inttoptr i64 %"tmp#5##0" to i64* 
+  %96 = getelementptr  i64, i64* %95, i64 0 
+  %97 = load  i64, i64* %96 
+  %98 = add   i64 %"tmp#5##0", 8 
+  %99 = inttoptr i64 %98 to i64* 
+  %100 = getelementptr  i64, i64* %99, i64 0 
+  %101 = load  i64, i64* %100 
+  %"2#tmp#6##0" = icmp eq i64 %97, 3 
+  br i1 %"2#tmp#6##0", label %if.then1, label %if.else1 
+if.else:
+  ret void 
+if.then1:
+  ret void 
+if.else1:
+  tail call ccc  void  @print_int(i64  %97)  
+  tail call ccc  void  @putchar(i8  10)  
+  tail call fastcc  void  @"stmt_for.gen#5<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %101, i64  %"x##0")  
+  ret void 
+}
+
+
+define external fastcc  void @"stmt_for.gen#6<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0")    {
+entry:
+  %102 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
+  %103 = extractvalue {i64, i64, i1} %102, 0 
+  %104 = extractvalue {i64, i64, i1} %102, 1 
+  %105 = extractvalue {i64, i64, i1} %102, 2 
+  br i1 %105, label %if.then, label %if.else 
+if.then:
+  tail call ccc  void  @print_int(i64  %103)  
+  tail call ccc  void  @putchar(i8  10)  
+  tail call fastcc  void  @"stmt_for.gen#6<0>"(i64  %104, i64  %"tmp#1##0")  
+  ret void 
+if.else:
+  ret void 
+}
+
+
+define external fastcc  void @"stmt_for.gen#7<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0")    {
+entry:
+  %106 = tail call fastcc  {i64, i64, i1}  @"stmt_for.int_sequence.[|]<0>"(i64  %"tmp#0##0")  
+  %107 = extractvalue {i64, i64, i1} %106, 0 
+  %108 = extractvalue {i64, i64, i1} %106, 1 
+  %109 = extractvalue {i64, i64, i1} %106, 2 
+  br i1 %109, label %if.then, label %if.else 
+if.then:
+  tail call ccc  void  @print_int(i64  %107)  
+  tail call ccc  void  @putchar(i8  10)  
+  tail call fastcc  void  @"stmt_for.gen#7<0>"(i64  %108, i64  %"tmp#1##0")  
+  ret void 
+if.else:
+  ret void 
+}
+
+
+define external fastcc  void @"stmt_for.gen#8<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
+entry:
+  %"1#tmp#9##0" = icmp ne i64 %"tmp#5##0", 0 
+  br i1 %"1#tmp#9##0", label %if.then, label %if.else 
+if.then:
+  %110 = inttoptr i64 %"tmp#5##0" to i64* 
   %111 = getelementptr  i64, i64* %110, i64 0 
   %112 = load  i64, i64* %111 
-  %113 = add   i64 %"tmp#9##0", 8 
+  %113 = add   i64 %"tmp#5##0", 8 
   %114 = inttoptr i64 %113 to i64* 
   %115 = getelementptr  i64, i64* %114, i64 0 
   %116 = load  i64, i64* %115 
-  tail call ccc  void  @print_int(i64  %"i##0")  
-  tail call ccc  void  @putchar(i8  10)  
-  tail call ccc  void  @print_int(i64  %112)  
-  tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen#6<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %"tmp#8##0", i64  %116, i64  %"x##0", i64  %"y##0")  
-  ret void 
+  %"2#tmp#6##0" = icmp eq i64 %112, 3 
+  br i1 %"2#tmp#6##0", label %if.then1, label %if.else1 
 if.else:
   ret void 
-}
-
-
-define external fastcc  void @"stmt_for.gen#8<0>"(i64  %"i##0", i64  %"j##0", i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %"tmp#8##0", i64  %"tmp#9##0", i64  %"x##0", i64  %"y##0")    {
-entry:
-  tail call ccc  void  @print_int(i64  %"i##0")  
+if.then1:
+  tail call fastcc  void  @"stmt_for.gen#8<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %116, i64  %"x##0")  
+  ret void 
+if.else1:
+  tail call ccc  void  @print_int(i64  %112)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call ccc  void  @print_int(i64  %"j##0")  
-  tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen#6<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"tmp#6##0", i64  %"tmp#7##0", i64  %"tmp#8##0", i64  %"tmp#9##0", i64  %"x##0", i64  %"y##0")  
+  tail call fastcc  void  @"stmt_for.gen#8<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %116, i64  %"x##0")  
   ret void 
 }
 
 
-define external fastcc  void @"stmt_for.gen#9<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"x##0")    {
+define external fastcc  void @"stmt_for.gen#9<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %"tmp#5##0", i64  %"x##0")    {
 entry:
-  %"1#tmp#8##0" = icmp ne i64 %"tmp#4##0", 0 
-  br i1 %"1#tmp#8##0", label %if.then, label %if.else 
+  %"1#tmp#9##0" = icmp ne i64 %"tmp#5##0", 0 
+  br i1 %"1#tmp#9##0", label %if.then, label %if.else 
 if.then:
-  %117 = inttoptr i64 %"tmp#4##0" to i64* 
+  %117 = inttoptr i64 %"tmp#5##0" to i64* 
   %118 = getelementptr  i64, i64* %117, i64 0 
   %119 = load  i64, i64* %118 
-  %120 = add   i64 %"tmp#4##0", 8 
+  %120 = add   i64 %"tmp#5##0", 8 
   %121 = inttoptr i64 %120 to i64* 
   %122 = getelementptr  i64, i64* %121, i64 0 
   %123 = load  i64, i64* %122 
+  %"2#tmp#6##0" = icmp slt i64 %119, 3 
+  br i1 %"2#tmp#6##0", label %if.then1, label %if.else1 
+if.else:
+  ret void 
+if.then1:
+  tail call fastcc  void  @"stmt_for.gen#9<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %123, i64  %"x##0")  
+  ret void 
+if.else1:
   tail call ccc  void  @print_int(i64  %119)  
   tail call ccc  void  @putchar(i8  10)  
-  tail call fastcc  void  @"stmt_for.gen#9<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %123, i64  %"x##0")  
-  ret void 
-if.else:
+  tail call fastcc  void  @"stmt_for.gen#9<0>"(i64  %"tmp#0##0", i64  %"tmp#1##0", i64  %"tmp#2##0", i64  %"tmp#3##0", i64  %"tmp#4##0", i64  %123, i64  %"x##0")  
   ret void 
 }
 
@@ -1457,8 +1276,8 @@ entry:
 
 define external fastcc  i1 @"stmt_for.semi_det_for_loop<0>"()    {
 entry:
-  %"1#tmp#3##0" = tail call fastcc  i64  @"stmt_for.xrange<0>"(i64  0, i64  1, i64  10)  
-  %"1##success##0" = tail call fastcc  i1  @"stmt_for.gen#4<0>"(i64  %"1#tmp#3##0", i64  %"1#tmp#3##0")  
+  %"1#tmp#1##0" = tail call fastcc  i64  @"stmt_for.xrange<0>"(i64  0, i64  1, i64  10)  
+  %"1##success##0" = tail call fastcc  i1  @"stmt_for.gen#2<0>"(i64  %"1#tmp#1##0", i64  %"1#tmp#1##0")  
   ret i1 %"1##success##0" 
 }
 
@@ -1525,7 +1344,7 @@ entry:
   %240 = inttoptr i64 %239 to i64* 
   %241 = getelementptr  i64, i64* %240, i64 0 
   store  i64 %228, i64* %241 
-  tail call fastcc  void  @"stmt_for.gen#6<0>"(i64  %220, i64  %212, i64  %204, i64  %196, i64  0, i64  %236, i64  %228, i64  0, i64  %220, i64  %236, i64  %220, i64  %236)  
+  tail call fastcc  void  @"stmt_for.gen#3<0>"(i64  %220, i64  %212, i64  %204, i64  %196, i64  0, i64  %236, i64  %228, i64  0, i64  %220, i64  %236, i64  %220, i64  %236)  
   ret void 
 }
 
@@ -1562,7 +1381,7 @@ entry:
   %264 = inttoptr i64 %263 to i64* 
   %265 = getelementptr  i64, i64* %264, i64 0 
   store  i64 %252, i64* %265 
-  tail call fastcc  void  @"stmt_for.gen#9<0>"(i64  %260, i64  %252, i64  %244, i64  0, i64  %260, i64  %260)  
+  tail call fastcc  void  @"stmt_for.gen#4<0>"(i64  %260, i64  %252, i64  %244, i64  0, i64  %260, i64  %260)  
   ret void 
 }
 
@@ -1609,23 +1428,23 @@ entry:
   %296 = inttoptr i64 %295 to i64* 
   %297 = getelementptr  i64, i64* %296, i64 0 
   store  i64 %284, i64* %297 
-  tail call fastcc  void  @"stmt_for.gen#10<0>"(i64  %292, i64  %284, i64  %276, i64  %268, i64  0, i64  %292, i64  %292)  
+  tail call fastcc  void  @"stmt_for.gen#5<0>"(i64  %292, i64  %284, i64  %276, i64  %268, i64  0, i64  %292, i64  %292)  
   ret void 
 }
 
 
 define external fastcc  void @"stmt_for.using_irange<0>"()    {
 entry:
-  %"1#tmp#3##0" = tail call fastcc  i64  @"stmt_for.irange<0>"(i64  1, i64  1, i64  10)  
-  tail call fastcc  void  @"stmt_for.gen#12<0>"(i64  %"1#tmp#3##0", i64  %"1#tmp#3##0")  
+  %"1#tmp#1##0" = tail call fastcc  i64  @"stmt_for.irange<0>"(i64  1, i64  1, i64  10)  
+  tail call fastcc  void  @"stmt_for.gen#6<0>"(i64  %"1#tmp#1##0", i64  %"1#tmp#1##0")  
   ret void 
 }
 
 
 define external fastcc  void @"stmt_for.using_irange_reverse<0>"()    {
 entry:
-  %"1#tmp#3##0" = tail call fastcc  i64  @"stmt_for.irange<0>"(i64  10, i64  -1, i64  1)  
-  tail call fastcc  void  @"stmt_for.gen#13<0>"(i64  %"1#tmp#3##0", i64  %"1#tmp#3##0")  
+  %"1#tmp#1##0" = tail call fastcc  i64  @"stmt_for.irange<0>"(i64  10, i64  -1, i64  1)  
+  tail call fastcc  void  @"stmt_for.gen#7<0>"(i64  %"1#tmp#1##0", i64  %"1#tmp#1##0")  
   ret void 
 }
 
@@ -1672,7 +1491,7 @@ entry:
   %328 = inttoptr i64 %327 to i64* 
   %329 = getelementptr  i64, i64* %328, i64 0 
   store  i64 %316, i64* %329 
-  tail call fastcc  void  @"stmt_for.gen#14<0>"(i64  %324, i64  %316, i64  %308, i64  %300, i64  0, i64  %324, i64  %324)  
+  tail call fastcc  void  @"stmt_for.gen#8<0>"(i64  %324, i64  %316, i64  %308, i64  %300, i64  0, i64  %324, i64  %324)  
   ret void 
 }
 
@@ -1719,7 +1538,7 @@ entry:
   %360 = inttoptr i64 %359 to i64* 
   %361 = getelementptr  i64, i64* %360, i64 0 
   store  i64 %348, i64* %361 
-  tail call fastcc  void  @"stmt_for.gen#16<0>"(i64  %356, i64  %348, i64  %340, i64  %332, i64  0, i64  %356, i64  %356)  
+  tail call fastcc  void  @"stmt_for.gen#9<0>"(i64  %356, i64  %348, i64  %340, i64  %332, i64  0, i64  %356, i64  %356)  
   ret void 
 }
 
@@ -1766,7 +1585,7 @@ entry:
   %392 = inttoptr i64 %391 to i64* 
   %393 = getelementptr  i64, i64* %392, i64 0 
   store  i64 %380, i64* %393 
-  tail call fastcc  void  @"stmt_for.gen#18<0>"(i64  %388, i64  %380, i64  %372, i64  %364, i64  0, i64  %388, i64  %388)  
+  tail call fastcc  void  @"stmt_for.gen#10<0>"(i64  %388, i64  %380, i64  %372, i64  %364, i64  0, i64  %388, i64  %388)  
   ret void 
 }
 
@@ -1813,7 +1632,7 @@ entry:
   %424 = inttoptr i64 %423 to i64* 
   %425 = getelementptr  i64, i64* %424, i64 0 
   store  i64 %412, i64* %425 
-  tail call fastcc  void  @"stmt_for.gen#20<0>"(i64  %420, i64  %412, i64  %404, i64  %396, i64  0, i64  %420, i64  %420)  
+  tail call fastcc  void  @"stmt_for.gen#11<0>"(i64  %420, i64  %412, i64  %404, i64  %396, i64  0, i64  %420, i64  %420)  
   ret void 
 }
 
@@ -1860,23 +1679,23 @@ entry:
   %456 = inttoptr i64 %455 to i64* 
   %457 = getelementptr  i64, i64* %456, i64 0 
   store  i64 %444, i64* %457 
-  tail call fastcc  void  @"stmt_for.gen#22<0>"(i64  %452, i64  %444, i64  %436, i64  %428, i64  0, i64  %452, i64  %452)  
+  tail call fastcc  void  @"stmt_for.gen#12<0>"(i64  %452, i64  %444, i64  %436, i64  %428, i64  0, i64  %452, i64  %452)  
   ret void 
 }
 
 
 define external fastcc  void @"stmt_for.using_xrange<0>"()    {
 entry:
-  %"1#tmp#3##0" = tail call fastcc  i64  @"stmt_for.xrange<0>"(i64  1, i64  1, i64  10)  
-  tail call fastcc  void  @"stmt_for.gen#24<0>"(i64  %"1#tmp#3##0", i64  %"1#tmp#3##0")  
+  %"1#tmp#1##0" = tail call fastcc  i64  @"stmt_for.xrange<0>"(i64  1, i64  1, i64  10)  
+  tail call fastcc  void  @"stmt_for.gen#13<0>"(i64  %"1#tmp#1##0", i64  %"1#tmp#1##0")  
   ret void 
 }
 
 
 define external fastcc  void @"stmt_for.using_xrange_reverse<0>"()    {
 entry:
-  %"1#tmp#3##0" = tail call fastcc  i64  @"stmt_for.xrange<0>"(i64  10, i64  -1, i64  1)  
-  tail call fastcc  void  @"stmt_for.gen#25<0>"(i64  %"1#tmp#3##0", i64  %"1#tmp#3##0")  
+  %"1#tmp#1##0" = tail call fastcc  i64  @"stmt_for.xrange<0>"(i64  10, i64  -1, i64  1)  
+  tail call fastcc  void  @"stmt_for.gen#14<0>"(i64  %"1#tmp#1##0", i64  %"1#tmp#1##0")  
   ret void 
 }
 

--- a/test-cases/final-dump/string.exp
+++ b/test-cases/final-dump/string.exp
@@ -100,24 +100,24 @@ gen#1(io##0:wybe.phantom, s##0:wybe.string, tmp#0##0:wybe.string, ?io##2:wybe.ph
  AliasPairs: []
  InterestingCallProperties: [InterestingUnaliased 2]
  MultiSpeczDepInfo: [(0,(wybe.string.[|]<0>,fromList [NonAliasedParamCond 2 [2]])),(2,(string.gen#1<0>,fromList [NonAliasedParamCond 2 []]))]
-    wybe.string.[|]<0>(?c##0:wybe.char, ?tmp#1##0:wybe.string, ~tmp#0##0:wybe.string, ?tmp#2##0:wybe.bool) #0
-    case ~tmp#2##0:wybe.bool of
+    wybe.string.[|]<0>(?c##0:wybe.char, ?tmp#0##1:wybe.string, ~tmp#0##0:wybe.string, ?tmp#1##0:wybe.bool) #0
+    case ~tmp#1##0:wybe.bool of
     0:
         foreign c putchar('\n':wybe.char, ~#io##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
     1:
         foreign c putchar(~c##0:wybe.char, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        string.gen#1<0>[785a827a1b](~io##1:wybe.phantom, ~s##0:wybe.string, ~tmp#1##0:wybe.string, ?io##2:wybe.phantom) #2 @string:nn:nn
+        string.gen#1<0>[785a827a1b](~io##1:wybe.phantom, ~s##0:wybe.string, ~tmp#0##1:wybe.string, ?io##2:wybe.phantom) #2 @string:nn:nn
 
  [785a827a1b] [NonAliasedParam 2] :
-    wybe.string.[|]<0>[785a827a1b](?c##0:wybe.char, ?tmp#1##0:wybe.string, ~tmp#0##0:wybe.string, ?tmp#2##0:wybe.bool) #0
-    case ~tmp#2##0:wybe.bool of
+    wybe.string.[|]<0>[785a827a1b](?c##0:wybe.char, ?tmp#0##1:wybe.string, ~tmp#0##0:wybe.string, ?tmp#1##0:wybe.bool) #0
+    case ~tmp#1##0:wybe.bool of
     0:
         foreign c putchar('\n':wybe.char, ~#io##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 
     1:
         foreign c putchar(~c##0:wybe.char, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        string.gen#1<0>[785a827a1b](~io##1:wybe.phantom, ~s##0:wybe.string, ~tmp#1##0:wybe.string, ?io##2:wybe.phantom) #2 @string:nn:nn
+        string.gen#1<0>[785a827a1b](~io##1:wybe.phantom, ~s##0:wybe.string, ~tmp#0##1:wybe.string, ?io##2:wybe.phantom) #2 @string:nn:nn
 
 
 

--- a/wybelibs/wybe/string.wybe
+++ b/wybelibs/wybe/string.wybe
@@ -59,7 +59,8 @@ pub def {test} `[|]`(?head:char, ?tail:_, s:_) {
             if { [?head | ?t] = left :: ?tail = concat(t, right)
                | else :: [?head | ?tail] = right
             }
-       | s = slice(?base, ?range) :: 
+       | s = slice(?base, ?range) ::
+            ?head = nullbyte; ?tail = empty
             do { # this could be faster
                 [?idx | ?range] = range
                 if { ?head = base[idx] :: ?tail = slice(base, range); break }


### PR DESCRIPTION
This PR adds fixes for #173 & #191 


* mode checking a `Cond`s and `Loop`s sets the correct (?) `then&else` variable dict 
  * I'm not 100% confident with these changes, but the tested behaviors appears correct
* for loop flattening has been refactored
  * generates less temporary variables
  * handles det `[|]`
* added some test-cases for the mentioned issues examples