### PR TITLE
Uniqueness improvements

### DIFF
--- a/src/AST.hs
+++ b/src/AST.hs
@@ -1435,8 +1435,9 @@ data ModuleInterface = ModuleInterface {
                                      -- ^The procs this module exports
     pubSubmods   :: Map Ident ModSpec, -- ^The submodules this module exports
     dependencies :: Set ModSpec,      -- ^The other modules that must be linked
-    typeModifiers :: TypeModifiers   -- ^The extra information of the type
-    }                               --  in by modules that depend on this one
+                                      --  in by modules that depend on this one
+    typeModifiers :: TypeModifiers    -- ^The extra information of the type
+    }
     deriving (Eq, Generic)
 
 emptyInterface :: ModuleInterface

--- a/src/AST.hs
+++ b/src/AST.hs
@@ -337,15 +337,19 @@ content :: Placed t -> t
 content (Placed content _) = content
 content (Unplaced content) = content
 
+
 -- |Attach a source position to a data value, if one is available.
 maybePlace :: t -> OptPos -> Placed t
 maybePlace t (Just pos) = Placed t pos
 maybePlace t Nothing    = Unplaced t
 
--- |Attach a source position to a data value, if one is available.
-rePlace :: t -> Placed t -> Placed t
-rePlace t (Placed _ pos) = Placed t pos
-rePlace t (Unplaced _)   = Unplaced t
+
+-- |Replace the source position of the Placed value with the given position, if
+-- one is given; otherwise leave the position it already has.
+rePlace :: OptPos -> Placed t -> Placed t
+rePlace Nothing    t            = t
+rePlace (Just pos) (Placed t _) = Placed t pos
+rePlace (Just pos) (Unplaced t) = Placed t pos
 
 
 -- |Extract the place and payload of a Placed value
