### PR TITLE
Added option to dump optimised LLVM code

### DIFF
--- a/src/ASTShow.hs
+++ b/src/ASTShow.hs
@@ -6,7 +6,7 @@
 --           : LICENSE in the root directory of this project.
 
 module ASTShow (
-  logDump
+  logDump, logDumpWith
   ) where
 
 import AST
@@ -87,13 +87,25 @@ showMapPoses = showMap "" ", " "" id showOptPos
 -- of the specified log selectors have been selected for logging.  This
 -- is called between the passes of those two selectors.
 logDump :: LogSelection -> LogSelection -> String -> Compiler ()
-logDump selector1 selector2 pass =
+logDump = logDumpWith (const $ return Nothing)
+
+
+-- |Dump the content of the specified module and all submodules, with the 
+-- result of an optional action applied to each module if either of the 
+-- specified log selectors have been selected for logging.  This is called 
+-- between the passes of those two selectors.
+logDumpWith :: (Module -> Compiler (Maybe String))
+            -> LogSelection -> LogSelection -> String -> Compiler ()
+logDumpWith action selector1 selector2 pass =
     whenLogging2 selector1 selector2 $ do
-      modList <- gets (Map.elems . modules)
-      dumpLib <- gets (optDumpLib . options)
-      let toLog mod = let spec  = modSpec mod
-                      in  List.null spec || dumpLib || head spec /= "wybe"
-      liftIO $ hPutStrLn stderr $ replicate 70 '='
-        ++ "\nAFTER " ++ pass ++ ":\n"
-        ++ intercalate ("\n" ++ replicate 50 '-' ++ "\n")
-        (List.map show $ List.filter toLog modList)
+        modList <- gets (Map.elems . modules)
+        dumpLib <- gets (optDumpLib . options)
+        let toLog mod = let spec  = modSpec mod
+                        in  List.null spec || dumpLib || head spec /= "wybe"
+        let logging = List.filter toLog modList
+        mbStrs <- mapM action logging
+        liftIO $ hPutStrLn stderr $ replicate 70 '='
+          ++ "\nAFTER " ++ pass ++ ":\n"
+          ++ intercalate ("\n" ++ replicate 50 '-' ++ "\n")
+          (zipWith (\mod mbStr -> show mod ++ maybe "" ("\n\n" ++) mbStr)
+              logging mbStrs)

--- a/src/Builder.hs
+++ b/src/Builder.hs
@@ -193,7 +193,7 @@ module Builder (buildTargets) where
 
 import           Analysis
 import           AST
-import           ASTShow                   (logDump)
+import           ASTShow                   (logDump, logDumpWith)
 import           Blocks                    (blockTransformModule,
                                             concatLLVMASTModules)
 import           Callers                   (collectCallers)
@@ -215,7 +215,7 @@ import           Normalise                 (normalise, completeNormalisation, no
 import           ObjectInterface
 
 import           Optimise                  (optimiseMod)
-import           Options                   (LogSelection (..), Options,
+import           Options                   (LogSelection (..), Options (..),
                                             optForce, optForceAll, optLibDirs,
                                             optNoMultiSpecz)
 import           Parser                    (parseWybe)
@@ -249,7 +249,11 @@ buildTargets targets = do
     mapM_ buildTarget targets
     showMessages
     stopOnError "building outputs"
-    logDump FinalDump FinalDump "EVERYTHING"
+    dumpOpt <- option optDumpOptLLVM
+    let dumper = if dumpOpt then logDumpWith ((Just <$>) . extractLLVM) 
+                            else logDump
+    dumper FinalDump FinalDump "EVERYTHING"
+
 
 
 -- |Build a single top-level target

--- a/src/Options.hs
+++ b/src/Options.hs
@@ -27,8 +27,8 @@ import           System.Directory
 import           System.Console.ANSI
 
 -- |Command line options for the wybe compiler.
-data Options = Options{
-    optForce          :: Bool     -- ^Compile specified files even if up to date
+data Options = Options
+    { optForce        :: Bool     -- ^Compile specified files even if up to date
     , optForceAll     :: Bool     -- ^Compile all files even if up to date
     , optShowVersion  :: Bool     -- ^Print compiler version and exit
     , optHelpLog      :: Bool     -- ^Print log option help and exit
@@ -45,27 +45,29 @@ data Options = Options{
     , optVerbose      :: Bool     -- ^Be verbose in compiler output
     , optNoFont       :: Bool     -- ^Disable ISO font change codes in messages
     , optNoVerifyLLVM :: Bool     -- ^Don't run LLVM verification
+    , optDumpOptLLVM  :: Bool     -- ^Dump optimised LLVM code
     } deriving Show
 
 
 -- |Defaults for all compiler options
 defaultOptions :: Options
-defaultOptions     = Options
- { optForce        = False
- , optForceAll     = False
- , optShowVersion  = False
- , optHelpLog      = False
- , optShowHelp     = False
- , optLibDirs      = []
- , optLogAspects   = Set.empty
- , optLogUnknown   = Set.empty
- , optNoLLVMOpt    = False
- , optNoMultiSpecz = False 
- , optDumpLib      = False
- , optVerbose      = False
- , optNoFont       = False
- , optNoVerifyLLVM = False
- }
+defaultOptions = Options
+  { optForce        = False
+  , optForceAll     = False
+  , optShowVersion  = False
+  , optHelpLog      = False
+  , optShowHelp     = False
+  , optLibDirs      = []
+  , optLogAspects   = Set.empty
+  , optLogUnknown   = Set.empty
+  , optNoLLVMOpt    = False
+  , optNoMultiSpecz = False 
+  , optDumpLib      = False
+  , optVerbose      = False
+  , optNoFont       = False
+  , optNoVerifyLLVM = False
+  , optDumpOptLLVM  = False
+  }
 
 -- |All compiler features we may want to log
 data LogSelection =
@@ -160,6 +162,9 @@ options =
  , Option [] ["no-verify-llvm"]
      (NoArg (\opts -> opts { optNoVerifyLLVM = True }))
      "disable verification of generated LLVM code"
+ , Option [] ["dump-opt-llvm"]
+     (NoArg (\opts -> opts { optDumpOptLLVM = True }))
+     "dump optimised LLVM code"
  ]
 
 


### PR DESCRIPTION
Can be turned on via the `--dump-opt-llvm` flag, dumping only when FinalDump is logged.

Manually checking a few instances of what's dumped, we may close some issues, such as #207, as the unused declarations are removed in the LLVM optimisation passes

Some issues, such as #186, should not be closed. Perhaps we should curate our own set of LLVM passes that includes, amongst others, `-constmerge`