### PR TITLE
Revert some changes for fix for #149

### DIFF
--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1260,11 +1260,9 @@ matchTypeList' callee pos callArgTypes calleeInfo = do
     if List.null mismatches
     then return $ OK
          (calleeInfo
-        -- XXX this throws away the types of the callee
-        --   {procInfoArgs = List.zipWith TypeFlow matches calleeFlows},
-          {procInfoArgs = List.zipWith TypeFlow calleeTypes calleeFlows},
-
-          typing)
+          {procInfoArgs=List.zipWith TypeFlow matches calleeFlows},
+        
+           typing)
     else return $ Err [ReasonArgType callee n pos | n <- mismatches]
 
 

--- a/test-cases/complex/exp/testcase_multi_specz-drone.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-drone.exp
@@ -88,8 +88,8 @@ LLVM code       : None
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp#4##0:wybe.array(T))
     foreign lpvm mutate(~tmp#4##0:wybe.array(T), ?tmp#5##0:wybe.array(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
-    foreign lpvm mutate(~tmp#5##0:wybe.array(T), ?tmp#0##0:wybe.array(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(T))
-    wybe.array.[|]<0>(?command##1:T, ?arguments##1:wybe.array(T), ~tmp#0##0:wybe.array(T), ?tmp#1##0:wybe.bool) #1 @command_line:nn:nn
+    foreign lpvm mutate(~tmp#5##0:wybe.array(T), ?tmp#0##0:wybe.array(wybe.c_string), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(T))
+    wybe.array.[|]<0>(?command##1:wybe.c_string, ?arguments##1:wybe.array(wybe.c_string), ~tmp#0##0:wybe.array(wybe.c_string), ?tmp#1##0:wybe.bool) #1 @command_line:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
         foreign c {terminal,semipure} error_exit(c"command_line:15:14":wybe.c_string, c"Erroneous program argument vector":wybe.c_string) @control:nn:nn
@@ -689,8 +689,8 @@ entry:
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp#4##0:wybe.array(T))
     foreign lpvm mutate(~tmp#4##0:wybe.array(T), ?tmp#5##0:wybe.array(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
-    foreign lpvm mutate(~tmp#5##0:wybe.array(T), ?tmp#0##0:wybe.array(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(T))
-    wybe.array.[|]<0>(?command##1:T, ?arguments##1:wybe.array(T), ~tmp#0##0:wybe.array(T), ?tmp#1##0:wybe.bool) #1 @command_line:nn:nn
+    foreign lpvm mutate(~tmp#5##0:wybe.array(T), ?tmp#0##0:wybe.array(wybe.c_string), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(T))
+    wybe.array.[|]<0>(?command##1:wybe.c_string, ?arguments##1:wybe.array(wybe.c_string), ~tmp#0##0:wybe.array(wybe.c_string), ?tmp#1##0:wybe.bool) #1 @command_line:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
         foreign c {terminal,semipure} error_exit(c"command_line:15:14":wybe.c_string, c"Erroneous program argument vector":wybe.c_string) @control:nn:nn

--- a/test-cases/complex/exp/testcase_multi_specz-int_list.exp
+++ b/test-cases/complex/exp/testcase_multi_specz-int_list.exp
@@ -157,8 +157,8 @@ LLVM code       : None
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp#4##0:wybe.array(T))
     foreign lpvm mutate(~tmp#4##0:wybe.array(T), ?tmp#5##0:wybe.array(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
-    foreign lpvm mutate(~tmp#5##0:wybe.array(T), ?tmp#0##0:wybe.array(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(T))
-    wybe.array.[|]<0>(?command##1:T, ?arguments##1:wybe.array(T), ~tmp#0##0:wybe.array(T), ?tmp#1##0:wybe.bool) #1 @command_line:nn:nn
+    foreign lpvm mutate(~tmp#5##0:wybe.array(T), ?tmp#0##0:wybe.array(wybe.c_string), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(T))
+    wybe.array.[|]<0>(?command##1:wybe.c_string, ?arguments##1:wybe.array(wybe.c_string), ~tmp#0##0:wybe.array(wybe.c_string), ?tmp#1##0:wybe.bool) #1 @command_line:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
         foreign c {terminal,semipure} error_exit(c"command_line:15:14":wybe.c_string, c"Erroneous program argument vector":wybe.c_string) @control:nn:nn
@@ -1009,8 +1009,8 @@ entry:
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp#4##0:wybe.array(T))
     foreign lpvm mutate(~tmp#4##0:wybe.array(T), ?tmp#5##0:wybe.array(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
-    foreign lpvm mutate(~tmp#5##0:wybe.array(T), ?tmp#0##0:wybe.array(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(T))
-    wybe.array.[|]<0>(?command##1:T, ?arguments##1:wybe.array(T), ~tmp#0##0:wybe.array(T), ?tmp#1##0:wybe.bool) #1 @command_line:nn:nn
+    foreign lpvm mutate(~tmp#5##0:wybe.array(T), ?tmp#0##0:wybe.array(wybe.c_string), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(T))
+    wybe.array.[|]<0>(?command##1:wybe.c_string, ?arguments##1:wybe.array(wybe.c_string), ~tmp#0##0:wybe.array(wybe.c_string), ?tmp#1##0:wybe.bool) #1 @command_line:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
         foreign c {terminal,semipure} error_exit(c"command_line:15:14":wybe.c_string, c"Erroneous program argument vector":wybe.c_string) @control:nn:nn

--- a/test-cases/final-dump/anon_field_variable.exp
+++ b/test-cases/final-dump/anon_field_variable.exp
@@ -19,7 +19,7 @@ AFTER EVERYTHING:
  AliasPairs: []
  InterestingCallProperties: []
     foreign lpvm alloc(8:wybe.int, ?tmp#4##0:anon_field_variable(T))
-    foreign lpvm mutate(~tmp#4##0:anon_field_variable(T), ?tmp#0##0:anon_field_variable(T), 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 0:T)
+    foreign lpvm mutate(~tmp#4##0:anon_field_variable(T), ?tmp#0##0:anon_field_variable(wybe.bool), 0:wybe.int, 1:wybe.int, 8:wybe.int, 0:wybe.int, 0:T)
     foreign llvm and(~tmp#0##0:wybe.int, 1:wybe.int, ?tmp#6##0:wybe.int)
     foreign llvm icmp_eq(~tmp#6##0:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.bool)
     case ~tmp#7##0:wybe.bool of

--- a/test-cases/final-dump/generic_use.exp
+++ b/test-cases/final-dump/generic_use.exp
@@ -389,13 +389,13 @@ entry:
     foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
     generic_use.print<0>(tmp#1##0:generic_list(wybe.int), ~#io##1:wybe.phantom, ?tmp#13##0:wybe.phantom) #13 @generic_use:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#13##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    generic_use.concat<0>(tmp#0##0:generic_list(T), tmp#1##0:generic_list(T), ?tmp#2##0:generic_list(T)) #4 @generic_use:nn:nn
+    generic_use.concat<0>(tmp#0##0:generic_list(wybe.int), tmp#1##0:generic_list(wybe.int), ?tmp#2##0:generic_list(wybe.int)) #4 @generic_use:nn:nn
     generic_use.print<0>(~tmp#2##0:generic_list(wybe.int), ~#io##2:wybe.phantom, ?tmp#16##0:wybe.phantom) #14 @generic_use:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#16##0:wybe.phantom, ?#io##3:wybe.phantom) @io:nn:nn
-    generic_use.reverse1<0>[410bae77d3](~tmp#0##0:generic_list(T), 0:generic_list(T), ?tmp#3##0:generic_list(T)) #15 @generic_use:nn:nn
+    generic_use.reverse1<0>[410bae77d3](~tmp#0##0:generic_list(T), 0:generic_list(T), ?tmp#3##0:generic_list(wybe.int)) #15 @generic_use:nn:nn
     generic_use.print<0>(~tmp#3##0:generic_list(wybe.int), ~#io##3:wybe.phantom, ?tmp#20##0:wybe.phantom) #16 @generic_use:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#20##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
-    generic_use.nrev<0>[410bae77d3](~tmp#1##0:generic_list(T), ?tmp#4##0:generic_list(T)) #8 @generic_use:nn:nn
+    generic_use.nrev<0>[410bae77d3](~tmp#1##0:generic_list(wybe.int), ?tmp#4##0:generic_list(wybe.int)) #8 @generic_use:nn:nn
     generic_use.print<0>(~tmp#4##0:generic_list(wybe.int), ~#io##4:wybe.phantom, ?tmp#23##0:wybe.phantom) #17 @generic_use:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#23##0:wybe.phantom, ?#io##5:wybe.phantom) @io:nn:nn
 
@@ -454,7 +454,7 @@ fromto1(lo##0:wybe.int, hi##0:wybe.int, sofar##0:generic_list(wybe.int), ?#resul
         foreign llvm sub(hi##0:wybe.int, 1:wybe.int, ?tmp#2##0:wybe.int) @int:nn:nn
         foreign lpvm alloc(16:wybe.int, ?tmp#11##0:generic_list(T))
         foreign lpvm mutate(~tmp#11##0:generic_list(T), ?tmp#12##0:generic_list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~hi##0:T)
-        foreign lpvm mutate(~tmp#12##0:generic_list(T), ?tmp#3##0:generic_list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~sofar##0:generic_list(T))
+        foreign lpvm mutate(~tmp#12##0:generic_list(T), ?tmp#3##0:generic_list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~sofar##0:generic_list(T))
         generic_use.fromto1<0>(~lo##0:wybe.int, ~tmp#2##0:wybe.int, ~tmp#3##0:generic_list(wybe.int), ?#result##0:generic_list(wybe.int)) #3 @generic_use:nn:nn
 
 
@@ -513,8 +513,8 @@ print(lst##0:generic_list(wybe.int), io##0:wybe.phantom, ?io##4:wybe.phantom):
         foreign c putchar(']':wybe.char, ~#io##1:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
 
     1:
-        foreign lpvm access(lst##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:T)
-        foreign lpvm access(~lst##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T))
+        foreign lpvm access(lst##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+        foreign lpvm access(~lst##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(wybe.int))
         foreign c print_int(~h##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
         generic_use.print_tail<0>(~t##0:generic_list(wybe.int), ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @generic_use:nn:nn
         foreign c putchar(']':wybe.char, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn
@@ -532,8 +532,8 @@ print_tail(lst##0:generic_list(wybe.int), io##0:wybe.phantom, ?io##3:wybe.phanto
         foreign llvm move(~io##0:wybe.phantom, ?io##3:wybe.phantom)
 
     1:
-        foreign lpvm access(lst##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:T)
-        foreign lpvm access(~lst##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(T))
+        foreign lpvm access(lst##0:generic_list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?h##0:wybe.int)
+        foreign lpvm access(~lst##0:generic_list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?t##0:generic_list(wybe.int))
         wybe.string.print_string<0>(", ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #4 @io:nn:nn
         foreign c print_int(~h##0:wybe.int, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
         generic_use.print_tail<0>(~t##0:generic_list(wybe.int), ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @generic_use:nn:nn

--- a/test-cases/final-dump/main_hello.exp
+++ b/test-cases/final-dump/main_hello.exp
@@ -25,8 +25,8 @@ AFTER EVERYTHING:
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp#4##0:wybe.array(T))
     foreign lpvm mutate(~tmp#4##0:wybe.array(T), ?tmp#5##0:wybe.array(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argc##0:wybe.int)
-    foreign lpvm mutate(~tmp#5##0:wybe.array(T), ?tmp#0##0:wybe.array(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(T))
-    wybe.array.[|]<0>(?command##1:T, ?arguments##1:wybe.array(T), ~tmp#0##0:wybe.array(T), ?tmp#1##0:wybe.bool) #1 @command_line:nn:nn
+    foreign lpvm mutate(~tmp#5##0:wybe.array(T), ?tmp#0##0:wybe.array(wybe.c_string), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, argv##0:wybe.array.raw_array(T))
+    wybe.array.[|]<0>(?command##1:wybe.c_string, ?arguments##1:wybe.array(wybe.c_string), ~tmp#0##0:wybe.array(wybe.c_string), ?tmp#1##0:wybe.bool) #1 @command_line:nn:nn
     case ~tmp#1##0:wybe.bool of
     0:
         foreign c {terminal,semipure} error_exit(c"command_line:15:14":wybe.c_string, c"Erroneous program argument vector":wybe.c_string) @control:nn:nn

--- a/test-cases/final-dump/stmt_for.exp
+++ b/test-cases/final-dump/stmt_for.exp
@@ -86,7 +86,7 @@ AFTER EVERYTHING:
 
 gen#1 > (2 calls)
 0: stmt_for.gen#1<0>
-gen#1(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(T), tmp#5##0:wybe.list(T), tmp#6##0:wybe.list(T), tmp#7##0:wybe.list(T), tmp#8##0:wybe.list(wybe.int), tmp#9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int), ?io##3:wybe.phantom):
+gen#1(io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), tmp#6##0:wybe.list(wybe.int), tmp#7##0:wybe.list(wybe.int), tmp#8##0:wybe.list(wybe.int), tmp#9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int), ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(tmp#8##0:wybe.int, 0:wybe.int, ?tmp#13##0:wybe.bool)
@@ -95,28 +95,28 @@ gen#1(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0
         foreign llvm move(~io##0:wybe.phantom, ?io##3:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp#8##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:T)
-        foreign lpvm access(~tmp#8##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##1:wybe.list(T))
+        foreign lpvm access(tmp#8##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int)
+        foreign lpvm access(~tmp#8##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##1:wybe.list(wybe.int))
         foreign llvm icmp_ne(tmp#9##0:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.bool)
         case ~tmp#15##0:wybe.bool of
         0:
             foreign llvm move(~io##0:wybe.phantom, ?io##3:wybe.phantom)
 
         1:
-            foreign lpvm access(tmp#9##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?j##0:T)
-            foreign lpvm access(~tmp#9##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##1:wybe.list(T))
+            foreign lpvm access(tmp#9##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?j##0:wybe.int)
+            foreign lpvm access(~tmp#9##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##1:wybe.list(wybe.int))
             foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @io:nn:nn
             foreign c putchar('\n':wybe.char, ~tmp#18##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
             foreign c print_int(~j##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#21##0:wybe.phantom) @io:nn:nn
             foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-            stmt_for.gen#1<0>(~io##2:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##0:wybe.list(T), ~tmp#6##0:wybe.list(T), ~tmp#7##0:wybe.list(T), ~tmp#8##1:wybe.list(wybe.int), ~tmp#9##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##3:wybe.phantom) #4 @stmt_for:nn:nn
+            stmt_for.gen#1<0>(~io##2:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int), ~tmp#6##0:wybe.list(wybe.int), ~tmp#7##0:wybe.list(wybe.int), ~tmp#8##1:wybe.list(wybe.int), ~tmp#9##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##3:wybe.phantom) #4 @stmt_for:nn:nn
 
 
 
 
 gen#10 > (2 calls)
 0: stmt_for.gen#10<0>
-gen#10(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
+gen#10(io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
@@ -125,14 +125,14 @@ gen#10(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:T)
-        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(T))
+        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int)
+        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(wybe.int))
         foreign llvm icmp_eq(i##0:wybe.int, 3:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
         case ~tmp#6##0:wybe.bool of
         0:
             foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
             foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-            stmt_for.gen#10<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #3 @stmt_for:nn:nn
+            stmt_for.gen#10<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #3 @stmt_for:nn:nn
 
         1:
             foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
@@ -142,7 +142,7 @@ gen#10(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##
 
 gen#11 > (3 calls)
 0: stmt_for.gen#11<0>
-gen#11(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
+gen#11(io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
@@ -151,24 +151,24 @@ gen#11(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:T)
-        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(T))
+        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int)
+        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(wybe.int))
         foreign llvm icmp_slt(i##0:wybe.int, 3:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
         case ~tmp#6##0:wybe.bool of
         0:
-            stmt_for.gen#11<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #4 @stmt_for:nn:nn
+            stmt_for.gen#11<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #4 @stmt_for:nn:nn
 
         1:
             foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
             foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-            stmt_for.gen#11<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #3 @stmt_for:nn:nn
+            stmt_for.gen#11<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #3 @stmt_for:nn:nn
 
 
 
 
 gen#12 > (2 calls)
 0: stmt_for.gen#12<0>
-gen#12(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
+gen#12(io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
@@ -177,8 +177,8 @@ gen#12(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:T)
-        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(T))
+        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int)
+        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(wybe.int))
         foreign llvm icmp_slt(i##0:wybe.int, 3:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
         case ~tmp#6##0:wybe.bool of
         0:
@@ -187,7 +187,7 @@ gen#12(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##
         1:
             foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
             foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-            stmt_for.gen#12<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #3 @stmt_for:nn:nn
+            stmt_for.gen#12<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #3 @stmt_for:nn:nn
 
 
 
@@ -254,7 +254,7 @@ gen#2(io##0:wybe.phantom, tmp#0##0:stmt_for.int_sequence, tmp#1##0:stmt_for.int_
 
 gen#3 > (2 calls)
 0: stmt_for.gen#3<0>
-gen#3(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(T), tmp#5##0:wybe.list(T), tmp#6##0:wybe.list(T), tmp#7##0:wybe.list(T), tmp#8##0:wybe.list(wybe.int), tmp#9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int), ?io##3:wybe.phantom):
+gen#3(io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), tmp#6##0:wybe.list(wybe.int), tmp#7##0:wybe.list(wybe.int), tmp#8##0:wybe.list(wybe.int), tmp#9##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), y##0:wybe.list(wybe.int), ?io##3:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(tmp#8##0:wybe.int, 0:wybe.int, ?tmp#13##0:wybe.bool)
@@ -263,28 +263,28 @@ gen#3(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0
         foreign llvm move(~io##0:wybe.phantom, ?io##3:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp#8##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:T)
-        foreign lpvm access(~tmp#8##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##1:wybe.list(T))
+        foreign lpvm access(tmp#8##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int)
+        foreign lpvm access(~tmp#8##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#8##1:wybe.list(wybe.int))
         foreign llvm icmp_ne(tmp#9##0:wybe.int, 0:wybe.int, ?tmp#15##0:wybe.bool)
         case ~tmp#15##0:wybe.bool of
         0:
             foreign llvm move(~io##0:wybe.phantom, ?io##3:wybe.phantom)
 
         1:
-            foreign lpvm access(tmp#9##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?j##0:T)
-            foreign lpvm access(~tmp#9##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##1:wybe.list(T))
+            foreign lpvm access(tmp#9##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?j##0:wybe.int)
+            foreign lpvm access(~tmp#9##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#9##1:wybe.list(wybe.int))
             foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#18##0:wybe.phantom) @io:nn:nn
             foreign c putchar('\n':wybe.char, ~tmp#18##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
             foreign c print_int(~j##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#21##0:wybe.phantom) @io:nn:nn
             foreign c putchar('\n':wybe.char, ~tmp#21##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-            stmt_for.gen#3<0>(~io##2:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##0:wybe.list(T), ~tmp#6##0:wybe.list(T), ~tmp#7##0:wybe.list(T), ~tmp#8##1:wybe.list(wybe.int), ~tmp#9##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##3:wybe.phantom) #4 @stmt_for:nn:nn
+            stmt_for.gen#3<0>(~io##2:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int), ~tmp#6##0:wybe.list(wybe.int), ~tmp#7##0:wybe.list(wybe.int), ~tmp#8##1:wybe.list(wybe.int), ~tmp#9##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ~y##0:wybe.list(wybe.int), ?io##3:wybe.phantom) #4 @stmt_for:nn:nn
 
 
 
 
 gen#4 > (2 calls)
 0: stmt_for.gen#4<0>
-gen#4(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
+gen#4(io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(tmp#4##0:wybe.int, 0:wybe.int, ?tmp#7##0:wybe.bool)
@@ -293,17 +293,17 @@ gen#4(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp#4##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:T)
-        foreign lpvm access(~tmp#4##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##1:wybe.list(T))
+        foreign lpvm access(tmp#4##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int)
+        foreign lpvm access(~tmp#4##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#4##1:wybe.list(wybe.int))
         foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @io:nn:nn
         foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-        stmt_for.gen#4<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
+        stmt_for.gen#4<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
 
 
 
 gen#5 > (2 calls)
 0: stmt_for.gen#5<0>
-gen#5(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
+gen#5(io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
@@ -312,14 +312,14 @@ gen#5(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:T)
-        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(T))
+        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int)
+        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(wybe.int))
         foreign llvm icmp_eq(i##0:wybe.int, 3:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
         case ~tmp#6##0:wybe.bool of
         0:
             foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
             foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-            stmt_for.gen#5<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #3 @stmt_for:nn:nn
+            stmt_for.gen#5<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #3 @stmt_for:nn:nn
 
         1:
             foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
@@ -363,7 +363,7 @@ gen#7(io##0:wybe.phantom, tmp#0##0:stmt_for.int_sequence, tmp#1##0:stmt_for.int_
 
 gen#8 > (3 calls)
 0: stmt_for.gen#8<0>
-gen#8(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
+gen#8(io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
@@ -372,24 +372,24 @@ gen#8(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:T)
-        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(T))
+        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int)
+        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(wybe.int))
         foreign llvm icmp_eq(i##0:wybe.int, 3:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
         case ~tmp#6##0:wybe.bool of
         0:
             foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
             foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-            stmt_for.gen#8<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #4 @stmt_for:nn:nn
+            stmt_for.gen#8<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #4 @stmt_for:nn:nn
 
         1:
-            stmt_for.gen#8<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
+            stmt_for.gen#8<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
 
 
 
 
 gen#9 > (3 calls)
 0: stmt_for.gen#9<0>
-gen#9(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0:wybe.list(T), tmp#3##0:wybe.list(T), tmp#4##0:wybe.list(T), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
+gen#9(io##0:wybe.phantom, tmp#0##0:wybe.list(wybe.int), tmp#1##0:wybe.list(wybe.int), tmp#2##0:wybe.list(wybe.int), tmp#3##0:wybe.list(wybe.int), tmp#4##0:wybe.list(wybe.int), tmp#5##0:wybe.list(wybe.int), x##0:wybe.list(wybe.int), ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(tmp#5##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
@@ -398,17 +398,17 @@ gen#9(io##0:wybe.phantom, tmp#0##0:wybe.list(T), tmp#1##0:wybe.list(T), tmp#2##0
         foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:T)
-        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(T))
+        foreign lpvm access(tmp#5##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?i##0:wybe.int)
+        foreign lpvm access(~tmp#5##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#5##1:wybe.list(wybe.int))
         foreign llvm icmp_slt(i##0:wybe.int, 3:wybe.int, ?tmp#6##0:wybe.bool) @int:nn:nn
         case ~tmp#6##0:wybe.bool of
         0:
             foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
             foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-            stmt_for.gen#9<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #4 @stmt_for:nn:nn
+            stmt_for.gen#9<0>(~io##1:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #4 @stmt_for:nn:nn
 
         1:
-            stmt_for.gen#9<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
+            stmt_for.gen#9<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#5##1:wybe.list(wybe.int), ~x##0:wybe.list(wybe.int), ?io##2:wybe.phantom) #2 @stmt_for:nn:nn
 
 
 
@@ -443,23 +443,23 @@ multiple_generator(io##0:wybe.phantom, ?io##1:wybe.phantom):
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T))
     foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
-    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
     foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T))
     foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
-    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
     foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T))
     foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
-    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
     foreign lpvm alloc(16:wybe.int, ?tmp#26##0:wybe.list(T))
     foreign lpvm mutate(~tmp#26##0:wybe.list(T), ?tmp#27##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 6:T)
-    foreign lpvm mutate(~tmp#27##0:wybe.list(T), ?tmp#6##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm mutate(~tmp#27##0:wybe.list(T), ?tmp#6##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
     foreign lpvm alloc(16:wybe.int, ?tmp#30##0:wybe.list(T))
     foreign lpvm mutate(~tmp#30##0:wybe.list(T), ?tmp#31##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 5:T)
-    foreign lpvm mutate(~tmp#31##0:wybe.list(T), ?tmp#5##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#6##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#31##0:wybe.list(T), ?tmp#5##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#6##0:wybe.list(T))
     foreign lpvm alloc(16:wybe.int, ?tmp#34##0:wybe.list(T))
     foreign lpvm mutate(~tmp#34##0:wybe.list(T), ?tmp#35##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
-    foreign lpvm mutate(~tmp#35##0:wybe.list(T), ?tmp#4##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#5##0:wybe.list(T))
-    stmt_for.gen#1<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), 0:wybe.list(T), ~tmp#4##0:wybe.list(T), ~tmp#5##0:wybe.list(T), ~tmp#6##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #8 @stmt_for:nn:nn
+    foreign lpvm mutate(~tmp#35##0:wybe.list(T), ?tmp#4##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#5##0:wybe.list(T))
+    stmt_for.gen#1<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), 0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int), ~tmp#6##0:wybe.list(wybe.int), 0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#4##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #8 @stmt_for:nn:nn
 
 
 semi_det_for_loop > public (0 calls)
@@ -478,23 +478,23 @@ shortest_generator_termination(io##0:wybe.phantom, ?io##1:wybe.phantom):
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T))
     foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
-    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#3##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#3##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
     foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T))
     foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
-    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
     foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T))
     foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
-    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
     foreign lpvm alloc(16:wybe.int, ?tmp#26##0:wybe.list(T))
     foreign lpvm mutate(~tmp#26##0:wybe.list(T), ?tmp#27##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
-    foreign lpvm mutate(~tmp#27##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#27##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
     foreign lpvm alloc(16:wybe.int, ?tmp#30##0:wybe.list(T))
     foreign lpvm mutate(~tmp#30##0:wybe.list(T), ?tmp#31##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 5:T)
-    foreign lpvm mutate(~tmp#31##0:wybe.list(T), ?tmp#6##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm mutate(~tmp#31##0:wybe.list(T), ?tmp#6##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
     foreign lpvm alloc(16:wybe.int, ?tmp#34##0:wybe.list(T))
     foreign lpvm mutate(~tmp#34##0:wybe.list(T), ?tmp#35##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
-    foreign lpvm mutate(~tmp#35##0:wybe.list(T), ?tmp#5##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#6##0:wybe.list(T))
-    stmt_for.gen#3<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), 0:wybe.list(T), ~tmp#5##0:wybe.list(T), ~tmp#6##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #8 @stmt_for:nn:nn
+    foreign lpvm mutate(~tmp#35##0:wybe.list(T), ?tmp#5##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#6##0:wybe.list(T))
+    stmt_for.gen#3<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), 0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int), ~tmp#6##0:wybe.list(wybe.int), 0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#5##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #8 @stmt_for:nn:nn
 
 
 single_generator > public (1 calls)
@@ -504,14 +504,14 @@ single_generator(io##0:wybe.phantom, ?io##1:wybe.phantom):
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp#8##0:wybe.list(T))
     foreign lpvm mutate(~tmp#8##0:wybe.list(T), ?tmp#9##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
-    foreign lpvm mutate(~tmp#9##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm mutate(~tmp#9##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
     foreign lpvm alloc(16:wybe.int, ?tmp#12##0:wybe.list(T))
     foreign lpvm mutate(~tmp#12##0:wybe.list(T), ?tmp#13##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
-    foreign lpvm mutate(~tmp#13##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#13##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
     foreign lpvm alloc(16:wybe.int, ?tmp#16##0:wybe.list(T))
     foreign lpvm mutate(~tmp#16##0:wybe.list(T), ?tmp#17##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
-    foreign lpvm mutate(~tmp#17##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
-    stmt_for.gen#4<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #4 @stmt_for:nn:nn
+    foreign lpvm mutate(~tmp#17##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
+    stmt_for.gen#4<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), 0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #4 @stmt_for:nn:nn
 
 
 using_break > public (1 calls)
@@ -521,17 +521,17 @@ using_break(io##0:wybe.phantom, ?io##1:wybe.phantom):
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp#10##0:wybe.list(T))
     foreign lpvm mutate(~tmp#10##0:wybe.list(T), ?tmp#11##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
-    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
     foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T))
     foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
-    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
     foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T))
     foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
-    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
     foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T))
     foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
-    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
-    stmt_for.gen#5<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
+    stmt_for.gen#5<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), 0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
 using_irange > public (1 calls)
@@ -559,17 +559,17 @@ using_next(io##0:wybe.phantom, ?io##1:wybe.phantom):
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp#10##0:wybe.list(T))
     foreign lpvm mutate(~tmp#10##0:wybe.list(T), ?tmp#11##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
-    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
     foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T))
     foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
-    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
     foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T))
     foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
-    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
     foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T))
     foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
-    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
-    stmt_for.gen#8<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
+    stmt_for.gen#8<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), 0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
 using_unless > public (1 calls)
@@ -579,17 +579,17 @@ using_unless(io##0:wybe.phantom, ?io##1:wybe.phantom):
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp#10##0:wybe.list(T))
     foreign lpvm mutate(~tmp#10##0:wybe.list(T), ?tmp#11##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
-    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
     foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T))
     foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
-    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
     foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T))
     foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
-    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
     foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T))
     foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
-    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
-    stmt_for.gen#9<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
+    stmt_for.gen#9<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), 0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
 using_until > public (1 calls)
@@ -599,17 +599,17 @@ using_until(io##0:wybe.phantom, ?io##1:wybe.phantom):
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp#10##0:wybe.list(T))
     foreign lpvm mutate(~tmp#10##0:wybe.list(T), ?tmp#11##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
-    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
     foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T))
     foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
-    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
     foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T))
     foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
-    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
     foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T))
     foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
-    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
-    stmt_for.gen#10<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
+    stmt_for.gen#10<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), 0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
 using_when > public (1 calls)
@@ -619,17 +619,17 @@ using_when(io##0:wybe.phantom, ?io##1:wybe.phantom):
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp#10##0:wybe.list(T))
     foreign lpvm mutate(~tmp#10##0:wybe.list(T), ?tmp#11##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
-    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
     foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T))
     foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
-    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
     foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T))
     foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
-    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
     foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T))
     foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
-    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
-    stmt_for.gen#11<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
+    stmt_for.gen#11<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), 0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
 using_while > public (1 calls)
@@ -639,17 +639,17 @@ using_while(io##0:wybe.phantom, ?io##1:wybe.phantom):
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp#10##0:wybe.list(T))
     foreign lpvm mutate(~tmp#10##0:wybe.list(T), ?tmp#11##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 4:T)
-    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm mutate(~tmp#11##0:wybe.list(T), ?tmp#3##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
     foreign lpvm alloc(16:wybe.int, ?tmp#14##0:wybe.list(T))
     foreign lpvm mutate(~tmp#14##0:wybe.list(T), ?tmp#15##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 3:T)
-    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#15##0:wybe.list(T), ?tmp#2##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#3##0:wybe.list(T))
     foreign lpvm alloc(16:wybe.int, ?tmp#18##0:wybe.list(T))
     foreign lpvm mutate(~tmp#18##0:wybe.list(T), ?tmp#19##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 2:T)
-    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
+    foreign lpvm mutate(~tmp#19##0:wybe.list(T), ?tmp#1##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#2##0:wybe.list(T))
     foreign lpvm alloc(16:wybe.int, ?tmp#22##0:wybe.list(T))
     foreign lpvm mutate(~tmp#22##0:wybe.list(T), ?tmp#23##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 1:T)
-    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
-    stmt_for.gen#12<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(T), ~tmp#1##0:wybe.list(T), ~tmp#2##0:wybe.list(T), ~tmp#3##0:wybe.list(T), 0:wybe.list(T), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
+    foreign lpvm mutate(~tmp#23##0:wybe.list(T), ?tmp#0##0:wybe.list(wybe.int), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, tmp#1##0:wybe.list(T))
+    stmt_for.gen#12<0>(~io##0:wybe.phantom, ~tmp#0##0:wybe.list(wybe.int), ~tmp#1##0:wybe.list(wybe.int), ~tmp#2##0:wybe.list(wybe.int), ~tmp#3##0:wybe.list(wybe.int), 0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ~tmp#0##0:wybe.list(wybe.int), ?io##1:wybe.phantom) #5 @stmt_for:nn:nn
 
 
 using_xrange > public (1 calls)

--- a/test-cases/final-dump/type_generics.exp
+++ b/test-cases/final-dump/type_generics.exp
@@ -14,11 +14,11 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##6:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    type_generics.foo<0>(1:T, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @type_generics:nn:nn
-    type_generics.foo<0>(1:T, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #2 @type_generics:nn:nn
-    type_generics.foo<0>(1.0:T, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @type_generics:nn:nn
-    type_generics.foo<0>(1.0:T, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @type_generics:nn:nn
-    type_generics.foo2<0>(1:T0, ?y##0:T0, ?tmp#7##0:wybe.bool) #5 @type_generics:nn:nn
+    type_generics.foo<0>(1:wybe.int, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #0 @type_generics:nn:nn
+    type_generics.foo<0>(1:wybe.bool, ~#io##1:wybe.phantom, ?#io##2:wybe.phantom) #2 @type_generics:nn:nn
+    type_generics.foo<0>(1.0:wybe.float, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #3 @type_generics:nn:nn
+    type_generics.foo<0>(1.0:wybe.float, ~#io##3:wybe.phantom, ?#io##4:wybe.phantom) #4 @type_generics:nn:nn
+    type_generics.foo2<0>(1:wybe.int, ?y##0:wybe.int, ?tmp#7##0:wybe.bool) #5 @type_generics:nn:nn
     case ~tmp#7##0:wybe.bool of
     0:
         type_generics.gen#1<0>(~io##4:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##6:wybe.phantom) #8
@@ -50,15 +50,15 @@ foo2(x##0:T0, ?y##0:T0, ?#success##0:wybe.bool):
  InterestingCallProperties: []
     foreign lpvm alloc(16:wybe.int, ?tmp#6##0:wybe.list(T))
     foreign lpvm mutate(~tmp#6##0:wybe.list(T), ?tmp#7##0:wybe.list(T), 0:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, ~x##0:T)
-    foreign lpvm mutate(~tmp#7##0:wybe.list(T), ?tmp#0##0:wybe.list(T), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
+    foreign lpvm mutate(~tmp#7##0:wybe.list(T), ?tmp#0##0:wybe.list(T0), 8:wybe.int, 1:wybe.int, 16:wybe.int, 0:wybe.int, 0:wybe.list(T))
     foreign llvm icmp_ne(tmp#0##0:wybe.int, 0:wybe.int, ?tmp#9##0:wybe.bool)
     case ~tmp#9##0:wybe.bool of
     0:
         foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
-        foreign llvm move(undef:T, ?y##0:T)
+        foreign llvm move(undef:T, ?y##0:T0)
 
     1:
-        foreign lpvm access(~tmp#0##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:T)
+        foreign lpvm access(~tmp#0##0:wybe.list(T), 0:wybe.int, 16:wybe.int, 0:wybe.int, ?y##0:T0)
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
 
 
@@ -68,7 +68,7 @@ gen#1 > (2 calls)
 gen#1(io##0:wybe.phantom, [tmp#0##0:wybe.bool], [x##0:wybe.float], ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    type_generics.foo2<0>(1:T0, ?y##0:T0, ?tmp#6##0:wybe.bool) #0 @type_generics:nn:nn
+    type_generics.foo2<0>(1:wybe.int, ?y##0:wybe.int, ?tmp#6##0:wybe.bool) #0 @type_generics:nn:nn
     case ~tmp#6##0:wybe.bool of
     0:
         type_generics.gen#2<0>(_:wybe.int, ~io##0:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##2:wybe.phantom) #3
@@ -85,7 +85,7 @@ gen#2 > (2 calls)
 gen#2([i##0:wybe.int], io##0:wybe.phantom, [tmp#0##0:wybe.bool], [x##0:wybe.float], ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    type_generics.foo2<0>(1.0:T0, ?fx##0:T0, ?tmp#5##0:wybe.bool) #0 @type_generics:nn:nn
+    type_generics.foo2<0>(1.0:wybe.float, ?fx##0:wybe.float, ?tmp#5##0:wybe.bool) #0 @type_generics:nn:nn
     case ~tmp#5##0:wybe.bool of
     0:
         type_generics.gen#3<0>(_:wybe.float, _:wybe.int, ~io##0:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##2:wybe.phantom) #3
@@ -102,7 +102,7 @@ gen#3 > (2 calls)
 gen#3([f##0:wybe.float], [i##0:wybe.int], io##0:wybe.phantom, [tmp#0##0:wybe.bool], [x##0:wybe.float], ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    type_generics.foo2<0>(1.0:T0, ?x##1:T0, ?tmp#4##0:wybe.bool) #0 @type_generics:nn:nn
+    type_generics.foo2<0>(1.0:wybe.float, ?x##1:wybe.float, ?tmp#4##0:wybe.bool) #0 @type_generics:nn:nn
     case ~tmp#4##0:wybe.bool of
     0:
         type_generics.gen#4<0>(_:wybe.float, _:wybe.int, ~io##0:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##2:wybe.phantom) #3
@@ -119,7 +119,7 @@ gen#4 > (2 calls)
 gen#4([f##0:wybe.float], [i##0:wybe.int], io##0:wybe.phantom, [tmp#0##0:wybe.bool], [x##0:wybe.float], ?io##2:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    type_generics.foo2<0>('a':T0, ?z##0:T0, ?tmp#3##0:wybe.bool) #0 @type_generics:nn:nn
+    type_generics.foo2<0>('a':wybe.char, ?z##0:wybe.char, ?tmp#3##0:wybe.bool) #0 @type_generics:nn:nn
     case ~tmp#3##0:wybe.bool of
     0:
         type_generics.gen#5<0>(_:wybe.float, _:wybe.int, ~io##0:wybe.phantom, _:wybe.bool, _:wybe.float, ?io##2:wybe.phantom) #3
@@ -136,7 +136,7 @@ gen#5 > (2 calls)
 gen#5([f##0:wybe.float], [i##0:wybe.int], io##0:wybe.phantom, [tmp#0##0:wybe.bool], [x##0:wybe.float], ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    type_generics.foo2<0>(0:T0, ?b##0:T0, ?tmp#2##0:wybe.bool) #1 @type_generics:nn:nn
+    type_generics.foo2<0>(0:wybe.bool, ?b##0:wybe.bool, ?tmp#2##0:wybe.bool) #1 @type_generics:nn:nn
     case ~tmp#2##0:wybe.bool of
     0:
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)

--- a/test-cases/final-dump/unbranch_bug.exp
+++ b/test-cases/final-dump/unbranch_bug.exp
@@ -14,7 +14,7 @@ AFTER EVERYTHING:
 (io##0:wybe.phantom, ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
-    unbranch_bug.gen#3<0>(~io##0:wybe.phantom, 0:wybe.list(4), 0:wybe.list(T), ?io##1:wybe.phantom) #1 @unbranch_bug:nn:nn
+    unbranch_bug.gen#3<0>(~io##0:wybe.phantom, 0:wybe.list(4), 0:wybe.list(5), ?io##1:wybe.phantom) #1 @unbranch_bug:nn:nn
 
 
 gen#1 > {inline} (1 calls)
@@ -34,7 +34,7 @@ gen#2(io##0:wybe.phantom, [tmp#0##0:wybe.list(4)], [tmp#1##0:wybe.list(4)], [?io
 
 gen#3 > (2 calls)
 0: unbranch_bug.gen#3<0>
-gen#3(io##0:wybe.phantom, tmp#0##0:wybe.list(4), tmp#1##0:wybe.list(T), ?io##1:wybe.phantom):
+gen#3(io##0:wybe.phantom, tmp#0##0:wybe.list(4), tmp#1##0:wybe.list(5), ?io##1:wybe.phantom):
  AliasPairs: []
  InterestingCallProperties: []
     foreign llvm icmp_ne(tmp#0##0:wybe.int, 0:wybe.int, ?tmp#6##0:wybe.bool)
@@ -43,8 +43,8 @@ gen#3(io##0:wybe.phantom, tmp#0##0:wybe.list(4), tmp#1##0:wybe.list(T), ?io##1:w
         foreign llvm move(~io##0:wybe.phantom, ?io##1:wybe.phantom)
 
     1:
-        foreign lpvm access(~tmp#0##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##1:wybe.list(T))
-        unbranch_bug.gen#3<0>(~io##0:wybe.phantom, ~tmp#0##1:wybe.list(4), ~tmp#1##0:wybe.list(T), ?io##1:wybe.phantom) #1 @unbranch_bug:nn:nn
+        foreign lpvm access(~tmp#0##0:wybe.list(T), 8:wybe.int, 16:wybe.int, 0:wybe.int, ?tmp#0##1:wybe.list(5))
+        unbranch_bug.gen#3<0>(~io##0:wybe.phantom, ~tmp#0##1:wybe.list(4), ~tmp#1##0:wybe.list(5), ?io##1:wybe.phantom) #1 @unbranch_bug:nn:nn
 
 
   LLVM code       :


### PR DESCRIPTION
This reverts some changes made in the fix for #149 

- types correspond to the callee types, again
- argument types are coerced into parameter types in codegen