@@ -2956,12 +2960,12 @@ isHalfUpdate _ _ = False
 varsInPrimArg :: PrimFlow -> PrimArg -> Set PrimVarName
 varsInPrimArg dir ArgVar{argVarName=var,argVarFlow=dir'} =
   if dir == dir' then Set.singleton var else Set.empty
-varsInPrimArg _ (ArgInt _ _)            = Set.empty
-varsInPrimArg _ (ArgFloat _ _)          = Set.empty
-varsInPrimArg _ (ArgString {})       = Set.empty
-varsInPrimArg _ (ArgChar _ _)           = Set.empty
-varsInPrimArg _ (ArgUnneeded _ _)       = Set.empty
-varsInPrimArg _ (ArgUndef _)            = Set.empty
+varsInPrimArg _ ArgInt{}      = Set.empty
+varsInPrimArg _ ArgFloat{}    = Set.empty
+varsInPrimArg _ ArgString{}   = Set.empty
+varsInPrimArg _ ArgChar{}     = Set.empty
+varsInPrimArg _ ArgUnneeded{} = Set.empty
+varsInPrimArg _ ArgUndef{}    = Set.empty
 
 
 ----------------------------------------------------------------

--- a/src/Resources.hs
+++ b/src/Resources.hs
@@ -242,8 +242,9 @@ transformStmt (UseResources allRes oldRes body) pos = do
     let ress = zip3 toSave tmpNames types
     let get v ty = varGet v `withType` ty
     let set v ty = varSet v `withType` ty
-    let saves = (\(r,t,ty) -> move (get r ty) (set t ty)) <$> ress
-    let restores = (\(r,t,ty) -> move (get t ty) (set r ty)) <$> ress
+    let saves = (\(r,t,ty) -> rePlace pos (move (get r ty) (set t ty))) <$> ress
+    let restores = (\(r,t,ty) -> rePlace pos (move (get t ty) (set r ty)))
+                   <$> ress
     let tmpVars = Map.fromList $ zip tmpNames types
     body' <- transformWithTmpVars (tmp + length toSave) tmpVars
            $ transformStmts body

--- a/src/Unique.hs
+++ b/src/Unique.hs
@@ -35,13 +35,18 @@ data UniquenessError = ReuseUnique {
 
 -- | Set used to check correctness of uniqueness of the program
 data UniquenessState = UniquenessState {
+    -- |The variables used so far in the current scope, with their types.
     uniquenessUsedMap :: VarDict,
-    uniquenessErrors  :: [UniquenessError]
+    -- |The uniqueness errors seen so far.
+    uniquenessErrors  :: [UniquenessError],
+    -- |The maximum determinism allowed in the current scope.  Assignment to
+    -- unique variables is not allowed outside a deterministic scope.
+    uniquenessDetism  :: Determinism
 } deriving Show
 
 
 -- | Return an initial state for uniqueness checker
-initUniquenessState :: UniquenessState
+initUniquenessState :: Determinism -> UniquenessState
 initUniquenessState = UniquenessState Map.empty []
 
 
@@ -54,6 +59,8 @@ uniquenessCheckProc def _ = do
     let detism = procDetism def
     let params = procProtoParams $ procProto def
     logUniqueness $ "with params: " ++ show params
+    -- XXX this only considers whether arguments are unique, ignoring direction
+    -- of flow.  When users can declare their own unique types, this won't work.
     someUnique <- elem (Just True) <$>
                   mapM (((tmUniqueness . typeModifiers . modInterface <$>) <$>)
                         <$> getLoadingModule)
@@ -63,38 +70,186 @@ uniquenessCheckProc def _ = do
             $ showProcName name ++ " with unique argument can fail") 
     case procImpln def of
         ProcDefSrc body -> do
-            let state = foldStmts (const . const) uniquenessCheckExp
-                        initUniquenessState body
-            logUniqueness $ "After checking body: " ++ show state
-            let state' = List.foldl (uniquenessCheckParam name pos) state params
-            logUniqueness $ "After checking params: " ++ show state'
-            errs <- filterM (typeIsUnique . errTypeSpec) (uniquenessErrors state')
-            mapM_ reportUniquenessError errs
+            state <- uniquenessCheckDef name pos detism body params
+            logUniqueness $ "After checking params: " ++ show state
+            mapM_ reportUniquenessError $ reverse $ uniquenessErrors state
             return def
         _ -> shouldnt $ "Uniqueness check of non-source proc def "
                         ++ show (procName def)
 
 
--- | Check correctness of uniqueness for an expression
-uniquenessCheckExp :: UniquenessState -> Exp -> OptPos -> UniquenessState
-uniquenessCheckExp state (Typed (Var name ParamIn flow) ty _) pos =
-    let (UniquenessState usedMap errs) = state
-    in if Map.member name usedMap
-    then state {uniquenessErrors = ReuseUnique name ty pos flow Nothing : errs}
-    else state {uniquenessUsedMap = Map.insert name ty usedMap}
-uniquenessCheckExp state (Typed (Var name ParamOut _) ty _) _ =
-    state {uniquenessUsedMap = Map.delete name (uniquenessUsedMap state)}
-uniquenessCheckExp state _ _ = state
+----------------------------------------------------------------
+--               The Uniqueness Checker Monad
+----------------------------------------------------------------
+
+-- |The Uniqueness monad is a state transformer monad carrying the 
+--  uniqueness state over the compiler monad.
+type Uniqueness = StateT UniquenessState Compiler
 
 
-uniquenessCheckParam :: ProcName -> OptPos -> UniquenessState -> Param
-                     -> UniquenessState
-uniquenessCheckParam name pos state (Param p ty flow flowType)
- |  flowsOut flow && Map.member p (uniquenessUsedMap state) =
-     -- error:  producing value as output after using it
-     state { uniquenessErrors = ReuseUnique p ty pos flowType (Just name)
-                                : uniquenessErrors state}
- |  otherwise = state
+uniquenessCheckDef :: ProcName -> OptPos -> Determinism -> [Placed Stmt]
+                   -> [Param] -> Compiler UniquenessState
+uniquenessCheckDef name pos detism body params =
+    execStateT 
+    (uniquenessCheckStmts body >> mapM_ (uniquenessCheckParam name pos) params)
+    $ initUniquenessState detism
+
+
+-- | Note a variable use, reporting an error if it has already been used.
+variableUsed :: VarName -> OptPos -> TypeSpec -> ArgFlowType -> Uniqueness ()
+variableUsed name pos ty flowType = do
+    alreadyUsed <- Map.member name <$> gets uniquenessUsedMap
+    when alreadyUsed $ uniquenessErr $ ReuseUnique name ty pos flowType Nothing
+    isUnique <- lift $ typeIsUnique ty
+    when isUnique
+     $ modify $ \st -> st {uniquenessUsedMap = Map.insert name ty
+                                              $ uniquenessUsedMap st }
+
+
+-- | Note a variable use, reporting an error if it has already been used.
+variableAssigned :: VarName -> Uniqueness ()
+variableAssigned name =
+    modify $ \st -> st {uniquenessUsedMap = Map.delete name
+                                            $ uniquenessUsedMap st }
+
+
+-- | Report a uniqueness error
+uniquenessErr :: UniquenessError -> Uniqueness ()
+uniquenessErr err = do
+    modify $ \st -> st { uniquenessErrors = err : uniquenessErrors st }
+
+
+withDetism :: Uniqueness a -> Determinism -> Uniqueness a
+withDetism a detism = do
+    oldDetism <- gets uniquenessDetism
+    modify $ \state -> state { uniquenessDetism = detism }
+    result <- a
+    modify $ \state -> state { uniquenessDetism = oldDetism }
+    return result
+
+
+joinUniqueness :: Uniqueness () -> Uniqueness () -> Uniqueness ()
+joinUniqueness first second = do
+    initial <- get
+    let start = initial { uniquenessErrors = [] }
+    put start
+    first
+    firstState <- get
+    put start
+    second
+    secondState <- get
+    let allErrs = uniquenessErrors secondState ++ uniquenessErrors firstState
+                  ++ uniquenessErrors initial
+    let joinUsed = uniquenessUsedMap firstState 
+                   `Map.intersection` uniquenessUsedMap secondState
+    put $ UniquenessState joinUsed allErrs $ uniquenessDetism initial
+
+
+-- | Uniqueness check a statement sequence
+uniquenessCheckStmts :: [Placed Stmt] -> Uniqueness ()
+uniquenessCheckStmts = mapM_ $ placedApply uniquenessCheckStmt
+
+
+-- | Uniqueness check a single statement
+uniquenessCheckStmt :: Stmt -> OptPos -> Uniqueness ()
+uniquenessCheckStmt (ProcCall _ _ _ _ _ args) pos =
+    mapM_ (defaultPlacedApply uniquenessCheckExp pos) args
+uniquenessCheckStmt (ForeignCall _ _ _ args) pos =
+    mapM_ (defaultPlacedApply uniquenessCheckExp pos) args
+uniquenessCheckStmt (Cond tst thn els _ _) pos =
+    (defaultPlacedApply uniquenessCheckStmt pos tst `withDetism` SemiDet
+     >> uniquenessCheckStmts thn)
+    `joinUniqueness` uniquenessCheckStmts els
+uniquenessCheckStmt (Case exp cases deflt) pos = do
+    defaultPlacedApply uniquenessCheckExp pos exp
+    uniquenessCheckCases uniquenessCheckStmts cases deflt
+uniquenessCheckStmt (And stmts) _ = uniquenessCheckStmts stmts
+uniquenessCheckStmt (Or [] _) pos = return ()
+uniquenessCheckStmt (Or [stmt] _) pos =
+    defaultPlacedApply uniquenessCheckStmt pos stmt
+uniquenessCheckStmt (Or (stmt:stmts) x) pos =
+    (defaultPlacedApply uniquenessCheckStmt pos stmt `withDetism` SemiDet)
+    `joinUniqueness` uniquenessCheckStmt (Or stmts x) pos
+uniquenessCheckStmt (Not negated) pos =
+    defaultPlacedApply uniquenessCheckStmt pos negated
+uniquenessCheckStmt (TestBool exp) pos = uniquenessCheckExp exp pos
+uniquenessCheckStmt Nop pos = return ()
+uniquenessCheckStmt Fail pos = return ()
+uniquenessCheckStmt (Loop body _) _ = uniquenessCheckStmts body
+uniquenessCheckStmt (UseResources _ _ body) _ = uniquenessCheckStmts body
+uniquenessCheckStmt (For generators body) pos = do
+    mapM_ ((\gen -> do
+            placedApply uniquenessCheckExp $ genExp gen
+            placedApply uniquenessCheckExp $ loopVar gen
+        ) . content) generators
+    uniquenessCheckStmts body
+uniquenessCheckStmt Break pos = return ()
+uniquenessCheckStmt Next pos = return ()
+
+
+-- | Uniqueness check the cases in a case statement.
+uniquenessCheckCases :: (a -> Uniqueness ()) -> [(Placed Exp,a)] -> Maybe a
+                     -> Uniqueness ()
+uniquenessCheckCases f [] deflt = maybe (return ()) f deflt
+uniquenessCheckCases f ((pexp, body):rest) deflt =
+    (placedApply uniquenessCheckExp pexp `withDetism` SemiDet >> f body)
+    `joinUniqueness` uniquenessCheckCases f rest deflt
+
+
+-- | Uniqueness check an expression (recursively). When we see a use of a unique
+-- variable, we add it to a dictionary (recording its type).  When we see a
+-- subsequent use, we report an error.  When we see an assignment of a variable,
+-- we remove it from the map, as that means we have not yet seen a use of that
+-- value.  For an in/out flow, we treat this as first a use and then an
+-- assignment.
+uniquenessCheckExp :: Exp -> OptPos -> Uniqueness ()
+uniquenessCheckExp (Typed (Var name ParamIn flowType) ty _) pos =
+    variableUsed name pos ty flowType
+uniquenessCheckExp (Typed (Var name ParamOut _) ty _) _ =
+    variableAssigned name
+uniquenessCheckExp (Typed (Var name ParamInOut flowType) ty _) pos = do
+    variableUsed name pos ty flowType
+    variableAssigned name
+uniquenessCheckExp (Typed exp _ _) pos = uniquenessCheckExp exp pos
+uniquenessCheckExp IntValue{} _ = return ()
+uniquenessCheckExp FloatValue{} _ = return ()
+uniquenessCheckExp CharValue{} _ = return ()
+uniquenessCheckExp StringValue{} _ = return ()
+uniquenessCheckExp var@Var{} _ =
+    shouldnt $ "Untyped variable " ++ show var ++ " in uniqueness checking"
+uniquenessCheckExp (Where stmts exp) pos = do
+    uniquenessCheckStmts stmts
+    defaultPlacedApply uniquenessCheckExp pos exp
+uniquenessCheckExp (DisjExp e1 e2) pos =
+    (defaultPlacedApply uniquenessCheckExp pos e1 `withDetism` SemiDet)
+    `joinUniqueness` defaultPlacedApply uniquenessCheckExp pos e2
+uniquenessCheckExp (CondExp stmt e1 e2) pos =
+    (placedApply uniquenessCheckStmt stmt `withDetism` SemiDet
+     >> placedApply uniquenessCheckExp e1)
+    `joinUniqueness` placedApply uniquenessCheckExp e2
+uniquenessCheckExp (Fncall _ _ exps) pos =
+    mapM_  (placedApply uniquenessCheckExp) exps
+uniquenessCheckExp (ForeignFn _ _ _ exps) pos =
+    mapM_  (placedApply uniquenessCheckExp) exps
+uniquenessCheckExp (CaseExp exp cases deflt) pos = do
+    placedApply uniquenessCheckExp exp
+    uniquenessCheckCases (placedApply uniquenessCheckExp) cases deflt
+
+
+-- -- | Fold over the cases in a case expression
+-- foldCaseExp :: (Placed Exp,Placed Exp) -> a
+-- foldCaseExp sfn efn val (pexp, pval) =
+--     placedApply (foldExp sfn efn (placedApply (foldExp sfn efn val) pexp)) pval
+
+
+-- | Uniqueness check a parameter (including used resources) following checking
+-- of the proc body.  This will catch unique outputs following use of the value.
+uniquenessCheckParam :: ProcName -> OptPos -> Param -> Uniqueness ()
+uniquenessCheckParam name pos (Param p ty flow flowType) = do
+    used <- Map.member p <$> gets uniquenessUsedMap
+    when  (flowsOut flow && used)
+     $ uniquenessErr $ ReuseUnique p ty pos flowType (Just name)
+
 
 -- | Check if a type is unique
 typeIsUnique :: TypeSpec -> Compiler Bool

--- a/test-cases/final-dump/io_flow_error.exp
+++ b/test-cases/final-dump/io_flow_error.exp
@@ -1,3 +1,4 @@
 Error detected during uniqueness checking of module(s) io_flow_error
 [91mUnique resource wybe.io.io live at end of module top-level code
+[0m[91mfinal-dump/io_flow_error.wybe:6:6: Reuse of unique resource wybe.io.io
 [0m

--- a/test-cases/final-dump/io_flow_error.exp
+++ b/test-cases/final-dump/io_flow_error.exp
@@ -1,4 +1,5 @@
 Error detected during uniqueness checking of module(s) io_flow_error
 [91mUnique resource wybe.io.io live at end of module top-level code
-[0m[91mfinal-dump/io_flow_error.wybe:6:6: Reuse of unique resource wybe.io.io
+[0m[91mfinal-dump/io_flow_error.wybe:8:6: Reuse of unique resource wybe.io.io
+[0m[91mfinal-dump/io_flow_error.wybe:11:7: Unique resource wybe.io.io assigned in a test context
 [0m

--- a/test-cases/final-dump/io_flow_error.wybe
+++ b/test-cases/final-dump/io_flow_error.wybe
@@ -2,8 +2,14 @@ def woops use io {
     !println("hello world!")
 }
 
+def {test,noinline} dunno { pass }
+
 use io in {
     !println("shouldn't be allowed.")
 }
+
+if { !println("no go") & dunno :: pass
+   | pass
+   }
 
 !woops

--- a/test-cases/final-dump/io_flow_error.wybe
+++ b/test-cases/final-dump/io_flow_error.wybe
@@ -2,4 +2,8 @@ def woops use io {
     !println("hello world!")
 }
 
+use io in {
+    !println("shouldn't be allowed.")
+}
+
 !woops

--- a/test-cases/final-dump/resource_tmp_vars.exp
+++ b/test-cases/final-dump/resource_tmp_vars.exp
@@ -16,7 +16,7 @@ module top-level code > public {impure} (0 calls)
  InterestingCallProperties: []
     foreign c print_int(1:wybe.int, ~io##0:wybe.phantom, ?tmp#5##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#5##0:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
-    foreign llvm move(0:wybe.int, ?counter##1:wybe.int)
+    foreign llvm move(0:wybe.int, ?counter##1:wybe.int) @resource_tmp_vars:nn:nn
     foreign c print_int(0:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?io##1:wybe.phantom) @io:nn:nn
 
@@ -28,7 +28,7 @@ gen#1([counter##0:wybe.int], io##0:wybe.phantom, tmp#0##0:wybe.int, ?counter##2:
  InterestingCallProperties: []
     foreign c print_int(1:wybe.int, ~#io##0:wybe.phantom, ?tmp#3##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#3##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign llvm move(tmp#0##0:wybe.int, ?counter##2:wybe.int)
+    foreign llvm move(tmp#0##0:wybe.int, ?counter##2:wybe.int) @resource_tmp_vars:nn:nn
     foreign c print_int(~tmp#0##0:wybe.int, ~#io##1:wybe.phantom, ?tmp#6##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#6##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
 

--- a/test-cases/final-dump/stmt_for.exp
+++ b/test-cases/final-dump/stmt_for.exp
@@ -228,26 +228,22 @@ gen#14(io##0:wybe.phantom, tmp#0##0:stmt_for.int_sequence, tmp#1##0:stmt_for.int
 
 gen#2 > (2 calls)
 0: stmt_for.gen#2<0>
-gen#2(io##0:wybe.phantom, tmp#0##0:stmt_for.int_sequence, tmp#1##0:stmt_for.int_sequence, ?io##2:wybe.phantom, ?#success##0:wybe.bool):
+gen#2(tmp#0##0:stmt_for.int_sequence, tmp#1##0:stmt_for.int_sequence, ?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     stmt_for.int_sequence.[|]<0>(?i##0:wybe.int, ?tmp#0##1:stmt_for.int_sequence, ~tmp#0##0:stmt_for.int_sequence, ?tmp#3##0:wybe.bool) #0 @stmt_for:nn:nn
     case ~tmp#3##0:wybe.bool of
     0:
         foreign llvm move(1:wybe.bool, ?#success##0:wybe.bool)
-        foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
     1:
-        foreign llvm icmp_slt(i##0:wybe.int, 5:wybe.int, ?tmp#2##0:wybe.bool) @int:nn:nn
+        foreign llvm icmp_slt(~i##0:wybe.int, 5:wybe.int, ?tmp#2##0:wybe.bool) @int:nn:nn
         case ~tmp#2##0:wybe.bool of
         0:
             foreign llvm move(0:wybe.bool, ?#success##0:wybe.bool)
-            foreign llvm move(~io##0:wybe.phantom, ?io##2:wybe.phantom)
 
         1:
-            foreign c print_int(~i##0:wybe.int, ~#io##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @io:nn:nn
-            foreign c putchar('\n':wybe.char, ~tmp#8##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-            stmt_for.gen#2<0>(~io##1:wybe.phantom, ~tmp#0##1:stmt_for.int_sequence, ~tmp#1##0:stmt_for.int_sequence, ?io##2:wybe.phantom, ?#success##0:wybe.bool) #3 @stmt_for:nn:nn
+            stmt_for.gen#2<0>(~tmp#0##1:stmt_for.int_sequence, ~tmp#1##0:stmt_for.int_sequence, ?#success##0:wybe.bool) #2 @stmt_for:nn:nn
 
 
 
@@ -464,11 +460,11 @@ multiple_generator(io##0:wybe.phantom, ?io##1:wybe.phantom):
 
 semi_det_for_loop > public (0 calls)
 0: stmt_for.semi_det_for_loop<0>
-semi_det_for_loop(io##0:wybe.phantom, ?io##1:wybe.phantom, ?#success##0:wybe.bool):
+semi_det_for_loop(?#success##0:wybe.bool):
  AliasPairs: []
  InterestingCallProperties: []
     stmt_for.xrange<0>(0:wybe.int, 1:wybe.int, 10:wybe.int, ?tmp#1##0:stmt_for.int_sequence) #0 @stmt_for:nn:nn
-    stmt_for.gen#2<0>(~io##0:wybe.phantom, ~tmp#1##0:stmt_for.int_sequence, ~tmp#1##0:stmt_for.int_sequence, ?io##1:wybe.phantom, ?#success##0:wybe.bool) #1 @stmt_for:nn:nn
+    stmt_for.gen#2<0>(~tmp#1##0:stmt_for.int_sequence, ~tmp#1##0:stmt_for.int_sequence, ?#success##0:wybe.bool) #1 @stmt_for:nn:nn
 
 
 shortest_generator_termination > public (1 calls)
@@ -987,8 +983,6 @@ if.then:
 if.else:
   ret i1 1 
 if.then1:
-  tail call ccc  void  @print_int(i64  %71)  
-  tail call ccc  void  @putchar(i8  10)  
   %"4##success##0" = tail call fastcc  i1  @"stmt_for.gen#2<0>"(i64  %72, i64  %"tmp#1##0")  
   ret i1 %"4##success##0" 
 if.else1:

--- a/test-cases/final-dump/stmt_for.wybe
+++ b/test-cases/final-dump/stmt_for.wybe
@@ -131,12 +131,10 @@ pub def using_irange_reverse use !io {
     }
 }
 
-pub def {test} semi_det_for_loop use !io {
-    for ?i in xrange(0, 1, 10):int_sequence {
-        (i < 5)
-        !println(i)
-    }
+pub def {test} semi_det_for_loop {
+    for ?i in xrange(0, 1, 10):int_sequence { i < 5 }
 }
+
 
 # Testing code
 !println("single_generator:")

--- a/test-cases/final-dump/top_level_use.exp
+++ b/test-cases/final-dump/top_level_use.exp
@@ -16,7 +16,7 @@ module top-level code > public {inline,impure} (0 calls)
  InterestingCallProperties: []
     foreign c print_int(0:wybe.int, ~#io##0:wybe.phantom, ?tmp#3##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#3##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
-    foreign llvm move(0:wybe.int, ?res##2:wybe.int)
+    foreign llvm move(0:wybe.int, ?res##2:wybe.int) @top_level_use:nn:nn
 
   LLVM code       :
 

--- a/test-cases/final-dump/use_resource.exp
+++ b/test-cases/final-dump/use_resource.exp
@@ -17,7 +17,7 @@ module top-level code > public {impure} (0 calls)
     wybe.string.print_string<0>("Inner count (4): ":wybe.string, ~#io##0:wybe.phantom, ?tmp#6##0:wybe.phantom) #1 @io:nn:nn
     foreign c print_int(4:wybe.int, ~tmp#6##0:wybe.phantom, ?tmp#7##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#7##0:wybe.phantom, ?tmp#8##0:wybe.phantom) @io:nn:nn
-    foreign llvm move(1:wybe.int, ?#count##1:wybe.int)
+    foreign llvm move(1:wybe.int, ?#count##1:wybe.int) @use_resource:nn:nn
     wybe.string.print_string<0>("Outer count (1): ":wybe.string, ~tmp#8##0:wybe.phantom, ?tmp#9##0:wybe.phantom) #2 @io:nn:nn
     foreign c print_int(1:wybe.int, ~tmp#9##0:wybe.phantom, ?tmp#10##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#10##0:wybe.phantom, ?#io##1:wybe.phantom) @io:nn:nn
@@ -43,7 +43,7 @@ use_test(count##0:wybe.int, ?count##5:wybe.int, io##0:wybe.phantom, ?io##4:wybe.
     wybe.string.print_string<0>("Inner count (4): ":wybe.string, ~#io##0:wybe.phantom, ?#io##1:wybe.phantom) #8 @io:nn:nn
     foreign c print_int(~count##4:wybe.int, ~#io##1:wybe.phantom, ?tmp#9##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#9##0:wybe.phantom, ?#io##2:wybe.phantom) @io:nn:nn
-    foreign llvm move(count##1:wybe.int, ?count##5:wybe.int)
+    foreign llvm move(count##1:wybe.int, ?count##5:wybe.int) @use_resource:nn:nn
     wybe.string.print_string<0>("Outer count (1): ":wybe.string, ~#io##2:wybe.phantom, ?#io##3:wybe.phantom) #9 @io:nn:nn
     foreign c print_int(~count##1:wybe.int, ~#io##3:wybe.phantom, ?tmp#14##0:wybe.phantom) @io:nn:nn
     foreign c putchar('\n':wybe.char, ~tmp#14##0:wybe.phantom, ?#io##4:wybe.phantom) @io:nn:nn

--- a/wybelibs/wybe/io.wybe
+++ b/wybelibs/wybe/io.wybe
@@ -6,7 +6,8 @@ use foreign library gc
 use wybe.bool, wybe.int, wybe.count, wybe.float, wybe.char, wybe.string, wybe.c_string
 use wybe.phantom
 
-pub resource io:phantom = phantom
+# XXX We shouldn't need to initialise a resource (or variable) of a 0-bit type
+pub resource io:phantom = 0:phantom
 
 pub def nl use !io { foreign c putchar('\n', !io) }
 

--- a/wybelibs/wybe/phantom.wybe
+++ b/wybelibs/wybe/phantom.wybe
@@ -3,4 +3,4 @@ pragma no_standard_library  # Standard library can't depend on itself!
 use wybe.bool
 
 # This is a unit type, and needs 0 bits to represent.
-pub constructor {unique} phantom
+representation is {unique} 0 bit unsigned


### PR DESCRIPTION
Make test (and failure) procs with unique arguments/resources illegal.

Make assignment to unique variables/resources in a test or failure context illegal.

Closes issue #223.